### PR TITLE
feat: experiment watchdog and updated docs

### DIFF
--- a/rlvr/README.md
+++ b/rlvr/README.md
@@ -173,17 +173,29 @@ adapted for diffusion planners with reward-based selection and Savitzky-Golay tr
 }
 ```
 
-**Key results (April 2026, 10+ experiments):**
-- Miraikan exit val: 25/50 → **0/50 lane departures** (with no_block0 trick)
-- Full 1076 miraikan scenes: 70/1076 → **4/1076** lane departures (94% reduction)
-- Ego L2: +1.9% (baseline 5.388), Neighbor L2: +29% (baseline 4.393)
-- Outperforms GRPO logprob on all metrics (GRPO best: 4/50 LD, +1.7% ego, +48% neighbor)
+**Key results (April 2026, 70+ experiments):**
 
-**The no_block0 trick:** After training with `lora_target="all"` (3 DiT blocks), zero out
-block 0 LoRA weights. This consistently improves lane keeping (e.g. 2/50 → 0/50) AND halves
-L2 degradation. Block 0 learns noisy patterns that interfere with the precise lane-keeping
-signal in blocks 1+2. Training all blocks then removing block 0 is better than training only
-block 2, because distributing gradients across all blocks produces smaller per-parameter changes.
+*Legacy (no neighbor reg):*
+- Miraikan exit val: 25/50 → **0/50 lane departures** (with no_block0 trick)
+- Ego L2: +1.9% (baseline 5.388), Neighbor L2: +29% (baseline 4.393)
+
+*With neighbor regularization (current best):*
+- Two-stage training: S1 (50 scenes, lr=5e-4) → S2 (500 scenes, lr=1e-5)
+- **Best deployable: S1 ep7 no_blk1** — 0/50 val LD, ego +2.0%, neighbor +2.0%
+- Neighbor reg (`neighbor_reg_only=true, neighbor_reg_weight=1.0`) reduces neighbor degradation from +91% to +1.8%
+
+**Block ablation trick:** After training with `lora_target="all"` (3 DiT blocks), zero out
+one block's LoRA weights post-hoc. With neighbor reg, **no_blk1 is best**. Without reg,
+**no_blk0 is best**. **NEVER zero block 2** — it's critical for lane keeping (22/50 LD).
+
+Training all blocks then removing one post-hoc is strictly better than training only a
+subset of blocks — tested `lora_target="last"` (block 2 only), which converges fast (1/50 LD
+by ep3) but diverges by ep9. Distributing gradients across all blocks produces smaller
+per-parameter changes, preventing destabilization.
+
+**neighbor_reg_weight must be ≥ 1.0** at lr=5e-4. Tested 0.5 and 0.75 — both diverge at
+epoch 5-6 with rb_cross>20. Lower reg gives the ego loss more freedom but insufficient
+constraint on neighbor weights causes catastrophic drift through shared DiT parameters.
 
 **LR sweep:**
 

--- a/rlvr/autoresearch/README.md
+++ b/rlvr/autoresearch/README.md
@@ -149,6 +149,27 @@ python -m rlvr.autoresearch.compare_models \
   --indices 48 47 49 1 3 --cols 2
 ```
 
+### `tools/experiment_watchdog.py` — Background Experiment Monitor
+
+Tracks named experiments in the background. Only outputs NEW eval lines as they appear.
+Fires alerts on `stopped>2` or `rb_cross>10`. Detects when experiment processes die.
+Supports adding experiments dynamically. Never exits on its own.
+
+```bash
+# Start after launching experiments:
+nohup python -m rlvr.autoresearch.tools.experiment_watchdog \
+  --exp_dir /path/to/experiments --names exp1 exp2 --interval 30 &
+
+# Add more experiments later:
+echo "exp3" >> /tmp/watchdog_add.txt
+
+# Check status:
+cat /tmp/experiment_status.log
+
+# Kill when done (avoid zombie processes):
+pkill -f experiment_watchdog
+```
+
 ## Scene Lists
 
 Training requires three JSON files, each a list of NPZ paths:
