### PR TITLE
feat: Add speed-feasible ego trajectory data augmentation

### DIFF
--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -1,10 +1,8 @@
 import numpy as np
 import torch
 
-from diffusion_planner.utils.unicycle_accel_curvature import smoothing_future_trajectory
-
-NUM_REFINE = 20
 TIME_INTERVAL = 0.1
+DENSE_SAMPLE_DS = 0.05
 
 
 def vector_transform(vector, transform_mat, bias=None):
@@ -14,12 +12,12 @@ def vector_transform(vector, transform_mat, bias=None):
     bias: (B, ..., 2)
     """
     shape = vector.shape
-    B = vector.shape[0]
+    bsz = vector.shape[0]
     nexpand = vector.ndim - 2
     if bias is not None:
-        vector = vector - bias.reshape(B, *([1] * nexpand), -1)
-    vector = vector.reshape(B, -1, 2).permute(0, 2, 1)  # (B, 2, N1 * N2 ...)
-    return torch.bmm(transform_mat, vector).permute(0, 2, 1).reshape(*shape)  # (B, ..., 2)
+        vector = vector - bias.reshape(bsz, *([1] * nexpand), -1)
+    vector = vector.reshape(bsz, -1, 2).permute(0, 2, 1)
+    return torch.bmm(transform_mat, vector).permute(0, 2, 1).reshape(*shape)
 
 
 def heading_transform(heading, transform_mat):
@@ -27,10 +25,10 @@ def heading_transform(heading, transform_mat):
     heading: (B, ...)
     transform_mat: (B, 2, 2)
     """
-    B = heading.shape[0]
+    bsz = heading.shape[0]
     shape = heading.shape
-    heading = heading.reshape(B, -1)
-    transform_mat = transform_mat.reshape(B, 1, 2, 2)
+    heading = heading.reshape(bsz, -1)
+    transform_mat = transform_mat.reshape(bsz, 1, 2, 2)
     return torch.atan2(
         torch.cos(heading) * transform_mat[..., 1, 0]
         + torch.sin(heading) * transform_mat[..., 1, 1],
@@ -39,10 +37,251 @@ def heading_transform(heading, transform_mat):
     ).reshape(*shape)
 
 
