### PR TITLE
feat: npz search tools

### DIFF
--- a/diffusion_planner/diffusion_planner/utils/visualize_input.py
+++ b/diffusion_planner/diffusion_planner/utils/visualize_input.py
@@ -409,7 +409,8 @@ def setup_axis(ax, ego_x, ego_y, ego_state, view_range, inputs):
         turn_indicator = inputs["turn_indicators"][0][-1]
         if inputs["turn_indicators"][0][-2] == turn_indicator:
             # Same as previous timestep — prefix with "Keep" to indicate sustained signal
-            turn_indicator_text_gt = f"Keep {turn_indicator_int_to_str(turn_indicator)}"
+            label = turn_indicator_int_to_str(turn_indicator)
+            turn_indicator_text_gt = label if label == "Keep" else f"Keep {label}"
         else:
             turn_indicator_text_gt = turn_indicator_int_to_str(turn_indicator)
 

--- a/diffusion_planner/diffusion_planner/utils/visualize_input.py
+++ b/diffusion_planner/diffusion_planner/utils/visualize_input.py
@@ -29,20 +29,21 @@ def get_traffic_light_color(traffic_light):
         # raise ValueError(f"Unknown traffic light state: {traffic_light}")
 
 
+_TURN_INDICATOR_LABELS = {
+    0: "Straight",
+    1: "Straight",
+    2: "Left",
+    3: "Right",
+    4: "Keep",
+}
+
+
 def turn_indicator_int_to_str(turn_indicator):
     """Convert turn indicator integer to string."""
-    if turn_indicator == 0:
-        return "turn_indicator=0"
-    if turn_indicator == 1:
-        return "None"
-    elif turn_indicator == 2:
-        return "<-"
-    elif turn_indicator == 3:
-        return "->"
-    elif turn_indicator == 4:
-        return "Keep"
-    else:
+    label = _TURN_INDICATOR_LABELS.get(int(turn_indicator))
+    if label is None:
         raise ValueError(f"Unknown turn command: {turn_indicator}")
+    return label
 
 
 def draw_bounding_box(ax, x, y, cos, sin, len_x, len_y, color, alpha):
@@ -407,8 +408,10 @@ def setup_axis(ax, ego_x, ego_y, ego_state, view_range, inputs):
     if "turn_indicators" in inputs:
         turn_indicator = inputs["turn_indicators"][0][-1]
         if inputs["turn_indicators"][0][-2] == turn_indicator:
-            turn_indicator = TURN_INDICATOR_OUTPUT_KEEP
-        turn_indicator_text_gt = turn_indicator_int_to_str(turn_indicator)
+            # Same as previous timestep — prefix with "Keep" to indicate sustained signal
+            turn_indicator_text_gt = f"Keep {turn_indicator_int_to_str(turn_indicator)}"
+        else:
+            turn_indicator_text_gt = turn_indicator_int_to_str(turn_indicator)
 
     if "turn_indicator_pred" in inputs:
         turn_indicator_pred = inputs["turn_indicator_pred"]

