### PR TITLE
feat: per-epoch scheduling for reward weights and guidance

### DIFF
--- a/rlvr/README.md
+++ b/rlvr/README.md
@@ -41,10 +41,12 @@ rlvr/
                              + logprob config: grpo_loss_type, logprob_num_steps, logprob_t_start,
                                logprob_discount, logprob_min_std, il_loss_weight, il_adaptive
                              + advantage_mode: "ddv2" (inter-anchor truncated GRPO)
+                             + per-epoch scheduling: schedules dict with linear/cosine/step/peak types
   grpo_sft_trainer.py        Ranked SFT trainer: generate N trajs, pick best by reward,
                              SG-filter, train with SFT diffusion loss (ego + neighbor GT)
                              + "gt_neighbor" and "baseline_neighbor" modes
-                             + Post-hoc no_block0 trick for L2 preservation
+                             + Post-hoc no_block1 trick for L2 preservation (with neighbor reg)
+                             + Per-epoch scheduled reward weights and longitudinal guidance
   grpo_trainer.py            Standard GRPO training loop (batched loss)
                              + logprob loss path when grpo_loss_type="logprob"
   grpo_trainer_batched.py    Fully batched GRPO trainer (all scenes in ~5 forward passes)
@@ -87,6 +89,7 @@ rlvr/
     test_real_scene.py       Integration test with real NPZ scene
   test_reward.py             Unit tests for reward (no model needed)
   test_grpo_sampler.py       Unit tests for sampler (needs model for full suite)
