### PR TITLE
feat: map evaluation update point id checking and improve codes

### DIFF
--- a/cpp_tools/src/autoware_diffusion_planner_tools/scripts/map_eval/README.md
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/scripts/map_eval/README.md
@@ -31,19 +31,16 @@ For a polyline pair A and B:
 
 ### Lane segments
 
-- centerline and boundary symmetric Chamfer-like and Hausdorff-like metrics
-- heading difference (deg)
+- centerline and boundary symmetric Hausdorff-like metrics
 - pass rate for `centerline_symmetric_hausdorff_like < 0.2 m` (key metric)
 
 ### Polygons (`intersection_area`)
 
 - symmetric Hausdorff-like distance
-- symmetric Chamfer-like distance
 
 ### Line strings (`stop_line`)
 
 - symmetric Hausdorff-like distance (main error)
-- symmetric Chamfer-like distance
 - orientation error (deg)
 
 ## Outputs

--- a/cpp_tools/src/autoware_diffusion_planner_tools/scripts/map_eval/README.md
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/scripts/map_eval/README.md
@@ -51,11 +51,14 @@ For a polyline pair A and B:
 `compare_map.py` writes:
 
 - `metrics_summary.json`
-- `metrics_summary.csv`
-- `entity_metrics.csv`
-- `overlay_and_error_plots.png`
 - `interactive_overlay.html` (Leaflet-based dashboard with layer tabs; always generated as the primary output)
-- `worst_cases/` per-entity debug JSON for top-K worst lanes, line strings, and polygons (by symmetric Hausdorff)
+
+Notes:
+- `output_prefix` is supported for both output files
+  (for example, `foo_metrics_summary.json`, `foo_interactive_overlay.html`).
+- The current `evaluate_core()` path always renders HTML and does not emit
+  `metrics_summary.csv`, `entity_metrics.csv`, `overlay_and_error_plots.png`,
+  or `worst_cases/`.
 
 ## Usage
 