@@ -179,7 +200,7 @@ See `rlvr/configs/grpo_onpolicy.json` for the recommended config. Key parameters
 | `rejection_keep` | 8 | Keep top 8 of 16 trajectories |
 | `n_prob_scenes` | 0-50 | Problem scenes in training set. **Always set explicitly.** |
 | `n_normal_scenes` | 250-300 | Normal scenes. **Always set explicitly.** |
-| `lora_target` | `"first"` | Block 0 only. Other blocks degrade neighbor predictions. |
+| `lora_target` | `"all"` | All blocks + post-hoc block removal. `"last"` (block 2 only) diverges by ep9. |
 | `advantage_mode` | `"normalized"` | `"normalized"`, `"vd_grpo"`, `"raw"`, `"positive_only"`, `"absolute"`, `"softmax"` |
 | `advantage_fixed_scale` | 10.0 | Denominator for vd_grpo/raw/absolute; temperature for softmax |
 | `diffusion_k_steps` | 8 | Number of (noise, t) samples averaged per GRPO loss (matches DPO K=8) |
@@ -193,7 +214,7 @@ See `rlvr/configs/grpo_onpolicy.json` for the recommended config. Key parameters
 | `progress_norm_scale` | 20.0 | Max progress points at 100% GT match (when overprogress enabled) |
 | `lane_dep_trim_n` | 0 | Drop N scenes with worst lane departure fraction per epoch (0=disabled) |
 | `neighbor_loss_weight` | 0.0 | Neighbor prediction regularization weight vs GT (0=disabled) |
-| `neighbor_reg_weight` | 0.0 | Neighbor reg: MSE(lora_neighbor, base_neighbor). Prevents neighbor L2 drift. |
+| `neighbor_reg_weight` | 1.0 | Neighbor reg: MSE(lora_neighbor, base_neighbor). Must be ≥1.0 at lr=5e-4 (0.5/0.75 diverge at ep5-6). |
 | `neighbor_reg_only` | `true` | When true, drop neighbor SFT loss; only use reg term (loss = ego_sft + reg) |
 | `kl_schedule` | `"constant"` | `"constant"`, `"linear"`, `"cosine"`, or `"step"` (see below) |
 | `kl_coef_final` | 0.05 | Target KL coef at end of training (for non-constant schedules) |

--- a/rlvr/autoresearch/README.md
+++ b/rlvr/autoresearch/README.md
@@ -166,7 +166,7 @@ echo "exp3" >> /tmp/watchdog_add.txt
 # Check status:
 cat /tmp/experiment_status.log
 