+  test_scheduling.py         Unit tests for per-epoch scheduling (14 tests)
 ```
 
 ## Training Modes
@@ -179,10 +182,11 @@ adapted for diffusion planners with reward-based selection and Savitzky-Golay tr
 - Miraikan exit val: 25/50 → **0/50 lane departures** (with no_block0 trick)
 - Ego L2: +1.9% (baseline 5.388), Neighbor L2: +29% (baseline 4.393)
 
-*With neighbor regularization (current best):*
-- Two-stage training: S1 (50 scenes, lr=5e-4) → S2 (500 scenes, lr=1e-5)
-- **Best deployable: S1 ep7 no_blk1** — 0/50 val LD, ego +2.0%, neighbor +2.0%
-- Neighbor reg (`neighbor_reg_only=true, neighbor_reg_weight=1.0`) reduces neighbor degradation from +91% to +1.8%
+*With neighbor regularization + longitudinal guidance scheduling (current best):*
+- noise_scale_range [0.5, 2.0], gentle lon guidance (eta 0→0.3)
+- **Best deployable: S1 ep7 no_blk1** — 0/50 val LD, **15.0m path**, ego +1.4%, neighbor +1.6%
+- Without lon guidance: S1 ep3 — 0/50 val LD, 13.1m path, ego +1.0%, neighbor +0.8%
+- Neighbor reg (`neighbor_reg_only=true, neighbor_reg_weight=1.0`) reduces neighbor degradation from +91% to +1.6%
 
 **Block ablation trick:** After training with `lora_target="all"` (3 DiT blocks), zero out
 one block's LoRA weights post-hoc. With neighbor reg, **no_blk1 is best**. Without reg,

--- a/rlvr/autoresearch/run_experiment.py
+++ b/rlvr/autoresearch/run_experiment.py
@@ -445,22 +445,8 @@ def run(config_path: Path, name: str, skip_baseline: bool = False):
 
     args_dict = {"exp_name": name}
 
-    # Reward scheduling: epoch 1 uses softer w_feasibility to let model explore,
-    # epoch 2+ uses full strength to lock in on-road behavior.
-    reward_schedule = config_data_raw.get("reward_schedule", None)
-
     for epoch in range(1, grpo_config.train_epochs + 1):
         print(f"\n--- Epoch {epoch}/{grpo_config.train_epochs} ---")
-
-        # Apply reward schedule if provided
-        if reward_schedule and str(epoch) in reward_schedule:
-            sched = reward_schedule[str(epoch)]
-            for k, v in sched.items():
-                if hasattr(trainer.reward_config, k):
-                    setattr(trainer.reward_config, k, v)
-                if hasattr(train_reward_config, k):
-                    setattr(train_reward_config, k, v)
-                print(f"  [schedule] epoch {epoch}: {k}={v}")
 
         if epoch == 1 and hasattr(trainer, 'save_epoch1_baselines'):
             trainer.save_epoch1_baselines(train_paths)

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -277,7 +277,7 @@ class GRPOConfig:
     # --- Per-epoch scheduling for arbitrary parameters ---
     # Generic scheduling system for reward weights, guidance scales, etc.
     # Each entry maps a parameter name to a schedule spec:
-    #   {"type": "linear"|"cosine"|"step", "start": float, "end": float,
+    #   {"type": "constant"|"linear"|"cosine"|"step", "start": float, "end": float,
     #    "warmup_fraction": float (for "step" only, default 0.5)}
     #
     # Schedulable parameters:
@@ -431,11 +431,12 @@ class GRPOConfig:
 
         Returns dict of {name: value} for all parameters with schedules defined.
         """
-        return {
-            name: self.get_scheduled_value(name, epoch, total_epochs)
-            for name in self.schedules
-            if self.get_scheduled_value(name, epoch, total_epochs) is not None
-        }
+        result: dict[str, float] = {}
+        for name in self.schedules:
+            value = self.get_scheduled_value(name, epoch, total_epochs)
+            if value is not None:
+                result[name] = value
+        return result
 
     @property
     def uses_importance_sampling(self) -> bool:

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -277,8 +277,9 @@ class GRPOConfig:
     # --- Per-epoch scheduling for arbitrary parameters ---
     # Generic scheduling system for reward weights, guidance scales, etc.
     # Each entry maps a parameter name to a schedule spec:
-    #   {"type": "constant"|"linear"|"cosine"|"step", "start": float, "end": float,
-    #    "warmup_fraction": float (for "step" only, default 0.5)}
+    #   {"type": "constant"|"linear"|"cosine"|"step"|"peak", "start": float, "end": float,
+    #    "warmup_fraction": float (for "step" only, default 0.5),
+    #    "peak": float, "peak_fraction": float (for "peak" only, default 0.5)}
     #
     # Schedulable parameters:
     #   Reward weights: w_progress, w_safety, w_smooth, w_feasibility, w_centerline,
@@ -423,9 +424,25 @@ class GRPOConfig:
                 )
             return start if progress < warmup else end
 
+        if stype == "peak":
+            # Ramp start → peak → end. Linear interpolation on each half.
+            #   {"type": "peak", "start": 0.0, "end": 0.0, "peak": 0.3, "peak_fraction": 0.5}
+            peak_val = float(spec["peak"])
+            peak_frac = float(spec.get("peak_fraction", 0.5))
+            if not 0.0 < peak_frac < 1.0:
+                raise ValueError(
+                    f"peak_fraction for '{name}' must be in (0, 1), got {peak_frac}"
+                )
+            if progress <= peak_frac:
+                t = progress / peak_frac
+                return start + (peak_val - start) * t
+            else:
+                t = (progress - peak_frac) / (1.0 - peak_frac)
+                return peak_val + (end - peak_val) * t
+
         raise ValueError(
             f"Unknown schedule type for '{name}': {stype!r}. "
-            f"Expected 'constant', 'linear', 'cosine', or 'step'."
+            f"Expected 'constant', 'linear', 'cosine', 'step', or 'peak'."
         )
 
     def get_all_scheduled_values(

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -274,6 +274,24 @@ class GRPOConfig:
     closed_loop_online_interval: int = 0   # online explorer update every N steps (0=off, 10=PlannerRFT-style)
     closed_loop_explorer_mini_batch: int = 0  # step explorer optimizer every N scenes (0=all scenes at once)
 
+    # --- Per-epoch scheduling for arbitrary parameters ---
+    # Generic scheduling system for reward weights, guidance scales, etc.
+    # Each entry maps a parameter name to a schedule spec:
+    #   {"type": "linear"|"cosine"|"step", "start": float, "end": float,
+    #    "warmup_fraction": float (for "step" only, default 0.5)}
+    #
+    # Schedulable parameters:
+    #   Reward weights: w_progress, w_safety, w_smooth, w_feasibility, w_centerline,
+    #                   stopped_penalty, underprogress_penalty, progress_norm_scale
+    #   Guidance:       longitudinal_eta, longitudinal_lambda, longitudinal_scale
+    #
+    # Example config JSON:
+    #   "schedules": {
+    #     "w_progress": {"type": "linear", "start": 3.0, "end": 10.0},
+    #     "longitudinal_eta": {"type": "linear", "start": 0.0, "end": 1.0}
+    #   }
+    schedules: dict = field(default_factory=dict)
+
     @classmethod
     def from_json(cls, path: str | Path) -> GRPOConfig:
         """Load config from JSON file."""
@@ -364,6 +382,60 @@ class GRPOConfig:
             f"Unknown exploration_kl_schedule: {self.exploration_kl_schedule!r}. "
             f"Expected 'constant', 'linear', or 'cosine'."
         )
+
+    def get_scheduled_value(
+        self, name: str, epoch: int, total_epochs: int,
+    ) -> float | None:
+        """Get the scheduled value for a parameter at the given epoch.
+
+        Returns None if no schedule is defined for this parameter.
+        Looks up the schedule spec in self.schedules[name].
+
+        Args:
+            name: Parameter name (e.g. "w_progress", "longitudinal_eta").
+            epoch: Current epoch (1-indexed).
+            total_epochs: Total number of training epochs.
+        """
+        spec = self.schedules.get(name)
+        if spec is None:
+            return None
+
+        stype = spec.get("type", "linear")
+        start = float(spec["start"])
+        end = float(spec["end"])
+
+        if stype == "constant" or total_epochs <= 1:
+            return start
+
+        progress = (epoch - 1) / (total_epochs - 1)
+
+        if stype == "linear":
+            return start + (end - start) * progress
+
+        if stype == "cosine":
+            return end + (start - end) * 0.5 * (1.0 + math.cos(math.pi * progress))
+
+        if stype == "step":
+            warmup = float(spec.get("warmup_fraction", 0.5))
+            return start if progress < warmup else end
+
+        raise ValueError(
+            f"Unknown schedule type for '{name}': {stype!r}. "
+            f"Expected 'constant', 'linear', 'cosine', or 'step'."
+        )
+
+    def get_all_scheduled_values(
+        self, epoch: int, total_epochs: int,
+    ) -> dict[str, float]:
+        """Get all scheduled values for the given epoch.
+
+        Returns dict of {name: value} for all parameters with schedules defined.
+        """
+        return {
+            name: self.get_scheduled_value(name, epoch, total_epochs)
+            for name in self.schedules
+            if self.get_scheduled_value(name, epoch, total_epochs) is not None
+        }
 
     @property
     def uses_importance_sampling(self) -> bool:

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -417,6 +417,10 @@ class GRPOConfig:
 
         if stype == "step":
             warmup = float(spec.get("warmup_fraction", 0.5))
+            if not 0.0 <= warmup <= 1.0:
+                raise ValueError(
+                    f"warmup_fraction for '{name}' must be in [0, 1], got {warmup}"
+                )
             return start if progress < warmup else end
 
         raise ValueError(

--- a/rlvr/grpo_sft_trainer.py
+++ b/rlvr/grpo_sft_trainer.py
@@ -385,6 +385,24 @@ def train_epoch_ranked_sft(
             gt_speeds_list.append(3.0)
     median_gt_speed = float(np.median(gt_speeds_list))
 
+    # 2b. Apply per-epoch schedules to reward weights and guidance params
+    scheduled = config.get_all_scheduled_values(epoch, config.train_epochs)
+    reward_weight_names = {
+        "w_progress", "w_safety", "w_smooth", "w_feasibility", "w_centerline",
+        "stopped_penalty", "underprogress_penalty", "progress_norm_scale",
+    }
+    for name, value in scheduled.items():
+        if name in reward_weight_names and hasattr(reward_config, name):
+            setattr(reward_config, name, value)
+    if scheduled:
+        sched_str = ", ".join(f"{k}={v:.3f}" for k, v in scheduled.items())
+        print(f"  [schedule] epoch {epoch}: {sched_str}")
+
+    # Extract longitudinal guidance params from schedule (default: off)
+    lon_eta = scheduled.get("longitudinal_eta", 0.0)
+    lon_lambda = scheduled.get("longitudinal_lambda", config.lambda_lon)
+    lon_scale = scheduled.get("longitudinal_scale", 10.0)
+
     # 3. Generate K trajectories for all scenes (batched)
     print(f"  Generating {K} trajectories x {N} scenes (batched)...")
     model.eval()
@@ -392,6 +410,9 @@ def train_epoch_ranked_sft(
         all_trajs = generate_all_scenes_batched(
             model, model_args, norm_batch, K, config.noise_scale_range, device,
             gt_max_speed=median_gt_speed,
+            longitudinal_eta=lon_eta,
+            longitudinal_lambda=lon_lambda,
+            longitudinal_scale=lon_scale,
         )  # [N, K, T, 4]
 
     torch.cuda.empty_cache()

--- a/rlvr/grpo_trainer_batched.py
+++ b/rlvr/grpo_trainer_batched.py
@@ -100,10 +100,10 @@ def generate_all_scenes_batched(
     all_k_trajs.append(det_trajs)
 
     # Use deterministic trajectory as reference for longitudinal guidance.
-    # det_trajs is already in (x, y, cos_yaw, sin_yaw) format.
+    # det_trajs is already in (x, y, cos_yaw, sin_yaw) format — no conversion needed.
     use_lon = abs(longitudinal_eta) > 1e-6
     if use_lon:
-        norm_batch["reference_trajectory"] = det_trajs.clone()
+        norm_batch["reference_trajectory"] = det_trajs  # no clone needed, not mutated
 
     # --- Config 2-9: Strong CL + SPD guidance sweep for lane keeping ---
     # 8 guided trajectories at CL5-10 to ensure ~8-10/16 stay in-lane on curves.
@@ -117,7 +117,6 @@ def generate_all_scenes_batched(
         (10.0, 8.0,  0.3, 0.8),   # CL10+SPD8, noise
         (10.0, 10.0, 0.5, 1.0),   # CL10+SPD10, noise
     ]
-    use_lon = abs(longitudinal_eta) > 1e-6
     for cl_scale, spd_scale, n_min, n_max in cl_spd_configs:
         fns = [
             GuidanceConfig("centerline_following", enabled=True, scale=cl_scale),

--- a/rlvr/grpo_trainer_batched.py
+++ b/rlvr/grpo_trainer_batched.py
@@ -132,6 +132,9 @@ def generate_all_scenes_batched(
         trajs = _chunked_generate(model, model_args, norm_batch, n_min, n_max, comp, device, gen_chunk_size)
         all_k_trajs.append(trajs)
 
+    # Clean up reference_trajectory before random passes (not needed, wastes VRAM on expand)
+    norm_batch.pop("reference_trajectory", None)
+
     # --- Config 5+: Random guidance (no road_border to avoid OOM) ---
     n_fixed = len(all_k_trajs)
     n_random = K - n_fixed

--- a/rlvr/grpo_trainer_batched.py
+++ b/rlvr/grpo_trainer_batched.py
@@ -99,15 +99,11 @@ def generate_all_scenes_batched(
     det_trajs = _chunked_generate(model, model_args, norm_batch, 0.0, 0.0, None, device, gen_chunk_size)
     all_k_trajs.append(det_trajs)
 
-    # Use deterministic trajectory as reference for longitudinal guidance
+    # Use deterministic trajectory as reference for longitudinal guidance.
+    # det_trajs is already in (x, y, cos_yaw, sin_yaw) format.
     use_lon = abs(longitudinal_eta) > 1e-6
     if use_lon:
-        # det_trajs: [N, T, 4] — need [N, T, 4] with (x, y, cos_yaw, sin_yaw)
-        ref = det_trajs.clone()
-        heading = ref[..., 2]  # heading angle
-        ref[..., 2] = torch.cos(heading)  # cos_yaw
-        ref[..., 3] = torch.sin(heading)  # sin_yaw
-        norm_batch["reference_trajectory"] = ref
+        norm_batch["reference_trajectory"] = det_trajs.clone()
 
     # --- Config 2-9: Strong CL + SPD guidance sweep for lane keeping ---
     # 8 guided trajectories at CL5-10 to ensure ~8-10/16 stay in-lane on curves.

--- a/rlvr/grpo_trainer_batched.py
+++ b/rlvr/grpo_trainer_batched.py
@@ -237,6 +237,23 @@ def train_epoch_batched(
     median_gt_speed = float(_np2.median(gt_speeds_list))
     print(f"  Median GT max speed: {median_gt_speed:.1f} m/s")
 
+    # 2b. Apply per-epoch schedules to reward weights and guidance params
+    scheduled = config.get_all_scheduled_values(epoch, config.train_epochs)
+    reward_weight_names = {
+        "w_progress", "w_safety", "w_smooth", "w_feasibility", "w_centerline",
+        "stopped_penalty", "underprogress_penalty", "progress_norm_scale",
+    }
+    for name, value in scheduled.items():
+        if name in reward_weight_names and hasattr(reward_config, name):
+            setattr(reward_config, name, value)
+    if scheduled:
+        sched_str = ", ".join(f"{k}={v:.3f}" for k, v in scheduled.items())
+        print(f"  [schedule] epoch {epoch}: {sched_str}")
+
+    lon_eta = scheduled.get("longitudinal_eta", 0.0)
+    lon_lambda = scheduled.get("longitudinal_lambda", config.lambda_lon)
+    lon_scale = scheduled.get("longitudinal_scale", 10.0)
+
     # 3. Generate K trajectories for all scenes (batched)
     print(f"  Generating {K} trajectories × {N} scenes (batched)...")
     model.eval()
@@ -244,6 +261,9 @@ def train_epoch_batched(
         all_trajs = generate_all_scenes_batched(
             model, model_args, norm_batch, K, config.noise_scale_range, device,
             gt_max_speed=median_gt_speed,
+            longitudinal_eta=lon_eta,
+            longitudinal_lambda=lon_lambda,
+            longitudinal_scale=lon_scale,
         )  # [N, K, T, 4]
 
     # Free generation memory before scoring + training

--- a/rlvr/grpo_trainer_batched.py
+++ b/rlvr/grpo_trainer_batched.py
@@ -76,8 +76,17 @@ def generate_all_scenes_batched(
     device: torch.device,
     gen_chunk_size: int = 64,
     gt_max_speed: float = 3.0,
+    longitudinal_eta: float = 0.0,
+    longitudinal_lambda: float = 0.5,
+    longitudinal_scale: float = 10.0,
 ) -> torch.Tensor:
     """Generate K trajectories for all N scenes in ~5 chunked-batched passes.
+
+    Args:
+        longitudinal_eta: Longitudinal guidance eta (0=off, >0=faster than ref).
+            Applied to CL-guided trajectories when nonzero.
+        longitudinal_lambda: Speed scaling constant for longitudinal guidance.
+        longitudinal_scale: Guidance scale for longitudinal guidance.
 
     Returns:
         [N, K, T, 4] tensor.
@@ -89,6 +98,16 @@ def generate_all_scenes_batched(
     # --- Config 1: Deterministic ---
     det_trajs = _chunked_generate(model, model_args, norm_batch, 0.0, 0.0, None, device, gen_chunk_size)
     all_k_trajs.append(det_trajs)
+
+    # Use deterministic trajectory as reference for longitudinal guidance
+    use_lon = abs(longitudinal_eta) > 1e-6
+    if use_lon:
+        # det_trajs: [N, T, 4] — need [N, T, 4] with (x, y, cos_yaw, sin_yaw)
+        ref = det_trajs.clone()
+        heading = ref[..., 2]  # heading angle
+        ref[..., 2] = torch.cos(heading)  # cos_yaw
+        ref[..., 3] = torch.sin(heading)  # sin_yaw
+        norm_batch["reference_trajectory"] = ref
 
     # --- Config 2-9: Strong CL + SPD guidance sweep for lane keeping ---
     # 8 guided trajectories at CL5-10 to ensure ~8-10/16 stay in-lane on curves.
@@ -102,12 +121,18 @@ def generate_all_scenes_batched(
         (10.0, 8.0,  0.3, 0.8),   # CL10+SPD8, noise
         (10.0, 10.0, 0.5, 1.0),   # CL10+SPD10, noise
     ]
+    use_lon = abs(longitudinal_eta) > 1e-6
     for cl_scale, spd_scale, n_min, n_max in cl_spd_configs:
         fns = [
             GuidanceConfig("centerline_following", enabled=True, scale=cl_scale),
             GuidanceConfig("speed", enabled=True, scale=spd_scale,
                            params={"v_high": gt_max_speed, "v_low": 0.5}),
         ]
+        if use_lon:
+            fns.append(GuidanceConfig(
+                "longitudinal", enabled=True, scale=longitudinal_scale,
+                params={"eta_lon": longitudinal_eta, "lambda_lon": longitudinal_lambda},
+            ))
         comp = GuidanceComposer(GuidanceSetConfig(functions=fns, global_scale=1.0))
         trajs = _chunked_generate(model, model_args, norm_batch, n_min, n_max, comp, device, gen_chunk_size)
         all_k_trajs.append(trajs)

--- a/rlvr/test_scheduling.py
+++ b/rlvr/test_scheduling.py
@@ -1,0 +1,110 @@
+"""Unit tests for GRPOConfig per-epoch scheduling."""
+
+from __future__ import annotations
+
+import math
+import pytest
+
+from rlvr.grpo_config import GRPOConfig
+
+
+def test_linear_schedule():
+    c = GRPOConfig(schedules={"w_progress": {"type": "linear", "start": 3.0, "end": 10.0}})
+    assert c.get_scheduled_value("w_progress", 1, 20) == 3.0
+    assert c.get_scheduled_value("w_progress", 20, 20) == 10.0
+    mid = c.get_scheduled_value("w_progress", 11, 20)
+    assert 6.0 < mid < 7.0  # ~6.68
+
+
+def test_cosine_schedule():
+    c = GRPOConfig(schedules={"w_progress": {"type": "cosine", "start": 3.0, "end": 10.0}})
+    assert c.get_scheduled_value("w_progress", 1, 20) == pytest.approx(3.0)
+    assert c.get_scheduled_value("w_progress", 20, 20) == pytest.approx(10.0)
+    mid = c.get_scheduled_value("w_progress", 11, 20)
+    # Cosine is slower than linear at midpoint
+    assert 5.5 < mid < 7.5
+
+
+def test_step_schedule():
+    c = GRPOConfig(schedules={
+        "w_progress": {"type": "step", "start": 3.0, "end": 10.0, "warmup_fraction": 0.5},
+    })
+    # Before warmup: start
+    assert c.get_scheduled_value("w_progress", 1, 20) == 3.0
+    assert c.get_scheduled_value("w_progress", 10, 20) == 3.0
+    # After warmup: end
+    assert c.get_scheduled_value("w_progress", 11, 20) == 10.0
+    assert c.get_scheduled_value("w_progress", 20, 20) == 10.0
+
+
+def test_constant_schedule():
+    c = GRPOConfig(schedules={"w_progress": {"type": "constant", "start": 5.0, "end": 10.0}})
+    assert c.get_scheduled_value("w_progress", 1, 20) == 5.0
+    assert c.get_scheduled_value("w_progress", 20, 20) == 5.0
+
+
+def test_total_epochs_one():
+    c = GRPOConfig(schedules={"w_progress": {"type": "linear", "start": 3.0, "end": 10.0}})
+    assert c.get_scheduled_value("w_progress", 1, 1) == 3.0
+
+
+def test_no_schedule_returns_none():
+    c = GRPOConfig(schedules={"w_progress": {"type": "linear", "start": 3.0, "end": 10.0}})
+    assert c.get_scheduled_value("nonexistent", 1, 20) is None
+
+
+def test_get_all_scheduled_values():
+    c = GRPOConfig(schedules={
+        "w_progress": {"type": "linear", "start": 3.0, "end": 10.0},
+        "longitudinal_eta": {"type": "linear", "start": 0.0, "end": 1.0},
+    })
+    vals = c.get_all_scheduled_values(1, 20)
+    assert "w_progress" in vals
+    assert "longitudinal_eta" in vals
+    assert vals["w_progress"] == pytest.approx(3.0)
+    assert vals["longitudinal_eta"] == pytest.approx(0.0)
+
+
+def test_step_warmup_boundary():
+    c = GRPOConfig(schedules={
+        "x": {"type": "step", "start": 1.0, "end": 2.0, "warmup_fraction": 0.3},
+    })
+    # progress at ep7/20 = 6/19 ≈ 0.316 > 0.3 → end
+    assert c.get_scheduled_value("x", 7, 20) == 2.0
+    # progress at ep6/20 = 5/19 ≈ 0.263 < 0.3 → start
+    assert c.get_scheduled_value("x", 6, 20) == 1.0
+
+
+def test_invalid_warmup_fraction():
+    c = GRPOConfig(schedules={
+        "x": {"type": "step", "start": 1.0, "end": 2.0, "warmup_fraction": 1.5},
+    })
+    with pytest.raises(ValueError, match="warmup_fraction"):
+        c.get_scheduled_value("x", 1, 20)
+
+
+def test_invalid_schedule_type():
+    c = GRPOConfig(schedules={"x": {"type": "invalid", "start": 1.0, "end": 2.0}})
+    with pytest.raises(ValueError, match="Unknown schedule type"):
+        c.get_scheduled_value("x", 1, 20)
+
+
+def test_json_roundtrip():
+    import json
+    import tempfile
+    import os
+
+    c = GRPOConfig(schedules={
+        "w_progress": {"type": "cosine", "start": 3.0, "end": 10.0},
+        "longitudinal_eta": {"type": "linear", "start": 0.0, "end": 0.5},
+    })
+    path = os.path.join(tempfile.gettempdir(), "test_sched_roundtrip.json")
+    c.to_json(path)
+    c2 = GRPOConfig.from_json(path)
+    assert c2.schedules == c.schedules
+    assert c2.get_scheduled_value("w_progress", 20, 20) == pytest.approx(10.0)
+    os.unlink(path)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/rlvr/test_scheduling.py
+++ b/rlvr/test_scheduling.py
@@ -83,6 +83,41 @@ def test_invalid_warmup_fraction():
         c.get_scheduled_value("x", 1, 20)
 
 
+def test_peak_schedule():
+    c = GRPOConfig(schedules={
+        "x": {"type": "peak", "start": 0.0, "end": 0.0, "peak": 0.3, "peak_fraction": 0.5},
+    })
+    # Endpoints
+    assert c.get_scheduled_value("x", 1, 20) == pytest.approx(0.0)
+    assert c.get_scheduled_value("x", 20, 20) == pytest.approx(0.0)
+    # Peak at midpoint (ep11, progress=10/19≈0.526 > 0.5 → descending)
+    mid = c.get_scheduled_value("x", 10, 20)  # progress=9/19≈0.474 < 0.5 → ascending
+    assert 0.25 < mid < 0.31
+    # Exactly at peak_fraction
+    # ep11: progress = 10/19 ≈ 0.526 → just past peak, should be close to 0.3
+    val_at_peak = c.get_scheduled_value("x", 11, 20)
+    assert 0.25 < val_at_peak < 0.31
+
+
+def test_peak_asymmetric():
+    c = GRPOConfig(schedules={
+        "x": {"type": "peak", "start": 0.0, "end": 0.1, "peak": 0.5, "peak_fraction": 0.3},
+    })
+    assert c.get_scheduled_value("x", 1, 20) == pytest.approx(0.0)
+    assert c.get_scheduled_value("x", 20, 20) == pytest.approx(0.1)
+    # Early peak means fast ramp up, slow ramp down
+    ep4 = c.get_scheduled_value("x", 4, 20)  # progress=3/19≈0.158 < 0.3 → ascending
+    assert ep4 > 0.2
+
+
+def test_peak_invalid_fraction():
+    c = GRPOConfig(schedules={
+        "x": {"type": "peak", "start": 0.0, "end": 0.0, "peak": 0.3, "peak_fraction": 0.0},
+    })
+    with pytest.raises(ValueError, match="peak_fraction"):
+        c.get_scheduled_value("x", 1, 20)
+
+
 def test_invalid_schedule_type():
     c = GRPOConfig(schedules={"x": {"type": "invalid", "start": 1.0, "end": 2.0}})
     with pytest.raises(ValueError, match="Unknown schedule type"):

--- a/rlvr/test_scheduling.py
+++ b/rlvr/test_scheduling.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import math
 import pytest
 
 from rlvr.grpo_config import GRPOConfig
@@ -124,21 +123,16 @@ def test_invalid_schedule_type():
         c.get_scheduled_value("x", 1, 20)
 
 
-def test_json_roundtrip():
-    import json
-    import tempfile
-    import os
-
+def test_json_roundtrip(tmp_path):
     c = GRPOConfig(schedules={
         "w_progress": {"type": "cosine", "start": 3.0, "end": 10.0},
         "longitudinal_eta": {"type": "linear", "start": 0.0, "end": 0.5},
     })
-    path = os.path.join(tempfile.gettempdir(), "test_sched_roundtrip.json")
-    c.to_json(path)
-    c2 = GRPOConfig.from_json(path)
+    path = tmp_path / "test_sched_roundtrip.json"
+    c.to_json(str(path))
+    c2 = GRPOConfig.from_json(str(path))
     assert c2.schedules == c.schedules
     assert c2.get_scheduled_value("w_progress", 20, 20) == pytest.approx(10.0)
-    os.unlink(path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add generic `schedules` dict to `GRPOConfig` for smooth per-epoch interpolation of any reward weight or guidance parameter
- Supports `constant`, `linear`, `cosine`, `step`, and `peak` (ramp-up-then-down) schedule types
- Wire longitudinal guidance into batched trajectory generation (CL-guided configs) as first use case
- Replace old `reward_schedule` dict in `run_experiment.py` with the new unified system
- 14 unit tests covering all schedule types, edge cases, and JSON roundtrip

## Config example

```json
"schedules": {
    "w_progress": {"type": "linear", "start": 3.0, "end": 10.0},
    "longitudinal_eta": {"type": "peak", "start": 0.0, "end": 0.0, "peak": 0.3, "peak_fraction": 0.35}
}
```

## Schedule types

| Type | Description |
|------|-------------|
| `constant` | Fixed at `start` value |
| `linear` | Linear interpolation `start` → `end` |
| `cosine` | Cosine annealing `start` → `end` |
| `step` | Hold `start` until `warmup_fraction`, then jump to `end` |
| `peak` | Linear ramp `start` → `peak` → `end` with configurable `peak_fraction` |

## Validation

Scheduled longitudinal guidance on 50-scene ranked SFT (noise [0.5, 2.0], bugfixed ref trajectory):
- **Without lon guidance**: paths shrink from 13.3→12.8m over 20 epochs
- **With gentle lon guidance (eta 0→0.3)**: paths grow from 13.3→15.0m, 0/50 LD through ep7
- **Best checkpoint (ep7 no_blk1)**: 0/50 LD, 15.0m path, ego L2 +1.4%, neighbor L2 +1.6%

## Files changed

- `rlvr/grpo_config.py` — `schedules` field, `get_scheduled_value()`, `get_all_scheduled_values()`, peak type
- `rlvr/grpo_trainer_batched.py` — longitudinal guidance in `generate_all_scenes_batched()`, VRAM cleanup
- `rlvr/grpo_sft_trainer.py` — apply scheduled values per epoch to reward config + generation
- `rlvr/autoresearch/run_experiment.py` — remove old `reward_schedule` mechanism
- `rlvr/test_scheduling.py` — 14 unit tests
- `rlvr/README.md` — document scheduling system and updated results