### PR TITLE
feat: use `ego_agent_past`

### DIFF
--- a/diffusion_planner/diffusion_planner/utils/dataset.py
+++ b/diffusion_planner/diffusion_planner/utils/dataset.py
@@ -17,6 +17,7 @@ class DiffusionPlannerData(Dataset):
     def __getitem__(self, idx):
         data = np.load(self.data_list[idx], allow_pickle=True)
 
+        ego_agent_past = data["ego_agent_past"].astype(np.float32)
         ego_current_state = data["ego_current_state"]
         ego_agent_future = data["ego_agent_future"].astype(np.float32)
 
@@ -36,6 +37,7 @@ class DiffusionPlannerData(Dataset):
         turn_indicator = data["turn_indicator"]
 
         data = {
+            "ego_agent_past": ego_agent_past,
             "ego_current_state": ego_current_state,
             "ego_future_gt": ego_agent_future,
             "neighbor_agents_past": neighbor_agents_past,


### PR DESCRIPTION
## Pull Request Overview

Adds support for the ego agent’s past trajectory in both data loading and model encoding, refactors heading-to-(cos, sin) conversion into a shared helper, and introduces a dedicated encoder for ego history.

- Load and pass `ego_agent_past` through dataset and training/validation pipelines  
- Refactor repeated heading-to-cos/sin logic into `heading_to_cos_sin`  
- Update main encoder to include a new `EgoFusionEncoder` and adjust token count

## Result

![image](https://github.com/user-attachments/assets/71c38e67-3098-4ce8-adfa-d63da5259b19)