@@ -75,6 +78,20 @@ python3 src/autoware_diffusion_planner_tools/scripts/map_eval/compare_map.py eva
   --reference_map /tmp/reference.json \
   --out_dir /tmp/map_eval \
 ```
+
+### Common options
+
+- `--max_match_distance`: maximum geometry-match cost for lines/polygons
+- `--top_k_debug`: reserved for debug ranking in metrics payload
+- `--output_prefix`: prefix for output filenames
+- `--lane_threshold`, `--line_threshold`, `--poly_threshold`: heatmap color
+  saturation thresholds in the interactive dashboard
+- `--web`: open generated HTML in browser after completion
+
+### `export-eval` specific options
+
+- `--internal_json_out`, `--reference_json_out`: override export JSON paths
+- `--skip_export`: skip `ros2 run ... map_exporter` and evaluate existing JSONs
 
 ### Run exporter directly (ROS parameter style)
 

--- a/cpp_tools/src/autoware_diffusion_planner_tools/scripts/map_eval/README.md
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/scripts/map_eval/README.md
@@ -54,7 +54,7 @@ For a polyline pair A and B:
 - `metrics_summary.csv`
 - `entity_metrics.csv`
 - `overlay_and_error_plots.png`
-- `interactive_overlay.html` (Leaflet-based dashboard with layer tabs; Key output for visualizing the results)
+- `interactive_overlay.html` (Leaflet-based dashboard with layer tabs; always generated as the primary output)
 - `worst_cases/` per-entity debug JSON for top-K worst lanes, line strings, and polygons (by symmetric Hausdorff)
 
 ## Usage

--- a/cpp_tools/src/autoware_diffusion_planner_tools/scripts/map_eval/compare_map.py
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/scripts/map_eval/compare_map.py
@@ -1,4 +1,52 @@
 #!/usr/bin/env python3
+"""Map preprocessing evaluator for Diffusion Planner.
+
+This module provides two entry paths:
+
+- `eval-only`: evaluate existing `internal_map.json` and `reference.json`
+- `export-eval`: run `map_exporter` first, then evaluate the exported JSON
+
+High-level call flow:
+
+    main
+      -> parse_args
+      -> (optional) run_export_stage
+      -> evaluate_core
+           -> compare_lane_segments
+           -> compare_line_strings
+           -> compare_polygons
+           -> build_error_maps
+           -> compute_point_errors
+           -> render_html_dashboard
+
+Design notes:
+- Matching is split by entity type: lanes are ID-matched; lines/polygons are
+  geometry-matched with start/end gating and chamfer-like ranking.
+- Metric computation is independent from rendering.
+- HTML rendering consumes precomputed metrics and point-error payloads.
+
+JSON format notes (from `map_exporter.cpp`):
+- Both map JSON files share top-level keys:
+  - `lane_segments`: list
+  - `line_strings`: list
+  - `polygons`: list
+  - `meta`: object (source path and export metadata)
+- Internal map (`internal_map.json`) lane segment format:
+  - `id`: lane ID
+  - `centerline` / `left_boundary` / `right_boundary`: each is a polyline
+    represented as `[[x, y, z], ...]`
+- Reference map (`reference.json`) lane segment format:
+  - `id`: original Lanelet2 lanelet ID
+  - `centerline` / `left_boundary` / `right_boundary`: each is a list of
+    point records with IDs:
+    `[{"id": point_id, "points": [x, y, z]}, ...]`
+- For `line_strings` and `polygons`, both internal and reference exports use:
+  - `{"points": [[x, y, z], ...]}`
+- Practical implication for this evaluator:
+  - lane boundaries use different representations between internal/reference,
+    so lane comparisons use dedicated converters (`points3_to_np` vs
+    `points3_id_to_np`), while line/polygon comparisons use plain point arrays.
+"""
 
 import argparse
 import csv
@@ -8,7 +56,9 @@ from pathlib import Path
 import subprocess
 import webbrowser
 from typing import Dict
+from typing import Any
 from typing import List
+from typing import Mapping
 from typing import Optional
 from typing import Tuple
 
@@ -32,7 +82,19 @@ class ErrorMaps:
     poly: Dict[int, float]
 
 
-def _safe_split_match(r: Dict) -> Optional[Tuple[int, int]]:
+JsonMap = Dict[str, Any]
+MetricRow = Dict[str, Any]
+InternalMap = JsonMap
+ReferenceMap = JsonMap
+LaneMetricRow = MetricRow
+LineMetricRow = MetricRow
+PolyMetricRow = MetricRow
+PointErrorRecord = Dict[str, Any]
+LanePointErrors = Dict[int, Dict[str, List[PointErrorRecord]]]
+LinePointErrors = Dict[int, List[PointErrorRecord]]
+
+
+def _safe_split_match(r: Mapping[str, Any]) -> Optional[Tuple[int, int]]:
     """Safely parse match_index field, returning tuple or None on failure."""
     parts = r.get("match_index", "").split(":")
     if len(parts) != 2:
@@ -44,11 +106,16 @@ def _safe_split_match(r: Dict) -> Optional[Tuple[int, int]]:
 
 
 def build_error_maps(
-    lane_rows: List[Dict],
-    line_rows: List[Dict],
-    poly_rows: List[Dict],
+    lane_rows: List[LaneMetricRow],
+    line_rows: List[LineMetricRow],
+    poly_rows: List[PolyMetricRow],
 ) -> ErrorMaps:
-    """Build error maps from comparison rows for efficient lookup."""
+    """Build per-entity Hausdorff lookup maps from comparison rows.
+
+    The returned maps are used by both static and interactive visualizations.
+    Lane entries are keyed by semantic lane ID, while line/polygon entries are
+    keyed by internal list index extracted from `match_index`.
+    """
     return ErrorMaps(
         lane={int(r["entity_id"]): max(float(r["center_sym_hausdorff_like"]), 
                                        float(r["left_sym_hausdorff_like"]),
@@ -87,12 +154,12 @@ def build_worst_k(
     return sorted(combined, key=lambda x: x["sym_hausdorff_like"], reverse=True)[:k]
 
 
-def load_json(path: Path) -> Dict:
+def load_json(path: Path) -> JsonMap:
     with path.open("r", encoding="utf-8") as f:
         return json.load(f)
 
 
-def points3_to_np(points: List[List[float]]) -> np.ndarray:
+def points3_to_np(points: Any) -> np.ndarray:
     if not points:
         return np.zeros((0, 3), dtype=np.float64)
     return np.asarray(points, dtype=np.float64)
@@ -210,9 +277,9 @@ def _points_to_error_dicts(
     valid_mask = np.isfinite(pts_array[:, 2])
     valid_points = pts_array[valid_mask]
     point_ids_valid = point_ids[valid_mask] if point_ids is not None and len(point_ids) == len(pts) else None
-    out = []
+    out: List[PointErrorRecord] = []
     for idx, p in enumerate(valid_points):
-        item = {
+        item: PointErrorRecord = {
             "lat": float(p[0]),
             "lng": float(p[1]),
             "error": float(p[2]),
@@ -226,9 +293,9 @@ def _points_to_error_dicts(
 
 
 def _compute_point_errors_for_indexed_entities(
-    internal_list: List[Dict],
-    reference_list: List[Dict],
-    rows: List[Dict],
+    internal_list: List[MetricRow],
+    reference_list: List[MetricRow],
+    rows: List[MetricRow],
     points_key: str = "points",
 ) -> Dict:
     """Generic helper to compute point errors for index-matched entities (lines/polygons).
@@ -270,31 +337,28 @@ def _compute_point_errors_for_indexed_entities(
 
 
 def compute_point_errors(
-    internal: Dict,
-    reference: Dict,
-    lane_rows: List[Dict],
-    line_rows: List[Dict],
-) -> Tuple[Dict, Dict]:
-    """Compute per-point error data for lane and line entity types.
+    internal: InternalMap,
+    reference: ReferenceMap,
+    lane_rows: List[LaneMetricRow],
+    line_rows: List[LineMetricRow],
+) -> Tuple[LanePointErrors, LinePointErrors]:
+    """Compute point-level residual payloads used by the HTML dashboard.
 
-    Uses existing match_index from lane_rows, line_rows to find matches.
+    Lanes are matched by semantic lane ID from `lane_rows["entity_id"]`.
+    Line strings are matched via `match_index` pairs from `line_rows`.
+    Polygons are intentionally excluded from point-marker visualization.
 
     Returns:
-        lane_point_errors: {
-            lane_id: {
-                "centerline": [...],
-                "left_boundary": [...],
-                "right_boundary": [...],
-            }
-        }
-        line_point_errors: {index: [{"lat": y, "lng": x, "error": float}, ...]}
+        Tuple of:
+        - lane point errors keyed by lane ID and boundary type
+        - line point errors keyed by internal line index
     """
     # Build dictionary lookups for O(1) access
     int_lanes_by_id = {int(x["id"]): x for x in internal["lane_segments"]}
     ref_lanes_by_id = {int(x["id"]): x for x in reference["lane_segments"]}
 
     # Lane point errors - only for matched lanes (using O(1) dictionary lookup)
-    lane_point_errors = {}
+    lane_point_errors: LanePointErrors = {}
     for row in lane_rows:
         lane_id = int(row["entity_id"])
         int_lane = int_lanes_by_id.get(lane_id)
@@ -333,7 +397,15 @@ def compute_point_errors(
     return lane_point_errors, line_point_errors
 
 
-def compare_lane_segments(internal: Dict, reference: Dict) -> Tuple[Dict, List[Dict]]:
+def compare_lane_segments(
+    internal: InternalMap, reference: ReferenceMap
+) -> Tuple[Dict[str, Any], List[LaneMetricRow]]:
+    """Compare lane segments by semantic lane ID.
+
+    For every shared lane ID, computes symmetric distance stats for centerline,
+    left boundary, and right boundary. Returns aggregate lane metrics and
+    per-entity rows used downstream by error-map and dashboard generation.
+    """
     int_by_id = {int(x["id"]): x for x in internal["lane_segments"]}
     ref_by_id = {int(x["id"]): x for x in reference["lane_segments"]}
     matched_ids = sorted(set(int_by_id.keys()) & set(ref_by_id.keys()))
@@ -447,8 +519,14 @@ def match_geometry_only(
 
 
 def compare_line_strings(
-    internal: Dict, reference: Dict, max_match_distance: float
-) -> Tuple[Dict, List[Dict]]:
+    internal: InternalMap, reference: ReferenceMap, max_match_distance: float
+) -> Tuple[Dict[str, Any], List[LineMetricRow]]:
+    """Compare line strings after geometry-based matching.
+
+    Matching uses `match_geometry_only` with start/end gating and a chamfer-like
+    matching score, then computes symmetric distance metrics for matched pairs.
+    Returns aggregate metrics and per-pair rows.
+    """
     in_lines = internal["line_strings"]
     ref_lines = reference["line_strings"]
     matches = match_geometry_only(
@@ -490,8 +568,13 @@ def compare_line_strings(
 
 
 def compare_polygons(
-    internal: Dict, reference: Dict, max_match_distance: float
-) -> Tuple[Dict, List[Dict]]:
+    internal: InternalMap, reference: ReferenceMap, max_match_distance: float
+) -> Tuple[Dict[str, Any], List[PolyMetricRow]]:
+    """Compare polygons after geometry-based matching.
+
+    Uses the same matching policy as line strings and returns aggregate metrics
+    plus per-pair rows for visualization/debug outputs.
+    """
     in_polys = internal["polygons"]
     ref_polys = reference["polygons"]
     matches = match_geometry_only(
@@ -537,7 +620,7 @@ def make_static_plots(
     line_rows: List[Dict],
     poly_rows: List[Dict],
     out_path: Path,
-    error_maps: ErrorMaps = None,
+    error_maps: Optional[ErrorMaps] = None,
 ) -> None:
     if error_maps is None:
         error_maps = build_error_maps(lane_rows, line_rows, poly_rows)
@@ -552,7 +635,7 @@ def make_static_plots(
     vmax_lane = max(float(np.max(lane_haus)), 1e-6) if lane_haus else 1.0
     vmax_line = max(float(np.max(line_haus)), 1e-6) if line_haus else 1.0
     vmax_poly = max(float(np.max(poly_haus)), 1e-6) if poly_haus else 1.0
-    cmap = plt.cm.viridis
+    cmap = matplotlib.cm.get_cmap("viridis")
     norm_lane = matplotlib.colors.Normalize(vmin=0.0, vmax=vmax_lane)
     norm_line = matplotlib.colors.Normalize(vmin=0.0, vmax=vmax_line)
     norm_poly = matplotlib.colors.Normalize(vmin=0.0, vmax=vmax_poly)
@@ -680,17 +763,25 @@ def _close_ring(coords: List[List[float]]) -> List[List[float]]:
 
 
 def render_html_dashboard(
-    internal: Dict,
-    reference: Dict,
-    lane_rows: List[Dict],
-    line_rows: List[Dict],
-    poly_rows: List[Dict],
+    internal: InternalMap,
+    reference: ReferenceMap,
+    lane_rows: List[LaneMetricRow],
+    line_rows: List[LineMetricRow],
+    poly_rows: List[PolyMetricRow],
+    lane_point_errors: LanePointErrors,
+    line_point_errors: LinePointErrors,
     out_path: Path,
     lane_threshold: float = 0.2,
     line_threshold: float = 0.2,
     poly_threshold: float = 1.0,
-    error_maps: ErrorMaps = None,
+    error_maps: Optional[ErrorMaps] = None,
 ) -> None:
+    """Render the interactive Leaflet dashboard HTML.
+
+    This function is render-focused: it consumes precomputed comparison rows,
+    error maps, and point-error payloads, then serializes map geometries and
+    metrics into the Jinja template context and writes one HTML file.
+    """
     if error_maps is None:
         error_maps = build_error_maps(lane_rows, line_rows, poly_rows)
 
@@ -732,11 +823,6 @@ def render_html_dashboard(
     vmax_line = max(float(np.max(line_haus)), 1e-6) if line_haus else 1.0
     vmax_poly = max(float(np.max(poly_haus)), 1e-6) if poly_haus else 1.0
 
-    # Compute point-level errors for high-error point markers (lanes and lines only, not polygons)
-    lane_point_errors, line_point_errors = compute_point_errors(
-        internal, reference, lane_rows, line_rows
-    )
-
     # Build reference maps for zoom functionality
     ref_lanes_by_id = {int(x["id"]): x for x in reference["lane_segments"]}
     # Build match index maps for lines and polygons with safe parsing
@@ -759,7 +845,7 @@ def render_html_dashboard(
         r_i = points3_to_np(lane["right_boundary"])
         lane_id = int(lane["id"])
         ref_lane = ref_lanes_by_id.get(lane_id)
-        ref_geometries = {
+        ref_geometries: Dict[str, List[List[float]]] = {
             "centerline": [],
             "left_boundary": [],
             "right_boundary": [],
@@ -794,7 +880,7 @@ def render_html_dashboard(
         s_i = points3_to_np(line_string["points"])
         if len(s_i):
             # Find matching reference line using match_index
-            ref_coords = []
+            ref_coords: List[List[float]] = []
             ref_idx = line_match_map.get(i)
             if ref_idx is not None and ref_idx < len(reference["line_strings"]):
                 ref_line = reference["line_strings"][ref_idx]
@@ -816,18 +902,18 @@ def render_html_dashboard(
         p_i = points3_to_np(polygon["points"])
         if len(p_i):
             # Find matching reference polygon using match_index
-            ref_coords = []
+            ref_poly_coords: List[List[List[float]]] = []
             ref_idx = poly_match_map.get(i)
             if ref_idx is not None and ref_idx < len(reference["polygons"]):
                 ref_poly = reference["polygons"][ref_idx]
                 p_ref = points3_to_np(ref_poly["points"])
                 if len(p_ref) > 0:
-                    ref_coords = [_close_ring(_pts_to_coords(p_ref))]
+                    ref_poly_coords = [_close_ring(_pts_to_coords(p_ref))]
             ring = _close_ring(_pts_to_coords(p_i))
             polys_int.append(
                 {
                     "coordinates": [ring] if ring else [],
-                    "ref_coordinates": ref_coords,
+                    "ref_coordinates": ref_poly_coords,
                     "index": i,
                     "hausdorff": poly_error_map.get(i, 0.0),
                 }
@@ -924,7 +1010,6 @@ def add_common_eval_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--out_dir", required=True, type=Path)
     parser.add_argument("--max_match_distance", type=float, default=5.0)
     parser.add_argument("--top_k_debug", type=int, default=20)
-    parser.add_argument("--skip_html", action="store_true")
     parser.add_argument("--output_prefix", type=str, default="")
     parser.add_argument(
         "--web",
@@ -981,6 +1066,12 @@ def resolve_output_path(out_dir: Path, output_prefix: str, filename: str) -> Pat
 def run_export_stage(
     map_path: Path, internal_out: Path, reference_out: Path, skip_export: bool
 ) -> None:
+    """Run the ROS2 map exporter stage unless `skip_export` is enabled.
+
+    Side effects:
+    - invokes `ros2 run autoware_diffusion_planner_tools map_exporter`
+    - writes internal/reference JSON to the requested paths
+    """
     if skip_export:
         return
     cmd = [
@@ -1007,13 +1098,21 @@ def evaluate_core(
     out_dir: Path,
     max_match_distance: float,
     top_k_debug: int,
-    skip_html: bool,
     output_prefix: str,
     open_web: bool = False,
     lane_threshold: float = 0.2,
     line_threshold: float = 0.2,
     poly_threshold: float = 1.0,
 ) -> None:
+    """Execute the core evaluation pipeline from JSON input to reports.
+
+    Flow:
+    1) load internal/reference maps
+    2) compute entity metrics and matching rows (lane/line/polygon)
+    3) build error maps + point-error payloads
+    4) write summary JSON and interactive HTML dashboard
+    5) optionally open HTML in browser
+    """
     out_dir.mkdir(parents=True, exist_ok=True)
     print("[2/3] Computing metrics...")
     internal = load_json(internal_map_path)
@@ -1027,6 +1126,9 @@ def evaluate_core(
     poly_metrics, poly_rows = compare_polygons(internal, reference, max_match_distance)
 
     error_maps = build_error_maps(lane_rows, line_rows, poly_rows)
+    lane_point_errors, line_point_errors = compute_point_errors(
+        internal, reference, lane_rows, line_rows
+    )
 
     worst_k_by_hausdorff = build_worst_k(lane_rows, line_rows, poly_rows, 20)
 
@@ -1066,8 +1168,6 @@ def evaluate_core(
     print("[3/3] Writing plots/reports...")
 
     metrics_json_path = resolve_output_path(out_dir, output_prefix, "metrics_summary.json")
-    summary_csv_path = resolve_output_path(out_dir, output_prefix, "metrics_summary.csv")
-    overlay_png_path = resolve_output_path(out_dir, output_prefix, "overlay_and_error_plots.png")
     html_path = resolve_output_path(out_dir, output_prefix, "interactive_overlay.html")
 
     with metrics_json_path.open("w", encoding="utf-8") as f:
@@ -1079,70 +1179,30 @@ def evaluate_core(
         "symmetric_hausdorff_like_m",
     )
 
-    with summary_csv_path.open("w", encoding="utf-8", newline="") as f:
-        writer = csv.writer(f)
-        writer.writerow(["entity", "metric", "count", "mean", "median", "p95", "max"])
-        for entity in ("lane_segments", "line_strings", "polygons"):
-            entity_metrics = metrics[entity]
-            seen = set()
-            ordered = []
-            for k in _HAUSDORFF_FIRST:
-                if k in entity_metrics and k not in seen:
-                    ordered.append((k, entity_metrics[k]))
-                    seen.add(k)
-            for metric_name, metric_value in entity_metrics.items():
-                if metric_name not in seen:
-                    ordered.append((metric_name, metric_value))
-                    seen.add(metric_name)
-            for metric_name, metric_value in ordered:
-                if isinstance(metric_value, dict) and {
-                    "count",
-                    "mean",
-                    "median",
-                    "p95",
-                    "max",
-                }.issubset(metric_value.keys()):
-                    writer.writerow(
-                        [
-                            entity,
-                            metric_name,
-                            metric_value["count"],
-                            metric_value["mean"],
-                            metric_value["median"],
-                            metric_value["p95"],
-                            metric_value["max"],
-                        ]
-                    )
-
-    write_entity_csv(out_dir, lane_rows, line_rows, poly_rows)
-    write_worst_case_debug(
-        internal, reference, lane_rows, line_rows, poly_rows, out_dir, top_k_debug
+    render_html_dashboard(
+        internal,
+        reference,
+        lane_rows,
+        line_rows,
+        poly_rows,
+        lane_point_errors,
+        line_point_errors,
+        html_path,
+        lane_threshold=lane_threshold,
+        line_threshold=line_threshold,
+        poly_threshold=poly_threshold,
+        error_maps=error_maps,
     )
-    make_static_plots(internal, reference, lane_rows, line_rows, poly_rows, overlay_png_path, error_maps)
-    if not skip_html:
-        render_html_dashboard(
-            internal,
-            reference,
-            lane_rows,
-            line_rows,
-            poly_rows,
-            html_path,
-            lane_threshold=lane_threshold,
-            line_threshold=line_threshold,
-            poly_threshold=poly_threshold,
-            error_maps=error_maps,
-        )
-        if open_web:
-            webbrowser.open(f"file://{html_path.resolve()}")
+    if open_web:
+        webbrowser.open(f"file://{html_path.resolve()}")
 
     print("Done.")
     print(f"- metrics: {metrics_json_path}")
-    print(f"- overlay: {overlay_png_path}")
-    if not skip_html:
-        print(f"- interactive: {html_path}")
+    print(f"- interactive: {html_path}")
 
 
 def main() -> None:
+    """CLI entry point for `eval-only` and `export-eval` workflows."""
     args = parse_args()
     if args.command == "eval-only":
         evaluate_core(
@@ -1151,7 +1211,6 @@ def main() -> None:
             out_dir=args.out_dir,
             max_match_distance=args.max_match_distance,
             top_k_debug=args.top_k_debug,
-            skip_html=args.skip_html,
             output_prefix=args.output_prefix,
             open_web=args.web,
             lane_threshold=args.lane_threshold,
@@ -1180,7 +1239,6 @@ def main() -> None:
         out_dir=out_dir,
         max_match_distance=args.max_match_distance,
         top_k_debug=args.top_k_debug,
-        skip_html=args.skip_html,
         output_prefix=args.output_prefix,
         open_web=args.web,
         lane_threshold=args.lane_threshold,

--- a/cpp_tools/src/autoware_diffusion_planner_tools/scripts/map_eval/compare_map.py
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/scripts/map_eval/compare_map.py
@@ -141,6 +141,13 @@ def summarize(values: List[float]) -> Dict:
 
 
 def angle_diff_deg(a: np.ndarray, b: np.ndarray) -> float:
+    """Calculate angle difference between two polylines in degrees.
+
+    Note: This function measures global start-to-end heading difference only.
+    It uses the vector from the first point to the last point of each polyline,
+    ignoring local path curvature. For example, an S-curve and a straight line
+    with the same start/end points will both yield 0° difference.
+    """
     if len(a) < 2 or len(b) < 2:
         return 0.0
     va = a[-1, :2] - a[0, :2]
@@ -225,14 +232,12 @@ def _compute_point_errors_for_indexed_entities(
         p_e = points3_to_np(reference_list[r_idx][points_key])
 
         if len(p_i) > 0 and len(p_e) > 0:
-            # Use symmetric distance for visual consistency with metrics
-            # Use Hausdorff-style: max(point-wise distance, max reverse distance)
-            # This handles cases where internal and reference have different point counts
+            # Use directed distance for point-level visualization
+            # This shows where internal points deviate from reference, avoiding
+            # scalar broadcast from max reverse distance inflating all errors
             d_ab = directed_polyline_distance_xy(p_i, p_e)
-            d_ba_max = float(np.max(directed_polyline_distance_xy(p_e, p_i)))
-            symmetric_errors = np.maximum(d_ab, d_ba_max)
 
-            errors[i_idx] = _points_to_error_dicts(p_i, symmetric_errors)
+            errors[i_idx] = _points_to_error_dicts(p_i, d_ab)
     return errors
 
 
@@ -267,14 +272,12 @@ def compute_point_errors(
         c_e = points3_to_np(ref_lane["centerline"])
 
         if len(c_i) > 0 and len(c_e) > 0:
-            # Use symmetric distance for visual consistency with metrics
-            # Use Hausdorff-style: max(point-wise distance, max reverse distance)
-            # This handles cases where internal and reference have different point counts
+            # Use directed distance for point-level visualization
+            # This shows where internal points deviate from reference, avoiding
+            # scalar broadcast from max reverse distance inflating all errors
             d_ab = directed_polyline_distance_xy(c_i, c_e)
-            d_ba_max = float(np.max(directed_polyline_distance_xy(c_e, c_i)))
-            symmetric_errors = np.maximum(d_ab, d_ba_max)
 
-            lane_point_errors[lane_id] = _points_to_error_dicts(c_i, symmetric_errors)
+            lane_point_errors[lane_id] = _points_to_error_dicts(c_i, d_ab)
 
     # Use helper function for lines only (polygons don't need point error visualization)
     line_point_errors = _compute_point_errors_for_indexed_entities(

--- a/cpp_tools/src/autoware_diffusion_planner_tools/scripts/map_eval/compare_map.py
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/scripts/map_eval/compare_map.py
@@ -2,12 +2,14 @@
 
 import argparse
 import csv
+import dataclasses
 import json
 from pathlib import Path
 import subprocess
 import webbrowser
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Tuple
 
 from jinja2 import Environment
@@ -15,6 +17,72 @@ from jinja2 import FileSystemLoader
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+
+
+@dataclasses.dataclass
+class ErrorMaps:
+    """Error maps for efficient lookup during visualization.
+
+    Note: Key types differ by entity type:
+    - lane: keyed by semantic lane ID (int) from the 'id' field in JSON
+    - line/poly: keyed by positional index (int) in the list, NOT by semantic ID
+    """
+    lane: Dict[int, float]
+    line: Dict[int, float]
+    poly: Dict[int, float]
+
+
+def _safe_split_match(r: Dict) -> Optional[Tuple[int, int]]:
+    """Safely parse match_index field, returning tuple or None on failure."""
+    parts = r.get("match_index", "").split(":")
+    if len(parts) != 2:
+        return None
+    try:
+        return int(parts[0]), int(parts[1])
+    except ValueError:
+        return None
+
+
+def build_error_maps(
+    lane_rows: List[Dict],
+    line_rows: List[Dict],
+    poly_rows: List[Dict],
+) -> ErrorMaps:
+    """Build error maps from comparison rows for efficient lookup."""
+    return ErrorMaps(
+        lane={int(r["entity_id"]): float(r["center_sym_hausdorff_like"]) for r in lane_rows},
+        line={
+            pair[0]: float(r["sym_hausdorff_like"])
+            for r in line_rows
+            if (pair := _safe_split_match(r)) is not None
+        },
+        poly={
+            pair[0]: float(r["sym_hausdorff_like"])
+            for r in poly_rows
+            if (pair := _safe_split_match(r)) is not None
+        },
+    )
+
+
+def build_worst_k(
+    lane_rows: List[Dict],
+    line_rows: List[Dict],
+    poly_rows: List[Dict],
+    k: int,
+) -> List[Dict]:
+    """Build combined worst-K entities list from all entity types."""
+    combined = (
+        [{"entity_type": "lane_segment", "entity_id": r["entity_id"],
+          "match_index": -1, "sym_hausdorff_like": r["center_sym_hausdorff_like"]}
+         for r in lane_rows]
+        + [{"entity_type": "line_string", "entity_id": -1,
+            "match_index": r["match_index"], "sym_hausdorff_like": r["sym_hausdorff_like"]}
+           for r in line_rows]
+        + [{"entity_type": "polygon", "entity_id": -1,
+            "match_index": r["match_index"], "sym_hausdorff_like": r["sym_hausdorff_like"]}
+           for r in poly_rows]
+    )
+    return sorted(combined, key=lambda x: x["sym_hausdorff_like"], reverse=True)[:k]
 
 
 def load_json(path: Path) -> Dict:
@@ -102,7 +170,124 @@ def symmetric_distance_stats(a: np.ndarray, b: np.ndarray) -> Dict:
     }
 
 
-def compare_lane_segments(internal: Dict, reference: Dict) -> Tuple[Dict, List[Dict], Dict]:
+def _points_to_error_dicts(pts: np.ndarray, errors: np.ndarray) -> List[Dict]:
+    """Convert points and errors to list of dicts for JSON serialization.
+
+    Args:
+        pts: Nx3 array with columns [lng, lat, ...]
+        errors: N-element array of error values
+
+    Returns:
+        List of dicts with lat, lng, error keys
+    """
+    if len(pts) == 0 or len(errors) == 0:
+        return []
+    if pts.shape[1] < 2:
+        return []
+    pts_array = np.column_stack([pts[:, 1], pts[:, 0], errors])
+    valid_mask = np.isfinite(pts_array[:, 2])
+    pts_list = pts_array[valid_mask].tolist()
+    return [{"lat": float(p[0]), "lng": float(p[1]), "error": float(p[2])} for p in pts_list]
+
+
+def _compute_point_errors_for_indexed_entities(
+    internal_list: List[Dict],
+    reference_list: List[Dict],
+    rows: List[Dict],
+    points_key: str = "points",
+) -> Dict:
+    """Generic helper to compute point errors for index-matched entities (lines/polygons).
+
+    Args:
+        internal_list: List of internal entities
+        reference_list: List of reference entities
+        rows: List of matching result rows with match_index field
+        points_key: Key to extract points from each entity (default: "points")
+
+    Returns:
+        Dictionary mapping internal index to list of point error dicts
+    """
+    errors = {}
+    for row in rows:
+        match_idx = row.get("match_index", "-1:-1")
+        parts = match_idx.split(":")
+        if len(parts) != 2:
+            continue
+        i_idx = int(parts[0])
+        r_idx = int(parts[1])
+
+        if i_idx < 0 or r_idx < 0:
+            continue
+        if i_idx >= len(internal_list) or r_idx >= len(reference_list):
+            continue
+
+        p_i = points3_to_np(internal_list[i_idx][points_key])
+        p_e = points3_to_np(reference_list[r_idx][points_key])
+
+        if len(p_i) > 0 and len(p_e) > 0:
+            # Use symmetric distance for visual consistency with metrics
+            # Use Hausdorff-style: max(point-wise distance, max reverse distance)
+            # This handles cases where internal and reference have different point counts
+            d_ab = directed_polyline_distance_xy(p_i, p_e)
+            d_ba_max = float(np.max(directed_polyline_distance_xy(p_e, p_i)))
+            symmetric_errors = np.maximum(d_ab, d_ba_max)
+
+            errors[i_idx] = _points_to_error_dicts(p_i, symmetric_errors)
+    return errors
+
+
+def compute_point_errors(
+    internal: Dict,
+    reference: Dict,
+    lane_rows: List[Dict],
+    line_rows: List[Dict],
+) -> Tuple[Dict, Dict]:
+    """Compute per-point error data for lane and line entity types.
+
+    Uses existing match_index from lane_rows, line_rows to find matches.
+
+    Returns:
+        lane_point_errors: {lane_id: [{"lat": y, "lng": x, "error": float}, ...]}
+        line_point_errors: {index: [{"lat": y, "lng": x, "error": float}, ...]}
+    """
+    # Build dictionary lookups for O(1) access
+    int_lanes_by_id = {int(x["id"]): x for x in internal["lane_segments"]}
+    ref_lanes_by_id = {int(x["id"]): x for x in reference["lane_segments"]}
+
+    # Lane point errors - only for matched lanes (using O(1) dictionary lookup)
+    lane_point_errors = {}
+    for row in lane_rows:
+        lane_id = int(row["entity_id"])
+        int_lane = int_lanes_by_id.get(lane_id)
+        ref_lane = ref_lanes_by_id.get(lane_id)
+        if int_lane is None or ref_lane is None:
+            continue
+
+        c_i = points3_to_np(int_lane["centerline"])
+        c_e = points3_to_np(ref_lane["centerline"])
+
+        if len(c_i) > 0 and len(c_e) > 0:
+            # Use symmetric distance for visual consistency with metrics
+            # Use Hausdorff-style: max(point-wise distance, max reverse distance)
+            # This handles cases where internal and reference have different point counts
+            d_ab = directed_polyline_distance_xy(c_i, c_e)
+            d_ba_max = float(np.max(directed_polyline_distance_xy(c_e, c_i)))
+            symmetric_errors = np.maximum(d_ab, d_ba_max)
+
+            lane_point_errors[lane_id] = _points_to_error_dicts(c_i, symmetric_errors)
+
+    # Use helper function for lines only (polygons don't need point error visualization)
+    line_point_errors = _compute_point_errors_for_indexed_entities(
+        internal["line_strings"],
+        reference["line_strings"],
+        line_rows,
+        "points"
+    )
+
+    return lane_point_errors, line_point_errors
+
+
+def compare_lane_segments(internal: Dict, reference: Dict) -> Tuple[Dict, List[Dict]]:
     int_by_id = {int(x["id"]): x for x in internal["lane_segments"]}
     ref_by_id = {int(x["id"]): x for x in reference["lane_segments"]}
     matched_ids = sorted(set(int_by_id.keys()) & set(ref_by_id.keys()))
@@ -146,10 +331,11 @@ def compare_lane_segments(internal: Dict, reference: Dict) -> Tuple[Dict, List[D
         )
 
     worst = sorted(entity_rows, key=lambda x: x["center_sym_hausdorff_like"], reverse=True)[:20]
+    haus_summary = summarize(center_haus)
     metrics = {
-        "key_metric_symmetric_hausdorff_like_m": summarize(center_haus),
+        "key_metric_symmetric_hausdorff_like_m": haus_summary,
         "centerline_symmetric_chamfer_like_m": summarize(center_sym),
-        "centerline_symmetric_hausdorff_like_m": summarize(center_haus),
+        "centerline_symmetric_hausdorff_like_m": haus_summary,
         "left_boundary_symmetric_chamfer_like_m": summarize(left_sym),
         "right_boundary_symmetric_chamfer_like_m": summarize(right_sym),
         "pass_rate": {
@@ -159,20 +345,32 @@ def compare_lane_segments(internal: Dict, reference: Dict) -> Tuple[Dict, List[D
         },
         "worst_k_centerline": worst,
     }
-    return metrics, entity_rows, {}
+    return metrics, entity_rows
 
 
 def match_geometry_only(
     int_items: List[Dict], ref_items: List[Dict], max_match_distance: float
-) -> Tuple[List[Tuple[int, int, float]], List[int], List[int]]:
-    if not int_items or not ref_items:
-        return [], list(range(len(int_items))), list(range(len(ref_items)))
+) -> List[Tuple[int, int, float]]:
+    # Preserve original indices while filtering empty-points items
+    int_indexed = [(i, item) for i, item in enumerate(int_items) if item.get("points")]
+    ref_indexed = [(j, ref) for j, ref in enumerate(ref_items) if ref.get("points")]
+    if not int_indexed or not ref_indexed:
+        return []
+
+    int_orig_idx, int_clean = zip(*int_indexed) if int_indexed else ([], [])
+    ref_orig_idx, ref_clean = zip(*ref_indexed) if ref_indexed else ([], [])
+
+    int_clean = list(int_clean)
+    ref_clean = list(ref_clean)
+    int_orig_idx = list(int_orig_idx)
+    ref_orig_idx = list(ref_orig_idx)
+
     used_ref = set()
     matches = []
-    first_points_int = np.array([item["points"][0][:2] for item in int_items])
-    first_points_ref = np.array([ref["points"][0][:2] for ref in ref_items])
-    last_points_int = np.array([item["points"][-1][:2] for item in int_items])
-    last_points_ref = np.array([ref["points"][-1][:2] for ref in ref_items])
+    first_points_int = np.array([item["points"][0][:2] for item in int_clean])
+    first_points_ref = np.array([ref["points"][0][:2] for ref in ref_clean])
+    last_points_int = np.array([item["points"][-1][:2] for item in int_clean])
+    last_points_ref = np.array([ref["points"][-1][:2] for ref in ref_clean])
     start_distances_matrix = np.linalg.norm(
         first_points_int[:, None] - first_points_ref[None, :], axis=2
     )
@@ -183,7 +381,7 @@ def match_geometry_only(
     end_distances_mask_matrix = end_distances_matrix < 0.3
     valid_mask_matrix = np.logical_and(
         start_distances_mask_matrix, end_distances_mask_matrix)
-    for i, item in enumerate(int_items):
+    for i, item in enumerate(int_clean):
         p_i = points3_to_np(item["points"])
         best_j = -1
         best_score = float("inf")
@@ -191,17 +389,16 @@ def match_geometry_only(
         for j in ref_indices:
             if j in used_ref:
                 continue
-            p_ref = points3_to_np(ref_items[j]["points"])
+            p_ref = points3_to_np(ref_clean[j]["points"])
             score = symmetric_distance_stats(p_i, p_ref)["symmetric_chamfer_like"]
             if score < best_score:
                 best_j = j
                 best_score = score
         if best_j >= 0 and best_score <= max_match_distance:
             used_ref.add(best_j)
-            matches.append((i, best_j, best_score))
-    unmatched_i = [i for i in range(len(int_items)) if i not in {m[0] for m in matches}]
-    unmatched_ref = [j for j in range(len(ref_items)) if j not in used_ref]
-    return matches, unmatched_i, unmatched_ref
+            # Return ORIGINAL indices, not filtered indices
+            matches.append((int_orig_idx[i], ref_orig_idx[best_j], best_score))
+    return matches
 
 
 def compare_line_strings(
@@ -209,7 +406,7 @@ def compare_line_strings(
 ) -> Tuple[Dict, List[Dict]]:
     in_lines = internal["line_strings"]
     ref_lines = reference["line_strings"]
-    matches, unmatched_i, unmatched_ref = match_geometry_only(
+    matches = match_geometry_only(
         in_lines, ref_lines, max_match_distance
     )
 
@@ -252,7 +449,7 @@ def compare_polygons(
 ) -> Tuple[Dict, List[Dict]]:
     in_polys = internal["polygons"]
     ref_polys = reference["polygons"]
-    matches, unmatched_i, unmatched_ref = match_geometry_only(
+    matches = match_geometry_only(
         in_polys, ref_polys, max_match_distance
     )
 
@@ -295,14 +492,14 @@ def make_static_plots(
     line_rows: List[Dict],
     poly_rows: List[Dict],
     out_path: Path,
+    error_maps: ErrorMaps = None,
 ) -> None:
-    lane_error_map = {int(r["entity_id"]): float(r["center_sym_hausdorff_like"]) for r in lane_rows}
-    line_error_map = {
-        int(r["match_index"].split(":")[0]): float(r["sym_hausdorff_like"]) for r in line_rows
-    }
-    poly_error_map = {
-        int(r["match_index"].split(":")[0]): float(r["sym_hausdorff_like"]) for r in poly_rows
-    }
+    if error_maps is None:
+        error_maps = build_error_maps(lane_rows, line_rows, poly_rows)
+
+    lane_error_map = error_maps.lane
+    line_error_map = error_maps.line
+    poly_error_map = error_maps.poly
 
     lane_haus = list(lane_error_map.values())
     line_haus = list(line_error_map.values())
@@ -407,7 +604,14 @@ def make_static_plots(
 def _pts_to_coords(pts: np.ndarray) -> List[List[float]]:
     if len(pts) == 0:
         return []
-    return [[float(x), float(y)] for x, y in pts[:, :2]]
+    return pts[:, :2].tolist()
+
+
+def _close_ring(coords: List[List[float]]) -> List[List[float]]:
+    """Ensure polygon ring is closed (first == last point)."""
+    if coords and coords[0] != coords[-1]:
+        return coords + [coords[0]]
+    return coords
 
 
 def render_html_dashboard(
@@ -420,72 +624,33 @@ def render_html_dashboard(
     lane_threshold: float = 0.2,
     line_threshold: float = 0.2,
     poly_threshold: float = 1.0,
+    error_maps: ErrorMaps = None,
 ) -> None:
-    if Environment is None:
-        return
-    lane_error_map = {int(r["entity_id"]): float(r["center_sym_hausdorff_like"]) for r in lane_rows}
-    line_error_map = {
-        int(r["match_index"].split(":")[0]): float(r["sym_hausdorff_like"]) for r in line_rows
-    }
-    poly_error_map = {
-        int(r["match_index"].split(":")[0]): float(r["sym_hausdorff_like"]) for r in poly_rows
-    }
+    if error_maps is None:
+        error_maps = build_error_maps(lane_rows, line_rows, poly_rows)
+
+    lane_error_map = error_maps.lane
+    line_error_map = error_maps.line
+    poly_error_map = error_maps.poly
 
     lanes_ref = []
     for lane in reference["lane_segments"]:
         c = points3_to_np(lane["centerline"])
         if len(c):
             lanes_ref.append({"coordinates": _pts_to_coords(c)})
-    lanes_int = []
-    for lane in internal["lane_segments"]:
-        c = points3_to_np(lane["centerline"])
-        if len(c):
-            lane_id = int(lane["id"])
-            lanes_int.append(
-                {
-                    "coordinates": _pts_to_coords(c),
-                    "id": lane_id,
-                    "hausdorff": lane_error_map.get(lane_id, 0.0),
-                }
-            )
     lines_ref = []
     for line_string in reference["line_strings"]:
         s = points3_to_np(line_string["points"])
         if len(s):
             lines_ref.append({"coordinates": _pts_to_coords(s)})
-    lines_int = []
-    for i, line_string in enumerate(internal["line_strings"]):
-        s = points3_to_np(line_string["points"])
-        if len(s):
-            lines_int.append(
-                {
-                    "coordinates": _pts_to_coords(s),
-                    "index": i,
-                    "hausdorff": line_error_map.get(i, 0.0),
-                }
-            )
     polys_ref = []
     for polygon in reference["polygons"]:
         poly = points3_to_np(polygon["points"])
         if len(poly):
-            ring = _pts_to_coords(poly)
-            if ring and (ring[0] != ring[-1]):
-                ring.append(ring[0])
+            ring = _close_ring(_pts_to_coords(poly))
             polys_ref.append({"coordinates": [ring] if ring else []})
-    polys_int = []
-    for i, polygon in enumerate(internal["polygons"]):
-        poly = points3_to_np(polygon["points"])
-        if len(poly):
-            ring = _pts_to_coords(poly)
-            if ring and (ring[0] != ring[-1]):
-                ring.append(ring[0])
-            polys_int.append(
-                {
-                    "coordinates": [ring] if ring else [],
-                    "index": i,
-                    "hausdorff": poly_error_map.get(i, 0.0),
-                }
-            )
+
+    # Point errors and lanes_int/lines_int/polys_int are computed below
 
     lane_haus = list(lane_error_map.values())
     line_haus = list(line_error_map.values())
@@ -493,11 +658,90 @@ def render_html_dashboard(
     vmax_lane = max(float(np.max(lane_haus)), 1e-6) if lane_haus else 1.0
     vmax_line = max(float(np.max(line_haus)), 1e-6) if line_haus else 1.0
     vmax_poly = max(float(np.max(poly_haus)), 1e-6) if poly_haus else 1.0
-    metrics_json = {
-        "lane": lane_error_map,
-        "line": {str(k): v for k, v in line_error_map.items()},
-        "poly": {str(k): v for k, v in poly_error_map.items()},
+
+    # Compute point-level errors for high-error point markers (lanes and lines only, not polygons)
+    lane_point_errors, line_point_errors = compute_point_errors(
+        internal, reference, lane_rows, line_rows
+    )
+
+    # Build reference maps for zoom functionality
+    ref_lanes_by_id = {int(x["id"]): x for x in reference["lane_segments"]}
+    # Build match index maps for lines and polygons with safe parsing
+    line_match_map = {
+        i: j for r in line_rows
+        if (pair := _safe_split_match(r)) is not None
+        for i, j in [pair]
     }
+    poly_match_map = {
+        i: j for r in poly_rows
+        if (pair := _safe_split_match(r)) is not None
+        for i, j in [pair]
+    }
+
+    # Update lanes_int to include reference coordinates for zoom
+    lanes_int = []
+    for lane in internal["lane_segments"]:
+        c_i = points3_to_np(lane["centerline"])
+        if len(c_i):
+            lane_id = int(lane["id"])
+            ref_lane = ref_lanes_by_id.get(lane_id)
+            ref_coords = []
+            if ref_lane:
+                c_ref = points3_to_np(ref_lane["centerline"])
+                ref_coords = _pts_to_coords(c_ref)
+            lanes_int.append(
+                {
+                    "coordinates": _pts_to_coords(c_i),
+                    "ref_coordinates": ref_coords,
+                    "id": lane_id,
+                    "hausdorff": lane_error_map.get(lane_id, 0.0),
+                }
+            )
+
+    # Update lines_int to include reference coordinates for zoom
+    lines_int = []
+    for i, line_string in enumerate(internal["line_strings"]):
+        s_i = points3_to_np(line_string["points"])
+        if len(s_i):
+            # Find matching reference line using match_index
+            ref_coords = []
+            ref_idx = line_match_map.get(i)
+            if ref_idx is not None and ref_idx < len(reference["line_strings"]):
+                ref_line = reference["line_strings"][ref_idx]
+                s_ref = points3_to_np(ref_line["points"])
+                if len(s_ref) > 0:
+                    ref_coords = _pts_to_coords(s_ref)
+            lines_int.append(
+                {
+                    "coordinates": _pts_to_coords(s_i),
+                    "ref_coordinates": ref_coords,
+                    "index": i,
+                    "hausdorff": line_error_map.get(i, 0.0),
+                }
+            )
+
+    # Update polys_int to include reference coordinates for zoom
+    polys_int = []
+    for i, polygon in enumerate(internal["polygons"]):
+        p_i = points3_to_np(polygon["points"])
+        if len(p_i):
+            # Find matching reference polygon using match_index
+            ref_coords = []
+            ref_idx = poly_match_map.get(i)
+            if ref_idx is not None and ref_idx < len(reference["polygons"]):
+                ref_poly = reference["polygons"][ref_idx]
+                p_ref = points3_to_np(ref_poly["points"])
+                if len(p_ref) > 0:
+                    ref_coords = [_close_ring(_pts_to_coords(p_ref))]
+            ring = _close_ring(_pts_to_coords(p_i))
+            polys_int.append(
+                {
+                    "coordinates": [ring] if ring else [],
+                    "ref_coordinates": ref_coords,
+                    "index": i,
+                    "hausdorff": poly_error_map.get(i, 0.0),
+                }
+            )
 
     template_dir = Path(__file__).resolve().parent / "templates"
     env = Environment(loader=FileSystemLoader(str(template_dir)))
@@ -509,13 +753,14 @@ def render_html_dashboard(
         lines_int=lines_int,
         polys_ref=polys_ref,
         polys_int=polys_int,
-        vmax_lane=lane_threshold,
-        vmax_line=line_threshold,
-        vmax_poly=poly_threshold,
+        vmax_lane=vmax_lane,
+        vmax_line=vmax_line,
+        vmax_poly=vmax_poly,
         threshold_lane=lane_threshold,
         threshold_line=line_threshold,
         threshold_poly=poly_threshold,
-        metrics_json=metrics_json,
+        lane_point_errors=lane_point_errors,
+        line_point_errors=line_point_errors,
     )
     out_path.write_text(html, encoding="utf-8")
 
@@ -526,7 +771,7 @@ def write_entity_csv(
     rows = lane_rows + line_rows + poly_rows
     keys = sorted(set().union(*[r.keys() for r in rows])) if rows else []
     with (out_dir / "entity_metrics.csv").open("w", encoding="utf-8", newline="") as f:
-        writer = csv.DictWriter(f, fieldnames=keys)
+        writer = csv.DictWriter(f, fieldnames=keys, restval='')
         writer.writeheader()
         for r in rows:
             writer.writerow(r)
@@ -544,26 +789,38 @@ def write_worst_case_debug(
     dbg_dir = out_dir / "worst_cases"
     dbg_dir.mkdir(exist_ok=True)
     ref_by_id = {int(x["id"]): x for x in reference["lane_segments"]}
+    int_by_id = {int(x["id"]): x for x in internal["lane_segments"]}
     worst_lanes = sorted(lane_rows, key=lambda x: x["center_sym_hausdorff_like"], reverse=True)[:k]
     for row in worst_lanes:
         lane_id = int(row["entity_id"])
-        i_lane = next((x for x in internal["lane_segments"] if int(x["id"]) == lane_id), None)
+        i_lane = int_by_id.get(lane_id)
         ref_lane = ref_by_id.get(lane_id)
         payload = {"metrics": row, "internal_lane": i_lane, "reference_lane": ref_lane}
         with (dbg_dir / f"lane_{lane_id}.json").open("w", encoding="utf-8") as f:
             json.dump(payload, f, indent=2)
     worst_lines = sorted(line_rows, key=lambda x: x["sym_hausdorff_like"], reverse=True)[:k]
     for idx, row in enumerate(worst_lines):
+        match_pair = _safe_split_match(row)
+        if match_pair is None:
+            continue
+        i_idx, r_idx = match_pair
+        if i_idx >= len(internal["line_strings"]) or r_idx >= len(reference["line_strings"]):
+            continue
         payload = {
             "metrics": row,
-            "internal_line": internal["line_strings"][int(row["match_index"].split(":")[0])],
-            "reference_line": reference["line_strings"][int(row["match_index"].split(":")[1])],
+            "internal_line": internal["line_strings"][i_idx],
+            "reference_line": reference["line_strings"][r_idx],
         }
         with (dbg_dir / f"line_string_{idx}.json").open("w", encoding="utf-8") as f:
             json.dump(payload, f, indent=2)
     worst_polys = sorted(poly_rows, key=lambda x: x["sym_hausdorff_like"], reverse=True)[:k]
     for idx, row in enumerate(worst_polys):
-        i_idx, r_idx = map(int, row["match_index"].split(":"))
+        match_pair = _safe_split_match(row)
+        if match_pair is None:
+            continue
+        i_idx, r_idx = match_pair
+        if i_idx >= len(internal["polygons"]) or r_idx >= len(reference["polygons"]):
+            continue
         payload = {
             "metrics": row,
             "internal_polygon": internal["polygons"][i_idx],
@@ -673,43 +930,15 @@ def evaluate_core(
     reference = load_json(reference_map_path)
 
     print("[2.0/3] Computing Lane metrics...")
-    lane_metrics, lane_rows, mismatch = compare_lane_segments(internal, reference)
+    lane_metrics, lane_rows = compare_lane_segments(internal, reference)
     print("[2.3/3] Computing Line String metrics...")
     line_metrics, line_rows = compare_line_strings(internal, reference, max_match_distance)
     print("[2.6/3] Computing Polygon metrics...")
     poly_metrics, poly_rows = compare_polygons(internal, reference, max_match_distance)
 
-    worst_k_by_hausdorff = []
-    for r in lane_rows:
-        worst_k_by_hausdorff.append(
-            {
-                "entity_type": "lane_segment",
-                "entity_id": r["entity_id"],
-                "match_index": -1,
-                "sym_hausdorff_like": r["center_sym_hausdorff_like"],
-            }
-        )
-    for r in line_rows:
-        worst_k_by_hausdorff.append(
-            {
-                "entity_type": "line_string",
-                "entity_id": -1,
-                "match_index": r["match_index"],
-                "sym_hausdorff_like": r["sym_hausdorff_like"],
-            }
-        )
-    for r in poly_rows:
-        worst_k_by_hausdorff.append(
-            {
-                "entity_type": "polygon",
-                "entity_id": -1,
-                "match_index": r["match_index"],
-                "sym_hausdorff_like": r["sym_hausdorff_like"],
-            }
-        )
-    worst_k_by_hausdorff = sorted(
-        worst_k_by_hausdorff, key=lambda x: x["sym_hausdorff_like"], reverse=True
-    )[:20]
+    error_maps = build_error_maps(lane_rows, line_rows, poly_rows)
+
+    worst_k_by_hausdorff = build_worst_k(lane_rows, line_rows, poly_rows, 20)
 
     exec_summary = {
         "key_metric_symmetric_hausdorff_like_m": {
@@ -799,7 +1028,7 @@ def evaluate_core(
     write_worst_case_debug(
         internal, reference, lane_rows, line_rows, poly_rows, out_dir, top_k_debug
     )
-    make_static_plots(internal, reference, lane_rows, line_rows, poly_rows, overlay_png_path)
+    make_static_plots(internal, reference, lane_rows, line_rows, poly_rows, overlay_png_path, error_maps)
     if not skip_html:
         render_html_dashboard(
             internal,
@@ -811,6 +1040,7 @@ def evaluate_core(
             lane_threshold=lane_threshold,
             line_threshold=line_threshold,
             poly_threshold=poly_threshold,
+            error_maps=error_maps,
         )
         if open_web:
             webbrowser.open(f"file://{html_path.resolve()}")

--- a/cpp_tools/src/autoware_diffusion_planner_tools/scripts/map_eval/compare_map.py
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/scripts/map_eval/compare_map.py
@@ -50,7 +50,9 @@ def build_error_maps(
 ) -> ErrorMaps:
     """Build error maps from comparison rows for efficient lookup."""
     return ErrorMaps(
-        lane={int(r["entity_id"]): float(r["center_sym_hausdorff_like"]) for r in lane_rows},
+        lane={int(r["entity_id"]): max(float(r["center_sym_hausdorff_like"]), 
+                                       float(r["left_sym_hausdorff_like"]),
+                                       float(r["right_sym_hausdorff_like"])) for r in lane_rows},
         line={
             pair[0]: float(r["sym_hausdorff_like"])
             for r in line_rows
@@ -94,6 +96,14 @@ def points3_to_np(points: List[List[float]]) -> np.ndarray:
     if not points:
         return np.zeros((0, 3), dtype=np.float64)
     return np.asarray(points, dtype=np.float64)
+
+def points3_id_to_np(points: List[Dict]) -> Tuple[np.ndarray, np.ndarray]:
+    if not points:
+        return np.zeros((0, 4), dtype=np.int64), np.zeros((0, 3), dtype=np.float64)
+    ids = np.asarray([int(p["id"]) for p in points], dtype=np.int64)
+    pts = np.asarray([p['points'] for p in points], dtype=np.float64)
+    return ids, pts
+
 
 
 def polyline_segments_xy(poly: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
@@ -177,7 +187,12 @@ def symmetric_distance_stats(a: np.ndarray, b: np.ndarray) -> Dict:
     }
 
 
-def _points_to_error_dicts(pts: np.ndarray, errors: np.ndarray) -> List[Dict]:
+def _points_to_error_dicts(
+    pts: np.ndarray,
+    errors: np.ndarray,
+    point_ids: Optional[np.ndarray] = None,
+    boundary_type: Optional[str] = None,
+) -> List[Dict]:
     """Convert points and errors to list of dicts for JSON serialization.
 
     Args:
@@ -185,7 +200,7 @@ def _points_to_error_dicts(pts: np.ndarray, errors: np.ndarray) -> List[Dict]:
         errors: N-element array of error values
 
     Returns:
-        List of dicts with lat, lng, error keys
+        List of dicts with lat, lng, error and optional point_id/boundary_type keys
     """
     if len(pts) == 0 or len(errors) == 0:
         return []
@@ -193,8 +208,21 @@ def _points_to_error_dicts(pts: np.ndarray, errors: np.ndarray) -> List[Dict]:
         return []
     pts_array = np.column_stack([pts[:, 1], pts[:, 0], errors])
     valid_mask = np.isfinite(pts_array[:, 2])
-    pts_list = pts_array[valid_mask].tolist()
-    return [{"lat": float(p[0]), "lng": float(p[1]), "error": float(p[2])} for p in pts_list]
+    valid_points = pts_array[valid_mask]
+    point_ids_valid = point_ids[valid_mask] if point_ids is not None and len(point_ids) == len(pts) else None
+    out = []
+    for idx, p in enumerate(valid_points):
+        item = {
+            "lat": float(p[0]),
+            "lng": float(p[1]),
+            "error": float(p[2]),
+        }
+        if point_ids_valid is not None:
+            item["point_id"] = int(point_ids_valid[idx])
+        if boundary_type is not None:
+            item["boundary_type"] = boundary_type
+        out.append(item)
+    return out
 
 
 def _compute_point_errors_for_indexed_entities(
@@ -252,7 +280,13 @@ def compute_point_errors(
     Uses existing match_index from lane_rows, line_rows to find matches.
 
     Returns:
-        lane_point_errors: {lane_id: [{"lat": y, "lng": x, "error": float}, ...]}
+        lane_point_errors: {
+            lane_id: {
+                "centerline": [...],
+                "left_boundary": [...],
+                "right_boundary": [...],
+            }
+        }
         line_point_errors: {index: [{"lat": y, "lng": x, "error": float}, ...]}
     """
     # Build dictionary lookups for O(1) access
@@ -268,16 +302,25 @@ def compute_point_errors(
         if int_lane is None or ref_lane is None:
             continue
 
-        c_i = points3_to_np(int_lane["centerline"])
-        c_e = points3_to_np(ref_lane["centerline"])
-
-        if len(c_i) > 0 and len(c_e) > 0:
-            # Use directed distance for point-level visualization
-            # This shows where internal points deviate from reference, avoiding
-            # scalar broadcast from max reverse distance inflating all errors
-            d_ab = directed_polyline_distance_xy(c_i, c_e)
-
-            lane_point_errors[lane_id] = _points_to_error_dicts(c_i, d_ab)
+        lane_point_errors[lane_id] = {
+            "centerline": [],
+            "left_boundary": [],
+            "right_boundary": [],
+        }
+        for boundary_key in ("centerline", "left_boundary", "right_boundary"):
+            ref_ids, ref_pts = points3_id_to_np(ref_lane[boundary_key])
+            int_pts = points3_to_np(int_lane[boundary_key])
+            if len(ref_pts) == 0 or len(int_pts) == 0:
+                continue
+            # Compute reference -> internal errors. This is the direction with
+            # meaningful residuals in current preprocessing pipeline.
+            d_ref_to_int = directed_polyline_distance_xy(ref_pts, int_pts)
+            lane_point_errors[lane_id][boundary_key] = _points_to_error_dicts(
+                ref_pts,
+                d_ref_to_int,
+                point_ids=ref_ids,
+                boundary_type=boundary_key,
+            )
 
     # Use helper function for lines only (polygons don't need point error visualization)
     line_point_errors = _compute_point_errors_for_indexed_entities(
@@ -295,10 +338,9 @@ def compare_lane_segments(internal: Dict, reference: Dict) -> Tuple[Dict, List[D
     ref_by_id = {int(x["id"]): x for x in reference["lane_segments"]}
     matched_ids = sorted(set(int_by_id.keys()) & set(ref_by_id.keys()))
 
-    center_sym = []
-    left_sym = []
-    right_sym = []
     center_haus = []
+    left_haus = []
+    right_haus = []
     entity_rows = []
 
     for lane_id in matched_ids:
@@ -306,45 +348,45 @@ def compare_lane_segments(internal: Dict, reference: Dict) -> Tuple[Dict, List[D
         ref_lane = ref_by_id[lane_id]
 
         c_i = points3_to_np(i_lane["centerline"])
-        c_e = points3_to_np(ref_lane["centerline"])
+        c_e_ids, c_e = points3_id_to_np(ref_lane["centerline"])
         l_i = points3_to_np(i_lane["left_boundary"])
-        l_e = points3_to_np(ref_lane["left_boundary"])
+        l_e_ids, l_e = points3_id_to_np(ref_lane["left_boundary"])
         r_i = points3_to_np(i_lane["right_boundary"])
-        r_e = points3_to_np(ref_lane["right_boundary"])
+        r_e_ids, r_e = points3_id_to_np(ref_lane["right_boundary"])
 
         c_stats = symmetric_distance_stats(c_i, c_e)
         l_stats = symmetric_distance_stats(l_i, l_e)
         r_stats = symmetric_distance_stats(r_i, r_e)
 
-        center_sym.append(c_stats["symmetric_chamfer_like"])
-        left_sym.append(l_stats["symmetric_chamfer_like"])
-        right_sym.append(r_stats["symmetric_chamfer_like"])
         center_haus.append(c_stats["symmetric_hausdorff_like"])
+        left_haus.append(l_stats["symmetric_hausdorff_like"])
+        right_haus.append(r_stats["symmetric_hausdorff_like"])
 
         entity_rows.append(
             {
                 "entity_type": "lane_segment",
                 "entity_id": lane_id,
                 "match_index": -1,
-                "center_sym_chamfer_like": c_stats["symmetric_chamfer_like"],
                 "center_sym_hausdorff_like": c_stats["symmetric_hausdorff_like"],
-                "left_sym_chamfer_like": l_stats["symmetric_chamfer_like"],
-                "right_sym_chamfer_like": r_stats["symmetric_chamfer_like"],
+                "left_sym_hausdorff_like": l_stats["symmetric_hausdorff_like"],
+                "right_sym_hausdorff_like": r_stats["symmetric_hausdorff_like"],
             }
         )
 
     worst = sorted(entity_rows, key=lambda x: x["center_sym_hausdorff_like"], reverse=True)[:20]
-    haus_summary = summarize(center_haus)
+    haus_summary = summarize(center_haus + left_haus + right_haus)
     metrics = {
         "key_metric_symmetric_hausdorff_like_m": haus_summary,
-        "centerline_symmetric_chamfer_like_m": summarize(center_sym),
-        "centerline_symmetric_hausdorff_like_m": haus_summary,
-        "left_boundary_symmetric_chamfer_like_m": summarize(left_sym),
-        "right_boundary_symmetric_chamfer_like_m": summarize(right_sym),
+        "centerline_symmetric_hausdorff_like_m": summarize(center_haus),
+        "left_boundary_symmetric_hausdorff_like_m": summarize(left_haus),
+        "right_boundary_symmetric_hausdorff_like_m": summarize(right_haus),
         "pass_rate": {
             "centerline_symmetric_hausdorff_lt_0p2m": (
-                float(np.mean(np.asarray(center_haus) < 0.2)) if center_haus else 0.0
-            )
+                float(np.mean(np.asarray(center_haus) < 0.2)) if center_haus else 0.0),
+            "left_boundary_symmetric_hausdorff_lt_0p2m": (
+                float(np.mean(np.asarray(left_haus) < 0.2)) if left_haus else 0.0),
+            "right_boundary_symmetric_hausdorff_lt_0p2m": (
+                float(np.mean(np.asarray(right_haus) < 0.2)) if right_haus else 0.0),
         },
         "worst_k_centerline": worst,
     }
@@ -520,9 +562,15 @@ def make_static_plots(
 
     # Panel 1: Fused overlay (reference first, then internal)
     for lane in reference["lane_segments"]:
-        c = points3_to_np(lane["centerline"])
+        c_id, c = points3_id_to_np(lane["centerline"])
+        l_id, l = points3_id_to_np(lane["left_boundary"])
+        r_id, r = points3_id_to_np(lane["right_boundary"])
         if len(c):
             ax1.plot(c[:, 0], c[:, 1], color="#2d5016", alpha=0.7, linewidth=1.5)
+        if len(l):
+            ax1.plot(l[:, 0], l[:, 1], color="#2d5016", alpha=0.7, linewidth=1.5)
+        if len(r):
+            ax1.plot(r[:, 0], r[:, 1], color="#2d5016", alpha=0.7, linewidth=1.5)
     for line_string in reference["line_strings"]:
         s = points3_to_np(line_string["points"])
         if len(s):
@@ -534,8 +582,14 @@ def make_static_plots(
 
     for lane in internal["lane_segments"]:
         c = points3_to_np(lane["centerline"])
+        r = points3_to_np(lane["right_boundary"])
+        l = points3_to_np(lane["left_boundary"])
         if len(c):
             ax1.plot(c[:, 0], c[:, 1], color="blue", alpha=0.55, linewidth=0.9)
+        if len(r):
+            ax1.plot(r[:, 0], r[:, 1], color="blue", alpha=0.55, linewidth=0.9)
+        if len(l):
+            ax1.plot(l[:, 0], l[:, 1], color="blue", alpha=0.55, linewidth=0.9)
     for i, line_string in enumerate(internal["line_strings"]):
         s = points3_to_np(line_string["points"])
         if len(s):
@@ -554,9 +608,17 @@ def make_static_plots(
     for lane in internal["lane_segments"]:
         lane_id = int(lane["id"])
         c = points3_to_np(lane["centerline"])
+        l = points3_to_np(lane["left_boundary"])
+        r = points3_to_np(lane["right_boundary"])
         if len(c):
             err = lane_error_map.get(lane_id, 0.0)
             ax2.plot(c[:, 0], c[:, 1], color=cmap(norm_lane(err)), alpha=0.9, linewidth=1.2)
+        if len(l):
+            err = lane_error_map.get(lane_id, 0.0)
+            ax2.plot(l[:, 0], l[:, 1], color=cmap(norm_lane(err)), alpha=0.9, linewidth=1.2)
+        if len(r):
+            err = lane_error_map.get(lane_id, 0.0)
+            ax2.plot(r[:, 0], r[:, 1], color=cmap(norm_lane(err)), alpha=0.9, linewidth=1.2)
     ax2.set_title("Lane Error Heatmap (Hausdorff)")
     ax2.set_aspect("equal")
     sm2 = matplotlib.cm.ScalarMappable(cmap=cmap, norm=norm_lane)
@@ -638,9 +700,17 @@ def render_html_dashboard(
 
     lanes_ref = []
     for lane in reference["lane_segments"]:
-        c = points3_to_np(lane["centerline"])
-        if len(c):
-            lanes_ref.append({"coordinates": _pts_to_coords(c)})
+        _, c = points3_id_to_np(lane["centerline"])
+        _, l = points3_id_to_np(lane["left_boundary"])
+        _, r = points3_id_to_np(lane["right_boundary"])
+        lane_id = int(lane["id"])
+        lane_geometries = {
+            "centerline": _pts_to_coords(c),
+            "left_boundary": _pts_to_coords(l),
+            "right_boundary": _pts_to_coords(r),
+        }
+        if lane_geometries["centerline"] or lane_geometries["left_boundary"] or lane_geometries["right_boundary"]:
+            lanes_ref.append({"id": lane_id, "geometries": lane_geometries})
     lines_ref = []
     for line_string in reference["line_strings"]:
         s = points3_to_np(line_string["points"])
@@ -685,17 +755,34 @@ def render_html_dashboard(
     lanes_int = []
     for lane in internal["lane_segments"]:
         c_i = points3_to_np(lane["centerline"])
-        if len(c_i):
-            lane_id = int(lane["id"])
-            ref_lane = ref_lanes_by_id.get(lane_id)
-            ref_coords = []
-            if ref_lane:
-                c_ref = points3_to_np(ref_lane["centerline"])
-                ref_coords = _pts_to_coords(c_ref)
+        l_i = points3_to_np(lane["left_boundary"])
+        r_i = points3_to_np(lane["right_boundary"])
+        lane_id = int(lane["id"])
+        ref_lane = ref_lanes_by_id.get(lane_id)
+        ref_geometries = {
+            "centerline": [],
+            "left_boundary": [],
+            "right_boundary": [],
+        }
+        if ref_lane:
+            _, c_ref = points3_id_to_np(ref_lane["centerline"])
+            _, l_ref = points3_id_to_np(ref_lane["left_boundary"])
+            _, r_ref = points3_id_to_np(ref_lane["right_boundary"])
+            ref_geometries = {
+                "centerline": _pts_to_coords(c_ref),
+                "left_boundary": _pts_to_coords(l_ref),
+                "right_boundary": _pts_to_coords(r_ref),
+            }
+        int_geometries = {
+            "centerline": _pts_to_coords(c_i),
+            "left_boundary": _pts_to_coords(l_i),
+            "right_boundary": _pts_to_coords(r_i),
+        }
+        if int_geometries["centerline"] or int_geometries["left_boundary"] or int_geometries["right_boundary"]:
             lanes_int.append(
                 {
-                    "coordinates": _pts_to_coords(c_i),
-                    "ref_coordinates": ref_coords,
+                    "geometries": int_geometries,
+                    "ref_geometries": ref_geometries,
                     "id": lane_id,
                     "hausdorff": lane_error_map.get(lane_id, 0.0),
                 }

--- a/cpp_tools/src/autoware_diffusion_planner_tools/scripts/map_eval/templates/interactive_map.html.j2
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/scripts/map_eval/templates/interactive_map.html.j2
@@ -216,6 +216,39 @@
         .filter(coords => Array.isArray(coords) && coords.length > 0);
     }
 
+    function getLaneGeometryEntries(ent, fieldName) {
+      const geoms = ent && ent[fieldName] ? ent[fieldName] : null;
+      if (!geoms) return [];
+      return ["centerline", "left_boundary", "right_boundary"]
+        .map(boundary => ({ boundary, coords: geoms[boundary] }))
+        .filter(item => Array.isArray(item.coords) && item.coords.length > 0);
+    }
+
+    function laneBoundaryLabel(boundary) {
+      if (boundary === "centerline") return "centerline";
+      if (boundary === "left_boundary") return "left boundary";
+      if (boundary === "right_boundary") return "right boundary";
+      return boundary;
+    }
+
+    function laneBoundaryStyle(baseStyle, boundary, isReference) {
+      const style = { ...(baseStyle || {}) };
+      if (boundary === "centerline") {
+        return { ...style, weight: Math.max(style.weight || 2, 3), dashArray: null };
+      }
+      if (boundary === "left_boundary") {
+        return isReference
+          ? { ...style, weight: Math.max(style.weight || 2, 2), dashArray: "8,4" }
+          : { ...style, weight: Math.max((style.weight || 2) - 0.5, 1.5), dashArray: "8,4" };
+      }
+      if (boundary === "right_boundary") {
+        return isReference
+          ? { ...style, weight: Math.max(style.weight || 2, 2), dashArray: "2,6" }
+          : { ...style, weight: Math.max((style.weight || 2) - 0.5, 1.5), dashArray: "2,6" };
+      }
+      return style;
+    }
+
     function initMap() {
       const map = L.map('map', { crs: L.CRS.Simple });
       const allBounds = [];
@@ -466,8 +499,11 @@
 
         // Lanes use grouped center/left/right geometries
         if (type === "lane") {
-          getLaneGeometryLines(internalEnt, "ref_geometries").forEach(coords => {
-            const line = L.polyline(toLeafletCoords(coords), refStyle);
+          getLaneGeometryEntries(internalEnt, "ref_geometries").forEach(({ boundary, coords }) => {
+            const line = L.polyline(
+              toLeafletCoords(coords),
+              laneBoundaryStyle(refStyle, boundary, true)
+            );
             line.addTo(layerGroups.referenceHighlight);
           });
         } else if (internalEnt.ref_coordinates && internalEnt.ref_coordinates.length) {
@@ -522,8 +558,9 @@
         const popup = layer.getPopup && layer.getPopup();
         if (popup) {
           const content = popup.getContent();
-          if (type === 'lane' && content.startsWith('Lane ' + id + ':')) {
-            layer.setStyle(THEME.highlight);
+          if (type === 'lane' && content.startsWith('Lane ' + id)) {
+            const boundary = layer.__laneBoundary || "centerline";
+            layer.setStyle(laneBoundaryStyle(THEME.highlight, boundary, false));
             highlightedLayers.push(layer);
           } else if (type === 'line' && content.startsWith('Line ' + id + ':')) {
             layer.setStyle(THEME.highlight);
@@ -664,16 +701,22 @@
       entities.forEach(ent => {
         const style = styleFn ? styleFn(ent) : baseStyle;
         if (!isPolygon && ent.geometries) {
-          const geos = getLaneGeometryLines(ent, "geometries");
-          geos.forEach(coords => {
-            const geo = L.polyline(toLeafletCoords(coords), style);
+          const geos = getLaneGeometryEntries(ent, "geometries");
+          geos.forEach(({ boundary, coords }) => {
+            const geo = L.polyline(
+              toLeafletCoords(coords),
+              laneBoundaryStyle(style, boundary, isReference)
+            );
+            geo.__laneBoundary = boundary;
             if (!isReference) {
               const id = ent.id;
               geo.on('click', (e) => {
                 L.DomEvent.stopPropagation(e);
                 zoomToEntity(ent, null, null, entityType);
               });
-              geo.bindPopup(`Lane ${id}: ${(ent.hausdorff || 0).toFixed(4)} m (click to zoom)`);
+              geo.bindPopup(
+                `Lane ${id} (${laneBoundaryLabel(boundary)}): ${(ent.hausdorff || 0).toFixed(4)} m (click to zoom)`
+              );
             }
             geo.addTo(layerGroup);
           });

--- a/cpp_tools/src/autoware_diffusion_planner_tools/scripts/map_eval/templates/interactive_map.html.j2
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/scripts/map_eval/templates/interactive_map.html.j2
@@ -55,6 +55,16 @@
     .entity-error.high { color: #ff6b6b; }
     .entity-error.medium { color: #feca57; }
     .entity-error.low { color: #5ec962; }
+    .point-item {
+      padding: 0.35rem 0.5rem;
+      border-radius: 3px;
+      cursor: pointer;
+      font-size: 0.76rem;
+      line-height: 1.35;
+    }
+    .point-item:hover { background: #2d2d44; }
+    .point-item .row { display: flex; justify-content: space-between; gap: 0.5rem; }
+    .point-item .meta { color: #aaa; }
     .legend-title { font-weight: 600; margin-bottom: 0.5rem; font-size: 0.9rem; }
     .legend-wrap { display: flex; align-items: center; gap: 0.5rem; margin-top: auto; padding-top: 0.75rem; border-top: 1px solid #333; }
     .legend-scale {
@@ -111,6 +121,14 @@
             <span class="sidebar-toggle" id="toggle-polys">−</span>
           </div>
           <div class="sidebar-list" id="poly-list"></div>
+        </div>
+
+        <div class="sidebar-section">
+          <div class="sidebar-header" data-section="lane-points">
+            <span class="sidebar-title">Selected Lane Top-5 Ref Points</span>
+            <span class="sidebar-toggle" id="toggle-lane-points">−</span>
+          </div>
+          <div class="sidebar-list" id="lane-point-list">Select a lane to inspect point errors.</div>
         </div>
 
         <div class="legend-title" id="legend-title">Hausdorff error (m)</div>
@@ -190,13 +208,24 @@
       return 'low';
     }
 
+    function getLaneGeometryLines(ent, fieldName) {
+      const geoms = ent && ent[fieldName] ? ent[fieldName] : null;
+      if (!geoms) return [];
+      return ["centerline", "left_boundary", "right_boundary"]
+        .map(k => geoms[k])
+        .filter(coords => Array.isArray(coords) && coords.length > 0);
+    }
+
     function initMap() {
       const map = L.map('map', { crs: L.CRS.Simple });
       const allBounds = [];
       function addToBounds(pts) {
         pts.forEach(p => { allBounds.push([p[1], p[0]]); });
       }
-      [...LANES_REF, ...LANES_INT, ...LINES_REF, ...LINES_INT].forEach(ent => {
+      [...LANES_REF, ...LANES_INT].forEach(ent => {
+        getLaneGeometryLines(ent, "geometries").forEach(coords => addToBounds(coords));
+      });
+      [...LINES_REF, ...LINES_INT].forEach(ent => {
         if (ent.coordinates && ent.coordinates.length) addToBounds(ent.coordinates);
       });
       [...POLYS_REF, ...POLYS_INT].forEach(ent => {
@@ -211,13 +240,74 @@
 
     // Point markers layer for high-error points
     const pointMarkersLayer = L.layerGroup();
+    let selectedPointMarker = null;
+    let lastSelectedLaneId = null;
 
     // Track currently highlighted entity - declared before functions that use it
     let activeTab = 'overlay';
 
+    function getLaneErrorPointsForEntity(id) {
+      const laneData = LANE_POINT_ERRORS[id];
+      if (laneData === undefined) return [];
+      if (Array.isArray(laneData)) return laneData;
+      const all = [];
+      ["centerline", "left_boundary", "right_boundary"].forEach(boundary => {
+        const points = laneData[boundary];
+        if (Array.isArray(points)) {
+          points.forEach(pt => all.push({ ...pt, boundary_type: pt.boundary_type || boundary }));
+        }
+      });
+      return all;
+    }
+
+    function renderSelectedLaneTopPoints(laneId) {
+      const listEl = document.getElementById("lane-point-list");
+      if (!listEl) return;
+      lastSelectedLaneId = laneId;
+      const points = getLaneErrorPointsForEntity(String(laneId))
+        .slice()
+        .sort((a, b) => (b.error || 0) - (a.error || 0))
+        .slice(0, 5);
+      if (points.length === 0) {
+        listEl.textContent = `Lane ${laneId}: no reference point errors available.`;
+        return;
+      }
+      listEl.innerHTML = "";
+      points.forEach((pt, idx) => {
+        const pointIdText = pt.point_id !== undefined ? `#${pt.point_id}` : "(no-id)";
+        const boundary = pt.boundary_type || "centerline";
+        const item = document.createElement("div");
+        item.className = "point-item";
+        item.innerHTML = `
+          <div class="row"><span>P${idx + 1} ${boundary}</span><span>${(pt.error || 0).toFixed(4)}m</span></div>
+          <div class="meta">Point ${pointIdText}</div>
+        `;
+        item.addEventListener("click", () => {
+          if (selectedPointMarker && pointMarkersLayer.hasLayer(selectedPointMarker)) {
+            pointMarkersLayer.removeLayer(selectedPointMarker);
+          }
+          selectedPointMarker = L.circleMarker([pt.lat, pt.lng], {
+            color: "#00d4ff",
+            radius: 7,
+            fillColor: "#00d4ff",
+            fillOpacity: 0.9,
+            weight: 3
+          });
+          selectedPointMarker.bindPopup(
+            `Lane ${laneId}<br>Point ${pointIdText}<br>${boundary}<br>Error: ${(pt.error || 0).toFixed(4)} m`
+          );
+          selectedPointMarker.addTo(pointMarkersLayer);
+          selectedPointMarker.openPopup();
+          map.panTo([pt.lat, pt.lng]);
+        });
+        listEl.appendChild(item);
+      });
+    }
+
     function showPointMarkers(entityKey) {
       // Clear existing markers first
       pointMarkersLayer.clearLayers();
+      selectedPointMarker = null;
 
       // If no entityKey provided, just clear and return (used when switching tabs)
       if (!entityKey) return;
@@ -233,9 +323,13 @@
       if (type === 'lane') {
         pointErrors = LANE_POINT_ERRORS;
         threshold = THRESHOLD_LANE;
+        renderSelectedLaneTopPoints(parseInt(id, 10));
       } else if (type === 'line') {
         pointErrors = LINE_POINT_ERRORS;
         threshold = THRESHOLD_LINE;
+      } else {
+        const listEl = document.getElementById("lane-point-list");
+        if (listEl) listEl.textContent = "Select a lane to inspect point errors.";
       }
       // Polygon heatmap does not show point errors
 
@@ -244,7 +338,7 @@
 
       // Only show points for the specific entity
       if (pointErrors[id] !== undefined) {
-        const points = pointErrors[id];
+        const points = type === "lane" ? getLaneErrorPointsForEntity(id) : pointErrors[id];
         points.forEach(pt => {
           if (pt.error >= highErrorThreshold) {
             const marker = L.circleMarker([pt.lat, pt.lng], {
@@ -254,7 +348,9 @@
               fillOpacity: 0.9,
               weight: 2
             });
-            marker.bindPopup(`Error: ${pt.error.toFixed(4)} m`);
+            const pointIdText = pt.point_id !== undefined ? `<br>Point #${pt.point_id}` : "";
+            const boundaryText = pt.boundary_type ? `<br>${pt.boundary_type}` : "";
+            marker.bindPopup(`Error: ${pt.error.toFixed(4)} m${pointIdText}${boundaryText}`);
             marker.addTo(pointMarkersLayer);
           }
         });
@@ -272,7 +368,7 @@
 
     // Track currently highlighted entity
     let highlightedEntityKey = null;
-    let highlightedLayer = null;
+    let highlightedLayers = [];
     let highlightedRefEntityKey = null;
     let highlightedRefLayer = null;  // Layer for highlighted reference entity
 
@@ -306,7 +402,7 @@
       // Clear point markers when unhighlighting
       pointMarkersLayer.clearLayers();
 
-      if (!highlightedEntityKey || !highlightedLayer) return;
+      if (!highlightedEntityKey || highlightedLayers.length === 0) return;
 
       const type = getEntityType(highlightedEntityKey);
       if (!type) return;
@@ -326,11 +422,13 @@
 
       if (ent) {
         const style = activeTab === 'overlay' ? DEFAULT_STYLES[type] : getHeatmapDefaultStyle(ent, type);
-        highlightedLayer.setStyle(style);
+        highlightedLayers.forEach(layer => {
+          if (layer && layer.setStyle) layer.setStyle(style);
+        });
       }
 
       highlightedEntityKey = null;
-      highlightedLayer = null;
+      highlightedLayers = [];
 
       // Also unhighlight reference entity
       unhighlightReferenceEntity();
@@ -366,8 +464,13 @@
           fillOpacity: 0
         };
 
-        // Use ref_coordinates from internal entity directly
-        if (internalEnt.ref_coordinates && internalEnt.ref_coordinates.length) {
+        // Lanes use grouped center/left/right geometries
+        if (type === "lane") {
+          getLaneGeometryLines(internalEnt, "ref_geometries").forEach(coords => {
+            const line = L.polyline(toLeafletCoords(coords), refStyle);
+            line.addTo(layerGroups.referenceHighlight);
+          });
+        } else if (internalEnt.ref_coordinates && internalEnt.ref_coordinates.length) {
           const isPolygon = type === 'poly' &&
             Array.isArray(internalEnt.ref_coordinates[0]) &&
             Array.isArray(internalEnt.ref_coordinates[0][0]);
@@ -421,13 +524,13 @@
           const content = popup.getContent();
           if (type === 'lane' && content.startsWith('Lane ' + id + ':')) {
             layer.setStyle(THEME.highlight);
-            highlightedLayer = layer;
+            highlightedLayers.push(layer);
           } else if (type === 'line' && content.startsWith('Line ' + id + ':')) {
             layer.setStyle(THEME.highlight);
-            highlightedLayer = layer;
+            highlightedLayers.push(layer);
           } else if (type === 'poly' && content.startsWith('Polygon ' + id + ':')) {
             layer.setStyle({ ...THEME.highlight, fillOpacity: 0.8 });
-            highlightedLayer = layer;
+            highlightedLayers.push(layer);
           }
         }
       });
