### PR TITLE
feat: neighbor regularization — reduces neighbor L2 degradation from +91% to +1.8%

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,115 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Diffusion-Planner is a diffusion-based trajectory planner for autonomous driving (Tier4 fork). It uses an encoder-decoder architecture: observations are encoded via MLP-Mixer + fusion attention, then a diffusion transformer (DiT) decoder generates ego/neighbor trajectories through iterative denoising.
+
+Training has four phases:
+1. **SFT** (supervised fine-tuning) — base model training on driving data (`diffusion_planner/`)
+2. **DPO** (direct preference optimization) — preference-based fine-tuning (`preference_optimization/`)
+3. **GRPO** (group relative policy optimization) — RL with rule-based rewards (`rlvr/`)
+4. **Ranked SFT** (GRPO-ranked self-distillation) — generate N trajectories, select best by reward, SG-filter, retrain with SFT loss (`rlvr/grpo_sft_trainer.py`). Inspired by self-distillation approaches (cf. [Zhang et al. 2025](https://arxiv.org/abs/2604.01193)).
+
+An optional **exploration policy** (`exploration_policy/`) learns scene-conditional guidance parameters for GRPO sampling.
+
+## Setup
+
+```bash
+cd diffusion_planner
+python3 -m pip install pip==24.1
+pip install -r requirements.txt
+pip install -e .
+```
+
+## Common Commands
+
+### SFT Training (8-GPU DDP)
+```bash
+cd diffusion_planner
+python3 -m torch.distributed.run --nnodes 1 --nproc-per-node 8 --standalone train_predictor.py \
+  --exp_name <name> --train_set_list <train.json> --valid_set_list <valid.json> \
+  --diffusion_model_type "x_start" --save_dir <dir> --train_epochs 50
+```
+
+### DPO Training
+```bash
+python3 -m preference_optimization.train_dpo \
+  --model_path <model.pth> --train_npz_list <train.json> --valid_npz_list <valid.json> \
+  --preference_mode rule --use_lora --lora_rank 16 --lora_target first
+```
+
+### GRPO Training
+```bash
+python3 -m rlvr.train_grpo \
+  --model_path <model.pth> --train_npz_list <train.json> --valid_npz_list <valid.json> \
+  --config rlvr/configs/grpo_onpolicy.json --exp_name <name>
+```
+
+### Ranked SFT Training
+```bash
+# Set ranked_sft_mode in config JSON to "gt_neighbor" or "baseline_neighbor"
+python3 -m rlvr.autoresearch.run_experiment \
+  --config <config.json> --name <name> --model_path <model.pth> \
+  --prob_scenes <scenes.json> --normal_scenes <scenes.json> --val_scenes <val.json> \
+  --output_dir <dir> --skip_baseline
+```
+
+### Validation
+```bash
+python3 -m diffusion_planner.valid_predictor  # SFT validation
+```
+
+### Evaluation Scripts
+```bash
+python3 -m rlvr.autoresearch.eval_border_distance  # Border distance metrics
+python3 -m rlvr.autoresearch.tools.eval_driving_metrics  # Full driving metrics
+python3 -m rlvr.autoresearch.visualize_scenes  # Scene visualization
+```
+
+### Tests
+```bash
+python3 -m pytest exploration_policy/test_exploration_policy.py
+python3 -m pytest exploration_policy/test_integration.py
+python3 -m pytest rlvr/test_grpo_sampler.py
+python3 -m pytest rlvr/test_reward.py
+```
+
+### Linting
+```bash
+ruff check .  # Import sorting only (configured in pyproject.toml)
+```
+
+## Architecture
+
+### Data Format
+- Training data: NPZ files containing ego/neighbor trajectories, lane geometry, route info, goal poses
+- Dataset lists: JSON files mapping to NPZ paths, created via `diffusion_planner/util_scripts/create_train_set_path.py`
+- Normalization: `normalization.json` computed via `diffusion_planner/util_scripts/normalize.py`
+
+### Model Architecture (`diffusion_planner/model/`)
+- **Encoder** (`module/encoder.py`): MLP-Mixer for agent mixing + fusion attention for contextual fusion
+- **Decoder** (`module/decoder.py`): DiT-based diffusion decoder, outputs ego trajectory [B, 80, 4] (x, y, heading, velocity) + neighbor predictions
+- **Guidance system** (`model/guidance/`): Pluggable guidance functions (road_border, collision, lane_keeping, centerline, route, speed, lateral, longitudinal) applied during diffusion sampling via `guidance_wrapper.py`
+
+### GRPO Pipeline (`rlvr/`)
+- **Config**: `GRPOConfig` dataclass in `grpo_config.py` — 100+ params, JSON-serializable. Preset configs in `rlvr/configs/`
+- **Sampling**: `grpo_sampler.py` / `grpo_sampler_batched.py` generate N diverse trajectories per scene with varying noise scales and guidance
+- **Reward**: `reward.py` scores trajectories on safety (collision, border, lane departure), progress, smoothness, feasibility, centerline following. Lane departure uses polygon containment + midpoint nudge to classify road edges (see algorithm overview in reward.py)
+- **Loss**: `grpo_loss.py` computes advantage-weighted diffusion loss with K=8 (noise, timestep) averaging
+- **Closed-loop**: `closed_loop/` contains rollout, state update, per-step reward, and GAE for multi-step evaluation
+- **Ranked SFT**: `grpo_sft_trainer.py` generates N trajectories, selects best by reward, applies Savitzky-Golay filter, trains with standard SFT diffusion loss including neighbor outputs. Config: `ranked_sft_mode` = "gt_neighbor" or "baseline_neighbor". Supports **neighbor regularization** (`neighbor_reg_weight`): MSE(lora_neighbor, base_neighbor) prevents neighbor L2 drift through shared DiT weights. `neighbor_reg_only=true` drops the neighbor SFT loss for a cleaner signal. Two-stage training recommended: stage 1 on 50 problem scenes (lr=5e-4), stage 2 warm-start on 500 mixed scenes (lr=1e-5)
+- **Trainers**: `grpo_trainer_batched.py` (standard), `closed_loop_trainer.py` (hybrid CL+OL), `grpo_exploration_trainer.py` (joint DiT + exploration policy), `grpo_sft_trainer.py` (ranked self-distillation)
+
+### LoRA Fine-tuning
+- Applied to DiT attention layers via `peft` library
+- `lora_target` controls which blocks: "all", "first" (block 0), "last", "blocks01"
+- Load with `load_lora_checkpoint()` — never use `PeftModel.from_pretrained` directly
+- **Block ablation**: zeroing LoRA blocks post-training can improve L2. With neighbor reg, block 2 is critical for lane keeping (removing it → 22/50 LD). Block 0 and block 1 are safe to zero — **no_block1 gives best ego L2** while preserving both LD and neighbor L2
+
+### Key Conventions
+- Always use `python -m <module>` to run scripts, never `sys.path` hacks
+- Experiment artifacts go to external SSD, not the repo
+- Config reproducibility: every experiment saves its full config (args.json or grpo_config.json)
+- Checkpoints saved as `epoch_NNN/best_model.pth` with accompanying `best_model_info.json`

--- a/rlvr/autoresearch/README.md
+++ b/rlvr/autoresearch/README.md
@@ -194,7 +194,7 @@ See `rlvr/configs/grpo_onpolicy.json` for the recommended config. Key parameters
 | `lane_dep_trim_n` | 0 | Drop N scenes with worst lane departure fraction per epoch (0=disabled) |
 | `neighbor_loss_weight` | 0.0 | Neighbor prediction regularization weight vs GT (0=disabled) |
 | `neighbor_reg_weight` | 0.0 | Neighbor reg: MSE(lora_neighbor, base_neighbor). Prevents neighbor L2 drift. |
-| `neighbor_reg_only` | `false` | When true, drop neighbor SFT loss; only use reg term (loss = ego_sft + reg) |
+| `neighbor_reg_only` | `true` | When true, drop neighbor SFT loss; only use reg term (loss = ego_sft + reg) |
 | `kl_schedule` | `"constant"` | `"constant"`, `"linear"`, `"cosine"`, or `"step"` (see below) |
 | `kl_coef_final` | 0.05 | Target KL coef at end of training (for non-constant schedules) |
 | `kl_warmup_fraction` | 0.5 | Fraction of epochs to hold initial `kl_coef` (for `"step"` schedule) |

--- a/rlvr/autoresearch/README.md
+++ b/rlvr/autoresearch/README.md
@@ -192,7 +192,9 @@ See `rlvr/configs/grpo_onpolicy.json` for the recommended config. Key parameters
 | `underprogress_threshold` | 0.5 | Penalize if model_path/gt_path < threshold |
 | `progress_norm_scale` | 20.0 | Max progress points at 100% GT match (when overprogress enabled) |
 | `lane_dep_trim_n` | 0 | Drop N scenes with worst lane departure fraction per epoch (0=disabled) |
-| `neighbor_loss_weight` | 0.0 | Neighbor prediction regularization weight (0=disabled) |
+| `neighbor_loss_weight` | 0.0 | Neighbor prediction regularization weight vs GT (0=disabled) |
+| `neighbor_reg_weight` | 0.0 | Neighbor reg: MSE(lora_neighbor, base_neighbor). Prevents neighbor L2 drift. |
+| `neighbor_reg_only` | `false` | When true, drop neighbor SFT loss; only use reg term (loss = ego_sft + reg) |
 | `kl_schedule` | `"constant"` | `"constant"`, `"linear"`, `"cosine"`, or `"step"` (see below) |
 | `kl_coef_final` | 0.05 | Target KL coef at end of training (for non-constant schedules) |
 | `kl_warmup_fraction` | 0.5 | Fraction of epochs to hold initial `kl_coef` (for `"step"` schedule) |

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -174,12 +174,18 @@ class GRPOConfig:
     sg_filter_window: int = 11  # Savitzky-Golay filter window length (must be odd)
     sg_filter_order: int = 3    # Savitzky-Golay filter polynomial order
     # Neighbor regularization: penalize LoRA neighbor outputs diverging from base model.
+    # Computes MSE(lora_neighbor_pred, base_neighbor_pred) at the same (noise, timestep)
+    # by running a second forward pass with LoRA disabled. Adds ~2x training cost.
     # loss += neighbor_reg_weight * MSE(neighbor_pred_lora, neighbor_pred_base)
-    # Only active in ranked SFT mode. 0 = disabled.
+    # Active in both ranked SFT and GRPO modes. 0 = disabled.
     neighbor_reg_weight: float = 0.0
-    # When True, drop the neighbor SFT loss (term 2) and only use reg (term 3).
-    # Loss = ego_sft + neighbor_reg_weight * MSE(lora_neighbor, base_neighbor)
-    neighbor_reg_only: bool = False
+    # Controls whether to include the neighbor SFT loss (MSE vs GT neighbors).
+    # When True (recommended): loss = ego_sft + neighbor_reg (no GT neighbor loss).
+    #   The base model already learned good neighbor predictions; the reg term anchors
+    #   them while ego improves freely. Neighbor L2 degradation: +1.8% (vs +91% without).
+    # When False: loss = ego_sft + neighbor_sft + neighbor_reg (all 3 terms).
+    #   Adding GT neighbor loss on top of reg causes overfitting at high LR (collapses by ep12).
+    neighbor_reg_only: bool = True
 
     # LoRA
     use_lora: bool = True

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -173,6 +173,13 @@ class GRPOConfig:
     ranked_sft_mode: str = "none"
     sg_filter_window: int = 11  # Savitzky-Golay filter window length (must be odd)
     sg_filter_order: int = 3    # Savitzky-Golay filter polynomial order
+    # Neighbor regularization: penalize LoRA neighbor outputs diverging from base model.
+    # loss += neighbor_reg_weight * MSE(neighbor_pred_lora, neighbor_pred_base)
+    # Only active in ranked SFT mode. 0 = disabled.
+    neighbor_reg_weight: float = 0.0
+    # When True, drop the neighbor SFT loss (term 2) and only use reg (term 3).
+    # Loss = ego_sft + neighbor_reg_weight * MSE(lora_neighbor, base_neighbor)
+    neighbor_reg_only: bool = False
 
     # LoRA
     use_lora: bool = True

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -177,7 +177,7 @@ class GRPOConfig:
     # Computes MSE(lora_neighbor_pred, base_neighbor_pred) at the same (noise, timestep)
     # by running a second forward pass with LoRA disabled. Adds ~2x training cost.
     # loss += neighbor_reg_weight * MSE(neighbor_pred_lora, neighbor_pred_base)
-    # Active in both ranked SFT and GRPO modes. 0 = disabled.
+    # Active in both ranked SFT and GRPO paths. 0 = disabled.
     neighbor_reg_weight: float = 0.0
     # Controls whether to include the neighbor SFT loss (MSE vs GT neighbors).
     # When True (recommended): loss = ego_sft + neighbor_reg (no GT neighbor loss).

--- a/rlvr/grpo_loss.py
+++ b/rlvr/grpo_loss.py
@@ -493,6 +493,122 @@ def _compute_batched_losses_and_ref(
     return policy_losses, ref_losses
 
 
+def _compute_neighbor_reg_loss(
+    policy_model, data, model_args, device, K, P, future_len, config,
+):
+    """Compute MSE between LoRA and base model neighbor outputs.
+
+    Runs K forward passes with random (noise, t), compares neighbor predictions
+    from the LoRA model vs the base model (LoRA disabled). Returns a scalar loss
+    with gradients flowing only through the LoRA model.
+    """
+    import random as _random
+    from diffusion_planner.model.diffusion_utils.sde import VPSDE_linear
+    from diffusion_planner.model.module.decoder import generate_prefix_mask
+
+    inner = policy_model.module if hasattr(policy_model, "module") else policy_model
+    if not hasattr(inner, "disable_adapter"):
+        return torch.tensor(0.0, device=device)
+
+    eps = 1e-3
+    Pn = P - 1
+
+    # Build normalized scene data (B=1)
+    ego_mean = model_args.state_normalizer.mean[0].to(device)
+    ego_std = model_args.state_normalizer.std[0].to(device)
+    ego_current = data["ego_current_state"][:, :4]
+    ego_current_norm = (ego_current - ego_mean) / ego_std
+
+    if Pn > 0:
+        neighbors_current = data["neighbor_agents_past"][:, :Pn, -1, :4]
+        neighbors_current_norm = (neighbors_current - ego_mean) / ego_std
+    else:
+        neighbors_current_norm = torch.zeros(1, 0, 4, device=device)
+
+    current_states = torch.cat([ego_current_norm[:, None], neighbors_current_norm], dim=1)
+
+    # Build neighbor GT for the all_gt tensor
+    gt_future = torch.zeros(1, P, future_len, 4, device=device)
+    nf_pn = 0
+    neighbor_future_valid = None
+    if Pn > 0 and "neighbor_agents_future" in data:
+        nf = data["neighbor_agents_future"]
+        nf_pn = min(nf.shape[1], Pn)
+        nf_4d = torch.zeros(1, nf_pn, future_len, 4, device=device)
+        nf_4d[..., :2] = nf[:, :nf_pn, :future_len, :2]
+        if nf.shape[-1] >= 3:
+            heading = nf[:, :nf_pn, :future_len, 2]
+            nf_4d[..., 2] = torch.cos(heading)
+            nf_4d[..., 3] = torch.sin(heading)
+        nf_4d_norm = (nf_4d - ego_mean) / ego_std
+        gt_future[:, 1:1 + nf_pn, :, :] = nf_4d_norm
+        neighbor_future_valid = (nf[:, :nf_pn, :future_len, :2].abs().sum(dim=-1) > 0.1)
+
+    # Also need ego GT for the noise target
+    if "ego_agent_future" in data:
+        ego_gt = data["ego_agent_future"]
+        if ego_gt.dim() == 3:
+            ego_gt = ego_gt[:, :future_len, :4]
+        ego_gt_norm = (ego_gt - ego_mean) / ego_std
+        gt_future[:, 0, :ego_gt_norm.shape[1], :] = ego_gt_norm
+
+    all_gt = torch.cat([current_states[:, :, None, :], gt_future], dim=2)
+
+    # Normalize observation data
+    data_normalized = model_args.observation_normalizer(
+        {k: v.clone() if isinstance(v, torch.Tensor) else v for k, v in data.items()}
+    )
+
+    if neighbor_future_valid is None or not neighbor_future_valid.any():
+        return torch.tensor(0.0, device=device)
+
+    # Also exclude neighbors absent at current timestep
+    neighbor_current_mask = (data["neighbor_agents_past"][:, :Pn, -1, :4].abs().sum(dim=-1) == 0)
+    neighbor_future_valid = neighbor_future_valid & (~neighbor_current_mask[:, :nf_pn].unsqueeze(-1))
+
+    total_reg = torch.tensor(0.0, device=device)
+    for _ in range(K):
+        t = torch.rand(1, device=device) * (1 - eps) + eps
+        t_4d = t.view(1, 1, 1, 1).expand(1, P, future_len + 1, 1).clone()
+
+        max_delay = 5
+        delay = torch.randint(0, max_delay + 1, (1,), device=device)
+        prefix_mask = generate_prefix_mask(delay, P, future_len + 1)
+        mask_coeff = _random.uniform(0.0, 1.0)
+        curr_mask_time = torch.maximum(t_4d * mask_coeff, torch.tensor(eps, device=device))
+        t_4d = torch.where(prefix_mask, curr_mask_time, t_4d)
+
+        z = torch.randn(1, P, future_len, 4, device=device)
+        mean, std = VPSDE_linear().marginal_prob(all_gt[..., 1:, :], t_4d[..., 1:, :])
+        xT = mean + std * z
+        xT_full = torch.cat([all_gt[:, :, :1, :], xT], dim=2)
+        xT_full = torch.where(prefix_mask, all_gt, xT_full)
+
+        merged = {**data_normalized}
+        merged["gt_trajectories"] = all_gt
+        merged["sampled_trajectories"] = xT_full
+        merged["diffusion_time"] = t_4d
+        merged["prefix_mask"] = prefix_mask
+        if "delay" not in merged:
+            merged["delay"] = delay
+
+        # LoRA forward (with grad)
+        _, lora_out = policy_model(merged)
+        lora_neighbor = lora_out["model_output"][:, 1:1 + nf_pn, 1:, :]  # [1, Pn', T, 4]
+
+        # Base forward (no grad)
+        with inner.disable_adapter(), torch.no_grad():
+            _, base_out = policy_model(merged)
+        base_neighbor = base_out["model_output"][:, 1:1 + nf_pn, 1:, :]
+
+        reg_mse = ((lora_neighbor - base_neighbor.detach()) ** 2).mean(dim=-1)  # [1, Pn', T]
+        masked_reg = reg_mse[:, :nf_pn][neighbor_future_valid[:, :nf_pn]]
+        if masked_reg.numel() > 0:
+            total_reg = total_reg + masked_reg.mean()
+
+    return total_reg / K
+
+
 def compute_batched_grpo_loss(
     policy_model: nn.Module,
     trajectories_tensor: torch.Tensor,
@@ -557,12 +673,23 @@ def compute_batched_grpo_loss(
     weighted_loss = (advantages_t * policy_losses).sum() / max(N, 1)
     total_loss = weighted_loss + config.kl_coef * kl_loss
 
+    # Neighbor regularization: MSE(lora_neighbor, base_neighbor) at same inputs.
+    # Prevents LoRA from distorting neighbor predictions through shared attention.
+    neighbor_reg_w = getattr(config, 'neighbor_reg_weight', 0.0)
+    neighbor_reg_loss_val = 0.0
+    if neighbor_reg_w > 0 and P > 1:
+        neighbor_reg_loss_val = _compute_neighbor_reg_loss(
+            policy_model, data, model_args, device, K, P, future_len, config,
+        )
+        total_loss = total_loss + neighbor_reg_w * neighbor_reg_loss_val
+
     metrics = {
         "loss": total_loss.item(),
         "policy_loss_mean": policy_losses.mean().item(),
         "ref_loss_mean": ref_losses.mean().item(),
         "kl": kl_loss.item(),
         "weighted_loss": weighted_loss.item(),
+        "neighbor_reg_loss": neighbor_reg_loss_val.item() if isinstance(neighbor_reg_loss_val, torch.Tensor) else 0.0,
     }
 
     return total_loss, metrics

--- a/rlvr/grpo_loss.py
+++ b/rlvr/grpo_loss.py
@@ -501,10 +501,16 @@ def _compute_neighbor_reg_loss(
     Runs K forward passes with random (noise, t), compares neighbor predictions
     from the LoRA model vs the base model (LoRA disabled). Returns a scalar loss
     with gradients flowing only through the LoRA model.
+
+    NOTE: assumes B=1 (single scene per call), which matches the GRPO trainer's
+    per-scene processing loop. Will raise AssertionError if B>1.
     """
     import random as _random
     from diffusion_planner.model.diffusion_utils.sde import VPSDE_linear
     from diffusion_planner.model.module.decoder import generate_prefix_mask
+
+    B = data["ego_current_state"].shape[0]
+    assert B == 1, f"_compute_neighbor_reg_loss requires B=1, got B={B}"
 
     inner = policy_model.module if hasattr(policy_model, "module") else policy_model
     if not hasattr(inner, "disable_adapter"):

--- a/rlvr/grpo_sft_trainer.py
+++ b/rlvr/grpo_sft_trainer.py
@@ -130,6 +130,8 @@ def _compute_sft_diffusion_loss(
     neighbor_mask: torch.Tensor,
     device: torch.device,
     K: int = 8,
+    neighbor_reg_weight: float = 0.0,
+    neighbor_reg_only: bool = False,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     """Compute standard SFT diffusion loss with ego + neighbor targets.
 
@@ -138,6 +140,10 @@ def _compute_sft_diffusion_loss(
     - Add noise via VPSDE marginal_prob
     - Model predicts x_0 from x_t
     - MSE loss against GT
+
+    When neighbor_reg_weight > 0, adds a regularization term that penalizes
+    the LoRA model's neighbor predictions from diverging from the base model's
+    neighbor predictions at the same (noise, timestep) inputs.
 
     Args:
         model: Policy model (LoRA-wrapped).
@@ -148,6 +154,7 @@ def _compute_sft_diffusion_loss(
         neighbor_mask: [B, Pn, T] boolean mask (True = invalid/padded).
         device: Torch device.
         K: Number of (noise, timestep) samples to average over.
+        neighbor_reg_weight: Weight for neighbor regularization loss (0=disabled).
 
     Returns:
         (loss, metrics_dict)
@@ -196,10 +203,15 @@ def _compute_sft_diffusion_loss(
 
     total_ego_loss = 0.0
     total_neighbor_loss = 0.0
+    total_neighbor_reg_loss = 0.0
     # Combine future padding mask with current-timestep validity:
     # a neighbor absent at the current timestep should not contribute to loss.
     neighbors_future_valid = ~neighbor_mask  # [B, Pn, T]
     neighbors_future_valid = neighbors_future_valid & (~neighbor_current_mask.unsqueeze(-1))  # [B, Pn, T]
+
+    # Check if model supports LoRA disable (needed for neighbor regularization)
+    inner = model.module if hasattr(model, "module") else model
+    use_neighbor_reg = neighbor_reg_weight > 0.0 and Pn > 0 and hasattr(inner, "disable_adapter")
 
     for _ in range(K):
         # Sample random timestep
@@ -243,8 +255,8 @@ def _compute_sft_diffusion_loss(
         ego_loss = F.mse_loss(model_output[:, 0], gt_target[:, 0])
         total_ego_loss += ego_loss
 
-        # Neighbor loss: MSE over valid timesteps only
-        if Pn > 0 and neighbors_future_valid.any():
+        # Neighbor loss: MSE over valid timesteps only (skipped when neighbor_reg_only)
+        if Pn > 0 and neighbors_future_valid.any() and not neighbor_reg_only:
             neighbor_pred = model_output[:, 1:]  # [B, Pn, T, 4]
             neighbor_target = gt_target[:, 1:]  # [B, Pn, T, 4]
             # Per-element MSE, then mask
@@ -253,16 +265,31 @@ def _compute_sft_diffusion_loss(
             if masked_loss.numel() > 0:
                 total_neighbor_loss += masked_loss.mean()
 
+        # Neighbor regularization: MSE(lora_neighbor, base_neighbor) at same inputs
+        if use_neighbor_reg and neighbors_future_valid.any():
+            with inner.disable_adapter(), torch.no_grad():
+                _, base_outputs = model(merged_inputs)
+            base_neighbor = base_outputs["model_output"][:, 1:, 1:, :]  # [B, Pn, T, 4]
+            lora_neighbor = model_output[:, 1:]  # [B, Pn, T, 4]
+            reg_mse = ((lora_neighbor - base_neighbor.detach()) ** 2).mean(dim=-1)  # [B, Pn, T]
+            masked_reg = reg_mse[neighbors_future_valid]
+            if masked_reg.numel() > 0:
+                total_neighbor_reg_loss += masked_reg.mean()
+
     ego_loss_avg = total_ego_loss / K
     neighbor_loss_avg = total_neighbor_loss / K if isinstance(total_neighbor_loss, torch.Tensor) else torch.tensor(0.0, device=device)
+    neighbor_reg_avg = total_neighbor_reg_loss / K if isinstance(total_neighbor_reg_loss, torch.Tensor) else torch.tensor(0.0, device=device)
 
-    # Combined loss: ego + neighbor (neighbor weight = 1.0 to match SFT)
+    # Combined loss: ego + neighbor (neighbor weight = 1.0 to match SFT) + neighbor reg
     loss = ego_loss_avg + neighbor_loss_avg
+    if use_neighbor_reg:
+        loss = loss + neighbor_reg_weight * neighbor_reg_avg
 
     metrics = {
         "sft_ego_loss": ego_loss_avg.item(),
         "sft_neighbor_loss": neighbor_loss_avg.item() if isinstance(neighbor_loss_avg, torch.Tensor) else 0.0,
         "sft_total_loss": loss.item(),
+        "sft_neighbor_reg_loss": neighbor_reg_avg.item() if isinstance(neighbor_reg_avg, torch.Tensor) else 0.0,
     }
     return loss, metrics
 
@@ -310,7 +337,8 @@ def train_epoch_ranked_sft(
 
     if epoch == 1:
         print(f"  [ranked-sft] mode={mode}, K={K}, "
-              f"sg_window={config.sg_filter_window}, sg_order={config.sg_filter_order}")
+              f"sg_window={config.sg_filter_window}, sg_order={config.sg_filter_order}, "
+              f"neighbor_reg={config.neighbor_reg_weight}, reg_only={config.neighbor_reg_only}")
 
     # 1. Load all scenes
     print(f"  Loading {len(scene_paths)} scenes...")
@@ -513,6 +541,8 @@ def train_epoch_ranked_sft(
             neighbor_mask=neighbor_mask,
             device=device,
             K=config.diffusion_k_steps,
+            neighbor_reg_weight=config.neighbor_reg_weight,
+            neighbor_reg_only=config.neighbor_reg_only,
         )
 
         scaled_loss = loss / accum_target

--- a/rlvr/grpo_sft_trainer.py
+++ b/rlvr/grpo_sft_trainer.py
@@ -155,6 +155,9 @@ def _compute_sft_diffusion_loss(
         device: Torch device.
         K: Number of (noise, timestep) samples to average over.
         neighbor_reg_weight: Weight for neighbor regularization loss (0=disabled).
+        neighbor_reg_only: If True, drop the neighbor SFT loss and only use the
+            reg term. Only takes effect when neighbor reg is active (model has
+            disable_adapter and neighbor_reg_weight > 0).
 
     Returns:
         (loss, metrics_dict)

--- a/rlvr/grpo_sft_trainer.py
+++ b/rlvr/grpo_sft_trainer.py
@@ -255,8 +255,10 @@ def _compute_sft_diffusion_loss(
         ego_loss = F.mse_loss(model_output[:, 0], gt_target[:, 0])
         total_ego_loss += ego_loss
 
-        # Neighbor loss: MSE over valid timesteps only (skipped when neighbor_reg_only)
-        if Pn > 0 and neighbors_future_valid.any() and not neighbor_reg_only:
+        # Neighbor loss: MSE over valid timesteps only.
+        # Skipped when neighbor_reg_only=True AND reg is actually active.
+        skip_neighbor_sft = neighbor_reg_only and use_neighbor_reg
+        if Pn > 0 and neighbors_future_valid.any() and not skip_neighbor_sft:
             neighbor_pred = model_output[:, 1:]  # [B, Pn, T, 4]
             neighbor_target = gt_target[:, 1:]  # [B, Pn, T, 4]
             # Per-element MSE, then mask

--- a/rlvr/test_neighbor_reg.py
+++ b/rlvr/test_neighbor_reg.py
@@ -83,8 +83,8 @@ def _make_scene_data(B=1, P=5, T=80, device="cpu"):
         "ego_agent_future": torch.randn(B, T, 4, device=device),
     }
     # Make neighbor data non-zero so validity checks pass
-    data["neighbor_agents_past"][:, :, -1, :4] = torch.ones(B, Pn, 4) * 0.5
-    data["neighbor_agents_future"][:, :, :, :2] = torch.ones(B, Pn, T, 2) * 0.5
+    data["neighbor_agents_past"][:, :, -1, :4] = torch.ones(B, Pn, 4, device=device) * 0.5
+    data["neighbor_agents_future"][:, :, :, :2] = torch.ones(B, Pn, T, 2, device=device) * 0.5
     return data
 
 

--- a/rlvr/test_neighbor_reg.py
+++ b/rlvr/test_neighbor_reg.py
@@ -1,0 +1,256 @@
+"""Unit tests for neighbor regularization in ranked SFT and GRPO loss paths.
+
+Tests that:
+1. neighbor_reg_weight > 0 produces a non-zero regularization loss
+2. Gradients flow only through the LoRA model (base model is no_grad)
+3. neighbor_reg_only=True skips the neighbor SFT loss when reg is active
+4. neighbor_reg_only=True falls back to neighbor SFT loss when reg can't run
+5. B=1 assertion in GRPO path
+"""
+
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+
+
+# ---------------------------------------------------------------------------
+# Stub model that mimics PeftModel with disable_adapter()
+# ---------------------------------------------------------------------------
+class _StubDiT(nn.Module):
+    """Minimal model that returns different outputs with/without LoRA."""
+
+    def __init__(self, P=5, T=80):
+        super().__init__()
+        self.P = P
+        self.T = T
+        # "LoRA" parameter — when disabled, output shifts
+        self.lora_delta = nn.Parameter(torch.ones(1) * 0.1)
+        self._adapter_disabled = False
+
+    @contextlib.contextmanager
+    def disable_adapter(self):
+        self._adapter_disabled = True
+        try:
+            yield
+        finally:
+            self._adapter_disabled = False
+
+    def forward(self, inputs):
+        B = inputs["ego_current_state"].shape[0]
+        P, T = self.P, self.T
+        # Base output: zeros
+        output = torch.zeros(B, P, T + 1, 4, device=inputs["ego_current_state"].device)
+        if not self._adapter_disabled:
+            # LoRA adds a small delta to all outputs
+            output = output + self.lora_delta
+        return None, {"model_output": output}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+def _make_model_args(P=5, T=80):
+    """Create a minimal model_args mock."""
+    args = MagicMock()
+    args.predicted_neighbor_num = P - 1
+    args.future_len = T
+
+    # State normalizer (identity)
+    norm = MagicMock()
+    norm.mean = [torch.zeros(4)]
+    norm.std = [torch.ones(4)]
+    args.state_normalizer = norm
+
+    # Observation normalizer (pass-through)
+    args.observation_normalizer = lambda x: x
+
+    return args
+
+
+def _make_scene_data(B=1, P=5, T=80, device="cpu"):
+    """Create minimal scene data dict."""
+    Pn = P - 1
+    data = {
+        "ego_current_state": torch.randn(B, 10, device=device),
+        "neighbor_agents_past": torch.randn(B, Pn, 31, 11, device=device),
+        "neighbor_agents_future": torch.randn(B, Pn, T, 3, device=device),
+        "ego_agent_future": torch.randn(B, T, 4, device=device),
+    }
+    # Make neighbor data non-zero so validity checks pass
+    data["neighbor_agents_past"][:, :, -1, :4] = torch.ones(B, Pn, 4) * 0.5
+    data["neighbor_agents_future"][:, :, :, :2] = torch.ones(B, Pn, T, 2) * 0.5
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Tests for ranked SFT path (grpo_sft_trainer.py)
+# ---------------------------------------------------------------------------
+class TestRankedSFTNeighborReg:
+    """Tests for _compute_sft_diffusion_loss neighbor regularization."""
+
+    def test_reg_produces_nonzero_loss(self):
+        """neighbor_reg_weight > 0 should produce a non-zero reg loss."""
+        from rlvr.grpo_sft_trainer import _compute_sft_diffusion_loss
+
+        model = _StubDiT(P=5, T=80)
+        model_args = _make_model_args(P=5, T=80)
+        data = _make_scene_data(B=1, P=5, T=80)
+
+        ego_gt = torch.randn(1, 80, 4)
+        neighbor_gt = torch.randn(1, 4, 80, 4)
+        neighbor_mask = torch.zeros(1, 4, 80, dtype=torch.bool)
+
+        loss, metrics = _compute_sft_diffusion_loss(
+            model=model, model_args=model_args, data=data,
+            ego_gt=ego_gt, neighbor_gt=neighbor_gt, neighbor_mask=neighbor_mask,
+            device=torch.device("cpu"), K=1,
+            neighbor_reg_weight=1.0, neighbor_reg_only=False,
+        )
+        assert metrics["sft_neighbor_reg_loss"] > 0, "Reg loss should be non-zero"
+        assert loss.requires_grad, "Loss should have gradients"
+
+    def test_reg_only_skips_neighbor_sft(self):
+        """neighbor_reg_only=True should zero out the neighbor SFT loss."""
+        from rlvr.grpo_sft_trainer import _compute_sft_diffusion_loss
+
+        model = _StubDiT(P=5, T=80)
+        model_args = _make_model_args(P=5, T=80)
+        data = _make_scene_data(B=1, P=5, T=80)
+
+        ego_gt = torch.randn(1, 80, 4)
+        neighbor_gt = torch.randn(1, 4, 80, 4)
+        neighbor_mask = torch.zeros(1, 4, 80, dtype=torch.bool)
+
+        _, metrics = _compute_sft_diffusion_loss(
+            model=model, model_args=model_args, data=data,
+            ego_gt=ego_gt, neighbor_gt=neighbor_gt, neighbor_mask=neighbor_mask,
+            device=torch.device("cpu"), K=1,
+            neighbor_reg_weight=1.0, neighbor_reg_only=True,
+        )
+        assert metrics["sft_neighbor_loss"] == 0.0, \
+            "Neighbor SFT loss should be 0 when reg_only=True and reg is active"
+
+    def test_reg_only_fallback_without_adapter(self):
+        """When model lacks disable_adapter, reg_only should fall back to neighbor SFT."""
+        from rlvr.grpo_sft_trainer import _compute_sft_diffusion_loss
+
+        # Plain model without disable_adapter
+        model = nn.Linear(10, 10)
+
+        # Override forward to return expected format
+        P, T = 5, 80
+
+        def fake_forward(inputs):
+            B = 1
+            output = torch.zeros(B, P, T + 1, 4)
+            return None, {"model_output": output}
+
+        model.forward = fake_forward
+
+        model_args = _make_model_args(P=P, T=T)
+        data = _make_scene_data(B=1, P=P, T=T)
+
+        ego_gt = torch.randn(1, T, 4)
+        neighbor_gt = torch.randn(1, P - 1, T, 4)
+        neighbor_mask = torch.zeros(1, P - 1, T, dtype=torch.bool)
+
+        _, metrics = _compute_sft_diffusion_loss(
+            model=model, model_args=model_args, data=data,
+            ego_gt=ego_gt, neighbor_gt=neighbor_gt, neighbor_mask=neighbor_mask,
+            device=torch.device("cpu"), K=1,
+            neighbor_reg_weight=1.0, neighbor_reg_only=True,
+        )
+        # Should fall back: reg is 0 (can't run), but neighbor SFT should be non-zero
+        assert metrics["sft_neighbor_reg_loss"] == 0.0, "Reg should be 0 without adapter"
+        assert metrics["sft_neighbor_loss"] > 0, \
+            "Should fall back to neighbor SFT when reg can't run"
+
+    def test_gradients_only_through_lora(self):
+        """Base model forward (disable_adapter) should be no_grad."""
+        from rlvr.grpo_sft_trainer import _compute_sft_diffusion_loss
+
+        model = _StubDiT(P=5, T=80)
+        model_args = _make_model_args(P=5, T=80)
+        data = _make_scene_data(B=1, P=5, T=80)
+
+        ego_gt = torch.randn(1, 80, 4)
+        neighbor_gt = torch.randn(1, 4, 80, 4)
+        neighbor_mask = torch.zeros(1, 4, 80, dtype=torch.bool)
+
+        model.zero_grad()
+        loss, _ = _compute_sft_diffusion_loss(
+            model=model, model_args=model_args, data=data,
+            ego_gt=ego_gt, neighbor_gt=neighbor_gt, neighbor_mask=neighbor_mask,
+            device=torch.device("cpu"), K=1,
+            neighbor_reg_weight=1.0, neighbor_reg_only=True,
+        )
+        loss.backward()
+        # lora_delta should have a gradient (it's in the LoRA forward path)
+        assert model.lora_delta.grad is not None, "LoRA param should have gradient"
+        assert model.lora_delta.grad.abs().sum() > 0, "Gradient should be non-zero"
+
+
+# ---------------------------------------------------------------------------
+# Tests for GRPO path (grpo_loss.py)
+# ---------------------------------------------------------------------------
+class TestGRPONeighborReg:
+    """Tests for _compute_neighbor_reg_loss in GRPO loss path."""
+
+    def test_b1_assertion(self):
+        """Should raise AssertionError when B > 1."""
+        from rlvr.grpo_loss import _compute_neighbor_reg_loss
+        from rlvr.grpo_config import GRPOConfig
+
+        model = _StubDiT(P=5, T=80)
+        data = _make_scene_data(B=2, P=5, T=80)  # B=2 should fail
+        model_args = _make_model_args(P=5, T=80)
+        config = GRPOConfig(neighbor_reg_weight=1.0)
+
+        with pytest.raises(AssertionError, match="B=1"):
+            _compute_neighbor_reg_loss(
+                model, data, model_args, torch.device("cpu"),
+                K=1, P=5, future_len=80, config=config,
+            )
+
+    def test_reg_loss_nonzero(self):
+        """Should produce non-zero loss for B=1."""
+        from rlvr.grpo_loss import _compute_neighbor_reg_loss
+        from rlvr.grpo_config import GRPOConfig
+
+        model = _StubDiT(P=5, T=80)
+        data = _make_scene_data(B=1, P=5, T=80)
+        model_args = _make_model_args(P=5, T=80)
+        config = GRPOConfig(neighbor_reg_weight=1.0)
+
+        loss = _compute_neighbor_reg_loss(
+            model, data, model_args, torch.device("cpu"),
+            K=1, P=5, future_len=80, config=config,
+        )
+        assert isinstance(loss, torch.Tensor)
+        assert loss.item() > 0, "Reg loss should be non-zero when LoRA changes output"
+
+    def test_no_adapter_returns_zero(self):
+        """Model without disable_adapter should return zero loss."""
+        from rlvr.grpo_loss import _compute_neighbor_reg_loss
+        from rlvr.grpo_config import GRPOConfig
+
+        model = nn.Linear(10, 10)
+        data = _make_scene_data(B=1, P=5, T=80)
+        model_args = _make_model_args(P=5, T=80)
+        config = GRPOConfig(neighbor_reg_weight=1.0)
+
+        loss = _compute_neighbor_reg_loss(
+            model, data, model_args, torch.device("cpu"),
+            K=1, P=5, future_len=80, config=config,
+        )
+        assert loss.item() == 0.0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Add `neighbor_reg_weight` and `neighbor_reg_only` config options to prevent LoRA from degrading neighbor predictions through shared DiT attention weights
- The regularization computes `MSE(lora_neighbor, base_neighbor)` at the same (noise, timestep) inputs by running a second forward pass with LoRA disabled
- Implemented in both `grpo_sft_trainer.py` (ranked SFT) and `grpo_loss.py` (GRPO logprob) training paths
- `neighbor_reg_only=True` (default) drops the GT neighbor SFT loss — reg-only consistently outperforms all-3-terms

## Two-Stage Training Recipe

**Stage 1** (50 problem scenes, from scratch, lr=5e-4):
- `neighbor_reg_weight=1.0`, `neighbor_reg_only=true`
- Best: ep7 → 0/50 val LD, ego +2.6%, **neighbor +1.8%**

**Stage 2** (500 mixed scenes, warm-start from S1 ep7, lr=1e-5):
- Same config, seeded from stage 1
- Best: ep5 → 0/50 val LD, ego +5.3%, **neighbor +2.9%**

## Block Ablation Results

With neighbor reg, **no_block1** is the best post-hoc trick (previously no_block0):

| Variant | S1 ep7 ego Δ | S1 neigh Δ | S2 ep5 ego Δ | S2 neigh Δ | val LD |
|---------|-------------|-----------|-------------|-----------|--------|
| full | +2.6% | +1.8% | +5.3% | +2.9% | 0/50 |
| **no_blk1** | **+2.0%** | **+2.0%** | **+4.4%** | **+3.0%** | **0/50** |
| no_blk0 | +2.2% | +3.0% | +4.5% | +4.1% | 0/50 |
| no_blk2 | — | — | — | — | 22/50 ❌ |

## Comparison vs Previous Best (no reg)

| | ego Δ | neigh Δ | val LD |
|---|---|---|---|
| **Old best** (no reg, ep7 full) | +0.6% | **+91%** | 0/50 |
| **New best** (S1 ep7 no_blk1) | +2.0% | **+2.0%** | 0/50 |

Ego L2 trades +1.4pp for a **45x improvement** in neighbor preservation.

## Test plan

- [x] Verified 0/50 val LD across 17 consecutive S2 epochs (ep3-19)
- [x] L2 sweep on S1 ep5/7/8, S2 ep5/7/10/12, plus all block ablations
- [x] Block ablation sweep on both stages (full/no_blk0/no_blk1/no_blk2)
- [x] ONNX export and validation for 4 deploy checkpoints
- [x] Syntax check and ruff lint pass