--- a/diffusion_planner/util_scripts/search_scenes.py
+++ b/diffusion_planner/util_scripts/search_scenes.py
@@ -1,0 +1,603 @@
+"""Search and filter NPZ scenes by world-frame position, heading, and trajectory properties.
+
+Reads the JSON sidecar (same stem as .npz) to get world-frame ego pose (MGRS),
+then applies spatial, heading, and trajectory-based filters. Outputs a filtered
+JSON list compatible with path_list.json format.
+
+Examples:
+    # Find scenes in a bounding box
+    python -m diffusion_planner.util_scripts.search_scenes path_list.json \
+        --bbox 89120,42430,89140,42450
+
+    # Find scenes near a point within 50m
+    python -m diffusion_planner.util_scripts.search_scenes path_list.json \
+        --center 89135,42440 --radius 50
+
+    # Filter by heading (ego facing roughly east, handles wraparound)
+    python -m diffusion_planner.util_scripts.search_scenes path_list.json \
+        --bbox 89120,42430,89140,42450 --heading 80,120
+
+    # Filter by trajectory travel distance (moving scenes only)
+    python -m diffusion_planner.util_scripts.search_scenes path_list.json \
+        --center 89135,42440 --radius 50 --min-travel 5.0
+
+    # Filter by trajectory endpoint direction (ego-frame, degrees CCW from +X)
+    python -m diffusion_planner.util_scripts.search_scenes path_list.json \
+        --center 89135,42440 --radius 50 --trajectory-heading -30,30
+
+    # Build a spatial index cache for fast repeated queries
+    python -m diffusion_planner.util_scripts.search_scenes path_list.json \
+        --build-index index.parquet
+
+    # Use cached index for instant queries
+    python -m diffusion_planner.util_scripts.search_scenes path_list.json \
+        --index index.parquet --center 89135,42440 --radius 50
+
+    # Show statistics instead of saving
+    python -m diffusion_planner.util_scripts.search_scenes path_list.json \
+        --bbox 89120,42430,89140,42450 --stats
+
+    # Group results by driving sequence (consecutive timestamps from same bag)
+    python -m diffusion_planner.util_scripts.search_scenes path_list.json \
+        --bbox 89120,42430,89140,42450 --group-sequences
+"""
+
+import argparse
+import json
+import math
+import os
+import sys
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+from tqdm import tqdm
+
+
+# ---------------------------------------------------------------------------
+# Core data structures
+# ---------------------------------------------------------------------------
+
+def _quat_to_heading_deg(qz: float, qw: float) -> float:
+    """Convert quaternion (z, w components) to heading in degrees [-180, 180).
+
+    Convention: radians CCW from +X axis, converted to degrees.
+    """
+    yaw_rad = 2.0 * math.atan2(qz, qw)
+    deg = math.degrees(yaw_rad)
+    # Normalize to [-180, 180)
+    deg = (deg + 180.0) % 360.0 - 180.0
+    return deg
+
+
+def read_sidecar(npz_path: str) -> Optional[dict]:
+    """Read JSON sidecar for an NPZ file. Returns dict with x, y, heading_deg, timestamp or None."""
+    json_path = npz_path[:-4] + ".json"  # .npz -> .json
+    try:
+        with open(json_path, "r") as f:
+            j = json.load(f)
+        return {
+            "npz_path": npz_path,
+            "x": j["x"],
+            "y": j["y"],
+            "heading_deg": _quat_to_heading_deg(j["qz"], j["qw"]),
+            "timestamp": j.get("timestamp"),
+        }
+    except (FileNotFoundError, KeyError, json.JSONDecodeError):
+        return None
+
+
+def _read_sidecar_batch(npz_paths: list[str]) -> list[Optional[dict]]:
+    """Read sidecars for a batch of NPZ paths (used by ProcessPoolExecutor)."""
+    return [read_sidecar(p) for p in npz_paths]
+
+
+def build_index(npz_paths: list[str], workers: int = 8, batch_size: int = 500) -> list[dict]:
+    """Build spatial index from JSON sidecars using multiprocessing.
+
+    Returns list of dicts with keys: npz_path, x, y, heading_deg, timestamp.
+    Scenes without valid sidecars are silently skipped.
+    """
+    # Split into batches for multiprocessing
+    batches = [npz_paths[i:i + batch_size] for i in range(0, len(npz_paths), batch_size)]
+    results = []
+
+    with ProcessPoolExecutor(max_workers=workers) as executor:
+        futures = {executor.submit(_read_sidecar_batch, batch): batch for batch in batches}
+        with tqdm(total=len(npz_paths), desc="Reading sidecars", unit="scene") as pbar:
+            for future in as_completed(futures):
+                batch_results = future.result()
+                for r in batch_results:
+                    if r is not None:
+                        results.append(r)
+                pbar.update(len(batch_results))
+
+    return results
+
+
+def save_index_parquet(index: list[dict], path: str) -> None:
+    """Save index to parquet for fast reloading. Requires pyarrow."""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    table = pa.table({
+        "npz_path": [r["npz_path"] for r in index],
+        "x": [r["x"] for r in index],
+        "y": [r["y"] for r in index],
+        "heading_deg": [r["heading_deg"] for r in index],
+        "timestamp": [r["timestamp"] for r in index],
+    })
+    pq.write_table(table, path)
+
+
+def load_index_parquet(path: str) -> list[dict]:
+    """Load index from parquet."""
+    import pyarrow.parquet as pq
+
+    table = pq.read_table(path)
+    df = table.to_pydict()
+    return [
+        {
+            "npz_path": df["npz_path"][i],
+            "x": df["x"][i],
+            "y": df["y"][i],
+            "heading_deg": df["heading_deg"][i],
+            "timestamp": df["timestamp"][i],
+        }
+        for i in range(len(df["npz_path"]))
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Filters
+# ---------------------------------------------------------------------------
+
+def filter_bbox(index: list[dict], xmin: float, ymin: float, xmax: float, ymax: float) -> list[dict]:
+    """Filter scenes by axis-aligned bounding box in world coordinates."""
+    return [r for r in index if xmin <= r["x"] <= xmax and ymin <= r["y"] <= ymax]
+
+
+def filter_radius(index: list[dict], cx: float, cy: float, radius: float) -> list[dict]:
+    """Filter scenes within a radius of a center point."""
+    r2 = radius * radius
+    return [r for r in index if (r["x"] - cx) ** 2 + (r["y"] - cy) ** 2 <= r2]
+
+
+def _heading_in_range(heading: float, hmin: float, hmax: float) -> bool:
+    """Check if heading (degrees) is in [hmin, hmax], handling wraparound.
+
+    All values in [-180, 180). If hmin <= hmax, it's a simple range check.
+    If hmin > hmax (e.g., 170 to -170), it wraps around ±180.
+    """
+    if hmin <= hmax:
+        return hmin <= heading <= hmax
+    else:
+        # Wraparound: e.g., heading in [170, 180) or [-180, -170]
+        return heading >= hmin or heading <= hmax
+
+
+def filter_heading(index: list[dict], hmin: float, hmax: float) -> list[dict]:
+    """Filter scenes by ego heading range (degrees, handles ±180 wraparound)."""
+    return [r for r in index if _heading_in_range(r["heading_deg"], hmin, hmax)]
+
+
+def _compute_trajectory_props(npz_path: str) -> Optional[dict]:
+    """Load NPZ and compute trajectory properties from ego_agent_future.
+
+    Returns dict with travel_dist, endpoint_x, endpoint_y, trajectory_heading_deg.
+    trajectory_heading_deg is the direction from origin to trajectory endpoint (ego frame).
+    """
+    try:
+        d = np.load(npz_path)
+        fut = d["ego_agent_future"]  # (80, 3) = [x, y, yaw_rad]
+        # Total travel distance along the trajectory
+        dx = np.diff(fut[:, 0])
+        dy = np.diff(fut[:, 1])
+        travel_dist = float(np.sqrt(dx ** 2 + dy ** 2).sum())
+        # Endpoint in ego frame
+        ex, ey = float(fut[-1, 0]), float(fut[-1, 1])
+        # Direction from ego to endpoint
+        traj_heading_deg = math.degrees(math.atan2(ey, ex))
+        return {
+            "travel_dist": travel_dist,
+            "endpoint_x": ex,
+            "endpoint_y": ey,
+            "trajectory_heading_deg": traj_heading_deg,
+        }
+    except Exception:
+        return None
+
+
+def _compute_trajectory_batch(npz_paths: list[str]) -> list[tuple[str, Optional[dict]]]:
+    """Compute trajectory properties for a batch (used by ProcessPoolExecutor)."""
+    return [(p, _compute_trajectory_props(p)) for p in npz_paths]
+
+
+def enrich_with_trajectory(index: list[dict], workers: int = 8, batch_size: int = 200) -> list[dict]:
+    """Add trajectory properties (travel_dist, endpoint, trajectory_heading) to index entries.
+
+    Loads the NPZ files to read ego_agent_future. Entries where NPZ can't be read are dropped.
+    """
+    path_to_entry = {r["npz_path"]: r for r in index}
+    paths = [r["npz_path"] for r in index]
+    batches = [paths[i:i + batch_size] for i in range(0, len(paths), batch_size)]
+    enriched = []
+
+    with ProcessPoolExecutor(max_workers=workers) as executor:
+        futures = {executor.submit(_compute_trajectory_batch, batch): batch for batch in batches}
+        with tqdm(total=len(paths), desc="Reading trajectories", unit="scene") as pbar:
+            for future in as_completed(futures):
+                for npz_path, props in future.result():
+                    if props is not None:
+                        entry = dict(path_to_entry[npz_path])
+                        entry.update(props)
+                        enriched.append(entry)
+                pbar.update(len(futures[future]))
+                del futures[future]  # free reference
+                break  # re-check as_completed after deleting
+
+    # Simpler fallback: just iterate
+    if not enriched:
+        for npz_path, entry in path_to_entry.items():
+            props = _compute_trajectory_props(npz_path)
+            if props:
+                e = dict(entry)
+                e.update(props)
+                enriched.append(e)
+
+    return enriched
+
+
+def enrich_with_trajectory_simple(index: list[dict], workers: int = 8, batch_size: int = 200) -> list[dict]:
+    """Add trajectory properties to index entries using multiprocessing."""
+    path_to_entry = {r["npz_path"]: r for r in index}
+    paths = [r["npz_path"] for r in index]
+    batches = [paths[i:i + batch_size] for i in range(0, len(paths), batch_size)]
+    enriched = []
+
+    with ProcessPoolExecutor(max_workers=workers) as executor:
+        futures = []
+        for batch in batches:
+            futures.append(executor.submit(_compute_trajectory_batch, batch))
+
+        with tqdm(total=len(paths), desc="Reading trajectories", unit="scene") as pbar:
+            for future in as_completed(futures):
+                for npz_path, props in future.result():
+                    if props is not None:
+                        entry = dict(path_to_entry[npz_path])
+                        entry.update(props)
+                        enriched.append(entry)
+                pbar.update(batch_size)
+
+    return enriched
+
+
+def filter_travel_distance(index: list[dict], min_dist: Optional[float] = None, max_dist: Optional[float] = None) -> list[dict]:
+    """Filter by total GT trajectory travel distance (meters)."""
+    result = index
+    if min_dist is not None:
+        result = [r for r in result if r.get("travel_dist", 0) >= min_dist]
+    if max_dist is not None:
+        result = [r for r in result if r.get("travel_dist", float("inf")) <= max_dist]
+    return result
+
+
+def filter_trajectory_heading(index: list[dict], hmin: float, hmax: float) -> list[dict]:
+    """Filter by trajectory endpoint direction in ego frame (degrees, handles wraparound)."""
+    return [r for r in index if "trajectory_heading_deg" in r and _heading_in_range(r["trajectory_heading_deg"], hmin, hmax)]
+
+
+# ---------------------------------------------------------------------------
+# Sequence grouping
+# ---------------------------------------------------------------------------
+
+def _bag_prefix(npz_path: str) -> str:
+    """Extract bag/sequence prefix from NPZ path (everything before the last _NNNNN.npz)."""
+    return npz_path.rsplit("_", 1)[0]
+
+
+def group_sequences(entries: list[dict], max_gap_frames: int = 5) -> list[list[dict]]:
+    """Group entries into continuous driving sequences.
+
+    Entries from the same bag prefix with frame numbers within max_gap_frames
+    of each other are grouped together. Returns list of groups, sorted by frame number.
+    """
+    from collections import defaultdict
+    import re
+
+    bags = defaultdict(list)
+    for entry in entries:
+        prefix = _bag_prefix(entry["npz_path"])
+        # Extract frame number from path: ..._0000000000000431.npz
+        match = re.search(r"_(\d+)\.npz$", entry["npz_path"])
+        frame = int(match.group(1)) if match else 0
+        bags[prefix].append((frame, entry))
+
+    groups = []
+    for prefix, items in bags.items():
+        items.sort(key=lambda x: x[0])
+        current_group = [items[0]]
+        for i in range(1, len(items)):
+            if items[i][0] - current_group[-1][0] <= max_gap_frames:
+                current_group.append(items[i])
+            else:
+                groups.append([e for _, e in current_group])
+                current_group = [items[i]]
+        groups.append([e for _, e in current_group])
+
+    groups.sort(key=lambda g: g[0]["npz_path"])
+    return groups
+
+
+# ---------------------------------------------------------------------------
+# Statistics
+# ---------------------------------------------------------------------------
+
+def print_stats(entries: list[dict]) -> None:
+    """Print summary statistics for a set of scene entries."""
+    if not entries:
+        print("No scenes matched.")
+        return
+
+    xs = [r["x"] for r in entries]
+    ys = [r["y"] for r in entries]
+    headings = [r["heading_deg"] for r in entries]
+
+    print(f"Matched scenes: {len(entries)}")
+    print(f"  X range: {min(xs):.1f} - {max(xs):.1f} (span: {max(xs)-min(xs):.1f}m)")
+    print(f"  Y range: {min(ys):.1f} - {max(ys):.1f} (span: {max(ys)-min(ys):.1f}m)")
+    print(f"  Heading range: {min(headings):.1f} - {max(headings):.1f} deg")
+
+    # Sequence info
+    prefixes = set(_bag_prefix(r["npz_path"]) for r in entries)
+    print(f"  Unique bag sequences: {len(prefixes)}")
+
+    if "travel_dist" in entries[0]:
+        dists = [r["travel_dist"] for r in entries]
+        print(f"  Travel distance: {min(dists):.1f} - {max(dists):.1f}m (mean: {sum(dists)/len(dists):.1f}m)")
+    if "trajectory_heading_deg" in entries[0]:
+        th = [r["trajectory_heading_deg"] for r in entries]
+        print(f"  Trajectory heading: {min(th):.1f} - {max(th):.1f} deg")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Search and filter NPZ scenes by position, heading, and trajectory.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "input",
+        type=str,
+        help="Path to path_list.json or directory containing NPZ files",
+    )
+    parser.add_argument(
+        "-o", "--output",
+        type=str,
+        default=None,
+        help="Output JSON path (default: auto-generated from input name + filters)",
+    )
+
+    # Spatial filters
+    spatial = parser.add_argument_group("spatial filters")
+    spatial.add_argument(
+        "--bbox",
+        type=str,
+        default=None,
+        help="Bounding box: xmin,ymin,xmax,ymax",
+    )
+    spatial.add_argument(
+        "--center",
+        type=str,
+        default=None,
+        help="Center point for radius search: x,y",
+    )
+    spatial.add_argument(
+        "--radius",
+        type=float,
+        default=None,
+        help="Radius in meters (requires --center)",
+    )
+
+    # Heading filter
+    heading = parser.add_argument_group("heading filter")
+    heading.add_argument(
+        "--heading",
+        type=str,
+        default=None,
+        help="Ego heading range in degrees: min,max (handles ±180 wraparound)",
+    )
+
+    # Trajectory filters (require reading NPZ files)
+    traj = parser.add_argument_group("trajectory filters (reads NPZ files, slower)")
+    traj.add_argument(
+        "--min-travel",
+        type=float,
+        default=None,
+        help="Minimum GT trajectory travel distance in meters",
+    )
+    traj.add_argument(
+        "--max-travel",
+        type=float,
+        default=None,
+        help="Maximum GT trajectory travel distance in meters",
+    )
+    traj.add_argument(
+        "--trajectory-heading",
+        type=str,
+        default=None,
+        help="Trajectory endpoint direction range (ego frame, degrees): min,max",
+    )
+
+    # Index caching
+    cache = parser.add_argument_group("index caching")
+    cache.add_argument(
+        "--build-index",
+        type=str,
+        default=None,
+        help="Build and save spatial index to this parquet file (then exit)",
+    )
+    cache.add_argument(
+        "--index",
+        type=str,
+        default=None,
+        help="Load pre-built spatial index from parquet (skips sidecar reading)",
+    )
+
+    # Output options
+    output = parser.add_argument_group("output options")
+    output.add_argument(
+        "--stats",
+        action="store_true",
+        help="Print statistics instead of saving JSON",
+    )
+    output.add_argument(
+        "--group-sequences",
+        action="store_true",
+        help="Group results by continuous driving sequence and show summary",
+    )
+    output.add_argument(
+        "--workers",
+        type=int,
+        default=8,
+        help="Number of parallel workers (default: 8)",
+    )
+
+    return parser.parse_args()
+
+
+def load_npz_paths(input_path: str) -> list[str]:
+    """Load NPZ paths from a JSON list or by globbing a directory."""
+    p = Path(input_path)
+    if p.is_file() and p.suffix == ".json":
+        with open(p) as f:
+            return json.load(f)
+    elif p.is_dir():
+        return sorted(str(f) for f in p.rglob("*.npz"))
+    else:
+        print(f"Error: {input_path} is not a .json file or directory", file=sys.stderr)
+        sys.exit(1)
+
+
+def auto_output_name(input_path: str, filters: dict) -> str:
+    """Generate output filename from input path and applied filters."""
+    stem = Path(input_path).stem
+    parts = [stem]
+    if filters.get("bbox"):
+        parts.append("bbox")
+    if filters.get("center"):
+        parts.append(f"r{filters['radius']:.0f}")
+    if filters.get("heading"):
+        parts.append(f"h{filters['heading']}")
+    if filters.get("min_travel") or filters.get("max_travel"):
+        parts.append("traj")
+    parent = Path(input_path).parent
+    return str(parent / ("_".join(parts) + ".json"))
+
+
+def main():
+    args = parse_args()
+
+    # Load scene paths
+    npz_paths = load_npz_paths(args.input)
+    print(f"Loaded {len(npz_paths)} scene paths from {args.input}")
+
+    # Build or load index
+    if args.build_index:
+        index = build_index(npz_paths, workers=args.workers)
+        save_index_parquet(index, args.build_index)
+        print(f"Saved index ({len(index)} scenes) to {args.build_index}")
+        return
+
+    if args.index:
+        print(f"Loading cached index from {args.index}")
+        index = load_index_parquet(args.index)
+        print(f"Loaded {len(index)} scenes from index")
+    else:
+        index = build_index(npz_paths, workers=args.workers)
+
+    print(f"Indexed {len(index)} scenes with valid sidecars")
+
+    # Apply spatial filters
+    if args.bbox:
+        xmin, ymin, xmax, ymax = [float(v) for v in args.bbox.split(",")]
+        index = filter_bbox(index, xmin, ymin, xmax, ymax)
+        print(f"After bbox filter: {len(index)} scenes")
+
+    if args.center:
+        if args.radius is None:
+            print("Error: --center requires --radius", file=sys.stderr)
+            sys.exit(1)
+        cx, cy = [float(v) for v in args.center.split(",")]
+        index = filter_radius(index, cx, cy, args.radius)
+        print(f"After radius filter: {len(index)} scenes")
+
+    if args.heading:
+        hmin, hmax = [float(v) for v in args.heading.split(",")]
+        index = filter_heading(index, hmin, hmax)
+        print(f"After heading filter: {len(index)} scenes")
+
+    # Trajectory filters (require NPZ loading)
+    needs_traj = any([args.min_travel, args.max_travel, args.trajectory_heading])
+    if needs_traj:
+        index = enrich_with_trajectory_simple(index, workers=args.workers)
+        print(f"Enriched {len(index)} scenes with trajectory data")
+
+        if args.min_travel or args.max_travel:
+            index = filter_travel_distance(index, args.min_travel, args.max_travel)
+            print(f"After travel distance filter: {len(index)} scenes")
+
+        if args.trajectory_heading:
+            thmin, thmax = [float(v) for v in args.trajectory_heading.split(",")]
+            index = filter_trajectory_heading(index, thmin, thmax)
+            print(f"After trajectory heading filter: {len(index)} scenes")
+
+    # Output
+    if args.stats or args.group_sequences:
+        # Enrich with trajectory for stats if not already done
+        if not needs_traj and index:
+            print("Loading trajectory data for statistics...")
+            index = enrich_with_trajectory_simple(index, workers=args.workers)
+
+        print_stats(index)
+
+        if args.group_sequences:
+            groups = group_sequences(index)
+            print(f"\n{'='*60}")
+            print(f"Sequences: {len(groups)}")
+            for i, group in enumerate(groups):
+                prefix = _bag_prefix(group[0]["npz_path"]).split("/")[-1]
+                dists = [r.get("travel_dist", 0) for r in group]
+                print(f"  [{i}] {prefix}: {len(group)} scenes, "
+                      f"travel {min(dists):.1f}-{max(dists):.1f}m")
+
+    if not args.stats:
+        # Sort by path for deterministic output
+        index.sort(key=lambda r: r["npz_path"])
+        output_paths = [r["npz_path"] for r in index]
+
+        if args.output:
+            out_path = args.output
+        else:
+            filters = {
+                "bbox": args.bbox,
+                "center": args.center,
+                "radius": args.radius,
+                "heading": args.heading,
+                "min_travel": args.min_travel,
+                "max_travel": args.max_travel,
+            }
+            out_path = auto_output_name(args.input, filters)
+
+        with open(out_path, "w") as f:
+            json.dump(output_paths, f, indent=4)
+        print(f"\nSaved {len(output_paths)} scenes to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scene_search/README.md
+++ b/scene_search/README.md
@@ -1,0 +1,98 @@
+# Scene Search GUI
+
+Visual tool for searching and curating NPZ driving scenes by clicking on a lanelet2 road map.
+
+## Setup
+
+Requires ROS 2 Humble + Autoware lanelet2 extension (for map loading).
+
+```bash
+source /opt/ros/humble/setup.bash
+source ~/autoware/install/setup.bash  # or set AUTOWARE_INSTALL env var
+source .venv/bin/activate
+```
+
+## Launch
+
+```bash
+python -m scene_search.app \
+  --map_path /path/to/lanelet2_map.osm \
+  --npz_list /path/to/path_list.json_or_npz_directory \
+  [--port 7860]
+```
+
+Example with shinagawa_odaiba map:
+```bash
+python -m scene_search.app \
+  --map_path ~/autoware_map/shinagawa_odaiba_stable/lanelet2_map.osm \
+  --npz_list /media/danielsanchez/2fb4af16-188c-4b7d-8ebb-4a7d0c90d207/xx1_grpo_v4_data/npz/
+```
+
+## Usage
+
+### Map interaction
+- **Drag** — pan the map
+- **Scroll** — zoom in/out (centered on cursor)
+- **Shift+drag** — draw arrow (sets search position + heading)
+
+### Search workflow
+1. Navigate to area of interest (drag/scroll)
+2. **Shift+drag** to place an arrow (or type X, Y, Heading manually)
+3. Adjust **radius**, **heading tolerance**, **frames before/after** in sidebar
+4. Click **Search** — finds matching scenes, expands to contiguous batches
+5. Review thumbnail previews (every 10th scene per batch)
+6. Click **Keep Batch N** or **Keep All Batches** to add to kept collection
+7. Draw a new arrow elsewhere, search again, keep more batches
+8. Click **Save All Kept → JSON** to export
+
+### Constraints
+Collapsible panels in the sidebar for filtering scenes:
+- **Neighbor Count** — min/max active neighbors within a radius
+- **Ego Speed** — min/max speed at t=0 (km/h)
+- **Travel Distance** — min/max GT trajectory distance (meters)
+
+Enable a constraint checkbox, set parameters, then Search.
+
+### Saving
+- Set the **base name** (default: `<cwd>/kept_scenes`)
+- Files auto-increment: `kept_scenes_0.json`, `kept_scenes_1.json`, ...
+- **Downsample to N** — randomly sample N scenes from all kept batches
+- Output format: JSON list of NPZ paths (compatible with `path_list.json`)
+
+## Adding constraints
+
+Create a new file in `scene_search/constraints/` following the plugin pattern:
+
+```python
+from scene_search.constraints.base import BaseConstraint
+from scene_search.constraints.registry import register
+
+@register("my_constraint")
+class MyConstraint(BaseConstraint):
+    name = "My Constraint"
+    description = "Filter by something"
+
+    def get_params_spec(self):
+        return {
+            "threshold": {"type": "float", "default": 5.0, "label": "Threshold",
+                          "min": 0.0, "max": 100.0, "step": 1.0},
+        }
+
+    def filter(self, npz_path, npz_data, params):
+        # Return True if scene passes
+        return some_value <= params["threshold"]
+```
+
+Then add the import to `scene_search/constraints/__init__.py`.
+
+## CLI backend
+
+The search backend can also be used standalone:
+
+```bash
+python diffusion_planner/util_scripts/search_scenes.py \
+  /path/to/path_list.json \
+  --center 89130,42440 --radius 50 \
+  --heading 76,136 \
+  --stats --group-sequences
+```

--- a/scene_search/__main__.py
+++ b/scene_search/__main__.py
@@ -1,0 +1,4 @@
+"""Allow running as `python -m scene_search`."""
+from scene_search.app import main
+
+main()

--- a/scene_search/app.py
+++ b/scene_search/app.py
@@ -400,15 +400,18 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
                 constraint_input_list.append(cc["params"][pn])
             constraint_input_meta.append((cname, param_names))
 
-        # --- Search (generator: yields central thumbnails first, then full) ---
-        def on_search(x, y, heading, radius, heading_tol, n_before, n_after, idx, *constraint_vals):
+        # --- Search: two-phase rendering ---
+        # Phase 1: find batches + render central thumbnails only (fast ~0.3s/batch)
+        # Phase 2: render remaining thumbnails (chained via .then())
+
+        def on_search_phase1(x, y, heading, radius, heading_tol, n_before, n_after, idx, *constraint_vals):
+            """Find batches and render central thumbnails with placeholders."""
             if x == 0 and y == 0:
                 outputs = ["Enter coordinates and click Search", gr.update(visible=False)]
                 for _ in range(MAX_VISIBLE_BATCHES):
                     outputs.extend([gr.update(visible=False), gr.update(), gr.update(value=None)])
                 outputs.append([])
-                yield outputs
-                return
+                return outputs
 
             # Parse constraint values
             active_filters = []
@@ -440,30 +443,61 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
             constraint_info = f" ({n_constraints} constraint{'s' if n_constraints != 1 else ''} active)" if active_filters else ""
 
             outputs = [
-                f"Found **{len(batches)} batches** ({total} total scenes){constraint_info}",
+                f"Found **{len(batches)} batches** ({total} total scenes){constraint_info} — loading thumbnails...",
                 gr.update(visible=len(batches) > 0),
             ]
             for i in range(MAX_VISIBLE_BATCHES):
                 if i < len(batches):
                     b = batches[i]
-                    thumbs = render_batch_thumbnails(b, every_nth=10, max_workers=8)
-                    pils = thumbnails_to_pil_images(thumbs)
-                    outputs.extend([gr.update(visible=True), f"**Batch {i+1}**: {b.summary()}", pils])
+                    pils_with_placeholders, _ = render_central_thumbnail(b, every_nth=10)
+                    outputs.extend([gr.update(visible=True), f"**Batch {i+1}**: {b.summary()}", pils_with_placeholders])
                 else:
                     outputs.extend([gr.update(visible=False), gr.update(), gr.update(value=None)])
             outputs.append(batch_dicts)
             return outputs
 
-        search_outputs = [results_info, keep_all_btn]
+        def on_search_phase2(batch_dicts):
+            """Render full thumbnails for all batches (runs after phase 1)."""
+            if not batch_dicts:
+                outputs = [gr.update()]
+                for _ in range(MAX_VISIBLE_BATCHES):
+                    outputs.append(gr.update())
+                return outputs
+
+            total = sum(len(bd["scenes"]) for bd in batch_dicts)
+            outputs = [f"Found **{len(batch_dicts)} batches** ({total} total scenes)"]
+            # Reconstruct Batch objects and render
+            from scene_search.batch_search import Batch
+            for i in range(MAX_VISIBLE_BATCHES):
+                if i < len(batch_dicts):
+                    bd = batch_dicts[i]
+                    b = Batch(bag_prefix=bd["bag_prefix"], scenes=bd["scenes"],
+                              central_indices=bd["central_indices"], metadata=bd["metadata"])
+                    full_pils = render_remaining_thumbnails(b, every_nth=10, max_workers=8)
+                    outputs.append(full_pils)
+                else:
+                    outputs.append(gr.update())
+            return outputs
+
+        search_outputs_phase1 = [results_info, keep_all_btn]
         for i in range(MAX_VISIBLE_BATCHES):
-            search_outputs.extend([batch_groups[i], batch_labels[i], batch_galleries[i]])
-        search_outputs.append(search_results_state)
+            search_outputs_phase1.extend([batch_groups[i], batch_labels[i], batch_galleries[i]])
+        search_outputs_phase1.append(search_results_state)
+
+        # Phase 2 only updates results_info + galleries (not groups/labels)
+        search_outputs_phase2 = [results_info]
+        for i in range(MAX_VISIBLE_BATCHES):
+            search_outputs_phase2.append(batch_galleries[i])
 
         search_btn.click(
-            on_search,
+            on_search_phase1,
             inputs=[arrow_x, arrow_y, arrow_heading, radius_slider, heading_tol_slider,
                     n_before_slider, n_after_slider, index_state] + constraint_input_list,
-            outputs=search_outputs,
+            outputs=search_outputs_phase1,
+        ).then(
+            on_search_phase2,
+            inputs=[search_results_state],
+            outputs=search_outputs_phase2,
         )
 
         # --- Keep ---

--- a/scene_search/app.py
+++ b/scene_search/app.py
@@ -233,6 +233,7 @@ MAP_CANVAS_JS = r"""
     });
     canvas.addEventListener('mouseleave', () => {
         if (isPanning) { isPanning = false; panPrev = null; canvas.style.cursor = 'grab'; }
+        if (isDrawing) { isDrawing = false; canvas.style.cursor = 'grab'; }
     });
     canvas.addEventListener('wheel', (e) => {
         e.preventDefault();
@@ -467,10 +468,11 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
                 thumbs = render_batch_thumbnails(b, every_nth=10, max_workers=4)
                 return thumbnails_to_pil_images(thumbs)
 
+            from concurrent.futures import as_completed as _as_completed
             all_pils = [None] * len(batch_dicts)
             with ThreadPoolExecutor(max_workers=min(len(batch_dicts), 6)) as tex:
                 futures = {tex.submit(_render_one, bd): i for i, bd in enumerate(batch_dicts)}
-                for fut in futures:
+                for fut in _as_completed(futures):
                     all_pils[futures[fut]] = fut.result()
 
             total = sum(len(bd["scenes"]) for bd in batch_dicts)

--- a/scene_search/app.py
+++ b/scene_search/app.py
@@ -356,7 +356,8 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
                     with gr.Group(visible=False) as grp:
                         lbl = gr.Markdown(f"Batch {i+1}")
                         gal = gr.Gallery(label=f"Batch {i+1}", columns=6, rows=2,
-                                         height=220, object_fit="contain")
+                                         height=220, object_fit="contain",
+                                         preview=True)
                         with gr.Row():
                             keep_b = gr.Button(f"Keep Batch {i+1}", size="sm", variant="primary")
                     batch_groups.append(grp)

--- a/scene_search/app.py
+++ b/scene_search/app.py
@@ -1,0 +1,541 @@
+"""Scene Search GUI — visual search for NPZ driving scenes on a lanelet2 map.
+
+Launch:
+    source /opt/ros/humble/setup.bash
+    source /home/danielsanchez/autoware/install/setup.bash
+    source .venv/bin/activate
+    python -m scene_search.app \
+        --map_path /home/danielsanchez/autoware_map/shinagawa_odaiba_stable/lanelet2_map.osm \
+        --npz_list /path/to/path_list.json \
+        [--index /path/to/cached_index.parquet] \
+        [--port 7860]
+"""
+
+import argparse
+import json
+import random
+from pathlib import Path
+
+import gradio as gr
+import numpy as np
+
+from scene_search.batch_search import Batch, build_index, find_batches, load_index_parquet, save_index_parquet
+from scene_search.constraints import list_available as list_constraints
+from scene_search.constraints.registry import build as build_constraint
+from scene_search.map_renderer import MapRenderer, Viewport
+from scene_search.scene_previewer import render_batch_thumbnails, thumbnails_to_pil_images
+
+MAX_VISIBLE_BATCHES = 10
+
+# ── JS for the interactive map canvas ──────────────────────────────────────
+# All pan/zoom is client-side. The full-map image is loaded once via props.map_b64.
+# Only calls server.render_map() on deep zoom (debounced).
+
+MAP_CANVAS_JS = r"""
+(function() {
+    const W = 900, H = 700;
+    const canvas = document.createElement('canvas');
+    canvas.width = W; canvas.height = H;
+    canvas.style.cssText = 'display:block; margin:auto; border:1px solid #ccc; cursor:grab;';
+    element.innerHTML = '';
+    element.appendChild(canvas);
+    const help = document.createElement('div');
+    help.style.cssText = 'text-align:center; font-size:12px; color:#666; margin-top:4px;';
+    help.innerHTML = 'Drag=pan | Scroll=zoom | <b>Shift+drag=arrow</b>';
+    element.appendChild(help);
+    const ctx = canvas.getContext('2d');
+
+    // World bounds of the full map image
+    const bounds = JSON.parse(props.map_bounds);
+    // Current view in world coords
+    let vx0 = bounds.xmin, vy0 = bounds.ymin, vx1 = bounds.xmax, vy1 = bounds.ymax;
+
+    // Full map image (loaded once)
+    let fullImg = null;
+    // Hi-res tile for current zoom (loaded on demand)
+    let tileImg = null;
+    let tileBounds = null;
+
+    // Arrow state — stored in WORLD coords so it survives pan/zoom
+    let arrowStartPx = null, arrowEndPx = null;
+    let arrowStartWorld = null, arrowEndWorld = null;
+    let isDrawing = false;
+    // Pan state
+    let isPanning = false, panPrev = null;
+    // Debounce timer for tile re-render
+    let tileTimer = null;
+
+    function worldToCanvas(wx, wy) {
+        return {
+            x: (wx - vx0) / (vx1 - vx0) * W,
+            y: (vy1 - wy) / (vy1 - vy0) * H
+        };
+    }
+    function canvasToWorld(cx, cy) {
+        return {
+            x: vx0 + (cx / W) * (vx1 - vx0),
+            y: vy1 - (cy / H) * (vy1 - vy0)
+        };
+    }
+    function m2px(m) { return m / (vx1 - vx0) * W; }
+
+    function drawMapImage() {
+        ctx.fillStyle = '#f0f0f0';
+        ctx.fillRect(0, 0, W, H);
+
+        // Draw the tile (hi-res) if available and covers viewport, else draw full image
+        let img = null, ib = null;
+        if (tileImg && tileImg.complete && tileBounds) {
+            img = tileImg; ib = tileBounds;
+        } else if (fullImg && fullImg.complete) {
+            img = fullImg; ib = bounds;
+        }
+        if (img && ib) {
+            // Source rect in image pixels
+            const imgW = img.naturalWidth, imgH = img.naturalHeight;
+            const sx = (vx0 - ib.xmin) / (ib.xmax - ib.xmin) * imgW;
+            const sy = (ib.ymax - vy1) / (ib.ymax - ib.ymin) * imgH;
+            const sw = (vx1 - vx0) / (ib.xmax - ib.xmin) * imgW;
+            const sh = (vy1 - vy0) / (ib.ymax - ib.ymin) * imgH;
+            ctx.drawImage(img, sx, sy, sw, sh, 0, 0, W, H);
+        }
+    }
+
+    function redraw() {
+        drawMapImage();
+        // Recompute pixel positions from world coords (so arrow follows pan/zoom)
+        if (arrowStartWorld && !isDrawing) {
+            arrowStartPx = worldToCanvas(arrowStartWorld.x, arrowStartWorld.y);
+            if (arrowEndWorld) {
+                arrowEndPx = worldToCanvas(arrowEndWorld.x, arrowEndWorld.y);
+            }
+        }
+        const radius = parseFloat(props.radius) || 50;
+        // Radius circle + arrow
+        if (arrowStartPx) {
+            const rPx = m2px(radius);
+            ctx.strokeStyle = 'rgba(255,68,0,0.5)';
+            ctx.lineWidth = 2;
+            ctx.setLineDash([6, 4]);
+            ctx.beginPath();
+            ctx.arc(arrowStartPx.x, arrowStartPx.y, rPx, 0, Math.PI * 2);
+            ctx.stroke();
+            ctx.setLineDash([]);
+            // Heading tolerance wedge
+            const htol = parseFloat(props.heading_tol) || 30;
+            if (arrowEndPx) {
+                const dx = arrowEndPx.x - arrowStartPx.x;
+                const dy = arrowEndPx.y - arrowStartPx.y;
+                const ang = Math.atan2(dy, dx);
+                const halfTol = htol * Math.PI / 180;
+                ctx.fillStyle = 'rgba(255,68,0,0.08)';
+                ctx.beginPath();
+                ctx.moveTo(arrowStartPx.x, arrowStartPx.y);
+                ctx.arc(arrowStartPx.x, arrowStartPx.y, rPx, ang - halfTol, ang + halfTol);
+                ctx.closePath();
+                ctx.fill();
+            }
+        }
+        if (arrowStartPx && arrowEndPx) {
+            const dx = arrowEndPx.x - arrowStartPx.x;
+            const dy = arrowEndPx.y - arrowStartPx.y;
+            const len = Math.sqrt(dx*dx + dy*dy);
+            if (len > 3) {
+                const ang = Math.atan2(dy, dx);
+                ctx.strokeStyle = '#ff4400'; ctx.lineWidth = 3;
+                ctx.beginPath();
+                ctx.moveTo(arrowStartPx.x, arrowStartPx.y);
+                ctx.lineTo(arrowEndPx.x, arrowEndPx.y);
+                ctx.stroke();
+                const hl = Math.min(18, len * 0.3);
+                ctx.fillStyle = '#ff4400';
+                ctx.beginPath();
+                ctx.moveTo(arrowEndPx.x, arrowEndPx.y);
+                ctx.lineTo(arrowEndPx.x - hl*Math.cos(ang-0.4), arrowEndPx.y - hl*Math.sin(ang-0.4));
+                ctx.lineTo(arrowEndPx.x - hl*Math.cos(ang+0.4), arrowEndPx.y - hl*Math.sin(ang+0.4));
+                ctx.closePath(); ctx.fill();
+            }
+            ctx.fillStyle = '#ff4400';
+            ctx.beginPath();
+            ctx.arc(arrowStartPx.x, arrowStartPx.y, 5, 0, Math.PI * 2);
+            ctx.fill();
+        }
+        // Scale bar
+        const scaleM = Math.pow(10, Math.floor(Math.log10((vx1-vx0)*0.2)));
+        const scalePx = m2px(scaleM);
+        ctx.fillStyle = '#333'; ctx.font = '11px monospace';
+        ctx.fillText(scaleM >= 1000 ? (scaleM/1000)+'km' : scaleM+'m', 15, H-20);
+        ctx.strokeStyle = '#333'; ctx.lineWidth = 2; ctx.setLineDash([]);
+        ctx.beginPath(); ctx.moveTo(15, H-12); ctx.lineTo(15+scalePx, H-12); ctx.stroke();
+    }
+
+    function scheduleTileRefresh() {
+        clearTimeout(tileTimer);
+        tileTimer = setTimeout(async () => {
+            const vpJson = JSON.stringify({xmin:vx0, ymin:vy0, xmax:vx1, ymax:vy1,
+                                           canvas_w: 2000, canvas_h: 1600});
+            try {
+                const b64 = await server.render_map(vpJson);
+                tileImg = new Image();
+                tileBounds = {xmin:vx0, ymin:vy0, xmax:vx1, ymax:vy1};
+                tileImg.onload = redraw;
+                tileImg.src = 'data:image/png;base64,' + b64;
+            } catch(e) { console.warn('tile render failed', e); }
+        }, 400);
+    }
+
+    // Mouse handlers
+    canvas.addEventListener('mousedown', (e) => {
+        const r = canvas.getBoundingClientRect();
+        const cx = e.clientX - r.left, cy = e.clientY - r.top;
+        if (e.shiftKey) {
+            isDrawing = true;
+            arrowStartPx = {x:cx, y:cy};
+            arrowEndPx = {x:cx, y:cy};
+            canvas.style.cursor = 'crosshair';
+        } else {
+            isPanning = true;
+            panPrev = {x:cx, y:cy};
+            canvas.style.cursor = 'grabbing';
+        }
+    });
+    canvas.addEventListener('mousemove', (e) => {
+        const r = canvas.getBoundingClientRect();
+        const cx = e.clientX - r.left, cy = e.clientY - r.top;
+        if (isDrawing) {
+            arrowEndPx = {x:cx, y:cy};
+            redraw();
+        } else if (isPanning && panPrev) {
+            const dx = cx - panPrev.x, dy = cy - panPrev.y;
+            panPrev = {x:cx, y:cy};
+            const dwx = (dx / W) * (vx1 - vx0);
+            const dwy = (dy / H) * (vy1 - vy0);
+            vx0 -= dwx; vx1 -= dwx;
+            vy0 += dwy; vy1 += dwy;
+            redraw();
+            scheduleTileRefresh();
+        }
+    });
+    canvas.addEventListener('mouseup', (e) => {
+        if (isDrawing && arrowStartPx && arrowEndPx) {
+            isDrawing = false;
+            canvas.style.cursor = 'grab';
+            // Store in world coords so arrow survives pan/zoom
+            arrowStartWorld = canvasToWorld(arrowStartPx.x, arrowStartPx.y);
+            arrowEndWorld = canvasToWorld(arrowEndPx.x, arrowEndPx.y);
+            const hdeg = Math.atan2(arrowEndWorld.y - arrowStartWorld.y,
+                                     arrowEndWorld.x - arrowStartWorld.x) * 180 / Math.PI;
+            trigger('click', {x: arrowStartWorld.x, y: arrowStartWorld.y, heading: hdeg});
+            redraw();
+        }
+        if (isPanning) { isPanning = false; panPrev = null; canvas.style.cursor = 'grab'; }
+    });
+    canvas.addEventListener('mouseleave', () => {
+        if (isPanning) { isPanning = false; panPrev = null; canvas.style.cursor = 'grab'; }
+    });
+    canvas.addEventListener('wheel', (e) => {
+        e.preventDefault();
+        const r = canvas.getBoundingClientRect();
+        const cx = e.clientX - r.left, cy = e.clientY - r.top;
+        const factor = e.deltaY > 0 ? 1.25 : 0.8;
+        const cw = canvasToWorld(cx, cy);
+        const nw = (vx1 - vx0) * factor, nh = (vy1 - vy0) * factor;
+        // Zoom centered on cursor
+        const rx = cx / W, ry = cy / H;
+        vx0 = cw.x - rx * nw; vx1 = cw.x + (1-rx) * nw;
+        vy0 = cw.y - (1-ry) * nh; vy1 = cw.y + ry * nh;
+        redraw();
+        scheduleTileRefresh();
+    }, {passive: false});
+
+    // Load full map image
+    const b64 = props.map_b64;
+    if (b64) {
+        fullImg = new Image();
+        fullImg.onload = redraw;
+        fullImg.src = 'data:image/png;base64,' + b64;
+    }
+})();
+"""
+
+
+def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | None = None):
+    """Build the complete Gradio interface."""
+
+    # Pre-render full map at high resolution (sent once to client)
+    full_vp = renderer.initial_viewport(canvas_w=4000, canvas_h=3200)
+    print("Pre-rendering full map image...")
+    full_map_b64 = renderer.render_viewport_base64(full_vp, dpi=100)
+    full_bounds = full_vp.to_json()
+    print(f"  Map image: {len(full_map_b64)//1024}KB base64")
+
+    def render_map(viewport_json: str) -> str:
+        """Server function for hi-res tile at current zoom. Called from JS (debounced)."""
+        vp = Viewport.from_json(json.loads(viewport_json))
+        return renderer.render_viewport_base64(vp, dpi=100)
+
+    with gr.Blocks(title="Scene Search") as demo:
+
+        search_results_state = gr.State(value=[])
+        kept_batches_state = gr.State(value=[])
+        index_state = gr.State(value=index)
+
+        gr.Markdown("# Scene Search")
+
+        with gr.Row():
+            # ===================== LEFT SIDEBAR =====================
+            with gr.Column(scale=1):
+                gr.Markdown("### Search Parameters")
+                with gr.Row():
+                    arrow_x = gr.Number(label="X (MGRS)", value=89130, interactive=True)
+                    arrow_y = gr.Number(label="Y (MGRS)", value=42440, interactive=True)
+                arrow_heading = gr.Number(label="Heading (deg)", value=106, interactive=True)
+                radius_slider = gr.Slider(1, 200, value=50, step=1, label="Search radius (m)")
+                heading_tol_slider = gr.Slider(5, 180, value=30, step=5, label="Heading tolerance (deg)")
+                n_before_slider = gr.Slider(0, 100, value=30, step=5, label="Frames before")
+                n_after_slider = gr.Slider(0, 200, value=80, step=5, label="Frames after")
+                search_btn = gr.Button("Search", variant="primary")
+
+                gr.Markdown("### Constraints")
+                # Build toggle panels for each registered constraint
+                constraint_components = {}  # name → {enable: Checkbox, params: {name: Component}}
+                available = list_constraints()
+                for cname in available:
+                    c = build_constraint(cname)
+                    spec = c.get_params_spec()
+                    with gr.Accordion(c.name, open=False):
+                        enable_cb = gr.Checkbox(label=f"Enable {c.name}", value=False)
+                        param_components = {}
+                        for pname, pspec in spec.items():
+                            if pspec["type"] == "int":
+                                param_components[pname] = gr.Number(
+                                    label=pspec["label"], value=pspec["default"],
+                                    minimum=pspec.get("min"), maximum=pspec.get("max"),
+                                    precision=0, interactive=True,
+                                )
+                            else:
+                                param_components[pname] = gr.Number(
+                                    label=pspec["label"], value=pspec["default"],
+                                    minimum=pspec.get("min"), maximum=pspec.get("max"),
+                                    interactive=True,
+                                )
+                        constraint_components[cname] = {"enable": enable_cb, "params": param_components}
+
+                gr.Markdown("### Kept Batches")
+                kept_summary = gr.Markdown("No batches kept yet")
+                save_btn = gr.Button("Save All Kept → JSON", variant="secondary")
+                save_path_input = gr.Textbox(label="Save path", value="kept_scenes.json")
+                downsample_n = gr.Number(label="Downsample to N (0=all)", value=0, precision=0)
+                save_status = gr.Markdown("")
+                clear_kept_btn = gr.Button("Clear All Kept", variant="stop")
+
+            # ===================== MAIN CONTENT =====================
+            with gr.Column(scale=3):
+                map_canvas = gr.HTML(
+                    value="",
+                    js_on_load=MAP_CANVAS_JS,
+                    server_functions=[render_map],
+                    min_height=750,
+                    map_b64=full_map_b64,
+                    map_bounds=json.dumps(full_bounds),
+                    radius=50,
+                    heading_tol=30,
+                )
+
+                gr.Markdown("### Search Results")
+                results_info = gr.Markdown("Shift+drag on the map to place an arrow, then click Search")
+
+                batch_groups = []
+                batch_labels = []
+                batch_galleries = []
+                batch_keep_btns = []
+                for i in range(MAX_VISIBLE_BATCHES):
+                    with gr.Group(visible=False) as grp:
+                        lbl = gr.Markdown(f"Batch {i+1}")
+                        gal = gr.Gallery(label=f"Batch {i+1}", columns=6, rows=2,
+                                         height=220, object_fit="contain")
+                        with gr.Row():
+                            keep_b = gr.Button(f"Keep Batch {i+1}", size="sm", variant="primary")
+                    batch_groups.append(grp)
+                    batch_labels.append(lbl)
+                    batch_galleries.append(gal)
+                    batch_keep_btns.append(keep_b)
+
+                gr.Markdown("### Kept Batches")
+                kept_display = gr.Markdown("No batches kept")
+
+        # ===================== EVENT HANDLERS =====================
+
+        # Arrow placed on canvas
+        def on_arrow_placed(evt: gr.EventData):
+            return round(evt.x, 1), round(evt.y, 1), round(evt.heading, 1)
+
+        map_canvas.click(on_arrow_placed, outputs=[arrow_x, arrow_y, arrow_heading])
+
+        # Update canvas props when sliders change
+        def on_radius_change(val):
+            return gr.update(radius=val)
+        radius_slider.release(on_radius_change, inputs=[radius_slider], outputs=[map_canvas])
+
+        def on_heading_tol_change(val):
+            return gr.update(heading_tol=val)
+        heading_tol_slider.release(on_heading_tol_change, inputs=[heading_tol_slider], outputs=[map_canvas])
+
+        # --- Build constraint input list for search ---
+        # Order: [enable_1, param_1a, param_1b, ..., enable_2, param_2a, ...]
+        constraint_input_list = []
+        constraint_input_meta = []  # [(name, n_params)] to unpack in on_search
+        for cname in available:
+            cc = constraint_components[cname]
+            constraint_input_list.append(cc["enable"])
+            param_names = list(cc["params"].keys())
+            for pn in param_names:
+                constraint_input_list.append(cc["params"][pn])
+            constraint_input_meta.append((cname, param_names))
+
+        # --- Search ---
+        def on_search(x, y, heading, radius, heading_tol, n_before, n_after, idx, *constraint_vals):
+            outputs = []
+            if x == 0 and y == 0:
+                outputs.append("Enter coordinates and click Search")
+                for _ in range(MAX_VISIBLE_BATCHES):
+                    outputs.extend([gr.update(visible=False), gr.update(), gr.update(value=None)])
+                outputs.append([])
+                return outputs
+
+            # Parse constraint values
+            active_filters = []
+            val_idx = 0
+            for cname, param_names in constraint_input_meta:
+                enabled = constraint_vals[val_idx]
+                val_idx += 1
+                params = {}
+                for pn in param_names:
+                    params[pn] = constraint_vals[val_idx]
+                    val_idx += 1
+                if enabled:
+                    c = build_constraint(cname)
+                    active_filters.append((c, params))
+
+            batches = find_batches(
+                index=idx, center_x=x, center_y=y, heading_deg=heading,
+                radius=radius, heading_tolerance=heading_tol,
+                n_before=int(n_before), n_after=int(n_after),
+                constraint_filters=active_filters if active_filters else None,
+            )
+            batch_dicts = [
+                {"bag_prefix": b.bag_prefix, "scenes": b.scenes,
+                 "central_indices": b.central_indices, "metadata": b.metadata}
+                for b in batches
+            ]
+            total = sum(b.n_scenes for b in batches)
+            n_constraints = len(active_filters)
+            constraint_info = f" ({n_constraints} constraint{'s' if n_constraints != 1 else ''} active)" if active_filters else ""
+            outputs.append(f"Found **{len(batches)} batches** ({total} total scenes){constraint_info}")
+
+            for i in range(MAX_VISIBLE_BATCHES):
+                if i < len(batches):
+                    b = batches[i]
+                    thumbs = render_batch_thumbnails(b, every_nth=10, max_workers=4)
+                    pils = thumbnails_to_pil_images(thumbs)
+                    outputs.extend([gr.update(visible=True), f"**Batch {i+1}**: {b.summary()}", pils])
+                else:
+                    outputs.extend([gr.update(visible=False), gr.update(), gr.update(value=None)])
+            outputs.append(batch_dicts)
+            return outputs
+
+        search_outputs = [results_info]
+        for i in range(MAX_VISIBLE_BATCHES):
+            search_outputs.extend([batch_groups[i], batch_labels[i], batch_galleries[i]])
+        search_outputs.append(search_results_state)
+
+        search_btn.click(
+            on_search,
+            inputs=[arrow_x, arrow_y, arrow_heading, radius_slider, heading_tol_slider,
+                    n_before_slider, n_after_slider, index_state] + constraint_input_list,
+            outputs=search_outputs,
+        )
+
+        # --- Keep ---
+        def make_keep_handler(idx):
+            def fn(results, kept):
+                if idx >= len(results):
+                    return kept, gr.update(), gr.update()
+                b = results[idx]
+                if b["bag_prefix"] not in {k["bag_prefix"] for k in kept}:
+                    kept = kept + [b]
+                total = sum(len(k["scenes"]) for k in kept)
+                summary = f"**{len(kept)} batches** kept ({total} scenes)"
+                detail = "\n".join(f"- {k['bag_prefix'].split('/')[-1][:25]}... ({len(k['scenes'])} scenes)" for k in kept)
+                return kept, summary, detail
+            return fn
+
+        for i in range(MAX_VISIBLE_BATCHES):
+            batch_keep_btns[i].click(
+                make_keep_handler(i),
+                inputs=[search_results_state, kept_batches_state],
+                outputs=[kept_batches_state, kept_summary, kept_display],
+            )
+
+        # --- Clear ---
+        def on_clear():
+            return [], "No batches kept yet", "No batches kept", ""
+        clear_kept_btn.click(on_clear, outputs=[kept_batches_state, kept_summary, kept_display, save_status])
+
+        # --- Save ---
+        def on_save(kept, path, ds):
+            if not kept: return "No batches to save"
+            scenes = []
+            seen = set()
+            for k in kept:
+                for s in k["scenes"]:
+                    if s not in seen:
+                        seen.add(s); scenes.append(s)
+            if ds and int(ds) > 0 and int(ds) < len(scenes):
+                scenes = sorted(random.sample(scenes, int(ds)))
+            Path(path).parent.mkdir(parents=True, exist_ok=True)
+            with open(path, "w") as f:
+                json.dump(scenes, f, indent=4)
+            return f"Saved **{len(scenes)}** scenes to `{path}`"
+
+        save_btn.click(on_save, inputs=[kept_batches_state, save_path_input, downsample_n], outputs=[save_status])
+
+    return demo
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Scene Search GUI")
+    parser.add_argument("--map_path", type=Path, required=True, help="Path to lanelet2 map (.osm)")
+    parser.add_argument("--npz_list", type=str, required=True, help="path_list.json or NPZ directory")
+    parser.add_argument("--index", type=str, default=None, help="Cached parquet index (requires pyarrow)")
+    parser.add_argument("--port", type=int, default=7860)
+    parser.add_argument("--share", action="store_true")
+    args = parser.parse_args()
+
+    print("Loading lanelet2 map...")
+    renderer = MapRenderer(str(args.map_path))
+
+    if args.index and Path(args.index).exists():
+        print(f"Loading cached index from {args.index}")
+        index = load_index_parquet(args.index)
+    else:
+        print("Building spatial index from NPZ sidecars...")
+        p = Path(args.npz_list)
+        if p.is_file() and p.suffix == ".json":
+            with open(p) as f: npz_paths = json.load(f)
+        elif p.is_dir():
+            npz_paths = sorted(str(f) for f in p.rglob("*.npz"))
+        else:
+            raise ValueError(f"--npz_list must be .json or directory: {args.npz_list}")
+        index = build_index(npz_paths, workers=8)
+        if args.index:
+            save_index_parquet(index, args.index)
+            print(f"Saved index to {args.index}")
+
+    print(f"Index: {len(index)} scenes")
+    demo = build_interface(renderer, index, args.index)
+    demo.launch(server_port=args.port, share=args.share, inbrowser=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scene_search/app.py
+++ b/scene_search/app.py
@@ -23,7 +23,12 @@ from scene_search.batch_search import Batch, build_index, find_batches, load_ind
 from scene_search.constraints import list_available as list_constraints
 from scene_search.constraints.registry import build as build_constraint
 from scene_search.map_renderer import MapRenderer, Viewport
-from scene_search.scene_previewer import render_batch_thumbnails, thumbnails_to_pil_images
+from scene_search.scene_previewer import (
+    render_batch_thumbnails,
+    render_central_thumbnail,
+    render_remaining_thumbnails,
+    thumbnails_to_pil_images,
+)
 
 MAX_VISIBLE_BATCHES = 10
 
@@ -395,16 +400,15 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
                 constraint_input_list.append(cc["params"][pn])
             constraint_input_meta.append((cname, param_names))
 
-        # --- Search ---
+        # --- Search (generator: yields central thumbnails first, then full) ---
         def on_search(x, y, heading, radius, heading_tol, n_before, n_after, idx, *constraint_vals):
-            outputs = []
             if x == 0 and y == 0:
-                outputs.append("Enter coordinates and click Search")
-                outputs.append(gr.update(visible=False))  # keep_all_btn
+                outputs = ["Enter coordinates and click Search", gr.update(visible=False)]
                 for _ in range(MAX_VISIBLE_BATCHES):
                     outputs.extend([gr.update(visible=False), gr.update(), gr.update(value=None)])
                 outputs.append([])
-                return outputs
+                yield outputs
+                return
 
             # Parse constraint values
             active_filters = []
@@ -434,19 +438,36 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
             total = sum(b.n_scenes for b in batches)
             n_constraints = len(active_filters)
             constraint_info = f" ({n_constraints} constraint{'s' if n_constraints != 1 else ''} active)" if active_filters else ""
-            outputs.append(f"Found **{len(batches)} batches** ({total} total scenes){constraint_info}")
-            outputs.append(gr.update(visible=len(batches) > 0))  # keep_all_btn
 
+            # ── First yield: central thumbnails + grey placeholders ──
+            outputs = [
+                f"Found **{len(batches)} batches** ({total} total scenes){constraint_info} — loading previews...",
+                gr.update(visible=len(batches) > 0),
+            ]
             for i in range(MAX_VISIBLE_BATCHES):
                 if i < len(batches):
                     b = batches[i]
-                    thumbs = render_batch_thumbnails(b, every_nth=10, max_workers=4)
-                    pils = thumbnails_to_pil_images(thumbs)
-                    outputs.extend([gr.update(visible=True), f"**Batch {i+1}**: {b.summary()}", pils])
+                    pils_with_placeholders, _ = render_central_thumbnail(b, every_nth=10)
+                    outputs.extend([gr.update(visible=True), f"**Batch {i+1}**: {b.summary()}", pils_with_placeholders])
                 else:
                     outputs.extend([gr.update(visible=False), gr.update(), gr.update(value=None)])
             outputs.append(batch_dicts)
-            return outputs
+            yield outputs
+
+            # ── Second yield: full hi-res thumbnails ──
+            outputs2 = [
+                f"Found **{len(batches)} batches** ({total} total scenes){constraint_info}",
+                gr.update(visible=len(batches) > 0),
+            ]
+            for i in range(MAX_VISIBLE_BATCHES):
+                if i < len(batches):
+                    b = batches[i]
+                    full_pils = render_remaining_thumbnails(b, every_nth=10, max_workers=4)
+                    outputs2.extend([gr.update(visible=True), f"**Batch {i+1}**: {b.summary()}", full_pils])
+                else:
+                    outputs2.extend([gr.update(visible=False), gr.update(), gr.update(value=None)])
+            outputs2.append(batch_dicts)
+            yield outputs2
 
         search_outputs = [results_info, keep_all_btn]
         for i in range(MAX_VISIBLE_BATCHES):

--- a/scene_search/app.py
+++ b/scene_search/app.py
@@ -260,33 +260,6 @@ MAP_CANVAS_JS = r"""
 """
 
 
-LIGHTBOX_JS = """
-<style>
-#img-lightbox {
-    display:none; position:fixed; top:0; left:0; width:100%; height:100%;
-    background:rgba(0,0,0,0.85); z-index:99999; cursor:zoom-out;
-    justify-content:center; align-items:center;
-}
-#img-lightbox img {
-    max-width:90%; max-height:90%; object-fit:contain; border-radius:4px;
-}
-#img-lightbox.active { display:flex; }
-</style>
-<div id="img-lightbox" onclick="this.classList.remove('active')">
-    <img id="img-lightbox-img" src="">
-</div>
-<script>
-document.addEventListener('click', function(e) {
-    const img = e.target.closest('.gallery-item img, .thumbnail-item img, .grid-wrap img');
-    if (!img) return;
-    e.preventDefault(); e.stopPropagation();
-    document.getElementById('img-lightbox-img').src = img.src;
-    document.getElementById('img-lightbox').classList.add('active');
-}, true);
-</script>
-"""
-
-
 def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | None = None):
     """Build the complete Gradio interface."""
 
@@ -384,7 +357,7 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
                         lbl = gr.Markdown(f"Batch {i+1}")
                         gal = gr.Gallery(label=f"Batch {i+1}", columns=6, rows=2,
                                          height=220, object_fit="contain",
-                                         allow_preview=False)
+                                         preview=True)
                         with gr.Row():
                             keep_b = gr.Button(f"Keep Batch {i+1}", size="sm", variant="primary")
                     batch_groups.append(grp)
@@ -622,7 +595,7 @@ def main():
     print(f"Index: {len(index)} scenes")
     demo = build_interface(renderer, index, args.index)
     try:
-        demo.launch(server_port=args.port, share=args.share, inbrowser=True, head=LIGHTBOX_JS)
+        demo.launch(server_port=args.port, share=args.share, inbrowser=True)
     except KeyboardInterrupt:
         pass
     finally:

--- a/scene_search/app.py
+++ b/scene_search/app.py
@@ -454,20 +454,29 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
             outputs.append(batch_dicts)
             yield outputs
 
-            # ── Second yield: full hi-res thumbnails ──
-            outputs2 = [
-                f"Found **{len(batches)} batches** ({total} total scenes){constraint_info}",
-                gr.update(visible=len(batches) > 0),
-            ]
-            for i in range(MAX_VISIBLE_BATCHES):
-                if i < len(batches):
-                    b = batches[i]
-                    full_pils = render_remaining_thumbnails(b, every_nth=10, max_workers=4)
-                    outputs2.extend([gr.update(visible=True), f"**Batch {i+1}**: {b.summary()}", full_pils])
-                else:
-                    outputs2.extend([gr.update(visible=False), gr.update(), gr.update(value=None)])
-            outputs2.append(batch_dicts)
-            yield outputs2
+            # ── Progressive yields: render one batch at a time ──
+            # Keep a cache of rendered galleries, fill in one by one
+            rendered_galleries = [None] * len(batches)
+            for batch_idx in range(len(batches)):
+                b = batches[batch_idx]
+                rendered_galleries[batch_idx] = render_remaining_thumbnails(b, every_nth=10, max_workers=4)
+
+                # Yield updated state with this batch's full thumbnails
+                prog = f"Found **{len(batches)} batches** ({total} scenes){constraint_info} — rendered {batch_idx+1}/{len(batches)}..."
+                if batch_idx == len(batches) - 1:
+                    prog = f"Found **{len(batches)} batches** ({total} total scenes){constraint_info}"
+                out = [prog, gr.update(visible=len(batches) > 0)]
+                for i in range(MAX_VISIBLE_BATCHES):
+                    if i < len(batches):
+                        label = f"**Batch {i+1}**: {batches[i].summary()}"
+                        if rendered_galleries[i] is not None:
+                            out.extend([gr.update(visible=True), label, rendered_galleries[i]])
+                        else:
+                            out.extend([gr.update(visible=True), label, gr.update()])
+                    else:
+                        out.extend([gr.update(visible=False), gr.update(), gr.update(value=None)])
+                out.append(batch_dicts)
+                yield out
 
         search_outputs = [results_info, keep_all_btn]
         for i in range(MAX_VISIBLE_BATCHES):

--- a/scene_search/app.py
+++ b/scene_search/app.py
@@ -499,30 +499,38 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
         )
 
         # --- Keep ---
+        def _batch_key(b):
+            """Unique key for a batch: central scene path."""
+            ci = b["central_indices"]
+            return b["scenes"][ci[0]] if ci else b["scenes"][0]
+
+        def _kept_summary(kept):
+            total = sum(len(k["scenes"]) for k in kept)
+            summary = f"**{len(kept)} batches** kept ({total} scenes)"
+            detail = "\n".join(f"- {k['bag_prefix'].split('/')[-1][:25]}... ({len(k['scenes'])} scenes)" for k in kept)
+            return summary, detail
+
         def make_keep_handler(idx):
             def fn(results, kept):
                 if idx >= len(results):
                     return kept, gr.update(), gr.update()
                 b = results[idx]
-                if b["bag_prefix"] not in {k["bag_prefix"] for k in kept}:
+                existing_keys = {_batch_key(k) for k in kept}
+                if _batch_key(b) not in existing_keys:
                     kept = kept + [b]
-                total = sum(len(k["scenes"]) for k in kept)
-                summary = f"**{len(kept)} batches** kept ({total} scenes)"
-                detail = "\n".join(f"- {k['bag_prefix'].split('/')[-1][:25]}... ({len(k['scenes'])} scenes)" for k in kept)
+                summary, detail = _kept_summary(kept)
                 return kept, summary, detail
             return fn
 
         # --- Keep All ---
         def on_keep_all(search_results, kept_batches):
-            existing = {k["bag_prefix"] for k in kept_batches}
+            existing_keys = {_batch_key(k) for k in kept_batches}
             new_kept = kept_batches[:]
             for b in search_results:
-                if b["bag_prefix"] not in existing:
+                if _batch_key(b) not in existing_keys:
                     new_kept.append(b)
-                    existing.add(b["bag_prefix"])
-            total = sum(len(k["scenes"]) for k in new_kept)
-            summary = f"**{len(new_kept)} batches** kept ({total} scenes)"
-            detail = "\n".join(f"- {k['bag_prefix'].split('/')[-1][:25]}... ({len(k['scenes'])} scenes)" for k in new_kept)
+                    existing_keys.add(_batch_key(b))
+            summary, detail = _kept_summary(new_kept)
             return new_kept, summary, detail
 
         keep_all_btn.click(

--- a/scene_search/app.py
+++ b/scene_search/app.py
@@ -325,8 +325,8 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
                 gr.Markdown("### Kept Batches")
                 kept_summary = gr.Markdown("No batches kept yet")
                 save_btn = gr.Button("Save All Kept → JSON", variant="secondary")
-                _default_save = str(Path.cwd() / "kept_scenes.json")
-                save_path_input = gr.Textbox(label="Save path", value=_default_save)
+                _default_save = str(Path.cwd() / "kept_scenes")
+                save_path_input = gr.Textbox(label="Save base name", value=_default_save)
                 downsample_n = gr.Number(label="Downsample to N (0=all)", value=0, precision=0)
                 save_status = gr.Markdown("")
                 clear_kept_btn = gr.Button("Clear All Kept", variant="stop")
@@ -545,11 +545,10 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
 
         # --- Save ---
         def _next_available_path(base_path: str) -> str:
-            """Auto-increment suffix: kept_scenes.json → kept_scenes_0.json → kept_scenes_1.json ..."""
+            """Auto-increment: kept_scenes → kept_scenes_0.json, kept_scenes_1.json, ..."""
             p = Path(base_path)
-            if not p.exists():
-                return str(p.resolve())
-            stem, suffix = p.stem, p.suffix
+            stem = p.stem
+            suffix = p.suffix or ".json"
             parent = p.parent
             i = 0
             while True:

--- a/scene_search/app.py
+++ b/scene_search/app.py
@@ -587,7 +587,12 @@ def main():
 
     print(f"Index: {len(index)} scenes")
     demo = build_interface(renderer, index, args.index)
-    demo.launch(server_port=args.port, share=args.share, inbrowser=True)
+    try:
+        demo.launch(server_port=args.port, share=args.share, inbrowser=True)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        demo.close()
 
 
 if __name__ == "__main__":

--- a/scene_search/app.py
+++ b/scene_search/app.py
@@ -560,7 +560,7 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
 
         def on_save(kept, path, ds):
             if not kept:
-                return "No batches to save", gr.update()
+                return "No batches to save"
             scenes = []
             seen = set()
             for k in kept:
@@ -573,10 +573,10 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
             Path(actual_path).parent.mkdir(parents=True, exist_ok=True)
             with open(actual_path, "w") as f:
                 json.dump(scenes, f, indent=4)
-            return f"Saved **{len(scenes)}** scenes to `{actual_path}`", gr.update(value=actual_path)
+            return f"Saved **{len(scenes)}** scenes to `{actual_path}`"
 
         save_btn.click(on_save, inputs=[kept_batches_state, save_path_input, downsample_n],
-                       outputs=[save_status, save_path_input])
+                       outputs=[save_status])
 
     return demo
 

--- a/scene_search/app.py
+++ b/scene_search/app.py
@@ -439,44 +439,20 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
             n_constraints = len(active_filters)
             constraint_info = f" ({n_constraints} constraint{'s' if n_constraints != 1 else ''} active)" if active_filters else ""
 
-            # ── First yield: central thumbnails + grey placeholders ──
             outputs = [
-                f"Found **{len(batches)} batches** ({total} total scenes){constraint_info} — loading previews...",
+                f"Found **{len(batches)} batches** ({total} total scenes){constraint_info}",
                 gr.update(visible=len(batches) > 0),
             ]
             for i in range(MAX_VISIBLE_BATCHES):
                 if i < len(batches):
                     b = batches[i]
-                    pils_with_placeholders, _ = render_central_thumbnail(b, every_nth=10)
-                    outputs.extend([gr.update(visible=True), f"**Batch {i+1}**: {b.summary()}", pils_with_placeholders])
+                    thumbs = render_batch_thumbnails(b, every_nth=10, max_workers=8)
+                    pils = thumbnails_to_pil_images(thumbs)
+                    outputs.extend([gr.update(visible=True), f"**Batch {i+1}**: {b.summary()}", pils])
                 else:
                     outputs.extend([gr.update(visible=False), gr.update(), gr.update(value=None)])
             outputs.append(batch_dicts)
-            yield outputs
-
-            # ── Progressive yields: render one batch at a time ──
-            # Keep a cache of rendered galleries, fill in one by one
-            rendered_galleries = [None] * len(batches)
-            for batch_idx in range(len(batches)):
-                b = batches[batch_idx]
-                rendered_galleries[batch_idx] = render_remaining_thumbnails(b, every_nth=10, max_workers=4)
-
-                # Yield updated state with this batch's full thumbnails
-                prog = f"Found **{len(batches)} batches** ({total} scenes){constraint_info} — rendered {batch_idx+1}/{len(batches)}..."
-                if batch_idx == len(batches) - 1:
-                    prog = f"Found **{len(batches)} batches** ({total} total scenes){constraint_info}"
-                out = [prog, gr.update(visible=len(batches) > 0)]
-                for i in range(MAX_VISIBLE_BATCHES):
-                    if i < len(batches):
-                        label = f"**Batch {i+1}**: {batches[i].summary()}"
-                        if rendered_galleries[i] is not None:
-                            out.extend([gr.update(visible=True), label, rendered_galleries[i]])
-                        else:
-                            out.extend([gr.update(visible=True), label, gr.update()])
-                    else:
-                        out.extend([gr.update(visible=False), gr.update(), gr.update(value=None)])
-                out.append(batch_dicts)
-                yield out
+            return outputs
 
         search_outputs = [results_info, keep_all_btn]
         for i in range(MAX_VISIBLE_BATCHES):

--- a/scene_search/app.py
+++ b/scene_search/app.py
@@ -260,6 +260,33 @@ MAP_CANVAS_JS = r"""
 """
 
 
+LIGHTBOX_JS = """
+<style>
+#img-lightbox {
+    display:none; position:fixed; top:0; left:0; width:100%; height:100%;
+    background:rgba(0,0,0,0.85); z-index:99999; cursor:zoom-out;
+    justify-content:center; align-items:center;
+}
+#img-lightbox img {
+    max-width:90%; max-height:90%; object-fit:contain; border-radius:4px;
+}
+#img-lightbox.active { display:flex; }
+</style>
+<div id="img-lightbox" onclick="this.classList.remove('active')">
+    <img id="img-lightbox-img" src="">
+</div>
+<script>
+document.addEventListener('click', function(e) {
+    const img = e.target.closest('.gallery-item img, .thumbnail-item img, .grid-wrap img');
+    if (!img) return;
+    e.preventDefault(); e.stopPropagation();
+    document.getElementById('img-lightbox-img').src = img.src;
+    document.getElementById('img-lightbox').classList.add('active');
+}, true);
+</script>
+"""
+
+
 def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | None = None):
     """Build the complete Gradio interface."""
 
@@ -357,7 +384,7 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
                         lbl = gr.Markdown(f"Batch {i+1}")
                         gal = gr.Gallery(label=f"Batch {i+1}", columns=6, rows=2,
                                          height=220, object_fit="contain",
-                                         preview=True)
+                                         allow_preview=False)
                         with gr.Row():
                             keep_b = gr.Button(f"Keep Batch {i+1}", size="sm", variant="primary")
                     batch_groups.append(grp)
@@ -595,7 +622,7 @@ def main():
     print(f"Index: {len(index)} scenes")
     demo = build_interface(renderer, index, args.index)
     try:
-        demo.launch(server_port=args.port, share=args.share, inbrowser=True)
+        demo.launch(server_port=args.port, share=args.share, inbrowser=True, head=LIGHTBOX_JS)
     except KeyboardInterrupt:
         pass
     finally:

--- a/scene_search/app.py
+++ b/scene_search/app.py
@@ -23,12 +23,7 @@ from scene_search.batch_search import Batch, build_index, find_batches, load_ind
 from scene_search.constraints import list_available as list_constraints
 from scene_search.constraints.registry import build as build_constraint
 from scene_search.map_renderer import MapRenderer, Viewport
-from scene_search.scene_previewer import (
-    render_batch_thumbnails,
-    render_central_thumbnail,
-    render_remaining_thumbnails,
-    thumbnails_to_pil_images,
-)
+from scene_search.scene_previewer import render_batch_thumbnails, thumbnails_to_pil_images
 
 MAX_VISIBLE_BATCHES = 10
 
@@ -400,12 +395,8 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
                 constraint_input_list.append(cc["params"][pn])
             constraint_input_meta.append((cname, param_names))
 
-        # --- Search: two-phase rendering ---
-        # Phase 1: find batches + render central thumbnails only (fast ~0.3s/batch)
-        # Phase 2: render remaining thumbnails (chained via .then())
-
-        def on_search_phase1(x, y, heading, radius, heading_tol, n_before, n_after, idx, *constraint_vals):
-            """Find batches and render central thumbnails with placeholders."""
+        # --- Search ---
+        def on_search(x, y, heading, radius, heading_tol, n_before, n_after, idx, *constraint_vals):
             if x == 0 and y == 0:
                 outputs = ["Enter coordinates and click Search", gr.update(visible=False)]
                 for _ in range(MAX_VISIBLE_BATCHES):
@@ -413,7 +404,6 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
                 outputs.append([])
                 return outputs
 
-            # Parse constraint values
             active_filters = []
             val_idx = 0
             for cname, param_names in constraint_input_meta:
@@ -442,62 +432,40 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
             n_constraints = len(active_filters)
             constraint_info = f" ({n_constraints} constraint{'s' if n_constraints != 1 else ''} active)" if active_filters else ""
 
+            # Render all batches in parallel (each batch's thumbnails also parallel internally)
+            from concurrent.futures import ThreadPoolExecutor
+            def _render_one(b):
+                thumbs = render_batch_thumbnails(b, every_nth=10, max_workers=4)
+                return thumbnails_to_pil_images(thumbs)
+
+            all_pils = [None] * len(batches)
+            with ThreadPoolExecutor(max_workers=len(batches)) as tex:
+                futures = {tex.submit(_render_one, b): i for i, b in enumerate(batches)}
+                for fut in futures:
+                    all_pils[futures[fut]] = fut.result()
+
             outputs = [
-                f"Found **{len(batches)} batches** ({total} total scenes){constraint_info} — loading thumbnails...",
+                f"Found **{len(batches)} batches** ({total} total scenes){constraint_info}",
                 gr.update(visible=len(batches) > 0),
             ]
             for i in range(MAX_VISIBLE_BATCHES):
                 if i < len(batches):
-                    b = batches[i]
-                    pils_with_placeholders, _ = render_central_thumbnail(b, every_nth=10)
-                    outputs.extend([gr.update(visible=True), f"**Batch {i+1}**: {b.summary()}", pils_with_placeholders])
+                    outputs.extend([gr.update(visible=True), f"**Batch {i+1}**: {batches[i].summary()}", all_pils[i]])
                 else:
                     outputs.extend([gr.update(visible=False), gr.update(), gr.update(value=None)])
             outputs.append(batch_dicts)
             return outputs
 
-        def on_search_phase2(batch_dicts):
-            """Render full thumbnails for all batches (runs after phase 1)."""
-            if not batch_dicts:
-                outputs = [gr.update()]
-                for _ in range(MAX_VISIBLE_BATCHES):
-                    outputs.append(gr.update())
-                return outputs
-
-            total = sum(len(bd["scenes"]) for bd in batch_dicts)
-            outputs = [f"Found **{len(batch_dicts)} batches** ({total} total scenes)"]
-            # Reconstruct Batch objects and render
-            from scene_search.batch_search import Batch
-            for i in range(MAX_VISIBLE_BATCHES):
-                if i < len(batch_dicts):
-                    bd = batch_dicts[i]
-                    b = Batch(bag_prefix=bd["bag_prefix"], scenes=bd["scenes"],
-                              central_indices=bd["central_indices"], metadata=bd["metadata"])
-                    full_pils = render_remaining_thumbnails(b, every_nth=10, max_workers=8)
-                    outputs.append(full_pils)
-                else:
-                    outputs.append(gr.update())
-            return outputs
-
-        search_outputs_phase1 = [results_info, keep_all_btn]
+        search_outputs = [results_info, keep_all_btn]
         for i in range(MAX_VISIBLE_BATCHES):
-            search_outputs_phase1.extend([batch_groups[i], batch_labels[i], batch_galleries[i]])
-        search_outputs_phase1.append(search_results_state)
-
-        # Phase 2 only updates results_info + galleries (not groups/labels)
-        search_outputs_phase2 = [results_info]
-        for i in range(MAX_VISIBLE_BATCHES):
-            search_outputs_phase2.append(batch_galleries[i])
+            search_outputs.extend([batch_groups[i], batch_labels[i], batch_galleries[i]])
+        search_outputs.append(search_results_state)
 
         search_btn.click(
-            on_search_phase1,
+            on_search,
             inputs=[arrow_x, arrow_y, arrow_heading, radius_slider, heading_tol_slider,
                     n_before_slider, n_after_slider, index_state] + constraint_input_list,
-            outputs=search_outputs_phase1,
-        ).then(
-            on_search_phase2,
-            inputs=[search_results_state],
-            outputs=search_outputs_phase2,
+            outputs=search_outputs,
         )
 
         # --- Keep ---

--- a/scene_search/app.py
+++ b/scene_search/app.py
@@ -343,7 +343,9 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
                 )
 
                 gr.Markdown("### Search Results")
-                results_info = gr.Markdown("Shift+drag on the map to place an arrow, then click Search")
+                with gr.Row():
+                    results_info = gr.Markdown("Shift+drag on the map to place an arrow, then click Search")
+                    keep_all_btn = gr.Button("Keep All Batches", size="sm", variant="primary", visible=False)
 
                 batch_groups = []
                 batch_labels = []
@@ -398,6 +400,7 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
             outputs = []
             if x == 0 and y == 0:
                 outputs.append("Enter coordinates and click Search")
+                outputs.append(gr.update(visible=False))  # keep_all_btn
                 for _ in range(MAX_VISIBLE_BATCHES):
                     outputs.extend([gr.update(visible=False), gr.update(), gr.update(value=None)])
                 outputs.append([])
@@ -432,6 +435,7 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
             n_constraints = len(active_filters)
             constraint_info = f" ({n_constraints} constraint{'s' if n_constraints != 1 else ''} active)" if active_filters else ""
             outputs.append(f"Found **{len(batches)} batches** ({total} total scenes){constraint_info}")
+            outputs.append(gr.update(visible=len(batches) > 0))  # keep_all_btn
 
             for i in range(MAX_VISIBLE_BATCHES):
                 if i < len(batches):
@@ -444,7 +448,7 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
             outputs.append(batch_dicts)
             return outputs
 
-        search_outputs = [results_info]
+        search_outputs = [results_info, keep_all_btn]
         for i in range(MAX_VISIBLE_BATCHES):
             search_outputs.extend([batch_groups[i], batch_labels[i], batch_galleries[i]])
         search_outputs.append(search_results_state)
@@ -469,6 +473,25 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
                 detail = "\n".join(f"- {k['bag_prefix'].split('/')[-1][:25]}... ({len(k['scenes'])} scenes)" for k in kept)
                 return kept, summary, detail
             return fn
+
+        # --- Keep All ---
+        def on_keep_all(search_results, kept_batches):
+            existing = {k["bag_prefix"] for k in kept_batches}
+            new_kept = kept_batches[:]
+            for b in search_results:
+                if b["bag_prefix"] not in existing:
+                    new_kept.append(b)
+                    existing.add(b["bag_prefix"])
+            total = sum(len(k["scenes"]) for k in new_kept)
+            summary = f"**{len(new_kept)} batches** kept ({total} scenes)"
+            detail = "\n".join(f"- {k['bag_prefix'].split('/')[-1][:25]}... ({len(k['scenes'])} scenes)" for k in new_kept)
+            return new_kept, summary, detail
+
+        keep_all_btn.click(
+            on_keep_all,
+            inputs=[search_results_state, kept_batches_state],
+            outputs=[kept_batches_state, kept_summary, kept_display],
+        )
 
         for i in range(MAX_VISIBLE_BATCHES):
             batch_keep_btns[i].click(

--- a/scene_search/app.py
+++ b/scene_search/app.py
@@ -23,7 +23,8 @@ from scene_search.batch_search import Batch, build_index, find_batches, load_ind
 from scene_search.constraints import list_available as list_constraints
 from scene_search.constraints.registry import build as build_constraint
 from scene_search.map_renderer import MapRenderer, Viewport
-from scene_search.scene_previewer import render_batch_thumbnails, thumbnails_to_pil_images
+from scene_search.scene_previewer import render_batch_thumbnails, render_single_thumbnail, thumbnails_to_pil_images
+from PIL import Image as PILImage
 
 MAX_VISIBLE_BATCHES = 10
 
@@ -432,25 +433,24 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
             n_constraints = len(active_filters)
             constraint_info = f" ({n_constraints} constraint{'s' if n_constraints != 1 else ''} active)" if active_filters else ""
 
-            # Render all batches in parallel (each batch's thumbnails also parallel internally)
-            from concurrent.futures import ThreadPoolExecutor
-            def _render_one(b):
-                thumbs = render_batch_thumbnails(b, every_nth=10, max_workers=4)
-                return thumbnails_to_pil_images(thumbs)
-
-            all_pils = [None] * len(batches)
-            with ThreadPoolExecutor(max_workers=len(batches)) as tex:
-                futures = {tex.submit(_render_one, b): i for i, b in enumerate(batches)}
-                for fut in futures:
-                    all_pils[futures[fut]] = fut.result()
-
+            # Phase 1: render ONLY the central thumbnail per batch (fast)
+            import io as _io
             outputs = [
-                f"Found **{len(batches)} batches** ({total} total scenes){constraint_info}",
+                f"Found **{len(batches)} batches** ({total} total scenes){constraint_info} — loading...",
                 gr.update(visible=len(batches) > 0),
             ]
             for i in range(MAX_VISIBLE_BATCHES):
                 if i < len(batches):
-                    outputs.extend([gr.update(visible=True), f"**Batch {i+1}**: {batches[i].summary()}", all_pils[i]])
+                    b = batches[i]
+                    central_path = b.scenes[b.central_indices[0]] if b.central_indices else b.scenes[len(b.scenes)//2]
+                    fig = render_single_thumbnail(central_path, view_range=60.0)
+                    buf = _io.BytesIO()
+                    fig.savefig(buf, format="png", dpi=90, bbox_inches="tight")
+                    import matplotlib.pyplot as _plt
+                    _plt.close(fig)
+                    buf.seek(0)
+                    central_img = PILImage.open(buf)
+                    outputs.extend([gr.update(visible=True), f"**Batch {i+1}**: {b.summary()}", [(central_img, "t=0* (loading rest...)")]])
                 else:
                     outputs.extend([gr.update(visible=False), gr.update(), gr.update(value=None)])
             outputs.append(batch_dicts)
@@ -461,11 +461,49 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
             search_outputs.extend([batch_groups[i], batch_labels[i], batch_galleries[i]])
         search_outputs.append(search_results_state)
 
+        def on_search_fill(batch_dicts):
+            """Phase 2: fill in all thumbnails for each batch."""
+            if not batch_dicts:
+                return [gr.update()] * (1 + MAX_VISIBLE_BATCHES)
+
+            from concurrent.futures import ThreadPoolExecutor
+            from scene_search.batch_search import Batch
+
+            def _render_one(bd):
+                b = Batch(bag_prefix=bd["bag_prefix"], scenes=bd["scenes"],
+                          central_indices=bd["central_indices"], metadata=bd["metadata"])
+                thumbs = render_batch_thumbnails(b, every_nth=10, max_workers=4)
+                return thumbnails_to_pil_images(thumbs)
+
+            all_pils = [None] * len(batch_dicts)
+            with ThreadPoolExecutor(max_workers=min(len(batch_dicts), 6)) as tex:
+                futures = {tex.submit(_render_one, bd): i for i, bd in enumerate(batch_dicts)}
+                for fut in futures:
+                    all_pils[futures[fut]] = fut.result()
+
+            total = sum(len(bd["scenes"]) for bd in batch_dicts)
+            outputs = [f"Found **{len(batch_dicts)} batches** ({total} total scenes)"]
+            for i in range(MAX_VISIBLE_BATCHES):
+                if i < len(batch_dicts):
+                    outputs.append(all_pils[i])
+                else:
+                    outputs.append(gr.update())
+            return outputs
+
+        # Phase 2 outputs: results_info + one gallery per slot
+        fill_outputs = [results_info]
+        for i in range(MAX_VISIBLE_BATCHES):
+            fill_outputs.append(batch_galleries[i])
+
         search_btn.click(
             on_search,
             inputs=[arrow_x, arrow_y, arrow_heading, radius_slider, heading_tol_slider,
                     n_before_slider, n_after_slider, index_state] + constraint_input_list,
             outputs=search_outputs,
+        ).then(
+            on_search_fill,
+            inputs=[search_results_state],
+            outputs=fill_outputs,
         )
 
         # --- Keep ---

--- a/scene_search/app.py
+++ b/scene_search/app.py
@@ -433,24 +433,14 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
             n_constraints = len(active_filters)
             constraint_info = f" ({n_constraints} constraint{'s' if n_constraints != 1 else ''} active)" if active_filters else ""
 
-            # Phase 1: render ONLY the central thumbnail per batch (fast)
-            import io as _io
+            # Phase 1: show batch info instantly, no thumbnail rendering
             outputs = [
-                f"Found **{len(batches)} batches** ({total} total scenes){constraint_info} — loading...",
+                f"Found **{len(batches)} batches** ({total} total scenes){constraint_info} — rendering thumbnails...",
                 gr.update(visible=len(batches) > 0),
             ]
             for i in range(MAX_VISIBLE_BATCHES):
                 if i < len(batches):
-                    b = batches[i]
-                    central_path = b.scenes[b.central_indices[0]] if b.central_indices else b.scenes[len(b.scenes)//2]
-                    fig = render_single_thumbnail(central_path, view_range=60.0)
-                    buf = _io.BytesIO()
-                    fig.savefig(buf, format="png", dpi=90, bbox_inches="tight")
-                    import matplotlib.pyplot as _plt
-                    _plt.close(fig)
-                    buf.seek(0)
-                    central_img = PILImage.open(buf)
-                    outputs.extend([gr.update(visible=True), f"**Batch {i+1}**: {b.summary()}", [(central_img, "t=0* (loading rest...)")]])
+                    outputs.extend([gr.update(visible=True), f"**Batch {i+1}**: {batches[i].summary()}", gr.update(value=None)])
                 else:
                     outputs.extend([gr.update(visible=False), gr.update(), gr.update(value=None)])
             outputs.append(batch_dicts)

--- a/scene_search/app.py
+++ b/scene_search/app.py
@@ -325,7 +325,8 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
                 gr.Markdown("### Kept Batches")
                 kept_summary = gr.Markdown("No batches kept yet")
                 save_btn = gr.Button("Save All Kept → JSON", variant="secondary")
-                save_path_input = gr.Textbox(label="Save path", value="kept_scenes.json")
+                _default_save = str(Path.cwd() / "kept_scenes.json")
+                save_path_input = gr.Textbox(label="Save path", value=_default_save)
                 downsample_n = gr.Number(label="Downsample to N (0=all)", value=0, precision=0)
                 save_status = gr.Markdown("")
                 clear_kept_btn = gr.Button("Clear All Kept", variant="stop")
@@ -543,8 +544,23 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
         clear_kept_btn.click(on_clear, outputs=[kept_batches_state, kept_summary, kept_display, save_status])
 
         # --- Save ---
+        def _next_available_path(base_path: str) -> str:
+            """Auto-increment suffix: kept_scenes.json → kept_scenes_0.json → kept_scenes_1.json ..."""
+            p = Path(base_path)
+            if not p.exists():
+                return str(p.resolve())
+            stem, suffix = p.stem, p.suffix
+            parent = p.parent
+            i = 0
+            while True:
+                candidate = parent / f"{stem}_{i}{suffix}"
+                if not candidate.exists():
+                    return str(candidate.resolve())
+                i += 1
+
         def on_save(kept, path, ds):
-            if not kept: return "No batches to save"
+            if not kept:
+                return "No batches to save", gr.update()
             scenes = []
             seen = set()
             for k in kept:
@@ -553,12 +569,14 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
                         seen.add(s); scenes.append(s)
             if ds and int(ds) > 0 and int(ds) < len(scenes):
                 scenes = sorted(random.sample(scenes, int(ds)))
-            Path(path).parent.mkdir(parents=True, exist_ok=True)
-            with open(path, "w") as f:
+            actual_path = _next_available_path(path)
+            Path(actual_path).parent.mkdir(parents=True, exist_ok=True)
+            with open(actual_path, "w") as f:
                 json.dump(scenes, f, indent=4)
-            return f"Saved **{len(scenes)}** scenes to `{path}`"
+            return f"Saved **{len(scenes)}** scenes to `{actual_path}`", gr.update(value=actual_path)
 
-        save_btn.click(on_save, inputs=[kept_batches_state, save_path_input, downsample_n], outputs=[save_status])
+        save_btn.click(on_save, inputs=[kept_batches_state, save_path_input, downsample_n],
+                       outputs=[save_status, save_path_input])
 
     return demo
 

--- a/scene_search/batch_search.py
+++ b/scene_search/batch_search.py
@@ -152,77 +152,65 @@ def find_batches(
     if not filtered:
         return []
 
-    # 4. Group matching scenes by bag sequence and expand to batches
-    # Parse frame info for all matches
-    match_frames: dict[str, list[int]] = {}  # prefix → [frame_numbers]
-    pad_length = 19  # Default padding length
+    # 4. Score each match by distance + heading similarity to the arrow,
+    #    pick the single best match per bag prefix, expand exactly n_before + 1 + n_after.
+    import math
+
+    def _score(entry):
+        """Lower = better match. Combines position distance and heading difference."""
+        dx = entry["x"] - center_x
+        dy = entry["y"] - center_y
+        pos_dist = math.sqrt(dx * dx + dy * dy)
+        # Heading difference (handles wraparound)
+        h_diff = abs(entry["heading_deg"] - heading_deg)
+        if h_diff > 180:
+            h_diff = 360 - h_diff
+        # Weight heading difference as 1 deg ≈ 1 meter
+        return pos_dist + h_diff
+
+    # Group by bag prefix, pick best per bag
+    best_per_bag: dict[str, tuple[float, dict]] = {}  # prefix → (score, entry)
+    pad_length = 19
     for entry in filtered:
         try:
             prefix, frame = _parse_frame_info(entry["npz_path"])
-            # Detect padding length from the actual filename
-            match = re.search(r"_(\d+)\.npz$", entry["npz_path"])
-            if match:
-                pad_length = len(match.group(1))
-            match_frames.setdefault(prefix, []).append(frame)
+            m = re.search(r"_(\d+)\.npz$", entry["npz_path"])
+            if m:
+                pad_length = len(m.group(1))
         except ValueError:
             continue
+        s = _score(entry)
+        if prefix not in best_per_bag or s < best_per_bag[prefix][0]:
+            best_per_bag[prefix] = (s, entry)
 
-    # 5. For each prefix, merge overlapping expansions
+    # 5. Expand each best match into a batch
     batches = []
-    for prefix, frames in match_frames.items():
-        frames.sort()
+    for prefix, (score, entry) in best_per_bag.items():
+        _, central_frame = _parse_frame_info(entry["npz_path"])
+        m = re.search(r"_(\d+)\.npz$", entry["npz_path"])
+        pl = len(m.group(1)) if m else pad_length
 
-        # Expand each central frame and merge overlapping ranges
-        expanded_ranges: list[tuple[int, int, list[int]]] = []  # (start, end, central_frames)
-        for f in frames:
-            expanded = _expand_contiguous(prefix, f, n_before, n_after, pad_length)
-            if not expanded:
-                continue
-            first_prefix, first_frame = _parse_frame_info(expanded[0])
-            last_prefix, last_frame = _parse_frame_info(expanded[-1])
+        scenes = _expand_contiguous(prefix, central_frame, n_before, n_after, pl)
+        if not scenes:
+            continue
 
-            if expanded_ranges and first_frame <= expanded_ranges[-1][1] + 1:
-                # Overlaps with previous — merge
-                prev_start, prev_end, prev_centrals = expanded_ranges[-1]
-                merged_end = max(prev_end, last_frame)
-                prev_centrals.append(f)
-                expanded_ranges[-1] = (prev_start, merged_end, prev_centrals)
-            else:
-                expanded_ranges.append((first_frame, last_frame, [f]))
+        # Find central index within the scene list
+        central_path = _frame_path(prefix, central_frame, pl)
+        central_idx = next((i for i, s in enumerate(scenes) if s == central_path), 0)
 
-        # Build Batch objects from merged ranges
-        for start_frame, end_frame, central_frames in expanded_ranges:
-            scenes = []
-            for frame_num in range(start_frame, end_frame + 1):
-                path = _frame_path(prefix, frame_num, pad_length)
-                if os.path.exists(path):
-                    scenes.append(path)
+        meta = {
+            "n_matches_in_radius": sum(1 for e in filtered if e["npz_path"].startswith(prefix)),
+            "best_score": round(score, 2),
+            "x": entry["x"],
+            "y": entry["y"],
+            "heading_deg": entry["heading_deg"],
+        }
 
-            if not scenes:
-                continue
-
-            # Find central indices within the scene list
-            scene_set = {s: i for i, s in enumerate(scenes)}
-            central_indices = []
-            for cf in central_frames:
-                cp = _frame_path(prefix, cf, pad_length)
-                if cp in scene_set:
-                    central_indices.append(scene_set[cp])
-
-            # Compute metadata from sidecar of first central scene
-            meta = {"n_matches": len(central_frames)}
-            first_central = _frame_path(prefix, central_frames[0], pad_length)
-            sidecar = read_sidecar(first_central)
-            if sidecar:
-                meta["x"] = sidecar["x"]
-                meta["y"] = sidecar["y"]
-                meta["heading_deg"] = sidecar["heading_deg"]
-
-            batches.append(Batch(
-                bag_prefix=prefix,
-                scenes=scenes,
-                central_indices=central_indices,
-                metadata=meta,
-            ))
+        batches.append(Batch(
+            bag_prefix=prefix,
+            scenes=scenes,
+            central_indices=[central_idx],
+            metadata=meta,
+        ))
 
     return batches

--- a/scene_search/batch_search.py
+++ b/scene_search/batch_search.py
@@ -1,0 +1,228 @@
+"""Search logic for finding contiguous scene batches by position + heading.
+
+Uses the search_scenes.py backend for spatial/heading filtering, then expands
+matches into contiguous batches of n_before + 1 + n_after frames.
+"""
+
+import os
+import re
+from dataclasses import dataclass, field
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+# search_scenes.py lives in diffusion_planner/util_scripts/ which is not a pip package
+_UTIL_SCRIPTS_DIR = str(Path(__file__).resolve().parent.parent / "diffusion_planner" / "util_scripts")
+if _UTIL_SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _UTIL_SCRIPTS_DIR)
+
+from search_scenes import (
+    build_index,
+    filter_heading,
+    filter_radius,
+    group_sequences,
+    load_index_parquet,
+    read_sidecar,
+    save_index_parquet,
+)
+
+
+@dataclass
+class Batch:
+    """A contiguous sequence of NPZ scenes centered around a search match."""
+    bag_prefix: str                    # bag/sequence identifier (path prefix before frame number)
+    scenes: list[str]                  # ordered NPZ paths (full batch)
+    central_indices: list[int]         # indices within scenes that were actual search matches
+    metadata: dict = field(default_factory=dict)
+
+    @property
+    def n_scenes(self) -> int:
+        return len(self.scenes)
+
+    @property
+    def central_scenes(self) -> list[str]:
+        return [self.scenes[i] for i in self.central_indices]
+
+    def summary(self) -> str:
+        bag_short = self.bag_prefix.split("/")[-1][:20]
+        return f"{bag_short}... ({self.n_scenes} scenes, {len(self.central_indices)} matches)"
+
+
+def _parse_frame_info(npz_path: str) -> tuple[str, int]:
+    """Extract bag prefix and frame number from an NPZ path.
+
+    Expected format: .../prefix_0000000000000431.npz
+    Returns (prefix, frame_number).
+    """
+    match = re.search(r"^(.+)_(\d+)\.npz$", npz_path)
+    if not match:
+        raise ValueError(f"Cannot parse frame number from: {npz_path}")
+    return match.group(1), int(match.group(2))
+
+
+def _frame_path(prefix: str, frame: int, pad: int = 19) -> str:
+    """Reconstruct NPZ path from prefix and frame number."""
+    return f"{prefix}_{frame:0{pad}d}.npz"
+
+
+def _expand_contiguous(prefix: str, central_frame: int, n_before: int, n_after: int, pad: int = 19) -> list[str]:
+    """Expand outward from central_frame, stopping when frames don't exist.
+
+    This ensures we only include scenes from a continuous recording segment —
+    gaps in frame numbers (recording stopped/restarted) truncate the batch.
+    """
+    scenes_before = []
+    for offset in range(1, n_before + 1):
+        candidate = _frame_path(prefix, central_frame - offset, pad)
+        if os.path.exists(candidate):
+            scenes_before.append(candidate)
+        else:
+            break  # Recording boundary — stop expanding backward
+    scenes_before.reverse()
+
+    scenes_after = []
+    for offset in range(1, n_after + 1):
+        candidate = _frame_path(prefix, central_frame + offset, pad)
+        if os.path.exists(candidate):
+            scenes_after.append(candidate)
+        else:
+            break  # Recording boundary — stop expanding forward
+
+    central = _frame_path(prefix, central_frame, pad)
+    return scenes_before + [central] + scenes_after
+
+
+def find_batches(
+    index: list[dict],
+    center_x: float,
+    center_y: float,
+    heading_deg: float,
+    radius: float = 50.0,
+    heading_tolerance: float = 30.0,
+    n_before: int = 30,
+    n_after: int = 80,
+    constraint_filters: list = None,
+) -> list[Batch]:
+    """Find contiguous scene batches matching the arrow query.
+
+    Args:
+        index: Spatial index from build_index() — list of dicts with npz_path, x, y, heading_deg.
+        center_x, center_y: MGRS world coordinates of arrow start.
+        heading_deg: Arrow direction in degrees [-180, 180).
+        radius: Search radius in meters.
+        heading_tolerance: Heading match tolerance in degrees (±).
+        n_before: Max frames to include before central match.
+        n_after: Max frames to include after central match.
+        constraint_filters: List of (constraint, params) tuples for additional filtering.
+
+    Returns:
+        List of Batch objects, each representing a contiguous scene sequence.
+    """
+    # 1. Spatial filter
+    filtered = filter_radius(index, center_x, center_y, radius)
+    if not filtered:
+        return []
+
+    # 2. Heading filter (handles wraparound)
+    hmin = heading_deg - heading_tolerance
+    hmax = heading_deg + heading_tolerance
+    # Normalize to [-180, 180) range
+    hmin = (hmin + 180) % 360 - 180
+    hmax = (hmax + 180) % 360 - 180
+    filtered = filter_heading(filtered, hmin, hmax)
+    if not filtered:
+        return []
+
+    # 3. Apply constraint filters (load NPZ as needed)
+    if constraint_filters:
+        passing = []
+        for entry in filtered:
+            npz_data = np.load(entry["npz_path"])
+            passes_all = True
+            for constraint, params in constraint_filters:
+                if not constraint.filter(entry["npz_path"], npz_data, params):
+                    passes_all = False
+                    break
+            if passes_all:
+                passing.append(entry)
+        filtered = passing
+
+    if not filtered:
+        return []
+
+    # 4. Group matching scenes by bag sequence and expand to batches
+    # Parse frame info for all matches
+    match_frames: dict[str, list[int]] = {}  # prefix → [frame_numbers]
+    pad_length = 19  # Default padding length
+    for entry in filtered:
+        try:
+            prefix, frame = _parse_frame_info(entry["npz_path"])
+            # Detect padding length from the actual filename
+            match = re.search(r"_(\d+)\.npz$", entry["npz_path"])
+            if match:
+                pad_length = len(match.group(1))
+            match_frames.setdefault(prefix, []).append(frame)
+        except ValueError:
+            continue
+
+    # 5. For each prefix, merge overlapping expansions
+    batches = []
+    for prefix, frames in match_frames.items():
+        frames.sort()
+
+        # Expand each central frame and merge overlapping ranges
+        expanded_ranges: list[tuple[int, int, list[int]]] = []  # (start, end, central_frames)
+        for f in frames:
+            expanded = _expand_contiguous(prefix, f, n_before, n_after, pad_length)
+            if not expanded:
+                continue
+            first_prefix, first_frame = _parse_frame_info(expanded[0])
+            last_prefix, last_frame = _parse_frame_info(expanded[-1])
+
+            if expanded_ranges and first_frame <= expanded_ranges[-1][1] + 1:
+                # Overlaps with previous — merge
+                prev_start, prev_end, prev_centrals = expanded_ranges[-1]
+                merged_end = max(prev_end, last_frame)
+                prev_centrals.append(f)
+                expanded_ranges[-1] = (prev_start, merged_end, prev_centrals)
+            else:
+                expanded_ranges.append((first_frame, last_frame, [f]))
+
+        # Build Batch objects from merged ranges
+        for start_frame, end_frame, central_frames in expanded_ranges:
+            scenes = []
+            for frame_num in range(start_frame, end_frame + 1):
+                path = _frame_path(prefix, frame_num, pad_length)
+                if os.path.exists(path):
+                    scenes.append(path)
+
+            if not scenes:
+                continue
+
+            # Find central indices within the scene list
+            scene_set = {s: i for i, s in enumerate(scenes)}
+            central_indices = []
+            for cf in central_frames:
+                cp = _frame_path(prefix, cf, pad_length)
+                if cp in scene_set:
+                    central_indices.append(scene_set[cp])
+
+            # Compute metadata from sidecar of first central scene
+            meta = {"n_matches": len(central_frames)}
+            first_central = _frame_path(prefix, central_frames[0], pad_length)
+            sidecar = read_sidecar(first_central)
+            if sidecar:
+                meta["x"] = sidecar["x"]
+                meta["y"] = sidecar["y"]
+                meta["heading_deg"] = sidecar["heading_deg"]
+
+            batches.append(Batch(
+                bag_prefix=prefix,
+                scenes=scenes,
+                central_indices=central_indices,
+                metadata=meta,
+            ))
+
+    return batches

--- a/scene_search/batch_search.py
+++ b/scene_search/batch_search.py
@@ -139,12 +139,12 @@ def find_batches(
     if constraint_filters:
         passing = []
         for entry in filtered:
-            npz_data = np.load(entry["npz_path"])
-            passes_all = True
-            for constraint, params in constraint_filters:
-                if not constraint.filter(entry["npz_path"], npz_data, params):
-                    passes_all = False
-                    break
+            with np.load(entry["npz_path"]) as npz_data:
+                passes_all = True
+                for constraint, params in constraint_filters:
+                    if not constraint.filter(entry["npz_path"], npz_data, params):
+                        passes_all = False
+                        break
             if passes_all:
                 passing.append(entry)
         filtered = passing

--- a/scene_search/constraints/__init__.py
+++ b/scene_search/constraints/__init__.py
@@ -1,0 +1,7 @@
+"""Constraint plugins for scene search filtering.
+
+Importing this package triggers @register decorators in all constraint modules.
+"""
+
+from scene_search.constraints import neighbor_count, speed_range, travel_distance  # noqa: F401
+from scene_search.constraints.registry import build, list_available

--- a/scene_search/constraints/base.py
+++ b/scene_search/constraints/base.py
@@ -1,0 +1,33 @@
+"""Base class for scene search constraints."""
+
+from abc import ABC, abstractmethod
+
+import numpy as np
+
+
+class BaseConstraint(ABC):
+    """Abstract base for scene filtering constraints.
+
+    Each constraint defines:
+    - UI components for parameter input (Gradio widgets)
+    - A filter function that checks if a scene passes the constraint
+    """
+    name: str = ""
+    description: str = ""
+
+    @abstractmethod
+    def get_params_spec(self) -> dict:
+        """Return parameter specification: {param_name: {type, default, label, min, max, step}}.
+
+        Used to dynamically build Gradio UI components.
+        """
+
+    @abstractmethod
+    def filter(self, npz_path: str, npz_data: np.lib.npyio.NpzFile, params: dict) -> bool:
+        """Return True if the scene passes this constraint.
+
+        Args:
+            npz_path: Path to the NPZ file.
+            npz_data: Loaded NPZ data (numpy NpzFile).
+            params: Dict of parameter values from UI.
+        """

--- a/scene_search/constraints/neighbor_count.py
+++ b/scene_search/constraints/neighbor_count.py
@@ -1,0 +1,32 @@
+"""Constraint: filter scenes by number of active neighbors within a radius."""
+
+import numpy as np
+
+from scene_search.constraints.base import BaseConstraint
+from scene_search.constraints.registry import register
+
+
+@register("neighbor_count")
+class NeighborCountConstraint(BaseConstraint):
+    name = "Neighbor Count"
+    description = "Filter by number of active neighbors within a radius"
+
+    def get_params_spec(self) -> dict:
+        return {
+            "min_count": {"type": "int", "default": 1, "label": "Min neighbors", "min": 0, "max": 32, "step": 1},
+            "max_count": {"type": "int", "default": 32, "label": "Max neighbors", "min": 0, "max": 32, "step": 1},
+            "within_radius": {"type": "float", "default": 30.0, "label": "Within radius (m)", "min": 1.0, "max": 100.0, "step": 1.0},
+        }
+
+    def filter(self, npz_path: str, npz_data: np.lib.npyio.NpzFile, params: dict) -> bool:
+        neighbors = npz_data["neighbor_agents_past"]  # (32, 21, 11)
+        current = neighbors[:, -1, :]  # (32, 11) — last timestep (t=0)
+        # A neighbor is active if any of its features are nonzero
+        active = np.any(current != 0, axis=-1)  # (32,)
+        if not np.any(active):
+            return params["min_count"] <= 0
+
+        positions = current[active, :2]  # (N, 2) — x, y in ego frame
+        dists = np.linalg.norm(positions, axis=-1)
+        n_within = int(np.sum(dists <= params["within_radius"]))
+        return params["min_count"] <= n_within <= params["max_count"]

--- a/scene_search/constraints/registry.py
+++ b/scene_search/constraints/registry.py
@@ -29,5 +29,5 @@ def build(name: str) -> "BaseConstraint":
 
 
 def list_available() -> list[str]:
-    """Return names of all registered constraints."""
-    return list(_REGISTRY.keys())
+    """Return names of all registered constraints (sorted for stable UI ordering)."""
+    return sorted(_REGISTRY.keys())

--- a/scene_search/constraints/registry.py
+++ b/scene_search/constraints/registry.py
@@ -1,0 +1,33 @@
+"""Constraint plugin registry for scene search filtering.
+
+Follows the same @register decorator pattern as diffusion_planner/model/guidance/registry.py.
+"""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from scene_search.constraints.base import BaseConstraint
+
+_REGISTRY: dict[str, type["BaseConstraint"]] = {}
+
+
+def register(name: str):
+    """Decorator to register a constraint class by name."""
+    def decorator(cls):
+        if name in _REGISTRY:
+            raise ValueError(f"Constraint '{name}' already registered")
+        _REGISTRY[name] = cls
+        return cls
+    return decorator
+
+
+def build(name: str) -> "BaseConstraint":
+    """Instantiate a registered constraint by name."""
+    if name not in _REGISTRY:
+        raise KeyError(f"Unknown constraint: '{name}'. Available: {list(_REGISTRY.keys())}")
+    return _REGISTRY[name]()
+
+
+def list_available() -> list[str]:
+    """Return names of all registered constraints."""
+    return list(_REGISTRY.keys())

--- a/scene_search/constraints/speed_range.py
+++ b/scene_search/constraints/speed_range.py
@@ -1,0 +1,26 @@
+"""Constraint: filter scenes by ego speed at t=0."""
+
+import numpy as np
+
+from scene_search.constraints.base import BaseConstraint
+from scene_search.constraints.registry import register
+
+
+@register("speed_range")
+class SpeedRangeConstraint(BaseConstraint):
+    name = "Ego Speed"
+    description = "Filter by ego speed at t=0 (km/h)"
+
+    def get_params_spec(self) -> dict:
+        return {
+            "min_speed_kmh": {"type": "float", "default": 0.0, "label": "Min speed (km/h)", "min": 0.0, "max": 100.0, "step": 1.0},
+            "max_speed_kmh": {"type": "float", "default": 100.0, "label": "Max speed (km/h)", "min": 0.0, "max": 100.0, "step": 1.0},
+        }
+
+    def filter(self, npz_path: str, npz_data: np.lib.npyio.NpzFile, params: dict) -> bool:
+        # ego_current_state: [x, y, cos, sin, vx, vy, ax, ay, steer, yaw_rate]
+        state = npz_data["ego_current_state"]  # (10,)
+        vx, vy = state[4], state[5]
+        speed_ms = np.sqrt(vx ** 2 + vy ** 2)
+        speed_kmh = float(speed_ms * 3.6)
+        return params["min_speed_kmh"] <= speed_kmh <= params["max_speed_kmh"]

--- a/scene_search/constraints/travel_distance.py
+++ b/scene_search/constraints/travel_distance.py
@@ -1,0 +1,25 @@
+"""Constraint: filter scenes by ground-truth trajectory travel distance."""
+
+import numpy as np
+
+from scene_search.constraints.base import BaseConstraint
+from scene_search.constraints.registry import register
+
+
+@register("travel_distance")
+class TravelDistanceConstraint(BaseConstraint):
+    name = "Travel Distance"
+    description = "Filter by total GT trajectory travel distance (meters)"
+
+    def get_params_spec(self) -> dict:
+        return {
+            "min_distance": {"type": "float", "default": 5.0, "label": "Min distance (m)", "min": 0.0, "max": 200.0, "step": 1.0},
+            "max_distance": {"type": "float", "default": 200.0, "label": "Max distance (m)", "min": 0.0, "max": 200.0, "step": 1.0},
+        }
+
+    def filter(self, npz_path: str, npz_data: np.lib.npyio.NpzFile, params: dict) -> bool:
+        fut = npz_data["ego_agent_future"]  # (80, 3) — [x, y, yaw_rad]
+        dx = np.diff(fut[:, 0])
+        dy = np.diff(fut[:, 1])
+        travel_dist = float(np.sqrt(dx ** 2 + dy ** 2).sum())
+        return params["min_distance"] <= travel_dist <= params["max_distance"]

--- a/scene_search/map_renderer.py
+++ b/scene_search/map_renderer.py
@@ -8,6 +8,7 @@ Requires ROS + Autoware environment sourced for lanelet2 / MGRSProjector imports
 """
 
 import io
