### PR TITLE
fix resume_model_path

### DIFF
--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -137,7 +137,7 @@ def model_training(args):
         print("Use device: {}".format(args.device))
 
         if args.resume_model_path is not None:
-            save_path = args.resume_model_path
+            save_path = os.path.dirname(args.resume_model_path)
         else:
             from datetime import datetime
 


### PR DESCRIPTION
## Description
[resume_mode](https://github.com/tier4/Diffusion-Planner/blob/tier4-main/diffusion_planner/diffusion_planner/utils/train_utils.py#L39) expects a model path, whereas the [save_path](https://github.com/tier4/Diffusion-Planner/blob/tier4-main/diffusion_planner/train_predictor.py#L140) expects a directory path.
This PR solves the problem.