### PR TITLE
fix: GRPO loss corrections, reward improvements, and lane keeping tools

### DIFF
--- a/rlvr/README.md
+++ b/rlvr/README.md
@@ -16,18 +16,24 @@ The GRPO pipeline differs from the existing DPO pipeline in two key ways:
 ```
 rlvr/
   reward.py                  Rule-based reward (road border + safety + progress + feasibility
-                             + lane departure detection with K=3 nearest centerlines)
-  grpo_loss.py               Advantage-weighted diffusion loss with PPO clipping + KL
+                             + lane departure detection with K=3 nearest centerlines
+                             + underprogress penalty, GT-normalized progress, survival mode
+                             + lane_crossing_steps as terminal event in survival mode)
+  grpo_loss.py               Advantage-weighted diffusion loss with K=8 (noise,t) averaging
+                             + prefix mask matching SFT training distribution
+                             + optional neighbor prediction regularization
                              + compute_batched_grpo_loss for N-trajectory batched loss
-                             + compute_batched_trajectory_losses for SFT regression
   grpo_config.py             Dataclass config with JSON serialization
-                             + random_guidance_mode, lane departure config
+                             + lane departure, underprogress, progress normalization config
+                             + diffusion_k_steps, neighbor_loss_weight, lane_dep_trim_n
   grpo_trainer.py            Standard GRPO training loop (batched loss)
   grpo_trainer_batched.py    Fully batched GRPO trainer (all scenes in ~5 forward passes)
+                             + lane_dep_trim_n: drop worst lane-departure scenes per epoch
+                             + fixed gradient accumulation scaling for incomplete last chunks
   grpo_exploration_trainer.py  Joint GRPO + exploration policy trainer
                              + random_guidance_mode: skip explorer, sample η directly
   grpo_sampler.py            Diverse trajectory generation with random noise + guidance
-  grpo_sampler_batched.py    CL+SPD focused sampler (deterministic + guided + random)
+  grpo_sampler_batched.py    Strong CL+SPD sampler (1 det + 8 CL5-10 guided + 7 random)
   configs/
     grpo_onpolicy.json       Recommended on-policy config (best for v4)
     grpo_zi_300sc.json       Zero-init exploration + Block 0 LoRA (best baseline)
@@ -51,6 +57,7 @@ rlvr/
     eval_reward_vs_gt.py     Per-scene reward breakdown vs ground truth
     eval_driving_metrics.py  Speed/lat_accel/path length/stopped metrics
     viz_guidance_actual.py   Visualize actual DiT inference with/without guidance
+    grpo_viz.py              Visualize K trajectories per scene with reward ranking table
   autoresearch/tests/         Tests for closed-loop components
     test_gae.py              Unit tests for GAE computation
     test_state_update.py     Unit tests for coordinate transforms
@@ -179,10 +186,15 @@ weighted values (column * weight) so that columns add up to the total.
 1. Find K=3 nearest centerlines from **different lane segments** (not just closest points)
 2. For each of 80 ego perimeter sample points, check containment against all K lanes
 3. Thresholds: crossing (clearance <10cm from lane edge, including outside), near (<25cm), wide (<40cm), continuous (<80cm)
-4. Returns `lane_crossing` (bool) and `lane_near_frac` (fraction of timesteps where min perimeter clearance is below threshold)
+4. Returns `(crossing_gate, near_frac, wide_frac, lane_crossing_steps, cont_penalty)`
+   - `lane_crossing_steps`: first timestep of lane departure per trajectory (for survival mode)
+   - `lane_wide_frac`: fraction of timesteps within 40cm of lane edge
 
-Enabled via `enable_lane_departure: true` in config. Can be used as gate (hard penalty)
-or soft penalty via `lane_near_scale`, `lane_wide_scale`, `lane_cont_scale`.
+Enabled via `enable_lane_departure: true` in config. Can be used as:
+- **Soft penalty** via `lane_near_scale`, `lane_wide_scale`, `lane_cont_scale`
+- **Hard gate** via `lane_gate_enabled: true` (lane crossing zeros the reward in gate mode)
+- **Survival terminal event** when `reward_mode: "survival"` + `enable_lane_departure: true`,
+  lane departure reduces `survival_frac` proportionally to when it occurs
 
 ### Group Advantages
 

--- a/rlvr/autoresearch/README.md
+++ b/rlvr/autoresearch/README.md
@@ -72,9 +72,13 @@ output_dir/YYYYMMDD-HHMMSS_name/
 **Key eval metrics reported:**
 - `rb_cross`: scenes where ego perimeter crosses road border (within 10cm)
 - `rb_near`: fraction of timesteps with ego edge within 25cm of border
+- `lane_dep`: scenes where ego departs lane (within 10cm of lane edge)
+- `lane_near`: fraction of timesteps within 25cm of lane edge
+- `lane_wide`: fraction of timesteps within 40cm of lane edge
 - `reward`: total reward (road border + progress + safety + feasibility)
 - `collision`: collision rate
 - `path`: mean trajectory path length
+- `stopped`: count of scenes where model path < 1m
 
 ### `check_lora_training.py` — LoRA Verification
 
@@ -176,8 +180,19 @@ See `rlvr/configs/grpo_onpolicy.json` for the recommended config. Key parameters
 | `n_prob_scenes` | 0-50 | Problem scenes in training set. **Always set explicitly.** |
 | `n_normal_scenes` | 250-300 | Normal scenes. **Always set explicitly.** |
 | `lora_target` | `"first"` | Block 0 only. Other blocks degrade neighbor predictions. |
-| `advantage_mode` | `"normalized"` | `"normalized"` or `"vd_grpo"` (see below) |
-| `advantage_fixed_scale` | 10.0 | Denominator for VD-GRPO mode |
+| `advantage_mode` | `"normalized"` | `"normalized"`, `"vd_grpo"`, `"raw"`, `"positive_only"`, `"absolute"`, `"softmax"` |
+| `advantage_fixed_scale` | 10.0 | Denominator for vd_grpo/raw/absolute; temperature for softmax |
+| `diffusion_k_steps` | 8 | Number of (noise, t) samples averaged per GRPO loss (matches DPO K=8) |
+| `enable_lane_departure` | `false` | Enable lane departure detection in reward |
+| `lane_gate_enabled` | `false` | Lane crossing as hard gate in survival mode |
+| `lane_near_scale` | 3.0 | Soft penalty for being within 25cm of lane edge |
+| `lane_wide_scale` | 0.2 | Soft penalty for being within 40cm of lane edge |
+| `lane_cont_scale` | 0.0 | Continuous lane proximity penalty |
+| `underprogress_penalty` | 0.0 | Penalize model driving << GT path (0=disabled) |
+| `underprogress_threshold` | 0.5 | Penalize if model_path/gt_path < threshold |
+| `progress_norm_scale` | 20.0 | Max progress points at 100% GT match (when overprogress enabled) |
+| `lane_dep_trim_n` | 0 | Drop N scenes with worst lane departure fraction per epoch (0=disabled) |
+| `neighbor_loss_weight` | 0.0 | Neighbor prediction regularization weight (0=disabled) |
 | `kl_schedule` | `"constant"` | `"constant"`, `"linear"`, `"cosine"`, or `"step"` (see below) |
 | `kl_coef_final` | 0.05 | Target KL coef at end of training (for non-constant schedules) |
 | `kl_warmup_fraction` | 0.5 | Fraction of epochs to hold initial `kl_coef` (for `"step"` schedule) |
@@ -217,6 +232,27 @@ absolute magnitude of negative rewards for crashes across groups.
 **`advantage_fixed_scale` tuning:** Controls advantage magnitude. Larger values
 produce smaller advantages (more conservative updates). Start with 10.0. If
 training is too aggressive, increase to 20.0. If too slow, decrease to 5.0.
+
+### Additional Advantage Modes
+
+- **`raw`**: Centered (subtract group mean), divided by `advantage_fixed_scale`. Same as
+  VD-GRPO. If all trajectories are bad, all get negative advantages.
+- **`positive_only`**: Standard normalization but clips negative advantages to zero. Only
+  reinforces trajectories better than group mean; never pushes away from bad ones.
+- **`absolute`**: No centering. `advantage = total / fixed_scale`. Positive reward → positive
+  advantage. Unstable in practice (can explode), use with caution.
+- **`softmax`**: Softmax-weighted advantages with temperature = `advantage_fixed_scale`.
+  Rank 1 gets disproportionate weight. Low temperature (5) = very sharp; high (20) = softer.
+
+### GRPO Loss: K-Averaging and Prefix Mask
+
+The GRPO loss averages over `diffusion_k_steps` (default 8) different (noise, timestep)
+samples per trajectory, matching DPO's K=8 approach. A single sample gives noisy gradients
+that can point in the wrong direction. K=8 was verified to fix gradient direction.
+
+The loss also applies SFT-style prefix masking: a random delay (0-5 steps) conditions
+the denoising on clean initial timesteps, matching the training distribution the model
+was pretrained with. Without prefix mask, gradient signal is 27x weaker.
 
 ### KL Schedule: Decaying KL Coefficient
 

--- a/rlvr/autoresearch/run_experiment.py
+++ b/rlvr/autoresearch/run_experiment.py
@@ -81,7 +81,7 @@ def evaluate_checkpoint(model, model_args, scene_paths, reward_config, label="",
     model.eval()
     totals, offroads, collisions, path_lengths = [], [], 0, []
     rb_crossings, rb_nears = 0, []
-    lane_departures, lane_nears = 0, []
+    lane_departures, lane_nears, lane_wides = 0, [], []
 
     if batch_size > 1:
         # Batched evaluation
@@ -140,6 +140,7 @@ def evaluate_checkpoint(model, model_args, scene_paths, reward_config, label="",
                 if reward.lane_crossing:
                     lane_departures += 1
                 lane_nears.append(reward.lane_near_frac)
+                lane_wides.append(reward.lane_wide_frac)
                 traj_np = det_trajs[local_i].cpu().numpy()
                 pl = np.linalg.norm(np.diff(traj_np[:, :2], axis=0), axis=1).sum()
                 path_lengths.append(pl)
@@ -164,6 +165,7 @@ def evaluate_checkpoint(model, model_args, scene_paths, reward_config, label="",
                 if reward.lane_crossing:
                     lane_departures += 1
                 lane_nears.append(reward.lane_near_frac)
+                lane_wides.append(reward.lane_wide_frac)
                 pl = np.linalg.norm(np.diff(det_traj[0, :, :2], axis=0), axis=1).sum()
                 path_lengths.append(pl)
             except Exception as e:
@@ -186,11 +188,13 @@ def evaluate_checkpoint(model, model_args, scene_paths, reward_config, label="",
         "rb_near_mean": float(np.mean(rb_nears)),
         "lane_departures": lane_departures,
         "lane_near_mean": float(np.mean(lane_nears)) if lane_nears else 0.0,
+        "lane_wide_mean": float(np.mean(lane_wides)) if lane_wides else 0.0,
     }
     tag = f" [{label}]" if label else ""
     print(f"  Eval{tag}: {n} scenes, reward={result['reward_mean']:+.2f}, "
           f"rb_cross={rb_crossings}/{n}, lane_dep={lane_departures}/{n}, "
           f"rb_near={np.mean(rb_nears):.2f}, "
+          f"lane_near={result['lane_near_mean']:.2f}, lane_wide={result['lane_wide_mean']:.2f}, "
           f"collision={result['collision_rate']:.1%}, "
           f"path={result['path_length_mean']:.1f}m, stopped={result['stopped_count']}")
     return result
@@ -384,6 +388,9 @@ def run(config_path: Path, name: str, skip_baseline: bool = False):
         overprogress_margin=grpo_config.overprogress_margin,
         overprogress_penalty=grpo_config.overprogress_penalty,
         stopped_penalty=grpo_config.stopped_penalty,
+        underprogress_penalty=grpo_config.underprogress_penalty,
+        underprogress_threshold=grpo_config.underprogress_threshold,
+        progress_norm_scale=grpo_config.progress_norm_scale,
         enable_lane_departure=grpo_config.enable_lane_departure,
         lane_gate_enabled=grpo_config.lane_gate_enabled,
         lane_near_scale=grpo_config.lane_near_scale,

--- a/rlvr/autoresearch/tools/README.md
+++ b/rlvr/autoresearch/tools/README.md
@@ -27,6 +27,17 @@ python -m rlvr.autoresearch.tools.eval_reward_vs_gt \
   --model_path <model.pth> --scenes <scenes.json> --tag <name>
 ```
 