+def normalize_angle_torch(angle: torch.Tensor) -> torch.Tensor:
+    return torch.atan2(torch.sin(angle), torch.cos(angle))
+
+
+def cumulative_distance_torch(xy: torch.Tensor) -> torch.Tensor:
+    if xy.shape[0] == 0:
+        return torch.zeros(0, dtype=xy.dtype, device=xy.device)
+    deltas = torch.diff(xy, dim=0)
+    segment_lengths = torch.linalg.norm(deltas, dim=-1)
+    distance = torch.zeros(xy.shape[0], dtype=xy.dtype, device=xy.device)
+    distance[1:] = torch.cumsum(segment_lengths, dim=0)
+    return distance
+
+
+def interp1d_torch(x: torch.Tensor, y: torch.Tensor, xq: torch.Tensor) -> torch.Tensor:
+    if x.numel() == 1:
+        return y[0].expand_as(xq) if y.ndim == 1 else y[0].expand(xq.shape[0], *y.shape[1:])
+
+    xq_clamped = torch.clamp(xq, min=x[0], max=x[-1])
+    idx = torch.searchsorted(x, xq_clamped, right=False)
+    idx = torch.clamp(idx, 1, x.shape[0] - 1)
+    x0 = x[idx - 1]
+    x1 = x[idx]
+    weight = (xq_clamped - x0) / torch.clamp(x1 - x0, min=1.0e-6)
+
+    if y.ndim == 1:
+        y0 = y[idx - 1]
+        y1 = y[idx]
+        return y0 + weight * (y1 - y0)
+
+    y0 = y[idx - 1]
+    y1 = y[idx]
+    return y0 + weight.unsqueeze(-1) * (y1 - y0)
+
+
+def interp_heading_torch(
+    x: torch.Tensor, heading: torch.Tensor, xq: torch.Tensor
+) -> torch.Tensor:
+    cos_interp = interp1d_torch(x, torch.cos(heading), xq)
+    sin_interp = interp1d_torch(x, torch.sin(heading), xq)
+    return torch.atan2(sin_interp, cos_interp)
+
+
+def heading_from_positions_torch(
+    xy: torch.Tensor, fallback_heading: torch.Tensor | None = None
+) -> torch.Tensor:
+    num_points = xy.shape[0]
+    if num_points == 0:
+        return torch.zeros(0, dtype=xy.dtype, device=xy.device)
+    if num_points == 1:
+        if fallback_heading is not None:
+            return fallback_heading[:1]
+        return torch.zeros(1, dtype=xy.dtype, device=xy.device)
+
+    heading = torch.zeros(num_points, dtype=xy.dtype, device=xy.device)
+    first_delta = xy[1] - xy[0]
+    last_delta = xy[-1] - xy[-2]
+    heading[0] = torch.atan2(first_delta[1], first_delta[0])
+    heading[-1] = torch.atan2(last_delta[1], last_delta[0])
+    if num_points > 2:
+        middle_delta = xy[2:] - xy[:-2]
+        heading[1:-1] = torch.atan2(middle_delta[:, 1], middle_delta[:, 0])
+
+    if fallback_heading is not None:
+        delta_norm = torch.zeros(num_points, dtype=xy.dtype, device=xy.device)
+        delta_norm[0] = torch.linalg.norm(first_delta)
+        delta_norm[-1] = torch.linalg.norm(last_delta)
+        if num_points > 2:
+            delta_norm[1:-1] = torch.linalg.norm(middle_delta, dim=-1)
+        heading = torch.where(delta_norm < 1.0e-6, fallback_heading, heading)
+
+    return normalize_angle_torch(heading)
+
+
+def quintic_decay_torch(unit_s: torch.Tensor) -> torch.Tensor:
+    u = torch.clamp(unit_s, 0.0, 1.0)
+    return 1.0 - 10.0 * u**3 + 15.0 * u**4 - 6.0 * u**5
+
+
+def sample_centerline_torch(
+    center_s: torch.Tensor,
+    center_xy: torch.Tensor,
+    center_heading: torch.Tensor,
+    query_s: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    base_xy = interp1d_torch(center_s, center_xy, query_s)
+    base_heading = interp_heading_torch(center_s, center_heading, query_s)
+    return base_xy, base_heading
+
+
+def build_offset_path_torch(
+    center_xy: torch.Tensor,
+    center_heading: torch.Tensor,
+    center_s: torch.Tensor,
+    s_merge: torch.Tensor,
+    lateral_offset: torch.Tensor,
+    dense_ds: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    device = center_xy.device
+    dtype = center_xy.dtype
+    num_dense = max(int(torch.ceil(s_merge / dense_ds).item()), 1)
+    dense_s = torch.linspace(0.0, float(s_merge.item()), num_dense + 1, device=device, dtype=dtype)
+    base_xy, base_heading = sample_centerline_torch(center_s, center_xy, center_heading, dense_s)
+
+    offset = lateral_offset * quintic_decay_torch(dense_s / torch.clamp(s_merge, min=1.0e-6))
+    normals = torch.stack([-torch.sin(base_heading), torch.cos(base_heading)], dim=-1)
+    path_xy = base_xy + offset.unsqueeze(-1) * normals
+    path_sigma = cumulative_distance_torch(path_xy)
+    path_heading = heading_from_positions_torch(path_xy, fallback_heading=base_heading)
+    return path_xy, path_sigma, path_heading
+
+
+def merge_path_length_torch(
+    center_xy: torch.Tensor,
+    center_heading: torch.Tensor,
+    center_s: torch.Tensor,
+    s_merge: torch.Tensor,
+    lateral_offset: torch.Tensor,
+    dense_ds: float,
+) -> torch.Tensor:
+    _, path_sigma, _ = build_offset_path_torch(
+        center_xy, center_heading, center_s, s_merge, lateral_offset, dense_ds
+    )
+    return path_sigma[-1]
+
+
+def solve_merge_centerline_s_torch(
+    center_xy: torch.Tensor,
+    center_heading: torch.Tensor,
+    center_s: torch.Tensor,
+    distance_budget: torch.Tensor,
+    lateral_offset: torch.Tensor,
+    dense_ds: float,
+    tol_m: float = 1.0e-3,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    device = center_xy.device
+    dtype = center_xy.dtype
+    upper = torch.minimum(distance_budget, center_s[-1])
+    lower = torch.minimum(
+        torch.maximum(
+            torch.tensor(dense_ds, device=device, dtype=dtype),
+            torch.abs(lateral_offset) * 0.25,
+        ),
+        upper * 0.5,
+    )
+
+    while lower > dense_ds * 1.0e-3:
+        length_lower = merge_path_length_torch(
+            center_xy, center_heading, center_s, lower, lateral_offset, dense_ds
+        )
+        if length_lower < distance_budget:
+            break
+        lower = lower * 0.5
+
+    upper_length = merge_path_length_torch(
+        center_xy, center_heading, center_s, upper, lateral_offset, dense_ds
+    )
+    if upper_length < distance_budget:
+        raise RuntimeError("Unable to find a feasible merge point within the distance budget.")
+
+    for _ in range(50):
+        mid = 0.5 * (lower + upper)
+        mid_length = merge_path_length_torch(
+            center_xy, center_heading, center_s, mid, lateral_offset, dense_ds
+        )
+        if mid_length < distance_budget:
+            lower = mid
+        else:
+            upper = mid
+        if upper - lower < tol_m:
+            break
+
+    s_merge = 0.5 * (lower + upper)
+    path_xy, path_sigma, path_heading = build_offset_path_torch(
+        center_xy, center_heading, center_s, s_merge, lateral_offset, dense_ds
+    )
+    return s_merge, path_xy, path_sigma, path_heading
+
+
+def augment_segment_torch(
+    segment_xy: torch.Tensor,
+    segment_heading: torch.Tensor,
+    segment_time: torch.Tensor,
+    lateral_offset: torch.Tensor,
+    connect_time_s: float,
+    dense_ds: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    center_s = cumulative_distance_torch(segment_xy)
+    # Use GT heading directly so past-bridge generation keeps the same lateral
+    # offset convention even when the past segment is traversed in reverse.
+    center_heading = normalize_angle_torch(segment_heading)
+    connect_time = torch.tensor(connect_time_s, dtype=segment_xy.dtype, device=segment_xy.device)
+    connect_time = torch.clamp(connect_time, min=segment_time[0], max=segment_time[-1])
+    distance_budget = interp1d_torch(segment_time, center_s, connect_time.unsqueeze(0))[0]
+
+    path_xy_candidate, path_sigma_candidate, _ = build_offset_path_torch(
+        center_xy=segment_xy,
+        center_heading=center_heading,
+        center_s=center_s,
+        s_merge=distance_budget,
+        lateral_offset=lateral_offset,
+        dense_ds=dense_ds,
+    )
+    candidate_length = path_sigma_candidate[-1]
+
+    if candidate_length <= distance_budget + 1.0e-3:
+        s_merge = distance_budget
+        merge_xy = path_xy_candidate
+        merge_sigma = path_sigma_candidate
+        speed_scale = candidate_length / torch.clamp(distance_budget, min=1.0e-6)
+    else:
+        s_merge, merge_xy, merge_sigma, _ = solve_merge_centerline_s_torch(
+            center_xy=segment_xy,
+            center_heading=center_heading,
+            center_s=center_s,
+            distance_budget=distance_budget,
+            lateral_offset=lateral_offset,
+            dense_ds=dense_ds,
+        )
+        speed_scale = torch.tensor(1.0, dtype=segment_xy.dtype, device=segment_xy.device)
+
+    connect_mask = segment_time <= connect_time + 1.0e-6
+    query_xy = torch.zeros_like(segment_xy)
+    progress = torch.zeros_like(segment_time)
+
+    connect_sigma = speed_scale * center_s[connect_mask]
+    query_xy[connect_mask] = interp1d_torch(merge_sigma, merge_xy, connect_sigma)
+    progress[connect_mask] = connect_sigma
+
+    continue_mask = ~connect_mask
+    if torch.any(continue_mask):
+        continue_s = s_merge + (center_s[continue_mask] - distance_budget)
+        query_xy[continue_mask], _ = sample_centerline_torch(
+            center_s, segment_xy, center_heading, continue_s
+        )
+        progress[continue_mask] = merge_sigma[-1] + (center_s[continue_mask] - distance_budget)
+
+    query_heading = heading_from_positions_torch(query_xy, fallback_heading=segment_heading)
+    return query_xy, query_heading, progress
+
+
 class StatePerturbation:
     """
-    Data augmentation that perturbs the current ego position and generates a feasible trajectory that
-    satisfies polynomial constraints.
+    Data augmentation that perturbs the current ego position laterally and generates a feasible
+    bidirectional bridge trajectory that reconnects to the original GT without requiring overspeed.
     """
 
     def __init__(
@@ -50,214 +289,229 @@ class StatePerturbation:
         augment_prob: float = 0.5,
         wheel_base: float = 2.75,
         device: torch.device | str = "cpu",
+        past_bridge_sec: float = 1.0,
+        future_bridge_sec: float = 1.5,
+        dense_sample_ds: float = DENSE_SAMPLE_DS,
     ) -> None:
-        """
-        Initialize the augmentor,
-        :param low: Parameter to set lower bound vector of the Uniform noise on [x, y, yaw, vx, vy, ax, ay, steering angle, yaw rate].
-        :param high: Parameter to set upper bound vector of the Uniform noise on [x, y, yaw, vx, vy, ax, ay, steering angle, yaw rate].
-        :param augment_prob: probability between 0 and 1 of applying the data augmentation
-        """
         self._augment_prob = augment_prob
         self._device = torch.device(device)
-        lo = ([0.0, -0.75, -0.2, -1, -0.5, -0.2, -0.1, 0.0, 0.0],)
-        hi = ([0.0, +0.75, +0.2, +1, +0.5, +0.2, +0.1, 0.0, 0.0],)
-        self._low = torch.tensor(lo).to(self._device)
-        self._high = torch.tensor(hi).to(self._device)
+        lo = ([0.0, -0.75, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],)
+        hi = ([0.0, +0.75, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],)
+        self._low = torch.tensor(lo, dtype=torch.float32, device=self._device)
+        self._high = torch.tensor(hi, dtype=torch.float32, device=self._device)
         self._wheel_base = wheel_base
-
-        self.num_refine = NUM_REFINE
+        self._past_bridge_sec = past_bridge_sec
+        self._future_bridge_sec = future_bridge_sec
         self.time_interval = TIME_INTERVAL
-
-        REFINE_HORIZON = NUM_REFINE * TIME_INTERVAL
-
-        T = REFINE_HORIZON + TIME_INTERVAL
-        self.coeff_matrix = torch.linalg.inv(
-            torch.tensor(
-                [
-                    [1, 0, 0, 0, 0, 0],
-                    [0, 1, 0, 0, 0, 0],
-                    [0, 0, 2, 0, 0, 0],
-                    [1, T, T**2, T**3, T**4, T**5],
-                    [0, 1, 2 * T, 3 * T**2, 4 * T**3, 5 * T**4],
-                    [0, 0, 2, 6 * T, 12 * T**2, 20 * T**3],
-                ],
-                device=device,
-                dtype=torch.float32,
-            )
-        )
-        self.t_matrix = torch.pow(
-            torch.linspace(TIME_INTERVAL, REFINE_HORIZON, NUM_REFINE).unsqueeze(1),
-            torch.arange(6).unsqueeze(0),
-        ).to(device=device)  # shape (B, N+1)
+        self.dense_sample_ds = dense_sample_ds
 
     def __call__(self, inputs, ego_future, neighbors_future):
-        aug_flag, aug_ego_current_state = self.augment(inputs)
+        aug_flag, aug_current_state, aug_ego_past, aug_ego_future = self.augment(inputs, ego_future)
 
-        # Interpolate future trajectory
-        interpolated_ego_future = self.interpolation_future_trajectory(
-            aug_ego_current_state, ego_future
-        )
-
-        inputs["ego_current_state"][aug_flag] = aug_ego_current_state[aug_flag]
-        ego_future[aug_flag] = interpolated_ego_future[aug_flag]
+        inputs["ego_current_state"][aug_flag] = aug_current_state[aug_flag]
+        inputs["ego_agent_past"][aug_flag] = aug_ego_past[aug_flag]
+        ego_future[aug_flag] = aug_ego_future[aug_flag]
 
         return self.centric_transform(inputs, ego_future, neighbors_future)
-
-    def augment(self, inputs):
-        # Only aug current state
-        ego_current_state = inputs["ego_current_state"].clone()
-
-        B = ego_current_state.shape[0]
-        aug_flag = (torch.rand(B) < self._augment_prob).bool().to(self._device) & ~(
-            abs(ego_current_state[:, 4]) < 2.0
-        )
-
-        random_tensor = torch.rand(B, len(self._low)).to(self._device)
-        scaled_random_tensor = self._low + (self._high - self._low) * random_tensor
-
-        new_state = torch.zeros((B, 9), dtype=torch.float32).to(self._device)
-        new_state[:, 3:] = ego_current_state[
-            :, 4:10
-        ]  # x, y, h is 0 because of ego-centric, update vx, vy, ax, ay, steering angle, yaw rate
-        new_state = new_state + scaled_random_tensor
-        new_state[:, 3] = torch.max(new_state[:, 3], torch.tensor(0.0, device=new_state.device))
-        new_state[:, -1] = torch.clip(new_state[:, -1], -0.85, 0.85)
-
-        ego_current_state[:, :2] = new_state[:, :2]
-        ego_current_state[:, 2] = torch.cos(new_state[:, 2])
-        ego_current_state[:, 3] = torch.sin(new_state[:, 2])
-        ego_current_state[:, 4:8] = new_state[:, 3:7]
-        ego_current_state[:, 8:10] = new_state[:, -2:]  # steering angle, yaw rate
-
-        # update steering angle and yaw rate
-        cur_velocity = ego_current_state[:, 4]
-        yaw_rate = ego_current_state[:, 9]
-
-        steering_angle = torch.zeros_like(cur_velocity)
-        new_yaw_rate = torch.zeros_like(yaw_rate)
-
-        mask = torch.abs(cur_velocity) < 0.2
-        not_mask = ~mask
-        steering_angle[not_mask] = torch.atan(
-            yaw_rate[not_mask] * self._wheel_base / torch.abs(cur_velocity[not_mask])
-        )
-        steering_angle[not_mask] = torch.clamp(
-            steering_angle[not_mask], -2 / 3 * np.pi, 2 / 3 * np.pi
-        )
-        new_yaw_rate[not_mask] = yaw_rate[not_mask]
-
-        ego_current_state[:, 8] = steering_angle
-        ego_current_state[:, 9] = new_yaw_rate
-
-        return aug_flag, ego_current_state
 
     def normalize_angle(self, angle: np.ndarray | torch.Tensor) -> np.ndarray | torch.Tensor:
         return (angle + np.pi) % (2 * np.pi) - np.pi
 
     def get_transform_matrix_batch(self, cur_state):
-        processed_input = torch.column_stack(
-            (
-                cur_state[:, 2],  # cos
-                cur_state[:, 3],  # sin
-            )
-        )
-
+        processed_input = torch.column_stack((cur_state[:, 2], cur_state[:, 3]))
         reshaping_tensor = torch.tensor(
-            [
-                [1, 0, 0, 1],
-                [0, 1, -1, 0],
-            ],
-            dtype=torch.float32,
-        ).to(processed_input.device)
+            [[1, 0, 0, 1], [0, 1, -1, 0]], dtype=torch.float32, device=processed_input.device
+        )
         return (processed_input @ reshaping_tensor).reshape(-1, 2, 2)
 
-    def centric_transform(
+    def _sample_lateral_offsets(self, batch_size: int) -> torch.Tensor:
+        random_tensor = torch.rand(batch_size, device=self._device)
+        return self._low[:, 1] + (self._high[:, 1] - self._low[:, 1]) * random_tensor
+
+    def _state_to_heading(self, current_state: torch.Tensor) -> torch.Tensor:
+        return torch.atan2(current_state[..., 3], current_state[..., 2])
+
+    def _build_augmented_sample(
         self,
-        inputs: torch.Tensor,
+        ego_past: torch.Tensor,
+        ego_current_state: torch.Tensor,
         ego_future: torch.Tensor,
-        neighbors_future: torch.Tensor,
-    ):
+        lateral_offset: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        dt = self.time_interval
+        dtype = ego_past.dtype
+        device = ego_past.device
+
+        past_len = ego_past.shape[0]
+        future_len = ego_future.shape[0]
+
+        past_xy = ego_past[:, :2].clone()
+        past_heading = torch.atan2(ego_past[:, 3], ego_past[:, 2]).clone()
+        current_xy = ego_current_state[:2].clone()
+        current_heading = self._state_to_heading(ego_current_state).clone()
+        future_xy = ego_future[:, :2].clone()
+        future_heading = ego_future[:, 2].clone()
+
+        past_xy[-1] = current_xy
+        past_heading[-1] = current_heading
+
+        future_segment_xy = torch.cat([current_xy.unsqueeze(0), future_xy], dim=0)
+        future_segment_heading = torch.cat([current_heading.unsqueeze(0), future_heading], dim=0)
+        future_time = torch.arange(
+            0.0, (future_len + 1) * dt, dt, dtype=dtype, device=device
+        )
+
+        past_segment_xy = torch.flip(past_xy, dims=[0])
+        past_segment_heading = torch.flip(past_heading, dims=[0])
+        past_time = torch.arange(0.0, past_len * dt, dt, dtype=dtype, device=device)
+
+        aug_future_xy, _, _ = augment_segment_torch(
+            future_segment_xy,
+            future_segment_heading,
+            future_time,
+            lateral_offset,
+            min(self._future_bridge_sec, float(future_time[-1].item())),
+            self.dense_sample_ds,
+        )
+        aug_past_reverse_xy, _, _ = augment_segment_torch(
+            past_segment_xy,
+            past_segment_heading,
+            past_time,
+            lateral_offset,
+            min(self._past_bridge_sec, float(past_time[-1].item())),
+            self.dense_sample_ds,
+        )
+
+        aug_past_xy = torch.flip(aug_past_reverse_xy, dims=[0])
+        full_xy = torch.cat([aug_past_xy[:-1], aug_future_xy], dim=0)
+
+        original_full_heading = torch.cat(
+            [past_heading[:-1], current_heading.unsqueeze(0), future_heading], dim=0
+        )
+        full_heading = heading_from_positions_torch(full_xy, fallback_heading=original_full_heading)
+
+        current_index = past_len - 1
+        aug_past_heading = full_heading[:past_len]
+        aug_future_heading = full_heading[past_len:]
+
+        aug_past_4d = torch.stack(
+            [
+                aug_past_xy[:, 0],
+                aug_past_xy[:, 1],
+                torch.cos(aug_past_heading),
+                torch.sin(aug_past_heading),
+            ],
+            dim=-1,
+        )
+        aug_future_3d = torch.stack(
+            [full_xy[past_len:, 0], full_xy[past_len:, 1], aug_future_heading], dim=-1
+        )
+
+        if current_index == 0:
+            velocity = (full_xy[1] - full_xy[0]) / dt
+            acceleration = torch.zeros(2, dtype=dtype, device=device)
+            yaw_rate = normalize_angle_torch(full_heading[1] - full_heading[0]) / dt
+        elif current_index == full_xy.shape[0] - 1:
+            velocity = (full_xy[-1] - full_xy[-2]) / dt
+            acceleration = torch.zeros(2, dtype=dtype, device=device)
+            yaw_rate = normalize_angle_torch(full_heading[-1] - full_heading[-2]) / dt
+        else:
+            velocity = (full_xy[current_index + 1] - full_xy[current_index - 1]) / (2.0 * dt)
+            acceleration = (
+                full_xy[current_index + 1]
+                - 2.0 * full_xy[current_index]
+                + full_xy[current_index - 1]
+            ) / (dt**2)
+            yaw_rate = normalize_angle_torch(
+                full_heading[current_index + 1] - full_heading[current_index - 1]
+            ) / (2.0 * dt)
+
+        speed = torch.linalg.norm(velocity)
+        steering_angle = torch.tensor(0.0, dtype=dtype, device=device)
+        if speed >= 0.2:
+            steering_angle = torch.atan(yaw_rate * self._wheel_base / torch.abs(speed))
+            steering_angle = torch.clamp(steering_angle, -2.0 / 3.0 * np.pi, 2.0 / 3.0 * np.pi)
+        else:
+            yaw_rate = torch.tensor(0.0, dtype=dtype, device=device)
+
+        aug_current_state = ego_current_state.clone()
+        aug_current_state[:2] = full_xy[current_index]
+        aug_current_state[2] = torch.cos(full_heading[current_index])
+        aug_current_state[3] = torch.sin(full_heading[current_index])
+        aug_current_state[4:6] = velocity
+        aug_current_state[6:8] = acceleration
+        aug_current_state[8] = steering_angle
+        aug_current_state[9] = yaw_rate
+
+        return aug_current_state, aug_past_4d, aug_future_3d
+
+    def augment(self, inputs, ego_future):
+        ego_current_state = inputs["ego_current_state"].clone()
+        ego_agent_past = inputs["ego_agent_past"].clone()
+        aug_ego_future = ego_future.clone()
+
+        batch_size = ego_current_state.shape[0]
+        lateral_offsets = self._sample_lateral_offsets(batch_size)
+        valid_speed = torch.abs(ego_current_state[:, 4]) >= 2.0
+        valid_offset = torch.abs(lateral_offsets) > 1.0e-3
+        aug_flag = ((torch.rand(batch_size, device=self._device) < self._augment_prob) & valid_speed & valid_offset)
+
+        for batch_index in torch.nonzero(aug_flag, as_tuple=False).flatten():
+            aug_state, aug_past, aug_future = self._build_augmented_sample(
+                ego_past=ego_agent_past[batch_index],
+                ego_current_state=ego_current_state[batch_index],
+                ego_future=ego_future[batch_index],
+                lateral_offset=lateral_offsets[batch_index],
+            )
+            ego_current_state[batch_index] = aug_state
+            ego_agent_past[batch_index] = aug_past
+            aug_ego_future[batch_index] = aug_future
+
+        return aug_flag, ego_current_state, ego_agent_past, aug_ego_future
+
+    def centric_transform(self, inputs, ego_future, neighbors_future):
         cur_state = inputs["ego_current_state"].clone()
         center_xy = cur_state[:, :2]
         transform_matrix = self.get_transform_matrix_batch(cur_state)
 
-        # ego xy
         inputs["ego_current_state"][..., :2] = vector_transform(
             inputs["ego_current_state"][..., :2], transform_matrix, center_xy
         )
-        # ego cos sin
         inputs["ego_current_state"][..., 2:4] = vector_transform(
             inputs["ego_current_state"][..., 2:4], transform_matrix
         )
-        # ego vx, vy
         inputs["ego_current_state"][..., 4:6] = vector_transform(
             inputs["ego_current_state"][..., 4:6], transform_matrix
         )
-        # ego ax, ay
         inputs["ego_current_state"][..., 6:8] = vector_transform(
             inputs["ego_current_state"][..., 6:8], transform_matrix
         )
 
-        # ego future xy
+        ego_past_mask = torch.sum(torch.ne(inputs["ego_agent_past"][..., :4], 0), dim=-1) == 0
+        inputs["ego_agent_past"][..., :2] = vector_transform(
+            inputs["ego_agent_past"][..., :2], transform_matrix, center_xy
+        )
+        inputs["ego_agent_past"][..., 2:4] = vector_transform(
+            inputs["ego_agent_past"][..., 2:4], transform_matrix
+        )
+        inputs["ego_agent_past"][ego_past_mask] = 0.0
+
         ego_future[..., :2] = vector_transform(ego_future[..., :2], transform_matrix, center_xy)
         ego_future[..., 2] = heading_transform(ego_future[..., 2], transform_matrix)
-
-        # ego past
-        # inputs["ego_agent_past"][..., :2] = vector_transform(
-        #     inputs["ego_agent_past"][..., :2], transform_matrix, center_xy
-        # )
-        # inputs["ego_agent_past"][..., 2:4] = vector_transform(
-        #     inputs["ego_agent_past"][..., 2:4], transform_matrix
-        # )
-
-        ego_past4d = torch.cat(
-            [
-                inputs["ego_agent_past"][..., :2],  # x, y
-                torch.cos(inputs["ego_agent_past"][..., 2:3]),  # cos
-                torch.sin(inputs["ego_agent_past"][..., 2:3]),  # sin
-            ],
-            dim=-1,
-        )
-        ego_future4d = torch.cat(
-            [
-                ego_future[..., :2],  # x, y
-                torch.cos(ego_future[..., 2:3]),  # cos
-                torch.sin(ego_future[..., 2:3]),  # sin
-            ],
-            dim=-1,
-        )
-
-        ego_future4d = smoothing_future_trajectory(
-            ego_past4d, inputs["ego_current_state"], ego_future4d
-        )
-
-        ego_future = torch.cat(
-            [
-                ego_future4d[..., :2],  # x, y
-                torch.atan2(ego_future4d[..., 3], ego_future4d[..., 2]).unsqueeze(
-                    -1
-                ),  # heading from cos, sin
-            ],
-            dim=-1,
-        )
         inputs["ego_agent_future"] = ego_future
 
-        # neighbor past xy
         mask = torch.sum(torch.ne(inputs["neighbor_agents_past"][..., :6], 0), dim=-1) == 0
         inputs["neighbor_agents_past"][..., :2] = vector_transform(
             inputs["neighbor_agents_past"][..., :2], transform_matrix, center_xy
         )
-        # neighbor past cos sin
         inputs["neighbor_agents_past"][..., 2:4] = vector_transform(
             inputs["neighbor_agents_past"][..., 2:4], transform_matrix
         )
-        # neighbor past vx, vy
         inputs["neighbor_agents_past"][..., 4:6] = vector_transform(
             inputs["neighbor_agents_past"][..., 4:6], transform_matrix
         )
         inputs["neighbor_agents_past"][mask] = 0.0
 
-        # neighbor future xy
         mask = torch.sum(torch.ne(neighbors_future[..., :2], 0), dim=-1) == 0
         neighbors_future[..., :2] = vector_transform(
             neighbors_future[..., :2], transform_matrix, center_xy
@@ -265,17 +519,13 @@ class StatePerturbation:
         neighbors_future[..., 2] = heading_transform(neighbors_future[..., 2], transform_matrix)
         neighbors_future[mask] = 0.0
 
-        # lanes
         mask = torch.sum(torch.ne(inputs["lanes"][..., :8], 0), dim=-1) == 0
-        inputs["lanes"][..., :2] = vector_transform(
-            inputs["lanes"][..., :2], transform_matrix, center_xy
-        )
+        inputs["lanes"][..., :2] = vector_transform(inputs["lanes"][..., :2], transform_matrix, center_xy)
         inputs["lanes"][..., 2:4] = vector_transform(inputs["lanes"][..., 2:4], transform_matrix)
         inputs["lanes"][..., 4:6] = vector_transform(inputs["lanes"][..., 4:6], transform_matrix)
         inputs["lanes"][..., 6:8] = vector_transform(inputs["lanes"][..., 6:8], transform_matrix)
         inputs["lanes"][mask] = 0.0
 
-        # route_lanes
         mask = torch.sum(torch.ne(inputs["route_lanes"][..., :8], 0), dim=-1) == 0
         inputs["route_lanes"][..., :2] = vector_transform(
             inputs["route_lanes"][..., :2], transform_matrix, center_xy
@@ -291,127 +541,26 @@ class StatePerturbation:
         )
         inputs["route_lanes"][mask] = 0.0
 
-        # polygons
         mask = torch.sum(torch.ne(inputs["polygons"], 0), dim=-1) == 0
-        inputs["polygons"][..., :2] = vector_transform(
-            inputs["polygons"][..., :2], transform_matrix, center_xy
-        )
+        inputs["polygons"][..., :2] = vector_transform(inputs["polygons"][..., :2], transform_matrix, center_xy)
         inputs["polygons"][mask] = 0.0
 
-        # line_strings
         mask = torch.sum(torch.ne(inputs["line_strings"], 0), dim=-1) == 0
         inputs["line_strings"][..., :2] = vector_transform(
             inputs["line_strings"][..., :2], transform_matrix, center_xy
         )
         inputs["line_strings"][mask] = 0.0
 
-        # static objects xy
         mask = torch.sum(torch.ne(inputs["static_objects"][..., :10], 0), dim=-1) == 0
         inputs["static_objects"][..., :2] = vector_transform(
             inputs["static_objects"][..., :2], transform_matrix, center_xy
         )
-        # static objects cos sin
         inputs["static_objects"][..., 2:4] = vector_transform(
             inputs["static_objects"][..., 2:4], transform_matrix
         )
         inputs["static_objects"][mask] = 0.0
 
         return inputs, ego_future, neighbors_future
-
-    def interpolation_future_trajectory(self, aug_current_state, ego_future, keep_remaining=True):
-        """
-        refine future trajectory with quintic Hermite interpolation
-
-        Args:
-            aug_current_state: (B, 16) current state of the ego vehicle after augmentation
-            ego_future:        (B, T, 3) future trajectory of the ego vehicle
-            keep_remaining:    If True, keep the remaining trajectory after P frames (default: True)
-
-        Returns:
-            ego_future: refined future trajectory of the ego vehicle
-        """
-
-        P = self.num_refine
-        dt = self.time_interval
-        B = aug_current_state.shape[0]
-        M_t = self.t_matrix.unsqueeze(0).expand(B, -1, -1)
-        A = self.coeff_matrix.unsqueeze(0).expand(B, -1, -1)
-
-        # state: [x, y, heading, velocity, acceleration, yaw_rate]
-
-        x0, y0, theta0, v0, a0, omega0 = (
-            aug_current_state[:, 0],
-            aug_current_state[:, 1],
-            torch.atan2(
-                (ego_future[:, int(P / 2), 1] - aug_current_state[:, 1]),
-                (ego_future[:, int(P / 2), 0] - aug_current_state[:, 0]),
-            ),
-            torch.norm(aug_current_state[:, 4:6], dim=-1),
-            torch.norm(aug_current_state[:, 6:8], dim=-1),
-            aug_current_state[:, 9],
-        )
-
-        xT, yT, thetaT, vT, aT, omegaT = (
-            ego_future[:, P, 0],
-            ego_future[:, P, 1],
-            ego_future[:, P, 2],
-            torch.norm(ego_future[:, P, :2] - ego_future[:, P - 1, :2], dim=-1) / dt,
-            torch.norm(
-                ego_future[:, P, :2] - 2 * ego_future[:, P - 1, :2] + ego_future[:, P - 2, :2],
-                dim=-1,
-            )
-            / dt**2,
-            self.normalize_angle(ego_future[:, P, 2] - ego_future[:, P - 1, 2]) / dt,
-        )
-
-        # Boundary conditions
-        sx = torch.stack(
-            [
-                x0,
-                v0 * torch.cos(theta0),
-                a0 * torch.cos(theta0) - v0 * torch.sin(theta0) * omega0,
-                xT,
-                vT * torch.cos(thetaT),
-                aT * torch.cos(thetaT) - vT * torch.sin(thetaT) * omegaT,
-            ],
-            dim=-1,
-        )
-
-        sy = torch.stack(
-            [
-                y0,
-                v0 * torch.sin(theta0),
-                a0 * torch.sin(theta0) + v0 * torch.cos(theta0) * omega0,
-                yT,
-                vT * torch.sin(thetaT),
-                aT * torch.sin(thetaT) + vT * torch.cos(thetaT) * omegaT,
-            ],
-            dim=-1,
-        )
-
-        ax = A @ sx[:, :, None]  # B, 6, 1
-        ay = A @ sy[:, :, None]  # B, 6, 1
-
-        traj_x = M_t @ ax
-        traj_y = M_t @ ay
-        traj_heading = torch.cat(
-            [
-                torch.atan2(
-                    traj_y[:, :1, 0] - y0.unsqueeze(-1), traj_x[:, :1, 0] - x0.unsqueeze(-1)
-                ),
-                torch.atan2(
-                    traj_y[:, 1:, 0] - traj_y[:, :-1, 0], traj_x[:, 1:, 0] - traj_x[:, :-1, 0]
-                ),
-            ],
-            dim=1,
-        )
-
-        interpolated = torch.cat([traj_x, traj_y, traj_heading[..., None]], axis=-1)
-
-        if keep_remaining and ego_future.shape[1] > P:
-            return torch.concatenate([interpolated, ego_future[:, P:, :]], axis=1)
-        else:
-            return interpolated
 
 
 if __name__ == "__main__":
@@ -443,27 +592,21 @@ if __name__ == "__main__":
         if key == "goal_pose" or key == "ego_agent_past":
             data[key] = heading_to_cos_sin(data[key])
 
-    # Load future trajectories separately
     ego_future = torch.tensor(loaded["ego_agent_future"]).unsqueeze(0)
     neighbors_future = torch.tensor(loaded["neighbor_agents_future"]).unsqueeze(0)
 
     aug = StatePerturbation(augment_prob=1.0, device="cpu")
 
-    # Save original data visualization with augmentation range rectangle
     original_save_path = save_dir / "original.png"
     fig, ax = plt.subplots(figsize=(10, 10))
-
-    # Visualize inputs on the ax
     view_range = 20
     visualize_inputs(deepcopy(data), save_path=None, ax=ax, view_ranges=[view_range])
 
-    # Get augmentation ranges from the aug object
-    lo = aug._low.cpu().numpy()[0]  # Extract from tuple
-    hi = aug._high.cpu().numpy()[0]  # Extract from tuple
+    lo = aug._low.cpu().numpy()[0]
+    hi = aug._high.cpu().numpy()[0]
     x_min, y_min = lo[0], lo[1]
     x_max, y_max = hi[0], hi[1]
 
-    # Draw the augmentation range rectangle
     rect = patches.Rectangle(
         (x_min, y_min),
         x_max - x_min,
@@ -487,7 +630,6 @@ if __name__ == "__main__":
             deepcopy(data), ego_future.clone(), neighbors_future.clone()
         )
 
-        # Save augmented data to npz file
         data_dict = {}
         for key, value in aug_data.items():
             if isinstance(value, torch.Tensor):
@@ -495,17 +637,14 @@ if __name__ == "__main__":
             else:
                 data_dict[key] = value
 
-        # Add future trajectories with consistent naming
         data_dict["ego_agent_future"] = aug_ego_future.squeeze(0).detach().cpu().numpy()
         data_dict["neighbor_agents_future"] = aug_neighbors_future.squeeze(0).detach().cpu().numpy()
         aug_data["ego_agent_future"] = aug_ego_future
         aug_data["neighbor_agents_future"] = aug_neighbors_future
 
-        # Save to npz file
         output_path = save_dir / f"augmented_{i:08d}.npz"
         np.savez(output_path, **data_dict)
 
-        # Use deepcopy to avoid side effects from visualize_inputs
         visualize_inputs(
             deepcopy(aug_data), save_dir / f"augmented_{i:08d}.png", view_ranges=[view_range]
         )

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -116,6 +116,52 @@ def quintic_decay_torch(unit_s: torch.Tensor) -> torch.Tensor:
     return 1.0 - 10.0 * u**3 + 15.0 * u**4 - 6.0 * u**5
 
 
+def solve_lateral_profile_coeffs_torch(
+    s_merge: torch.Tensor,
+    lateral_offset: torch.Tensor,
+    heading_offset: torch.Tensor,
+) -> torch.Tensor:
+    if s_merge <= 0.0:
+        raise ValueError("s_merge must be positive.")
+
+    length = s_merge
+    a0 = lateral_offset
+    a1 = torch.tan(heading_offset)
+    a2 = torch.zeros((), dtype=length.dtype, device=length.device)
+
+    system = torch.stack(
+        [
+            torch.stack([length**3, length**4, length**5]),
+            torch.stack([3.0 * length**2, 4.0 * length**3, 5.0 * length**4]),
+            torch.stack([6.0 * length, 12.0 * length**2, 20.0 * length**3]),
+        ]
+    )
+    rhs = torch.stack(
+        [
+            -(a0 + a1 * length + a2 * length**2),
+            -(a1 + 2.0 * a2 * length),
+            -(2.0 * a2),
+        ]
+    )
+    a3_to_a5 = torch.linalg.solve(system, rhs)
+    return torch.stack([a0, a1, a2, a3_to_a5[0], a3_to_a5[1], a3_to_a5[2]])
+
+
+def lateral_offset_profile_torch(
+    s: torch.Tensor,
+    s_merge: torch.Tensor,
+    lateral_offset: torch.Tensor,
+    heading_offset: torch.Tensor,
+) -> torch.Tensor:
+    coeffs = solve_lateral_profile_coeffs_torch(
+        s_merge=s_merge,
+        lateral_offset=lateral_offset,
+        heading_offset=heading_offset,
+    )
+    powers = torch.stack([s**idx for idx in range(6)], dim=-1)
+    return powers @ coeffs
+
+
 def sample_centerline_torch(
     center_s: torch.Tensor,
     center_xy: torch.Tensor,
@@ -133,6 +179,7 @@ def build_offset_path_torch(
     center_s: torch.Tensor,
     s_merge: torch.Tensor,
     lateral_offset: torch.Tensor,
+    heading_offset: torch.Tensor,
     dense_ds: float,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     device = center_xy.device
@@ -141,7 +188,12 @@ def build_offset_path_torch(
     dense_s = torch.linspace(0.0, float(s_merge.item()), num_dense + 1, device=device, dtype=dtype)
     base_xy, base_heading = sample_centerline_torch(center_s, center_xy, center_heading, dense_s)
 
-    offset = lateral_offset * quintic_decay_torch(dense_s / torch.clamp(s_merge, min=1.0e-6))
+    offset = lateral_offset_profile_torch(
+        dense_s,
+        torch.clamp(s_merge, min=1.0e-6),
+        lateral_offset,
+        heading_offset,
+    )
     normals = torch.stack([-torch.sin(base_heading), torch.cos(base_heading)], dim=-1)
     path_xy = base_xy + offset.unsqueeze(-1) * normals
     path_sigma = cumulative_distance_torch(path_xy)
@@ -155,10 +207,11 @@ def merge_path_length_torch(
     center_s: torch.Tensor,
     s_merge: torch.Tensor,
     lateral_offset: torch.Tensor,
+    heading_offset: torch.Tensor,
     dense_ds: float,
 ) -> torch.Tensor:
     _, path_sigma, _ = build_offset_path_torch(
-        center_xy, center_heading, center_s, s_merge, lateral_offset, dense_ds
+        center_xy, center_heading, center_s, s_merge, lateral_offset, heading_offset, dense_ds
     )
     return path_sigma[-1]
 
@@ -169,6 +222,7 @@ def solve_merge_centerline_s_torch(
     center_s: torch.Tensor,
     distance_budget: torch.Tensor,
     lateral_offset: torch.Tensor,
+    heading_offset: torch.Tensor,
     dense_ds: float,
     tol_m: float = 1.0e-3,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -185,14 +239,14 @@ def solve_merge_centerline_s_torch(
 
     while lower > dense_ds * 1.0e-3:
         length_lower = merge_path_length_torch(
-            center_xy, center_heading, center_s, lower, lateral_offset, dense_ds
+            center_xy, center_heading, center_s, lower, lateral_offset, heading_offset, dense_ds
         )
         if length_lower < distance_budget:
             break
         lower = lower * 0.5
 
     upper_length = merge_path_length_torch(
-        center_xy, center_heading, center_s, upper, lateral_offset, dense_ds
+        center_xy, center_heading, center_s, upper, lateral_offset, heading_offset, dense_ds
     )
     if upper_length < distance_budget:
         raise RuntimeError("Unable to find a feasible merge point within the distance budget.")
@@ -200,7 +254,7 @@ def solve_merge_centerline_s_torch(
     for _ in range(50):
         mid = 0.5 * (lower + upper)
         mid_length = merge_path_length_torch(
-            center_xy, center_heading, center_s, mid, lateral_offset, dense_ds
+            center_xy, center_heading, center_s, mid, lateral_offset, heading_offset, dense_ds
         )
         if mid_length < distance_budget:
             lower = mid
@@ -211,7 +265,7 @@ def solve_merge_centerline_s_torch(
 
     s_merge = 0.5 * (lower + upper)
     path_xy, path_sigma, path_heading = build_offset_path_torch(
-        center_xy, center_heading, center_s, s_merge, lateral_offset, dense_ds
+        center_xy, center_heading, center_s, s_merge, lateral_offset, heading_offset, dense_ds
     )
     return s_merge, path_xy, path_sigma, path_heading
 
@@ -221,6 +275,7 @@ def augment_segment_torch(
     segment_heading: torch.Tensor,
     segment_time: torch.Tensor,
     lateral_offset: torch.Tensor,
+    heading_offset: torch.Tensor,
     connect_time_s: float,
     dense_ds: float,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -238,6 +293,7 @@ def augment_segment_torch(
         center_s=center_s,
         s_merge=distance_budget,
         lateral_offset=lateral_offset,
+        heading_offset=heading_offset,
         dense_ds=dense_ds,
     )
     candidate_length = path_sigma_candidate[-1]
@@ -254,6 +310,7 @@ def augment_segment_torch(
             center_s=center_s,
             distance_budget=distance_budget,
             lateral_offset=lateral_offset,
+            heading_offset=heading_offset,
             dense_ds=dense_ds,
         )
         speed_scale = torch.tensor(1.0, dtype=segment_xy.dtype, device=segment_xy.device)
@@ -292,6 +349,7 @@ class StatePerturbation:
         past_bridge_sec: float = 1.0,
         future_bridge_sec: float = 1.5,
         dense_sample_ds: float = DENSE_SAMPLE_DS,
+        max_heading_offset_deg: float = 15.0,
     ) -> None:
         """
         Initialize the augmentor.
@@ -299,11 +357,13 @@ class StatePerturbation:
         :param past_bridge_sec: duration used to connect the past trajectory to the perturbed state
         :param future_bridge_sec: duration used to reconnect the perturbed state to the GT future
         :param dense_sample_ds: dense sampling resolution used for path-length feasibility checks
+        :param max_heading_offset_deg: maximum absolute initial heading perturbation in degrees
         """
         self._augment_prob = augment_prob
         self._device = torch.device(device)
-        lo = ([0.0, -0.75, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],)
-        hi = ([0.0, +0.75, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],)
+        heading_limit_rad = np.deg2rad(max_heading_offset_deg)
+        lo = ([0.0, -0.75, -heading_limit_rad, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],)
+        hi = ([0.0, +0.75, +heading_limit_rad, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],)
         self._low = torch.tensor(lo, dtype=torch.float32, device=self._device)
         self._high = torch.tensor(hi, dtype=torch.float32, device=self._device)
         self._wheel_base = wheel_base
@@ -345,6 +405,10 @@ class StatePerturbation:
         random_tensor = torch.rand(batch_size, device=self._device)
         return self._low[:, 1] + (self._high[:, 1] - self._low[:, 1]) * random_tensor
 
+    def _sample_heading_offsets(self, batch_size: int) -> torch.Tensor:
+        random_tensor = torch.rand(batch_size, device=self._device)
+        return self._low[:, 2] + (self._high[:, 2] - self._low[:, 2]) * random_tensor
+
     def _state_to_heading(self, current_state: torch.Tensor) -> torch.Tensor:
         return torch.atan2(current_state[..., 3], current_state[..., 2])
 
@@ -354,6 +418,7 @@ class StatePerturbation:
         ego_current_state: torch.Tensor,
         ego_future: torch.Tensor,
         lateral_offset: torch.Tensor,
+        heading_offset: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Rebuild ego past/current/future around a laterally perturbed current state while keeping
@@ -391,6 +456,7 @@ class StatePerturbation:
             future_segment_heading,
             future_time,
             lateral_offset,
+            heading_offset,
             min(self._future_bridge_sec, float(future_time[-1].item())),
             self.dense_sample_ds,
         )
@@ -399,6 +465,7 @@ class StatePerturbation:
             past_segment_heading,
             past_time,
             lateral_offset,
+            -heading_offset,
             min(self._past_bridge_sec, float(past_time[-1].item())),
             self.dense_sample_ds,
         )
@@ -473,8 +540,9 @@ class StatePerturbation:
 
         batch_size = ego_current_state.shape[0]
         lateral_offsets = self._sample_lateral_offsets(batch_size)
+        heading_offsets = self._sample_heading_offsets(batch_size)
         valid_speed = torch.abs(ego_current_state[:, 4]) >= 2.0
-        valid_offset = torch.abs(lateral_offsets) > 1.0e-3
+        valid_offset = (torch.abs(lateral_offsets) > 1.0e-3) | (torch.abs(heading_offsets) > 1.0e-3)
         aug_flag = (
             (torch.rand(batch_size, device=self._device) < self._augment_prob)
             & valid_speed
@@ -487,6 +555,7 @@ class StatePerturbation:
                 ego_current_state=ego_current_state[batch_index],
                 ego_future=ego_future[batch_index],
                 lateral_offset=lateral_offsets[batch_index],
+                heading_offset=heading_offsets[batch_index],
             )
             ego_current_state[batch_index] = aug_state
             ego_agent_past[batch_index] = aug_past

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -526,10 +526,53 @@ def generate_time_candidates(
     return [tick * step_s for tick in range(start_tick, end_tick + 1)]
 
 
+def segment_kinematics_torch(
+    segment_result: SegmentAugmentationResultTorch,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    gt_speed = speed_from_progress_torch(
+        segment_result.distance_profile, segment_result.segment_time
+    )
+    augmented_speed = segment_result.exact_speed
+    gt_acceleration = acceleration_from_speed_torch(gt_speed, segment_result.segment_time)
+    augmented_acceleration = acceleration_from_speed_torch(
+        augmented_speed, segment_result.segment_time
+    )
+    gt_jerk = jerk_from_acceleration_torch(gt_acceleration, segment_result.segment_time)
+    augmented_jerk = jerk_from_acceleration_torch(
+        augmented_acceleration, segment_result.segment_time
+    )
+    return gt_speed, augmented_speed, gt_jerk, augmented_jerk
+
+
+def bridge_constraint_series_torch(
+    sample_result: AugmentedSampleTorchResult,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    past_gt_speed, past_aug_speed, past_gt_jerk, past_aug_jerk = segment_kinematics_torch(
+        sample_result.past_segment
+    )
+    future_gt_speed, future_aug_speed, future_gt_jerk, future_aug_jerk = segment_kinematics_torch(
+        sample_result.future_segment
+    )
+    bridge_speed_gap = torch.cat(
+        [
+            torch.abs(past_aug_speed - past_gt_speed).flip(0)[:-1],
+            torch.abs(future_aug_speed - future_gt_speed),
+        ],
+        dim=0,
+    )
+    augmented_jerk = torch.cat(
+        [past_aug_jerk.flip(0)[:-1], future_aug_jerk],
+        dim=0,
+    )
+    gt_arc_speed = torch.cat([past_gt_speed.flip(0)[:-1], future_gt_speed], dim=0)
+    augmented_arc_speed = torch.cat([past_aug_speed.flip(0)[:-1], future_aug_speed], dim=0)
+    return gt_arc_speed, augmented_arc_speed, bridge_speed_gap, augmented_jerk
+
+
 class StatePerturbation:
     """
     Data augmentation that perturbs the current ego position and generates a feasible trajectory that
-    reconnects to the original GT without requiring overspeed.
+    reconnects to the original GT while respecting longitudinal progress and bridge feasibility limits.
     """
 
     def __init__(
@@ -627,7 +670,7 @@ class StatePerturbation:
     ) -> AugmentedSampleTorchResult:
         """
         Rebuild ego past/current/future around a laterally perturbed current state while keeping
-        the longitudinal progress speed-feasible against the available GT distance budget.
+        the longitudinal progress aligned with the GT progress-time relation after merge.
         """
         dt = self.time_interval
         dtype = ego_past.dtype
@@ -767,19 +810,9 @@ class StatePerturbation:
         full_time = sample_result.full_time
         original_sigma = cumulative_distance_torch(sample_result.original_full_xy)
         augmented_sigma = cumulative_distance_torch(sample_result.augmented_full_xy)
-
-        past_gt_speed = speed_from_progress_torch(
-            sample_result.past_segment.distance_profile,
-            sample_result.past_segment.segment_time,
-        ).flip(0)
-        past_aug_speed = sample_result.past_segment.exact_speed.flip(0)
-        future_gt_speed = speed_from_progress_torch(
-            sample_result.future_segment.distance_profile,
-            sample_result.future_segment.segment_time,
+        gt_arc_speed, augmented_arc_speed, bridge_speed_gap, augmented_jerk = (
+            bridge_constraint_series_torch(sample_result)
         )
-        future_aug_speed = sample_result.future_segment.exact_speed
-        gt_arc_speed = torch.cat([past_gt_speed[:-1], future_gt_speed], dim=0)
-        augmented_arc_speed = torch.cat([past_aug_speed[:-1], future_aug_speed], dim=0)
 
         gt_curvature = curvature_from_xy_torch(sample_result.original_full_xy, original_sigma)
         augmented_curvature = curvature_from_xy_torch(
@@ -790,60 +823,10 @@ class StatePerturbation:
         )
         max_abs_augmented_lateral_accel = float(torch.max(torch.abs(augmented_lateral_accel)).item())
 
-        past_gt_accel = acceleration_from_speed_torch(
-            speed_from_progress_torch(
-                sample_result.past_segment.distance_profile,
-                sample_result.past_segment.segment_time,
-            ),
-            sample_result.past_segment.segment_time,
-        )
-        past_aug_accel = acceleration_from_speed_torch(
-            sample_result.past_segment.exact_speed,
-            sample_result.past_segment.segment_time,
-        )
-        future_gt_accel = acceleration_from_speed_torch(
-            speed_from_progress_torch(
-                sample_result.future_segment.distance_profile,
-                sample_result.future_segment.segment_time,
-            ),
-            sample_result.future_segment.segment_time,
-        )
-        future_aug_accel = acceleration_from_speed_torch(
-            sample_result.future_segment.exact_speed,
-            sample_result.future_segment.segment_time,
-        )
-        past_gt_jerk = jerk_from_acceleration_torch(
-            past_gt_accel,
-            sample_result.past_segment.segment_time,
-        )
-        past_aug_jerk = jerk_from_acceleration_torch(
-            past_aug_accel,
-            sample_result.past_segment.segment_time,
-        )
-        future_gt_jerk = jerk_from_acceleration_torch(
-            future_gt_accel,
-            sample_result.future_segment.segment_time,
-        )
-        future_aug_jerk = jerk_from_acceleration_torch(
-            future_aug_accel,
-            sample_result.future_segment.segment_time,
-        )
-
         bridge_time = full_time
         bridge_mask = (
             (bridge_time >= -sample_result.past_connect_time_s - 1.0e-9)
             & (bridge_time <= sample_result.future_recover_time_s + 1.0e-9)
-        )
-        bridge_speed_gap = torch.cat(
-            [
-                torch.abs(past_aug_speed - past_gt_speed).flip(0)[:-1],
-                torch.abs(future_aug_speed - future_gt_speed),
-            ],
-            dim=0,
-        )
-        augmented_jerk = torch.cat(
-            [past_aug_jerk.flip(0)[:-1], future_aug_jerk],
-            dim=0,
         )
 
         if torch.any(bridge_mask):
@@ -880,12 +863,21 @@ class StatePerturbation:
         initial_past_connect_time_s: float,
         initial_future_recover_time_s: float,
     ) -> AugmentedSampleTorchResult:
-        initial_result = self._build_augmented_sample(
-            ego_past=ego_past,
-            ego_current_state=ego_current_state,
-            ego_future=ego_future,
-            lateral_offset=lateral_offset,
-            heading_offset=heading_offset,
+        def build_candidate(
+            past_connect_time_s: float,
+            future_recover_time_s: float,
+        ) -> AugmentedSampleTorchResult:
+            return self._build_augmented_sample(
+                ego_past=ego_past,
+                ego_current_state=ego_current_state,
+                ego_future=ego_future,
+                lateral_offset=lateral_offset,
+                heading_offset=heading_offset,
+                past_connect_time_s=past_connect_time_s,
+                future_recover_time_s=future_recover_time_s,
+            )
+
+        initial_result = build_candidate(
             past_connect_time_s=initial_past_connect_time_s,
             future_recover_time_s=initial_future_recover_time_s,
         )
@@ -902,12 +894,7 @@ class StatePerturbation:
             step_s=self.time_interval,
         )
         for candidate_n in future_candidates:
-            candidate_result = self._build_augmented_sample(
-                ego_past=ego_past,
-                ego_current_state=ego_current_state,
-                ego_future=ego_future,
-                lateral_offset=lateral_offset,
-                heading_offset=heading_offset,
+            candidate_result = build_candidate(
                 past_connect_time_s=initial_past_connect_time_s,
                 future_recover_time_s=candidate_n,
             )
@@ -926,12 +913,7 @@ class StatePerturbation:
         )
         for candidate_m in past_candidates:
             for candidate_n in future_with_past_candidates:
-                candidate_result = self._build_augmented_sample(
-                    ego_past=ego_past,
-                    ego_current_state=ego_current_state,
-                    ego_future=ego_future,
-                    lateral_offset=lateral_offset,
-                    heading_offset=heading_offset,
+                candidate_result = build_candidate(
                     past_connect_time_s=candidate_m,
                     future_recover_time_s=candidate_n,
                 )

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -12,12 +12,12 @@ def vector_transform(vector, transform_mat, bias=None):
     bias: (B, ..., 2)
     """
     shape = vector.shape
-    bsz = vector.shape[0]
+    B = vector.shape[0]
     nexpand = vector.ndim - 2
     if bias is not None:
-        vector = vector - bias.reshape(bsz, *([1] * nexpand), -1)
-    vector = vector.reshape(bsz, -1, 2).permute(0, 2, 1)
-    return torch.bmm(transform_mat, vector).permute(0, 2, 1).reshape(*shape)
+        vector = vector - bias.reshape(B, *([1] * nexpand), -1)
+    vector = vector.reshape(B, -1, 2).permute(0, 2, 1)  # (B, 2, N1 * N2 ...)
+    return torch.bmm(transform_mat, vector).permute(0, 2, 1).reshape(*shape)  # (B, ..., 2)
 
 
 def heading_transform(heading, transform_mat):
@@ -25,10 +25,10 @@ def heading_transform(heading, transform_mat):
     heading: (B, ...)
     transform_mat: (B, 2, 2)
     """
-    bsz = heading.shape[0]
+    B = heading.shape[0]
     shape = heading.shape
-    heading = heading.reshape(bsz, -1)
-    transform_mat = transform_mat.reshape(bsz, 1, 2, 2)
+    heading = heading.reshape(B, -1)
+    transform_mat = transform_mat.reshape(B, 1, 2, 2)
     return torch.atan2(
         torch.cos(heading) * transform_mat[..., 1, 0]
         + torch.sin(heading) * transform_mat[..., 1, 1],
@@ -280,8 +280,8 @@ def augment_segment_torch(
 
 class StatePerturbation:
     """
-    Data augmentation that perturbs the current ego position laterally and generates a feasible
-    bidirectional bridge trajectory that reconnects to the original GT without requiring overspeed.
+    Data augmentation that perturbs the current ego position and generates a feasible trajectory that
+    reconnects to the original GT without requiring overspeed.
     """
 
     def __init__(
@@ -293,6 +293,13 @@ class StatePerturbation:
         future_bridge_sec: float = 1.5,
         dense_sample_ds: float = DENSE_SAMPLE_DS,
     ) -> None:
+        """
+        Initialize the augmentor.
+        :param augment_prob: probability between 0 and 1 of applying the data augmentation
+        :param past_bridge_sec: duration used to connect the past trajectory to the perturbed state
+        :param future_bridge_sec: duration used to reconnect the perturbed state to the GT future
+        :param dense_sample_ds: dense sampling resolution used for path-length feasibility checks
+        """
         self._augment_prob = augment_prob
         self._device = torch.device(device)
         lo = ([0.0, -0.75, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],)
@@ -318,10 +325,20 @@ class StatePerturbation:
         return (angle + np.pi) % (2 * np.pi) - np.pi
 
     def get_transform_matrix_batch(self, cur_state):
-        processed_input = torch.column_stack((cur_state[:, 2], cur_state[:, 3]))
-        reshaping_tensor = torch.tensor(
-            [[1, 0, 0, 1], [0, 1, -1, 0]], dtype=torch.float32, device=processed_input.device
+        processed_input = torch.column_stack(
+            (
+                cur_state[:, 2],  # cos
+                cur_state[:, 3],  # sin
+            )
         )
+
+        reshaping_tensor = torch.tensor(
+            [
+                [1, 0, 0, 1],
+                [0, 1, -1, 0],
+            ],
+            dtype=torch.float32,
+        ).to(processed_input.device)
         return (processed_input @ reshaping_tensor).reshape(-1, 2, 2)
 
     def _sample_lateral_offsets(self, batch_size: int) -> torch.Tensor:
@@ -338,6 +355,10 @@ class StatePerturbation:
         ego_future: torch.Tensor,
         lateral_offset: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        Rebuild ego past/current/future around a laterally perturbed current state while keeping
+        the longitudinal progress speed-feasible against the available GT distance budget.
+        """
         dt = self.time_interval
         dtype = ego_past.dtype
         device = ego_past.device
@@ -454,7 +475,11 @@ class StatePerturbation:
         lateral_offsets = self._sample_lateral_offsets(batch_size)
         valid_speed = torch.abs(ego_current_state[:, 4]) >= 2.0
         valid_offset = torch.abs(lateral_offsets) > 1.0e-3
-        aug_flag = ((torch.rand(batch_size, device=self._device) < self._augment_prob) & valid_speed & valid_offset)
+        aug_flag = (
+            (torch.rand(batch_size, device=self._device) < self._augment_prob)
+            & valid_speed
+            & valid_offset
+        )
 
         for batch_index in torch.nonzero(aug_flag, as_tuple=False).flatten():
             aug_state, aug_past, aug_future = self._build_augmented_sample(
@@ -469,24 +494,34 @@ class StatePerturbation:
 
         return aug_flag, ego_current_state, ego_agent_past, aug_ego_future
 
-    def centric_transform(self, inputs, ego_future, neighbors_future):
+    def centric_transform(
+        self,
+        inputs: torch.Tensor,
+        ego_future: torch.Tensor,
+        neighbors_future: torch.Tensor,
+    ):
         cur_state = inputs["ego_current_state"].clone()
         center_xy = cur_state[:, :2]
         transform_matrix = self.get_transform_matrix_batch(cur_state)
 
+        # ego xy
         inputs["ego_current_state"][..., :2] = vector_transform(
             inputs["ego_current_state"][..., :2], transform_matrix, center_xy
         )
+        # ego cos sin
         inputs["ego_current_state"][..., 2:4] = vector_transform(
             inputs["ego_current_state"][..., 2:4], transform_matrix
         )
+        # ego vx, vy
         inputs["ego_current_state"][..., 4:6] = vector_transform(
             inputs["ego_current_state"][..., 4:6], transform_matrix
         )
+        # ego ax, ay
         inputs["ego_current_state"][..., 6:8] = vector_transform(
             inputs["ego_current_state"][..., 6:8], transform_matrix
         )
 
+        # ego past
         ego_past_mask = torch.sum(torch.ne(inputs["ego_agent_past"][..., :4], 0), dim=-1) == 0
         inputs["ego_agent_past"][..., :2] = vector_transform(
             inputs["ego_agent_past"][..., :2], transform_matrix, center_xy
@@ -496,22 +531,27 @@ class StatePerturbation:
         )
         inputs["ego_agent_past"][ego_past_mask] = 0.0
 
+        # ego future xy
         ego_future[..., :2] = vector_transform(ego_future[..., :2], transform_matrix, center_xy)
         ego_future[..., 2] = heading_transform(ego_future[..., 2], transform_matrix)
         inputs["ego_agent_future"] = ego_future
 
+        # neighbor past xy
         mask = torch.sum(torch.ne(inputs["neighbor_agents_past"][..., :6], 0), dim=-1) == 0
         inputs["neighbor_agents_past"][..., :2] = vector_transform(
             inputs["neighbor_agents_past"][..., :2], transform_matrix, center_xy
         )
+        # neighbor past cos sin
         inputs["neighbor_agents_past"][..., 2:4] = vector_transform(
             inputs["neighbor_agents_past"][..., 2:4], transform_matrix
         )
+        # neighbor past vx, vy
         inputs["neighbor_agents_past"][..., 4:6] = vector_transform(
             inputs["neighbor_agents_past"][..., 4:6], transform_matrix
         )
         inputs["neighbor_agents_past"][mask] = 0.0
 
+        # neighbor future xy
         mask = torch.sum(torch.ne(neighbors_future[..., :2], 0), dim=-1) == 0
         neighbors_future[..., :2] = vector_transform(
             neighbors_future[..., :2], transform_matrix, center_xy
@@ -519,13 +559,17 @@ class StatePerturbation:
         neighbors_future[..., 2] = heading_transform(neighbors_future[..., 2], transform_matrix)
         neighbors_future[mask] = 0.0
 
+        # lanes
         mask = torch.sum(torch.ne(inputs["lanes"][..., :8], 0), dim=-1) == 0
-        inputs["lanes"][..., :2] = vector_transform(inputs["lanes"][..., :2], transform_matrix, center_xy)
+        inputs["lanes"][..., :2] = vector_transform(
+            inputs["lanes"][..., :2], transform_matrix, center_xy
+        )
         inputs["lanes"][..., 2:4] = vector_transform(inputs["lanes"][..., 2:4], transform_matrix)
         inputs["lanes"][..., 4:6] = vector_transform(inputs["lanes"][..., 4:6], transform_matrix)
         inputs["lanes"][..., 6:8] = vector_transform(inputs["lanes"][..., 6:8], transform_matrix)
         inputs["lanes"][mask] = 0.0
 
+        # route_lanes
         mask = torch.sum(torch.ne(inputs["route_lanes"][..., :8], 0), dim=-1) == 0
         inputs["route_lanes"][..., :2] = vector_transform(
             inputs["route_lanes"][..., :2], transform_matrix, center_xy
@@ -541,20 +585,26 @@ class StatePerturbation:
         )
         inputs["route_lanes"][mask] = 0.0
 
+        # polygons
         mask = torch.sum(torch.ne(inputs["polygons"], 0), dim=-1) == 0
-        inputs["polygons"][..., :2] = vector_transform(inputs["polygons"][..., :2], transform_matrix, center_xy)
+        inputs["polygons"][..., :2] = vector_transform(
+            inputs["polygons"][..., :2], transform_matrix, center_xy
+        )
         inputs["polygons"][mask] = 0.0
 
+        # line_strings
         mask = torch.sum(torch.ne(inputs["line_strings"], 0), dim=-1) == 0
         inputs["line_strings"][..., :2] = vector_transform(
             inputs["line_strings"][..., :2], transform_matrix, center_xy
         )
         inputs["line_strings"][mask] = 0.0
 
+        # static objects xy
         mask = torch.sum(torch.ne(inputs["static_objects"][..., :10], 0), dim=-1) == 0
         inputs["static_objects"][..., :2] = vector_transform(
             inputs["static_objects"][..., :2], transform_matrix, center_xy
         )
+        # static objects cos sin
         inputs["static_objects"][..., 2:4] = vector_transform(
             inputs["static_objects"][..., 2:4], transform_matrix
         )
@@ -592,21 +642,27 @@ if __name__ == "__main__":
         if key == "goal_pose" or key == "ego_agent_past":
             data[key] = heading_to_cos_sin(data[key])
 
+    # Load future trajectories separately
     ego_future = torch.tensor(loaded["ego_agent_future"]).unsqueeze(0)
     neighbors_future = torch.tensor(loaded["neighbor_agents_future"]).unsqueeze(0)
 
     aug = StatePerturbation(augment_prob=1.0, device="cpu")
 
+    # Save original data visualization with augmentation range rectangle
     original_save_path = save_dir / "original.png"
     fig, ax = plt.subplots(figsize=(10, 10))
+
+    # Visualize inputs on the ax
     view_range = 20
     visualize_inputs(deepcopy(data), save_path=None, ax=ax, view_ranges=[view_range])
 
-    lo = aug._low.cpu().numpy()[0]
-    hi = aug._high.cpu().numpy()[0]
+    # Get augmentation ranges from the aug object
+    lo = aug._low.cpu().numpy()[0]  # Extract from tuple
+    hi = aug._high.cpu().numpy()[0]  # Extract from tuple
     x_min, y_min = lo[0], lo[1]
     x_max, y_max = hi[0], hi[1]
 
+    # Draw the augmentation range rectangle
     rect = patches.Rectangle(
         (x_min, y_min),
         x_max - x_min,
@@ -630,6 +686,7 @@ if __name__ == "__main__":
             deepcopy(data), ego_future.clone(), neighbors_future.clone()
         )
 
+        # Save augmented data to npz file
         data_dict = {}
         for key, value in aug_data.items():
             if isinstance(value, torch.Tensor):
@@ -637,14 +694,19 @@ if __name__ == "__main__":
             else:
                 data_dict[key] = value
 
+        # Add future trajectories with consistent naming
         data_dict["ego_agent_future"] = aug_ego_future.squeeze(0).detach().cpu().numpy()
-        data_dict["neighbor_agents_future"] = aug_neighbors_future.squeeze(0).detach().cpu().numpy()
+        data_dict["neighbor_agents_future"] = (
+            aug_neighbors_future.squeeze(0).detach().cpu().numpy()
+        )
         aug_data["ego_agent_future"] = aug_ego_future
         aug_data["neighbor_agents_future"] = aug_neighbors_future
 
+        # Save to npz file
         output_path = save_dir / f"augmented_{i:08d}.npz"
         np.savez(output_path, **data_dict)
 
+        # Use deepcopy to avoid side effects from visualize_inputs
         visualize_inputs(
             deepcopy(aug_data), save_dir / f"augmented_{i:08d}.png", view_ranges=[view_range]
         )

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -1,8 +1,54 @@
+from dataclasses import dataclass
+
 import numpy as np
 import torch
 
 TIME_INTERVAL = 0.1
 DENSE_SAMPLE_DS = 0.05
+
+
+@dataclass
+class SegmentAugmentationResultTorch:
+    query_xy: torch.Tensor
+    query_heading: torch.Tensor
+    progress: torch.Tensor
+    exact_speed: torch.Tensor
+    distance_profile: torch.Tensor
+    segment_time: torch.Tensor
+    merge_centerline_s: float
+    merge_path_length_m: float
+    connect_distance_budget_m: float
+    connect_speed_scale: float
+
+
+@dataclass
+class ConstraintDiagnosticsTorch:
+    max_abs_augmented_lateral_accel_mps2: float
+    max_bridge_speed_gap_mps: float
+    max_abs_bridge_jerk_mps3: float
+    lateral_accel_limit_mps2: float
+    speed_gap_limit_mps: float
+    jerk_limit_mps3: float
+    lateral_accel_passes: bool
+    speed_gap_passes: bool
+    jerk_passes: bool
+    passes: bool
+
+
+@dataclass
+class AugmentedSampleTorchResult:
+    aug_current_state: torch.Tensor
+    aug_past: torch.Tensor
+    aug_future: torch.Tensor
+    original_full_xy: torch.Tensor
+    augmented_full_xy: torch.Tensor
+    original_full_heading: torch.Tensor
+    augmented_full_heading: torch.Tensor
+    full_time: torch.Tensor
+    past_segment: SegmentAugmentationResultTorch
+    future_segment: SegmentAugmentationResultTorch
+    past_connect_time_s: float
+    future_recover_time_s: float
 
 
 def vector_transform(vector, transform_mat, bias=None):
@@ -51,6 +97,14 @@ def cumulative_distance_torch(xy: torch.Tensor) -> torch.Tensor:
     return distance
 
 
+def strictly_increasing_param_torch(param: torch.Tensor) -> torch.Tensor:
+    fixed = param.clone()
+    for idx in range(1, fixed.shape[0]):
+        if fixed[idx] <= fixed[idx - 1]:
+            fixed[idx] = fixed[idx - 1] + 1.0e-6
+    return fixed
+
+
 def interp1d_torch(x: torch.Tensor, y: torch.Tensor, xq: torch.Tensor) -> torch.Tensor:
     if x.numel() == 1:
         return y[0].expand_as(xq) if y.ndim == 1 else y[0].expand(xq.shape[0], *y.shape[1:])
@@ -78,6 +132,15 @@ def interp_heading_torch(
     cos_interp = interp1d_torch(x, torch.cos(heading), xq)
     sin_interp = interp1d_torch(x, torch.sin(heading), xq)
     return torch.atan2(sin_interp, cos_interp)
+
+
+def build_progress_time_lookup_torch(
+    progress: torch.Tensor, time: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    keep = torch.ones_like(progress, dtype=torch.bool)
+    if progress.shape[0] > 1:
+        keep[1:] = progress[1:] > progress[:-1] + 1.0e-9
+    return progress[keep], time[keep]
 
 
 def heading_from_positions_torch(
@@ -109,6 +172,37 @@ def heading_from_positions_torch(
         heading = torch.where(delta_norm < 1.0e-6, fallback_heading, heading)
 
     return normalize_angle_torch(heading)
+
+
+def speed_from_progress_torch(progress: torch.Tensor, time: torch.Tensor) -> torch.Tensor:
+    if time.shape[0] < 3:
+        return torch.zeros_like(time)
+    time = strictly_increasing_param_torch(time)
+    speed = torch.zeros_like(progress)
+    speed[0] = (progress[1] - progress[0]) / (time[1] - time[0])
+    speed[-1] = (progress[-1] - progress[-2]) / (time[-1] - time[-2])
+    speed[1:-1] = (progress[2:] - progress[:-2]) / (time[2:] - time[:-2])
+    return speed
+
+
+def acceleration_from_speed_torch(speed: torch.Tensor, time: torch.Tensor) -> torch.Tensor:
+    return speed_from_progress_torch(speed, time)
+
+
+def jerk_from_acceleration_torch(acceleration: torch.Tensor, time: torch.Tensor) -> torch.Tensor:
+    return speed_from_progress_torch(acceleration, time)
+
+
+def curvature_from_xy_torch(xy: torch.Tensor, param: torch.Tensor) -> torch.Tensor:
+    if xy.shape[0] < 3:
+        return torch.zeros(xy.shape[0], dtype=xy.dtype, device=xy.device)
+    param = strictly_increasing_param_torch(param)
+    dx = torch.gradient(xy[:, 0], spacing=(param,), edge_order=2)[0]
+    dy = torch.gradient(xy[:, 1], spacing=(param,), edge_order=2)[0]
+    ddx = torch.gradient(dx, spacing=(param,), edge_order=2)[0]
+    ddy = torch.gradient(dy, spacing=(param,), edge_order=2)[0]
+    denom = torch.clamp(dx * dx + dy * dy, min=1.0e-9) ** 1.5
+    return (dx * ddy - dy * ddx) / denom
 
 
 def quintic_decay_torch(unit_s: torch.Tensor) -> torch.Tensor:
@@ -270,6 +364,56 @@ def solve_merge_centerline_s_torch(
     return s_merge, path_xy, path_sigma, path_heading
 
 
+def build_full_augmented_path_torch(
+    center_xy: torch.Tensor,
+    center_heading: torch.Tensor,
+    center_s: torch.Tensor,
+    merge_xy: torch.Tensor,
+    merge_sigma: torch.Tensor,
+    merge_heading: torch.Tensor,
+    s_merge: torch.Tensor,
+    total_distance_m: torch.Tensor,
+    dense_ds: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    device = center_xy.device
+    dtype = center_xy.dtype
+    continuation_s = torch.arange(
+        float(s_merge.item()),
+        float(total_distance_m.item()),
+        dense_ds,
+        device=device,
+        dtype=dtype,
+    )
+    if continuation_s.numel() == 0 or not torch.isclose(continuation_s[-1], total_distance_m):
+        continuation_s = torch.cat([continuation_s, total_distance_m.unsqueeze(0)])
+
+    continuation_xy, continuation_heading = sample_centerline_torch(
+        center_s, center_xy, center_heading, continuation_s
+    )
+    continuation_sigma = merge_sigma[-1] + (continuation_s - s_merge)
+
+    full_sigma = torch.cat([merge_sigma, continuation_sigma[1:]], dim=0)
+    full_xy = torch.cat([merge_xy, continuation_xy[1:]], dim=0)
+    fallback_heading = torch.cat([merge_heading, continuation_heading[1:]], dim=0)
+    full_heading = heading_from_positions_torch(full_xy, fallback_heading=fallback_heading)
+    return full_xy, full_sigma, full_heading
+
+
+def sample_dense_path_torch(
+    path_sigma: torch.Tensor,
+    path_xy: torch.Tensor,
+    path_heading: torch.Tensor,
+    query_sigma: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if path_sigma.numel() == 0:
+        raise ValueError("Dense path must contain at least one sample.")
+    sigma = strictly_increasing_param_torch(path_sigma)
+    sigma_query = torch.clamp(query_sigma, min=sigma[0], max=sigma[-1])
+    xy = interp1d_torch(sigma, path_xy, sigma_query)
+    heading = interp_heading_torch(sigma, path_heading, sigma_query)
+    return xy, heading
+
+
 def augment_segment_torch(
     segment_xy: torch.Tensor,
     segment_heading: torch.Tensor,
@@ -278,7 +422,7 @@ def augment_segment_torch(
     heading_offset: torch.Tensor,
     connect_time_s: float,
     dense_ds: float,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> SegmentAugmentationResultTorch:
     center_s = cumulative_distance_torch(segment_xy)
     # Use GT heading directly so past-bridge generation keeps the same lateral
     # offset convention even when the past segment is traversed in reverse.
@@ -286,8 +430,10 @@ def augment_segment_torch(
     connect_time = torch.tensor(connect_time_s, dtype=segment_xy.dtype, device=segment_xy.device)
     connect_time = torch.clamp(connect_time, min=segment_time[0], max=segment_time[-1])
     distance_budget = interp1d_torch(segment_time, center_s, connect_time.unsqueeze(0))[0]
+    progress_samples, progress_time_lookup = build_progress_time_lookup_torch(center_s, segment_time)
+    total_distance = center_s[-1]
 
-    path_xy_candidate, path_sigma_candidate, _ = build_offset_path_torch(
+    path_xy_candidate, path_sigma_candidate, path_heading_candidate = build_offset_path_torch(
         center_xy=segment_xy,
         center_heading=center_heading,
         center_s=center_s,
@@ -302,9 +448,10 @@ def augment_segment_torch(
         s_merge = distance_budget
         merge_xy = path_xy_candidate
         merge_sigma = path_sigma_candidate
+        merge_heading = path_heading_candidate
         speed_scale = candidate_length / torch.clamp(distance_budget, min=1.0e-6)
     else:
-        s_merge, merge_xy, merge_sigma, _ = solve_merge_centerline_s_torch(
+        s_merge, merge_xy, merge_sigma, merge_heading = solve_merge_centerline_s_torch(
             center_xy=segment_xy,
             center_heading=center_heading,
             center_s=center_s,
@@ -315,24 +462,68 @@ def augment_segment_torch(
         )
         speed_scale = torch.tensor(1.0, dtype=segment_xy.dtype, device=segment_xy.device)
 
-    connect_mask = segment_time <= connect_time + 1.0e-6
-    query_xy = torch.zeros_like(segment_xy)
-    progress = torch.zeros_like(segment_time)
+    dense_full_xy, dense_full_sigma, dense_full_heading = build_full_augmented_path_torch(
+        center_xy=segment_xy,
+        center_heading=center_heading,
+        center_s=center_s,
+        merge_xy=merge_xy,
+        merge_sigma=merge_sigma,
+        merge_heading=merge_heading,
+        s_merge=s_merge,
+        total_distance_m=total_distance,
+        dense_ds=dense_ds,
+    )
 
-    connect_sigma = speed_scale * center_s[connect_mask]
-    query_xy[connect_mask] = interp1d_torch(merge_sigma, merge_xy, connect_sigma)
-    progress[connect_mask] = connect_sigma
+    connect_mask = segment_time <= connect_time + 1.0e-6
+    progress = torch.zeros_like(segment_time)
+    if distance_budget > 1.0e-9:
+        progress[connect_mask] = speed_scale * center_s[connect_mask]
+    else:
+        progress[connect_mask] = 0.0
 
     continue_mask = ~connect_mask
     if torch.any(continue_mask):
-        continue_s = s_merge + (center_s[continue_mask] - distance_budget)
-        query_xy[continue_mask], _ = sample_centerline_torch(
-            center_s, segment_xy, center_heading, continue_s
-        )
-        progress[continue_mask] = merge_sigma[-1] + (center_s[continue_mask] - distance_budget)
+        merge_time_on_gt = interp1d_torch(
+            progress_samples, progress_time_lookup, s_merge.unsqueeze(0)
+        )[0]
+        shifted_gt_time = merge_time_on_gt + (segment_time[continue_mask] - connect_time)
+        shifted_gt_time = torch.clamp(shifted_gt_time, min=segment_time[0], max=segment_time[-1])
+        centerline_progress = interp1d_torch(segment_time, center_s, shifted_gt_time)
+        progress[continue_mask] = merge_sigma[-1] + (centerline_progress - s_merge)
 
-    query_heading = heading_from_positions_torch(query_xy, fallback_heading=segment_heading)
-    return query_xy, query_heading, progress
+    progress = torch.clamp(progress, min=0.0, max=dense_full_sigma[-1])
+    query_xy, query_heading = sample_dense_path_torch(
+        dense_full_sigma, dense_full_xy, dense_full_heading, progress
+    )
+    exact_speed = speed_from_progress_torch(progress, segment_time)
+    return SegmentAugmentationResultTorch(
+        query_xy=query_xy,
+        query_heading=query_heading,
+        progress=progress,
+        exact_speed=exact_speed,
+        distance_profile=center_s,
+        segment_time=segment_time,
+        merge_centerline_s=float(s_merge.item()),
+        merge_path_length_m=float(merge_sigma[-1].item()),
+        connect_distance_budget_m=float(distance_budget.item()),
+        connect_speed_scale=float(speed_scale.item()),
+    )
+
+
+def lateral_acceleration_from_speed_and_curvature_torch(
+    speed: torch.Tensor, curvature: torch.Tensor
+) -> torch.Tensor:
+    return speed * speed * curvature
+
+
+def generate_time_candidates(
+    start_s: float,
+    end_s: float,
+    step_s: float = TIME_INTERVAL,
+) -> list[float]:
+    start_tick = int(np.ceil((start_s - 1.0e-9) / step_s))
+    end_tick = int(np.floor((end_s + 1.0e-9) / step_s))
+    return [tick * step_s for tick in range(start_tick, end_tick + 1)]
 
 
 class StatePerturbation:
@@ -350,6 +541,10 @@ class StatePerturbation:
         future_bridge_sec: float = 1.5,
         dense_sample_ds: float = DENSE_SAMPLE_DS,
         max_heading_offset_deg: float = 10.0,
+        max_lateral_accel_mps2: float = 3.0,
+        max_bridge_speed_gap_mps: float = 0.5,
+        max_bridge_jerk_mps3: float = 5.0,
+        adaptive_bridge_search: bool = True,
     ) -> None:
         """
         Initialize the augmentor.
@@ -358,6 +553,10 @@ class StatePerturbation:
         :param future_bridge_sec: duration used to reconnect the perturbed state to the GT future
         :param dense_sample_ds: dense sampling resolution used for path-length feasibility checks
         :param max_heading_offset_deg: maximum absolute initial heading perturbation in degrees
+        :param max_lateral_accel_mps2: lateral acceleration feasibility limit
+        :param max_bridge_speed_gap_mps: bridge speed-gap feasibility limit
+        :param max_bridge_jerk_mps3: bridge jerk feasibility limit
+        :param adaptive_bridge_search: if True, extend M/N to the first feasible candidate
         """
         self._augment_prob = augment_prob
         self._device = torch.device(device)
@@ -369,6 +568,10 @@ class StatePerturbation:
         self._wheel_base = wheel_base
         self._past_bridge_sec = past_bridge_sec
         self._future_bridge_sec = future_bridge_sec
+        self._max_lateral_accel_mps2 = max_lateral_accel_mps2
+        self._max_bridge_speed_gap_mps = max_bridge_speed_gap_mps
+        self._max_bridge_jerk_mps3 = max_bridge_jerk_mps3
+        self._adaptive_bridge_search = adaptive_bridge_search
         self.time_interval = TIME_INTERVAL
         self.dense_sample_ds = dense_sample_ds
 
@@ -419,7 +622,9 @@ class StatePerturbation:
         ego_future: torch.Tensor,
         lateral_offset: torch.Tensor,
         heading_offset: torch.Tensor,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        past_connect_time_s: float,
+        future_recover_time_s: float,
+    ) -> AugmentedSampleTorchResult:
         """
         Rebuild ego past/current/future around a laterally perturbed current state while keeping
         the longitudinal progress speed-feasible against the available GT distance budget.
@@ -451,31 +656,32 @@ class StatePerturbation:
         past_segment_heading = torch.flip(past_heading, dims=[0])
         past_time = torch.arange(0.0, past_len * dt, dt, dtype=dtype, device=device)
 
-        aug_future_xy, _, _ = augment_segment_torch(
+        future_result = augment_segment_torch(
             future_segment_xy,
             future_segment_heading,
             future_time,
             lateral_offset,
             heading_offset,
-            min(self._future_bridge_sec, float(future_time[-1].item())),
+            min(future_recover_time_s, float(future_time[-1].item())),
             self.dense_sample_ds,
         )
-        aug_past_reverse_xy, _, _ = augment_segment_torch(
+        past_result = augment_segment_torch(
             past_segment_xy,
             past_segment_heading,
             past_time,
             lateral_offset,
             -heading_offset,
-            min(self._past_bridge_sec, float(past_time[-1].item())),
+            min(past_connect_time_s, float(past_time[-1].item())),
             self.dense_sample_ds,
         )
 
-        aug_past_xy = torch.flip(aug_past_reverse_xy, dims=[0])
-        full_xy = torch.cat([aug_past_xy[:-1], aug_future_xy], dim=0)
+        aug_past_xy = torch.flip(past_result.query_xy, dims=[0])
+        full_xy = torch.cat([aug_past_xy[:-1], future_result.query_xy], dim=0)
 
         original_full_heading = torch.cat(
             [past_heading[:-1], current_heading.unsqueeze(0), future_heading], dim=0
         )
+        original_full_xy = torch.cat([past_xy[:-1], future_segment_xy], dim=0)
         full_heading = heading_from_positions_torch(full_xy, fallback_heading=original_full_heading)
 
         current_index = past_len - 1
@@ -531,7 +737,208 @@ class StatePerturbation:
         aug_current_state[8] = steering_angle
         aug_current_state[9] = yaw_rate
 
-        return aug_current_state, aug_past_4d, aug_future_3d
+        full_time = torch.arange(
+            -(past_len - 1) * dt,
+            (future_len + 1) * dt,
+            dt,
+            dtype=dtype,
+            device=device,
+        )
+
+        return AugmentedSampleTorchResult(
+            aug_current_state=aug_current_state,
+            aug_past=aug_past_4d,
+            aug_future=aug_future_3d,
+            original_full_xy=original_full_xy,
+            augmented_full_xy=full_xy,
+            original_full_heading=original_full_heading,
+            augmented_full_heading=full_heading,
+            full_time=full_time,
+            past_segment=past_result,
+            future_segment=future_result,
+            past_connect_time_s=past_connect_time_s,
+            future_recover_time_s=future_recover_time_s,
+        )
+
+    def _evaluate_constraints(
+        self,
+        sample_result: AugmentedSampleTorchResult,
+    ) -> ConstraintDiagnosticsTorch:
+        full_time = sample_result.full_time
+        original_sigma = cumulative_distance_torch(sample_result.original_full_xy)
+        augmented_sigma = cumulative_distance_torch(sample_result.augmented_full_xy)
+
+        past_gt_speed = speed_from_progress_torch(
+            sample_result.past_segment.distance_profile,
+            sample_result.past_segment.segment_time,
+        ).flip(0)
+        past_aug_speed = sample_result.past_segment.exact_speed.flip(0)
+        future_gt_speed = speed_from_progress_torch(
+            sample_result.future_segment.distance_profile,
+            sample_result.future_segment.segment_time,
+        )
+        future_aug_speed = sample_result.future_segment.exact_speed
+        gt_arc_speed = torch.cat([past_gt_speed[:-1], future_gt_speed], dim=0)
+        augmented_arc_speed = torch.cat([past_aug_speed[:-1], future_aug_speed], dim=0)
+
+        gt_curvature = curvature_from_xy_torch(sample_result.original_full_xy, original_sigma)
+        augmented_curvature = curvature_from_xy_torch(
+            sample_result.augmented_full_xy, augmented_sigma
+        )
+        augmented_lateral_accel = lateral_acceleration_from_speed_and_curvature_torch(
+            augmented_arc_speed, augmented_curvature
+        )
+        max_abs_augmented_lateral_accel = float(torch.max(torch.abs(augmented_lateral_accel)).item())
+
+        past_gt_accel = acceleration_from_speed_torch(
+            speed_from_progress_torch(
+                sample_result.past_segment.distance_profile,
+                sample_result.past_segment.segment_time,
+            ),
+            sample_result.past_segment.segment_time,
+        )
+        past_aug_accel = acceleration_from_speed_torch(
+            sample_result.past_segment.exact_speed,
+            sample_result.past_segment.segment_time,
+        )
+        future_gt_accel = acceleration_from_speed_torch(
+            speed_from_progress_torch(
+                sample_result.future_segment.distance_profile,
+                sample_result.future_segment.segment_time,
+            ),
+            sample_result.future_segment.segment_time,
+        )
+        future_aug_accel = acceleration_from_speed_torch(
+            sample_result.future_segment.exact_speed,
+            sample_result.future_segment.segment_time,
+        )
+        past_gt_jerk = jerk_from_acceleration_torch(
+            past_gt_accel,
+            sample_result.past_segment.segment_time,
+        )
+        past_aug_jerk = jerk_from_acceleration_torch(
+            past_aug_accel,
+            sample_result.past_segment.segment_time,
+        )
+        future_gt_jerk = jerk_from_acceleration_torch(
+            future_gt_accel,
+            sample_result.future_segment.segment_time,
+        )
+        future_aug_jerk = jerk_from_acceleration_torch(
+            future_aug_accel,
+            sample_result.future_segment.segment_time,
+        )
+
+        bridge_time = full_time
+        bridge_mask = (
+            (bridge_time >= -sample_result.past_connect_time_s - 1.0e-9)
+            & (bridge_time <= sample_result.future_recover_time_s + 1.0e-9)
+        )
+        bridge_speed_gap = torch.cat(
+            [
+                torch.abs(past_aug_speed - past_gt_speed).flip(0)[:-1],
+                torch.abs(future_aug_speed - future_gt_speed),
+            ],
+            dim=0,
+        )
+        augmented_jerk = torch.cat(
+            [past_aug_jerk.flip(0)[:-1], future_aug_jerk],
+            dim=0,
+        )
+
+        if torch.any(bridge_mask):
+            max_speed_gap = float(torch.max(bridge_speed_gap[bridge_mask]).item())
+            max_abs_bridge_jerk = float(torch.max(torch.abs(augmented_jerk[bridge_mask])).item())
+        else:
+            max_speed_gap = 0.0
+            max_abs_bridge_jerk = 0.0
+
+        lateral_accel_passes = max_abs_augmented_lateral_accel <= self._max_lateral_accel_mps2 + 1.0e-9
+        speed_gap_passes = max_speed_gap <= self._max_bridge_speed_gap_mps + 1.0e-9
+        jerk_passes = max_abs_bridge_jerk <= self._max_bridge_jerk_mps3 + 1.0e-9
+
+        return ConstraintDiagnosticsTorch(
+            max_abs_augmented_lateral_accel_mps2=max_abs_augmented_lateral_accel,
+            max_bridge_speed_gap_mps=max_speed_gap,
+            max_abs_bridge_jerk_mps3=max_abs_bridge_jerk,
+            lateral_accel_limit_mps2=self._max_lateral_accel_mps2,
+            speed_gap_limit_mps=self._max_bridge_speed_gap_mps,
+            jerk_limit_mps3=self._max_bridge_jerk_mps3,
+            lateral_accel_passes=lateral_accel_passes,
+            speed_gap_passes=speed_gap_passes,
+            jerk_passes=jerk_passes,
+            passes=lateral_accel_passes and speed_gap_passes and jerk_passes,
+        )
+
+    def _search_feasible_sample(
+        self,
+        ego_past: torch.Tensor,
+        ego_current_state: torch.Tensor,
+        ego_future: torch.Tensor,
+        lateral_offset: torch.Tensor,
+        heading_offset: torch.Tensor,
+        initial_past_connect_time_s: float,
+        initial_future_recover_time_s: float,
+    ) -> AugmentedSampleTorchResult:
+        initial_result = self._build_augmented_sample(
+            ego_past=ego_past,
+            ego_current_state=ego_current_state,
+            ego_future=ego_future,
+            lateral_offset=lateral_offset,
+            heading_offset=heading_offset,
+            past_connect_time_s=initial_past_connect_time_s,
+            future_recover_time_s=initial_future_recover_time_s,
+        )
+        initial_diag = self._evaluate_constraints(initial_result)
+        if not self._adaptive_bridge_search or initial_diag.passes:
+            return initial_result
+
+        max_future_recover_time_s = float(ego_future.shape[0] * self.time_interval)
+        max_past_connect_time_s = float((ego_past.shape[0] - 1) * self.time_interval)
+
+        future_candidates = generate_time_candidates(
+            start_s=initial_future_recover_time_s + self.time_interval,
+            end_s=max_future_recover_time_s,
+            step_s=self.time_interval,
+        )
+        for candidate_n in future_candidates:
+            candidate_result = self._build_augmented_sample(
+                ego_past=ego_past,
+                ego_current_state=ego_current_state,
+                ego_future=ego_future,
+                lateral_offset=lateral_offset,
+                heading_offset=heading_offset,
+                past_connect_time_s=initial_past_connect_time_s,
+                future_recover_time_s=candidate_n,
+            )
+            if self._evaluate_constraints(candidate_result).passes:
+                return candidate_result
+
+        past_candidates = generate_time_candidates(
+            start_s=initial_past_connect_time_s + self.time_interval,
+            end_s=max_past_connect_time_s,
+            step_s=self.time_interval,
+        )
+        future_with_past_candidates = generate_time_candidates(
+            start_s=initial_future_recover_time_s,
+            end_s=max_future_recover_time_s,
+            step_s=self.time_interval,
+        )
+        for candidate_m in past_candidates:
+            for candidate_n in future_with_past_candidates:
+                candidate_result = self._build_augmented_sample(
+                    ego_past=ego_past,
+                    ego_current_state=ego_current_state,
+                    ego_future=ego_future,
+                    lateral_offset=lateral_offset,
+                    heading_offset=heading_offset,
+                    past_connect_time_s=candidate_m,
+                    future_recover_time_s=candidate_n,
+                )
+                if self._evaluate_constraints(candidate_result).passes:
+                    return candidate_result
+
+        return initial_result
 
     def augment(self, inputs, ego_future):
         ego_current_state = inputs["ego_current_state"].clone()
@@ -550,16 +957,18 @@ class StatePerturbation:
         )
 
         for batch_index in torch.nonzero(aug_flag, as_tuple=False).flatten():
-            aug_state, aug_past, aug_future = self._build_augmented_sample(
+            best_result = self._search_feasible_sample(
                 ego_past=ego_agent_past[batch_index],
                 ego_current_state=ego_current_state[batch_index],
                 ego_future=ego_future[batch_index],
                 lateral_offset=lateral_offsets[batch_index],
                 heading_offset=heading_offsets[batch_index],
+                initial_past_connect_time_s=self._past_bridge_sec,
+                initial_future_recover_time_s=self._future_bridge_sec,
             )
-            ego_current_state[batch_index] = aug_state
-            ego_agent_past[batch_index] = aug_past
-            aug_ego_future[batch_index] = aug_future
+            ego_current_state[batch_index] = best_result.aug_current_state
+            ego_agent_past[batch_index] = best_result.aug_past
+            aug_ego_future[batch_index] = best_result.aug_future
 
         return aug_flag, ego_current_state, ego_agent_past, aug_ego_future
 

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -349,7 +349,7 @@ class StatePerturbation:
         past_bridge_sec: float = 1.0,
         future_bridge_sec: float = 1.5,
         dense_sample_ds: float = DENSE_SAMPLE_DS,
-        max_heading_offset_deg: float = 15.0,
+        max_heading_offset_deg: float = 10.0,
     ) -> None:
         """
         Initialize the augmentor.

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -13,12 +13,31 @@ class SegmentAugmentationResultTorch:
     query_heading: torch.Tensor
     progress: torch.Tensor
     exact_speed: torch.Tensor
+    exact_acceleration: torch.Tensor
+    exact_jerk: torch.Tensor
     distance_profile: torch.Tensor
     segment_time: torch.Tensor
+    connect_time_s: float
     merge_centerline_s: float
     merge_path_length_m: float
     connect_distance_budget_m: float
     connect_speed_scale: float
+
+
+@dataclass
+class PreparedDirectedSegmentTorch:
+    segment_xy: torch.Tensor
+    segment_heading: torch.Tensor
+    segment_time: torch.Tensor
+    center_s: torch.Tensor
+    center_heading: torch.Tensor
+    center_curvature: torch.Tensor
+    progress_samples: torch.Tensor
+    progress_time_lookup: torch.Tensor
+    total_distance_m: torch.Tensor
+    dense_ds: float
+    gt_exact_speed_profile: torch.Tensor
+    gt_longitudinal_jerk_profile: torch.Tensor
 
 
 @dataclass
@@ -49,6 +68,21 @@ class AugmentedSampleTorchResult:
     future_segment: SegmentAugmentationResultTorch
     past_connect_time_s: float
     future_recover_time_s: float
+
+
+@dataclass
+class BidirectionalAugmentationContextTorch:
+    original_full_xy: torch.Tensor
+    original_full_heading: torch.Tensor
+    full_time: torch.Tensor
+    current_index: int
+    past_len: int
+    future_len: int
+    future_segment: PreparedDirectedSegmentTorch
+    past_segment: PreparedDirectedSegmentTorch
+    gt_window_arc_speed: torch.Tensor
+    gt_window_lateral_accel: torch.Tensor
+    gt_window_longitudinal_jerk: torch.Tensor
 
 
 def vector_transform(vector, transform_mat, bias=None):
@@ -98,11 +132,16 @@ def cumulative_distance_torch(xy: torch.Tensor) -> torch.Tensor:
 
 
 def strictly_increasing_param_torch(param: torch.Tensor) -> torch.Tensor:
-    fixed = param.clone()
-    for idx in range(1, fixed.shape[0]):
-        if fixed[idx] <= fixed[idx - 1]:
-            fixed[idx] = fixed[idx - 1] + 1.0e-6
-    return fixed
+    if param.numel() < 2:
+        return param
+    if bool(torch.all(param[1:] > param[:-1])):
+        return param
+
+    eps = param.new_tensor(1.0e-6)
+    offset = eps * torch.arange(param.shape[0], device=param.device, dtype=param.dtype)
+    base = param - offset
+    fixed_base = torch.cummax(base, dim=0)[0]
+    return fixed_base + offset
 
 
 def interp1d_torch(x: torch.Tensor, y: torch.Tensor, xq: torch.Tensor) -> torch.Tensor:
@@ -143,6 +182,46 @@ def build_progress_time_lookup_torch(
     return progress[keep], time[keep]
 
 
+def build_longitudinal_gt_profiles_torch(
+    distance_profile: torch.Tensor,
+    time: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    gt_exact_speed_profile = speed_from_progress_torch(distance_profile, time)
+    gt_acceleration_profile = acceleration_from_speed_torch(gt_exact_speed_profile, time)
+    gt_longitudinal_jerk_profile = jerk_from_acceleration_torch(gt_acceleration_profile, time)
+    return gt_exact_speed_profile, gt_longitudinal_jerk_profile
+
+
+def make_prepared_directed_segment_torch(
+    segment_xy: torch.Tensor,
+    segment_heading: torch.Tensor,
+    segment_time: torch.Tensor,
+    dense_ds: float,
+) -> PreparedDirectedSegmentTorch:
+    center_s = cumulative_distance_torch(segment_xy)
+    center_heading = normalize_angle_torch(segment_heading)
+    center_curvature = curvature_from_xy_torch(segment_xy, center_s)
+    progress_samples, progress_time_lookup = build_progress_time_lookup_torch(center_s, segment_time)
+    gt_exact_speed_profile, gt_longitudinal_jerk_profile = build_longitudinal_gt_profiles_torch(
+        center_s,
+        segment_time,
+    )
+    return PreparedDirectedSegmentTorch(
+        segment_xy=segment_xy,
+        segment_heading=segment_heading,
+        segment_time=segment_time,
+        center_s=center_s,
+        center_heading=center_heading,
+        center_curvature=center_curvature,
+        progress_samples=progress_samples,
+        progress_time_lookup=progress_time_lookup,
+        total_distance_m=center_s[-1],
+        dense_ds=dense_ds,
+        gt_exact_speed_profile=gt_exact_speed_profile,
+        gt_longitudinal_jerk_profile=gt_longitudinal_jerk_profile,
+    )
+
+
 def heading_from_positions_torch(
     xy: torch.Tensor, fallback_heading: torch.Tensor | None = None
 ) -> torch.Tensor:
@@ -177,7 +256,8 @@ def heading_from_positions_torch(
 def speed_from_progress_torch(progress: torch.Tensor, time: torch.Tensor) -> torch.Tensor:
     if time.shape[0] < 3:
         return torch.zeros_like(time)
-    time = strictly_increasing_param_torch(time)
+    if not bool(torch.all(time[1:] > time[:-1])):
+        time = strictly_increasing_param_torch(time)
     speed = torch.zeros_like(progress)
     speed[0] = (progress[1] - progress[0]) / (time[1] - time[0])
     speed[-1] = (progress[-1] - progress[-2]) / (time[-1] - time[-2])
@@ -196,7 +276,8 @@ def jerk_from_acceleration_torch(acceleration: torch.Tensor, time: torch.Tensor)
 def curvature_from_xy_torch(xy: torch.Tensor, param: torch.Tensor) -> torch.Tensor:
     if xy.shape[0] < 3:
         return torch.zeros(xy.shape[0], dtype=xy.dtype, device=xy.device)
-    param = strictly_increasing_param_torch(param)
+    if not bool(torch.all(param[1:] > param[:-1])):
+        param = strictly_increasing_param_torch(param)
     dx = torch.gradient(xy[:, 0], spacing=(param,), edge_order=2)[0]
     dy = torch.gradient(xy[:, 1], spacing=(param,), edge_order=2)[0]
     ddx = torch.gradient(dx, spacing=(param,), edge_order=2)[0]
@@ -205,12 +286,8 @@ def curvature_from_xy_torch(xy: torch.Tensor, param: torch.Tensor) -> torch.Tens
     return (dx * ddy - dy * ddx) / denom
 
 
-def quintic_decay_torch(unit_s: torch.Tensor) -> torch.Tensor:
-    u = torch.clamp(unit_s, 0.0, 1.0)
-    return 1.0 - 10.0 * u**3 + 15.0 * u**4 - 6.0 * u**5
-
-
-def solve_lateral_profile_coeffs_torch(
+def lateral_offset_profile_torch(
+    s: torch.Tensor,
     s_merge: torch.Tensor,
     lateral_offset: torch.Tensor,
     heading_offset: torch.Tensor,
@@ -218,42 +295,25 @@ def solve_lateral_profile_coeffs_torch(
     if s_merge <= 0.0:
         raise ValueError("s_merge must be positive.")
 
-    length = s_merge
-    a0 = lateral_offset
-    a1 = torch.tan(heading_offset)
-    a2 = torch.zeros((), dtype=length.dtype, device=length.device)
-
-    system = torch.stack(
-        [
-            torch.stack([length**3, length**4, length**5]),
-            torch.stack([3.0 * length**2, 4.0 * length**3, 5.0 * length**4]),
-            torch.stack([6.0 * length, 12.0 * length**2, 20.0 * length**3]),
-        ]
-    )
-    rhs = torch.stack(
-        [
-            -(a0 + a1 * length + a2 * length**2),
-            -(a1 + 2.0 * a2 * length),
-            -(2.0 * a2),
-        ]
-    )
-    a3_to_a5 = torch.linalg.solve(system, rhs)
-    return torch.stack([a0, a1, a2, a3_to_a5[0], a3_to_a5[1], a3_to_a5[2]])
+    unit_s = torch.clamp(s / s_merge, 0.0, 1.0)
+    offset_basis = 1.0 - 10.0 * unit_s**3 + 15.0 * unit_s**4 - 6.0 * unit_s**5
+    heading_basis = unit_s - 6.0 * unit_s**3 + 8.0 * unit_s**4 - 3.0 * unit_s**5
+    return lateral_offset * offset_basis + torch.tan(heading_offset) * s_merge * heading_basis
 
 
-def lateral_offset_profile_torch(
+def lateral_offset_profile_derivative_torch(
     s: torch.Tensor,
     s_merge: torch.Tensor,
     lateral_offset: torch.Tensor,
     heading_offset: torch.Tensor,
 ) -> torch.Tensor:
-    coeffs = solve_lateral_profile_coeffs_torch(
-        s_merge=s_merge,
-        lateral_offset=lateral_offset,
-        heading_offset=heading_offset,
-    )
-    powers = torch.stack([s**idx for idx in range(6)], dim=-1)
-    return powers @ coeffs
+    if s_merge <= 0.0:
+        raise ValueError("s_merge must be positive.")
+
+    unit_s = torch.clamp(s / s_merge, 0.0, 1.0)
+    offset_basis_prime = (-30.0 * unit_s**2 + 60.0 * unit_s**3 - 30.0 * unit_s**4) / s_merge
+    heading_basis_prime = 1.0 - 18.0 * unit_s**2 + 32.0 * unit_s**3 - 15.0 * unit_s**4
+    return lateral_offset * offset_basis_prime + torch.tan(heading_offset) * heading_basis_prime
 
 
 def sample_centerline_torch(
@@ -298,21 +358,47 @@ def build_offset_path_torch(
 def merge_path_length_torch(
     center_xy: torch.Tensor,
     center_heading: torch.Tensor,
+    center_curvature: torch.Tensor,
     center_s: torch.Tensor,
     s_merge: torch.Tensor,
     lateral_offset: torch.Tensor,
     heading_offset: torch.Tensor,
     dense_ds: float,
 ) -> torch.Tensor:
-    _, path_sigma, _ = build_offset_path_torch(
-        center_xy, center_heading, center_s, s_merge, lateral_offset, heading_offset, dense_ds
+    if s_merge <= 0.0:
+        raise ValueError("s_merge must be positive.")
+
+    device = center_s.device
+    dtype = center_s.dtype
+    dense_s = torch.arange(0.0, float(s_merge.item()), dense_ds, device=device, dtype=dtype)
+    if dense_s.numel() == 0 or not torch.isclose(dense_s[-1], s_merge):
+        dense_s = torch.cat([dense_s, s_merge.unsqueeze(0)])
+
+    curvature = interp1d_torch(center_s, center_curvature, dense_s)
+
+    offset = lateral_offset_profile_torch(
+        dense_s,
+        torch.clamp(s_merge, min=1.0e-6),
+        lateral_offset,
+        heading_offset,
     )
-    return path_sigma[-1]
+    offset_prime = lateral_offset_profile_derivative_torch(
+        dense_s,
+        torch.clamp(s_merge, min=1.0e-6),
+        lateral_offset,
+        heading_offset,
+    )
+    integrand = torch.sqrt(
+        torch.clamp((1.0 - curvature * offset) ** 2 + offset_prime * offset_prime, min=1.0e-12)
+    )
+    ds = torch.diff(dense_s)
+    return torch.sum(0.5 * (integrand[:-1] + integrand[1:]) * ds)
 
 
 def solve_merge_centerline_s_torch(
     center_xy: torch.Tensor,
     center_heading: torch.Tensor,
+    center_curvature: torch.Tensor,
     center_s: torch.Tensor,
     distance_budget: torch.Tensor,
     lateral_offset: torch.Tensor,
@@ -333,14 +419,28 @@ def solve_merge_centerline_s_torch(
 
     while lower > dense_ds * 1.0e-3:
         length_lower = merge_path_length_torch(
-            center_xy, center_heading, center_s, lower, lateral_offset, heading_offset, dense_ds
+            center_xy,
+            center_heading,
+            center_curvature,
+            center_s,
+            lower,
+            lateral_offset,
+            heading_offset,
+            dense_ds,
         )
         if length_lower < distance_budget:
             break
         lower = lower * 0.5
 
     upper_length = merge_path_length_torch(
-        center_xy, center_heading, center_s, upper, lateral_offset, heading_offset, dense_ds
+        center_xy,
+        center_heading,
+        center_curvature,
+        center_s,
+        upper,
+        lateral_offset,
+        heading_offset,
+        dense_ds,
     )
     if upper_length < distance_budget:
         raise RuntimeError("Unable to find a feasible merge point within the distance budget.")
@@ -348,7 +448,14 @@ def solve_merge_centerline_s_torch(
     for _ in range(50):
         mid = 0.5 * (lower + upper)
         mid_length = merge_path_length_torch(
-            center_xy, center_heading, center_s, mid, lateral_offset, heading_offset, dense_ds
+            center_xy,
+            center_heading,
+            center_curvature,
+            center_s,
+            mid,
+            lateral_offset,
+            heading_offset,
+            dense_ds,
         )
         if mid_length < distance_budget:
             lower = mid
@@ -414,33 +521,27 @@ def sample_dense_path_torch(
     return xy, heading
 
 
-def augment_segment_torch(
-    segment_xy: torch.Tensor,
-    segment_heading: torch.Tensor,
-    segment_time: torch.Tensor,
+def augment_segment_prepared_torch(
+    prepared: PreparedDirectedSegmentTorch,
     lateral_offset: torch.Tensor,
     heading_offset: torch.Tensor,
     connect_time_s: float,
-    dense_ds: float,
 ) -> SegmentAugmentationResultTorch:
-    center_s = cumulative_distance_torch(segment_xy)
-    # Use GT heading directly so past-bridge generation keeps the same lateral
-    # offset convention even when the past segment is traversed in reverse.
-    center_heading = normalize_angle_torch(segment_heading)
-    connect_time = torch.tensor(connect_time_s, dtype=segment_xy.dtype, device=segment_xy.device)
-    connect_time = torch.clamp(connect_time, min=segment_time[0], max=segment_time[-1])
-    distance_budget = interp1d_torch(segment_time, center_s, connect_time.unsqueeze(0))[0]
-    progress_samples, progress_time_lookup = build_progress_time_lookup_torch(center_s, segment_time)
-    total_distance = center_s[-1]
-
+    connect_time = torch.tensor(
+        connect_time_s, dtype=prepared.segment_xy.dtype, device=prepared.segment_xy.device
+    )
+    connect_time = torch.clamp(connect_time, min=prepared.segment_time[0], max=prepared.segment_time[-1])
+    distance_budget = interp1d_torch(
+        prepared.segment_time, prepared.center_s, connect_time.unsqueeze(0)
+    )[0]
     path_xy_candidate, path_sigma_candidate, path_heading_candidate = build_offset_path_torch(
-        center_xy=segment_xy,
-        center_heading=center_heading,
-        center_s=center_s,
+        center_xy=prepared.segment_xy,
+        center_heading=prepared.center_heading,
+        center_s=prepared.center_s,
         s_merge=distance_budget,
         lateral_offset=lateral_offset,
         heading_offset=heading_offset,
-        dense_ds=dense_ds,
+        dense_ds=prepared.dense_ds,
     )
     candidate_length = path_sigma_candidate[-1]
 
@@ -452,61 +553,102 @@ def augment_segment_torch(
         speed_scale = candidate_length / torch.clamp(distance_budget, min=1.0e-6)
     else:
         s_merge, merge_xy, merge_sigma, merge_heading = solve_merge_centerline_s_torch(
-            center_xy=segment_xy,
-            center_heading=center_heading,
-            center_s=center_s,
+            center_xy=prepared.segment_xy,
+            center_heading=prepared.center_heading,
+            center_curvature=prepared.center_curvature,
+            center_s=prepared.center_s,
             distance_budget=distance_budget,
             lateral_offset=lateral_offset,
             heading_offset=heading_offset,
-            dense_ds=dense_ds,
+            dense_ds=prepared.dense_ds,
         )
-        speed_scale = torch.tensor(1.0, dtype=segment_xy.dtype, device=segment_xy.device)
+        speed_scale = torch.tensor(
+            1.0, dtype=prepared.segment_xy.dtype, device=prepared.segment_xy.device
+        )
 
     dense_full_xy, dense_full_sigma, dense_full_heading = build_full_augmented_path_torch(
-        center_xy=segment_xy,
-        center_heading=center_heading,
-        center_s=center_s,
+        center_xy=prepared.segment_xy,
+        center_heading=prepared.center_heading,
+        center_s=prepared.center_s,
         merge_xy=merge_xy,
         merge_sigma=merge_sigma,
         merge_heading=merge_heading,
         s_merge=s_merge,
-        total_distance_m=total_distance,
-        dense_ds=dense_ds,
+        total_distance_m=prepared.total_distance_m,
+        dense_ds=prepared.dense_ds,
     )
 
-    connect_mask = segment_time <= connect_time + 1.0e-6
-    progress = torch.zeros_like(segment_time)
+    connect_mask = prepared.segment_time <= connect_time + 1.0e-6
+    progress = torch.zeros_like(prepared.segment_time)
     if distance_budget > 1.0e-9:
-        progress[connect_mask] = speed_scale * center_s[connect_mask]
+        progress[connect_mask] = speed_scale * prepared.center_s[connect_mask]
     else:
         progress[connect_mask] = 0.0
 
     continue_mask = ~connect_mask
     if torch.any(continue_mask):
         merge_time_on_gt = interp1d_torch(
-            progress_samples, progress_time_lookup, s_merge.unsqueeze(0)
+            prepared.progress_samples,
+            prepared.progress_time_lookup,
+            s_merge.unsqueeze(0),
         )[0]
-        shifted_gt_time = merge_time_on_gt + (segment_time[continue_mask] - connect_time)
-        shifted_gt_time = torch.clamp(shifted_gt_time, min=segment_time[0], max=segment_time[-1])
-        centerline_progress = interp1d_torch(segment_time, center_s, shifted_gt_time)
+        shifted_gt_time = merge_time_on_gt + (prepared.segment_time[continue_mask] - connect_time)
+        shifted_gt_time = torch.clamp(
+            shifted_gt_time,
+            min=prepared.segment_time[0],
+            max=prepared.segment_time[-1],
+        )
+        centerline_progress = interp1d_torch(
+            prepared.segment_time,
+            prepared.center_s,
+            shifted_gt_time,
+        )
         progress[continue_mask] = merge_sigma[-1] + (centerline_progress - s_merge)
 
     progress = torch.clamp(progress, min=0.0, max=dense_full_sigma[-1])
     query_xy, query_heading = sample_dense_path_torch(
         dense_full_sigma, dense_full_xy, dense_full_heading, progress
     )
-    exact_speed = speed_from_progress_torch(progress, segment_time)
+    exact_speed = speed_from_progress_torch(progress, prepared.segment_time)
+    exact_acceleration = acceleration_from_speed_torch(exact_speed, prepared.segment_time)
+    exact_jerk = jerk_from_acceleration_torch(exact_acceleration, prepared.segment_time)
     return SegmentAugmentationResultTorch(
         query_xy=query_xy,
         query_heading=query_heading,
         progress=progress,
         exact_speed=exact_speed,
-        distance_profile=center_s,
-        segment_time=segment_time,
+        exact_acceleration=exact_acceleration,
+        exact_jerk=exact_jerk,
+        distance_profile=prepared.center_s,
+        segment_time=prepared.segment_time,
+        connect_time_s=float(connect_time.item()),
         merge_centerline_s=float(s_merge.item()),
         merge_path_length_m=float(merge_sigma[-1].item()),
         connect_distance_budget_m=float(distance_budget.item()),
         connect_speed_scale=float(speed_scale.item()),
+    )
+
+
+def augment_segment_torch(
+    segment_xy: torch.Tensor,
+    segment_heading: torch.Tensor,
+    segment_time: torch.Tensor,
+    lateral_offset: torch.Tensor,
+    heading_offset: torch.Tensor,
+    connect_time_s: float,
+    dense_ds: float,
+) -> SegmentAugmentationResultTorch:
+    prepared = make_prepared_directed_segment_torch(
+        segment_xy=segment_xy,
+        segment_heading=segment_heading,
+        segment_time=segment_time,
+        dense_ds=dense_ds,
+    )
+    return augment_segment_prepared_torch(
+        prepared=prepared,
+        lateral_offset=lateral_offset,
+        heading_offset=heading_offset,
+        connect_time_s=connect_time_s,
     )
 
 
@@ -528,25 +670,18 @@ def generate_time_candidates(
 
 def segment_kinematics_torch(
     segment_result: SegmentAugmentationResultTorch,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    gt_speed = speed_from_progress_torch(
-        segment_result.distance_profile, segment_result.segment_time
-    )
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    gt_speed = speed_from_progress_torch(segment_result.distance_profile, segment_result.segment_time)
     augmented_speed = segment_result.exact_speed
     gt_acceleration = acceleration_from_speed_torch(gt_speed, segment_result.segment_time)
-    augmented_acceleration = acceleration_from_speed_torch(
-        augmented_speed, segment_result.segment_time
-    )
     gt_jerk = jerk_from_acceleration_torch(gt_acceleration, segment_result.segment_time)
-    augmented_jerk = jerk_from_acceleration_torch(
-        augmented_acceleration, segment_result.segment_time
-    )
+    augmented_jerk = segment_result.exact_jerk
     return gt_speed, augmented_speed, gt_jerk, augmented_jerk
 
 
 def bridge_constraint_series_torch(
     sample_result: AugmentedSampleTorchResult,
-) -> tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     past_gt_speed, past_aug_speed, past_gt_jerk, past_aug_jerk = segment_kinematics_torch(
         sample_result.past_segment
     )
@@ -567,6 +702,287 @@ def bridge_constraint_series_torch(
     gt_arc_speed = torch.cat([past_gt_speed.flip(0)[:-1], future_gt_speed], dim=0)
     augmented_arc_speed = torch.cat([past_aug_speed.flip(0)[:-1], future_aug_speed], dim=0)
     return gt_arc_speed, augmented_arc_speed, bridge_speed_gap, augmented_jerk
+
+
+def window_series_from_segments_torch(
+    past_series: torch.Tensor,
+    future_series: torch.Tensor,
+) -> torch.Tensor:
+    return torch.cat([past_series.flip(0)[:-1], future_series], dim=0)
+
+
+def build_window_gt_metrics_torch(
+    original_full_xy: torch.Tensor,
+    future_segment: PreparedDirectedSegmentTorch,
+    past_segment: PreparedDirectedSegmentTorch,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    gt_window_arc_speed = window_series_from_segments_torch(
+        past_segment.gt_exact_speed_profile,
+        future_segment.gt_exact_speed_profile,
+    )
+    original_sigma = cumulative_distance_torch(original_full_xy)
+    gt_curvature = curvature_from_xy_torch(original_full_xy, original_sigma)
+    gt_window_lateral_accel = lateral_acceleration_from_speed_and_curvature_torch(
+        gt_window_arc_speed,
+        gt_curvature,
+    )
+    gt_window_longitudinal_jerk = window_series_from_segments_torch(
+        past_segment.gt_longitudinal_jerk_profile,
+        future_segment.gt_longitudinal_jerk_profile,
+    )
+    return gt_window_arc_speed, gt_window_lateral_accel, gt_window_longitudinal_jerk
+
+
+def make_bidirectional_context_torch(
+    original_full_xy: torch.Tensor,
+    original_full_heading: torch.Tensor,
+    full_time: torch.Tensor,
+    current_index: int,
+    past_len: int,
+    future_len: int,
+    future_segment: PreparedDirectedSegmentTorch,
+    past_segment: PreparedDirectedSegmentTorch,
+) -> BidirectionalAugmentationContextTorch:
+    gt_window_arc_speed, gt_window_lateral_accel, gt_window_longitudinal_jerk = (
+        build_window_gt_metrics_torch(
+            original_full_xy=original_full_xy,
+            future_segment=future_segment,
+            past_segment=past_segment,
+        )
+    )
+    return BidirectionalAugmentationContextTorch(
+        original_full_xy=original_full_xy,
+        original_full_heading=original_full_heading,
+        full_time=full_time,
+        current_index=current_index,
+        past_len=past_len,
+        future_len=future_len,
+        future_segment=future_segment,
+        past_segment=past_segment,
+        gt_window_arc_speed=gt_window_arc_speed,
+        gt_window_lateral_accel=gt_window_lateral_accel,
+        gt_window_longitudinal_jerk=gt_window_longitudinal_jerk,
+    )
+
+
+def prepare_bidirectional_context_torch(
+    ego_past: torch.Tensor,
+    ego_current_state: torch.Tensor,
+    ego_future: torch.Tensor,
+    dense_sample_ds: float,
+) -> BidirectionalAugmentationContextTorch:
+    dt = TIME_INTERVAL
+    dtype = ego_past.dtype
+    device = ego_past.device
+
+    past_len = ego_past.shape[0]
+    future_len = ego_future.shape[0]
+
+    past_xy = ego_past[:, :2].clone()
+    past_heading = torch.atan2(ego_past[:, 3], ego_past[:, 2]).clone()
+    current_xy = ego_current_state[:2].clone()
+    current_heading = torch.atan2(ego_current_state[3], ego_current_state[2]).clone()
+    future_xy = ego_future[:, :2].clone()
+    future_heading = ego_future[:, 2].clone()
+
+    past_xy[-1] = current_xy
+    past_heading[-1] = current_heading
+
+    future_segment_xy = torch.cat([current_xy.unsqueeze(0), future_xy], dim=0)
+    future_segment_heading = torch.cat([current_heading.unsqueeze(0), future_heading], dim=0)
+    future_time = torch.arange(
+        0.0, (future_len + 1) * dt, dt, dtype=dtype, device=device
+    )
+
+    past_segment_xy = torch.flip(past_xy, dims=[0])
+    past_segment_heading = torch.flip(past_heading, dims=[0])
+    past_time = torch.arange(0.0, past_len * dt, dt, dtype=dtype, device=device)
+
+    original_full_xy = torch.cat([past_xy[:-1], future_segment_xy], dim=0)
+    original_full_heading = torch.cat(
+        [past_heading[:-1], current_heading.unsqueeze(0), future_heading],
+        dim=0,
+    )
+    full_time = torch.arange(
+        -(past_len - 1) * dt,
+        (future_len + 1) * dt,
+        dt,
+        dtype=dtype,
+        device=device,
+    )
+
+    future_segment = make_prepared_directed_segment_torch(
+        segment_xy=future_segment_xy,
+        segment_heading=future_segment_heading,
+        segment_time=future_time,
+        dense_ds=dense_sample_ds,
+    )
+    past_segment = make_prepared_directed_segment_torch(
+        segment_xy=past_segment_xy,
+        segment_heading=past_segment_heading,
+        segment_time=past_time,
+        dense_ds=dense_sample_ds,
+    )
+    return make_bidirectional_context_torch(
+        original_full_xy=original_full_xy,
+        original_full_heading=original_full_heading,
+        full_time=full_time,
+        current_index=past_len - 1,
+        past_len=past_len,
+        future_len=future_len,
+        future_segment=future_segment,
+        past_segment=past_segment,
+    )
+
+
+def evaluate_constraints_from_segments_torch(
+    context: BidirectionalAugmentationContextTorch,
+    past_result: SegmentAugmentationResultTorch,
+    future_result: SegmentAugmentationResultTorch,
+    max_lateral_accel_mps2: float,
+    max_bridge_speed_gap_mps: float,
+    max_bridge_jerk_mps3: float,
+) -> ConstraintDiagnosticsTorch:
+    augmented_arc_speed = window_series_from_segments_torch(
+        past_result.exact_speed,
+        future_result.exact_speed,
+    )
+    augmented_full_xy = window_series_from_segments_torch(
+        past_result.query_xy,
+        future_result.query_xy,
+    )
+    augmented_sigma = cumulative_distance_torch(augmented_full_xy)
+    augmented_curvature = curvature_from_xy_torch(augmented_full_xy, augmented_sigma)
+    augmented_lateral_accel = lateral_acceleration_from_speed_and_curvature_torch(
+        augmented_arc_speed,
+        augmented_curvature,
+    )
+    max_abs_augmented_lateral_accel = float(torch.max(torch.abs(augmented_lateral_accel)).item())
+
+    bridge_speed_gap = window_series_from_segments_torch(
+        torch.abs(past_result.exact_speed - context.past_segment.gt_exact_speed_profile),
+        torch.abs(future_result.exact_speed - context.future_segment.gt_exact_speed_profile),
+    )
+    augmented_longitudinal_jerk = window_series_from_segments_torch(
+        past_result.exact_jerk,
+        future_result.exact_jerk,
+    )
+    bridge_mask = (
+        (context.full_time >= -past_result.connect_time_s - 1.0e-9)
+        & (context.full_time <= future_result.connect_time_s + 1.0e-9)
+    )
+    max_speed_gap = 0.0
+    max_abs_bridge_jerk = 0.0
+    if torch.any(bridge_mask):
+        max_speed_gap = float(torch.max(bridge_speed_gap[bridge_mask]).item())
+        max_abs_bridge_jerk = float(torch.max(torch.abs(augmented_longitudinal_jerk[bridge_mask])).item())
+
+    lateral_accel_passes = max_abs_augmented_lateral_accel <= max_lateral_accel_mps2 + 1.0e-9
+    speed_gap_passes = max_speed_gap <= max_bridge_speed_gap_mps + 1.0e-9
+    jerk_passes = max_abs_bridge_jerk <= max_bridge_jerk_mps3 + 1.0e-9
+
+    return ConstraintDiagnosticsTorch(
+        max_abs_augmented_lateral_accel_mps2=max_abs_augmented_lateral_accel,
+        max_bridge_speed_gap_mps=max_speed_gap,
+        max_abs_bridge_jerk_mps3=max_abs_bridge_jerk,
+        lateral_accel_limit_mps2=max_lateral_accel_mps2,
+        speed_gap_limit_mps=max_bridge_speed_gap_mps,
+        jerk_limit_mps3=max_bridge_jerk_mps3,
+        lateral_accel_passes=lateral_accel_passes,
+        speed_gap_passes=speed_gap_passes,
+        jerk_passes=jerk_passes,
+        passes=lateral_accel_passes and speed_gap_passes and jerk_passes,
+    )
+
+
+def assemble_augmented_sample_from_segments_torch(
+    context: BidirectionalAugmentationContextTorch,
+    ego_current_state: torch.Tensor,
+    past_result: SegmentAugmentationResultTorch,
+    future_result: SegmentAugmentationResultTorch,
+    past_connect_time_s: float,
+    future_recover_time_s: float,
+    wheel_base: float,
+) -> AugmentedSampleTorchResult:
+    dt = TIME_INTERVAL
+    dtype = ego_current_state.dtype
+    device = ego_current_state.device
+
+    aug_past_xy = torch.flip(past_result.query_xy, dims=[0])
+    full_xy = torch.cat([aug_past_xy[:-1], future_result.query_xy], dim=0)
+    full_heading = heading_from_positions_torch(
+        full_xy,
+        fallback_heading=context.original_full_heading,
+    )
+
+    aug_past_heading = full_heading[: context.past_len]
+    aug_future_heading = full_heading[context.past_len :]
+
+    aug_past_4d = torch.stack(
+        [
+            aug_past_xy[:, 0],
+            aug_past_xy[:, 1],
+            torch.cos(aug_past_heading),
+            torch.sin(aug_past_heading),
+        ],
+        dim=-1,
+    )
+    aug_future_3d = torch.stack(
+        [full_xy[context.past_len :, 0], full_xy[context.past_len :, 1], aug_future_heading],
+        dim=-1,
+    )
+
+    current_index = context.current_index
+    if current_index == 0:
+        velocity = (full_xy[1] - full_xy[0]) / dt
+        acceleration = torch.zeros(2, dtype=dtype, device=device)
+        yaw_rate = normalize_angle_torch(full_heading[1] - full_heading[0]) / dt
+    elif current_index == full_xy.shape[0] - 1:
+        velocity = (full_xy[-1] - full_xy[-2]) / dt
+        acceleration = torch.zeros(2, dtype=dtype, device=device)
+        yaw_rate = normalize_angle_torch(full_heading[-1] - full_heading[-2]) / dt
+    else:
+        velocity = (full_xy[current_index + 1] - full_xy[current_index - 1]) / (2.0 * dt)
+        acceleration = (
+            full_xy[current_index + 1]
+            - 2.0 * full_xy[current_index]
+            + full_xy[current_index - 1]
+        ) / (dt**2)
+        yaw_rate = normalize_angle_torch(
+            full_heading[current_index + 1] - full_heading[current_index - 1]
+        ) / (2.0 * dt)
+
+    speed = torch.linalg.norm(velocity)
+    steering_angle = torch.tensor(0.0, dtype=dtype, device=device)
+    if speed >= 0.2:
+        steering_angle = torch.atan(yaw_rate * wheel_base / torch.abs(speed))
+        steering_angle = torch.clamp(steering_angle, -2.0 / 3.0 * np.pi, 2.0 / 3.0 * np.pi)
+    else:
+        yaw_rate = torch.tensor(0.0, dtype=dtype, device=device)
+
+    aug_current_state = ego_current_state.clone()
+    aug_current_state[:2] = full_xy[current_index]
+    aug_current_state[2] = torch.cos(full_heading[current_index])
+    aug_current_state[3] = torch.sin(full_heading[current_index])
+    aug_current_state[4:6] = velocity
+    aug_current_state[6:8] = acceleration
+    aug_current_state[8] = steering_angle
+    aug_current_state[9] = yaw_rate
+
+    return AugmentedSampleTorchResult(
+        aug_current_state=aug_current_state,
+        aug_past=aug_past_4d,
+        aug_future=aug_future_3d,
+        original_full_xy=context.original_full_xy,
+        augmented_full_xy=full_xy,
+        original_full_heading=context.original_full_heading,
+        augmented_full_heading=full_heading,
+        full_time=context.full_time,
+        past_segment=past_result,
+        future_segment=future_result,
+        past_connect_time_s=past_connect_time_s,
+        future_recover_time_s=future_recover_time_s,
+    )
 
 
 class StatePerturbation:
@@ -672,135 +1088,40 @@ class StatePerturbation:
         Rebuild ego past/current/future around a laterally perturbed current state while keeping
         the longitudinal progress aligned with the GT progress-time relation after merge.
         """
-        dt = self.time_interval
-        dtype = ego_past.dtype
-        device = ego_past.device
-
-        past_len = ego_past.shape[0]
-        future_len = ego_future.shape[0]
-
-        past_xy = ego_past[:, :2].clone()
-        past_heading = torch.atan2(ego_past[:, 3], ego_past[:, 2]).clone()
-        current_xy = ego_current_state[:2].clone()
-        current_heading = self._state_to_heading(ego_current_state).clone()
-        future_xy = ego_future[:, :2].clone()
-        future_heading = ego_future[:, 2].clone()
-
-        past_xy[-1] = current_xy
-        past_heading[-1] = current_heading
-
-        future_segment_xy = torch.cat([current_xy.unsqueeze(0), future_xy], dim=0)
-        future_segment_heading = torch.cat([current_heading.unsqueeze(0), future_heading], dim=0)
-        future_time = torch.arange(
-            0.0, (future_len + 1) * dt, dt, dtype=dtype, device=device
+        context = prepare_bidirectional_context_torch(
+            ego_past=ego_past,
+            ego_current_state=ego_current_state,
+            ego_future=ego_future,
+            dense_sample_ds=self.dense_sample_ds,
         )
-
-        past_segment_xy = torch.flip(past_xy, dims=[0])
-        past_segment_heading = torch.flip(past_heading, dims=[0])
-        past_time = torch.arange(0.0, past_len * dt, dt, dtype=dtype, device=device)
-
-        future_result = augment_segment_torch(
-            future_segment_xy,
-            future_segment_heading,
-            future_time,
-            lateral_offset,
-            heading_offset,
-            min(future_recover_time_s, float(future_time[-1].item())),
-            self.dense_sample_ds,
+        clamped_future_recover_time_s = min(
+            future_recover_time_s,
+            float(context.future_segment.segment_time[-1].item()),
         )
-        past_result = augment_segment_torch(
-            past_segment_xy,
-            past_segment_heading,
-            past_time,
-            lateral_offset,
-            -heading_offset,
-            min(past_connect_time_s, float(past_time[-1].item())),
-            self.dense_sample_ds,
+        clamped_past_connect_time_s = min(
+            past_connect_time_s,
+            float(context.past_segment.segment_time[-1].item()),
         )
-
-        aug_past_xy = torch.flip(past_result.query_xy, dims=[0])
-        full_xy = torch.cat([aug_past_xy[:-1], future_result.query_xy], dim=0)
-
-        original_full_heading = torch.cat(
-            [past_heading[:-1], current_heading.unsqueeze(0), future_heading], dim=0
+        future_result = augment_segment_prepared_torch(
+            prepared=context.future_segment,
+            lateral_offset=lateral_offset,
+            heading_offset=heading_offset,
+            connect_time_s=clamped_future_recover_time_s,
         )
-        original_full_xy = torch.cat([past_xy[:-1], future_segment_xy], dim=0)
-        full_heading = heading_from_positions_torch(full_xy, fallback_heading=original_full_heading)
-
-        current_index = past_len - 1
-        aug_past_heading = full_heading[:past_len]
-        aug_future_heading = full_heading[past_len:]
-
-        aug_past_4d = torch.stack(
-            [
-                aug_past_xy[:, 0],
-                aug_past_xy[:, 1],
-                torch.cos(aug_past_heading),
-                torch.sin(aug_past_heading),
-            ],
-            dim=-1,
+        past_result = augment_segment_prepared_torch(
+            prepared=context.past_segment,
+            lateral_offset=lateral_offset,
+            heading_offset=-heading_offset,
+            connect_time_s=clamped_past_connect_time_s,
         )
-        aug_future_3d = torch.stack(
-            [full_xy[past_len:, 0], full_xy[past_len:, 1], aug_future_heading], dim=-1
-        )
-
-        if current_index == 0:
-            velocity = (full_xy[1] - full_xy[0]) / dt
-            acceleration = torch.zeros(2, dtype=dtype, device=device)
-            yaw_rate = normalize_angle_torch(full_heading[1] - full_heading[0]) / dt
-        elif current_index == full_xy.shape[0] - 1:
-            velocity = (full_xy[-1] - full_xy[-2]) / dt
-            acceleration = torch.zeros(2, dtype=dtype, device=device)
-            yaw_rate = normalize_angle_torch(full_heading[-1] - full_heading[-2]) / dt
-        else:
-            velocity = (full_xy[current_index + 1] - full_xy[current_index - 1]) / (2.0 * dt)
-            acceleration = (
-                full_xy[current_index + 1]
-                - 2.0 * full_xy[current_index]
-                + full_xy[current_index - 1]
-            ) / (dt**2)
-            yaw_rate = normalize_angle_torch(
-                full_heading[current_index + 1] - full_heading[current_index - 1]
-            ) / (2.0 * dt)
-
-        speed = torch.linalg.norm(velocity)
-        steering_angle = torch.tensor(0.0, dtype=dtype, device=device)
-        if speed >= 0.2:
-            steering_angle = torch.atan(yaw_rate * self._wheel_base / torch.abs(speed))
-            steering_angle = torch.clamp(steering_angle, -2.0 / 3.0 * np.pi, 2.0 / 3.0 * np.pi)
-        else:
-            yaw_rate = torch.tensor(0.0, dtype=dtype, device=device)
-
-        aug_current_state = ego_current_state.clone()
-        aug_current_state[:2] = full_xy[current_index]
-        aug_current_state[2] = torch.cos(full_heading[current_index])
-        aug_current_state[3] = torch.sin(full_heading[current_index])
-        aug_current_state[4:6] = velocity
-        aug_current_state[6:8] = acceleration
-        aug_current_state[8] = steering_angle
-        aug_current_state[9] = yaw_rate
-
-        full_time = torch.arange(
-            -(past_len - 1) * dt,
-            (future_len + 1) * dt,
-            dt,
-            dtype=dtype,
-            device=device,
-        )
-
-        return AugmentedSampleTorchResult(
-            aug_current_state=aug_current_state,
-            aug_past=aug_past_4d,
-            aug_future=aug_future_3d,
-            original_full_xy=original_full_xy,
-            augmented_full_xy=full_xy,
-            original_full_heading=original_full_heading,
-            augmented_full_heading=full_heading,
-            full_time=full_time,
-            past_segment=past_result,
-            future_segment=future_result,
-            past_connect_time_s=past_connect_time_s,
-            future_recover_time_s=future_recover_time_s,
+        return assemble_augmented_sample_from_segments_torch(
+            context=context,
+            ego_current_state=ego_current_state,
+            past_result=past_result,
+            future_result=future_result,
+            past_connect_time_s=clamped_past_connect_time_s,
+            future_recover_time_s=clamped_future_recover_time_s,
+            wheel_base=self._wheel_base,
         )
 
     def _evaluate_constraints(
@@ -863,30 +1184,81 @@ class StatePerturbation:
         initial_past_connect_time_s: float,
         initial_future_recover_time_s: float,
     ) -> AugmentedSampleTorchResult:
-        def build_candidate(
+        context = prepare_bidirectional_context_torch(
+            ego_past=ego_past,
+            ego_current_state=ego_current_state,
+            ego_future=ego_future,
+            dense_sample_ds=self.dense_sample_ds,
+        )
+        max_future_recover_time_s = float(context.future_segment.segment_time[-1].item())
+        max_past_connect_time_s = float(context.past_segment.segment_time[-1].item())
+        initial_future_recover_time_s = min(initial_future_recover_time_s, max_future_recover_time_s)
+        initial_past_connect_time_s = min(initial_past_connect_time_s, max_past_connect_time_s)
+
+        future_segment_cache: dict[float, SegmentAugmentationResultTorch] = {}
+        past_segment_cache: dict[float, SegmentAugmentationResultTorch] = {}
+        candidate_cache: dict[tuple[float, float], ConstraintDiagnosticsTorch] = {}
+
+        def get_future_segment(recover_time_s: float) -> SegmentAugmentationResultTorch:
+            key = round(recover_time_s, 6)
+            cached = future_segment_cache.get(key)
+            if cached is None:
+                cached = augment_segment_prepared_torch(
+                    prepared=context.future_segment,
+                    lateral_offset=lateral_offset,
+                    heading_offset=heading_offset,
+                    connect_time_s=recover_time_s,
+                )
+                future_segment_cache[key] = cached
+            return cached
+
+        def get_past_segment(connect_time_s: float) -> SegmentAugmentationResultTorch:
+            key = round(connect_time_s, 6)
+            cached = past_segment_cache.get(key)
+            if cached is None:
+                cached = augment_segment_prepared_torch(
+                    prepared=context.past_segment,
+                    lateral_offset=lateral_offset,
+                    heading_offset=-heading_offset,
+                    connect_time_s=connect_time_s,
+                )
+                past_segment_cache[key] = cached
+            return cached
+
+        def evaluate_candidate(
             past_connect_time_s: float,
             future_recover_time_s: float,
-        ) -> AugmentedSampleTorchResult:
-            return self._build_augmented_sample(
-                ego_past=ego_past,
-                ego_current_state=ego_current_state,
-                ego_future=ego_future,
-                lateral_offset=lateral_offset,
-                heading_offset=heading_offset,
-                past_connect_time_s=past_connect_time_s,
-                future_recover_time_s=future_recover_time_s,
-            )
+        ) -> tuple[SegmentAugmentationResultTorch, SegmentAugmentationResultTorch, ConstraintDiagnosticsTorch]:
+            future_result = get_future_segment(future_recover_time_s)
+            past_result = get_past_segment(past_connect_time_s)
+            key = (round(past_connect_time_s, 6), round(future_recover_time_s, 6))
+            diag = candidate_cache.get(key)
+            if diag is None:
+                diag = evaluate_constraints_from_segments_torch(
+                    context=context,
+                    past_result=past_result,
+                    future_result=future_result,
+                    max_lateral_accel_mps2=self._max_lateral_accel_mps2,
+                    max_bridge_speed_gap_mps=self._max_bridge_speed_gap_mps,
+                    max_bridge_jerk_mps3=self._max_bridge_jerk_mps3,
+                )
+                candidate_cache[key] = diag
+            return past_result, future_result, diag
 
-        initial_result = build_candidate(
+        initial_past_result, initial_future_result, initial_diag = evaluate_candidate(
             past_connect_time_s=initial_past_connect_time_s,
             future_recover_time_s=initial_future_recover_time_s,
         )
-        initial_diag = self._evaluate_constraints(initial_result)
         if not self._adaptive_bridge_search or initial_diag.passes:
-            return initial_result
-
-        max_future_recover_time_s = float(ego_future.shape[0] * self.time_interval)
-        max_past_connect_time_s = float((ego_past.shape[0] - 1) * self.time_interval)
+            return assemble_augmented_sample_from_segments_torch(
+                context=context,
+                ego_current_state=ego_current_state,
+                past_result=initial_past_result,
+                future_result=initial_future_result,
+                past_connect_time_s=initial_past_connect_time_s,
+                future_recover_time_s=initial_future_recover_time_s,
+                wheel_base=self._wheel_base,
+            )
 
         future_candidates = generate_time_candidates(
             start_s=initial_future_recover_time_s + self.time_interval,
@@ -894,12 +1266,20 @@ class StatePerturbation:
             step_s=self.time_interval,
         )
         for candidate_n in future_candidates:
-            candidate_result = build_candidate(
+            past_result, future_result, diag = evaluate_candidate(
                 past_connect_time_s=initial_past_connect_time_s,
                 future_recover_time_s=candidate_n,
             )
-            if self._evaluate_constraints(candidate_result).passes:
-                return candidate_result
+            if diag.passes:
+                return assemble_augmented_sample_from_segments_torch(
+                    context=context,
+                    ego_current_state=ego_current_state,
+                    past_result=past_result,
+                    future_result=future_result,
+                    past_connect_time_s=initial_past_connect_time_s,
+                    future_recover_time_s=candidate_n,
+                    wheel_base=self._wheel_base,
+                )
 
         past_candidates = generate_time_candidates(
             start_s=initial_past_connect_time_s + self.time_interval,
@@ -913,14 +1293,30 @@ class StatePerturbation:
         )
         for candidate_m in past_candidates:
             for candidate_n in future_with_past_candidates:
-                candidate_result = build_candidate(
+                past_result, future_result, diag = evaluate_candidate(
                     past_connect_time_s=candidate_m,
                     future_recover_time_s=candidate_n,
                 )
-                if self._evaluate_constraints(candidate_result).passes:
-                    return candidate_result
+                if diag.passes:
+                    return assemble_augmented_sample_from_segments_torch(
+                        context=context,
+                        ego_current_state=ego_current_state,
+                        past_result=past_result,
+                        future_result=future_result,
+                        past_connect_time_s=candidate_m,
+                        future_recover_time_s=candidate_n,
+                        wheel_base=self._wheel_base,
+                    )
 
-        return initial_result
+        return assemble_augmented_sample_from_segments_torch(
+            context=context,
+            ego_current_state=ego_current_state,
+            past_result=initial_past_result,
+            future_result=initial_future_result,
+            past_connect_time_s=initial_past_connect_time_s,
+            future_recover_time_s=initial_future_recover_time_s,
+            wheel_base=self._wheel_base,
+        )
 
     def augment(self, inputs, ego_future):
         ego_current_state = inputs["ego_current_state"].clone()

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -74,6 +74,36 @@ def get_args():
         help="maximum absolute heading perturbation in degrees for data augmentation",
         default=10.0,
     )
+    parser.add_argument(
+        "--augment_past_bridge_sec",
+        type=float,
+        default=1.0,
+        help="seed past bridge time M [s] for data augmentation",
+    )
+    parser.add_argument(
+        "--augment_future_bridge_sec",
+        type=float,
+        default=1.5,
+        help="seed future bridge time N [s] for data augmentation",
+    )
+    parser.add_argument(
+        "--augment_max_lateral_accel",
+        type=float,
+        default=3.0,
+        help="maximum allowed lateral acceleration [m/s^2] during adaptive bridge search",
+    )
+    parser.add_argument(
+        "--augment_max_bridge_speed_gap",
+        type=float,
+        default=0.5,
+        help="maximum allowed bridge speed gap |v_aug - v_gt| [m/s]",
+    )
+    parser.add_argument(
+        "--augment_max_bridge_jerk",
+        type=float,
+        default=5.0,
+        help="maximum allowed bridge longitudinal jerk [m/s^3]",
+    )
     parser.add_argument("--normalization_file_path", default="normalization.json", type=str)
     parser.add_argument("--num_workers", default=4, type=int)
     parser.add_argument("--pin-mem", action="store_true", help="Pin CPU memory in DataLoader")
@@ -199,7 +229,12 @@ def model_training(args):
         StatePerturbation(
             augment_prob=args.augment_prob,
             device=args.device,
+            past_bridge_sec=args.augment_past_bridge_sec,
+            future_bridge_sec=args.augment_future_bridge_sec,
             max_heading_offset_deg=args.augment_heading_offset_deg,
+            max_lateral_accel_mps2=args.augment_max_lateral_accel,
+            max_bridge_speed_gap_mps=args.augment_max_bridge_speed_gap,
+            max_bridge_jerk_mps3=args.augment_max_bridge_jerk,
         )
         if args.use_data_augment
         else None

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -72,7 +72,7 @@ def get_args():
         "--augment_heading_offset_deg",
         type=float,
         help="maximum absolute heading perturbation in degrees for data augmentation",
-        default=15.0,
+        default=10.0,
     )
     parser.add_argument("--normalization_file_path", default="normalization.json", type=str)
     parser.add_argument("--num_workers", default=4, type=int)

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -68,6 +68,12 @@ def get_args():
     # DataLoader parameters
     parser.add_argument("--use_data_augment", default=True, type=boolean)
     parser.add_argument("--augment_prob", type=float, help="augmentation probability", default=0.5)
+    parser.add_argument(
+        "--augment_heading_offset_deg",
+        type=float,
+        help="maximum absolute heading perturbation in degrees for data augmentation",
+        default=15.0,
+    )
     parser.add_argument("--normalization_file_path", default="normalization.json", type=str)
     parser.add_argument("--num_workers", default=4, type=int)
     parser.add_argument("--pin-mem", action="store_true", help="Pin CPU memory in DataLoader")
@@ -190,7 +196,11 @@ def model_training(args):
 
     # set up data loaders
     aug = (
-        StatePerturbation(augment_prob=args.augment_prob, device=args.device)
+        StatePerturbation(
+            augment_prob=args.augment_prob,
+            device=args.device,
+            max_heading_offset_deg=args.augment_heading_offset_deg,
+        )
         if args.use_data_augment
         else None
     )


### PR DESCRIPTION
## Summary
- replace the original current-state-only perturbation with a speed-feasible ego augmentation that rebuilds ego current, ego past, and ego future together
- generate bidirectional bridge trajectories in ego-centric coordinates so the perturbed state reconnects to the GT past/future without requiring overspeed
- transform `ego_agent_past` consistently together with the updated current/future trajectories to remove continuity issues at the current pose
- add heading perturbation support on top of lateral offset augmentation by encoding the initial heading error as a boundary condition of the bridge path
- set the default maximum heading perturbation to `10 deg` and expose it through `--augment_heading_offset_deg`

## Validation
- `python3 -m compileall diffusion_planner/diffusion_planner/utils/data_augmentation.py diffusion_planner/train_predictor.py`
- synthetic smoke tests for straight and angled trajectories through `StatePerturbation.__call__`
- synthetic straight-trajectory checks confirmed that a `+10 deg` heading perturbation is reflected in the rebuilt ego current state

## TODO
- This repo currently fixes the input/output horizons at `INPUT_T=30` and `OUTPUT_T=80` in `dimensions.py:39`, so the standalone design with extra full-GT context (`-5s/+10s`) and a narrower training window (`-3s/+8s`) is not available in the current data I/F yet.
