### PR TITLE
feat: per-trajectory guidance tuning GUI and sampling defaults

### DIFF
--- a/rlvr/configs/grpo_multi_epoch.json
+++ b/rlvr/configs/grpo_multi_epoch.json
@@ -7,7 +7,7 @@
   "learning_rate": 1e-5,
   "grad_accum_groups": 8,
   "sampling_randomization": true,
-  "noise_scale_range": [0.5, 4.0],
+  "noise_scale_range": [0.5, 2.0],
   "guidance_scale_range": [0.1, 2.0],
   "enable_guidance": true,
   "enable_centerline": true,

--- a/rlvr/configs/grpo_multi_epoch_vdgrpo.json
+++ b/rlvr/configs/grpo_multi_epoch_vdgrpo.json
@@ -7,7 +7,7 @@
   "learning_rate": 1e-5,
   "grad_accum_groups": 8,
   "sampling_randomization": true,
-  "noise_scale_range": [0.5, 4.0],
+  "noise_scale_range": [0.5, 2.0],
   "guidance_scale_range": [0.1, 2.0],
   "enable_guidance": true,
   "enable_centerline": true,

--- a/rlvr/configs/grpo_onpolicy.json
+++ b/rlvr/configs/grpo_onpolicy.json
@@ -8,7 +8,7 @@
   "learning_rate": 5e-4,
   "grad_accum_groups": 4,
   "sampling_randomization": true,
-  "noise_scale_range": [0.5, 4.0],
+  "noise_scale_range": [0.5, 2.0],
   "guidance_scale_range": [0.1, 2.0],
   "enable_guidance": true,
   "enable_centerline": false,

--- a/rlvr/configs/grpo_onpolicy_exploration.json
+++ b/rlvr/configs/grpo_onpolicy_exploration.json
@@ -10,7 +10,7 @@
   "learning_rate": 5e-4,
   "grad_accum_groups": 4,
   "sampling_randomization": true,
-  "noise_scale_range": [0.5, 4.0],
+  "noise_scale_range": [0.5, 2.0],
   "guidance_scale_range": [0.1, 2.0],
   "enable_guidance": true,
   "enable_centerline": false,

--- a/rlvr/configs/grpo_onpolicy_hybrid.json
+++ b/rlvr/configs/grpo_onpolicy_hybrid.json
@@ -10,7 +10,7 @@
   "learning_rate": 5e-4,
   "grad_accum_groups": 4,
   "sampling_randomization": true,
-  "noise_scale_range": [0.5, 4.0],
+  "noise_scale_range": [0.5, 2.0],
   "guidance_scale_range": [0.1, 2.0],
   "enable_guidance": true,
   "enable_centerline": false,

--- a/rlvr/configs/grpo_onpolicy_kl_cosine.json
+++ b/rlvr/configs/grpo_onpolicy_kl_cosine.json
@@ -10,7 +10,7 @@
   "learning_rate": 5e-4,
   "grad_accum_groups": 4,
   "sampling_randomization": true,
-  "noise_scale_range": [0.5, 4.0],
+  "noise_scale_range": [0.5, 2.0],
   "guidance_scale_range": [0.1, 2.0],
   "enable_guidance": true,
   "enable_centerline": false,

--- a/rlvr/configs/grpo_onpolicy_vdgrpo.json
+++ b/rlvr/configs/grpo_onpolicy_vdgrpo.json
@@ -8,7 +8,7 @@
   "learning_rate": 5e-4,
   "grad_accum_groups": 4,
   "sampling_randomization": true,
-  "noise_scale_range": [0.5, 4.0],
+  "noise_scale_range": [0.5, 2.0],
   "guidance_scale_range": [0.1, 2.0],
   "enable_guidance": true,
   "enable_centerline": false,

--- a/rlvr/configs/grpo_onpolicy_vdgrpo_kl_cosine.json
+++ b/rlvr/configs/grpo_onpolicy_vdgrpo_kl_cosine.json
@@ -10,7 +10,7 @@
   "learning_rate": 5e-4,
   "grad_accum_groups": 4,
   "sampling_randomization": true,
-  "noise_scale_range": [0.5, 4.0],
+  "noise_scale_range": [0.5, 2.0],
   "guidance_scale_range": [0.1, 2.0],
   "enable_guidance": true,
   "enable_centerline": false,

--- a/rlvr/configs/logprob_balanced_40sc.json
+++ b/rlvr/configs/logprob_balanced_40sc.json
@@ -13,7 +13,7 @@
     "learning_rate": 0.0002,
     "grad_accum_groups": 2,
 
-    "noise_scale_range": [0.5, 4.0],
+    "noise_scale_range": [0.5, 2.0],
     "rejection_keep": 0,
 
     "advantage_mode": "normalized",

--- a/rlvr/configs/logprob_curve20_norm.json
+++ b/rlvr/configs/logprob_curve20_norm.json
@@ -13,7 +13,7 @@
     "learning_rate": 0.0003,
     "grad_accum_groups": 2,
 
-    "noise_scale_range": [0.5, 4.0],
+    "noise_scale_range": [0.5, 2.0],
     "rejection_keep": 0,
 
     "advantage_mode": "normalized",

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -65,7 +65,7 @@ class GRPOConfig:
 
     # Sampling
     sampling_randomization: bool = True
-    noise_scale_range: list[float] = field(default_factory=lambda: [0.5, 4.0])
+    noise_scale_range: list[float] = field(default_factory=lambda: [0.5, 2.0])
     guidance_scale_range: list[float] = field(default_factory=lambda: [0.1, 2.0])
     enable_guidance: bool = True
     enable_centerline: bool = True

--- a/rlvr/grpo_sampler.py
+++ b/rlvr/grpo_sampler.py
@@ -21,7 +21,7 @@ from guidance_gui.generate_samples import generate_samples
 @dataclass
 class SamplerConfig:
     n_trajectories: int = 8
-    noise_scale_range: tuple[float, float] = (0.5, 4.0)
+    noise_scale_range: tuple[float, float] = (0.5, 2.0)
     guidance_scale_range: tuple[float, float] = (0.1, 2.0)
 
     enable_guidance: bool = True
@@ -41,7 +41,7 @@ class SamplerConfig:
 
     centerline_scale_range: tuple[float, float] = (0.5, 3.0)
     anchor_scale_range: tuple[float, float] = (0.5, 3.0)
-    collision_scale_range: tuple[float, float] = (0.5, 2.0)
+    collision_scale_range: tuple[float, float] = (0.1, 1.0)
     route_following_scale_range: tuple[float, float] = (0.5, 2.0)
     lane_keeping_scale_range: tuple[float, float] = (0.5, 2.0)
     road_border_scale_range: tuple[float, float] = (0.2, 1.5)

--- a/rlvr/test_grpo_sampler.py
+++ b/rlvr/test_grpo_sampler.py
@@ -23,7 +23,7 @@ from rlvr.grpo_sampler import SampledTrajectory, SamplerConfig, generate_diverse
 def test_sampler_config_defaults():
     cfg = SamplerConfig()
     assert cfg.n_trajectories == 8
-    assert cfg.noise_scale_range == (0.5, 4.0)
+    assert cfg.noise_scale_range == (0.5, 2.0)
     assert cfg.enable_guidance is True
     assert cfg.enable_centerline is True
     assert cfg.enable_anchor is True