+### grpo_viz.py
+Visualizes all K GRPO trajectories per scene with reward breakdown. Each scene gets one figure:
+left panel shows trajectories colored by rank (green=best, red=worst) with road borders and lane
+boundaries; right panel shows per-trajectory reward table with progress, smoothness, lane status, path length.
+```bash
+python -m rlvr.autoresearch.tools.grpo_viz \
+  --model_path <model.pth> --scenes <scenes.json> --output_dir <dir> \
+  --indices 0 4 8 --K 16 --enable_lane --survival \
+  --w_progress 1.0 --lane_near_scale 50.0
+```
+
 ## Diagnostic Tools
 
 ### diagnose_grpo_signal.py

--- a/rlvr/autoresearch/tools/cleanse_lane_scenes.py
+++ b/rlvr/autoresearch/tools/cleanse_lane_scenes.py
@@ -46,7 +46,7 @@ def check_scene_t0(npz_path: str, device: torch.device, threshold: float = 0.15,
 
     # Lane check — we need t=1 to not be skipped
     # Temporarily patch: compute on full trajectory but only t=1 matters
-    lane_gate, lane_near, lane_wide, lane_cont = compute_lane_departure_penalty(
+    lane_gate, lane_near, lane_wide, _, lane_cont = compute_lane_departure_penalty(
         traj_t0, ego_shape, data
     )
 

--- a/rlvr/autoresearch/tools/diagnose_grpo_signal.py
+++ b/rlvr/autoresearch/tools/diagnose_grpo_signal.py
@@ -45,7 +45,7 @@ def diagnose_scene(model, model_args, npz_path, K, reward_config, sampler_config
     for k_i in range(trajs.shape[0]):
         traj_t = trajs[k_i:k_i+1]
         r = compute_reward_batch(traj_t, data, reward_config)[0]
-        gate, near, _, _ = compute_lane_departure_penalty(traj_t, ego_shape, data)
+        gate, near, _, _, _ = compute_lane_departure_penalty(traj_t, ego_shape, data)
         results.append({
             "k": k_i, "total": r.total, "progress": r.progress,
             "smoothness": r.smoothness, "lane_crossing": r.lane_crossing,

--- a/rlvr/autoresearch/tools/eval_lane_border_distance.py
+++ b/rlvr/autoresearch/tools/eval_lane_border_distance.py
@@ -113,7 +113,7 @@ def main():
             rb_min_dists.append(float('inf'))
 
         # Lane departure
-        lane_gate, lane_near, lane_wide, lane_cont = compute_lane_departure_penalty(
+        lane_gate, lane_near, lane_wide, _, lane_cont = compute_lane_departure_penalty(
             traj_t, ego_shape, data
         )
         if lane_gate.item() < 0.5:

--- a/rlvr/autoresearch/tools/grpo_viz.py
+++ b/rlvr/autoresearch/tools/grpo_viz.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Visualize all K GRPO trajectories per scene with reward breakdown.
+
+One figure per scene showing:
+- Left: bird's eye view with all K trajectories colored by rank (green=best, red=worst)
+  with road borders, lane boundaries, GT, and ego footprints
+- Right: reward breakdown table for each trajectory
+
+Usage:
+    python -m rlvr.autoresearch.tools.grpo_viz \
+        --model_path /path/to/best_model.pth \
+        --scenes /path/to/scenes.json \
+        --output_dir /path/to/output \
+        --indices 0 1 2 3 4 \
+        --K 16 --enable_lane --survival \
+        --w_progress 3.0 --lane_near_scale 30.0 --lane_wide_scale 10.0
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import matplotlib.transforms as mtransforms
+import numpy as np
+import torch
+from matplotlib.patches import Rectangle
+
+from preference_optimization.utils import load_npz_data
+from preference_optimization.lora_utils import load_lora_checkpoint
+from diffusion_planner.utils.config import Config
+from diffusion_planner.model.diffusion_planner import Diffusion_Planner
+from rlvr.grpo_sampler import SamplerConfig
+from rlvr.grpo_sampler_batched import generate_diverse_group_batched
+from rlvr.reward import RewardConfig, compute_reward_batch, compute_lane_departure_penalty
+
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+
+
+def generate_and_score(model, model_args, npz_path, K, reward_config, sampler_config):
+    """Generate K trajectories and score each one with full breakdown."""
+    device = torch.device(DEVICE)
+    data = load_npz_data(npz_path, device)
+    es = data.get("ego_shape")
+    ego_shape = es[0] if es is not None and es.dim() > 1 else es
+
+    trajs = generate_diverse_group_batched(model, model_args, data, sampler_config, device)
+
+    # Compute GT path length for underprogress context
+    gt_path_len = 0.0
+    if "ego_agent_future" in data:
+        gt = data["ego_agent_future"]
+        if gt.dim() == 3:
+            gt = gt[0]
+        gt_xy = gt[:, :2]
+        gt_valid = gt_xy.abs().sum(dim=-1) > 0.1
+        if gt_valid.sum() >= 10:
+            gt_path_len = float(torch.diff(gt_xy[gt_valid], dim=0).norm(dim=-1).sum().item())
+
+    results = []
+    for k_i in range(trajs.shape[0]):
+        traj_t = trajs[k_i:k_i + 1]
+        r = compute_reward_batch(traj_t, data, reward_config)[0]
+        gate, near, _, _, _ = compute_lane_departure_penalty(traj_t, ego_shape, data)
+
+        # Compute path length
+        traj_np = trajs[k_i].cpu().numpy()
+        path_len = float(np.linalg.norm(np.diff(traj_np[:, :2], axis=0), axis=1).sum())
+
+        results.append({
+            "k": k_i,
+            "traj": traj_np,
+            "total": r.total,
+            "progress": r.progress,
+            "smoothness": r.smoothness,
+            "centerline": r.centerline,
+            "safety": r.safety,
+            "lane_crossing": r.lane_crossing,
+            "lane_near": r.lane_near_frac,
+            "rb_crossing": r.rb_crossing,
+            "rb_near": r.rb_near_frac,
+            "path_len": path_len,
+        })
+
+    results.sort(key=lambda x: -x["total"])
+    return results, data, gt_path_len
+
+
+def draw_grpo_scene(fig, results, npz_path, scene_idx, gt_path_len, tag):
+    """Draw one scene with all K trajectories + reward breakdown."""
+    npz = np.load(npz_path)
+    K = len(results)
+
+    # Layout: trajectory plot on left (60%), table on right (40%)
+    ax_map = fig.add_axes([0.02, 0.05, 0.55, 0.88])
+    ax_tbl = fig.add_axes([0.60, 0.05, 0.38, 0.88])
+    ax_tbl.axis("off")
+
+    wb, length, width = 2.75, 4.34, 1.70
+    es = npz.get("ego_shape", None)
+    if es is not None and len(es) >= 3:
+        wb, length, width = float(es[0]), float(es[1]), float(es[2])
+    ro = (length - wb) / 2
+
+    # Draw lane boundaries (grey)
+    lanes = npz["lanes"]
+    for i in range(lanes.shape[0]):
+        lane = lanes[i]
+        if np.abs(lane[:, :2]).sum() < 1e-6:
+            continue
+        if lane.shape[1] > 7:
+            pts = lane[:, :2]
+            lb, rb = lane[:, 4:6], lane[:, 6:8]
+            v = np.abs(pts).sum(axis=1) > 0.1
+            if v.sum() > 1:
+                ax_map.plot((pts + lb)[v, 0], (pts + lb)[v, 1], "-", color="#bbb", alpha=0.5, lw=0.7)
+                ax_map.plot((pts + rb)[v, 0], (pts + rb)[v, 1], "-", color="#bbb", alpha=0.5, lw=0.7)
+
+    # Draw road borders (red)
+    ls = npz["line_strings"]
+    for i in range(ls.shape[0]):
+        line = ls[i]
+        if np.abs(line[:, :2]).sum() < 1e-6:
+            continue
+        if ls.shape[-1] >= 4 and line[:, 3].max() > 0.5:
+            valid = (line[:, 3] > 0.5) & (np.abs(line[:, :2]).sum(axis=1) > 0.01)
+            if valid.sum() > 1:
+                ax_map.plot(line[valid, 0], line[valid, 1], color="red", lw=3, alpha=0.7, zorder=4)
+
+    # Draw GT (green dashed)
+    gt = npz["ego_agent_future"]
+    ax_map.plot(gt[:, 0], gt[:, 1], "g--", lw=2.5, alpha=0.6, zorder=5, label=f"GT ({gt_path_len:.1f}m)")
+
+    # Ego box at origin
+    ax_map.add_patch(Rectangle((-ro, -width / 2), length, width,
+                                lw=2, ec="black", fc="#3366cc", alpha=0.9, zorder=20))
+
+    # Color map: rank 1=dark green, rank K=dark red
+    cmap = plt.cm.RdYlGn_r  # reversed: green=low index=best rank
+    all_pts = [gt[:, :2], np.array([[0, 0]])]
+
+    for rank, r in enumerate(results):
+        traj = r["traj"]
+        color = cmap(rank / max(K - 1, 1))
+        alpha = 0.8 if rank < 3 else (0.5 if rank < 8 else 0.3)
+        lw = 2.5 if rank < 3 else 1.2
+
+        lc = "OUT" if r["lane_crossing"] else "IN"
+        rb = "RB!" if r["rb_crossing"] else ""
+        label = f"#{rank+1} {r['total']:+.0f} {lc}{rb}" if rank < 5 else None
+
+        ax_map.plot(traj[:, 0], traj[:, 1], "-", color=color, lw=lw, alpha=alpha, zorder=10 - rank * 0.1)
+        if rank < 5:
+            ax_map.plot(traj[-1, 0], traj[-1, 1], "o", color=color, ms=6, alpha=0.9, zorder=15, label=label)
+
+        # Endpoint footprint for top 3
+        if rank < 3:
+            t_end = len(traj) - 1
+            cx, cy = traj[t_end, 0], traj[t_end, 1]
+            cos_h, sin_h = traj[t_end, 2], traj[t_end, 3]
+            hn = np.sqrt(cos_h**2 + sin_h**2)
+            if hn > 0.01:
+                heading = np.arctan2(sin_h / hn, cos_h / hn)
+                t_rot = mtransforms.Affine2D().rotate(heading).translate(cx, cy) + ax_map.transData
+                ax_map.add_patch(Rectangle((-ro, -width / 2), length, width,
+                                           lw=1, ec=color, fc=color, alpha=0.25, zorder=8, transform=t_rot))
+
+        all_pts.append(traj[:, :2])
+
+    # Auto-zoom
+    all_pts = np.vstack(all_pts)
+    cx, cy = np.mean(all_pts[:, 0]), np.mean(all_pts[:, 1])
+    half = max(np.ptp(all_pts[:, 0]), np.ptp(all_pts[:, 1])) * 0.6 + 8
+    ax_map.set_xlim(cx - half, cx + half)
+    ax_map.set_ylim(cy - half, cy + half)
+    ax_map.set_aspect("equal")
+    ax_map.grid(True, alpha=0.15)
+    ax_map.legend(loc="upper left", fontsize=7, framealpha=0.8)
+
+    # Count in-lane and stopped
+    n_in = sum(1 for r in results if not r["lane_crossing"])
+    n_stopped = sum(1 for r in results if r["path_len"] < 1.0)
+    in_totals = [r["total"] for r in results if not r["lane_crossing"]]
+    out_totals = [r["total"] for r in results if r["lane_crossing"] and not r["rb_crossing"]]
+    in_mean = np.mean(in_totals) if in_totals else float("nan")
+    out_mean = np.mean(out_totals) if out_totals else float("nan")
+
+    ax_map.set_title(
+        f"Scene {scene_idx} [{tag}] — {n_in}/{K} in-lane, {n_stopped} stopped\n"
+        f"IN={in_mean:+.1f} vs OUT={out_mean:+.1f}  GT={gt_path_len:.1f}m",
+        fontsize=10,
+    )
+
+    # Reward breakdown table
+    headers = ["Rk", "Total", "Prog", "Smth", "CL", "Safe", "Lane", "LN%", "RB", "Path"]
+    col_widths = [0.06, 0.10, 0.09, 0.09, 0.09, 0.09, 0.08, 0.09, 0.06, 0.09]
+
+    # Header
+    y = 0.97
+    for j, h in enumerate(headers):
+        x = sum(col_widths[:j]) + col_widths[j] / 2
+        ax_tbl.text(x, y, h, fontsize=7, fontweight="bold", ha="center", va="top",
+                    transform=ax_tbl.transAxes)
+    y -= 0.02
+    ax_tbl.plot([0, 1], [y, y], color="black", lw=0.5, transform=ax_tbl.transAxes, clip_on=False)
+
+    for rank, r in enumerate(results):
+        y -= 0.055
+        if y < 0.0:
+            break
+
+        color = cmap(rank / max(K - 1, 1))
+        lc = "OUT" if r["lane_crossing"] else "IN"
+        rb = "X" if r["rb_crossing"] else ""
+        stopped = r["path_len"] < 1.0
+
+        row = [
+            f"{rank+1}",
+            f"{r['total']:+.1f}",
+            f"{r['progress']:.1f}",
+            f"{r['smoothness']:.2f}",
+            f"{r['centerline']:.2f}",
+            f"{r['safety']:.2f}",
+            f"{lc}",
+            f"{r['lane_near']:.0%}",
+            f"{rb}",
+            f"{r['path_len']:.1f}m",
+        ]
+
+        # Highlight: green bg for in-lane advancing, red for stopped, orange for out-of-lane
+        if stopped:
+            bg_color = "#ffcccc"  # light red for stopped
+        elif not r["lane_crossing"]:
+            bg_color = "#ccffcc"  # light green for in-lane
+        else:
+            bg_color = "#fff3cc"  # light yellow for out-of-lane
+
+        # Draw background row highlight
+        ax_tbl.fill_between([0, 1], y - 0.025, y + 0.03, color=bg_color, alpha=0.5,
+                            transform=ax_tbl.transAxes, clip_on=False)
+
+        for j, val in enumerate(row):
+            x = sum(col_widths[:j]) + col_widths[j] / 2
+            fw = "bold" if rank < 3 else "normal"
+            ax_tbl.text(x, y, val, fontsize=6.5, ha="center", va="center",
+                        fontweight=fw, color=color if rank < 5 else "#555",
+                        transform=ax_tbl.transAxes)
+
+    # Legend at bottom of table
+    y_leg = max(y - 0.06, 0.01)
+    ax_tbl.text(0.0, y_leg, "Green=in-lane  Yellow=out-of-lane  Red=stopped (<1m)",
+                fontsize=6, color="#666", transform=ax_tbl.transAxes)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="GRPO trajectory visualization with reward breakdown")
+    parser.add_argument("--model_path", type=str, required=True)
+    parser.add_argument("--scenes", type=str, required=True)
+    parser.add_argument("--lora_path", type=str, default=None)
+    parser.add_argument("--output_dir", type=str, required=True)
+    parser.add_argument("--indices", type=int, nargs="*", default=None)
+    parser.add_argument("--n_scenes", type=int, default=5)
+    parser.add_argument("--K", type=int, default=16)
+    parser.add_argument("--tag", type=str, default="model")
+    # Reward config
+    parser.add_argument("--survival", action="store_true")
+    parser.add_argument("--enable_lane", action="store_true")
+    parser.add_argument("--lane_gate", action="store_true")
+    parser.add_argument("--w_progress", type=float, default=3.0)
+    parser.add_argument("--near_edge_scale", type=float, default=5.0)
+    parser.add_argument("--wide_edge_scale", type=float, default=0.5)
+    parser.add_argument("--lane_near_scale", type=float, default=30.0)
+    parser.add_argument("--lane_wide_scale", type=float, default=10.0)
+    parser.add_argument("--lane_cont_scale", type=float, default=5.0)
+    parser.add_argument("--stopped_penalty", type=float, default=50.0)
+    parser.add_argument("--underprogress_penalty", type=float, default=100.0)
+    parser.add_argument("--underprogress_threshold", type=float, default=0.5)
+    parser.add_argument("--progress_norm_scale", type=float, default=20.0)
+    parser.add_argument("--overprogress_margin", type=float, default=1.0)
+    parser.add_argument("--overprogress_penalty", type=float, default=3.0)
+    args = parser.parse_args()
+
+    device = torch.device(DEVICE)
+    model_dir = Path(args.model_path).parent
+    args_path = model_dir / "args.json"
+    if not args_path.exists():
+        args_path = model_dir.parent / "args.json"
+    model_args = Config(str(args_path))
+    model = Diffusion_Planner(model_args)
+    ckpt = torch.load(args.model_path, map_location=device, weights_only=False)
+    state = ckpt.get("model", ckpt)
+    state = {k.replace("module.", ""): v for k, v in state.items()}
+    model.load_state_dict(state)
+    model.to(device)
+    if args.lora_path:
+        model = load_lora_checkpoint(model, args.lora_path)
+    model.eval()
+
+    rcfg = RewardConfig(
+        enable_lane_departure=args.enable_lane,
+        lane_gate_enabled=args.lane_gate,
+        w_progress=args.w_progress,
+        near_edge_scale=args.near_edge_scale,
+        wide_edge_scale=args.wide_edge_scale,
+        lane_near_scale=args.lane_near_scale,
+        lane_wide_scale=args.lane_wide_scale,
+        lane_cont_scale=args.lane_cont_scale,
+        reward_mode="survival" if args.survival else "gate",
+        enable_overprogress=True,
+        overprogress_margin=args.overprogress_margin,
+        overprogress_penalty=args.overprogress_penalty,
+        stopped_penalty=args.stopped_penalty,
+        underprogress_penalty=args.underprogress_penalty,
+        underprogress_threshold=args.underprogress_threshold,
+        progress_norm_scale=args.progress_norm_scale,
+    )
+
+    sampler_cfg = SamplerConfig(
+        n_trajectories=args.K,
+        enable_guidance=True,
+        enable_centerline=True,
+        enable_lane_keeping=True,
+        enable_road_border=True,
+        enable_speed=True,
+        guidance_prob=0.7,
+    )
+
+    with open(args.scenes) as f:
+        scenes = json.load(f)
+
+    if args.indices:
+        scene_indices = args.indices
+    else:
+        scene_indices = list(range(min(args.n_scenes, len(scenes))))
+
+    out = Path(args.output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    for si in scene_indices:
+        print(f"Processing scene {si}...")
+        results, data, gt_path_len = generate_and_score(
+            model, model_args, scenes[si], args.K, rcfg, sampler_cfg
+        )
+
+        fig = plt.figure(figsize=(18, 10))
+        draw_grpo_scene(fig, results, scenes[si], si, gt_path_len, args.tag)
+
+        fname = out / f"scene_{si:03d}.png"
+        fig.savefig(fname, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        print(f"  Saved: {fname}")
+
+        # Print quick summary
+        n_in = sum(1 for r in results if not r["lane_crossing"])
+        n_stopped = sum(1 for r in results if r["path_len"] < 1.0)
+        print(f"  {n_in}/{args.K} in-lane, {n_stopped} stopped, "
+              f"best={results[0]['total']:+.1f}, worst={results[-1]['total']:+.1f}")
+
+    print(f"\nDone. {len(scene_indices)} figures saved to {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -153,6 +153,7 @@ class GRPOConfig:
     # high-progress lane-departing scenes at top, heavily crashed scenes at bottom).
     reward_trim_pct: float = 0.0  # 0.05 = trim 5% of scenes from each end
     lane_dep_trim_n: int = 0  # drop N scenes with highest lane departure fraction (0=disabled)
+    neighbor_loss_weight: float = 0.0  # weight for neighbor prediction regularization (0=disabled)
 
     # LoRA
     use_lora: bool = True

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -104,6 +104,9 @@ class GRPOConfig:
     overprogress_margin: float = 1.1
     overprogress_penalty: float = 0.3
     stopped_penalty: float = 5.0
+    underprogress_penalty: float = 0.0  # penalize model driving << GT (0=disabled)
+    underprogress_threshold: float = 0.5  # penalize if model_path/gt_path < threshold
+    progress_norm_scale: float = 20.0  # max progress points at 100% GT match
 
     # Reward aggregation mode (passed to RewardConfig):
     # "gate": binary safety gates (default). Any terminal event → floor.
@@ -149,6 +152,7 @@ class GRPOConfig:
     # reward before training. Prevents learning from outlier scenes (e.g.,
     # high-progress lane-departing scenes at top, heavily crashed scenes at bottom).
     reward_trim_pct: float = 0.0  # 0.05 = trim 5% of scenes from each end
+    lane_dep_trim_n: int = 0  # drop N scenes with highest lane departure fraction (0=disabled)
 
     # LoRA
     use_lora: bool = True

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -125,7 +125,7 @@ class GRPOConfig:
     loss_mode: str = "diffusion"
     direct_loss_weight: float = 1.0
     diffusion_t_range: list[float] = field(default_factory=lambda: [0.001, 0.1])
-    diffusion_k_steps: int = 4
+    diffusion_k_steps: int = 8  # K (noise, t) samples averaged per GRPO loss (matches DPO K=8)
 
     # Advantage computation mode:
     # "normalized" (default): standard GRPO per-group normalization (mean=0, std=1).

--- a/rlvr/grpo_loss.py
+++ b/rlvr/grpo_loss.py
@@ -43,17 +43,17 @@ from rlvr.grpo_config import GRPOConfig
 def compute_trajectory_loss(model, data, trajectory, model_args, noise, t, device):
     """V4-compatible trajectory loss using 4D diffusion timestep.
 
-    The v4 DiT requires t as [B, P, T+1, 1] with t.shape[2] == x.shape[2].
-    The original dpo_loss.compute_trajectory_loss passes a single t to both
-    marginal_prob (which needs [B,P,T,1]) and diffusion_time (which needs
-    [B,P,T+1,1]). To resolve this, we replicate the essential logic here
-    with proper 4D t handling, matching the v4 training code in decoder.py.
+    Matches SFT training in decoder.py: includes prefix mask with random delay,
+    per-timestep t modulation, and clean prefix injection.
     """
+    import random as _random
     from diffusion_planner.model.diffusion_utils.sde import VPSDE_linear
+    from diffusion_planner.model.module.decoder import generate_prefix_mask
 
     B = data["ego_current_state"].shape[0]
     P = 1 + model_args.predicted_neighbor_num
     future_len = model_args.future_len
+    eps = 1e-3
 
     # Expand t to [B, P, T+1, 1]
     if t.dim() == 1:
@@ -62,6 +62,14 @@ def compute_trajectory_loss(model, data, trajectory, model_args, noise, t, devic
         t_4d = t
     else:
         t_4d = t.view(B, 1, 1, 1).expand(B, P, future_len + 1, 1).clone()
+
+    # Prefix mask with random delay — matches SFT (decoder.py line 95-100)
+    max_delay = 5
+    delay = torch.randint(0, max_delay + 1, (B,), device=device)
+    prefix_mask = generate_prefix_mask(delay, P, future_len + 1)  # (B, P, T+1, 1)
+    mask_coeff = _random.uniform(0.0, 1.0)
+    curr_mask_time = torch.maximum(t_4d * mask_coeff, torch.tensor(eps, device=device))
+    t_4d = torch.where(prefix_mask, curr_mask_time, t_4d)
 
     gt_trajectory = torch.as_tensor(trajectory, dtype=torch.float32, device=device)
     if gt_trajectory.dim() == 2:
@@ -84,11 +92,12 @@ def compute_trajectory_loss(model, data, trajectory, model_args, noise, t, devic
 
     all_gt = torch.cat([current_states[:, :, None, :], gt_future], dim=2)  # [B, P, T+1, 4]
 
-    # marginal_prob on future part with sliced t (matching decoder.py:111)
+    # Diffusion noise with prefix masking — matches SFT (decoder.py line 111-116)
     mean, std = VPSDE_linear().marginal_prob(all_gt[..., 1:, :], t_4d[..., 1:, :])
     xT = mean + std * noise
-
     xT_full = torch.cat([all_gt[:, :, :1, :], xT], dim=2)  # [B, P, T+1, 4]
+    # Prefix: replace noised steps with clean GT
+    xT_full = torch.where(prefix_mask, all_gt, xT_full)
 
     data_for_norm = {k: v.clone() if isinstance(v, torch.Tensor) else v for k, v in data.items()}
     data_normalized = model_args.observation_normalizer(data_for_norm)
@@ -97,13 +106,13 @@ def compute_trajectory_loss(model, data, trajectory, model_args, noise, t, devic
     merged_inputs["gt_trajectories"] = all_gt
     merged_inputs["sampled_trajectories"] = xT_full
     merged_inputs["diffusion_time"] = t_4d  # [B, P, T+1, 1]
+    merged_inputs["prefix_mask"] = prefix_mask
     if "delay" not in merged_inputs:
-        merged_inputs["delay"] = torch.zeros(B, dtype=torch.long, device=device)
+        merged_inputs["delay"] = delay
 
     _, outputs = model(merged_inputs)
 
     if "model_output" in outputs:
-        # model_output is [B, P, T+1, 4] from _forward_training; skip prefix at index 0
         model_output = outputs["model_output"][:, 0, 1:, :]  # [B, T, 4]
     else:
         model_output = outputs["prediction"][:, 0]
@@ -458,7 +467,7 @@ def compute_batched_grpo_loss(
     # Average over K (noise, t) samples for stable gradients — matches DPO which
     # uses K=8. A single sample is dominated by noise at that specific timestep
     # and doesn't reliably push the deterministic (t=0) trajectory.
-    K = 8
+    K = max(config.diffusion_k_steps, 1)
     advantages_t = torch.tensor(advantages, dtype=torch.float32, device=device)
 
     policy_losses_sum = torch.zeros(N, device=device)

--- a/rlvr/grpo_loss.py
+++ b/rlvr/grpo_loss.py
@@ -63,7 +63,9 @@ def compute_trajectory_loss(model, data, trajectory, model_args, noise, t, devic
     else:
         t_4d = t.view(B, 1, 1, 1).expand(B, P, future_len + 1, 1).clone()
 
-    gt_trajectory = torch.tensor(trajectory, dtype=torch.float32, device=device).unsqueeze(0)
+    gt_trajectory = torch.as_tensor(trajectory, dtype=torch.float32, device=device)
+    if gt_trajectory.dim() == 2:
+        gt_trajectory = gt_trajectory.unsqueeze(0)  # [T, 4] → [1, T, 4]
     ego_mean = model_args.state_normalizer.mean[0].to(device)
     ego_std = model_args.state_normalizer.std[0].to(device)
     gt_trajectory_norm = (gt_trajectory - ego_mean) / ego_std
@@ -230,8 +232,8 @@ def compute_batched_trajectory_losses(
 ):
     """Compute diffusion losses for N trajectories in ONE forward pass.
 
-    Instead of looping N times with B=1, expands scene data to B=N
-    and processes all trajectories at once.
+    Matches the SFT training path in decoder.py: includes prefix mask with
+    random delay, per-timestep t modulation, and proper noising.
 
     Args:
         model: Diffusion planner model (in train mode).
@@ -245,11 +247,14 @@ def compute_batched_trajectory_losses(
     Returns:
         [N] tensor of per-trajectory MSE losses.
     """
+    import random as _random
     from diffusion_planner.model.diffusion_utils.sde import VPSDE_linear
+    from diffusion_planner.model.module.decoder import generate_prefix_mask
 
     N = trajectories_tensor.shape[0]
     P = 1 + model_args.predicted_neighbor_num
     future_len = model_args.future_len
+    eps = 1e-3
 
     # Expand data from B=1 to B=N
     batch_data = {}
@@ -259,7 +264,7 @@ def compute_batched_trajectory_losses(
         else:
             batch_data[k] = v
 
-    # Expand t to [N, P, T+1, 1]
+    # Expand t to [N, P, T+1, 1] — matches SFT (decoder.py line 90-92)
     if t.dim() == 1:
         t_N = t.expand(N)
         t_4d = t_N.view(N, 1, 1, 1).expand(N, P, future_len + 1, 1).clone()
@@ -272,6 +277,16 @@ def compute_batched_trajectory_losses(
     else:
         noise_N = noise
 
+    # Prefix mask with random delay — matches SFT (decoder.py line 95-100)
+    # Forces first `delay` steps to use clean GT, training the model to
+    # predict the trajectory conditioned on a clean prefix.
+    max_delay = 5
+    delay = torch.randint(0, max_delay + 1, (N,), device=device)
+    prefix_mask = generate_prefix_mask(delay, P, future_len + 1)  # (N, P, T+1, 1)
+    mask_coeff = _random.uniform(0.0, 1.0)
+    curr_mask_time = torch.maximum(t_4d * mask_coeff, torch.tensor(eps, device=device))
+    t_4d = torch.where(prefix_mask, curr_mask_time, t_4d)
+
     # Normalize trajectories: [N, T, 4]
     ego_mean = model_args.state_normalizer.mean[0].to(device)
     ego_std = model_args.state_normalizer.std[0].to(device)
@@ -281,7 +296,7 @@ def compute_batched_trajectory_losses(
     gt_future = torch.zeros(N, P, future_len, 4, device=device)
     gt_future[:, 0, :, :] = gt_traj_norm
 
-    # Current states
+    # Current states — normalized (matches SFT decoder.py line 60-67)
     ego_current = batch_data["ego_current_state"][:, :4]  # [N, 4]
     if P > 1:
         neighbors_current = batch_data["neighbor_agents_past"][:, :P - 1, -1, :4]
@@ -293,10 +308,12 @@ def compute_batched_trajectory_losses(
 
     all_gt = torch.cat([current_states[:, :, None, :], gt_future], dim=2)  # [N, P, T+1, 4]
 
-    # Diffusion noise
+    # Diffusion noise with prefix masking — matches SFT (decoder.py line 111-116)
     mean, std = VPSDE_linear().marginal_prob(all_gt[..., 1:, :], t_4d[..., 1:, :])
     xT = mean + std * noise_N
     xT_full = torch.cat([all_gt[:, :, :1, :], xT], dim=2)
+    # Prefix: replace noised steps with clean GT for delay steps
+    xT_full = torch.where(prefix_mask, all_gt, xT_full)
 
     # Normalize observation data
     data_for_norm = {k: v.clone() if isinstance(v, torch.Tensor) else v for k, v in batch_data.items()}
@@ -306,8 +323,9 @@ def compute_batched_trajectory_losses(
     merged["gt_trajectories"] = all_gt
     merged["sampled_trajectories"] = xT_full
     merged["diffusion_time"] = t_4d
+    merged["prefix_mask"] = prefix_mask
     if "delay" not in merged:
-        merged["delay"] = torch.zeros(N, dtype=torch.long, device=device)
+        merged["delay"] = delay
 
     _, outputs = model(merged)
 
@@ -437,15 +455,28 @@ def compute_batched_grpo_loss(
     future_len = model_args.future_len
     eps = 1e-3
 
-    noise = torch.randn(1, P, future_len, 4, device=device)
-    t = torch.rand(1, device=device) * (1 - eps) + eps
-
+    # Average over K (noise, t) samples for stable gradients — matches DPO which
+    # uses K=8. A single sample is dominated by noise at that specific timestep
+    # and doesn't reliably push the deterministic (t=0) trajectory.
+    K = 8
     advantages_t = torch.tensor(advantages, dtype=torch.float32, device=device)
 
-    policy_losses, ref_losses = _compute_batched_losses_and_ref(
-        policy_model, trajectories_tensor, data, model_args, device, noise, t,
-        compute_ref=True,
-    )
+    policy_losses_sum = torch.zeros(N, device=device)
+    ref_losses_sum = torch.zeros(N, device=device)
+
+    for _ in range(K):
+        noise = torch.randn(1, P, future_len, 4, device=device)
+        t = torch.rand(1, device=device) * (1 - eps) + eps
+
+        policy_losses_k, ref_losses_k = _compute_batched_losses_and_ref(
+            policy_model, trajectories_tensor, data, model_args, device, noise, t,
+            compute_ref=True,
+        )
+        policy_losses_sum = policy_losses_sum + policy_losses_k
+        ref_losses_sum = ref_losses_sum + ref_losses_k
+
+    policy_losses = policy_losses_sum / K
+    ref_losses = ref_losses_sum / K
 
     kl_loss = (policy_losses - ref_losses).mean()
 

--- a/rlvr/grpo_loss.py
+++ b/rlvr/grpo_loss.py
@@ -310,6 +310,8 @@ def compute_batched_trajectory_losses(
 
     # Fill neighbor GT from data (matches SFT)
     Pn = P - 1
+    neighbor_future_valid = None
+    nf_pn = 0
     if Pn > 0 and "neighbor_agents_future" in batch_data:
         nf = batch_data["neighbor_agents_future"]  # [N, Pn_data, T, 3+]
         nf_pn = min(nf.shape[1], Pn)
@@ -319,25 +321,9 @@ def compute_batched_trajectory_losses(
         nf_4d[..., :2] = nf_xy
         nf_4d_norm = (nf_4d - ego_mean) / ego_std
         gt_future[:, 1:1 + nf_pn, :, :] = nf_4d_norm
-
-    # Neighbor validity mask — zero out invalid neighbors (matches SFT decoder.py line 108)
-    neighbor_future_valid = None
-    if Pn > 0 and "neighbor_agents_future" in batch_data:
-        nf = batch_data["neighbor_agents_future"]
-        nf_pn = min(nf.shape[1], Pn)
+        # Track validity for neighbor loss
         if nf.shape[-1] >= 3:
-            # Valid flag is typically indicated by non-zero xy
             neighbor_future_valid = (nf[:, :nf_pn, :future_len, :2].abs().sum(dim=-1) > 0.1)  # [N, Pn', T]
-        # Zero out invalid neighbor positions in gt_future
-        neighbors_current = batch_data["neighbor_agents_past"][:, :Pn, -1, :4]
-        neighbor_current_mask = (neighbors_current[..., :4].abs().sum(dim=-1) == 0)  # [N, Pn]
-        neighbor_future_mask = ~neighbor_future_valid if neighbor_future_valid is not None else torch.ones(N, nf_pn, future_len, dtype=torch.bool, device=device)
-        # Build full mask [N, Pn, T+1] and zero out
-        full_mask = torch.cat([neighbor_current_mask.unsqueeze(-1), neighbor_future_mask], dim=-1)  # [N, Pn, T+1]
-        gt_future_with_current = torch.cat([
-            torch.zeros(N, Pn, 1, 4, device=device),  # placeholder, will be overwritten
-            gt_future[:, 1:1 + nf_pn]
-        ], dim=2)  # not used directly, mask applied below
 
     # Current states — normalized (matches SFT decoder.py line 60-67)
     ego_current = batch_data["ego_current_state"][:, :4]  # [N, 4]

--- a/rlvr/grpo_loss.py
+++ b/rlvr/grpo_loss.py
@@ -238,6 +238,7 @@ def compute_direct_best_loss(
 
 def compute_batched_trajectory_losses(
     model, data, trajectories_tensor, model_args, noise, t, device,
+    neighbor_loss_weight: float = 0.0,
 ):
     """Compute diffusion losses for N trajectories in ONE forward pass.
 
@@ -397,9 +398,9 @@ def compute_batched_trajectory_losses(
     # Neighbor regularization loss: per-trajectory MSE on valid neighbor predictions.
     # This prevents the LoRA from distorting neighbor predictions, which feeds back
     # into the joint denoising and corrupts ego output over time.
-    # Weight = 0.5 to keep ego as primary signal.
-    _NEIGHBOR_LOSS_WEIGHT = 0.5
-    if P > 1 and neighbor_future_valid is not None:
+    # Disabled by default (neighbor_loss_weight=0). Set >0 to enable.
+    _NEIGHBOR_LOSS_WEIGHT = neighbor_loss_weight
+    if _NEIGHBOR_LOSS_WEIGHT > 0 and P > 1 and neighbor_future_valid is not None:
         neighbor_output = full_output[:, 1:1 + nf_pn]  # [N, Pn', T, 4]
         neighbor_gt = full_gt[:, 1:1 + nf_pn]  # [N, Pn', T, 4]
         neighbor_mse = F.mse_loss(neighbor_output, neighbor_gt, reduction='none')  # [N, Pn', T, 4]
@@ -473,6 +474,7 @@ def _compute_batched_losses_and_ref(
     noise: torch.Tensor,
     t: torch.Tensor,
     compute_ref: bool = True,
+    neighbor_loss_weight: float = 0.0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Batched version: compute all N trajectory losses in ONE forward pass.
 
@@ -485,6 +487,7 @@ def _compute_batched_losses_and_ref(
     # Policy losses: one batched forward pass for all N trajectories
     policy_losses = compute_batched_trajectory_losses(
         policy_model, data, trajectories_tensor, model_args, noise, t, device,
+        neighbor_loss_weight=neighbor_loss_weight,
     )  # [N]
 
     ref_losses = torch.zeros_like(policy_losses)
@@ -494,6 +497,7 @@ def _compute_batched_losses_and_ref(
             ref_losses = compute_batched_trajectory_losses(
                 policy_model, data, trajectories_tensor, model_args,
                 noise.clone(), t, device,
+                neighbor_loss_weight=neighbor_loss_weight,
             )  # [N]
 
     return policy_losses, ref_losses
@@ -546,6 +550,7 @@ def compute_batched_grpo_loss(
         policy_losses_k, ref_losses_k = _compute_batched_losses_and_ref(
             policy_model, trajectories_tensor, data, model_args, device, noise, t,
             compute_ref=True,
+            neighbor_loss_weight=getattr(config, 'neighbor_loss_weight', 0.0),
         )
         policy_losses_sum = policy_losses_sum + policy_losses_k
         ref_losses_sum = ref_losses_sum + ref_losses_k

--- a/rlvr/grpo_loss.py
+++ b/rlvr/grpo_loss.py
@@ -301,9 +301,42 @@ def compute_batched_trajectory_losses(
     ego_std = model_args.state_normalizer.std[0].to(device)
     gt_traj_norm = (trajectories_tensor - ego_mean) / ego_std
 
-    # Build gt_future: [N, P, T, 4] with ego trajectory only
+    # Build gt_future: [N, P, T, 4] with ego + neighbor GT
+    # Ego uses the GRPO sampled trajectory; neighbors use their actual GT futures.
+    # This matches SFT (decoder.py line 84-86) and provides neighbor regularization.
     gt_future = torch.zeros(N, P, future_len, 4, device=device)
     gt_future[:, 0, :, :] = gt_traj_norm
+
+    # Fill neighbor GT from data (matches SFT)
+    Pn = P - 1
+    if Pn > 0 and "neighbor_agents_future" in batch_data:
+        nf = batch_data["neighbor_agents_future"]  # [N, Pn_data, T, 3+]
+        nf_pn = min(nf.shape[1], Pn)
+        # neighbor_agents_future has [x, y, valid] — pad to 4 dims with zeros for heading
+        nf_xy = nf[:, :nf_pn, :future_len, :2]  # [N, Pn', T, 2]
+        nf_4d = torch.zeros(N, nf_pn, future_len, 4, device=device)
+        nf_4d[..., :2] = nf_xy
+        nf_4d_norm = (nf_4d - ego_mean) / ego_std
+        gt_future[:, 1:1 + nf_pn, :, :] = nf_4d_norm
+
+    # Neighbor validity mask — zero out invalid neighbors (matches SFT decoder.py line 108)
+    neighbor_future_valid = None
+    if Pn > 0 and "neighbor_agents_future" in batch_data:
+        nf = batch_data["neighbor_agents_future"]
+        nf_pn = min(nf.shape[1], Pn)
+        if nf.shape[-1] >= 3:
+            # Valid flag is typically indicated by non-zero xy
+            neighbor_future_valid = (nf[:, :nf_pn, :future_len, :2].abs().sum(dim=-1) > 0.1)  # [N, Pn', T]
+        # Zero out invalid neighbor positions in gt_future
+        neighbors_current = batch_data["neighbor_agents_past"][:, :Pn, -1, :4]
+        neighbor_current_mask = (neighbors_current[..., :4].abs().sum(dim=-1) == 0)  # [N, Pn]
+        neighbor_future_mask = ~neighbor_future_valid if neighbor_future_valid is not None else torch.ones(N, nf_pn, future_len, dtype=torch.bool, device=device)
+        # Build full mask [N, Pn, T+1] and zero out
+        full_mask = torch.cat([neighbor_current_mask.unsqueeze(-1), neighbor_future_mask], dim=-1)  # [N, Pn, T+1]
+        gt_future_with_current = torch.cat([
+            torch.zeros(N, Pn, 1, 4, device=device),  # placeholder, will be overwritten
+            gt_future[:, 1:1 + nf_pn]
+        ], dim=2)  # not used directly, mask applied below
 
     # Current states — normalized (matches SFT decoder.py line 60-67)
     ego_current = batch_data["ego_current_state"][:, :4]  # [N, 4]
@@ -316,6 +349,17 @@ def compute_batched_trajectory_losses(
     current_states = torch.cat([ego_current_norm[:, None], neighbors_current_norm], dim=1)
 
     all_gt = torch.cat([current_states[:, :, None, :], gt_future], dim=2)  # [N, P, T+1, 4]
+
+    # Zero out invalid neighbor entries in all_gt (matches SFT decoder.py line 108)
+    if Pn > 0:
+        neighbor_current_mask_final = (batch_data["neighbor_agents_past"][:, :Pn, -1, :4].abs().sum(dim=-1) == 0)  # [N, Pn]
+        if "neighbor_agents_future" in batch_data:
+            nf = batch_data["neighbor_agents_future"]
+            nf_pn = min(nf.shape[1], Pn)
+            nf_valid = (nf[:, :nf_pn, :future_len, :2].abs().sum(dim=-1) > 0.1)
+            nf_mask = ~nf_valid  # [N, Pn', T]
+            full_neighbor_mask = torch.cat([neighbor_current_mask_final[:, :nf_pn].unsqueeze(-1), nf_mask], dim=-1)  # [N, Pn', T+1]
+            all_gt[:, 1:1 + nf_pn][full_neighbor_mask.unsqueeze(-1).expand_as(all_gt[:, 1:1 + nf_pn])] = 0.0
 
     # Diffusion noise with prefix masking — matches SFT (decoder.py line 111-116)
     mean, std = VPSDE_linear().marginal_prob(all_gt[..., 1:, :], t_4d[..., 1:, :])
@@ -339,14 +383,36 @@ def compute_batched_trajectory_losses(
     _, outputs = model(merged)
 
     if "model_output" in outputs:
-        model_output = outputs["model_output"][:, 0, 1:, :]  # [N, T, 4]
+        full_output = outputs["model_output"][:, :, 1:, :]  # [N, P, T, 4]
     else:
-        model_output = outputs["prediction"][:, 0]
+        full_output = outputs["prediction"]  # [N, P, T, 4]
 
-    gt_target = all_gt[:, 0, 1:, :]  # [N, T, 4]
+    full_gt = all_gt[:, :, 1:, :]  # [N, P, T, 4]
 
-    # Per-trajectory MSE loss: [N]
-    per_traj_loss = F.mse_loss(model_output, gt_target, reduction='none').mean(dim=(1, 2))
+    # Ego loss: [N]
+    ego_output = full_output[:, 0]  # [N, T, 4]
+    ego_gt = full_gt[:, 0]  # [N, T, 4]
+    per_traj_ego_loss = F.mse_loss(ego_output, ego_gt, reduction='none').mean(dim=(1, 2))
+
+    # Neighbor regularization loss: per-trajectory MSE on valid neighbor predictions.
+    # This prevents the LoRA from distorting neighbor predictions, which feeds back
+    # into the joint denoising and corrupts ego output over time.
+    # Weight = 0.5 to keep ego as primary signal.
+    _NEIGHBOR_LOSS_WEIGHT = 0.5
+    if P > 1 and neighbor_future_valid is not None:
+        neighbor_output = full_output[:, 1:1 + nf_pn]  # [N, Pn', T, 4]
+        neighbor_gt = full_gt[:, 1:1 + nf_pn]  # [N, Pn', T, 4]
+        neighbor_mse = F.mse_loss(neighbor_output, neighbor_gt, reduction='none')  # [N, Pn', T, 4]
+        # Mask invalid neighbors to zero
+        valid_mask = neighbor_future_valid.unsqueeze(-1).expand_as(neighbor_mse)  # [N, Pn', T, 4]
+        neighbor_mse = neighbor_mse * valid_mask.float()
+        # Per-trajectory neighbor loss: [N] — average over valid neighbors, timesteps, dims
+        n_valid_per_traj = valid_mask.float().sum(dim=(1, 2, 3)).clamp(min=1)
+        per_traj_neighbor_loss = neighbor_mse.sum(dim=(1, 2, 3)) / n_valid_per_traj
+        per_traj_loss = per_traj_ego_loss + _NEIGHBOR_LOSS_WEIGHT * per_traj_neighbor_loss
+    else:
+        per_traj_loss = per_traj_ego_loss
+
     return per_traj_loss
 
 

--- a/rlvr/grpo_loss.py
+++ b/rlvr/grpo_loss.py
@@ -535,7 +535,7 @@ def compute_batched_grpo_loss(
 
     for _ in range(K):
         noise = torch.randn(1, P, future_len, 4, device=device)
-        t = torch.rand(1, device=device) * (1 - eps) + eps
+        t = _sample_t_for_mode(config, 1, device)
 
         policy_losses_k, ref_losses_k = _compute_batched_losses_and_ref(
             policy_model, trajectories_tensor, data, model_args, device, noise, t,

--- a/rlvr/grpo_loss.py
+++ b/rlvr/grpo_loss.py
@@ -313,12 +313,14 @@ def compute_batched_trajectory_losses(
     neighbor_future_valid = None
     nf_pn = 0
     if Pn > 0 and "neighbor_agents_future" in batch_data:
-        nf = batch_data["neighbor_agents_future"]  # [N, Pn_data, T, 3+]
+        nf = batch_data["neighbor_agents_future"]  # [N, Pn_data, T, 3] — x, y, heading_rad
         nf_pn = min(nf.shape[1], Pn)
-        # neighbor_agents_future has [x, y, valid] — pad to 4 dims with zeros for heading
-        nf_xy = nf[:, :nf_pn, :future_len, :2]  # [N, Pn', T, 2]
         nf_4d = torch.zeros(N, nf_pn, future_len, 4, device=device)
-        nf_4d[..., :2] = nf_xy
+        nf_4d[..., :2] = nf[:, :nf_pn, :future_len, :2]  # x, y
+        if nf.shape[-1] >= 3:
+            heading = nf[:, :nf_pn, :future_len, 2]  # heading_rad
+            nf_4d[..., 2] = torch.cos(heading)  # cos_yaw
+            nf_4d[..., 3] = torch.sin(heading)  # sin_yaw
         nf_4d_norm = (nf_4d - ego_mean) / ego_std
         gt_future[:, 1:1 + nf_pn, :, :] = nf_4d_norm
         # Track validity for neighbor loss
@@ -346,7 +348,9 @@ def compute_batched_trajectory_losses(
             nf_valid = (nf[:, :nf_pn, :future_len, :2].abs().sum(dim=-1) > 0.1)
             nf_mask = ~nf_valid  # [N, Pn', T]
             full_neighbor_mask = torch.cat([neighbor_current_mask_final[:, :nf_pn].unsqueeze(-1), nf_mask], dim=-1)  # [N, Pn', T+1]
-            all_gt[:, 1:1 + nf_pn][full_neighbor_mask.unsqueeze(-1).expand_as(all_gt[:, 1:1 + nf_pn])] = 0.0
+            # Use named slice + masked_fill_ to avoid chained indexing issues
+            neighbor_slice = all_gt[:, 1:1 + nf_pn]  # view into all_gt
+            neighbor_slice.masked_fill_(full_neighbor_mask.unsqueeze(-1).expand_as(neighbor_slice), 0.0)
 
     # Diffusion noise with prefix masking — matches SFT (decoder.py line 111-116)
     mean, std = VPSDE_linear().marginal_prob(all_gt[..., 1:, :], t_4d[..., 1:, :])

--- a/rlvr/grpo_sampler_batched.py
+++ b/rlvr/grpo_sampler_batched.py
@@ -11,6 +11,7 @@ Total: ~5 forward passes instead of 16 sequential.
 from __future__ import annotations
 
 import random
+from pathlib import Path
 
 import torch
 from torch import nn
@@ -90,28 +91,30 @@ def generate_diverse_group_batched(
     else:
         gt_v_high = 3.0
 
-    # --- Pass 2: CL+SPD deterministic (B=1, noise=0) + 3 with noise ---
-    # First: one deterministic CL5+SPD5 (guaranteed in-lane if CL works)
-    fns_det = [
-        GuidanceConfig("centerline_following", enabled=True, scale=5.0),
-        GuidanceConfig("speed", enabled=True, scale=5.0, params={"v_high": gt_v_high, "v_low": 0.5}),
+    # --- Pass 2-5: Strong CL + SPD guidance sweep for lane keeping (8 trajectories) ---
+    # 8 guided at CL5-10 to ensure ~8-10/16 stay in-lane on hard curves.
+    cl_spd_configs = [
+        (5.0,  5.0,  0.0, 0.0),   # CL5+SPD5, deterministic
+        (8.0,  5.0,  0.0, 0.0),   # CL8+SPD5, deterministic
+        (10.0, 8.0,  0.0, 0.0),   # CL10+SPD8, deterministic
+        (10.0, 10.0, 0.0, 0.0),   # CL10+SPD10, deterministic
+        (5.0,  5.0,  0.3, 0.8),   # CL5+SPD5, noise
+        (8.0,  8.0,  0.3, 0.8),   # CL8+SPD8, noise
+        (10.0, 8.0,  0.3, 0.8),   # CL10+SPD8, noise
+        (10.0, 10.0, 0.5, 1.0),   # CL10+SPD10, noise
     ]
-    comp_det = GuidanceComposer(GuidanceSetConfig(functions=fns_det, global_scale=1.0))
-    det_cl = generate_samples(model, model_args, norm_data, 0.0, 1, comp_det, device)
-    all_trajs.append(torch.from_numpy(det_cl[0]).to(device))
+    for cl_scale, spd_scale, n_min, n_max in cl_spd_configs:
+        fns_cl = [
+            GuidanceConfig("centerline_following", enabled=True, scale=cl_scale),
+            GuidanceConfig("speed", enabled=True, scale=spd_scale, params={"v_high": gt_v_high, "v_low": 0.5}),
+        ]
+        comp_cl = GuidanceComposer(GuidanceSetConfig(functions=fns_cl, global_scale=1.0))
+        noise_scale = random.uniform(n_min, n_max) if n_max > 0 else 0.0
+        cl_traj = generate_samples(model, model_args, norm_data, noise_scale, 1, comp_cl, device)
+        all_trajs.append(torch.from_numpy(cl_traj[0]).to(device))
 
-    # Then 3 with small noise
-    trajs_lo = _batched_cl_spd_pass(model, model_args, norm_data, 3, 3.5, 5.0, gt_v_high, 0.3, 0.8, device)
-    for i in range(3):
-        all_trajs.append(trajs_lo[i])
-
-    # --- Pass 3: High CL+SPD sweep (B=3, CL=8, SPD=8, noise 0.5-1.5) ---
-    trajs_hi = _batched_cl_spd_pass(model, model_args, norm_data, 3, 8.0, 8.0, gt_v_high, 0.5, 1.5, device)
-    for i in range(3):
-        all_trajs.append(trajs_hi[i])
-
-    # --- Pass 4: Random CL+RB (B=4) ---
-    n_rand1 = min(4, K - len(all_trajs))
+    # --- Pass 6: Random CL+RB (fill remaining except last 3 for noise-only) ---
+    n_rand1 = max(0, min(4, K - len(all_trajs) - 3))
     if n_rand1 > 0:
         fns1 = [GuidanceConfig("centerline_following", enabled=True, scale=random.uniform(2.0, 8.0))]
         if random.random() < 0.5:
@@ -126,7 +129,7 @@ def generate_diverse_group_batched(
         for i in range(n_rand1):
             all_trajs.append(trajs_r1[i])
 
-    # --- Pass 5: Noise-only or light guidance (B=remaining) ---
+    # --- Pass 7: Noise-only or light guidance (B=remaining) ---
     n_rand2 = K - len(all_trajs)
     if n_rand2 > 0:
         fns2 = []

--- a/rlvr/grpo_sampler_batched.py
+++ b/rlvr/grpo_sampler_batched.py
@@ -11,7 +11,6 @@ Total: ~5 forward passes instead of 16 sequential.
 from __future__ import annotations
 
 import random
-from pathlib import Path
 
 import torch
 from torch import nn

--- a/rlvr/grpo_trainer_batched.py
+++ b/rlvr/grpo_trainer_batched.py
@@ -90,11 +90,17 @@ def generate_all_scenes_batched(
     det_trajs = _chunked_generate(model, model_args, norm_batch, 0.0, 0.0, None, device, gen_chunk_size)
     all_k_trajs.append(det_trajs)
 
-    # --- Config 2-4: CL + SPD guidance sweep (stay in-lane AND drive) ---
+    # --- Config 2-9: Strong CL + SPD guidance sweep for lane keeping ---
+    # 8 guided trajectories at CL5-10 to ensure ~8-10/16 stay in-lane on curves.
     cl_spd_configs = [
-        (3.0, 5.0, 0.0, 0.0),   # CL3+SPD5, deterministic
-        (5.0, 5.0, 0.0, 0.0),   # CL5+SPD5, deterministic
-        (5.0, 8.0, 0.0, 0.5),   # CL5+SPD8, small noise
+        (5.0,  5.0,  0.0, 0.0),   # CL5+SPD5, deterministic
+        (8.0,  5.0,  0.0, 0.0),   # CL8+SPD5, deterministic
+        (10.0, 8.0,  0.0, 0.0),   # CL10+SPD8, deterministic
+        (10.0, 10.0, 0.0, 0.0),   # CL10+SPD10, deterministic
+        (5.0,  5.0,  0.3, 0.8),   # CL5+SPD5, noise
+        (8.0,  8.0,  0.3, 0.8),   # CL8+SPD8, noise
+        (10.0, 8.0,  0.3, 0.8),   # CL10+SPD8, noise
+        (10.0, 10.0, 0.5, 1.0),   # CL10+SPD10, noise
     ]
     for cl_scale, spd_scale, n_min, n_max in cl_spd_configs:
         fns = [
@@ -232,12 +238,17 @@ def train_epoch_batched(
     kept_advantages = []
     kept_mean_rewards = []
     kept_norm_data = []
+    kept_lane_dep_fracs = []  # fraction of K trajs that depart lane per scene
 
     for i in tqdm(range(N), desc="Scoring"):
         traj_K = all_trajs[i]  # [K, T, 4]
         data_i = all_data[i]
 
         rewards = compute_reward_batch(traj_K, data_i, reward_config)
+
+        # Track lane departure fraction before rejection sampling
+        n_lane_dep = sum(1 for r in rewards if r.lane_crossing)
+        lane_dep_frac = n_lane_dep / len(rewards)
 
         if keep and 0 < keep < K:
             reward_vals = np.array([r.total for r in rewards])
@@ -256,6 +267,7 @@ def train_epoch_batched(
         kept_trajs.append(traj_K)
         kept_advantages.append(advantages)
         kept_mean_rewards.append(float(np.mean([r.total for r in rewards])))
+        kept_lane_dep_fracs.append(lane_dep_frac)
         # Extract per-scene norm data (B=1 slice)
         norm_i = {}
         for k, v in norm_batch.items():
@@ -269,7 +281,27 @@ def train_epoch_batched(
     if N_kept == 0:
         return {}
 
-    # Scene trimming
+    # Lane departure scene trimming: drop scenes with highest lane departure fraction.
+    # E.g., lane_dep_trim_n=10 drops the 10 scenes where most trajectories leave lane.
+    lane_trim = config.lane_dep_trim_n
+    if lane_trim > 0 and N_kept > lane_trim:
+        # Sort by lane_dep_frac descending, drop the worst lane_trim scenes
+        sorted_idx = sorted(range(N_kept), key=lambda j: kept_lane_dep_fracs[j])
+        keep_idx = sorted_idx[:N_kept - lane_trim]
+        n_dropped = N_kept - len(keep_idx)
+        avg_dep_dropped = np.mean([kept_lane_dep_fracs[j] for j in sorted_idx[len(keep_idx):]])
+        avg_dep_kept = np.mean([kept_lane_dep_fracs[j] for j in keep_idx])
+        kept_trajs = [kept_trajs[j] for j in keep_idx]
+        kept_advantages = [kept_advantages[j] for j in keep_idx]
+        kept_mean_rewards = [kept_mean_rewards[j] for j in keep_idx]
+        kept_lane_dep_fracs = [kept_lane_dep_fracs[j] for j in keep_idx]
+        kept_norm_data = [kept_norm_data[j] for j in keep_idx]
+        print(f"  Lane-dep trim: dropped {n_dropped} worst scenes "
+              f"(avg_dep={avg_dep_dropped:.0%}), keeping {len(kept_trajs)} "
+              f"(avg_dep={avg_dep_kept:.0%})")
+        N_kept = len(kept_trajs)
+
+    # Scene trimming by reward
     trim = config.reward_trim_pct
     if trim > 0 and N_kept >= 10:
         n_trim = max(1, int(N_kept * trim))
@@ -296,6 +328,8 @@ def train_epoch_batched(
     total_loss = 0.0
     all_metrics = {}
     n_chunks = 0
+    accum_count = 0
+    accum_count_target = config.grad_accum_groups
 
     for c_start in range(0, N_kept, chunk_size):
         c_end = min(c_start + chunk_size, N_kept)
@@ -328,23 +362,34 @@ def train_epoch_batched(
             device=device,
         )
 
-        # Scale loss to match sequential trainer gradient magnitude.
-        # With chunk_size=1, c_n=1 and this simplifies to loss / grad_accum.
-        c_n = len(c_trajs)
-        scaled_loss = loss * c_n / config.grad_accum_groups
+        # Scale loss by chunk size for correct accumulation.
+        # Track actual accumulation count to handle last incomplete group correctly.
+        accum_count += 1
+        scaled_loss = loss * c_n / accum_count_target
         scaled_loss.backward()
 
         for k, v in metrics.items():
             all_metrics[k] = all_metrics.get(k, 0.0) + v
         n_chunks += 1
 
-        # Step optimizer every few chunks
-        if (c_end % (chunk_size * config.grad_accum_groups) == 0) or c_end == N_kept:
+        # Step optimizer every grad_accum_groups chunks, or at the end.
+        is_accum_boundary = (c_end % (chunk_size * config.grad_accum_groups) == 0)
+        is_last = (c_end == N_kept)
+        if is_accum_boundary or is_last:
+            if is_last and not is_accum_boundary and accum_count < accum_count_target:
+                # Last incomplete group: re-scale gradients to correct for under-accumulation.
+                # We accumulated `accum_count` gradients each divided by `accum_count_target`.
+                # Multiply by (accum_count_target / accum_count) to compensate.
+                scale_fix = accum_count_target / accum_count
+                for p in model.parameters():
+                    if p.requires_grad and p.grad is not None:
+                        p.grad.mul_(scale_fix)
             torch.nn.utils.clip_grad_norm_(
                 [p for p in model.parameters() if p.requires_grad],
                 max_norm=5.0,
             )
             optimizer.step()
             optimizer.zero_grad()
+            accum_count = 0
 
     return {k: v / max(n_chunks, 1) for k, v in all_metrics.items()}

--- a/rlvr/grpo_trainer_batched.py
+++ b/rlvr/grpo_trainer_batched.py
@@ -285,7 +285,7 @@ def train_epoch_batched(
     # E.g., lane_dep_trim_n=10 drops the 10 scenes where most trajectories leave lane.
     lane_trim = config.lane_dep_trim_n
     if lane_trim > 0 and N_kept > lane_trim:
-        # Sort by lane_dep_frac descending, drop the worst lane_trim scenes
+        # Sort by lane_dep_frac ascending, drop the worst lane_trim scenes (highest fractions)
         sorted_idx = sorted(range(N_kept), key=lambda j: kept_lane_dep_fracs[j])
         keep_idx = sorted_idx[:N_kept - lane_trim]
         n_dropped = N_kept - len(keep_idx)

--- a/rlvr/reward.py
+++ b/rlvr/reward.py
@@ -1848,7 +1848,8 @@ def compute_group_advantages(
         temp = max(fixed_scale, epsilon)
         logits = totals / temp
         logits = logits - logits.max()  # numerical stability
-        weights = np.exp(logits) / np.exp(logits).sum()
+        exp_logits = np.exp(logits)
+        weights = exp_logits / exp_logits.sum()
         # Center and scale: mean=0, max≈1
         advantages = (weights - weights.mean()) / max(weights.max(), epsilon)
         return advantages

--- a/rlvr/reward.py
+++ b/rlvr/reward.py
@@ -1479,11 +1479,12 @@ def compute_lane_departure_penalty(
     has_crossing = is_crossing.any(dim=1)
     crossing_gate = (~has_crossing).float()
 
-    # First crossing step per trajectory (for survival mode)
-    lane_crossing_steps: list[int | None] = []
-    for i in range(N):
-        crossing_ts = is_crossing[i].nonzero(as_tuple=False)
-        lane_crossing_steps.append(int(crossing_ts[0].item()) if crossing_ts.numel() > 0 else None)
+    # First crossing step per trajectory (for survival mode) — vectorized to avoid CUDA syncs
+    # argmax on float returns first True index; use has_crossing to mask non-crossing trajs
+    first_crossing_idx = is_crossing.float().argmax(dim=1)  # [N] — 0 if no crossing (need mask)
+    lane_crossing_steps: list[int | None] = [
+        int(first_crossing_idx[i].item()) if has_crossing[i] else None for i in range(N)
+    ]
 
     # Near penalty
     near_frac = (per_ts_min[:, 1:] < _LANE_NEAR_THRESH).float().mean(dim=1)

--- a/rlvr/reward.py
+++ b/rlvr/reward.py
@@ -1307,7 +1307,7 @@ def compute_lane_departure_penalty(
     ego_trajs: torch.Tensor,
     ego_shape: torch.Tensor,
     data: dict[str, torch.Tensor],
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, list, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, list[int | None], torch.Tensor]:
     """Compute per-trajectory lane departure penalties using ego perimeter sampling.
 
     For each of 80 ego perimeter points at each timestep, finds the K=3 nearest
@@ -1671,7 +1671,7 @@ def compute_reward_batch(
 
             # Normalize progress to [0, 1] as fraction of GT, capped at margin.
             # 100% GT = 1.0 (max), >margin% GT = capped + penalized.
-            progress_frac = (clamped_progress / gt_path_len).clamp(max=config.overprogress_margin)
+            progress_frac = (clamped_progress / gt_path_len.clamp(min=1e-3)).clamp(max=config.overprogress_margin)
             clamped_progress = progress_frac * config.progress_norm_scale
 
             # Overprogress: penalize model path exceeding margin × GT

--- a/rlvr/reward.py
+++ b/rlvr/reward.py
@@ -52,6 +52,15 @@ class RewardConfig:
     overprogress_penalty: float = 0.3
     stopped_penalty: float = 50.0
 
+    # Underprogress: penalize trajectories that drive much less than GT
+    underprogress_penalty: float = 0.0   # scale (0=disabled). Penalty = scale * max(0, threshold - ratio)
+    underprogress_threshold: float = 0.5  # penalize if model_path / gt_path < threshold
+
+    # Progress normalization scale: when enable_overprogress=True, progress is
+    # normalized to [0, 1] as fraction of GT, then multiplied by this scale.
+    # 100% GT progress → progress_norm_scale points. Default 20.
+    progress_norm_scale: float = 20.0
+
     # Reward aggregation mode:
     # "gate" (default): binary safety gates × quality. Any terminal event → floor (-50).
     # "survival" (PlannerRFT): proportional credit based on how long the trajectory
@@ -75,6 +84,7 @@ class RewardBreakdown:
     rb_near_frac: float = 0.0
     lane_crossing: bool = False
     lane_near_frac: float = 0.0
+    lane_wide_frac: float = 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -1297,7 +1307,7 @@ def compute_lane_departure_penalty(
     ego_trajs: torch.Tensor,
     ego_shape: torch.Tensor,
     data: dict[str, torch.Tensor],
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, list, torch.Tensor]:
     """Compute per-trajectory lane departure penalties using ego perimeter sampling.
 
     For each of 80 ego perimeter points at each timestep, finds the K=3 nearest
@@ -1311,7 +1321,7 @@ def compute_lane_departure_penalty(
         data: Observation dict with 'lanes' key.
 
     Returns:
-        Tuple of (crossing_gate, near_frac, wide_frac, cont_penalty):
+        Tuple of (crossing_gate, near_frac, wide_frac, lane_crossing_steps, cont_penalty):
         - crossing_gate: (N,) 1.0 if always in-lane, 0.0 if leaves lane
         - near_frac: (N,) fraction of timesteps within 25cm of lane edge
         - wide_frac: (N,) fraction of timesteps within 40cm of lane edge
@@ -1320,10 +1330,12 @@ def compute_lane_departure_penalty(
     N, T, _ = ego_trajs.shape
     device = ego_trajs.device
 
+    no_lane_crossing_steps: list[int | None] = [None] * N
     safe_return = (
         torch.ones(N, device=device),
         torch.zeros(N, device=device),
         torch.zeros(N, device=device),
+        no_lane_crossing_steps,
         torch.zeros(N, device=device),
     )
 
@@ -1467,6 +1479,12 @@ def compute_lane_departure_penalty(
     has_crossing = is_crossing.any(dim=1)
     crossing_gate = (~has_crossing).float()
 
+    # First crossing step per trajectory (for survival mode)
+    lane_crossing_steps: list[int | None] = []
+    for i in range(N):
+        crossing_ts = is_crossing[i].nonzero(as_tuple=False)
+        lane_crossing_steps.append(int(crossing_ts[0].item()) if crossing_ts.numel() > 0 else None)
+
     # Near penalty
     near_frac = (per_ts_min[:, 1:] < _LANE_NEAR_THRESH).float().mean(dim=1)
 
@@ -1476,7 +1494,7 @@ def compute_lane_departure_penalty(
     # Continuous proximity penalty
     cont_penalty = (1.0 - per_ts_min[:, 1:] / _LANE_CONT_THRESH).clamp(min=0, max=1).mean(dim=1)
 
-    return crossing_gate, near_frac, wide_frac, cont_penalty
+    return crossing_gate, near_frac, wide_frac, lane_crossing_steps, cont_penalty
 
 
 # ---------------------------------------------------------------------------
@@ -1585,13 +1603,14 @@ def compute_reward_batch(
 
     # Lane departure penalty
     if config.enable_lane_departure:
-        lane_crossing_gate, lane_near_frac, lane_wide_frac, lane_cont_penalty = compute_lane_departure_penalty(
+        lane_crossing_gate, lane_near_frac, lane_wide_frac, lane_crossing_steps, lane_cont_penalty = compute_lane_departure_penalty(
             ego_trajs, ego_shape, data,
         )
     else:
         lane_crossing_gate = torch.ones(N, device=device)
         lane_near_frac = torch.zeros(N, device=device)
         lane_wide_frac = torch.zeros(N, device=device)
+        lane_crossing_steps: list[int | None] = [None] * N
         lane_cont_penalty = torch.zeros(N, device=device)
 
     # NAVSIM PDMS-style multiplicative reward aggregation.
@@ -1636,11 +1655,10 @@ def compute_reward_batch(
     # Safety score includes proximity penalty to NPCs (closer = more negative).
     clamped_progress = progress_scores.clamp(min=0)
 
-    # Overprogress penalty: cap reward at GT path length × 1.3.
-    # Trajectories that go much further than the human drove get penalized,
-    # preventing the model from learning to drive too fast through curves.
-    # Overprogress: cap progress reward at GT path length × 1.1, then penalize
-    # excess mildly. Disabled by default — causes stopping when penalty is too
+    # Normalize progress as percentage of GT path length, then apply
+    # overprogress/underprogress/stopped penalties.
+    # This ensures a 10m path on a 12m GT scene and a 10m path on a 22m GT scene
+    # get different progress scores (83% vs 45%).
     if config.enable_overprogress and "ego_agent_future" in data:
         gt_future = data["ego_agent_future"]
         if gt_future.dim() == 3:
@@ -1649,18 +1667,31 @@ def compute_reward_batch(
         gt_valid = gt_xy.abs().sum(dim=-1) > 0.1
         if gt_valid.sum() >= 10:
             gt_path_len = torch.diff(gt_xy[gt_valid], dim=0).norm(dim=-1).sum()
-            cap = config.overprogress_margin * gt_path_len
             model_path_lens = torch.diff(ego_trajs[:, :, :2], dim=1).norm(dim=-1).sum(dim=-1)  # (N,)
-            # Cap: progress can't exceed cap value. Excess gets penalized.
-            capped = torch.minimum(clamped_progress, cap.expand(N))
+
+            # Normalize progress to [0, 1] as fraction of GT, capped at margin.
+            # 100% GT = 1.0 (max), >margin% GT = capped + penalized.
+            progress_frac = (clamped_progress / gt_path_len).clamp(max=config.overprogress_margin)
+            clamped_progress = progress_frac * config.progress_norm_scale
+
+            # Overprogress: penalize model path exceeding margin × GT
+            cap = config.overprogress_margin * gt_path_len
             excess = torch.relu(model_path_lens - cap)
-            clamped_progress = capped - config.overprogress_penalty * excess
+            clamped_progress = clamped_progress - config.overprogress_penalty * excess
 
             # Stopped penalty: if GT drives (>5m) but model barely moves (<1m),
             # apply extra negative progress to discourage stopping.
             if gt_path_len > 5.0:
                 is_stopped = (model_path_lens < 1.0).float()
                 clamped_progress = clamped_progress - config.stopped_penalty * is_stopped
+
+            # Underprogress penalty: penalize trajectories that drive much less than GT.
+            # Continuous penalty proportional to how far below threshold the ratio is.
+            # E.g., penalty=100, threshold=0.5: at 25% GT path → 100*(0.5-0.25)=25 penalty.
+            if config.underprogress_penalty > 0 and gt_path_len > 3.0:
+                progress_ratio = (model_path_lens / gt_path_len).clamp(max=1.0)
+                underprogress = torch.relu(config.underprogress_threshold - progress_ratio)
+                clamped_progress = clamped_progress - config.underprogress_penalty * underprogress
 
     # TTC as quality bonus
     ttc_bonus = config.w_safety * (ttc_scores - 0.5) * 2
@@ -1699,6 +1730,8 @@ def compute_reward_batch(
                 first_terminal = min(first_terminal, collision_steps[i])
             if rb_crossing_steps[i] is not None:
                 first_terminal = min(first_terminal, rb_crossing_steps[i])
+            if config.enable_lane_departure and lane_crossing_steps[i] is not None:
+                first_terminal = min(first_terminal, lane_crossing_steps[i])
             survival_frac[i] = max(first_terminal, 1) / T  # at least 1/T to avoid 0
 
         # Blend: survived portion gets quality, failed portion gets floor.
@@ -1732,6 +1765,7 @@ def compute_reward_batch(
             rb_near_frac=float(rb_near_frac[i]),
             lane_crossing=bool(lane_crossing_gate[i] < 0.5),
             lane_near_frac=float(lane_near_frac[i]),
+            lane_wide_frac=float(lane_wide_frac[i]),
         ))
 
     return results
@@ -1797,6 +1831,27 @@ def compute_group_advantages(
         if fixed_scale <= 0.0:
             raise ValueError(f"advantage_fixed_scale must be positive, got {fixed_scale}")
         return (totals - mean) / max(fixed_scale, epsilon)
+    elif mode == "absolute":
+        # No centering, no normalization. Advantage = total / fixed_scale.
+        # Positive reward → positive advantage, negative reward → negative advantage.
+        # A group where all trajs score -30 gets ALL negative advantages.
+        # Only trajs with positive absolute reward get reinforced.
+        if fixed_scale <= 0.0:
+            raise ValueError(f"advantage_fixed_scale must be positive, got {fixed_scale}")
+        return totals / max(fixed_scale, epsilon)
+    elif mode == "softmax":
+        # Softmax-weighted advantages. Temperature = fixed_scale.
+        # Rank 1 gets disproportionately strong signal (~0.9), others decay sharply.
+        # Low temperature (5) = very sharp (rank 1 dominates).
+        # High temperature (20) = softer (more spread across top trajs).
+        # Centered so mean≈0 for stable GRPO training.
+        temp = max(fixed_scale, epsilon)
+        logits = totals / temp
+        logits = logits - logits.max()  # numerical stability
+        weights = np.exp(logits) / np.exp(logits).sum()
+        # Center and scale: mean=0, max≈1
+        advantages = (weights - weights.mean()) / max(weights.max(), epsilon)
+        return advantages
     elif mode == "positive_only":
         # Standard normalization but clip negatives to zero.
         # Only reinforces trajectories better than the group mean.
@@ -1808,5 +1863,5 @@ def compute_group_advantages(
     else:
         raise ValueError(
             f"Unknown advantage mode: {mode!r}. "
-            f"Expected 'normalized', 'vd_grpo', 'raw', or 'positive_only'."
+            f"Expected 'normalized', 'vd_grpo', 'raw', 'absolute', 'softmax', or 'positive_only'."
         )

--- a/rlvr/test_reward.py
+++ b/rlvr/test_reward.py
@@ -755,7 +755,7 @@ def test_lane_departure_in_lane():
         lanes[0, 0, pt, 7] = -1.75        # right boundary dY
     ego_shape = torch.tensor([2.75, 4.34, 1.70])
     data = {"lanes": lanes}
-    crossing_gate, near_frac, wide_frac, cont = compute_lane_departure_penalty(ego, ego_shape, data)
+    crossing_gate, near_frac, wide_frac, _, cont = compute_lane_departure_penalty(ego, ego_shape, data)
     assert crossing_gate[0] == 1.0, f"In-lane trajectory should not cross: gate={crossing_gate[0]}"
     print("  PASS  test_lane_departure_in_lane")
 
@@ -782,7 +782,7 @@ def test_lane_departure_out_of_lane():
         lanes[0, 0, pt, 7] = -1.75
     ego_shape = torch.tensor([2.75, 4.34, 1.70])
     data = {"lanes": lanes}
-    crossing_gate, near_frac, wide_frac, cont = compute_lane_departure_penalty(ego, ego_shape, data)
+    crossing_gate, near_frac, wide_frac, _, cont = compute_lane_departure_penalty(ego, ego_shape, data)
     assert crossing_gate[0] == 0.0, f"Out-of-lane trajectory should cross: gate={crossing_gate[0]}"
     print("  PASS  test_lane_departure_out_of_lane")
 

--- a/rlvr/test_reward.py
+++ b/rlvr/test_reward.py
@@ -787,6 +787,37 @@ def test_lane_departure_out_of_lane():
     print("  PASS  test_lane_departure_out_of_lane")
 
 
+def test_advantage_absolute():
+    """Absolute mode: no centering, positive reward → positive advantage."""
+    from rlvr.reward import compute_group_advantages, RewardBreakdown
+    rewards = [RewardBreakdown(safety=0, progress=0, smoothness=0, feasibility=0, centerline=0,
+                               red_light=0, total=t, collision_step=None, off_road_fraction=0)
+               for t in [+10, +5, -5, -20]]
+    adv = compute_group_advantages(rewards, mode="absolute", fixed_scale=10.0)
+    assert adv[0] > 0, f"Positive reward should give positive advantage: {adv[0]}"
+    assert adv[1] > 0, f"Positive reward should give positive advantage: {adv[1]}"
+    assert adv[2] < 0, f"Negative reward should give negative advantage: {adv[2]}"
+    assert adv[3] < 0, f"Negative reward should give negative advantage: {adv[3]}"
+    assert abs(adv[0] - 1.0) < 1e-6, f"10/10 should be 1.0: {adv[0]}"
+    print("  PASS  test_advantage_absolute")
+
+
+def test_advantage_softmax():
+    """Softmax mode: rank 1 gets disproportionately high weight."""
+    from rlvr.reward import compute_group_advantages, RewardBreakdown
+    rewards = [RewardBreakdown(safety=0, progress=0, smoothness=0, feasibility=0, centerline=0,
+                               red_light=0, total=t, collision_step=None, off_road_fraction=0)
+               for t in [+20, +5, 0, -10, -30]]
+    adv = compute_group_advantages(rewards, mode="softmax", fixed_scale=5.0)
+    # Rank 1 should have the highest advantage
+    assert adv[0] > adv[1], f"Rank 1 should beat rank 2: {adv[0]} vs {adv[1]}"
+    # Rank 1 should be much larger than rank 2 (softmax concentrates)
+    assert adv[0] > 2 * adv[1], f"Softmax T=5 should concentrate on rank 1: {adv[0]} vs {adv[1]}"
+    # Last rank should be negative (centered)
+    assert adv[-1] < 0, f"Worst trajectory should have negative advantage: {adv[-1]}"
+    print("  PASS  test_advantage_softmax")
+
+
 if __name__ == "__main__":
     tests = [
         test_no_collision_straight_line,
@@ -831,6 +862,8 @@ if __name__ == "__main__":
         test_advantage_positive_only,
         test_lane_departure_in_lane,
         test_lane_departure_out_of_lane,
+        test_advantage_absolute,
+        test_advantage_softmax,
     ]
 
     print("=" * 60)


### PR DESCRIPTION
## Summary

- Fix critical GRPO loss bugs: add K=8 noise/timestep averaging and prefix mask to match SFT/DPO training distribution
- Fix gradient accumulation under-scaling on incomplete last chunks
- Add underprogress penalty, lane crossing steps in survival mode, and GT-normalized progress
- Add lane departure scene trimming, stronger CL sampler, and new advantage modes (absolute, softmax)
- Add `grpo_viz` tool for per-scene trajectory ranking visualization with reward breakdown
- Add optional neighbor prediction regularization loss (disabled by default)
- Add `lane_wide_frac` to eval output for better lane proximity tracking

## Key findings

Investigation of 65+ experiments revealed that MSE-based GRPO loss is a poor proxy for log-probability in diffusion models. Comparison with DiffusionDriveV2 and Flow-GRPO shows that proper Gaussian log-probability computation during denoising is needed. This PR fixes all identified bugs and adds tooling; the log-prob loss rewrite is planned as a follow-up.

## Bug fixes

- **K=8 averaging**: GRPO used a single (noise, t) sample per loss computation. DPO uses K=8. With K=1, gradient direction was wrong (moved model away from best trajectory). Fixed by averaging over K samples.
- **Prefix mask**: SFT training uses generate_prefix_mask with random delay to condition denoising on clean first N steps. GRPO was missing this entirely, causing 27x weaker gradient signal.
- **Gradient accumulation**: Last chunk was under-scaled when scene count was not divisible by grad_accum_groups.
- **Trajectory shape handling**: torch.as_tensor + dim check prevents shape errors.
- **Dead code cleanup**: Removed unused mask variables, redundant assignments, unused imports.

## New features

- underprogress_penalty / underprogress_threshold in RewardConfig — penalizes trajectories driving much less than GT
- lane_crossing_steps in survival mode — lane departure is now a terminal event
- progress_norm_scale — normalizes progress to percentage of GT path length
- lane_dep_trim_n — drops N worst lane-departure scenes during training
- neighbor_loss_weight — optional neighbor prediction regularization (default 0, disabled)
- grpo_viz.py — visualizes all K trajectories per scene colored by rank with reward breakdown table
- absolute and softmax advantage modes

## Test plan

- [x] python -m rlvr.test_reward passes (42/44, 2 pre-existing smoothness failures)
- [x] Smoke test: neighbor loss on/off both produce valid gradients
- [x] Smoke test: K=8 + prefix mask moves model toward best trajectory (verified in single-step test)
- [x] Training runs complete without errors on 20 clean miraikan scenes