-# Kill when done (avoid zombie processes):
+# Kill when done (avoid leaving a stray background process):
 pkill -f experiment_watchdog
 ```
 
@@ -200,7 +200,7 @@ See `rlvr/configs/grpo_onpolicy.json` for the recommended config. Key parameters
 | `rejection_keep` | 8 | Keep top 8 of 16 trajectories |
 | `n_prob_scenes` | 0-50 | Problem scenes in training set. **Always set explicitly.** |
 | `n_normal_scenes` | 250-300 | Normal scenes. **Always set explicitly.** |
-| `lora_target` | `"all"` | All blocks + post-hoc block removal. `"last"` (block 2 only) diverges by ep9. |
+| `lora_target` | `"first"` | Block 0 only for standard GRPO. For ranked SFT, use `"all"` + post-hoc block removal (`"last"` diverges by ep9). |
 | `advantage_mode` | `"normalized"` | `"normalized"`, `"vd_grpo"`, `"raw"`, `"positive_only"`, `"absolute"`, `"softmax"` |
 | `advantage_fixed_scale` | 10.0 | Denominator for vd_grpo/raw/absolute; temperature for softmax |
 | `diffusion_k_steps` | 8 | Number of (noise, t) samples averaged per GRPO loss (matches DPO K=8) |
@@ -214,7 +214,7 @@ See `rlvr/configs/grpo_onpolicy.json` for the recommended config. Key parameters
 | `progress_norm_scale` | 20.0 | Max progress points at 100% GT match (when overprogress enabled) |
 | `lane_dep_trim_n` | 0 | Drop N scenes with worst lane departure fraction per epoch (0=disabled) |
 | `neighbor_loss_weight` | 0.0 | Neighbor prediction regularization weight vs GT (0=disabled) |
-| `neighbor_reg_weight` | 1.0 | Neighbor reg: MSE(lora_neighbor, base_neighbor). Must be ≥1.0 at lr=5e-4 (0.5/0.75 diverge at ep5-6). |
+| `neighbor_reg_weight` | 0.0 | Neighbor reg: MSE(lora_neighbor, base_neighbor). 0 for standard GRPO. For ranked SFT, set to ≥1.0 (0.5/0.75 diverge at ep5-6). |
 | `neighbor_reg_only` | `true` | When true, drop neighbor SFT loss; only use reg term (loss = ego_sft + reg) |
 | `kl_schedule` | `"constant"` | `"constant"`, `"linear"`, `"cosine"`, or `"step"` (see below) |
 | `kl_coef_final` | 0.05 | Target KL coef at end of training (for non-constant schedules) |

--- a/rlvr/autoresearch/tools/experiment_watchdog.py
+++ b/rlvr/autoresearch/tools/experiment_watchdog.py
@@ -12,7 +12,8 @@ Usage:
     # Read status:
     cat /tmp/experiment_status.log
 
-Tracks named experiments. Outputs only NEW eval lines as they appear.
+Tracks named experiments via run_experiment.py logs. Outputs only NEW eval lines
+(matching "Eval [epochN-val]" / "Eval [epochN-prob]" format) as they appear.
 Alerts on stopped>2, rb_cross>10. Detects process death.
 Never exits — sleeps and watches for new experiments via add-file.
 """
@@ -21,6 +22,7 @@ import argparse
 import os
 import re
 import subprocess
+import tempfile
 import time
 from datetime import datetime
 
@@ -40,17 +42,26 @@ def is_experiment_running(name):
         return False
 
 
-def get_new_eval_lines(log_path, seen_count):
-    """Read new eval lines from a log file since seen_count."""
-    val_lines = []
+_EVAL_RE = re.compile(r"Eval \[epoch\d+-(val|prob)\]")
+
+
+def get_new_eval_lines(log_path, byte_offset):
+    """Read new eval lines from a log file starting from byte_offset.
+
+    Returns (new_lines, new_byte_offset).
+    Uses seek() to avoid re-reading the entire file each interval.
+    """
+    new_lines = []
     try:
         with open(log_path) as f:
+            f.seek(byte_offset)
             for line in f:
-                if re.search(r"Eval \[epoch\d+-(val|prob)\]", line):
-                    val_lines.append(line.strip())
+                if _EVAL_RE.search(line):
+                    new_lines.append(line.strip())
+            new_offset = f.tell()
     except Exception:
-        return [], seen_count
-    return val_lines[seen_count:], len(val_lines)
+        return [], byte_offset
+    return new_lines, new_offset
 
 
 def check_alerts(name, eval_line):
@@ -73,28 +84,30 @@ def write_status(sf, message):
 
 
 def snapshot_log(exp_dir, name):
-    """Count existing eval lines in a log so we only report new ones."""
+    """Seek to end of existing log so we only report new lines."""
     log_path = os.path.join(exp_dir, f"{name}.log")
-    count = 0
+    byte_offset = 0
     if os.path.exists(log_path):
         try:
-            with open(log_path) as f:
-                for line in f:
-                    if re.search(r"Eval \[epoch\d+-(val|prob)\]", line):
-                        count += 1
+            byte_offset = os.path.getsize(log_path)
         except Exception:
             pass
-    return {"log": log_path, "seen_count": count, "alive": True, "finished_reported": False}
+    return {"log": log_path, "byte_offset": byte_offset, "alive": True, "finished_reported": False}
 
 
 def check_add_file(add_file, exp_dir, tracked, status_file):
-    """Check if new experiment names were written to the add-file."""
+    """Check if new experiment names were written to the add-file.
+
+    Atomically rotates the file to avoid race conditions with concurrent writers.
+    """
     if not os.path.exists(add_file):
         return
     try:
-        with open(add_file) as f:
+        tmp_path = add_file + ".reading"
+        os.rename(add_file, tmp_path)
+        with open(tmp_path) as f:
             names = [line.strip() for line in f if line.strip()]
-        os.remove(add_file)
+        os.remove(tmp_path)
         for name in names:
             if name not in tracked:
                 tracked[name] = snapshot_log(exp_dir, name)
@@ -130,7 +143,6 @@ def main():
     print(f"Add file: {args.add_file}")
 
     while True:
-        # Check for dynamically added experiments
         check_add_file(args.add_file, args.exp_dir, tracked, args.status_file)
 
         new_output = []
@@ -139,10 +151,10 @@ def main():
             if state["finished_reported"]:
                 continue
 
-            # Check for new eval lines
+            # Check for new eval lines (seek-based, O(new data) not O(file size))
             if os.path.exists(state["log"]):
-                new_lines, new_count = get_new_eval_lines(state["log"], state["seen_count"])
-                state["seen_count"] = new_count
+                new_lines, new_offset = get_new_eval_lines(state["log"], state["byte_offset"])
+                state["byte_offset"] = new_offset
 
                 for line in new_lines:
                     new_output.append(f"  [{name}] {line}")

--- a/rlvr/autoresearch/tools/experiment_watchdog.py
+++ b/rlvr/autoresearch/tools/experiment_watchdog.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Experiment watchdog — tracks experiments, outputs only new events, never dies.
+
+Usage:
+    # Start with initial experiments:
+    nohup python -m rlvr.autoresearch.tools.experiment_watchdog \
+        --exp_dir /path/to/experiments --names exp1 exp2 &
+
+    # Add more experiments later (watchdog picks them up):
+    echo "exp3" >> /tmp/watchdog_add.txt
+
+    # Read status:
+    cat /tmp/experiment_status.log
+
+Tracks named experiments. Outputs only NEW eval lines as they appear.
+Alerts on stopped>2, rb_cross>10. Detects process death.
+Never exits — sleeps and watches for new experiments via add-file.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import time
+from datetime import datetime
+
+
+def is_experiment_running(name):
+    """Check if an experiment process is still alive by name."""
+    try:
+        result = subprocess.run(
+            ["ps", "aux"], capture_output=True, text=True, timeout=5
+        )
+        for line in result.stdout.split("\n"):
+            if name in line and "watchdog" not in line and "grep" not in line:
+                if any(k in line for k in ["run_experiment", "train_grpo", "grpo_sft"]):
+                    return True
+        return False
+    except Exception:
+        return False
+
+
+def get_new_eval_lines(log_path, seen_count):
+    """Read new eval lines from a log file since seen_count."""
+    val_lines = []
+    try:
+        with open(log_path) as f:
+            for line in f:
+                if re.search(r"Eval \[epoch\d+-(val|prob)\]", line):
+                    val_lines.append(line.strip())
+    except Exception:
+        return [], seen_count
+    return val_lines[seen_count:], len(val_lines)
+
+
+def check_alerts(name, eval_line):
+    """Check a single eval line for kill conditions."""
+    alerts = []
+    stopped = re.search(r"stopped=(\d+)", eval_line)
+    rb_cross = re.search(r"rb_cross=(\d+)/", eval_line)
+    if stopped and int(stopped.group(1)) > 2:
+        alerts.append(f"[ALERT] {name}: stopped={stopped.group(1)} (>2)")
+    if rb_cross and int(rb_cross.group(1)) > 10:
+        alerts.append(f"[ALERT] {name}: rb_cross={rb_cross.group(1)} (>10)")
+    return alerts
+
+
+def write_status(sf, message):
+    """Write a timestamped line."""
+    now = datetime.now().strftime("%H:%M:%S")
+    sf.write(f"[{now}] {message}\n")
+    sf.flush()
+
+
+def snapshot_log(exp_dir, name):
+    """Count existing eval lines in a log so we only report new ones."""
+    log_path = os.path.join(exp_dir, f"{name}.log")
+    count = 0
+    if os.path.exists(log_path):
+        try:
+            with open(log_path) as f:
+                for line in f:
+                    if re.search(r"Eval \[epoch\d+-(val|prob)\]", line):
+                        count += 1
+        except Exception:
+            pass
+    return {"log": log_path, "seen_count": count, "alive": True, "finished_reported": False}
+
+
+def check_add_file(add_file, exp_dir, tracked, status_file):
+    """Check if new experiment names were written to the add-file."""
+    if not os.path.exists(add_file):
+        return
+    try:
+        with open(add_file) as f:
+            names = [line.strip() for line in f if line.strip()]
+        os.remove(add_file)
+        for name in names:
+            if name not in tracked:
+                tracked[name] = snapshot_log(exp_dir, name)
+                with open(status_file, "a") as sf:
+                    write_status(sf, f"  Now tracking: {name}")
+                print(f"Added experiment: {name}")
+    except Exception:
+        pass
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Experiment watchdog")
+    parser.add_argument("--exp_dir", required=True, help="Experiment directory containing .log files")
+    parser.add_argument("--names", nargs="*", default=[], help="Initial experiment names to track")
+    parser.add_argument("--interval", type=int, default=60, help="Check interval in seconds")
+    parser.add_argument("--status_file", default="/tmp/experiment_status.log", help="Output file")
+    parser.add_argument("--add_file", default="/tmp/watchdog_add.txt", help="File to write new experiment names to")
+    args = parser.parse_args()
+
+    tracked = {}
+    for name in args.names:
+        tracked[name] = snapshot_log(args.exp_dir, name)
+
+    with open(args.status_file, "w") as sf:
+        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        sf.write(f"=== Watchdog started [{now}] ===\n")
+        if tracked:
+            sf.write(f"Tracking: {', '.join(args.names)}\n")
+        sf.write(f"Add experiments: echo <name> >> {args.add_file}\n\n")
+
+    print(f"Watchdog started. Tracking {len(tracked)} experiments, checking every {args.interval}s")
+    print(f"Status file: {args.status_file}")
+    print(f"Add file: {args.add_file}")
+
+    while True:
+        # Check for dynamically added experiments
+        check_add_file(args.add_file, args.exp_dir, tracked, args.status_file)
+
+        new_output = []
+
+        for name, state in tracked.items():
+            if state["finished_reported"]:
+                continue
+
+            # Check for new eval lines
+            if os.path.exists(state["log"]):
+                new_lines, new_count = get_new_eval_lines(state["log"], state["seen_count"])
+                state["seen_count"] = new_count
+
+                for line in new_lines:
+                    new_output.append(f"  [{name}] {line}")
+                    for a in check_alerts(name, line):
+                        new_output.append(f"  {a}")
+
+            # Check if process died (only if it was alive before)
+            if state["alive"]:
+                running = is_experiment_running(name)
+                if not running:
+                    state["alive"] = False
+                    state["finished_reported"] = True
+                    new_output.append(f"  [{name}] FINISHED (process no longer running)")
+
+        if new_output:
+            with open(args.status_file, "a") as sf:
+                for line in new_output:
+                    write_status(sf, line)
+
+        time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- **Experiment watchdog** (`rlvr/autoresearch/tools/experiment_watchdog.py`): background monitor that tracks named experiments, outputs only new eval lines as they appear, fires alerts on stopped>2 or rb_cross>10, detects process death, and supports dynamic experiment addition via file. Replaces repeated nvidia-smi/ps/grep polling for status checks.
- **Updated READMEs** with latest findings: two-stage ranked SFT recipe with neighbor reg, block ablation results (no_blk1 best with reg, block2-only diverges), reg_weight≥1.0 constraint, watchdog usage docs.

## Test plan
- [x] End-to-end test: simulated 2 experiments with fake processes and log writes — watchdog caught every new eval, fired alerts correctly, detected process death
- [x] Dynamic add: wrote experiment name to add-file mid-run, watchdog picked it up and tracked it
- [x] Tested on real experiments (rsft_s1_reg05, rsft_s1_block2only, rsft_s1_reg075) — all events captured correctly
- [x] Watchdog stays alive after all experiments finish (no auto-exit)