--- a/rlvr/trajectory_ranker_gui.py
+++ b/rlvr/trajectory_ranker_gui.py
@@ -148,6 +148,9 @@ def slot_config_to_composer(
         if name == "speed" and gt_max_speed is not None:
             p.setdefault("v_high", gt_max_speed)
             p.setdefault("v_low", gt_min_speed)
+        if name == "anchor_following":
+            p.setdefault("prototypes_path", _DEFAULT_PROTOTYPES_PATH)
+            p.setdefault("anchor_index", 0)
         fns.append(GuidanceConfig(name=name, enabled=True, scale=scale, params=p))
     if not fns:
         return None, None
@@ -376,6 +379,9 @@ class TrajectoryRanker:
             self._norm_data["reference_trajectory"] = self._ref_trajectory
         self.policy_model.eval()
         traj = self._generate_from_slot(slot)
+        if index == 0 and slot.is_deterministic:
+            self._ref_trajectory = torch.from_numpy(traj).unsqueeze(0).to(self.device)
+            self._norm_data["reference_trajectory"] = self._ref_trajectory
         self.sampled_trajectories[index] = SampledTrajectory(
             trajectory=traj,
             noise_scale=0.0 if slot.is_deterministic else slot.noise_scale,
@@ -426,9 +432,12 @@ class TrajectoryRanker:
             display_rank = N - ranks[i]
             is_selected = (i == selected_idx)
 
-            if st.is_deterministic and not any(
-                en for en, _, _ in self.slot_configs[i].guidance.values()
-            ) if i < len(self.slot_configs) else st.is_deterministic:
+            has_guidance = (
+                any(en for en, _, _ in self.slot_configs[i].guidance.values())
+                if i < len(self.slot_configs) else False
+            )
+            is_det_baseline = st.is_deterministic and not has_guidance
+            if is_det_baseline:
                 color = "dodgerblue"
                 lw = 3.0
                 alpha = 1.0

--- a/rlvr/trajectory_ranker_gui.py
+++ b/rlvr/trajectory_ranker_gui.py
@@ -138,6 +138,7 @@ def slot_config_to_composer(
     slot: TrajectorySlotConfig,
     gt_max_speed: float | None,
     gt_min_speed: float,
+    prototypes_path: str | None = None,
 ) -> tuple[GuidanceComposer | None, GuidanceSetConfig | None]:
     fns = []
     for name in ALL_GUIDANCE_NAMES:
@@ -149,7 +150,8 @@ def slot_config_to_composer(
             p.setdefault("v_high", gt_max_speed)
             p.setdefault("v_low", gt_min_speed)
         if name == "anchor_following":
-            p.setdefault("prototypes_path", _DEFAULT_PROTOTYPES_PATH)
+            if prototypes_path:
+                p.setdefault("prototypes_path", prototypes_path)
             p.setdefault("anchor_index", 0)
         fns.append(GuidanceConfig(name=name, enabled=True, scale=scale, params=p))
     if not fns:
@@ -356,7 +358,7 @@ class TrajectoryRanker:
 
     def _generate_from_slot(self, slot: TrajectorySlotConfig) -> np.ndarray:
         composer, set_cfg = slot_config_to_composer(
-            slot, self._gt_max_speed, self._gt_min_speed,
+            slot, self._gt_max_speed, self._gt_min_speed, self.prototypes_path,
         )
         noise = 0.0 if slot.is_deterministic else slot.noise_scale
         samples = generate_samples(
@@ -371,7 +373,11 @@ class TrajectoryRanker:
         return samples[0]
 
     def regenerate_single(self, index: int) -> None:
-        if self._norm_data is None or index >= len(self.slot_configs):
+        if (
+            self._norm_data is None
+            or index >= len(self.slot_configs)
+            or index >= len(self.sampled_trajectories)
+        ):
             return
         slot = self.slot_configs[index]
         # Ensure reference_trajectory is in norm_data for lat/lon guidance
@@ -1170,6 +1176,7 @@ def build_interface(
                     return (
                         "No groups queued. Accept some scenes first.",
                         _grpo_epoch_counter[0],
+                        f"0 groups queued",
                     )
 
                 trainer.beta = float(beta_val)
@@ -1201,7 +1208,7 @@ def build_interface(
                     log_lines.append(f"- {drift}")
                 log_lines.append(f"\nQueue cleared.")
 
-                return ("\n".join(log_lines), epoch)
+                return ("\n".join(log_lines), epoch, "0 groups queued")
 
             btn_accept.click(
                 _accept_and_advance,
@@ -1219,7 +1226,7 @@ def build_interface(
             btn_train.click(
                 _train_epoch,
                 inputs=[beta_sl, lr_sl, accum_sl],
-                outputs=[train_log, epoch_display],
+                outputs=[train_log, epoch_display, queue_status],
             )
 
         demo.load(_full_run, inputs=full_run_inputs, outputs=full_run_outputs)

--- a/rlvr/trajectory_ranker_gui.py
+++ b/rlvr/trajectory_ranker_gui.py
@@ -1,32 +1,25 @@
-"""Trajectory Ranker GUI -- visualization, reward debugging, and optional GRPO training.
+"""Trajectory Ranker GUI -- per-trajectory guidance tuning, reward debugging, and optional GRPO training.
 
-Generates N trajectories per scene with diverse noise/guidance configs, scores
-them with the rule-based reward, computes group-relative advantages, and
-visualizes everything with a red-to-green advantage colormap.
-
-When training is enabled (default), the GUI also provides Accept/Skip controls
-to collect groups and a "Train Epoch" button for GRPO updates.
-Pass --no-training to disable training controls (visualization-only mode).
+Generates N trajectories per scene matching the batched GRPO sampler strategy,
+scores them with the rule-based reward, and lets you edit each trajectory's
+guidance config individually (noise, guidance types, scales) with single-traj
+regeneration.
 
 Launch
 ------
 source .venv/bin/activate
 
-# Visualization + GRPO training (default):
-python rlvr/trajectory_ranker_gui.py \\
-  --model_path /path/to/model.pth \\
-  --npz_list   /path/to/train_or_valid.json \\
-  --use_lora
-
-# Visualization only (no training controls):
-python rlvr/trajectory_ranker_gui.py \\
-  --model_path /path/to/model.pth \\
-  --npz_list   /path/to/train_or_valid.json \\
+# Visualization + per-trajectory tuning (default):
+python rlvr/trajectory_ranker_gui.py \
+  --model_path /path/to/model.pth \
+  --npz_list   /path/to/train_or_valid.json \
   --no-training
 
-Prototypes are auto-generated from the npz_list if not provided.
-Use --prototypes to point to an existing file, or --regen-prototypes to force
-regeneration even if a cached file exists.
+# With GRPO training controls:
+python rlvr/trajectory_ranker_gui.py \
+  --model_path /path/to/model.pth \
+  --npz_list   /path/to/train_or_valid.json \
+  --use_lora
 """
 
 from __future__ import annotations
@@ -37,6 +30,7 @@ import json
 import random
 import subprocess
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import gradio as gr
@@ -45,19 +39,19 @@ import numpy as np
 import torch
 from matplotlib.figure import Figure
 
+from diffusion_planner.model.guidance.composer import GuidanceComposer
+from diffusion_planner.model.guidance.config import GuidanceConfig, GuidanceSetConfig
 from diffusion_planner.utils.visualize_input import visualize_inputs
+from guidance_gui.generate_samples import generate_samples
 from guidance_gui.visualization import (
     _calculate_curvature,
-    _calculate_lateral_acceleration,
     _calculate_velocities,
     _gt_curvature,
     _gt_velocities,
-    _draw_vehicle_footprint,
 )
 from preference_optimization.model_utils import load_model
 from preference_optimization.utils import load_npz_data
-
-from rlvr.grpo_sampler import SamplerConfig, SampledTrajectory, generate_diverse_group
+from rlvr.grpo_sampler import SampledTrajectory
 from rlvr.reward import RewardBreakdown, RewardConfig, compute_group_advantages, compute_reward_batch
 
 
@@ -66,20 +60,180 @@ _DIVERGING_CMAP = plt.get_cmap("RdYlGn")
 _DEFAULT_PROTOTYPES_PATH = str(Path(__file__).parent / "prototypes_k16.npy")
 _GENERATE_SCRIPT = Path(__file__).parent.parent / "guidance_gui" / "scripts" / "generate_prototypes.py"
 
+ALL_GUIDANCE_NAMES = [
+    "centerline_following",
+    "speed",
+    "lane_keeping",
+    "road_border",
+    "route_following",
+    "collision",
+    "anchor_following",
+    "lateral",
+    "longitudinal",
+]
+
+# Short display names for labels
+_SHORT_NAMES = {
+    "centerline_following": "cl",
+    "speed": "spd",
+    "lane_keeping": "lk",
+    "road_border": "rb",
+    "route_following": "rf",
+    "collision": "col",
+    "anchor_following": "anc",
+    "lateral": "lat",
+    "longitudinal": "lon",
+}
+
+
+# ---------------------------------------------------------------------------
+# Per-trajectory config data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TrajectorySlotConfig:
+    """Editable config for one trajectory slot."""
+    noise_scale: float = 0.0
+    global_guidance_scale: float = 1.0
+    is_deterministic: bool = False
+    # name -> (enabled, scale, params_dict)
+    guidance: dict[str, tuple[bool, float, dict]] = field(default_factory=dict)
+
+    def __post_init__(self):
+        for name in ALL_GUIDANCE_NAMES:
+            if name not in self.guidance:
+                self.guidance[name] = (False, 1.0, {})
+
+
+def _format_label(slot: TrajectorySlotConfig) -> str:
+    if slot.is_deterministic and not any(en for en, _, _ in slot.guidance.values()):
+        return "DET"
+    parts = []
+    if slot.is_deterministic:
+        parts.append("det")
+    elif slot.noise_scale > 0:
+        parts.append(f"ns={slot.noise_scale:.1f}")
+    for name in ALL_GUIDANCE_NAMES:
+        enabled, scale, _ = slot.guidance.get(name, (False, 1.0, {}))
+        if enabled:
+            parts.append(f"{_SHORT_NAMES[name]}={scale:.0f}")
+    return "+".join(parts) if parts else "none"
+
+
+def _format_dropdown_choices(
+    slot_configs: list[TrajectorySlotConfig],
+    reward_breakdowns: list[RewardBreakdown],
+) -> list[str]:
+    choices = []
+    for i, slot in enumerate(slot_configs):
+        label = _format_label(slot)
+        reward_str = ""
+        if i < len(reward_breakdowns):
+            reward_str = f" R={reward_breakdowns[i].total:.1f}"
+        choices.append(f"#{i + 1} {label}{reward_str}")
+    return choices
+
+
+def slot_config_to_composer(
+    slot: TrajectorySlotConfig,
+    gt_max_speed: float | None,
+    gt_min_speed: float,
+) -> tuple[GuidanceComposer | None, GuidanceSetConfig | None]:
+    fns = []
+    for name in ALL_GUIDANCE_NAMES:
+        enabled, scale, params = slot.guidance.get(name, (False, 1.0, {}))
+        if not enabled:
+            continue
+        p = dict(params)
+        if name == "speed" and gt_max_speed is not None:
+            p.setdefault("v_high", gt_max_speed)
+            p.setdefault("v_low", gt_min_speed)
+        fns.append(GuidanceConfig(name=name, enabled=True, scale=scale, params=p))
+    if not fns:
+        return None, None
+    set_cfg = GuidanceSetConfig(functions=fns, global_scale=slot.global_guidance_scale)
+    return GuidanceComposer(set_cfg), set_cfg
+
+
+def generate_batched_sampler_configs(
+    gt_max_speed: float | None,
+    gt_min_speed: float,
+    k: int = 16,
+) -> list[TrajectorySlotConfig]:
+    """Generate K trajectory configs matching the batched GRPO sampler strategy."""
+    configs: list[TrajectorySlotConfig] = []
+
+    # Slot 0: deterministic, no guidance
+    configs.append(TrajectorySlotConfig(is_deterministic=True))
+
+    # Slots 1-4: CL+SPD guided, deterministic
+    cl_spd_det = [
+        (5.0, 5.0),
+        (8.0, 5.0),
+        (10.0, 8.0),
+        (10.0, 10.0),
+    ]
+    for cl_s, spd_s in cl_spd_det:
+        slot = TrajectorySlotConfig(is_deterministic=True, global_guidance_scale=1.0)
+        slot.guidance["centerline_following"] = (True, cl_s, {})
+        if gt_max_speed is not None:
+            slot.guidance["speed"] = (True, spd_s, {"v_high": gt_max_speed, "v_low": gt_min_speed})
+        configs.append(slot)
+
+    # Slots 5-8: CL+SPD guided, with noise
+    cl_spd_noisy = [
+        (5.0, 5.0, 0.3, 0.8),
+        (8.0, 8.0, 0.3, 0.8),
+        (10.0, 8.0, 0.3, 0.8),
+        (10.0, 10.0, 0.5, 1.0),
+    ]
+    for cl_s, spd_s, n_lo, n_hi in cl_spd_noisy:
+        ns = round(random.uniform(n_lo, n_hi), 2)
+        slot = TrajectorySlotConfig(noise_scale=ns, global_guidance_scale=1.0)
+        slot.guidance["centerline_following"] = (True, cl_s, {})
+        if gt_max_speed is not None:
+            slot.guidance["speed"] = (True, spd_s, {"v_high": gt_max_speed, "v_low": gt_min_speed})
+        configs.append(slot)
+
+    # Slots 9-12: random CL + optional RB
+    n_rand1 = max(0, min(4, k - len(configs) - 3))
+    for _ in range(n_rand1):
+        ns = round(random.uniform(0.5, 2.0), 2)
+        gs = round(random.uniform(0.3, 1.5), 2)
+        cl_s = round(random.uniform(2.0, 8.0), 1)
+        slot = TrajectorySlotConfig(noise_scale=ns, global_guidance_scale=gs)
+        slot.guidance["centerline_following"] = (True, cl_s, {})
+        if random.random() < 0.5:
+            rb_s = round(random.uniform(0.3, 1.5), 1)
+            slot.guidance["road_border"] = (True, rb_s, {})
+        configs.append(slot)
+
+    # Slots 13-15: noise-only or light CL
+    n_rand2 = k - len(configs)
+    for _ in range(n_rand2):
+        ns = round(random.uniform(0.5, 2.0), 2)
+        slot = TrajectorySlotConfig(noise_scale=ns)
+        if random.random() < 0.5:
+            cl_s = round(random.uniform(1.0, 5.0), 1)
+            gs = round(random.uniform(0.2, 1.0), 2)
+            slot.guidance["centerline_following"] = (True, cl_s, {})
+            slot.global_guidance_scale = gs
+        configs.append(slot)
+
+    return configs[:k]
+
+
+# ---------------------------------------------------------------------------
+# Prototypes helper (unchanged)
+# ---------------------------------------------------------------------------
 
 def ensure_prototypes(npz_list_path: str, prototypes_path: str, force: bool = False) -> str | None:
-    """Generate prototypes from npz_list if they don't exist (or force=True).
-
-    Returns the path to the prototypes file, or None if generation failed.
-    """
     if not force and Path(prototypes_path).exists():
         print(f"Using existing prototypes: {prototypes_path}")
         return prototypes_path
-
     if not _GENERATE_SCRIPT.exists():
         print(f"Warning: generate_prototypes.py not found at {_GENERATE_SCRIPT}")
         return prototypes_path
-
     print(f"Generating prototypes from {npz_list_path} -> {prototypes_path} ...")
     try:
         subprocess.run(
@@ -97,16 +251,18 @@ def ensure_prototypes(npz_list_path: str, prototypes_path: str, force: bool = Fa
         print(f"Warning: prototype generation failed: {e}")
     except subprocess.TimeoutExpired:
         print("Warning: prototype generation timed out")
-
     if not Path(prototypes_path).exists():
         print(f"Warning: prototypes file not created at {prototypes_path}")
         return None
-
     return prototypes_path
 
 
+# ---------------------------------------------------------------------------
+# TrajectoryRanker
+# ---------------------------------------------------------------------------
+
 class TrajectoryRanker:
-    """Generates and scores N diverse trajectories per scene."""
+    """Generates and scores N diverse trajectories per scene with per-trajectory control."""
 
     def __init__(
         self,
@@ -115,25 +271,47 @@ class TrajectoryRanker:
         npz_paths: list[str],
         npz_list_path: str,
         prototypes_path: str,
+        n_trajectories: int = 16,
     ):
         self.policy_model = policy_model
         self.model_args = model_args
         self.npz_paths = npz_paths
         self.npz_list_path = npz_list_path
+        self.prototypes_path = prototypes_path
+        self.n_trajectories = n_trajectories
         self.current_index = 0
         self.device = next(policy_model.parameters()).device
 
-        self.sampler_config = SamplerConfig(prototypes_path=prototypes_path)
-        self.reward_config = RewardConfig()
-
         self.current_data: dict[str, torch.Tensor] | None = None
+        self._norm_data: dict[str, torch.Tensor] | None = None
+        self._gt_max_speed: float | None = None
+        self._gt_min_speed: float = 0.0
+        self._ref_trajectory: torch.Tensor | None = None  # [1, T, 4] from det traj
+
+        self.slot_configs: list[TrajectorySlotConfig] = []
         self.sampled_trajectories: list[SampledTrajectory] = []
         self.reward_breakdowns: list[RewardBreakdown] = []
         self.advantages: np.ndarray = np.array([])
         self.saved_scenes: list[dict] = []
 
-        # GRPO training state: groups accepted by the user for the next training step
+        self.reward_config = RewardConfig()
         self.accepted_groups: list[dict] = []
+
+    def _compute_gt_speed_bounds(self) -> None:
+        self._gt_max_speed = None
+        self._gt_min_speed = 0.0
+        if self.current_data is None or "ego_agent_future" not in self.current_data:
+            return
+        gt = self.current_data["ego_agent_future"]
+        if gt.dim() == 3:
+            gt = gt[0]
+        gt_np = gt.cpu().numpy()
+        valid = ~((gt_np[:, 0] == 0) & (gt_np[:, 1] == 0))
+        if valid.sum() >= 10:
+            vel = np.diff(gt_np[valid][:, :2], axis=0) / 0.1
+            speeds = np.linalg.norm(vel, axis=-1)
+            self._gt_max_speed = float(speeds.max())
+            self._gt_min_speed = float(np.percentile(speeds, 10))
 
     def load_sample(self) -> None:
         if not self.npz_paths or self.current_index >= len(self.npz_paths):
@@ -142,34 +320,85 @@ class TrajectoryRanker:
         self.current_data = load_npz_data(
             self.npz_paths[self.current_index], self.device
         )
-        # Ensure eval mode for inference (DPM-Solver sampling).
-        # Training mode is set only during GRPO loss computation.
+        self._compute_gt_speed_bounds()
+
+        self._norm_data = {
+            k: v.clone() if isinstance(v, torch.Tensor) else v
+            for k, v in self.current_data.items()
+        }
+        self._norm_data = self.model_args.observation_normalizer(self._norm_data)
+
+        self.slot_configs = generate_batched_sampler_configs(
+            self._gt_max_speed, self._gt_min_speed, k=self.n_trajectories,
+        )
+
         self.policy_model.eval()
-        self.sampled_trajectories = generate_diverse_group(
+        self.sampled_trajectories = []
+        self._ref_trajectory = None
+        for i, slot in enumerate(self.slot_configs):
+            traj = self._generate_from_slot(slot)
+            # Cache the first (deterministic) trajectory as reference for lat/lon guidance
+            if i == 0 and slot.is_deterministic:
+                self._ref_trajectory = torch.from_numpy(traj).unsqueeze(0).to(self.device)
+                self._norm_data["reference_trajectory"] = self._ref_trajectory
+            self.sampled_trajectories.append(SampledTrajectory(
+                trajectory=traj,
+                noise_scale=0.0 if slot.is_deterministic else slot.noise_scale,
+                guidance_config=None,
+                is_deterministic=slot.is_deterministic,
+                label=_format_label(slot),
+            ))
+
+        self._score_trajectories()
+
+    def _generate_from_slot(self, slot: TrajectorySlotConfig) -> np.ndarray:
+        composer, set_cfg = slot_config_to_composer(
+            slot, self._gt_max_speed, self._gt_min_speed,
+        )
+        noise = 0.0 if slot.is_deterministic else slot.noise_scale
+        samples = generate_samples(
             model=self.policy_model,
             model_args=self.model_args,
-            data=self.current_data,
-            config=self.sampler_config,
+            data=self._norm_data,
+            noise_scale=noise,
+            n_samples=1,
+            composer=composer,
             device=self.device,
+        )
+        return samples[0]
+
+    def regenerate_single(self, index: int) -> None:
+        if self._norm_data is None or index >= len(self.slot_configs):
+            return
+        slot = self.slot_configs[index]
+        # Ensure reference_trajectory is in norm_data for lat/lon guidance
+        if self._ref_trajectory is not None:
+            self._norm_data["reference_trajectory"] = self._ref_trajectory
+        self.policy_model.eval()
+        traj = self._generate_from_slot(slot)
+        self.sampled_trajectories[index] = SampledTrajectory(
+            trajectory=traj,
+            noise_scale=0.0 if slot.is_deterministic else slot.noise_scale,
+            guidance_config=None,
+            is_deterministic=slot.is_deterministic,
+            label=_format_label(slot),
         )
         self._score_trajectories()
 
     def _score_trajectories(self) -> None:
         if not self.sampled_trajectories or self.current_data is None:
             return
-
-        # Stack all trajectories into (N, T, 4) and evaluate in one batched pass
         traj_batch = torch.tensor(
             np.stack([st.trajectory for st in self.sampled_trajectories]),
             device=self.device, dtype=torch.float32,
-        )  # (N, T, 4)
+        )
         self.reward_breakdowns = compute_reward_batch(
-            traj_batch, self.current_data, self.reward_config
+            traj_batch, self.current_data, self.reward_config,
         )
         self.advantages = compute_group_advantages(self.reward_breakdowns)
 
     def _create_trajectory_plot(
-        self, time_step: int = 40, view_range: float = 60.0
+        self, time_step: int = 40, view_range: float = 60.0, selected_idx: int = 0,
     ) -> Figure:
         fig = Figure(figsize=(10, 11.5))
         ax = fig.add_subplot(111)
@@ -195,32 +424,51 @@ class TrajectoryRanker:
             traj = st.trajectory
             rank_frac = ranks[i] / max(N - 1, 1)
             display_rank = N - ranks[i]
+            is_selected = (i == selected_idx)
 
-            if st.is_deterministic:
+            if st.is_deterministic and not any(
+                en for en, _, _ in self.slot_configs[i].guidance.values()
+            ) if i < len(self.slot_configs) else st.is_deterministic:
                 color = "dodgerblue"
                 lw = 3.0
                 alpha = 1.0
                 linestyle = "--"
-                label = f"#{display_rank} R={self.reward_breakdowns[i].total:.1f} [DET]"
+                prefix = ">> " if is_selected else ""
+                label = f"{prefix}#{i+1} R={self.reward_breakdowns[i].total:.1f} [DET]"
             else:
                 color = _DIVERGING_CMAP(rank_frac)
                 lw = 1.0 + 2.5 * rank_frac
                 alpha = 0.3 + 0.7 * rank_frac
                 linestyle = "-"
-                label = f"#{display_rank} R={self.reward_breakdowns[i].total:.1f} ({st.label})"
+                prefix = ">> " if is_selected else ""
+                label = f"{prefix}#{i+1} R={self.reward_breakdowns[i].total:.1f} ({st.label})"
+
+            # Selected trajectory: white outline underneath
+            if is_selected:
+                ax.plot(
+                    traj[:, 0], traj[:, 1],
+                    color="white", linewidth=lw + 4, alpha=0.9,
+                    linestyle=linestyle, zorder=8,
+                )
+                ax.plot(
+                    traj[:, 0], traj[:, 1],
+                    color="black", linewidth=lw + 2, alpha=0.7,
+                    linestyle=linestyle, zorder=9,
+                )
 
             ax.plot(
                 traj[:, 0], traj[:, 1],
                 color=color, linewidth=lw, alpha=alpha,
                 linestyle=linestyle, label=label,
+                zorder=10 if is_selected else 5,
             )
 
-            # Top-3 get diamond markers, deterministic gets a star
-            if st.is_deterministic and 0 <= time_step < len(traj):
+            # Selected trajectory: star marker at time_step
+            if is_selected and 0 <= time_step < len(traj):
                 ax.scatter(
                     [traj[time_step, 0]], [traj[time_step, 1]],
-                    color=color, s=120, zorder=11,
-                    edgecolors="black", marker="*",
+                    color=color, s=200, zorder=15,
+                    edgecolors="black", linewidths=2, marker="*",
                 )
             elif ranks[i] >= N - 3 and 0 <= time_step < len(traj):
                 ax.scatter(
@@ -229,7 +477,6 @@ class TrajectoryRanker:
                     edgecolors="black", marker="D",
                 )
 
-            # Collision point: red X at the collision timestep
             rb = self.reward_breakdowns[i]
             if rb.collision_step is not None and 0 <= rb.collision_step < len(traj):
                 ct = rb.collision_step
@@ -251,7 +498,7 @@ class TrajectoryRanker:
                     "k--", linewidth=2, alpha=0.6, label="GT",
                 )
 
-        ax.legend(loc="upper left", fontsize=6, ncol=2)
+        ax.legend(loc="upper left", fontsize=5.5, ncol=2)
         ax.set_title(f"Scene {self.current_index + 1} / {len(self.npz_paths)}")
 
         ref = self.sampled_trajectories[0].trajectory
@@ -263,7 +510,7 @@ class TrajectoryRanker:
         ax.set_aspect("equal")
         return fig
 
-    def _create_speed_curvature_plot(self) -> Figure:
+    def _create_speed_curvature_plot(self, selected_idx: int = 0) -> Figure:
         fig = Figure(figsize=(8, 6))
         ax_speed = fig.add_subplot(211)
         ax_curv = fig.add_subplot(212)
@@ -279,26 +526,36 @@ class TrajectoryRanker:
 
         N = len(self.sampled_trajectories)
         rank_order = np.argsort(self.advantages)
-        top3_indices = rank_order[-min(3, N):][::-1]
+        top3_indices = set(rank_order[-min(3, N):][::-1])
 
-        for plot_i, idx in enumerate(top3_indices):
+        # Always include selected trajectory
+        plot_indices = [selected_idx] if selected_idx not in top3_indices else []
+        plot_indices += [i for i in rank_order[-min(3, N):][::-1]]
+
+        for plot_i, idx in enumerate(plot_indices):
             st = self.sampled_trajectories[idx]
             traj = st.trajectory
-            rank_frac = (N - 1 - plot_i) / max(N - 1, 1)
-            color = _DIVERGING_CMAP(rank_frac)
+            is_sel = (idx == selected_idx)
+
+            if is_sel:
+                color = "blue"
+                lw = 2.5
+            else:
+                rank_frac = (N - 1 - plot_i) / max(N - 1, 1)
+                color = _DIVERGING_CMAP(rank_frac)
+                lw = 1.8
 
             vel = _calculate_velocities(traj, ego_state)
             curv = _calculate_curvature(traj, ego_state)
             t = np.arange(len(vel))
-
-            display_rank = plot_i + 1
+            sel_tag = " [SEL]" if is_sel else ""
             ax_speed.plot(
-                t, vel, color=color, linewidth=1.8, alpha=0.8,
-                label=f"#{display_rank} {st.label}",
+                t, vel, color=color, linewidth=lw, alpha=0.8,
+                label=f"#{idx+1} {st.label}{sel_tag}",
             )
             ax_curv.plot(
                 np.arange(len(curv)), curv,
-                color=color, linewidth=1.8, alpha=0.8,
+                color=color, linewidth=lw, alpha=0.8,
             )
 
         if "ego_agent_future" in data_cpu:
@@ -318,21 +575,21 @@ class TrajectoryRanker:
 
         ax_speed.set_ylabel("Speed (km/h)")
         ax_speed.set_ylim(0, 80)
-        ax_speed.set_title("Speed (top-3)")
+        ax_speed.set_title("Speed (top-3 + selected)")
         ax_speed.legend(loc="upper right", fontsize=7)
         ax_speed.grid(True, alpha=0.3)
 
         ax_curv.set_ylabel("Curvature (1/m)")
         ax_curv.set_xlabel("Time step")
         ax_curv.set_ylim(-0.2, 0.2)
-        ax_curv.set_title("Curvature (top-3)")
+        ax_curv.set_title("Curvature (top-3 + selected)")
         ax_curv.grid(True, alpha=0.3)
         ax_curv.axhline(y=0, color="gray", linestyle="--", linewidth=0.5)
 
         fig.tight_layout()
         return fig
 
-    def _format_reward_table(self) -> str:
+    def _format_reward_table(self, selected_idx: int = 0) -> str:
         if not self.reward_breakdowns:
             return ""
 
@@ -346,21 +603,22 @@ class TrajectoryRanker:
 
         cfg = self.reward_config
         lines = [
-            "| Rank | Safety | Progress | Smooth | Feasible | Centerline | RedLight | Total | Adv | Config |",
-            "|------|--------|----------|--------|----------|------------|----------|-------|-----|--------|",
+            "| # | Rank | Safety | Progress | Smooth | Feasible | CL | RedLight | Total | Adv | Config |",
+            "|---|------|--------|----------|--------|----------|------|----------|-------|-----|--------|",
         ]
         for rank, (idx, rb, adv, st) in enumerate(rows, 1):
-            config_col = f"**[DET]**" if st.is_deterministic else st.label
-            b = "**" if st.is_deterministic else ""
-            # Show weighted values so columns add up to total
+            is_sel = (idx == selected_idx)
+            config_col = f"**[DET]**" if st.is_deterministic and st.label == "DET" else st.label
+            b = "**" if is_sel else ""
             ws = cfg.w_safety * rb.safety
             wp = cfg.w_progress * rb.progress
             wm = cfg.w_smooth * rb.smoothness
             wf = cfg.w_feasibility * rb.feasibility
             wc = cfg.w_centerline * rb.centerline
-            wr = rb.red_light  # red light is a hard gate, not weighted
+            wr = rb.red_light
+            sel_marker = ">>" if is_sel else ""
             lines.append(
-                f"| {b}{rank}{b} | {b}{ws:.1f}{b} | {b}{wp:.1f}{b} | "
+                f"| {b}{sel_marker}#{idx+1}{b} | {b}{rank}{b} | {b}{ws:.1f}{b} | {b}{wp:.1f}{b} | "
                 f"{b}{wm:.1f}{b} | {b}{wf:.1f}{b} | "
                 f"{b}{wc:.1f}{b} | {b}{wr:.1f}{b} | "
                 f"{b}{rb.total:.1f}{b} | {b}{adv:+.2f}{b} | {config_col} |"
@@ -368,7 +626,6 @@ class TrajectoryRanker:
         return "\n".join(lines)
 
     def save_current_scene(self, save_dir: str, zoom: int = 5, time_step: int = 40) -> str:
-        """Append current scene trajectories + rewards to a dump file, and save plot image."""
         if not self.sampled_trajectories or self.current_data is None:
             return "Nothing to save"
 
@@ -376,8 +633,6 @@ class TrajectoryRanker:
         save_path.mkdir(parents=True, exist_ok=True)
 
         save_idx = len(self.saved_scenes)
-
-        # Save the trajectory plot as image
         view_range = 100 - (int(zoom) - 1) * 90 / 9
         fig = self._create_trajectory_plot(time_step=int(time_step), view_range=view_range)
         img_path = save_path / f"scene_{save_idx}_idx{self.current_index}.png"
@@ -391,6 +646,18 @@ class TrajectoryRanker:
             "labels": [st.label for st in self.sampled_trajectories],
             "noise_scales": [st.noise_scale for st in self.sampled_trajectories],
             "is_deterministic": [st.is_deterministic for st in self.sampled_trajectories],
+            "slot_configs": [
+                {
+                    "noise_scale": s.noise_scale,
+                    "global_guidance_scale": s.global_guidance_scale,
+                    "is_deterministic": s.is_deterministic,
+                    "guidance": {
+                        name: {"enabled": en, "scale": sc}
+                        for name, (en, sc, _) in s.guidance.items() if en
+                    },
+                }
+                for s in self.slot_configs
+            ],
             "rewards": {
                 "safety": [rb.safety for rb in self.reward_breakdowns],
                 "progress": [rb.progress for rb in self.reward_breakdowns],
@@ -403,13 +670,6 @@ class TrajectoryRanker:
                 "off_road_fraction": [rb.off_road_fraction for rb in self.reward_breakdowns],
             },
             "advantages": self.advantages.tolist(),
-            "reward_config": {
-                "w_safety": self.reward_config.w_safety,
-                "w_progress": self.reward_config.w_progress,
-                "w_smooth": self.reward_config.w_smooth,
-                "w_feasibility": self.reward_config.w_feasibility,
-                "w_centerline": self.reward_config.w_centerline,
-            },
         }
         self.saved_scenes.append(scene_data)
 
@@ -419,23 +679,16 @@ class TrajectoryRanker:
             s = dict(sc)
             s["trajectories"] = sc["trajectories"].tolist()
             serializable.append(s)
-
         with open(dump_path, "w") as f:
             json.dump(serializable, f, indent=2)
 
         return f"Saved scene {self.current_index} ({len(self.saved_scenes)} total) -> {img_path.name}"
 
     def accept_current_group(self) -> str:
-        """Accept the current scene's trajectory group for GRPO training.
-
-        Returns a status message.
-        """
         if not self.sampled_trajectories or self.current_data is None:
             return "Nothing to accept (no trajectories loaded)"
-
         if np.all(self.advantages == 0):
             return "Skipped: all advantages are zero (no gradient signal)"
-
         self.accepted_groups.append({
             "npz_path": self.npz_paths[self.current_index],
             "data": self.current_data,
@@ -449,7 +702,6 @@ class TrajectoryRanker:
         )
 
     def clear_accepted_groups(self) -> str:
-        """Clear all accepted groups."""
         count = len(self.accepted_groups)
         self.accepted_groups.clear()
         return f"Cleared {count} groups"
@@ -463,18 +715,14 @@ def build_interface(
     ranker: TrajectoryRanker,
     trainer=None,
 ) -> gr.Blocks:
-    """Build Gradio interface.
-
-    Args:
-        ranker: TrajectoryRanker instance.
-        trainer: Optional GRPOTrainer. When provided, training controls are shown.
-            When None, the GUI is visualization-only.
-    """
     training_enabled = trainer is not None
     title = "Trajectory Ranker + GRPO" if training_enabled else "Trajectory Ranker"
 
     with gr.Blocks(title=title) as demo:
         gr.Markdown(f"# {title}")
+
+        # Hidden state for selected trajectory index
+        selected_state = gr.State(value=0)
 
         with gr.Row():
             # --- Left sidebar ---
@@ -489,72 +737,33 @@ def build_interface(
                     btn_p30 = gr.Button("30->", size="sm")
                 with gr.Row():
                     btn_shuffle = gr.Button("Shuffle", size="sm")
-                    btn_regen = gr.Button("Re-do", size="sm")
+                    btn_regen_all = gr.Button("Re-do All", size="sm")
                 jump_input = gr.Number(
-                    label="Jump to index", value=0, minimum=0, precision=0
+                    label="Jump to index", value=0, minimum=0, precision=0,
                 )
-
-                gr.Markdown("### Noise")
                 n_traj_sl = gr.Slider(
-                    2, 64, value=8, step=1, label="N trajectories"
+                    4, 32, value=ranker.n_trajectories, step=1, label="N trajectories",
                 )
-                noise_lo = gr.Slider(
-                    0.0, 5.0, value=0.5, step=0.1, label="Noise min"
-                )
-                noise_hi = gr.Slider(
-                    0.0, 5.0, value=4.0, step=0.1, label="Noise max"
-                )
-
-                gr.Markdown("### Guidance")
-                enable_guidance_cb = gr.Checkbox(
-                    value=True, label="Enable guidance (random per trajectory)"
-                )
-                guidance_prob_sl = gr.Slider(
-                    0.0, 1.0, value=0.5, step=0.05,
-                    label="Per-type inclusion probability",
-                )
-                guidance_scale_sl = gr.Slider(
-                    0.1, 5.0, value=2.0, step=0.1,
-                    label="Guidance scale max",
-                )
-                gr.Markdown("**Guidance types in random pool:**")
-                cb_centerline = gr.Checkbox(value=False, label="Centerline following")
-                cb_anchor = gr.Checkbox(value=False, label="Anchor following")
-                cb_collision = gr.Checkbox(value=False, label="Collision")
-                cb_route = gr.Checkbox(value=True, label="Route following")
-                cb_lane = gr.Checkbox(value=True, label="Lane keeping")
-                cb_road_border = gr.Checkbox(value=True, label="Road border")
-                cb_speed = gr.Checkbox(value=True, label="Speed (GT cap)")
 
                 gr.Markdown("### Reward Weights")
-                w_safety = gr.Slider(
-                    0.0, 20.0, value=5.0, step=0.5, label="w_safety"
-                )
-                w_progress = gr.Slider(
-                    0.0, 10.0, value=2.0, step=0.1, label="w_progress"
-                )
-                w_smooth = gr.Slider(
-                    0.0, 10.0, value=0.5, step=0.1, label="w_smooth"
-                )
-                w_feasibility = gr.Slider(
-                    0.0, 10.0, value=5.0, step=0.1, label="w_feasibility"
-                )
-                w_centerline = gr.Slider(
-                    0.0, 10.0, value=5.0, step=0.1, label="w_centerline"
-                )
-
-                gr.Markdown("### Prototypes")
-                proto_path = gr.Textbox(
-                    label="Prototypes path",
-                    value=ranker.sampler_config.prototypes_path or "",
-                )
-                btn_regen_protos = gr.Button("Regen Protos", size="sm")
+                w_safety = gr.Slider(0.0, 20.0, value=5.0, step=0.5, label="w_safety")
+                w_progress = gr.Slider(0.0, 10.0, value=2.0, step=0.1, label="w_progress")
+                w_smooth = gr.Slider(0.0, 10.0, value=0.5, step=0.1, label="w_smooth")
+                w_feasibility = gr.Slider(0.0, 10.0, value=5.0, step=0.1, label="w_feasibility")
+                w_centerline = gr.Slider(0.0, 10.0, value=5.0, step=0.1, label="w_centerline")
 
                 gr.Markdown("### Display")
                 zoom_sl = gr.Slider(1, 10, value=5, step=1, label="Zoom")
                 time_sl = gr.Slider(0, 79, value=40, step=1, label="Time step")
 
-            # --- Main content ---
+                gr.Markdown("### Prototypes")
+                proto_path = gr.Textbox(
+                    label="Prototypes path",
+                    value=ranker.prototypes_path or "",
+                )
+                btn_regen_protos = gr.Button("Regen Protos", size="sm")
+
+            # --- Center content ---
             with gr.Column(scale=2):
                 traj_plot = gr.Plot(label="Trajectories")
                 reward_table = gr.Markdown("")
@@ -570,82 +779,174 @@ def build_interface(
                     speed_curv_plot = gr.Plot(label="Speed & Curvature")
                 sample_info = gr.Markdown("Scene -- / --")
 
-                # --- GRPO Training Controls (only when trainer is provided) ---
+                # GRPO Training Controls
                 if training_enabled:
                     with gr.Accordion("GRPO Training", open=True):
                         with gr.Row():
-                            btn_accept = gr.Button(
-                                "Accept Group", variant="primary", size="sm",
-                            )
+                            btn_accept = gr.Button("Accept Group", variant="primary", size="sm")
                             btn_skip = gr.Button("Skip", size="sm")
-                            btn_clear_queue = gr.Button(
-                                "Clear Queue", size="sm",
-                            )
+                            btn_clear_queue = gr.Button("Clear Queue", size="sm")
                         queue_status = gr.Markdown("0 groups queued")
-
                         gr.Markdown("### Training Parameters")
                         with gr.Row():
-                            beta_sl = gr.Slider(
-                                0.0, 1.0, value=0.1, step=0.01,
-                                label="KL beta",
-                            )
-                            lr_sl = gr.Slider(
-                                1e-6, 1e-3, value=1e-5, step=1e-6,
-                                label="Learning rate",
-                            )
-                            accum_sl = gr.Slider(
-                                1, 16, value=4, step=1,
-                                label="Grad accum groups",
-                            )
-
+                            beta_sl = gr.Slider(0.0, 1.0, value=0.1, step=0.01, label="KL beta")
+                            lr_sl = gr.Slider(1e-6, 1e-3, value=1e-5, step=1e-6, label="Learning rate")
+                            accum_sl = gr.Slider(1, 16, value=4, step=1, label="Grad accum groups")
                         with gr.Row():
-                            btn_train = gr.Button(
-                                "Train on Queued Groups", variant="primary",
-                            )
-                            epoch_display = gr.Number(
-                                value=0, label="Current epoch",
-                                interactive=False,
-                            )
+                            btn_train = gr.Button("Train on Queued Groups", variant="primary")
+                            epoch_display = gr.Number(value=0, label="Current epoch", interactive=False)
                         train_log = gr.Markdown("No training yet.")
 
-        # --- Input lists (order matters for positional unpacking) ---
-        sampler_inputs = [
-            n_traj_sl, noise_lo, noise_hi,                          # 0-2
-            enable_guidance_cb, guidance_prob_sl, guidance_scale_sl, # 3-5
-            cb_centerline, cb_anchor, cb_collision, cb_route, cb_lane,  # 6-10
-            cb_road_border, cb_speed,                                # 11-12
-            proto_path,                                              # 13
-        ]
-        reward_inputs = [w_safety, w_progress, w_smooth, w_feasibility, w_centerline]  # 12-16
-        display_inputs = [zoom_sl, time_sl]                              # 17-18
-        all_inputs = sampler_inputs + reward_inputs + display_inputs
-        N_SAMPLER = len(sampler_inputs)
-        N_REWARD = len(reward_inputs)
-        outputs = [traj_plot, reward_table, speed_curv_plot, sample_info]
+            # --- Right sidebar: per-trajectory editor ---
+            with gr.Column(scale=1):
+                gr.Markdown("### Trajectory Editor")
+                traj_dropdown = gr.Dropdown(
+                    choices=[f"#{i+1}" for i in range(ranker.n_trajectories)],
+                    value="#1",
+                    label="Select trajectory",
+                    interactive=True,
+                )
+                config_summary = gr.Markdown("*Select a trajectory to edit*")
 
-        def _apply_sampler_config(
-            n_traj, ns_lo, ns_hi,
-            enable_guidance, guidance_prob, gs_max,
-            use_cl, use_anchor, use_col, use_route, use_lane,
-            use_rb, use_speed,
-            p_path,
-        ):
-            ranker.sampler_config = SamplerConfig(
-                n_trajectories=int(n_traj),
-                noise_scale_range=(float(ns_lo), float(ns_hi)),
-                guidance_scale_range=(0.1, float(gs_max)),
-                enable_guidance=bool(enable_guidance),
-                guidance_prob=float(guidance_prob),
-                enable_centerline=bool(use_cl),
-                enable_anchor=bool(use_anchor),
-                enable_collision=bool(use_col),
-                enable_route_following=bool(use_route),
-                enable_lane_keeping=bool(use_lane),
-                enable_road_border=bool(use_rb),
-                enable_speed=bool(use_speed),
-                prototypes_path=p_path if p_path else None,
+                gr.Markdown("---")
+                noise_sl = gr.Slider(0.0, 2.0, value=0.0, step=0.05, label="Noise scale")
+                global_g_sl = gr.Slider(0.1, 5.0, value=1.0, step=0.1, label="Global guidance scale")
+                det_cb = gr.Checkbox(value=True, label="Deterministic (noise=0)")
+
+                gr.Markdown("#### Guidance Functions")
+                # 9 guidance types: each gets a checkbox + scale slider
+                cb_cl = gr.Checkbox(value=False, label="Centerline following")
+                sl_cl = gr.Slider(0.1, 15.0, value=5.0, step=0.1, label="CL scale")
+
+                cb_spd = gr.Checkbox(value=False, label="Speed (GT cap)")
+                sl_spd = gr.Slider(0.1, 15.0, value=5.0, step=0.1, label="SPD scale")
+
+                cb_lk = gr.Checkbox(value=False, label="Lane keeping")
+                sl_lk = gr.Slider(0.1, 15.0, value=5.0, step=0.1, label="LK scale")
+
+                cb_rb = gr.Checkbox(value=False, label="Road border")
+                sl_rb = gr.Slider(0.1, 5.0, value=1.0, step=0.1, label="RB scale")
+
+                cb_rf = gr.Checkbox(value=False, label="Route following")
+                sl_rf = gr.Slider(0.1, 5.0, value=1.0, step=0.1, label="RF scale")
+
+                cb_col = gr.Checkbox(value=False, label="Collision")
+                sl_col = gr.Slider(0.1, 1.0, value=0.5, step=0.05, label="COL scale")
+
+                cb_anc = gr.Checkbox(value=False, label="Anchor following")
+                sl_anc = gr.Slider(0.1, 5.0, value=1.0, step=0.1, label="ANC scale")
+
+                cb_lat = gr.Checkbox(value=False, label="Lateral")
+                sl_lat = gr.Slider(0.1, 5.0, value=1.0, step=0.1, label="LAT scale")
+                eta_lat = gr.Slider(-1.0, 1.0, value=0.0, step=0.05, label="LAT eta (offset direction)")
+
+                cb_lon = gr.Checkbox(value=False, label="Longitudinal")
+                sl_lon = gr.Slider(0.1, 5.0, value=1.0, step=0.1, label="LON scale")
+                eta_lon = gr.Slider(-1.0, 1.0, value=0.0, step=0.05, label="LON eta (speed direction)")
+
+                gr.Markdown("---")
+                btn_regen_single = gr.Button(
+                    "Regenerate This Trajectory", variant="primary", size="sm",
+                )
+
+        # --- Component lists for callbacks ---
+        editor_guidance_components = [
+            cb_cl, sl_cl, cb_spd, sl_spd, cb_lk, sl_lk,
+            cb_rb, sl_rb, cb_rf, sl_rf, cb_col, sl_col,
+            cb_anc, sl_anc, cb_lat, sl_lat, eta_lat, cb_lon, sl_lon, eta_lon,
+        ]
+        editor_components = [noise_sl, global_g_sl, det_cb] + editor_guidance_components
+        reward_inputs = [w_safety, w_progress, w_smooth, w_feasibility, w_centerline]
+        display_inputs = [zoom_sl, time_sl]
+        main_outputs = [traj_plot, reward_table, speed_curv_plot, sample_info]
+
+        # --- Helper: parse selected index from dropdown ---
+        def _parse_dropdown(choice_str: str) -> int:
+            try:
+                return int(choice_str.split("#")[1].split(" ")[0]) - 1
+            except (IndexError, ValueError):
+                return 0
+
+        # --- Helper: populate editor from slot config ---
+        def _populate_editor(slot: TrajectorySlotConfig):
+            g = slot.guidance
+            lat_params = g.get("lateral", (False, 1.0, {}))[2]
+            lon_params = g.get("longitudinal", (False, 1.0, {}))[2]
+            return (
+                slot.noise_scale,
+                slot.global_guidance_scale,
+                slot.is_deterministic,
+                g.get("centerline_following", (False, 1.0, {}))[0],
+                g.get("centerline_following", (False, 5.0, {}))[1],
+                g.get("speed", (False, 1.0, {}))[0],
+                g.get("speed", (False, 5.0, {}))[1],
+                g.get("lane_keeping", (False, 1.0, {}))[0],
+                g.get("lane_keeping", (False, 5.0, {}))[1],
+                g.get("road_border", (False, 1.0, {}))[0],
+                g.get("road_border", (False, 1.0, {}))[1],
+                g.get("route_following", (False, 1.0, {}))[0],
+                g.get("route_following", (False, 1.0, {}))[1],
+                g.get("collision", (False, 1.0, {}))[0],
+                g.get("collision", (False, 1.0, {}))[1],
+                g.get("anchor_following", (False, 1.0, {}))[0],
+                g.get("anchor_following", (False, 1.0, {}))[1],
+                g.get("lateral", (False, 1.0, {}))[0],
+                g.get("lateral", (False, 1.0, {}))[1],
+                lat_params.get("eta_lat", 0.0),
+                g.get("longitudinal", (False, 1.0, {}))[0],
+                g.get("longitudinal", (False, 1.0, {}))[1],
+                lon_params.get("eta_lon", 0.0),
             )
 
+        # --- Helper: read editor into slot config ---
+        def _read_editor_into_slot(
+            noise_val, global_g_val, is_det,
+            cl_on, cl_s, spd_on, spd_s, lk_on, lk_s,
+            rb_on, rb_s, rf_on, rf_s, col_on, col_s,
+            anc_on, anc_s, lat_on, lat_s, eta_lat_val, lon_on, lon_s, eta_lon_val,
+        ) -> TrajectorySlotConfig:
+            slot = TrajectorySlotConfig(
+                noise_scale=float(noise_val),
+                global_guidance_scale=float(global_g_val),
+                is_deterministic=bool(is_det),
+            )
+            slot.guidance["centerline_following"] = (bool(cl_on), float(cl_s), {})
+            slot.guidance["speed"] = (bool(spd_on), float(spd_s), {})
+            slot.guidance["lane_keeping"] = (bool(lk_on), float(lk_s), {})
+            slot.guidance["road_border"] = (bool(rb_on), float(rb_s), {})
+            slot.guidance["route_following"] = (bool(rf_on), float(rf_s), {})
+            slot.guidance["collision"] = (bool(col_on), float(col_s), {})
+            slot.guidance["anchor_following"] = (bool(anc_on), float(anc_s), {})
+            slot.guidance["lateral"] = (bool(lat_on), float(lat_s), {
+                "eta_lat": float(eta_lat_val), "lambda_lat": 3.0,
+            })
+            slot.guidance["longitudinal"] = (bool(lon_on), float(lon_s), {
+                "eta_lon": float(eta_lon_val), "lambda_lon": 0.5,
+            })
+            return slot
+
+        # --- Helper: format config summary ---
+        def _config_summary_md(idx: int) -> str:
+            if idx >= len(ranker.slot_configs):
+                return ""
+            slot = ranker.slot_configs[idx]
+            lines = [f"**Trajectory #{idx + 1}**"]
+            lines.append(f"- Noise: {slot.noise_scale:.2f}")
+            lines.append(f"- Global scale: {slot.global_guidance_scale:.2f}")
+            lines.append(f"- Deterministic: {slot.is_deterministic}")
+            active = [(n, s) for n, (en, s, _) in slot.guidance.items() if en]
+            if active:
+                lines.append("- Active guidance:")
+                for name, scale in active:
+                    lines.append(f"  - {name}: {scale:.1f}")
+            else:
+                lines.append("- No guidance")
+            if idx < len(ranker.reward_breakdowns):
+                rb = ranker.reward_breakdowns[idx]
+                lines.append(f"- **Reward: {rb.total:.1f}**")
+            return "\n".join(lines)
+
+        # --- Render helpers ---
         def _apply_reward_config(ws, wp, wm, wf, wc):
             ranker.reward_config = RewardConfig(
                 w_safety=float(ws),
@@ -655,39 +956,48 @@ def build_interface(
                 w_centerline=float(wc),
             )
 
-        def _render(zoom, ts):
+        def _render(sel_idx, zoom, ts):
             view_range = 100 - (int(zoom) - 1) * 90 / 9
             traj_fig = ranker._create_trajectory_plot(
-                time_step=int(ts), view_range=view_range
+                time_step=int(ts), view_range=view_range, selected_idx=int(sel_idx),
             )
-            table = ranker._format_reward_table()
-            sc_fig = ranker._create_speed_curvature_plot()
+            table = ranker._format_reward_table(selected_idx=int(sel_idx))
+            sc_fig = ranker._create_speed_curvature_plot(selected_idx=int(sel_idx))
             info = f"Scene {ranker.current_index + 1} / {len(ranker.npz_paths)}"
             return traj_fig, table, sc_fig, info
 
-        def _full_run(*args):
-            sampler_args = args[:N_SAMPLER]
-            reward_args = args[N_SAMPLER:N_SAMPLER + N_REWARD]
-            display_args = args[N_SAMPLER + N_REWARD:]
-            _apply_sampler_config(*sampler_args)
-            _apply_reward_config(*reward_args)
+        def _dropdown_choices():
+            return _format_dropdown_choices(ranker.slot_configs, ranker.reward_breakdowns)
+
+        # --- Full run: load scene, generate all, render ---
+        def _full_run(n_traj, ws, wp, wm, wf, wc, zoom, ts):
+            ranker.n_trajectories = int(n_traj)
+            _apply_reward_config(ws, wp, wm, wf, wc)
             ranker.load_sample()
-            return _render(*display_args)
+            sel_idx = 0
+            renders = _render(sel_idx, zoom, ts)
+            choices = _dropdown_choices()
+            editor_vals = _populate_editor(ranker.slot_configs[0]) if ranker.slot_configs else _populate_editor(TrajectorySlotConfig())
+            summary = _config_summary_md(0)
+            return (
+                sel_idx,                                    # selected_state
+                gr.update(choices=choices, value=choices[0] if choices else "#1"),  # dropdown
+                summary,                                    # config_summary
+                *editor_vals,                               # editor components (21 values)
+                *renders,                                   # plot, table, speed_curv, info
+            )
 
-        def _rescore_and_render(*args):
-            reward_args = args[N_SAMPLER:N_SAMPLER + N_REWARD]
-            display_args = args[N_SAMPLER + N_REWARD:]
-            _apply_reward_config(*reward_args)
-            ranker._score_trajectories()
-            return _render(*display_args)
+        full_run_inputs = [n_traj_sl] + reward_inputs + display_inputs
+        full_run_outputs = (
+            [selected_state, traj_dropdown, config_summary]
+            + editor_components
+            + main_outputs
+        )
 
-        def _display_only(*args):
-            display_args = args[N_SAMPLER + N_REWARD:]
-            return _render(*display_args)
-
+        # --- Navigation ---
         def _nav(delta, *args):
             ranker.current_index = max(
-                0, min(len(ranker.npz_paths) - 1, ranker.current_index + delta)
+                0, min(len(ranker.npz_paths) - 1, ranker.current_index + delta),
             )
             return _full_run(*args)
 
@@ -698,10 +1008,99 @@ def build_interface(
 
         def _jump(idx, *args):
             ranker.current_index = max(
-                0, min(len(ranker.npz_paths) - 1, int(idx))
+                0, min(len(ranker.npz_paths) - 1, int(idx)),
             )
             return _full_run(*args)
 
+        for delta, btn in [
+            (-30, btn_m30), (-10, btn_m10), (-1, btn_m1),
+            (1, btn_p1), (10, btn_p10), (30, btn_p30),
+        ]:
+            btn.click(
+                functools.partial(_nav, delta),
+                inputs=full_run_inputs, outputs=full_run_outputs,
+            )
+        btn_shuffle.click(_shuffle, inputs=full_run_inputs, outputs=full_run_outputs)
+        btn_regen_all.click(_full_run, inputs=full_run_inputs, outputs=full_run_outputs)
+        jump_input.submit(
+            _jump, inputs=[jump_input] + full_run_inputs, outputs=full_run_outputs,
+        )
+
+        # N trajectories slider -> full regen
+        n_traj_sl.release(_full_run, inputs=full_run_inputs, outputs=full_run_outputs)
+
+        # --- Select trajectory from dropdown ---
+        def _on_select(choice_str, zoom, ts):
+            idx = _parse_dropdown(choice_str)
+            if idx >= len(ranker.slot_configs):
+                idx = 0
+            editor_vals = _populate_editor(ranker.slot_configs[idx])
+            summary = _config_summary_md(idx)
+            renders = _render(idx, zoom, ts)
+            return (idx, summary, *editor_vals, *renders)
+
+        select_outputs = (
+            [selected_state, config_summary]
+            + editor_components
+            + main_outputs
+        )
+        traj_dropdown.change(
+            _on_select,
+            inputs=[traj_dropdown] + display_inputs,
+            outputs=select_outputs,
+        )
+
+        # --- Regenerate single trajectory ---
+        def _regen_single(sel_idx, zoom, ts, *editor_args):
+            idx = int(sel_idx)
+            slot = _read_editor_into_slot(*editor_args)
+            if idx < len(ranker.slot_configs):
+                ranker.slot_configs[idx] = slot
+                ranker.regenerate_single(idx)
+            # Update renders and dropdown
+            renders = _render(idx, zoom, ts)
+            choices = _dropdown_choices()
+            summary = _config_summary_md(idx)
+            return (
+                gr.update(choices=choices, value=choices[idx] if idx < len(choices) else choices[0]),
+                summary,
+                *renders,
+            )
+
+        regen_single_outputs = [traj_dropdown, config_summary] + main_outputs
+        btn_regen_single.click(
+            _regen_single,
+            inputs=[selected_state] + display_inputs + editor_components,
+            outputs=regen_single_outputs,
+        )
+
+        # --- Reward weight changes -> rescore only ---
+        def _rescore_and_render(sel_idx, ws, wp, wm, wf, wc, zoom, ts):
+            _apply_reward_config(ws, wp, wm, wf, wc)
+            ranker._score_trajectories()
+            renders = _render(int(sel_idx), zoom, ts)
+            choices = _dropdown_choices()
+            current_idx = int(sel_idx)
+            return (
+                gr.update(choices=choices, value=choices[current_idx] if current_idx < len(choices) else choices[0]),
+                *renders,
+            )
+
+        rescore_inputs = [selected_state] + reward_inputs + display_inputs
+        rescore_outputs = [traj_dropdown] + main_outputs
+        for sl in reward_inputs:
+            sl.release(_rescore_and_render, inputs=rescore_inputs, outputs=rescore_outputs)
+            sl.change(_rescore_and_render, inputs=rescore_inputs, outputs=rescore_outputs)
+
+        # --- Display changes -> rerender only ---
+        def _display_only(sel_idx, zoom, ts):
+            return _render(int(sel_idx), zoom, ts)
+
+        display_only_inputs = [selected_state] + display_inputs
+        for sl in display_inputs:
+            sl.release(_display_only, inputs=display_only_inputs, outputs=main_outputs)
+
+        # --- Prototypes ---
         def _regen_protos(p_path):
             if not p_path:
                 p_path = _DEFAULT_PROTOTYPES_PATH
@@ -724,39 +1123,8 @@ def build_interface(
             except subprocess.TimeoutExpired:
                 return "Timeout generating prototypes"
 
-        # --- Wire events ---
-        for delta, btn in [
-            (-30, btn_m30), (-10, btn_m10), (-1, btn_m1),
-            (1, btn_p1), (10, btn_p10), (30, btn_p30),
-        ]:
-            btn.click(
-                functools.partial(_nav, delta),
-                inputs=all_inputs, outputs=outputs,
-            )
-
-        btn_shuffle.click(_shuffle, inputs=all_inputs, outputs=outputs)
-        btn_regen.click(_full_run, inputs=all_inputs, outputs=outputs)
-        jump_input.submit(
-            _jump, inputs=[jump_input] + all_inputs, outputs=outputs
-        )
-
-        # Sampler param changes -> full regeneration
-        for sl in [n_traj_sl, noise_lo, noise_hi, guidance_prob_sl, guidance_scale_sl]:
-            sl.release(_full_run, inputs=all_inputs, outputs=outputs)
-        for cb in [enable_guidance_cb, cb_centerline, cb_anchor, cb_collision, cb_route, cb_lane, cb_road_border, cb_speed]:
-            cb.change(_full_run, inputs=all_inputs, outputs=outputs)
-
-        # Reward weight changes -> rescore only (both release and change for responsiveness)
-        for sl in [w_safety, w_progress, w_smooth, w_feasibility, w_centerline]:
-            sl.release(_rescore_and_render, inputs=all_inputs, outputs=outputs)
-            sl.change(_rescore_and_render, inputs=all_inputs, outputs=outputs)
-
-        # Display changes -> rerender only
-        for sl in [zoom_sl, time_sl]:
-            sl.release(_display_only, inputs=all_inputs, outputs=outputs)
-
         btn_regen_protos.click(
-            _regen_protos, inputs=[proto_path], outputs=[sample_info]
+            _regen_protos, inputs=[proto_path], outputs=[sample_info],
         )
 
         btn_save.click(
@@ -769,100 +1137,83 @@ def build_interface(
             _grpo_epoch_counter = [0]
 
             def _accept_and_advance(*args):
+                # args = full_run_inputs
                 msg = ranker.accept_current_group()
-                # Auto-advance to next scene
                 ranker.current_index = min(
-                    len(ranker.npz_paths) - 1, ranker.current_index + 1
+                    len(ranker.npz_paths) - 1, ranker.current_index + 1,
                 )
-                render_out = _full_run(*args)
-                return (msg, *render_out)
+                full_out = _full_run(*args)
+                return (msg, *full_out)
 
             def _skip_and_advance(*args):
                 ranker.current_index = min(
-                    len(ranker.npz_paths) - 1, ranker.current_index + 1
+                    len(ranker.npz_paths) - 1, ranker.current_index + 1,
                 )
-                render_out = _full_run(*args)
+                full_out = _full_run(*args)
                 msg = f"Skipped. {len(ranker.accepted_groups)} groups queued"
-                return (msg, *render_out)
+                return (msg, *full_out)
 
             def _clear_queue():
                 return ranker.clear_accepted_groups()
 
             def _train_epoch(beta_val, lr_val, accum_val, *args):
                 if not ranker.accepted_groups:
-                    empty_render = _render(
-                        *args[N_SAMPLER + N_REWARD:]
-                    ) if args else (None, "", None, "")
                     return (
                         "No groups queued. Accept some scenes first.",
                         _grpo_epoch_counter[0],
-                        *empty_render,
                     )
 
-                # Update trainer params from GUI sliders
                 trainer.beta = float(beta_val)
                 trainer.grad_accum_groups = int(accum_val)
-
-                # Update learning rate
                 for pg in trainer.optimizer.param_groups:
                     pg["lr"] = float(lr_val)
 
                 _grpo_epoch_counter[0] += 1
                 epoch = _grpo_epoch_counter[0]
 
-                # Save baselines on first epoch
                 if epoch == 1:
                     npz_paths = [g["npz_path"] for g in ranker.accepted_groups]
                     trainer.save_epoch1_baselines(npz_paths)
 
                 groups = list(ranker.accepted_groups)
                 metrics = trainer.train_on_groups(groups, epoch)
-
-                # Drift tracking
                 drift = trainer.compute_trajectory_drift()
                 trainer.log_metrics(epoch, metrics)
                 trainer.save_checkpoint(epoch, {})
-
-                # Clear the queue after training
                 ranker.accepted_groups.clear()
 
                 log_lines = [
-                    f"**Epoch {epoch}** — trained on {len(groups)} groups",
+                    f"**Epoch {epoch}** -- trained on {len(groups)} groups",
                     f"- Loss: {metrics.get('loss', 0):.4f}",
                     f"- Policy loss: {metrics.get('policy_loss', 0):.4f}",
                     f"- KL loss: {metrics.get('kl_loss', 0):.4f}",
                 ]
                 if drift:
                     log_lines.append(f"- {drift}")
-                log_lines.append(f"\nQueue cleared. Regenerating current scene with updated model...")
+                log_lines.append(f"\nQueue cleared.")
 
-                # Regenerate current scene with the updated model (now in eval mode)
-                render_out = _full_run(*args) if args else (None, "", None, "")
-
-                return ("\n".join(log_lines), epoch, *render_out)
+                return ("\n".join(log_lines), epoch)
 
             btn_accept.click(
                 _accept_and_advance,
-                inputs=all_inputs,
-                outputs=[queue_status] + outputs,
+                inputs=full_run_inputs,
+                outputs=[queue_status] + full_run_outputs,
             )
             btn_skip.click(
                 _skip_and_advance,
-                inputs=all_inputs,
-                outputs=[queue_status] + outputs,
+                inputs=full_run_inputs,
+                outputs=[queue_status] + full_run_outputs,
             )
             btn_clear_queue.click(
-                _clear_queue,
-                inputs=[],
-                outputs=[queue_status],
+                _clear_queue, inputs=[], outputs=[queue_status],
             )
             btn_train.click(
                 _train_epoch,
-                inputs=[beta_sl, lr_sl, accum_sl] + all_inputs,
-                outputs=[train_log, epoch_display] + outputs,
+                inputs=[beta_sl, lr_sl, accum_sl],
+                outputs=[train_log, epoch_display],
             )
 
-        demo.load(_full_run, inputs=all_inputs, outputs=outputs)
+        demo.load(_full_run, inputs=full_run_inputs, outputs=full_run_outputs)
 
     return demo
 
@@ -880,11 +1231,10 @@ def main():
                         help="Path to prototypes .npy (auto-generated from npz_list if omitted)")
     parser.add_argument("--regen-prototypes", action="store_true",
                         help="Force regenerate prototypes from npz_list even if cached file exists")
-    parser.add_argument("--n_trajectories", type=int, default=8)
+    parser.add_argument("--n_trajectories", type=int, default=16)
     parser.add_argument("--port", type=int, default=7862)
     parser.add_argument("--share", action="store_true")
 
-    # Training controls
     parser.add_argument("--no-training", action="store_true",
                         help="Disable GRPO training controls (visualization-only mode)")
     parser.add_argument("--config", type=Path, default=None,
@@ -905,7 +1255,6 @@ def main():
         npz_paths = json.load(f)
     print(f"Loaded {len(npz_paths)} samples")
 
-    # Resolve prototypes: explicit path > default cached > auto-generate
     if args.prototypes:
         prototypes_path = str(args.prototypes)
     else:
@@ -918,7 +1267,6 @@ def main():
     )
     print(f"Prototypes: {prototypes_path}")
 
-    # Setup GRPO trainer (unless --no-training)
     grpo_trainer = None
     if not args.no_training:
         from rlvr.grpo_config import GRPOConfig
@@ -930,7 +1278,6 @@ def main():
             grpo_cfg = GRPOConfig()
             print("Using default GRPOConfig (on-policy: M=1)")
 
-        # CLI --use_lora overrides config
         if args.use_lora:
             grpo_cfg.use_lora = True
 
@@ -981,8 +1328,8 @@ def main():
         npz_paths=npz_paths,
         npz_list_path=str(args.npz_list),
         prototypes_path=prototypes_path,
+        n_trajectories=args.n_trajectories,
     )
-    ranker.sampler_config.n_trajectories = args.n_trajectories
 
     demo = build_interface(ranker, trainer=grpo_trainer)
     demo.launch(server_port=args.port, share=args.share, inbrowser=True)


### PR DESCRIPTION
Rewrite trajectory ranker GUI with per-trajectory editing:
- Each trajectory shows its exact guidance config (types, scales, noise)
- Dropdown to select any trajectory, sliders to edit its config
- Single-trajectory regeneration without regenerating all 16
- Selected trajectory highlighted on plot with outline and star marker
- Initial generation matches batched GRPO sampler strategy (K=16)
- Lateral/longitudinal guidance with eta sliders and reference trajectory

Update GRPO sampling defaults from guidance tuning:
- Noise scale range: (0.5, 4.0) -> (0.5, 2.0), reduces useless large trajs
- Collision scale range: (0.5, 2.0) -> (0.1, 1.0)