### PR TITLE
fix(cpp_tools): support rosbag2 Jazzy API for offered_qos_profiles

### DIFF
--- a/cpp_tools/src/autoware_diffusion_planner_tools/CMakeLists.txt
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/CMakeLists.txt
@@ -10,6 +10,13 @@ add_compile_options(-Wno-deprecated-declarations)
 # Suppress narrowing conversion warnings from TensorRT headers
 add_compile_options(-Wno-narrowing)
 
+# rosbag2_storage >= 0.26 (Jazzy+): offered_qos_profiles changed from
+# std::string to std::vector<rclcpp::QoS>. Pass a compile-time flag.
+find_package(rosbag2_storage REQUIRED)
+if(rosbag2_storage_VERSION VERSION_GREATER_EQUAL "0.26.0")
+  add_compile_definitions(ROSBAG2_QOS_PROFILES_AS_VECTOR)
+endif()
+
 ament_auto_add_executable(data_converter
   src/data_converter.cpp
 )

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/rosbag_parser.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/rosbag_parser.hpp
@@ -139,6 +139,14 @@ public:
     meta_data.name = topic_name;
     meta_data.type = type;
     meta_data.serialization_format = "cdr";
+    // offered_qos_profiles changed from std::string (Humble/Iron) to
+    // std::vector<rclcpp::QoS> (Jazzy+) in rosbag2_storage >= 0.26
+#if defined(ROSBAG2_QOS_PROFILES_AS_VECTOR)
+    rclcpp::QoS qos(rclcpp::KeepLast(1));
+    qos.reliability(rclcpp::ReliabilityPolicy::Reliable);
+    qos.durability(rclcpp::DurabilityPolicy::Volatile);
+    meta_data.offered_qos_profiles = {qos};
+#else
     meta_data.offered_qos_profiles =
       "- history: 1\n  depth: 1\n  reliability: 1\n  durability: 2\n"
       "  deadline:\n    sec: 9223372036\n    nsec: 854775807\n"
@@ -146,6 +154,7 @@ public:
       "  liveliness: 1\n  liveliness_lease_duration:\n"
       "    sec: 9223372036\n    nsec: 854775807\n"
       "  avoid_ros_namespace_conventions: false";
+#endif
     writer_.create_topic(meta_data);
   }
 


### PR DESCRIPTION
## Summary

- `TopicMetadata::offered_qos_profiles` changed from `std::string` (Humble/Iron) to `std::vector<rclcpp::QoS>` (Jazzy+) in rosbag2_storage >= 0.26
- Detect the API version at CMake configure time and select the appropriate code path via `#ifdef` guard
- Fully backward compatible: Humble and Iron continue to use the original string format

## Test plan

- [x] Built and confirmed compilation on ROS 2 Jazzy (rosbag2_storage 0.26.9)
- [x] Ran `benchmark_tool` on Drive AGX Thor (aarch64, Ubuntu 24.04 Noble, ROS 2 Jazzy)
- [ ] Verify compilation on ROS 2 Humble (rosbag2_storage ~0.15.x)

## Benchmark results (Drive AGX Thor, Diffusion Planner v3.1, TRT 10.10.10, fp32)

| Metric | Value |
|--------|-------|
| Mean   | 9.21 ms |
| Median | 9.19 ms |
| Min    | 9.12 ms |
| Max    | 9.80 ms |
| P95    | 9.34 ms |
| Std    | 0.090 ms |
| GPU memory | ~260 MiB |