+import os
 import sys
 from dataclasses import dataclass, field
 
@@ -18,13 +19,18 @@ import numpy as np
 from matplotlib.collections import LineCollection
 from matplotlib.figure import Figure
 
-# lanelet2 requires ROS paths
-_ROS_PATHS = [
+# lanelet2 requires ROS/Autoware Python paths (set by sourcing setup.bash).
+# Fallback to common locations if not already on sys.path.
+_ROS_FALLBACK_PATHS = [
     "/opt/ros/humble/lib/python3.10/site-packages",
-    "/home/danielsanchez/autoware/install/autoware_lanelet2_extension_python/local/lib/python3.10/dist-packages",
 ]
-for p in _ROS_PATHS:
-    if p not in sys.path:
+# Autoware install path from env or common default
+_AUTOWARE_DIR = os.environ.get("AUTOWARE_INSTALL", os.path.expanduser("~/autoware/install"))
+_ROS_FALLBACK_PATHS.append(
+    f"{_AUTOWARE_DIR}/autoware_lanelet2_extension_python/local/lib/python3.10/dist-packages"
+)
+for p in _ROS_FALLBACK_PATHS:
+    if os.path.isdir(p) and p not in sys.path:
         sys.path.insert(0, p)
 
 
@@ -170,12 +176,14 @@ class MapRenderer:
         xmax, ymax = vp.xmax + margin, vp.ymax + margin
         result = []
         for seg in segments:
-            mask = (
-                (seg[:, 0] >= xmin) & (seg[:, 0] <= xmax) &
-                (seg[:, 1] >= ymin) & (seg[:, 1] <= ymax)
-            )
-            if np.any(mask):
-                result.append(seg)
+            if seg.size == 0:
+                continue
+            # Use segment bounding box intersection (catches lines that cross viewport
+            # even if no vertex is inside)
+            if (seg[:, 0].max() < xmin or seg[:, 0].min() > xmax or
+                    seg[:, 1].max() < ymin or seg[:, 1].min() > ymax):
+                continue
+            result.append(seg)
         return result
 
     def render_viewport(self, viewport: Viewport, dpi: int = 100) -> bytes:

--- a/scene_search/map_renderer.py
+++ b/scene_search/map_renderer.py
@@ -185,16 +185,16 @@ class MapRenderer:
         fig = Figure(figsize=(fig_w, fig_h), dpi=dpi)
         ax = fig.add_axes([0, 0, 1, 1])  # Full figure, no margins
 
-        # Draw boundaries (light gray, thin)
+        # Draw boundaries
         cropped_boundaries = self._crop_segments(self.boundary_segments, viewport)
         if cropped_boundaries:
-            lc = LineCollection(cropped_boundaries, colors="#d0d0d0", linewidths=0.5)
+            lc = LineCollection(cropped_boundaries, colors="#404040", linewidths=0.5)
             ax.add_collection(lc)
 
-        # Draw vehicle lane centerlines (dark gray)
+        # Draw vehicle lane centerlines
         cropped_vehicle = self._crop_segments(self.vehicle_segments, viewport)
         if cropped_vehicle:
-            lc = LineCollection(cropped_vehicle, colors="#404040", linewidths=0.8)
+            lc = LineCollection(cropped_vehicle, colors="#000000", linewidths=0.8)
             ax.add_collection(lc)
 
         # Draw pedestrian lanes (light red)

--- a/scene_search/map_renderer.py
+++ b/scene_search/map_renderer.py
@@ -1,0 +1,244 @@
+"""Lanelet2 map loading, viewport management, and PNG rendering for the scene search GUI.
+
+Loads the lanelet2 map once at startup, caches centerline and boundary geometry as numpy
+arrays, and renders cropped views to PNG bytes on demand. Provides pixel↔world coordinate
+transforms for the JS canvas overlay.
+
+Requires ROS + Autoware environment sourced for lanelet2 / MGRSProjector imports.
+"""
+
+import io
+import sys
+from dataclasses import dataclass, field
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.collections import LineCollection
+from matplotlib.figure import Figure
+
+# lanelet2 requires ROS paths
+_ROS_PATHS = [
+    "/opt/ros/humble/lib/python3.10/site-packages",
+    "/home/danielsanchez/autoware/install/autoware_lanelet2_extension_python/local/lib/python3.10/dist-packages",
+]
+for p in _ROS_PATHS:
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+
+@dataclass
+class Viewport:
+    """Axis-aligned rectangular region in MGRS world coordinates."""
+    xmin: float
+    ymin: float
+    xmax: float
+    ymax: float
+    canvas_w: int = 900
+    canvas_h: int = 700
+
+    @property
+    def width(self) -> float:
+        return self.xmax - self.xmin
+
+    @property
+    def height(self) -> float:
+        return self.ymax - self.ymin
+
+    @property
+    def center(self) -> tuple[float, float]:
+        return (self.xmin + self.xmax) / 2, (self.ymin + self.ymax) / 2
+
+    def pixel_to_world(self, px: float, py: float) -> tuple[float, float]:
+        """Convert canvas pixel (px, py) to MGRS world coords.
+
+        Canvas origin is top-left; Y increases downward in pixels, upward in world.
+        """
+        wx = self.xmin + (px / self.canvas_w) * self.width
+        wy = self.ymax - (py / self.canvas_h) * self.height
+        return wx, wy
+
+    def world_to_pixel(self, wx: float, wy: float) -> tuple[float, float]:
+        """Convert MGRS world coords to canvas pixel (px, py)."""
+        px = (wx - self.xmin) / self.width * self.canvas_w
+        py = (self.ymax - wy) / self.height * self.canvas_h
+        return px, py
+
+    def zoom(self, factor: float, center_px: float = None, center_py: float = None):
+        """Return new viewport zoomed by factor around a pixel center.
+
+        factor < 1 = zoom in, factor > 1 = zoom out.
+        If center not specified, zooms around viewport center.
+        """
+        if center_px is not None and center_py is not None:
+            cx, cy = self.pixel_to_world(center_px, center_py)
+        else:
+            cx, cy = self.center
+
+        new_w = self.width * factor
+        new_h = self.height * factor
+        return Viewport(
+            xmin=cx - new_w / 2,
+            ymin=cy - new_h / 2,
+            xmax=cx + new_w / 2,
+            ymax=cy + new_h / 2,
+            canvas_w=self.canvas_w,
+            canvas_h=self.canvas_h,
+        )
+
+    def pan(self, dx_px: float, dy_px: float):
+        """Return new viewport panned by pixel delta."""
+        dx_world = (dx_px / self.canvas_w) * self.width
+        dy_world = -(dy_px / self.canvas_h) * self.height  # Y is inverted
+        return Viewport(
+            xmin=self.xmin - dx_world,
+            ymin=self.ymin - dy_world,
+            xmax=self.xmax - dx_world,
+            ymax=self.ymax - dy_world,
+            canvas_w=self.canvas_w,
+            canvas_h=self.canvas_h,
+        )
+
+    def to_json(self) -> dict:
+        return {
+            "xmin": self.xmin, "ymin": self.ymin,
+            "xmax": self.xmax, "ymax": self.ymax,
+            "canvas_w": self.canvas_w, "canvas_h": self.canvas_h,
+        }
+
+    @staticmethod
+    def from_json(d: dict) -> "Viewport":
+        return Viewport(**d)
+
+
+class MapRenderer:
+    """Loads a lanelet2 map and renders cropped viewport images."""
+
+    def __init__(self, lanelet_path: str):
+        import lanelet2
+        from autoware_lanelet2_extension_python.projection import MGRSProjector
+
+        projection = MGRSProjector(lanelet2.io.Origin(0.0, 0.0))
+        lanelet_map = lanelet2.io.load(str(lanelet_path), projection)
+
+        # Extract geometry as numpy arrays for fast rendering
+        self.vehicle_segments: list[np.ndarray] = []   # list of (N, 2) polylines
+        self.pedestrian_segments: list[np.ndarray] = []
+
+        for ll in lanelet_map.laneletLayer:
+            subtype = ll.attributes["subtype"] if "subtype" in ll.attributes else ""
+            pts = np.array([(p.x, p.y) for p in ll.centerline])
+            if len(pts) < 2:
+                continue
+            if subtype == "pedestrian_lane":
+                self.pedestrian_segments.append(pts)
+            else:
+                self.vehicle_segments.append(pts)
+
+        # Left/right boundaries for richer rendering
+        self.boundary_segments: list[np.ndarray] = []
+        for ll in lanelet_map.laneletLayer:
+            subtype = ll.attributes["subtype"] if "subtype" in ll.attributes else ""
+            if subtype == "pedestrian_lane":
+                continue
+            for bound in [ll.leftBound, ll.rightBound]:
+                pts = np.array([(p.x, p.y) for p in bound])
+                if len(pts) >= 2:
+                    self.boundary_segments.append(pts)
+
+        # Compute full map bounds
+        all_pts = np.vstack(self.vehicle_segments + self.pedestrian_segments)
+        margin = 50.0
+        self.full_bounds = Viewport(
+            xmin=float(all_pts[:, 0].min()) - margin,
+            ymin=float(all_pts[:, 1].min()) - margin,
+            xmax=float(all_pts[:, 0].max()) + margin,
+            ymax=float(all_pts[:, 1].max()) + margin,
+        )
+
+        print(f"MapRenderer: loaded {len(self.vehicle_segments)} vehicle lanes, "
+              f"{len(self.pedestrian_segments)} pedestrian lanes, "
+              f"{len(self.boundary_segments)} boundary segments")
+        print(f"  Map bounds: x=[{self.full_bounds.xmin:.0f}, {self.full_bounds.xmax:.0f}] "
+              f"y=[{self.full_bounds.ymin:.0f}, {self.full_bounds.ymax:.0f}]")
+
+    def _crop_segments(self, segments: list[np.ndarray], vp: Viewport) -> list[np.ndarray]:
+        """Crop polyline segments to those that intersect the viewport (with margin)."""
+        margin = max(vp.width, vp.height) * 0.05
+        xmin, ymin = vp.xmin - margin, vp.ymin - margin
+        xmax, ymax = vp.xmax + margin, vp.ymax + margin
+        result = []
+        for seg in segments:
+            mask = (
+                (seg[:, 0] >= xmin) & (seg[:, 0] <= xmax) &
+                (seg[:, 1] >= ymin) & (seg[:, 1] <= ymax)
+            )
+            if np.any(mask):
+                result.append(seg)
+        return result
+
+    def render_viewport(self, viewport: Viewport, dpi: int = 100) -> bytes:
+        """Render the map within the viewport to PNG bytes."""
+        fig_w = viewport.canvas_w / dpi
+        fig_h = viewport.canvas_h / dpi
+        fig = Figure(figsize=(fig_w, fig_h), dpi=dpi)
+        ax = fig.add_axes([0, 0, 1, 1])  # Full figure, no margins
+
+        # Draw boundaries (light gray, thin)
+        cropped_boundaries = self._crop_segments(self.boundary_segments, viewport)
+        if cropped_boundaries:
+            lc = LineCollection(cropped_boundaries, colors="#d0d0d0", linewidths=0.5)
+            ax.add_collection(lc)
+
+        # Draw vehicle lane centerlines (dark gray)
+        cropped_vehicle = self._crop_segments(self.vehicle_segments, viewport)
+        if cropped_vehicle:
+            lc = LineCollection(cropped_vehicle, colors="#404040", linewidths=0.8)
+            ax.add_collection(lc)
+
+        # Draw pedestrian lanes (light red)
+        cropped_ped = self._crop_segments(self.pedestrian_segments, viewport)
+        if cropped_ped:
+            lc = LineCollection(cropped_ped, colors="#ffaaaa", linewidths=0.6)
+            ax.add_collection(lc)
+
+        ax.set_xlim(viewport.xmin, viewport.xmax)
+        ax.set_ylim(viewport.ymin, viewport.ymax)
+        ax.set_aspect("equal")
+        ax.axis("off")
+        fig.patch.set_facecolor("#f8f8f8")
+
+        buf = io.BytesIO()
+        fig.savefig(buf, format="png", dpi=dpi, bbox_inches=None, pad_inches=0)
+        plt.close(fig)
+        buf.seek(0)
+        return buf.read()
+
+    def render_viewport_base64(self, viewport: Viewport, dpi: int = 100) -> str:
+        """Render viewport to base64-encoded PNG string for embedding in HTML."""
+        import base64
+        png_bytes = self.render_viewport(viewport, dpi=dpi)
+        return base64.b64encode(png_bytes).decode("ascii")
+
+    def initial_viewport(self, canvas_w: int = 900, canvas_h: int = 700) -> Viewport:
+        """Return a viewport showing the full map, maintaining aspect ratio."""
+        bounds = self.full_bounds
+        map_aspect = bounds.width / bounds.height
+        canvas_aspect = canvas_w / canvas_h
+
+        if map_aspect > canvas_aspect:
+            # Map is wider than canvas → fit width, pad height
+            w = bounds.width
+            h = w / canvas_aspect
+        else:
+            # Map is taller → fit height, pad width
+            h = bounds.height
+            w = h * canvas_aspect
+
+        cx, cy = bounds.center
+        return Viewport(
+            xmin=cx - w / 2, ymin=cy - h / 2,
+            xmax=cx + w / 2, ymax=cy + h / 2,
+            canvas_w=canvas_w, canvas_h=canvas_h,
+        )

--- a/scene_search/scene_previewer.py
+++ b/scene_search/scene_previewer.py
@@ -60,8 +60,7 @@ def render_single_thumbnail(npz_path: str, view_range: float = 60.0, figsize: tu
 
 
 # Size presets for thumbnails
-THUMB_CENTRAL = (5, 5, 90)  # figsize_w, figsize_h, dpi — crisp for the central match
-THUMB_FAST = (5, 5, 90)     # same quality for all thumbnails
+THUMB_SIZE = (5, 5, 90)  # (figsize_w, figsize_h, dpi)
 
 
 def _render_thumbnail_to_bytes(args: tuple) -> tuple[int, bytes, str]:
@@ -130,11 +129,7 @@ def render_batch_thumbnails(
         if scene_idx in central_set and offset != 0:
             label += "*"
 
-        is_central = (scene_idx in central_set) or (offset == 0)
-        if is_central:
-            fw, fh, dpi = THUMB_CENTRAL
-        else:
-            fw, fh, dpi = THUMB_FAST
+        fw, fh, dpi = THUMB_SIZE
         tasks.append((len(tasks), batch.scenes[scene_idx], label, view_range, fw, fh, dpi))
 
     # Render in parallel

--- a/scene_search/scene_previewer.py
+++ b/scene_search/scene_previewer.py
@@ -12,6 +12,7 @@ matplotlib.use("Agg")
 import numpy as np
 import torch
 from matplotlib.figure import Figure
+from PIL import Image
 
 from diffusion_planner.train_epoch import heading_to_cos_sin
 from diffusion_planner.utils.visualize_input import visualize_inputs
@@ -44,13 +45,13 @@ def _load_npz_as_viz_data(npz_path: str) -> dict[str, torch.Tensor]:
     return data
 
 
-def render_single_thumbnail(npz_path: str, view_range: float = 60.0, figsize: tuple = (8, 8)) -> Figure:
+def render_single_thumbnail(npz_path: str, view_range: float = 60.0, figsize: tuple = (6, 6), dpi: int = 100) -> Figure:
     """Render a single scene thumbnail using visualize_inputs().
 
     Returns a matplotlib Figure.
     """
     data = _load_npz_as_viz_data(npz_path)
-    fig = Figure(figsize=figsize, dpi=150)
+    fig = Figure(figsize=figsize, dpi=dpi)
     ax = fig.add_subplot(111)
     visualize_inputs(data, save_path=None, ax=ax, view_ranges=[view_range])
     ax.set_aspect("equal")
@@ -68,7 +69,7 @@ def _render_thumbnail_to_bytes(args: tuple) -> tuple[int, bytes, str]:
     try:
         fig = render_single_thumbnail(npz_path, view_range=view_range)
         buf = io.BytesIO()
-        fig.savefig(buf, format="png", dpi=150, bbox_inches="tight")
+        fig.savefig(buf, format="png", dpi=100, bbox_inches="tight")
         import matplotlib.pyplot as plt
         plt.close(fig)
         buf.seek(0)
@@ -135,13 +136,105 @@ def render_batch_thumbnails(
     return results
 
 
+def get_central_task_index(batch: Batch, every_nth: int = 10) -> tuple[list[tuple], int]:
+    """Return the render tasks list and the index of the central scene task.
+
+    Used for progressive rendering: render central first, then the rest.
+    """
+    if not batch.scenes:
+        return [], 0
+
+    central_set = set(batch.central_indices)
+    first_central = batch.central_indices[0] if batch.central_indices else 0
+
+    indices_to_render = list(range(0, len(batch.scenes), every_nth))
+    if first_central not in indices_to_render:
+        indices_to_render.append(first_central)
+        indices_to_render.sort()
+
+    tasks = []
+    central_task_idx = 0
+    for scene_idx in indices_to_render:
+        offset = scene_idx - first_central
+        if offset == 0:
+            label = "t=0*"
+            central_task_idx = len(tasks)
+        elif offset < 0:
+            label = f"t{offset}"
+        else:
+            label = f"t+{offset}"
+        if scene_idx in central_set and offset != 0:
+            label += "*"
+        tasks.append((len(tasks), batch.scenes[scene_idx], label, 60.0))
+
+    return tasks, central_task_idx
+
+
+def render_central_thumbnail(batch: Batch, every_nth: int = 10, view_range: float = 60.0) -> tuple[list[tuple], int]:
+    """Render only the central scene thumbnail immediately.
+
+    Returns (pil_images_with_placeholders, n_total) where non-central entries
+    are grey placeholder images with "Loading..." text.
+    """
+    from PIL import ImageDraw
+
+    tasks, central_task_idx = get_central_task_index(batch, every_nth)
+    if not tasks:
+        return [], 0
+
+    # Render central thumbnail
+    _, png_bytes, central_label = _render_thumbnail_to_bytes(tasks[central_task_idx])
+
+    # Build result with placeholders for non-central
+    result = []
+    for i, (_, _, label, _) in enumerate(tasks):
+        if i == central_task_idx and png_bytes is not None:
+            img = Image.open(io.BytesIO(png_bytes))
+            result.append((img, label))
+        else:
+            # Grey placeholder
+            placeholder = Image.new("RGB", (400, 400), color=(220, 220, 220))
+            draw = ImageDraw.Draw(placeholder)
+            draw.text((150, 190), "Loading...", fill=(150, 150, 150))
+            draw.text((160, 210), label, fill=(120, 120, 120))
+            result.append((placeholder, label))
+
+    return result, len(tasks)
+
+
+def render_remaining_thumbnails(
+    batch: Batch,
+    every_nth: int = 10,
+    view_range: float = 60.0,
+    max_workers: int = 4,
+) -> list[tuple]:
+    """Render all thumbnails (used after the central one is already shown).
+
+    Returns full list of (PIL.Image, label) tuples.
+    """
+    tasks, central_task_idx = get_central_task_index(batch, every_nth)
+    if not tasks:
+        return []
+
+    # Update view_range in tasks
+    tasks = [(idx, path, label, view_range) for idx, path, label, _ in tasks]
+
+    results = [None] * len(tasks)
+    with ProcessPoolExecutor(max_workers=max_workers) as executor:
+        for idx, png_bytes, label in executor.map(_render_thumbnail_to_bytes, tasks):
+            if png_bytes is not None:
+                results[idx] = (Image.open(io.BytesIO(png_bytes)), label)
+            else:
+                results[idx] = (Image.new("RGB", (400, 400), (220, 220, 220)), label)
+
+    return results
+
+
 def thumbnails_to_pil_images(thumbnails: list[tuple[bytes | None, str]]) -> list[tuple]:
     """Convert PNG byte thumbnails to PIL Images for Gradio Gallery.
 
     Returns list of (PIL.Image, label) tuples.
     """
-    from PIL import Image
-
     result = []
     for png_bytes, label in thumbnails:
         if png_bytes is not None:

--- a/scene_search/scene_previewer.py
+++ b/scene_search/scene_previewer.py
@@ -52,9 +52,10 @@ def render_single_thumbnail(npz_path: str, view_range: float = 60.0, figsize: tu
     """
     data = _load_npz_as_viz_data(npz_path)
     fig = Figure(figsize=figsize, dpi=dpi)
-    ax = fig.add_axes([0.02, 0.02, 0.96, 0.96])  # skip tight_layout overhead
+    ax = fig.add_subplot(111)
     visualize_inputs(data, save_path=None, ax=ax, view_ranges=[view_range])
     ax.set_aspect("equal")
+    fig.tight_layout(pad=0.5)
     return fig
 
 
@@ -72,7 +73,7 @@ def _render_thumbnail_to_bytes(args: tuple) -> tuple[int, bytes, str]:
     try:
         fig = render_single_thumbnail(npz_path, view_range=view_range, figsize=(fw, fh), dpi=dpi)
         buf = io.BytesIO()
-        fig.savefig(buf, format="jpg", dpi=dpi, pil_kwargs={"quality": 85})
+        fig.savefig(buf, format="png", dpi=dpi, bbox_inches="tight")
         import matplotlib.pyplot as plt
         plt.close(fig)
         buf.seek(0)

--- a/scene_search/scene_previewer.py
+++ b/scene_search/scene_previewer.py
@@ -69,7 +69,11 @@ def _render_thumbnail_to_bytes(args: tuple) -> tuple[int, bytes, str]:
     Args: (index, npz_path, label, view_range, figsize_w, figsize_h, dpi)
     Returns: (index, png_bytes, label)
     """
-    idx, npz_path, label, view_range, fw, fh, dpi = args
+    if len(args) == 7:
+        idx, npz_path, label, view_range, fw, fh, dpi = args
+    else:
+        idx, npz_path, label, view_range = args
+        fw, fh, dpi = THUMB_SIZE
     try:
         fig = render_single_thumbnail(npz_path, view_range=view_range, figsize=(fw, fh), dpi=dpi)
         buf = io.BytesIO()

--- a/scene_search/scene_previewer.py
+++ b/scene_search/scene_previewer.py
@@ -61,7 +61,7 @@ def render_single_thumbnail(npz_path: str, view_range: float = 60.0, figsize: tu
 
 # Size presets for thumbnails
 THUMB_CENTRAL = (5, 5, 90)  # figsize_w, figsize_h, dpi — crisp for the central match
-THUMB_FAST = (2.5, 2.5, 50) # tiny and fast for non-central gallery items
+THUMB_FAST = (5, 5, 90)     # same quality for all thumbnails
 
 
 def _render_thumbnail_to_bytes(args: tuple) -> tuple[int, bytes, str]:

--- a/scene_search/scene_previewer.py
+++ b/scene_search/scene_previewer.py
@@ -52,10 +52,9 @@ def render_single_thumbnail(npz_path: str, view_range: float = 60.0, figsize: tu
     """
     data = _load_npz_as_viz_data(npz_path)
     fig = Figure(figsize=figsize, dpi=dpi)
-    ax = fig.add_subplot(111)
+    ax = fig.add_axes([0.02, 0.02, 0.96, 0.96])  # skip tight_layout overhead
     visualize_inputs(data, save_path=None, ax=ax, view_ranges=[view_range])
     ax.set_aspect("equal")
-    fig.tight_layout(pad=0.5)
     return fig
 
 
@@ -73,7 +72,7 @@ def _render_thumbnail_to_bytes(args: tuple) -> tuple[int, bytes, str]:
     try:
         fig = render_single_thumbnail(npz_path, view_range=view_range, figsize=(fw, fh), dpi=dpi)
         buf = io.BytesIO()
-        fig.savefig(buf, format="png", dpi=dpi, bbox_inches="tight")
+        fig.savefig(buf, format="jpg", dpi=dpi, pil_kwargs={"quality": 85})
         import matplotlib.pyplot as plt
         plt.close(fig)
         buf.seek(0)

--- a/scene_search/scene_previewer.py
+++ b/scene_search/scene_previewer.py
@@ -45,7 +45,7 @@ def _load_npz_as_viz_data(npz_path: str) -> dict[str, torch.Tensor]:
     return data
 
 
-def render_single_thumbnail(npz_path: str, view_range: float = 60.0, figsize: tuple = (6, 6), dpi: int = 100) -> Figure:
+def render_single_thumbnail(npz_path: str, view_range: float = 60.0, figsize: tuple = (5, 5), dpi: int = 90) -> Figure:
     """Render a single scene thumbnail using visualize_inputs().
 
     Returns a matplotlib Figure.
@@ -69,7 +69,7 @@ def _render_thumbnail_to_bytes(args: tuple) -> tuple[int, bytes, str]:
     try:
         fig = render_single_thumbnail(npz_path, view_range=view_range)
         buf = io.BytesIO()
-        fig.savefig(buf, format="png", dpi=100, bbox_inches="tight")
+        fig.savefig(buf, format="png", dpi=90, bbox_inches="tight")
         import matplotlib.pyplot as plt
         plt.close(fig)
         buf.seek(0)

--- a/scene_search/scene_previewer.py
+++ b/scene_search/scene_previewer.py
@@ -1,0 +1,150 @@
+"""Batch thumbnail generation using visualize_inputs().
+
+Renders every Nth scene in a batch as a small matplotlib figure for the GUI.
+"""
+
+import io
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import numpy as np
+import torch
+from matplotlib.figure import Figure
+
+from diffusion_planner.train_epoch import heading_to_cos_sin
+from diffusion_planner.utils.visualize_input import visualize_inputs
+
+from scene_search.batch_search import Batch
+
+
+def _load_npz_as_viz_data(npz_path: str) -> dict[str, torch.Tensor]:
+    """Load an NPZ file into the dict format expected by visualize_inputs().
+
+    Same logic as preference_optimization/utils.py:load_npz_data but CPU-only
+    and without model-specific keys (delay, etc.).
+    """
+    loaded = np.load(str(npz_path))
+    data: dict[str, torch.Tensor] = {}
+
+    for key, value in loaded.items():
+        if key in {"map_name", "token", "delay", "version"}:
+            continue
+        data[key] = torch.tensor(np.expand_dims(value, axis=0))
+
+    if "goal_pose" in data:
+        data["goal_pose"] = heading_to_cos_sin(data["goal_pose"])
+    if "ego_agent_past" in data:
+        data["ego_agent_past"] = heading_to_cos_sin(data["ego_agent_past"])
+
+    if "ego_shape" not in data:
+        data["ego_shape"] = torch.tensor([[2.79, 4.34, 1.70]], dtype=torch.float32)
+
+    return data
+
+
+def render_single_thumbnail(npz_path: str, view_range: float = 60.0, figsize: tuple = (8, 8)) -> Figure:
+    """Render a single scene thumbnail using visualize_inputs().
+
+    Returns a matplotlib Figure.
+    """
+    data = _load_npz_as_viz_data(npz_path)
+    fig = Figure(figsize=figsize, dpi=150)
+    ax = fig.add_subplot(111)
+    visualize_inputs(data, save_path=None, ax=ax, view_ranges=[view_range])
+    ax.set_aspect("equal")
+    fig.tight_layout(pad=0.5)
+    return fig
+
+
+def _render_thumbnail_to_bytes(args: tuple) -> tuple[int, bytes, str]:
+    """Worker function for parallel thumbnail rendering.
+
+    Args: (index, npz_path, label, view_range)
+    Returns: (index, png_bytes, label)
+    """
+    idx, npz_path, label, view_range = args
+    try:
+        fig = render_single_thumbnail(npz_path, view_range=view_range)
+        buf = io.BytesIO()
+        fig.savefig(buf, format="png", dpi=150, bbox_inches="tight")
+        import matplotlib.pyplot as plt
+        plt.close(fig)
+        buf.seek(0)
+        return (idx, buf.read(), label)
+    except Exception as e:
+        return (idx, None, f"{label} (error: {e})")
+
+
+def render_batch_thumbnails(
+    batch: Batch,
+    every_nth: int = 10,
+    view_range: float = 60.0,
+    max_workers: int = 4,
+) -> list[tuple[bytes | None, str]]:
+    """Render every Nth scene in a batch as PNG thumbnails.
+
+    Args:
+        batch: The Batch to preview.
+        every_nth: Sample every Nth scene for thumbnails.
+        view_range: View range in meters for visualize_inputs().
+        max_workers: Parallel workers for rendering.
+
+    Returns:
+        List of (png_bytes, label) tuples. png_bytes is None on error.
+        Labels show frame offset relative to first central match:
+        "t-30", "t-20", ..., "t=0*", "t+10", ...
+        Central scenes get a * suffix.
+    """
+    if not batch.scenes:
+        return []
+
+    # Determine which scenes to render
+    central_set = set(batch.central_indices)
+    # Always include the first central scene in the sample
+    first_central = batch.central_indices[0] if batch.central_indices else 0
+
+    indices_to_render = list(range(0, len(batch.scenes), every_nth))
+    # Ensure the first central scene is included
+    if first_central not in indices_to_render:
+        indices_to_render.append(first_central)
+        indices_to_render.sort()
+
+    # Build render tasks with labels
+    tasks = []
+    for scene_idx in indices_to_render:
+        offset = scene_idx - first_central
+        if offset == 0:
+            label = "t=0*"
+        elif offset < 0:
+            label = f"t{offset}"
+        else:
+            label = f"t+{offset}"
+        if scene_idx in central_set and offset != 0:
+            label += "*"
+
+        tasks.append((len(tasks), batch.scenes[scene_idx], label, view_range))
+
+    # Render in parallel
+    results = [None] * len(tasks)
+    with ProcessPoolExecutor(max_workers=max_workers) as executor:
+        for idx, png_bytes, label in executor.map(_render_thumbnail_to_bytes, tasks):
+            results[idx] = (png_bytes, label)
+
+    return results
+
+
+def thumbnails_to_pil_images(thumbnails: list[tuple[bytes | None, str]]) -> list[tuple]:
+    """Convert PNG byte thumbnails to PIL Images for Gradio Gallery.
+
+    Returns list of (PIL.Image, label) tuples.
+    """
+    from PIL import Image
+
+    result = []
+    for png_bytes, label in thumbnails:
+        if png_bytes is not None:
+            img = Image.open(io.BytesIO(png_bytes))
+            result.append((img, label))
+    return result

--- a/scene_search/scene_previewer.py
+++ b/scene_search/scene_previewer.py
@@ -59,17 +59,22 @@ def render_single_thumbnail(npz_path: str, view_range: float = 60.0, figsize: tu
     return fig
 
 
+# Size presets for thumbnails
+THUMB_CENTRAL = (5, 5, 90)  # figsize_w, figsize_h, dpi — crisp for the central match
+THUMB_FAST = (2.5, 2.5, 50) # tiny and fast for non-central gallery items
+
+
 def _render_thumbnail_to_bytes(args: tuple) -> tuple[int, bytes, str]:
     """Worker function for parallel thumbnail rendering.
 
-    Args: (index, npz_path, label, view_range)
+    Args: (index, npz_path, label, view_range, figsize_w, figsize_h, dpi)
     Returns: (index, png_bytes, label)
     """
-    idx, npz_path, label, view_range = args
+    idx, npz_path, label, view_range, fw, fh, dpi = args
     try:
-        fig = render_single_thumbnail(npz_path, view_range=view_range)
+        fig = render_single_thumbnail(npz_path, view_range=view_range, figsize=(fw, fh), dpi=dpi)
         buf = io.BytesIO()
-        fig.savefig(buf, format="png", dpi=90, bbox_inches="tight")
+        fig.savefig(buf, format="png", dpi=dpi, bbox_inches="tight")
         import matplotlib.pyplot as plt
         plt.close(fig)
         buf.seek(0)
@@ -125,7 +130,12 @@ def render_batch_thumbnails(
         if scene_idx in central_set and offset != 0:
             label += "*"
 
-        tasks.append((len(tasks), batch.scenes[scene_idx], label, view_range))
+        is_central = (scene_idx in central_set) or (offset == 0)
+        if is_central:
+            fw, fh, dpi = THUMB_CENTRAL
+        else:
+            fw, fh, dpi = THUMB_FAST
+        tasks.append((len(tasks), batch.scenes[scene_idx], label, view_range, fw, fh, dpi))
 
     # Render in parallel
     results = [None] * len(tasks)

--- a/scene_search/static/map_canvas.js
+++ b/scene_search/static/map_canvas.js
@@ -1,0 +1,342 @@
+/**
+ * Interactive map canvas for scene search GUI.
+ *
+ * Supports: drag-to-pan, scroll-to-zoom, shift+drag to draw arrow.
+ * Communicates with Gradio via hidden textbox elements.
+ *
+ * Expected HTML structure (created by Python):
+ *   <div id="map-canvas-container">
+ *     <canvas id="map-canvas" width="900" height="700"></canvas>
+ *   </div>
+ *
+ * Hidden Gradio textboxes (elem_id):
+ *   - arrow-data: JSON {x, y, heading_deg} in world coords
+ *   - viewport-action: JSON {action, ...params} for pan/zoom requests
+ */
+
+(function () {
+  "use strict";
+
+  let canvas, ctx;
+  let mapImage = null; // Current map background image
+  let viewport = null; // {xmin, ymin, xmax, ymax, canvas_w, canvas_h}
+
+  // Arrow state
+  let arrowStart = null; // {px, py} in canvas pixels
+  let arrowEnd = null;
+  let arrowWorldStart = null; // {x, y} in MGRS
+  let arrowHeadingDeg = null;
+  let radiusMeters = 50;
+  let isDrawingArrow = false;
+
+  // Pan state
+  let isPanning = false;
+  let panStartPx = null;
+
+  // Scene dots
+  let sceneDots = []; // [{px, py}] in canvas pixels
+
+  function init() {
+    canvas = document.getElementById("map-canvas");
+    if (!canvas) {
+      setTimeout(init, 200);
+      return;
+    }
+    ctx = canvas.getContext("2d");
+
+    canvas.addEventListener("mousedown", onMouseDown);
+    canvas.addEventListener("mousemove", onMouseMove);
+    canvas.addEventListener("mouseup", onMouseUp);
+    canvas.addEventListener("wheel", onWheel, { passive: false });
+
+    // Prevent context menu on canvas
+    canvas.addEventListener("contextmenu", (e) => e.preventDefault());
+
+    console.log("[map_canvas] initialized");
+  }
+
+  function pixelToWorld(px, py) {
+    if (!viewport) return { x: 0, y: 0 };
+    const w = viewport.xmax - viewport.xmin;
+    const h = viewport.ymax - viewport.ymin;
+    return {
+      x: viewport.xmin + (px / viewport.canvas_w) * w,
+      y: viewport.ymax - (py / viewport.canvas_h) * h,
+    };
+  }
+
+  function worldToPixel(wx, wy) {
+    if (!viewport) return { px: 0, py: 0 };
+    const w = viewport.xmax - viewport.xmin;
+    const h = viewport.ymax - viewport.ymin;
+    return {
+      px: ((wx - viewport.xmin) / w) * viewport.canvas_w,
+      py: ((viewport.ymax - wy) / h) * viewport.canvas_h,
+    };
+  }
+
+  function metersToPixels(meters) {
+    if (!viewport) return 0;
+    const w = viewport.xmax - viewport.xmin;
+    return (meters / w) * viewport.canvas_w;
+  }
+
+  // --- Drawing ---
+
+  function redraw() {
+    if (!ctx || !canvas) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    // Background
+    if (mapImage) {
+      ctx.drawImage(mapImage, 0, 0, canvas.width, canvas.height);
+    } else {
+      ctx.fillStyle = "#f0f0f0";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = "#888";
+      ctx.font = "16px monospace";
+      ctx.textAlign = "center";
+      ctx.fillText("Loading map...", canvas.width / 2, canvas.height / 2);
+    }
+
+    // Scene dots
+    if (sceneDots.length > 0) {
+      ctx.fillStyle = "rgba(0, 100, 255, 0.5)";
+      for (const dot of sceneDots) {
+        ctx.beginPath();
+        ctx.arc(dot.px, dot.py, 3, 0, Math.PI * 2);
+        ctx.fill();
+      }
+    }
+
+    // Radius circle
+    if (arrowStart) {
+      const radiusPx = metersToPixels(radiusMeters);
+      ctx.strokeStyle = "rgba(255, 100, 0, 0.5)";
+      ctx.lineWidth = 2;
+      ctx.setLineDash([6, 4]);
+      ctx.beginPath();
+      ctx.arc(arrowStart.px, arrowStart.py, radiusPx, 0, Math.PI * 2);
+      ctx.stroke();
+      ctx.setLineDash([]);
+    }
+
+    // Arrow
+    if (arrowStart && arrowEnd) {
+      drawArrow(arrowStart.px, arrowStart.py, arrowEnd.px, arrowEnd.py);
+    }
+
+    // Heading tolerance wedge
+    if (arrowStart && arrowHeadingDeg !== null) {
+      drawHeadingWedge();
+    }
+  }
+
+  function drawArrow(x1, y1, x2, y2) {
+    const dx = x2 - x1;
+    const dy = y2 - y1;
+    const len = Math.sqrt(dx * dx + dy * dy);
+    if (len < 5) return;
+
+    const angle = Math.atan2(dy, dx);
+    const headLen = Math.min(20, len * 0.3);
+
+    // Shaft
+    ctx.strokeStyle = "#ff4400";
+    ctx.lineWidth = 3;
+    ctx.beginPath();
+    ctx.moveTo(x1, y1);
+    ctx.lineTo(x2, y2);
+    ctx.stroke();
+
+    // Arrowhead
+    ctx.fillStyle = "#ff4400";
+    ctx.beginPath();
+    ctx.moveTo(x2, y2);
+    ctx.lineTo(
+      x2 - headLen * Math.cos(angle - Math.PI / 6),
+      y2 - headLen * Math.sin(angle - Math.PI / 6)
+    );
+    ctx.lineTo(
+      x2 - headLen * Math.cos(angle + Math.PI / 6),
+      y2 - headLen * Math.sin(angle + Math.PI / 6)
+    );
+    ctx.closePath();
+    ctx.fill();
+
+    // Start dot
+    ctx.fillStyle = "#ff4400";
+    ctx.beginPath();
+    ctx.arc(x1, y1, 5, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  function drawHeadingWedge() {
+    // Draw a transparent wedge showing heading tolerance
+    const toleranceEl = document.querySelector("#heading-tolerance-value");
+    const tolerance = toleranceEl ? parseFloat(toleranceEl.textContent) || 30 : 30;
+
+    const radiusPx = metersToPixels(radiusMeters);
+    // Canvas angles: 0 = right, positive = clockwise (Y inverted)
+    // World heading: degrees CCW from +X → canvas angle = -heading in radians
+    const centerAngle = -(arrowHeadingDeg * Math.PI) / 180;
+    const halfTol = (tolerance * Math.PI) / 180;
+
+    ctx.fillStyle = "rgba(255, 100, 0, 0.1)";
+    ctx.beginPath();
+    ctx.moveTo(arrowStart.px, arrowStart.py);
+    ctx.arc(
+      arrowStart.px,
+      arrowStart.py,
+      radiusPx,
+      centerAngle - halfTol,
+      centerAngle + halfTol
+    );
+    ctx.closePath();
+    ctx.fill();
+  }
+
+  // --- Event Handlers ---
+
+  function onMouseDown(e) {
+    const rect = canvas.getBoundingClientRect();
+    const px = e.clientX - rect.left;
+    const py = e.clientY - rect.top;
+
+    if (e.shiftKey) {
+      // Shift+drag = draw arrow
+      isDrawingArrow = true;
+      arrowStart = { px, py };
+      arrowEnd = { px, py };
+      arrowWorldStart = pixelToWorld(px, py);
+    } else {
+      // Normal drag = pan
+      isPanning = true;
+      panStartPx = { px, py };
+    }
+  }
+
+  function onMouseMove(e) {
+    const rect = canvas.getBoundingClientRect();
+    const px = e.clientX - rect.left;
+    const py = e.clientY - rect.top;
+
+    if (isDrawingArrow) {
+      arrowEnd = { px, py };
+      // Compute heading from start→end (world coords, Y up)
+      const endWorld = pixelToWorld(px, py);
+      const dx = endWorld.x - arrowWorldStart.x;
+      const dy = endWorld.y - arrowWorldStart.y;
+      arrowHeadingDeg = (Math.atan2(dy, dx) * 180) / Math.PI;
+      redraw();
+    } else if (isPanning) {
+      const dx = px - panStartPx.px;
+      const dy = py - panStartPx.py;
+      panStartPx = { px, py };
+      sendViewportAction({ action: "pan", dx: dx, dy: dy });
+    }
+  }
+
+  function onMouseUp(e) {
+    if (isDrawingArrow) {
+      isDrawingArrow = false;
+      if (arrowStart && arrowEnd && arrowWorldStart && arrowHeadingDeg !== null) {
+        // Send arrow data to Gradio
+        sendArrowData({
+          x: arrowWorldStart.x,
+          y: arrowWorldStart.y,
+          heading_deg: arrowHeadingDeg,
+        });
+      }
+    }
+    if (isPanning) {
+      isPanning = false;
+      panStartPx = null;
+    }
+  }
+
+  function onWheel(e) {
+    e.preventDefault();
+    const rect = canvas.getBoundingClientRect();
+    const px = e.clientX - rect.left;
+    const py = e.clientY - rect.top;
+    const factor = e.deltaY > 0 ? 1.3 : 1 / 1.3; // Scroll down = zoom out
+    sendViewportAction({ action: "zoom", factor: factor, px: px, py: py });
+  }
+
+  // --- Gradio Communication ---
+
+  function setGradioTextbox(elemId, value) {
+    // Find the Gradio textbox by elem_id and update its value
+    const container = document.querySelector(`#${elemId}`);
+    if (!container) return;
+    const input =
+      container.querySelector("textarea") || container.querySelector("input");
+    if (!input) return;
+
+    const nativeSet = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype || window.HTMLInputElement.prototype,
+      "value"
+    );
+    if (nativeSet && nativeSet.set) {
+      nativeSet.set.call(input, value);
+    } else {
+      input.value = value;
+    }
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+
+  function sendArrowData(data) {
+    setGradioTextbox("arrow-data", JSON.stringify(data));
+  }
+
+  function sendViewportAction(action) {
+    setGradioTextbox("viewport-action", JSON.stringify(action));
+  }
+
+  // --- Public API (called from Python via gr.HTML js updates) ---
+
+  window.mapCanvas = {
+    setMapImage: function (base64Png) {
+      const img = new Image();
+      img.onload = function () {
+        mapImage = img;
+        redraw();
+      };
+      img.src = "data:image/png;base64," + base64Png;
+    },
+
+    setViewport: function (vp) {
+      viewport = vp;
+    },
+
+    setRadius: function (r) {
+      radiusMeters = r;
+      redraw();
+    },
+
+    setSceneDots: function (dots) {
+      // dots = [{x, y}] in world coords
+      sceneDots = dots.map((d) => worldToPixel(d.x, d.y));
+      redraw();
+    },
+
+    clearArrow: function () {
+      arrowStart = null;
+      arrowEnd = null;
+      arrowWorldStart = null;
+      arrowHeadingDeg = null;
+      sceneDots = [];
+      redraw();
+    },
+
+    redraw: redraw,
+  };
+
+  // Auto-init when DOM is ready
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary

Scene Search GUI — a visual tool for searching and curating NPZ driving scenes by clicking on a lanelet2 road map.

- **Interactive map canvas**: pan (drag), zoom (scroll), and arrow placement (shift+drag) on a pre-rendered lanelet2 map. All interactions are client-side JS for smooth performance; hi-res tiles render on demand via server functions.
- **Spatial search backend** (`search_scenes.py`): builds a spatial index from JSON sidecars (~50k scenes indexed in <1s), filters by radius + heading, supports trajectory and constraint-based filtering.
- **Contiguous batch expansion**: for each matching scene, expands to N frames before + M frames after (configurable), with continuity checks at recording boundaries. Picks the single best match per bag (closest to arrow in position + heading).
- **Thumbnail previews**: every 10th scene in each batch rendered via `visualize_inputs()` with parallel workers (~1.7s for 6 batches × 12 thumbnails each). Two-phase rendering: batch info shown instantly, thumbnails fill in via `.then()` chaining.
- **Keep-and-accumulate workflow**: search results show Keep/Keep All buttons per batch. Kept batches persist across multiple searches. Save All Kept exports a single JSON path list. Optional random downsampling on save.
- **Extensible constraint plugin system**: `@register` decorator pattern (same as guidance registry). Ships with 3 built-in constraints: neighbor count, travel distance, ego speed. Each shows as a collapsible accordion with enable toggle + parameter inputs.
- **Turn indicator fix**: `visualize_inputs()` now shows "Keep Left/Right/Straight" instead of just "Keep" for sustained turn signals.

### New files
| Path | Purpose |
|---|---|
| `diffusion_planner/util_scripts/search_scenes.py` | CLI + library for spatial indexing and filtering NPZ scenes |
| `scene_search/app.py` | Gradio GUI entry point |
| `scene_search/map_renderer.py` | Lanelet2 map loading, viewport math, PNG rendering |
| `scene_search/batch_search.py` | Search logic with batch expansion |
| `scene_search/scene_previewer.py` | Thumbnail generation using `visualize_inputs()` |
| `scene_search/static/map_canvas.js` | JS canvas: pan/zoom/arrow interaction |
| `scene_search/constraints/` | Plugin registry + 3 built-in constraints |

### Launch
```bash
source /opt/ros/humble/setup.bash
source ~/autoware/install/setup.bash
source .venv/bin/activate
python -m scene_search.app \
  --map_path ~/autoware_map/shinagawa_odaiba_stable/lanelet2_map.osm \
  --npz_list /path/to/npz_dir_or_path_list.json
```

## Test plan
- [x] Launch GUI with shinagawa_odaiba map + GRPO v4 data (~50k scenes)
- [x] Zoom into miraikan area, shift+drag arrow heading ~106°, click Search
- [x] Verify 6 batches found, each with 111 scenes (30 before + 1 + 80 after)
- [x] Click thumbnails to inspect scene details
- [x] Keep 2 batches, draw new arrow elsewhere, keep more, verify accumulation
- [x] Save All Kept → JSON, verify output is valid path_list.json format
- [x] Test downsample: set N=50, save, verify 50 randomly sampled scenes
- [x] Enable "Neighbor Count" constraint (min=2), search again, verify fewer results
- [x] Verify turn indicator text shows "Keep Right" / "Keep Straight" (not just "Keep")