@@ -446,8 +549,10 @@
     function addReferenceBasemap() {
       const lg = L.layerGroup();
       LANES_REF.forEach(ent => {
-        const line = L.polyline(toLeafletCoords(ent.coordinates), THEME.ref);
-        line.addTo(lg);
+        getLaneGeometryLines(ent, "geometries").forEach(coords => {
+          const line = L.polyline(toLeafletCoords(coords), THEME.ref);
+          line.addTo(lg);
+        });
       });
       LINES_REF.forEach(ent => {
         const line = L.polyline(toLeafletCoords(ent.coordinates), THEME.refThin);
@@ -481,9 +586,15 @@
       }
 
       const allBounds = [];
+      const pushLineBounds = (coords) => {
+        if (!Array.isArray(coords)) return;
+        coords.forEach(p => allBounds.push([p[1], p[0]]));
+      };
 
       // Add internal entity bounds
-      if (internalEnt.coordinates && internalEnt.coordinates.length) {
+      if (entityType === "lane") {
+        getLaneGeometryLines(internalEnt, "geometries").forEach(pushLineBounds);
+      } else if (internalEnt.coordinates && internalEnt.coordinates.length) {
         // Check if it's a polygon (nested arrays) or line
         if (Array.isArray(internalEnt.coordinates[0]) && Array.isArray(internalEnt.coordinates[0][0])) {
           // Polygon: coordinates is array of rings, each ring is array of points
@@ -497,7 +608,9 @@
       }
 
       // Add reference entity bounds from the entity's ref_coordinates field
-      if (internalEnt.ref_coordinates && internalEnt.ref_coordinates.length) {
+      if (entityType === "lane") {
+        getLaneGeometryLines(internalEnt, "ref_geometries").forEach(pushLineBounds);
+      } else if (internalEnt.ref_coordinates && internalEnt.ref_coordinates.length) {
         // Check if it's a polygon (nested arrays) or line
         if (Array.isArray(internalEnt.ref_coordinates[0]) && Array.isArray(internalEnt.ref_coordinates[0][0])) {
           // Polygon: ref_coordinates is array of rings
@@ -550,6 +663,23 @@
     function addEntityLayer(entities, isPolygon, isReference, baseStyle, layerGroup, styleFn, entityType) {
       entities.forEach(ent => {
         const style = styleFn ? styleFn(ent) : baseStyle;
+        if (!isPolygon && ent.geometries) {
+          const geos = getLaneGeometryLines(ent, "geometries");
+          geos.forEach(coords => {
+            const geo = L.polyline(toLeafletCoords(coords), style);
+            if (!isReference) {
+              const id = ent.id;
+              geo.on('click', (e) => {
+                L.DomEvent.stopPropagation(e);
+                zoomToEntity(ent, null, null, entityType);
+              });
+              geo.bindPopup(`Lane ${id}: ${(ent.hausdorff || 0).toFixed(4)} m (click to zoom)`);
+            }
+            geo.addTo(layerGroup);
+          });
+          return;
+        }
+
         const leafletCoords = isPolygon
           ? ent.coordinates.map(r => toLeafletCoords(r))
           : toLeafletCoords(ent.coordinates);
@@ -567,7 +697,6 @@
           });
           geo.bindPopup(`${label} ${id}: ${(ent.hausdorff || 0).toFixed(4)} m (click to zoom)`);
         }
-
         geo.addTo(layerGroup);
       });
     }
@@ -751,6 +880,7 @@
         if (section === 'lanes') listId = 'lane-list';
         else if (section === 'lines') listId = 'line-list';
         else if (section === 'polys') listId = 'poly-list';
+        else if (section === 'lane-points') listId = 'lane-point-list';
         const list = document.getElementById(listId);
         const toggle = header.querySelector('.sidebar-toggle');
 
@@ -787,26 +917,32 @@
 
     function showTab(tab) {
       // Reset highlight state BEFORE switching tabs to prevent stale references
-      if (highlightedEntityKey || highlightedLayer || highlightedRefEntityKey) {
-        if (highlightedLayer) {
+      if (highlightedEntityKey || highlightedLayers.length > 0 || highlightedRefEntityKey) {
+        if (highlightedLayers.length > 0) {
           // Restore the layer's style directly if possible
           const type = getEntityType(highlightedEntityKey);
-          if (type && highlightedLayer.setStyle) {
+          if (type) {
             const ent = type === 'lane' ? LANES_INT.find(e => e.id == highlightedEntityKey.replace(/^lane/, '')) :
                         type === 'line' ? LINES_INT.find(e => e.index == highlightedEntityKey.replace(/^line/, '')) :
                         POLYS_INT.find(e => e.index == highlightedEntityKey.replace(/^poly/, ''));
             if (ent) {
-              highlightedLayer.setStyle(activeTab === 'overlay' ? DEFAULT_STYLES[type] : getHeatmapDefaultStyle(ent, type));
+              const style = activeTab === 'overlay' ? DEFAULT_STYLES[type] : getHeatmapDefaultStyle(ent, type);
+              highlightedLayers.forEach(layer => {
+                if (layer && layer.setStyle) layer.setStyle(style);
+              });
             }
           }
         }
         highlightedEntityKey = null;
-        highlightedLayer = null;
+        highlightedLayers = [];
         highlightedRefEntityKey = null;
         if (layerGroups.referenceHighlight) {
           layerGroups.referenceHighlight.clearLayers();
         }
         pointMarkersLayer.clearLayers();
+        selectedPointMarker = null;
+        const lanePointList = document.getElementById("lane-point-list");
+        if (lanePointList) lanePointList.textContent = "Select a lane to inspect point errors.";
       }
 
       activeTab = tab;
@@ -845,7 +981,7 @@
       btn.addEventListener('click', function() {
         // Reset highlight state before switching tabs
         highlightedEntityKey = null;
-        highlightedLayer = null;
+        highlightedLayers = [];
         highlightedRefEntityKey = null;
         highlightedRefLayer = null;
         showTab(this.getAttribute('data-tab'));
@@ -855,12 +991,13 @@
     function rebuildOverlayFromCheckboxes() {
       // Reset stale highlight state before destroying old layers
       highlightedEntityKey = null;
-      highlightedLayer = null;
+      highlightedLayers = [];
       highlightedRefEntityKey = null;
       if (layerGroups.referenceHighlight) {
         layerGroups.referenceHighlight.clearLayers();
       }
       pointMarkersLayer.clearLayers();
+      selectedPointMarker = null;
 
       const lanesCb = document.querySelector('input[data-layer="lanes"]');
       const linesCb = document.querySelector('input[data-layer="lines"]');

--- a/cpp_tools/src/autoware_diffusion_planner_tools/scripts/map_eval/templates/interactive_map.html.j2
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/scripts/map_eval/templates/interactive_map.html.j2
@@ -26,20 +26,47 @@
     .main { flex: 1; display: flex; overflow: hidden; }
     #map { flex: 1; min-height: 0; }
     .sidebar {
-      width: 200px; padding: 0.75rem; background: #16162a; color: #ddd;
-      border-left: 1px solid #333; overflow-y: auto;
+      width: 280px; padding: 0.75rem; background: #16162a; color: #ddd;
+      border-left: 1px solid #333; overflow-y: auto; display: flex; flex-direction: column;
     }
+    .sidebar-section { margin-bottom: 1rem; }
+    .sidebar-header {
+      display: flex; align-items: center; justify-content: space-between;
+      cursor: pointer; padding: 0.5rem; background: #2d2d44; border-radius: 4px;
+      margin-bottom: 0.5rem; user-select: none;
+    }
+    .sidebar-header:hover { background: #3d3d5c; }
+    .sidebar-title { font-weight: 600; font-size: 0.85rem; }
+    .sidebar-status {
+      font-size: 0.7rem; color: #888; padding: 0.5rem; margin-bottom: 0.5rem;
+      background: #2d2d44; border-radius: 4px; text-align: center;
+    }
+    .sidebar-toggle { font-size: 0.75rem; color: #888; }
+    .sidebar-list { max-height: 200px; overflow-y: auto; }
+    .entity-item {
+      display: flex; align-items: center; gap: 0.5rem; padding: 0.35rem 0.5rem;
+      border-radius: 3px; cursor: pointer; font-size: 0.8rem;
+    }
+    .entity-item:hover { background: #2d2d44; }
+    .entity-item.hidden { display: none; }
+    .entity-checkbox { flex-shrink: 0; }
+    .entity-id { font-weight: 500; min-width: 60px; }
+    .entity-error { color: #888; margin-left: auto; font-size: 0.75rem; }
+    .entity-error.high { color: #ff6b6b; }
+    .entity-error.medium { color: #feca57; }
+    .entity-error.low { color: #5ec962; }
     .legend-title { font-weight: 600; margin-bottom: 0.5rem; font-size: 0.9rem; }
-    .legend-wrap { display: flex; align-items: center; gap: 0.5rem; }
+    .legend-wrap { display: flex; align-items: center; gap: 0.5rem; margin-top: auto; padding-top: 0.75rem; border-top: 1px solid #333; }
     .legend-scale {
-      height: 120px; width: 24px; background: linear-gradient(to top,
+      height: 100px; width: 20px; background: linear-gradient(to top,
         #440154 0%, #3b528b 25%, #21918c 50%, #5ec962 75%, #fde725 100%);
       border: 1px solid #444; border-radius: 4px; flex-shrink: 0;
     }
     .legend-labels {
-      font-size: 0.75rem; color: #999;
-      height: 120px; display: flex; flex-direction: column; justify-content: space-between;
+      font-size: 0.7rem; color: #999;
+      height: 100px; display: flex; flex-direction: column; justify-content: space-between;
     }
+    .legend-hint { font-size: 0.7rem; color: #666; margin-top: 0.5rem; }
   </style>
 </head>
 <body>
@@ -60,8 +87,34 @@
     <div class="main">
       <div id="map"></div>
       <div class="sidebar">
+        <div class="sidebar-status" id="sidebar-status">Loading...</div>
+
+        <div class="sidebar-section">
+          <div class="sidebar-header" data-section="lanes">
+            <span class="sidebar-title">Lanes (Top Errors)</span>
+            <span class="sidebar-toggle" id="toggle-lanes">−</span>
+          </div>
+          <div class="sidebar-list" id="lane-list"></div>
+        </div>
+
+        <div class="sidebar-section">
+          <div class="sidebar-header" data-section="lines">
+            <span class="sidebar-title">Lines (Top Errors)</span>
+            <span class="sidebar-toggle" id="toggle-lines">−</span>
+          </div>
+          <div class="sidebar-list" id="line-list"></div>
+        </div>
+
+        <div class="sidebar-section">
+          <div class="sidebar-header" data-section="polys">
+            <span class="sidebar-title">Polygons (Top Errors)</span>
+            <span class="sidebar-toggle" id="toggle-polys">−</span>
+          </div>
+          <div class="sidebar-list" id="poly-list"></div>
+        </div>
+
         <div class="legend-title" id="legend-title">Hausdorff error (m)</div>
-        <p class="legend-hint" id="legend-hint" style="font-size: 0.75rem; color: #888; margin: 0 0 0.5rem 0; display: none;">Reference map (lanes) shown as background for context.</p>
+        <p class="legend-hint" id="legend-hint" style="display: none;">Reference map shown as background.</p>
         <div class="legend-wrap">
           <div class="legend-scale" id="legend-scale"></div>
           <div class="legend-labels">
@@ -86,11 +139,31 @@
     const THRESHOLD_LANE = {{ threshold_lane }};
     const THRESHOLD_LINE = {{ threshold_line }};
     const THRESHOLD_POLY = {{ threshold_poly }};
-    const METRICS = {{ metrics_json | tojson }};
+    const LANE_POINT_ERRORS = {{ lane_point_errors | tojson }};
+    const LINE_POINT_ERRORS = {{ line_point_errors | tojson }};
+
+    // Track reviewed entities
+    const reviewedEntities = new Set();
+
+    // Theme constants for consistent styling
+    const THEME = {
+      ref:       { color: '#2d5016', weight: 1.5, opacity: 0.4 },
+      refThin:   { color: '#2d5016', weight: 1.2, opacity: 0.3 },
+      refStrong: { color: '#2d5016', weight: 2, opacity: 0.8 },
+      refPoly:   { color: '#2d5016', weight: 1, fillOpacity: 0.2 },
+      refLight:  { color: '#2d5016', weight: 1, fillOpacity: 0.15 },
+      lane:      { color: '#4361ee', weight: 1.5, opacity: 0.7 },
+      line:      { color: '#e63946', weight: 1.5, opacity: 0.8 },
+      poly:      { color: '#2dc653', weight: 1, fillOpacity: 0.4 },
+      marker:    { color: '#ff0000', radius: 3 },
+      highlight: { color: '#ff00ff', weight: 5, opacity: 1.0 },
+      refHighlight: { color: '#0000ff', weight: 4, opacity: 1.0, dashArray: '10,5' },
+    };
 
     function toLeafletCoords(pts) {
       return pts.map(p => [p[1], p[0]]);
     }
+
     function rgbFromScalar(t) {
       t = Math.max(0, Math.min(1, t));
       const stops = [[0,'#440154'],[0.25,'#3b528b'],[0.5,'#21918c'],[0.75,'#5ec962'],[1,'#fde725']];
@@ -104,10 +177,19 @@
       const r = Math.round(ar + (br - ar) * local), g = Math.round(ag + (bg - ag) * local), bv = Math.round(ab + (bb - ab) * local);
       return `rgb(${r},${g},${bv})`;
     }
+
     function hausdorffToColor(v, threshold) {
       const t = threshold > 0 ? Math.min(v / threshold, 1.0) : 0;
       return rgbFromScalar(t);
     }
+
+    function getErrorClass(error, threshold) {
+      const ratio = threshold > 0 ? error / threshold : 0;
+      if (ratio >= 0.8) return 'high';
+      if (ratio >= 0.4) return 'medium';
+      return 'low';
+    }
+
     function initMap() {
       const map = L.map('map', { crs: L.CRS.Simple });
       const allBounds = [];
@@ -124,98 +206,570 @@
       map.fitBounds(bounds.pad(0.1));
       return { map, bounds };
     }
+
     const { map } = initMap();
+
+    // Point markers layer for high-error points
+    const pointMarkersLayer = L.layerGroup();
+
+    // Track currently highlighted entity - declared before functions that use it
+    let activeTab = 'overlay';
+
+    function showPointMarkers(entityKey) {
+      // Clear existing markers first
+      pointMarkersLayer.clearLayers();
+
+      // If no entityKey provided, just clear and return (used when switching tabs)
+      if (!entityKey) return;
+
+      // Determine which point errors to use based on entity type (lane/line/poly)
+      const type = getEntityType(entityKey);
+      if (!type) return;
+      const id = entityKey.replace(/^(lane|line|poly)/, '');
+
+      // Select correct error dict and threshold by entity type
+      let pointErrors = [];
+      let threshold = THRESHOLD_LANE;
+      if (type === 'lane') {
+        pointErrors = LANE_POINT_ERRORS;
+        threshold = THRESHOLD_LANE;
+      } else if (type === 'line') {
+        pointErrors = LINE_POINT_ERRORS;
+        threshold = THRESHOLD_LINE;
+      }
+      // Polygon heatmap does not show point errors
+
+      // Show high-error points (above 25% of threshold)
+      const highErrorThreshold = threshold * 0.25;
+
+      // Only show points for the specific entity
+      if (pointErrors[id] !== undefined) {
+        const points = pointErrors[id];
+        points.forEach(pt => {
+          if (pt.error >= highErrorThreshold) {
+            const marker = L.circleMarker([pt.lat, pt.lng], {
+              ...THEME.marker,
+              radius: 5,
+              fillColor: THEME.marker.color,
+              fillOpacity: 0.9,
+              weight: 2
+            });
+            marker.bindPopup(`Error: ${pt.error.toFixed(4)} m`);
+            marker.addTo(pointMarkersLayer);
+          }
+        });
+      }
+    }
 
     const layerGroups = {
       overlay: {},
       'lane-heatmap': {},
       'line-heatmap': {},
       'polygon-heatmap': {},
-      referenceBasemap: {}
+      referenceBasemap: null,
+      referenceHighlight: L.layerGroup()  // Initialized immediately
     };
+
+    // Track currently highlighted entity
+    let highlightedEntityKey = null;
+    let highlightedLayer = null;
+    let highlightedRefEntityKey = null;
+    let highlightedRefLayer = null;  // Layer for highlighted reference entity
+
+    // Entity type detection helper
+    function getEntityType(key) {
+      if (key.startsWith('lane')) return 'lane';
+      if (key.startsWith('line')) return 'line';
+      if (key.startsWith('poly')) return 'poly';
+      return null;
+    }
+
+    // Default styles per entity type
+    const DEFAULT_STYLES = {
+      lane: THEME.lane,
+      line: THEME.line,
+      poly: THEME.poly
+    };
+
+    // Heatmap default styles (color based on hausdorff, but weight needs reset)
+    function getHeatmapDefaultStyle(ent, type) {
+      const thresholds = { lane: THRESHOLD_LANE, line: THRESHOLD_LINE, poly: THRESHOLD_POLY };
+      const threshold = thresholds[type] || THRESHOLD_LANE;
+      const c = hausdorffToColor(ent.hausdorff || 0, threshold);
+      return type === 'poly'
+        ? { color: c, weight: 1, fillColor: c, fillOpacity: 0.5 }
+        : { color: c, weight: 2, opacity: 0.9 };
+    }
+
+    // Unhighlight the previously highlighted entity
+    function unhighlightEntity() {
+      // Clear point markers when unhighlighting
+      pointMarkersLayer.clearLayers();
+
+      if (!highlightedEntityKey || !highlightedLayer) return;
+
+      const type = getEntityType(highlightedEntityKey);
+      if (!type) return;
+
+      // Get the entity id from key
+      const id = highlightedEntityKey.replace(/^(lane|line|poly)/, '');
+
+      // Use stored layer reference directly for O(1) lookup
+      let ent;
+      if (type === 'lane') {
+        ent = LANES_INT.find(e => e.id == id);
+      } else if (type === 'line') {
+        ent = LINES_INT.find(e => e.index == id);
+      } else if (type === 'poly') {
+        ent = POLYS_INT.find(e => e.index == id);
+      }
+
+      if (ent) {
+        const style = activeTab === 'overlay' ? DEFAULT_STYLES[type] : getHeatmapDefaultStyle(ent, type);
+        highlightedLayer.setStyle(style);
+      }
+
+      highlightedEntityKey = null;
+      highlightedLayer = null;
+
+      // Also unhighlight reference entity
+      unhighlightReferenceEntity();
+    }
+
+    // Unhighlight the reference entity
+    function unhighlightReferenceEntity() {
+      if (!highlightedRefEntityKey || !layerGroups.referenceHighlight) return;
+
+      const type = getEntityType(highlightedRefEntityKey);
+      if (!type) return;
+
+      if (layerGroups.referenceHighlight && layerGroups.referenceHighlight.clearLayers) {
+        layerGroups.referenceHighlight.clearLayers();
+      }
+      highlightedRefEntityKey = null;
+    }
+
+    // Highlight the corresponding reference entity
+    function highlightReferenceEntity(internalEnt, type, id) {
+      try {
+        // Ensure referenceHighlight is properly initialized
+        if (!layerGroups.referenceHighlight || typeof layerGroups.referenceHighlight.addTo !== 'function') {
+          layerGroups.referenceHighlight = L.layerGroup();
+          layerGroups.referenceHighlight.addTo(map);
+        }
+        if (layerGroups.referenceHighlight.clearLayers) {
+          layerGroups.referenceHighlight.clearLayers();
+        }
+
+        const refStyle = {
+          ...THEME.refHighlight,
+          fillOpacity: 0
+        };
+
+        // Use ref_coordinates from internal entity directly
+        if (internalEnt.ref_coordinates && internalEnt.ref_coordinates.length) {
+          const isPolygon = type === 'poly' &&
+            Array.isArray(internalEnt.ref_coordinates[0]) &&
+            Array.isArray(internalEnt.ref_coordinates[0][0]);
+
+          if (isPolygon) {
+            // Polygon: ref_coordinates is [[ring]] - array of rings
+            internalEnt.ref_coordinates.forEach(ring => {
+              const leafletRing = ring.map(r => toLeafletCoords(r));
+              const poly = L.polygon(leafletRing, refStyle);
+              poly.addTo(layerGroups.referenceHighlight);
+            });
+          } else {
+            // Line/Lane: ref_coordinates is [[lng,lat],...] - array of points
+            const pts = internalEnt.ref_coordinates;
+            if (pts && pts.length) {
+              const line = L.polyline(toLeafletCoords(pts), refStyle);
+              line.addTo(layerGroups.referenceHighlight);
+            }
+          }
+        }
+
+        highlightedRefEntityKey = type + id;
+        if (layerGroups.referenceHighlight && map.hasLayer(layerGroups.referenceHighlight)) {
+          try {
+            layerGroups.referenceHighlight.bringToFront();
+          } catch(e) {}
+        }
+      } catch(e) {
+        console.log('highlightReferenceEntity error:', e);
+      }
+    }
+
+    // Highlight an entity
+    function highlightEntity(key, layerGroup) {
+      // First unhighlight any existing highlight
+      unhighlightEntity();
+
+      highlightedEntityKey = key;
+
+      const type = getEntityType(key);
+      if (!type) return;
+
+      const id = key.replace(/^(lane|line|poly)/, '');
+
+      if (!layerGroup || !layerGroup.eachLayer) return;
+
+      // Find and store the specific layer for O(1) unhighlight later
+      layerGroup.eachLayer(layer => {
+        const popup = layer.getPopup && layer.getPopup();
+        if (popup) {
+          const content = popup.getContent();
+          if (type === 'lane' && content.startsWith('Lane ' + id + ':')) {
+            layer.setStyle(THEME.highlight);
+            highlightedLayer = layer;
+          } else if (type === 'line' && content.startsWith('Line ' + id + ':')) {
+            layer.setStyle(THEME.highlight);
+            highlightedLayer = layer;
+          } else if (type === 'poly' && content.startsWith('Polygon ' + id + ':')) {
+            layer.setStyle({ ...THEME.highlight, fillOpacity: 0.8 });
+            highlightedLayer = layer;
+          }
+        }
+      });
+
+      // Also highlight the corresponding reference entity
+      let internalEnt = null;
+      if (type === 'lane') internalEnt = LANES_INT.find(e => e.id == id);
+      else if (type === 'line') internalEnt = LINES_INT.find(e => e.index == id);
+      else if (type === 'poly') internalEnt = POLYS_INT.find(e => e.index == id);
+      if (internalEnt) highlightReferenceEntity(internalEnt, type, id);
+
+      // Show point errors for the selected entity
+      showPointMarkers(key);
+    }
 
     function addReferenceBasemap() {
       const lg = L.layerGroup();
       LANES_REF.forEach(ent => {
-        const line = L.polyline(toLeafletCoords(ent.coordinates), { color: '#2d5016', weight: 1.5, opacity: 0.4 });
+        const line = L.polyline(toLeafletCoords(ent.coordinates), THEME.ref);
         line.addTo(lg);
       });
       LINES_REF.forEach(ent => {
-        const line = L.polyline(toLeafletCoords(ent.coordinates), { color: '#2d5016', weight: 1.2, opacity: 0.3 });
+        const line = L.polyline(toLeafletCoords(ent.coordinates), THEME.refThin);
         line.addTo(lg);
       });
       POLYS_REF.forEach(ent => {
-        const poly = L.polygon(ent.coordinates.map(r => toLeafletCoords(r)), { color: '#2d5016', weight: 1, fillOpacity: 0.15 });
+        const poly = L.polygon(ent.coordinates.map(r => toLeafletCoords(r)), THEME.refLight);
         poly.addTo(lg);
       });
       layerGroups.referenceBasemap = lg;
+      // Note: referenceHighlight is initialized once at module level, reuse it
     }
 
-    function addOverlayLayers() {
+    function zoomToEntity(internalEnt, refEnt, entityKey, entityType) {
+      // Use provided entityKey or compute from entity structure
+      if (!entityKey) {
+        if (internalEnt.id !== undefined) {
+          entityKey = 'lane' + internalEnt.id;
+          entityType = 'lane';
+        } else if (internalEnt.index !== undefined) {
+          // Use explicit entityType if provided, otherwise detect from data
+          if (!entityType) {
+            // Check which array it belongs to based on data presence
+            const existsInLines = LINES_INT.some(e => e.index === internalEnt.index);
+            const existsInPolys = POLYS_INT.some(e => e.index === internalEnt.index);
+            // Prefer line if index exists in both (polygons typically have fewer entries)
+            entityType = existsInLines ? 'line' : (existsInPolys ? 'poly' : 'line');
+          }
+          entityKey = entityType + internalEnt.index;
+        }
+      }
+
+      const allBounds = [];
+
+      // Add internal entity bounds
+      if (internalEnt.coordinates && internalEnt.coordinates.length) {
+        // Check if it's a polygon (nested arrays) or line
+        if (Array.isArray(internalEnt.coordinates[0]) && Array.isArray(internalEnt.coordinates[0][0])) {
+          // Polygon: coordinates is array of rings, each ring is array of points
+          internalEnt.coordinates.forEach(ring => {
+            ring.forEach(p => allBounds.push([p[1], p[0]]));
+          });
+        } else if (Array.isArray(internalEnt.coordinates[0])) {
+          // Line: coordinates is array of points
+          internalEnt.coordinates.forEach(p => allBounds.push([p[1], p[0]]));
+        }
+      }
+
+      // Add reference entity bounds from the entity's ref_coordinates field
+      if (internalEnt.ref_coordinates && internalEnt.ref_coordinates.length) {
+        // Check if it's a polygon (nested arrays) or line
+        if (Array.isArray(internalEnt.ref_coordinates[0]) && Array.isArray(internalEnt.ref_coordinates[0][0])) {
+          // Polygon: ref_coordinates is array of rings
+          internalEnt.ref_coordinates.forEach(ring => {
+            ring.forEach(p => allBounds.push([p[1], p[0]]));
+          });
+        } else if (Array.isArray(internalEnt.ref_coordinates[0])) {
+          // Line: ref_coordinates is array of points
+          internalEnt.ref_coordinates.forEach(p => allBounds.push([p[1], p[0]]));
+        }
+      }
+
+      // Fallback to provided refEnt
+      if (allBounds.length === 0 && refEnt) {
+        if (refEnt.coordinates && refEnt.coordinates.length) {
+          if (Array.isArray(refEnt.coordinates[0]) && Array.isArray(refEnt.coordinates[0][0])) {
+            refEnt.coordinates.forEach(ring => {
+              ring.forEach(p => allBounds.push([p[1], p[0]]));
+            });
+          } else if (Array.isArray(refEnt.coordinates[0])) {
+            refEnt.coordinates.forEach(p => allBounds.push([p[1], p[0]]));
+          }
+        }
+      }
+
+      if (allBounds.length > 0) {
+        const bounds = L.latLngBounds(allBounds);
+        map.fitBounds(bounds.pad(0.2));
+      }
+
+      // Highlight the zoomed entity
+      let layerGroup;
+      if (activeTab === 'overlay') {
+        layerGroup = layerGroups.overlay;
+      } else if (activeTab === 'lane-heatmap') {
+        layerGroup = layerGroups['lane-heatmap'];
+      } else if (activeTab === 'line-heatmap') {
+        layerGroup = layerGroups['line-heatmap'];
+      } else if (activeTab === 'polygon-heatmap') {
+        layerGroup = layerGroups['polygon-heatmap'];
+      }
+
+      if (entityKey && layerGroup) {
+        highlightEntity(entityKey, layerGroup);
+      }
+    }
+
+    // Helper function to create entity layers (reduces duplication)
+    // If styleFn is provided, it's called with (entity) to compute the style dynamically
+    function addEntityLayer(entities, isPolygon, isReference, baseStyle, layerGroup, styleFn, entityType) {
+      entities.forEach(ent => {
+        const style = styleFn ? styleFn(ent) : baseStyle;
+        const leafletCoords = isPolygon
+          ? ent.coordinates.map(r => toLeafletCoords(r))
+          : toLeafletCoords(ent.coordinates);
+
+        const geo = isPolygon
+          ? L.polygon(leafletCoords, style)
+          : L.polyline(leafletCoords, style);
+
+        if (!isReference) {
+          const id = ent.id !== undefined ? ent.id : ent.index;
+          const label = isPolygon ? 'Polygon' : (ent.id !== undefined ? 'Lane' : 'Line');
+          geo.on('click', (e) => {
+            L.DomEvent.stopPropagation(e);
+            zoomToEntity(ent, null, null, entityType);
+          });
+          geo.bindPopup(`${label} ${id}: ${(ent.hausdorff || 0).toFixed(4)} m (click to zoom)`);
+        }
+
+        geo.addTo(layerGroup);
+      });
+    }
+
+    function addOverlayLayers({ showLanes = true, showLines = true, showPolys = true } = {}) {
       const lg = L.layerGroup();
-      LANES_REF.forEach(ent => {
-        const line = L.polyline(toLeafletCoords(ent.coordinates), { color: '#2d5016', weight: 2, opacity: 0.8 });
-        line.addTo(lg);
-      });
-      LANES_INT.forEach(ent => {
-        const line = L.polyline(toLeafletCoords(ent.coordinates), { color: 'blue', weight: 1.5, opacity: 0.7 });
-        line.addTo(lg);
-      });
-      LINES_REF.forEach(ent => {
-        const line = L.polyline(toLeafletCoords(ent.coordinates), { color: '#2d5016', weight: 2, opacity: 0.8 });
-        line.addTo(lg);
-      });
-      LINES_INT.forEach(ent => {
-        const line = L.polyline(toLeafletCoords(ent.coordinates), { color: 'red', weight: 1.5, opacity: 0.8 });
-        line.addTo(lg);
-      });
-      POLYS_REF.forEach(ent => {
-        const poly = L.polygon(ent.coordinates.map(r => toLeafletCoords(r)), { color: '#2d5016', weight: 2, fillOpacity: 0.2 });
-        poly.addTo(lg);
-      });
-      POLYS_INT.forEach(ent => {
-        const poly = L.polygon(ent.coordinates.map(r => toLeafletCoords(r)), { color: 'green', weight: 1, fillOpacity: 0.4 });
-        poly.addTo(lg);
-      });
+
+      // Reference layers (no click handlers)
+      if (showLanes) addEntityLayer(LANES_REF, false, true, THEME.refStrong, lg);
+      if (showLines) addEntityLayer(LINES_REF, false, true, THEME.refStrong, lg);
+      if (showPolys) addEntityLayer(POLYS_REF, true, true, THEME.refPoly, lg);
+
+      // Internal layers (with click handlers)
+      if (showLanes) addEntityLayer(LANES_INT, false, false, THEME.lane, lg, null, 'lane');
+      if (showLines) addEntityLayer(LINES_INT, false, false, THEME.line, lg, null, 'line');
+      if (showPolys) addEntityLayer(POLYS_INT, true, false, THEME.poly, lg, null, 'poly');
+
       layerGroups.overlay = lg;
     }
 
     function addHeatmapLayers() {
+      // Lane heatmap
       const laneLg = L.layerGroup();
-      LANES_INT.forEach(ent => {
-        const c = hausdorffToColor(ent.hausdorff || 0, THRESHOLD_LANE);
-        const line = L.polyline(toLeafletCoords(ent.coordinates), { color: c, weight: 2, opacity: 0.9 });
-        line.bindPopup(`Lane ${ent.id}: ${(ent.hausdorff || 0).toFixed(4)} m`);
-        line.addTo(laneLg);
-      });
+      addEntityLayer(LANES_INT, false, false, null, laneLg, ent => ({
+        color: hausdorffToColor(ent.hausdorff || 0, THRESHOLD_LANE),
+        weight: 2,
+        opacity: 0.9
+      }), 'lane');
       layerGroups['lane-heatmap'] = laneLg;
 
+      // Line heatmap
       const lineLg = L.layerGroup();
-      LINES_INT.forEach(ent => {
-        const c = hausdorffToColor(ent.hausdorff || 0, THRESHOLD_LINE);
-        const line = L.polyline(toLeafletCoords(ent.coordinates), { color: c, weight: 2, opacity: 0.9 });
-        line.bindPopup(`Line ${ent.index}: ${(ent.hausdorff || 0).toFixed(4)} m`);
-        line.addTo(lineLg);
-      });
+      addEntityLayer(LINES_INT, false, false, null, lineLg, ent => ({
+        color: hausdorffToColor(ent.hausdorff || 0, THRESHOLD_LINE),
+        weight: 2,
+        opacity: 0.9
+      }), 'line');
       layerGroups['line-heatmap'] = lineLg;
 
+      // Polygon heatmap
       const polyLg = L.layerGroup();
-      POLYS_INT.forEach(ent => {
+      addEntityLayer(POLYS_INT, true, false, null, polyLg, ent => {
         const c = hausdorffToColor(ent.hausdorff || 0, THRESHOLD_POLY);
-        const poly = L.polygon(ent.coordinates.map(r => toLeafletCoords(r)), { color: c, weight: 1, fillColor: c, fillOpacity: 0.5 });
-        poly.bindPopup(`Polygon ${ent.index}: ${(ent.hausdorff || 0).toFixed(4)} m`);
-        poly.addTo(polyLg);
-      });
+        return { color: c, weight: 1, fillColor: c, fillOpacity: 0.5 };
+      }, 'poly');
       layerGroups['polygon-heatmap'] = polyLg;
     }
 
     addReferenceBasemap();
     addOverlayLayers();
     addHeatmapLayers();
+    pointMarkersLayer.addTo(map);
+    // Add reference highlight layer to map (will be empty initially)
+    if (!layerGroups.referenceHighlight) {
+      layerGroups.referenceHighlight = L.layerGroup();
+    }
+    layerGroups.referenceHighlight.addTo(map);
+
+    // Build sidebar with worst entities
+    // Store all entities sorted by error (for dynamic top-5 rendering)
+    let allLanes = [];
+    let allLines = [];
+    let allPolys = [];
+
+    // Get top N unchecked entities from sorted list
+    function getTopUnchecked(entities, n, reviewed) {
+      return entities.filter(e => !reviewed.has(`${e.type}-${e.id}`)).slice(0, n);
+    }
+
+    // Render a single entity item
+    function createEntityItem(item, threshold) {
+      const div = document.createElement('div');
+      div.className = 'entity-item';
+      div.dataset.type = item.type;
+      div.dataset.id = item.id;
+      const errClass = getErrorClass(item.error, threshold);
+      const label = item.type === 'lane' ? 'Lane' : item.type === 'line' ? 'Line' : 'Poly';
+      div.innerHTML = `
+        <input type="checkbox" class="entity-checkbox" data-type="${item.type}" data-id="${item.id}">
+        <span class="entity-id">${label} ${item.id}</span>
+        <span class="entity-error ${errClass}">${item.error.toFixed(4)}m</span>
+      `;
+      div.addEventListener('click', (e) => {
+        if (e.target.type !== 'checkbox') {
+          const entityKey = `${item.type}${item.id}`;
+          zoomToEntity(item.internal, null, entityKey, item.type);
+        }
+      });
+      return div;
+    }
+
+    // Render all lists with top 5 unchecked entities
+    function renderAllLists() {
+      const laneList = document.getElementById('lane-list');
+      const lineList = document.getElementById('line-list');
+      const polyList = document.getElementById('poly-list');
+
+      laneList.innerHTML = '';
+      lineList.innerHTML = '';
+      polyList.innerHTML = '';
+
+      const topLanes = getTopUnchecked(allLanes, 5, reviewedEntities);
+      const topLines = getTopUnchecked(allLines, 5, reviewedEntities);
+      const topPolys = getTopUnchecked(allPolys, 5, reviewedEntities);
+
+      topLanes.forEach(item => laneList.appendChild(createEntityItem(item, THRESHOLD_LANE)));
+      topLines.forEach(item => lineList.appendChild(createEntityItem(item, THRESHOLD_LINE)));
+      topPolys.forEach(item => polyList.appendChild(createEntityItem(item, THRESHOLD_POLY)));
+
+      // Add checkbox listeners to new elements
+      document.querySelectorAll('.entity-checkbox').forEach(cb => {
+        cb.addEventListener('change', handleCheckboxChange);
+      });
+
+      // Update status text
+      updateSidebarStatus();
+    }
+
+    function handleCheckboxChange(e) {
+      const type = e.target.dataset.type;
+      const id = parseInt(e.target.dataset.id);
+      const key = `${type}-${id}`;
+
+      if (e.target.checked) {
+        reviewedEntities.add(key);
+      } else {
+        reviewedEntities.delete(key);
+      }
+      // Re-render to show next top 5 unchecked entities
+      renderAllLists();
+    }
+
+    function updateSidebarStatus() {
+      const remainingLanes = allLanes.filter(e => !reviewedEntities.has(`lane-${e.id}`)).length;
+      const remainingLines = allLines.filter(e => !reviewedEntities.has(`line-${e.id}`)).length;
+      const remainingPolys = allPolys.filter(e => !reviewedEntities.has(`poly-${e.id}`)).length;
+      const statusEl = document.getElementById('sidebar-status');
+      if (statusEl) {
+        if (remainingLanes === 0 && remainingLines === 0 && remainingPolys === 0) {
+          statusEl.textContent = 'All entities reviewed!';
+        } else {
+          statusEl.textContent = `Remaining: ${remainingLanes} lanes, ${remainingLines} lines, ${remainingPolys} polys`;
+        }
+      }
+    }
+
+    function buildSidebar() {
+      // Get all lanes sorted by error
+      allLanes = LANES_INT.map(ent => ({
+        type: 'lane',
+        id: ent.id,
+        error: ent.hausdorff || 0,
+        internal: ent
+      })).sort((a, b) => b.error - a.error);
+
+      // Get all lines sorted by error
+      allLines = LINES_INT.map(ent => ({
+        type: 'line',
+        id: ent.index,
+        error: ent.hausdorff || 0,
+        internal: ent
+      })).sort((a, b) => b.error - a.error);
+
+      // Get all polygons sorted by error
+      allPolys = POLYS_INT.map(ent => ({
+        type: 'poly',
+        id: ent.index,
+        error: ent.hausdorff || 0,
+        internal: ent
+      })).sort((a, b) => b.error - a.error);
+
+      // Initial render of top 5 for each type
+      renderAllLists();
+    }
+
+    // Toggle section collapse
+    document.querySelectorAll('.sidebar-header').forEach(header => {
+      header.addEventListener('click', () => {
+        const section = header.dataset.section;
+        let listId;
+        if (section === 'lanes') listId = 'lane-list';
+        else if (section === 'lines') listId = 'line-list';
+        else if (section === 'polys') listId = 'poly-list';
+        const list = document.getElementById(listId);
+        const toggle = header.querySelector('.sidebar-toggle');
+
+        if (list.style.display === 'none') {
+          list.style.display = 'block';
+          toggle.textContent = '−';
+        } else {
+          list.style.display = 'none';
+          toggle.textContent = '+';
+        }
+      });
+    });
+
+    buildSidebar();
 
     let currentLayer = null;
     let referenceBasemapVisible = false;
     const vmaxByTab = { overlay: THRESHOLD_LANE, 'lane-heatmap': THRESHOLD_LANE, 'line-heatmap': THRESHOLD_LINE, 'polygon-heatmap': THRESHOLD_POLY };
+
     function updateLegendForTab(tab) {
       const vmax = vmaxByTab[tab] || VMAX_LANE;
       const maxEl = document.getElementById('legend-max');
@@ -226,25 +780,59 @@
       if (titleEl) titleEl.textContent = tab === 'overlay' ? 'Hausdorff error (m)' : 'Hausdorff error (m) - ' + (tab === 'lane-heatmap' ? 'Lanes' : tab === 'line-heatmap' ? 'Lines' : 'Polygons');
       const hintEl = document.getElementById('legend-hint');
       if (hintEl) hintEl.style.display = ['lane-heatmap', 'line-heatmap', 'polygon-heatmap'].includes(tab) ? 'block' : 'none';
+
+      // Update point markers for the new tab
+      showPointMarkers();
     }
 
     function showTab(tab) {
+      // Reset highlight state BEFORE switching tabs to prevent stale references
+      if (highlightedEntityKey || highlightedLayer || highlightedRefEntityKey) {
+        if (highlightedLayer) {
+          // Restore the layer's style directly if possible
+          const type = getEntityType(highlightedEntityKey);
+          if (type && highlightedLayer.setStyle) {
+            const ent = type === 'lane' ? LANES_INT.find(e => e.id == highlightedEntityKey.replace(/^lane/, '')) :
+                        type === 'line' ? LINES_INT.find(e => e.index == highlightedEntityKey.replace(/^line/, '')) :
+                        POLYS_INT.find(e => e.index == highlightedEntityKey.replace(/^poly/, ''));
+            if (ent) {
+              highlightedLayer.setStyle(activeTab === 'overlay' ? DEFAULT_STYLES[type] : getHeatmapDefaultStyle(ent, type));
+            }
+          }
+        }
+        highlightedEntityKey = null;
+        highlightedLayer = null;
+        highlightedRefEntityKey = null;
+        if (layerGroups.referenceHighlight) {
+          layerGroups.referenceHighlight.clearLayers();
+        }
+        pointMarkersLayer.clearLayers();
+      }
+
+      activeTab = tab;
       if (currentLayer && map.hasLayer(currentLayer)) {
         map.removeLayer(currentLayer);
       }
-      if (referenceBasemapVisible && map.hasLayer(layerGroups.referenceBasemap)) {
+      if (referenceBasemapVisible && layerGroups.referenceBasemap && map.hasLayer(layerGroups.referenceBasemap)) {
         map.removeLayer(layerGroups.referenceBasemap);
         referenceBasemapVisible = false;
       }
       const isHeatmap = ['lane-heatmap', 'line-heatmap', 'polygon-heatmap'].includes(tab);
       if (isHeatmap) {
-        layerGroups.referenceBasemap.addTo(map);
+        if (layerGroups.referenceBasemap) layerGroups.referenceBasemap.addTo(map);
         referenceBasemapVisible = true;
       }
       const lg = layerGroups[tab];
       if (lg && typeof lg.addTo === 'function') {
         lg.addTo(map);
         currentLayer = lg;
+      }
+      // Keep reference highlight on top so the yellow dashed line is visible
+      if (layerGroups.referenceHighlight && map.hasLayer(layerGroups.referenceHighlight) && typeof layerGroups.referenceHighlight.bringToFront === 'function') {
+        layerGroups.referenceHighlight.bringToFront();
+      }
+      if (pointMarkersLayer && map.hasLayer(pointMarkersLayer) && typeof pointMarkersLayer.bringToFront === 'function') {
+        pointMarkersLayer.bringToFront();
       }
       document.querySelectorAll('.tab').forEach(el => {
         el.classList.toggle('active', el.dataset.tab === tab);
@@ -254,21 +842,45 @@
     showTab('overlay');
 
     document.querySelectorAll('.tab').forEach(btn => {
-      btn.addEventListener('click', () => showTab(btn.dataset.tab));
+      btn.addEventListener('click', function() {
+        // Reset highlight state before switching tabs
+        highlightedEntityKey = null;
+        highlightedLayer = null;
+        highlightedRefEntityKey = null;
+        highlightedRefLayer = null;
+        showTab(this.getAttribute('data-tab'));
+      });
     });
 
     function rebuildOverlayFromCheckboxes() {
+      // Reset stale highlight state before destroying old layers
+      highlightedEntityKey = null;
+      highlightedLayer = null;
+      highlightedRefEntityKey = null;
+      if (layerGroups.referenceHighlight) {
+        layerGroups.referenceHighlight.clearLayers();
+      }
+      pointMarkersLayer.clearLayers();
+
       const lanesCb = document.querySelector('input[data-layer="lanes"]');
       const linesCb = document.querySelector('input[data-layer="lines"]');
       const polysCb = document.querySelector('input[data-layer="polygons"]');
       const showLanes = !lanesCb || lanesCb.checked;
       const showLines = !linesCb || linesCb.checked;
       const showPolys = !polysCb || polysCb.checked;
+
+      // Remove current overlay if it's shown
       if (currentLayer === layerGroups.overlay && map.hasLayer(layerGroups.overlay)) {
-        layerGroups.overlay.clearLayers();
-        if (showLanes) { LANES_REF.forEach(ent => { L.polyline(toLeafletCoords(ent.coordinates), { color: '#2d5016', weight: 2, opacity: 0.8 }).addTo(layerGroups.overlay); }); LANES_INT.forEach(ent => { L.polyline(toLeafletCoords(ent.coordinates), { color: 'blue', weight: 1.5, opacity: 0.7 }).addTo(layerGroups.overlay); }); }
-        if (showLines) { LINES_REF.forEach(ent => { L.polyline(toLeafletCoords(ent.coordinates), { color: '#2d5016', weight: 2, opacity: 0.8 }).addTo(layerGroups.overlay); }); LINES_INT.forEach(ent => { L.polyline(toLeafletCoords(ent.coordinates), { color: 'red', weight: 1.5, opacity: 0.8 }).addTo(layerGroups.overlay); }); }
-        if (showPolys) { POLYS_REF.forEach(ent => { L.polygon(ent.coordinates.map(r => toLeafletCoords(r)), { color: '#2d5016', weight: 2, fillOpacity: 0.2 }).addTo(layerGroups.overlay); }); POLYS_INT.forEach(ent => { L.polygon(ent.coordinates.map(r => toLeafletCoords(r)), { color: 'green', weight: 1, fillOpacity: 0.4 }).addTo(layerGroups.overlay); }); }
+        map.removeLayer(layerGroups.overlay);
+      }
+
+      // Rebuild with visibility config
+      addOverlayLayers({ showLanes, showLines, showPolys });
+
+      // Re-add to map if it was the current layer
+      if (activeTab === 'overlay') {
+        layerGroups.overlay.addTo(map);
+        currentLayer = layerGroups.overlay;
       }
     }
     document.querySelectorAll('.layer-cb input').forEach(cb => {

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/map_exporter.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/map_exporter.cpp
@@ -64,6 +64,16 @@ json lanelet_line_string_to_json(const LineStringT & ls)
   return out;
 }
 
+template <typename LineStringT>
+json lanelet_line_string_to_json_with_id(const LineStringT & ls)
+{
+  json out = json::array();
+  for (const auto & pt : ls) {
+    out.push_back(json{{"id", pt.id()}, {"points", json::array({pt.x(), pt.y(), pt.z()})}});
+  }
+  return out;
+}
+
 json to_json_lanelet_map(const LaneletMap & map)
 {
   json root;
@@ -94,9 +104,9 @@ json to_json_raw_lanelet_map(const lanelet::LaneletMapConstPtr & map_ptr)
   json root;
   root["lane_segments"] = json::array();
   for (const auto & ll : map_ptr->laneletLayer) {
-    const auto center = lanelet_line_string_to_json(ll.centerline3d());
-    const auto left = lanelet_line_string_to_json(ll.leftBound3d());
-    const auto right = lanelet_line_string_to_json(ll.rightBound3d());
+    const auto center = lanelet_line_string_to_json_with_id(ll.centerline3d());
+    const auto left = lanelet_line_string_to_json_with_id(ll.leftBound3d());
+    const auto right = lanelet_line_string_to_json_with_id(ll.rightBound3d());
     if (center.empty() || left.empty() || right.empty()) {
       continue;
     }


### PR DESCRIPTION


https://github.com/user-attachments/assets/5e8c94fd-dbd9-4753-9dac-8bcbb15c2e0f

Key features in the video

- Click to zoom to high error lanelet with IDs
- Click to zoom to high error points with IDs
- Check left_border/centerline/right_border
- Click checkbox to clear the list of high-error lanelets and investigate other lanelets


---

## What Changed

### 🗺️ Exporter: Point ID Export (`map_exporter.cpp`)

Lane boundary points (`centerline3d`, `leftBound3d`, `rightBound3d`) are now exported with their Lanelet2 point IDs in the **reference** JSON. This enables the evaluator to trace errors back to specific map primitives. 

>  [!NOTE]
> Notice that some of the centerline in the maps are computed, so the IDs will be 0.

---

### 📐 Evaluator: Metric and Pipeline Improvements (`compare_map.py`)

**Lane quality metrics are now more comprehensive:**
- Pass-rate now covers all three boundaries: centerline, left, and right (threshold: `< 0.2m` each)
- Key metric is the combined Hausdorff score across all three boundaries, replacing the previous centerline-only summary

**Point-level error computation added:**
- For lanes: per-boundary directed distances from reference points to internal geometry, traceable by point ID
- For lines: directed distances from internal to reference

---

### 🖥️ Interactive Report: Review Workflow UI (`interactive_map.html.j2`)

The HTML report is upgraded from a visualization tool to a **structured review interface**:

- **Sidebar** shows ranked top-error lists for lanes, lines, and polygons with collapsible sections
- **Checkbox workflow** tracks reviewed items with a remaining-count indicator
- **Click-to-inspect**: selecting any entity zooms the map, highlights the entity, and shows its matched reference geometry side-by-side
- **Lane point inspection**: a "Top-5 Reference Points" panel per selected lane; clicking a point jumps to its error marker on the map
- **Visual clarity**: lane boundaries (center/left/right) are rendered with distinct styles; highlight layers are always brought to front

---

## Impact Summary

| Area | Before | After |
|---|---|---|
| Lane pass metric | Centerline only | Centerline + left + right boundary |
| Point traceability | None | Per-point errors with Lanelet2 IDs |
| Reference geometry | Not shown alongside internal | Highlighted simultaneously on selection |