### PR TITLE
feat: explorer guidance, lateral guidance, and unified loss naming

### DIFF
--- a/exploration_policy/loss.py
+++ b/exploration_policy/loss.py
@@ -2,12 +2,13 @@
 
 The policy outputs a Beta distribution, K η values are sampled from it,
 each generates a trajectory scored by the reward function. GRPO-style
-group-relative advantages are used to train the policy via REINFORCE.
+group-relative advantages are used to train the policy via advantage-weighted
+log probability (advantage_logprob mode).
 
 Loss = policy_gradient + c_e * entropy_loss + c_kl * kl_loss
 
 Where:
-- policy_gradient: -mean(A_k * log_prob_k) — REINFORCE with GRPO advantages
+- policy_gradient: -mean(A_k * log_prob_k) — advantage-weighted log_prob
 - entropy_loss: -mean(H(lat_dist) + H(lon_dist)) — encourage exploration
 - kl_loss: KL(current || init) — anchor to initial uniform-ish policy
 """
@@ -18,7 +19,6 @@ import math
 
 import torch
 from torch.distributions import Beta, kl_divergence
-
 
 # Initial Beta params from zero-initialized GuidanceHead: softplus(0) + 1
 _INIT_PARAM = math.log(2) + 1.0
@@ -59,7 +59,7 @@ def compute_exploration_loss(
     """
     device = advantages.device
 
-    # --- REINFORCE policy gradient ---
+    # --- Advantage-weighted policy gradient ---
     # Negative because we maximize reward (minimize negative advantage-weighted log_prob)
     policy_loss = -(advantages * log_probs).mean()
 

--- a/rlvr/README.md
+++ b/rlvr/README.md
@@ -32,7 +32,7 @@ rlvr/
                              (DEPRECATED — use logprob loss instead for trajectory shape learning)
   grpo_logprob_loss.py       DDV2-style Gaussian log-probability GRPO loss (NEW)
                              + Two-stage: collect_logprob_rollout + compute_logprob_grpo_loss
-                             + REINFORCE gradient via truncated VPSDE denoising rollout
+                             + advantage-weighted gradient via truncated VPSDE denoising rollout
                              + Mean-divergence KL regularization (analytical, properly scaled)
                              + Adaptive IL regularization
   vpsde_logprob.py           VPSDE denoising step with Gaussian log-probability (NEW)
@@ -48,7 +48,7 @@ rlvr/
                              + Post-hoc no_block1 trick for L2 preservation (with neighbor reg)
                              + Per-epoch scheduled reward weights and longitudinal guidance
   grpo_trainer.py            Standard GRPO training loop (batched loss)
-                             + logprob loss path when grpo_loss_type="logprob"
+                             + advantage_logprob loss path when grpo_loss_type="advantage_logprob"
   grpo_trainer_batched.py    Fully batched GRPO trainer (all scenes in ~5 forward passes)
                              + logprob loss path with per-scene collect + train
   grpo_exploration_trainer.py  Joint GRPO + exploration policy trainer
@@ -97,28 +97,28 @@ rlvr/
 | Mode | Config | Trainer | Description |
 |------|--------|---------|-------------|
 | **Ranked SFT** | `ranked_sft_mode: "gt_neighbor"` | `train_epoch_ranked_sft` | **Best for lane keeping.** Generate N trajs, pick best by reward, SG-filter, SFT loss on ego+neighbor. |
-| Logprob GRPO | `grpo_loss_type: "logprob"` | `train_epoch_batched` | DDV2-style Gaussian log-prob. Can learn curvature but degrades neighbor L2. |
-| Standard GRPO (MSE) | `grpo_loss_type: "mse"` | `train_epoch_batched` | Legacy. Cannot change trajectory shape, only length. |
+| Advantage Logprob GRPO | `grpo_loss_type: "advantage_logprob"` | `train_epoch_batched` | DDV2-style Gaussian log-prob. Can learn curvature but degrades neighbor L2. |
+| Advantage MSE GRPO | `grpo_loss_type: "advantage_mse"` | `train_epoch_batched` | Legacy. Cannot change trajectory shape, only length. |
 | Random guidance | `random_guidance_mode: "uniform"` | `GRPOExplorationTrainer` | Random η guidance diversity. |
 | Explorer (open-loop) | `random_guidance_mode: "explorer"` | `GRPOExplorationTrainer` | Learned Beta guidance + GRPO |
 | Explorer (closed-loop) | `use_closed_loop: true` | `ClosedLoopExplorationTrainer` | Per-step rollout + GAE + GRPO |
 
 All modes support GPU-batched trajectory generation and evaluation.
 
-### Logprob GRPO (DDV2-style)
+### Advantage Logprob GRPO (DDV2-style)
 
-The logprob loss computes actual Gaussian log-probabilities during a truncated VPSDE denoising
-rollout, enabling proper REINFORCE gradient for trajectory shape learning. Based on
+The advantage_logprob loss computes actual Gaussian log-probabilities during a truncated VPSDE denoising
+rollout, enabling proper advantage-weighted gradient for trajectory shape learning. Based on
 DiffusionDriveV2 (arXiv:2512.07745).
 
 **Two-stage approach:**
 1. **Collection** (no grad): Run model through multi-step denoising, store chain states + log-probs
-2. **Optimization** (with grad): Re-run model on stored chain, compute REINFORCE loss
+2. **Optimization** (with grad): Re-run model on stored chain, compute advantage-weighted loss
 
 **Config:**
 ```json
 {
-    "grpo_loss_type": "logprob",
+    "grpo_loss_type": "advantage_logprob",
     "logprob_num_steps": 5,
     "logprob_t_start": 0.01,
     "logprob_discount": 0.8,

--- a/rlvr/analyze_rewards.py
+++ b/rlvr/analyze_rewards.py
@@ -28,7 +28,7 @@ import torch
 from preference_optimization.model_utils import load_model
 from preference_optimization.utils import load_npz_data
 from rlvr.grpo_sampler import SamplerConfig, generate_diverse_group
-from rlvr.reward import RewardConfig, compute_reward_batch, compute_group_advantages
+from rlvr.reward import RewardConfig, compute_group_advantages, compute_reward_batch
 
 
 def analyze(

--- a/rlvr/autoresearch/README.md
+++ b/rlvr/autoresearch/README.md
@@ -170,6 +170,38 @@ cat /tmp/experiment_status.log
 pkill -f experiment_watchdog
 ```
 
+### `tools/viz_explorer_per_scene.py` — Exploration Policy Per-Scene Analysis
+
+Loads a trained exploration policy checkpoint and runs deterministic inference
+on each scene to show the learned eta_lat/eta_lon guidance parameters.
+
+```bash
+python -m rlvr.autoresearch.tools.viz_explorer_per_scene \
+  --model_path /path/to/base_model.pth \
+  --exp_dir /path/to/experiment_dir \
+  --scenes /path/to/scenes.json \
+  --epoch 10
+```
+
+Prints per-scene eta values, scene-to-scene statistics, and extreme scenes.
+
+### `tools/viz_explorer_trajectories.py` — Explorer Trajectory Visualization
+
+Generates images showing reference trajectory (blue) vs explorer-guided
+trajectory (red) for each scene, with road borders and lane geometry.
+
+```bash
+python -m rlvr.autoresearch.tools.viz_explorer_trajectories \
+  --model_path /path/to/base_model.pth \
+  --exp_dir /path/to/experiment_dir \
+  --scenes /path/to/scenes.json \
+  --epoch 10 \
+  --output_dir /path/to/output \
+  --n_scenes 12
+```
+
+Outputs a grid image and individual per-scene images with eta annotations.
+
 ## Scene Lists
 
 Training requires three JSON files, each a list of NPZ paths:

--- a/rlvr/autoresearch/check_lora_training.py
+++ b/rlvr/autoresearch/check_lora_training.py
@@ -5,21 +5,21 @@ Usage:
     python3 rlvr/scripts/check_lora_training.py <experiment_dir> [--scene <npz_path>]
 """
 import argparse
+import glob
 import json
 import os
 import sys
-import glob
 
 import numpy as np
 import torch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
-from preference_optimization.utils import load_npz_data as _load_raw
-from guidance_gui.generate_samples import generate_samples
-from diffusion_planner.utils.config import Config
 from diffusion_planner.model.diffusion_planner import Diffusion_Planner
+from diffusion_planner.utils.config import Config
 
+from guidance_gui.generate_samples import generate_samples
+from preference_optimization.utils import load_npz_data as _load_raw
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 

--- a/rlvr/autoresearch/compare_models.py
+++ b/rlvr/autoresearch/compare_models.py
@@ -20,18 +20,19 @@ import json
 from pathlib import Path
 
 import matplotlib
+
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import matplotlib.transforms as mtransforms
 import numpy as np
 import torch
+from diffusion_planner.loss import compute_ego_edge_points, point_to_segment_distance
+from diffusion_planner.model.diffusion_planner import Diffusion_Planner
+from diffusion_planner.utils.config import Config
 from matplotlib.patches import Rectangle
 
-from preference_optimization.utils import load_npz_data
-from diffusion_planner.utils.config import Config
-from diffusion_planner.model.diffusion_planner import Diffusion_Planner
-from diffusion_planner.loss import compute_ego_edge_points, point_to_segment_distance
 from guidance_gui.generate_samples import generate_samples
+from preference_optimization.utils import load_npz_data
 from rlvr.reward import RewardConfig, compute_reward_batch
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"

--- a/rlvr/autoresearch/eval_border_distance.py
+++ b/rlvr/autoresearch/eval_border_distance.py
@@ -42,20 +42,21 @@ import json
 from pathlib import Path
 
 import matplotlib
+
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
-from tqdm import tqdm
-
 from diffusion_planner.dimensions import OUTPUT_T
 from diffusion_planner.loss import compute_ego_edge_points, point_to_segment_distance
+from tqdm import tqdm
 
 
 def load_model_for_eval(args):
     """Load model — either base+LoRA or merged."""
-    from preference_optimization.model_utils import load_model
     from diffusion_planner.utils.config import Config
+
+    from preference_optimization.model_utils import load_model
 
     if args.merged_model_path:
         model, model_args = load_model(Path(args.merged_model_path), "cuda")

--- a/rlvr/autoresearch/run_experiment.py
+++ b/rlvr/autoresearch/run_experiment.py
@@ -491,11 +491,21 @@ def run(config_path: Path, name: str, skip_baseline: bool = False):
                         print(f"  Loaded frozen explorer from {_ckpt}")
                     _explorer = getattr(run, '_cached_explorer', None)
 
+                # Create explorer optimizer if training jointly
+                _explorer_opt = None
+                if _explorer is not None and not grpo_config.ranked_sft_freeze_explorer:
+                    if not hasattr(run, '_cached_explorer_opt'):
+                        run._cached_explorer_opt = torch.optim.AdamW(
+                            _explorer.parameters(), lr=grpo_config.exploration_lr,
+                        )
+                    _explorer_opt = run._cached_explorer_opt
+
                 metrics = train_epoch_ranked_sft(
                     model=policy_model, model_args=model_args, optimizer=optimizer,
                     scene_paths=train_paths, config=grpo_config,
                     reward_config=train_reward_config, device=DEVICE, epoch=epoch,
                     exploration_policy=_explorer,
+                    exploration_optimizer=_explorer_opt,
                 )
             else:
                 # Fully batched training: all scenes in ~5 forward passes

--- a/rlvr/autoresearch/run_experiment.py
+++ b/rlvr/autoresearch/run_experiment.py
@@ -468,7 +468,10 @@ def run(config_path: Path, name: str, skip_baseline: bool = False):
 
                     from exploration_policy.model import ExplorationPolicy, ExplorationPolicyConfig
                     _ckpt = _P(grpo_config.exploration_checkpoint_path)
-                    if _ckpt.exists() and not hasattr(run, '_cached_explorer'):
+                    if not _ckpt.exists():
+                        print(f"  WARNING: exploration_checkpoint_path not found: {_ckpt}")
+                        print(f"  Falling back to standard generation (no explorer)")
+                    elif not hasattr(run, '_cached_explorer'):
                         _ep_cfg = ExplorationPolicyConfig(
                             hidden_dim=grpo_config.exploration_hidden_dim,
                             n_mixer_layers=grpo_config.exploration_n_mixer_layers,

--- a/rlvr/autoresearch/run_experiment.py
+++ b/rlvr/autoresearch/run_experiment.py
@@ -27,9 +27,9 @@ if str(parent_dir) not in sys.path:
 import numpy as np
 import torch
 
+from guidance_gui.generate_samples import generate_samples
 from preference_optimization.model_utils import load_model
 from preference_optimization.utils import load_npz_data as _load_npz_data_raw
-from guidance_gui.generate_samples import generate_samples
 
 
 def load_npz_data(npz_path, device):
@@ -362,7 +362,12 @@ def run(config_path: Path, name: str, skip_baseline: bool = False):
             policy_model = load_lora_checkpoint(policy_model, seed_lora_path, is_trainable=True)
             print(f"Seeded from LoRA: {seed_lora_path}")
         else:
-            from preference_optimization.lora_utils import apply_lora, LORA_TARGET_LAST_BLOCK_REGEX, LORA_TARGET_FIRST_BLOCK_REGEX, LORA_TARGET_BLOCKS_01_REGEX
+            from preference_optimization.lora_utils import (
+                LORA_TARGET_BLOCKS_01_REGEX,
+                LORA_TARGET_FIRST_BLOCK_REGEX,
+                LORA_TARGET_LAST_BLOCK_REGEX,
+                apply_lora,
+            )
             target = {"last": LORA_TARGET_LAST_BLOCK_REGEX, "first": LORA_TARGET_FIRST_BLOCK_REGEX, "blocks01": LORA_TARGET_BLOCKS_01_REGEX}.get(grpo_config.lora_target)
             kwargs = dict(r=grpo_config.lora_rank, lora_alpha=grpo_config.lora_alpha,
                          lora_dropout=grpo_config.lora_dropout)
@@ -455,10 +460,38 @@ def run(config_path: Path, name: str, skip_baseline: bool = False):
             if grpo_config.ranked_sft_mode != "none":
                 # Ranked SFT: generate N trajs, pick best, SFT on it
                 from rlvr.grpo_sft_trainer import train_epoch_ranked_sft
+
+                # Optionally load a pre-trained exploration policy for guided generation
+                _explorer = None
+                if grpo_config.ranked_sft_use_explorer and grpo_config.exploration_checkpoint_path:
+                    from pathlib import Path as _P
+
+                    from exploration_policy.model import ExplorationPolicy, ExplorationPolicyConfig
+                    _ckpt = _P(grpo_config.exploration_checkpoint_path)
+                    if _ckpt.exists() and not hasattr(run, '_cached_explorer'):
+                        _ep_cfg = ExplorationPolicyConfig(
+                            hidden_dim=grpo_config.exploration_hidden_dim,
+                            n_mixer_layers=grpo_config.exploration_n_mixer_layers,
+                            n_attn_heads=grpo_config.exploration_n_attn_heads,
+                            dropout=grpo_config.exploration_dropout,
+                            encoder_hidden_dim=model_args.hidden_dim,
+                            head_init=grpo_config.exploration_head_init,
+                            head_raw_scale=grpo_config.exploration_head_raw_scale,
+                        )
+                        run._cached_explorer = ExplorationPolicy(
+                            _ep_cfg, ref_seq_len=model_args.future_len,
+                        ).to(DEVICE)
+                        _state = torch.load(_ckpt, map_location=DEVICE, weights_only=False)
+                        run._cached_explorer.load_state_dict(_state, strict=False)
+                        run._cached_explorer.eval()
+                        print(f"  Loaded frozen explorer from {_ckpt}")
+                    _explorer = getattr(run, '_cached_explorer', None)
+
                 metrics = train_epoch_ranked_sft(
                     model=policy_model, model_args=model_args, optimizer=optimizer,
                     scene_paths=train_paths, config=grpo_config,
                     reward_config=train_reward_config, device=DEVICE, epoch=epoch,
+                    exploration_policy=_explorer,
                 )
             else:
                 # Fully batched training: all scenes in ~5 forward passes

--- a/rlvr/autoresearch/run_experiment.py
+++ b/rlvr/autoresearch/run_experiment.py
@@ -313,6 +313,8 @@ def run(config_path: Path, name: str, skip_baseline: bool = False):
     for k, v in config_data.items():
         if hasattr(grpo_config, k):
             setattr(grpo_config, k, v)
+    # Re-run __post_init__ to normalize legacy loss type names
+    grpo_config.__post_init__()
 
     print(f"Experiment: {name}")
     print(f"Config: lr={grpo_config.learning_rate}, kl={grpo_config.kl_coef}, "

--- a/rlvr/autoresearch/run_experiment.py
+++ b/rlvr/autoresearch/run_experiment.py
@@ -471,7 +471,7 @@ def run(config_path: Path, name: str, skip_baseline: bool = False):
                     if not _ckpt.exists():
                         print(f"  WARNING: exploration_checkpoint_path not found: {_ckpt}")
                         print(f"  Falling back to standard generation (no explorer)")
-                    elif not hasattr(run, '_cached_explorer'):
+                    elif not hasattr(run, '_cached_explorer') or getattr(run, '_cached_explorer_path', None) != str(_ckpt):
                         _ep_cfg = ExplorationPolicyConfig(
                             hidden_dim=grpo_config.exploration_hidden_dim,
                             n_mixer_layers=grpo_config.exploration_n_mixer_layers,
@@ -487,6 +487,7 @@ def run(config_path: Path, name: str, skip_baseline: bool = False):
                         _state = torch.load(_ckpt, map_location=DEVICE, weights_only=False)
                         run._cached_explorer.load_state_dict(_state, strict=False)
                         run._cached_explorer.eval()
+                        run._cached_explorer_path = str(_ckpt)
                         print(f"  Loaded frozen explorer from {_ckpt}")
                     _explorer = getattr(run, '_cached_explorer', None)
 

--- a/rlvr/autoresearch/tools/diagnose_grpo_signal.py
+++ b/rlvr/autoresearch/tools/diagnose_grpo_signal.py
@@ -19,14 +19,14 @@ from pathlib import Path
 
 import numpy as np
 import torch
-
-from preference_optimization.utils import load_npz_data
-from preference_optimization.lora_utils import load_lora_checkpoint
-from diffusion_planner.utils.config import Config
 from diffusion_planner.model.diffusion_planner import Diffusion_Planner
+from diffusion_planner.utils.config import Config
+
+from preference_optimization.lora_utils import load_lora_checkpoint
+from preference_optimization.utils import load_npz_data
 from rlvr.grpo_sampler import SamplerConfig
 from rlvr.grpo_sampler_batched import generate_diverse_group_batched
-from rlvr.reward import RewardConfig, compute_reward_batch, compute_lane_departure_penalty
+from rlvr.reward import RewardConfig, compute_lane_departure_penalty, compute_reward_batch
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 

--- a/rlvr/autoresearch/tools/eval_driving_metrics.py
+++ b/rlvr/autoresearch/tools/eval_driving_metrics.py
@@ -24,10 +24,10 @@ from pathlib import Path
 
 import numpy as np
 import torch
-from rlvr.reward import _build_sg_diff_kernel
 
 from preference_optimization.model_utils import load_model
 from preference_optimization.utils import load_npz_data
+from rlvr.reward import _build_sg_diff_kernel
 
 DT = 0.1
 

--- a/rlvr/autoresearch/tools/eval_lane_border_distance.py
+++ b/rlvr/autoresearch/tools/eval_lane_border_distance.py
@@ -18,15 +18,15 @@ from pathlib import Path
 
 import numpy as np
 import torch
-
-from preference_optimization.utils import load_npz_data
-from preference_optimization.lora_utils import load_lora_checkpoint
-from diffusion_planner.utils.config import Config
 from diffusion_planner.model.diffusion_planner import Diffusion_Planner
+from diffusion_planner.utils.config import Config
+
 from guidance_gui.generate_samples import generate_samples
+from preference_optimization.lora_utils import load_lora_checkpoint
+from preference_optimization.utils import load_npz_data
 from rlvr.reward import (
-    compute_road_border_penalty,
     compute_lane_departure_penalty,
+    compute_road_border_penalty,
 )
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"

--- a/rlvr/autoresearch/tools/eval_reward_vs_gt.py
+++ b/rlvr/autoresearch/tools/eval_reward_vs_gt.py
@@ -20,12 +20,12 @@ from pathlib import Path
 
 import numpy as np
 import torch
-
-from preference_optimization.utils import load_npz_data
-from preference_optimization.lora_utils import load_lora_checkpoint
-from diffusion_planner.utils.config import Config
 from diffusion_planner.model.diffusion_planner import Diffusion_Planner
+from diffusion_planner.utils.config import Config
+
 from guidance_gui.generate_samples import generate_samples
+from preference_optimization.lora_utils import load_lora_checkpoint
+from preference_optimization.utils import load_npz_data
 from rlvr.reward import RewardConfig, compute_reward_batch
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"

--- a/rlvr/autoresearch/tools/grpo_viz.py
+++ b/rlvr/autoresearch/tools/grpo_viz.py
@@ -21,20 +21,21 @@ import json
 from pathlib import Path
 
 import matplotlib
+
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import matplotlib.transforms as mtransforms
 import numpy as np
 import torch
+from diffusion_planner.model.diffusion_planner import Diffusion_Planner
+from diffusion_planner.utils.config import Config
 from matplotlib.patches import Rectangle
 
-from preference_optimization.utils import load_npz_data
 from preference_optimization.lora_utils import load_lora_checkpoint
-from diffusion_planner.utils.config import Config
-from diffusion_planner.model.diffusion_planner import Diffusion_Planner
+from preference_optimization.utils import load_npz_data
 from rlvr.grpo_sampler import SamplerConfig
 from rlvr.grpo_sampler_batched import generate_diverse_group_batched
-from rlvr.reward import RewardConfig, compute_reward_batch, compute_lane_departure_penalty
+from rlvr.reward import RewardConfig, compute_lane_departure_penalty, compute_reward_batch
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 

--- a/rlvr/autoresearch/tools/reward_config_from_json.py
+++ b/rlvr/autoresearch/tools/reward_config_from_json.py
@@ -7,6 +7,7 @@ Note: only maps commonly-used reward fields, not every RewardConfig attribute.
 
 import json
 from pathlib import Path
+
 from rlvr.reward import RewardConfig
 
 

--- a/rlvr/autoresearch/tools/viz_explorer_per_scene.py
+++ b/rlvr/autoresearch/tools/viz_explorer_per_scene.py
@@ -1,0 +1,164 @@
+"""Visualize exploration policy per-scene guidance outputs.
+
+Loads a trained exploration policy checkpoint and runs deterministic inference
+on each scene to show the learned eta_lat/eta_lon guidance parameters.
+
+Usage:
+    python -m rlvr.autoresearch.tools.viz_explorer_per_scene \
+        --model_path /path/to/base_model.pth \
+        --exp_dir /path/to/experiment_dir \
+        --scenes /path/to/scenes.json \
+        --epoch 10
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from exploration_policy.model import ExplorationPolicy, ExplorationPolicyConfig
+from exploration_policy.utils import generate_reference_trajectory, run_frozen_encoder
+from preference_optimization.model_utils import load_model
+from preference_optimization.utils import load_npz_data
+from rlvr.grpo_config import GRPOConfig
+
+
+def analyze_explorer(
+    policy_model: torch.nn.Module,
+    model_args,
+    explorer: ExplorationPolicy,
+    scene_paths: list[str],
+    device: torch.device,
+) -> dict:
+    """Run explorer on all scenes and return per-scene eta outputs."""
+    eta_lats, eta_lons, scene_names = [], [], []
+
+    for path in scene_paths:
+        try:
+            data = load_npz_data(path, device)
+            if "delay" not in data:
+                data["delay"] = torch.zeros(1, dtype=torch.long, device=device)
+            norm_data = model_args.observation_normalizer(data)
+
+            with torch.no_grad():
+                x_ref_np = generate_reference_trajectory(
+                    policy_model, model_args, norm_data, device,
+                )
+                x_ref = torch.from_numpy(x_ref_np).unsqueeze(0).to(device)
+                scene_enc = run_frozen_encoder(policy_model, norm_data)
+                output = explorer(scene_enc, x_ref, deterministic=True)
+
+            eta_lats.append(output.eta_lat.item())
+            eta_lons.append(output.eta_lon.item())
+            scene_names.append(Path(path).stem)
+        except Exception as e:
+            print(f"  Skip {Path(path).stem}: {e}")
+
+    return {
+        "eta_lat": np.array(eta_lats),
+        "eta_lon": np.array(eta_lons),
+        "scenes": scene_names,
+    }
+
+
+def load_explorer(
+    exp_dir: Path, epoch: int, model_args, device: torch.device,
+) -> ExplorationPolicy | None:
+    """Load exploration policy from experiment checkpoint."""
+    with open(exp_dir / "grpo_config.json") as f:
+        cfg_dict = json.load(f)
+    config = GRPOConfig()
+    for k, v in cfg_dict.items():
+        if hasattr(config, k):
+            setattr(config, k, v)
+
+    # Find checkpoint
+    ckpt_dir = exp_dir / f"lora_epoch_{epoch:03d}"
+    if not ckpt_dir.exists():
+        for e in range(epoch, 0, -1):
+            ckpt_dir = exp_dir / f"lora_epoch_{e:03d}"
+            if ckpt_dir.exists():
+                epoch = e
+                break
+        else:
+            print(f"No checkpoint dirs found in {exp_dir}")
+            return None
+
+    policy_path = ckpt_dir / "exploration_policy.pth"
+    if not policy_path.exists():
+        print(f"No exploration_policy.pth in {ckpt_dir}")
+        return None
+
+    ep_config = ExplorationPolicyConfig(
+        hidden_dim=config.exploration_hidden_dim,
+        n_mixer_layers=config.exploration_n_mixer_layers,
+        n_attn_heads=config.exploration_n_attn_heads,
+        dropout=config.exploration_dropout,
+        learning_rate=config.exploration_lr,
+        encoder_hidden_dim=model_args.hidden_dim,
+        head_init=config.exploration_head_init,
+        head_raw_scale=config.exploration_head_raw_scale,
+    )
+    explorer = ExplorationPolicy(ep_config, ref_seq_len=model_args.future_len).to(device)
+    state = torch.load(policy_path, map_location=device, weights_only=False)
+    explorer.load_state_dict(state, strict=False)
+    explorer.eval()
+    print(f"Loaded explorer from {ckpt_dir} (epoch {epoch})")
+    return explorer
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Visualize exploration policy per-scene outputs")
+    parser.add_argument("--model_path", type=Path, required=True, help="Base model .pth")
+    parser.add_argument("--exp_dir", type=Path, required=True, help="Experiment directory (contains grpo_config.json)")
+    parser.add_argument("--scenes", type=Path, required=True, help="JSON list of scene NPZ paths")
+    parser.add_argument("--epoch", type=int, default=10, help="Checkpoint epoch to load")
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    policy_model, model_args = load_model(args.model_path, device)
+    policy_model.eval()
+
+    with open(args.scenes) as f:
+        scene_paths = json.load(f)
+
+    explorer = load_explorer(args.exp_dir, args.epoch, model_args, device)
+    if explorer is None:
+        return
+
+    result = analyze_explorer(policy_model, model_args, explorer, scene_paths, device)
+    lat = result["eta_lat"]
+    lon = result["eta_lon"]
+    n = len(lat)
+
+    if n == 0:
+        print("No scenes processed successfully.")
+        return
+
+    print(f"\n{'='*70}")
+    print(f"Exploration Policy Per-Scene Analysis ({n} scenes)")
+    print(f"{'='*70}")
+    print(f"  eta_lat: mean={lat.mean():.4f}, std={lat.std():.4f}, min={lat.min():.4f}, max={lat.max():.4f}")
+    print(f"  eta_lon: mean={lon.mean():.4f}, std={lon.std():.4f}, min={lon.min():.4f}, max={lon.max():.4f}")
+    print(f"  Scene-to-scene lat range: {lat.max() - lat.min():.4f}")
+    print(f"  Scene-to-scene lon range: {lon.max() - lon.min():.4f}")
+
+    print(f"\n  {'Scene':<50} {'eta_lat':>8} {'eta_lon':>8}")
+    print(f"  {'-'*66}")
+    for i in range(n):
+        print(f"  {result['scenes'][i]:<50} {lat[i]:>+8.4f} {lon[i]:>+8.4f}")
+
+    lat_order = np.argsort(lat)
+    lon_order = np.argsort(lon)
+    print(f"\n  Extremes:")
+    print(f"  Most LEFT:   {result['scenes'][lat_order[-1]]:<50} lat={lat[lat_order[-1]]:+.4f}")
+    print(f"  Most RIGHT:  {result['scenes'][lat_order[0]]:<50} lat={lat[lat_order[0]]:+.4f}")
+    print(f"  Fastest:     {result['scenes'][lon_order[-1]]:<50} lon={lon[lon_order[-1]]:+.4f}")
+    print(f"  Slowest:     {result['scenes'][lon_order[0]]:<50} lon={lon[lon_order[0]]:+.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/viz_explorer_per_scene.py
+++ b/rlvr/autoresearch/tools/viz_explorer_per_scene.py
@@ -68,7 +68,11 @@ def load_explorer(
     exp_dir: Path, epoch: int, model_args, device: torch.device,
 ) -> ExplorationPolicy | None:
     """Load exploration policy from experiment checkpoint."""
-    with open(exp_dir / "grpo_config.json") as f:
+    config_path = exp_dir / "grpo_config.json"
+    if not config_path.exists():
+        print(f"Config not found: {config_path}")
+        return None
+    with open(config_path) as f:
         cfg_dict = json.load(f)
     config = GRPOConfig()
     for k, v in cfg_dict.items():

--- a/rlvr/autoresearch/tools/viz_explorer_trajectories.py
+++ b/rlvr/autoresearch/tools/viz_explorer_trajectories.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+"""Visualize exploration policy's effect on trajectories.
+
+For each scene: generates a reference (unguided) trajectory and an explorer-guided
+trajectory, then plots both on the same scene with road borders and lane geometry.
+
+Usage:
+    python -m rlvr.autoresearch.tools.viz_explorer_trajectories \
+      --model_path /path/to/best_model.pth \
+      --exp_dir /path/to/experiment_dir \
+      --scenes /path/to/scenes.json \
+      --epoch 10 \
+      --output_dir /path/to/output \
+      [--lora_path /path/to/lora_dir] \
+      [--n_scenes 10] \
+      [--indices 0 5 10 15] \
+      [--lambda_lat 2.5] [--lambda_lon 0.25] [--guidance_scale 0.5] \
+      [--cols 3]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import matplotlib.transforms as mtransforms
+import numpy as np
+import torch
+from diffusion_planner.model.diffusion_planner import Diffusion_Planner
+from diffusion_planner.model.guidance.composer import GuidanceComposer
+from diffusion_planner.model.guidance.config import GuidanceConfig, GuidanceSetConfig
+from diffusion_planner.utils.config import Config
+from matplotlib.patches import Rectangle
+
+from exploration_policy.model import ExplorationPolicy, ExplorationPolicyConfig
+from exploration_policy.utils import generate_reference_trajectory, run_frozen_encoder
+from guidance_gui.generate_samples import generate_samples
+from preference_optimization.lora_utils import load_lora_checkpoint
+from preference_optimization.utils import load_npz_data
+from rlvr.grpo_config import GRPOConfig
+
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+
+
+# ---------------------------------------------------------------------------
+# Model / explorer loading
+# ---------------------------------------------------------------------------
+
+def load_model(model_path: str, lora_path: str | None = None):
+    """Load base model and optionally apply LoRA."""
+    model_dir = Path(model_path).parent
+    args_path = model_dir / "args.json"
+    if not args_path.exists():
+        args_path = model_dir.parent / "args.json"
+    args = Config(str(args_path))
+    model = Diffusion_Planner(args)
+    ckpt = torch.load(model_path, map_location=DEVICE)
+    state = ckpt.get("model", ckpt)
+    state = {k.replace("module.", ""): v for k, v in state.items()}
+    model.load_state_dict(state)
+    model.to(DEVICE)
+    if lora_path:
+        model = load_lora_checkpoint(model, lora_path)
+    model.eval()
+    return model, args
+
+
+def load_explorer(
+    exp_dir: Path, epoch: int, model_args, device: torch.device,
+) -> ExplorationPolicy | None:
+    """Load exploration policy from experiment checkpoint."""
+    cfg_path = exp_dir / "grpo_config.json"
+    if cfg_path.exists():
+        with open(cfg_path) as f:
+            cfg_dict = json.load(f)
+        config = GRPOConfig()
+        for k, v in cfg_dict.items():
+            if hasattr(config, k):
+                setattr(config, k, v)
+    else:
+        config = GRPOConfig()
+
+    # Find checkpoint dir
+    ckpt_dir = exp_dir / f"lora_epoch_{epoch:03d}"
+    if not ckpt_dir.exists():
+        for e in range(epoch, 0, -1):
+            ckpt_dir = exp_dir / f"lora_epoch_{e:03d}"
+            if ckpt_dir.exists():
+                epoch = e
+                break
+        else:
+            print(f"No checkpoint dirs found in {exp_dir}")
+            return None
+
+    policy_path = ckpt_dir / "exploration_policy.pth"
+    if not policy_path.exists():
+        print(f"No exploration_policy.pth in {ckpt_dir}")
+        return None
+
+    ep_config = ExplorationPolicyConfig(
+        hidden_dim=config.exploration_hidden_dim,
+        n_mixer_layers=config.exploration_n_mixer_layers,
+        n_attn_heads=config.exploration_n_attn_heads,
+        dropout=config.exploration_dropout,
+        learning_rate=config.exploration_lr,
+        encoder_hidden_dim=model_args.hidden_dim,
+        head_init=config.exploration_head_init,
+        head_raw_scale=config.exploration_head_raw_scale,
+    )
+    explorer = ExplorationPolicy(ep_config, ref_seq_len=model_args.future_len).to(device)
+    state = torch.load(policy_path, map_location=device, weights_only=False)
+    explorer.load_state_dict(state, strict=False)
+    explorer.eval()
+    print(f"Loaded explorer from {ckpt_dir} (epoch {epoch})")
+    return explorer
+
+
+# ---------------------------------------------------------------------------
+# Drawing helpers
+# ---------------------------------------------------------------------------
+
+def draw_borders_and_lanes(ax, npz_path: str):
+    """Draw road borders (line_strings ch3) and lane boundaries."""
+    npz = np.load(npz_path)
+
+    # Lane boundaries (left/right offsets from centerline)
+    lanes = npz["lanes"]
+    for i in range(lanes.shape[0]):
+        lane = lanes[i]
+        if np.abs(lane[:, :2]).sum() < 1e-6:
+            continue
+        if lane.shape[1] > 7:
+            pts = lane[:, :2]
+            lb, rb = lane[:, 4:6], lane[:, 6:8]
+            v = np.abs(pts).sum(axis=1) > 0.1
+            if v.sum() > 1:
+                ax.plot((pts + lb)[v, 0], (pts + lb)[v, 1], "-",
+                        color="#bbb", alpha=0.5, lw=0.7)
+                ax.plot((pts + rb)[v, 0], (pts + rb)[v, 1], "-",
+                        color="#bbb", alpha=0.5, lw=0.7)
+        # Centerline
+        valid = np.abs(lane[:, :2]).sum(axis=1) > 0.1
+        if valid.sum() > 1:
+            ax.plot(lane[valid, 0], lane[valid, 1], "--",
+                    color="#999", alpha=0.3, lw=0.5)
+
+    # Road borders from line_strings channel 3
+    ls = npz["line_strings"]
+    for i in range(ls.shape[0]):
+        line = ls[i]
+        if np.abs(line[:, :2]).sum() < 1e-6:
+            continue
+        if ls.shape[-1] >= 4 and line[:, 3].max() > 0.5:
+            valid = (line[:, 3] > 0.5) & (np.abs(line[:, :2]).sum(axis=1) > 0.01)
+            if valid.sum() > 1:
+                ax.plot(line[valid, 0], line[valid, 1],
+                        color="red", lw=3, alpha=0.7, zorder=4)
+
+    return npz
+
+
+def draw_trajectory(ax, traj, label, color, linestyle="-", zorder=10):
+    """Draw a trajectory with dots every 3 steps and endpoint footprint."""
+    pl = np.linalg.norm(np.diff(traj[:, :2], axis=0), axis=1).sum()
+    ax.plot(traj[:, 0], traj[:, 1], linestyle, color=color, lw=2,
+            alpha=0.6, zorder=zorder)
+    ax.plot(traj[::3, 0], traj[::3, 1], "o", color=color, ms=3.5,
+            alpha=0.9, mew=0, zorder=zorder + 1,
+            label=f"{label} ({pl:.1f}m)")
+
+
+def draw_footprints(ax, traj, color, zorder=8):
+    """Draw ego footprints at regular intervals along trajectory."""
+    wb, length, width = 2.75, 4.34, 1.70
+    ro = (length - wb) / 2
+
+    for ts in range(5, len(traj), 10):
+        cx, cy = traj[ts, 0], traj[ts, 1]
+        cos_h, sin_h = traj[ts, 2], traj[ts, 3]
+        hn = np.sqrt(cos_h ** 2 + sin_h ** 2)
+        if hn > 0.01:
+            heading = np.arctan2(sin_h / hn, cos_h / hn)
+            t_rot = (mtransforms.Affine2D().rotate(heading).translate(cx, cy)
+                     + ax.transData)
+            ax.add_patch(Rectangle(
+                (-ro, -width / 2), length, width, lw=0.5,
+                ec=color, fc=color, alpha=0.15, zorder=zorder, transform=t_rot,
+            ))
+
+    # Endpoint footprint (stronger)
+    t_end = len(traj) - 1
+    cx, cy = traj[t_end, 0], traj[t_end, 1]
+    cos_h, sin_h = traj[t_end, 2], traj[t_end, 3]
+    hn = np.sqrt(cos_h ** 2 + sin_h ** 2)
+    if hn > 0.01:
+        heading = np.arctan2(sin_h / hn, cos_h / hn)
+        t_rot = (mtransforms.Affine2D().rotate(heading).translate(cx, cy)
+                 + ax.transData)
+        ax.add_patch(Rectangle(
+            (-ro, -width / 2), length, width, lw=1.5,
+            ec=color, fc=color, alpha=0.4, zorder=zorder + 1, transform=t_rot,
+        ))
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+@torch.no_grad()
+def main():
+    parser = argparse.ArgumentParser(
+        description="Visualize exploration policy's effect on trajectories",
+    )
+    parser.add_argument("--model_path", type=Path, required=True,
+                        help="Base model .pth")
+    parser.add_argument("--exp_dir", type=Path, required=True,
+                        help="Experiment dir (contains grpo_config.json)")
+    parser.add_argument("--scenes", type=Path, required=True,
+                        help="JSON list of NPZ scene paths")
+    parser.add_argument("--epoch", type=int, default=10,
+                        help="Checkpoint epoch to load")
+    parser.add_argument("--output_dir", type=Path, required=True,
+                        help="Directory to save output images")
+    parser.add_argument("--lora_path", type=Path, default=None,
+                        help="LoRA checkpoint dir (optional)")
+    parser.add_argument("--n_scenes", type=int, default=10,
+                        help="Number of scenes (evenly spaced) if --indices not given")
+    parser.add_argument("--indices", type=int, nargs="*", default=None,
+                        help="Specific scene indices to visualize")
+    parser.add_argument("--lambda_lat", type=float, default=2.5,
+                        help="Lateral guidance lambda")
+    parser.add_argument("--lambda_lon", type=float, default=0.25,
+                        help="Longitudinal guidance lambda")
+    parser.add_argument("--guidance_scale", type=float, default=0.5,
+                        help="Global guidance scale")
+    parser.add_argument("--cols", type=int, default=3,
+                        help="Columns in grid layout")
+    args = parser.parse_args()
+
+    device = torch.device(DEVICE)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Load scenes
+    with open(args.scenes) as f:
+        all_scenes = json.load(f)
+
+    if args.indices:
+        indices = args.indices
+    else:
+        step = max(1, len(all_scenes) // args.n_scenes)
+        indices = list(range(0, len(all_scenes), step))[:args.n_scenes]
+
+    # Load model
+    lora_str = str(args.lora_path) if args.lora_path else None
+    print(f"Loading model from {args.model_path}")
+    model, model_args = load_model(str(args.model_path), lora_str)
+
+    # Load exploration policy
+    explorer = load_explorer(args.exp_dir, args.epoch, model_args, device)
+    if explorer is None:
+        print("Failed to load explorer. Exiting.")
+        return
+
+    # -----------------------------------------------------------------------
+    # Per-scene: generate reference + guided trajectories, collect eta values
+    # -----------------------------------------------------------------------
+    results = []  # list of dicts per scene
+
+    for si in indices:
+        npz_path = all_scenes[si]
+        name = Path(npz_path).stem
+        print(f"  Scene {si}: {name}")
+
+        try:
+            data = load_npz_data(npz_path, device)
+            if "delay" not in data:
+                data["delay"] = torch.zeros(1, dtype=torch.long, device=device)
+            norm_data = {k: v.clone() if isinstance(v, torch.Tensor) else v
+                         for k, v in data.items()}
+            norm_data = model_args.observation_normalizer(norm_data)
+
+            # 1) Reference trajectory (deterministic, no guidance)
+            traj_ref = generate_reference_trajectory(
+                model, model_args, norm_data, device,
+            )  # (T, 4) numpy
+
+            # 2) Get explorer's eta values
+            scene_enc = run_frozen_encoder(model, norm_data)
+            x_ref_t = torch.from_numpy(traj_ref).unsqueeze(0).float().to(device)
+            output = explorer(scene_enc, x_ref_t, deterministic=True)
+            eta_lat = output.eta_lat.item()
+            eta_lon = output.eta_lon.item()
+
+            # 3) Set reference trajectory for guidance displacement
+            norm_data["reference_trajectory"] = torch.tensor(
+                traj_ref[None], device=device, dtype=torch.float32,
+            )
+
+            # 4) Guided trajectory using explorer's etas
+            guidance_fns = [
+                GuidanceConfig(
+                    name="lateral", enabled=True, scale=1.0,
+                    params={"lambda_lat": args.lambda_lat, "eta_lat": eta_lat},
+                ),
+                GuidanceConfig(
+                    name="longitudinal", enabled=True, scale=1.0,
+                    params={"lambda_lon": args.lambda_lon, "eta_lon": eta_lon},
+                ),
+            ]
+            set_cfg = GuidanceSetConfig(
+                functions=guidance_fns, global_scale=args.guidance_scale,
+            )
+            composer = GuidanceComposer(set_cfg)
+
+            traj_guided = generate_samples(
+                model, model_args, norm_data, 0.0, 1, composer, device,
+            )[0]  # (T, 4) numpy
+
+            results.append({
+                "si": si,
+                "npz_path": npz_path,
+                "name": name,
+                "traj_ref": traj_ref,
+                "traj_guided": traj_guided,
+                "eta_lat": eta_lat,
+                "eta_lon": eta_lon,
+            })
+        except Exception as e:
+            print(f"    SKIP: {e}")
+
+    if not results:
+        print("No scenes processed successfully.")
+        return
+
+    # -----------------------------------------------------------------------
+    # Plot grid
+    # -----------------------------------------------------------------------
+    n = len(results)
+    cols = min(args.cols, n)
+    rows = (n + cols - 1) // cols
+    fig, axes = plt.subplots(rows, cols, figsize=(8 * cols, 8 * rows))
+    if n == 1:
+        axes = np.array([axes])
+    axes = np.atleast_2d(axes).reshape(-1)
+
+    for plot_idx, res in enumerate(results):
+        ax = axes[plot_idx]
+        npz_path = res["npz_path"]
+        traj_ref = res["traj_ref"]
+        traj_guided = res["traj_guided"]
+
+        # Scene geometry
+        npz = draw_borders_and_lanes(ax, npz_path)
+
+        # GT trajectory
+        gt = npz["ego_agent_future"]
+        ax.plot(gt[:, 0], gt[:, 1], "g-", lw=2, alpha=0.5, zorder=5)
+        ax.plot(gt[::3, 0], gt[::3, 1], "go", ms=3, alpha=0.7, mew=0,
+                zorder=6, label="GT")
+
+        # Ego box at origin
+        wb, length, width = 2.75, 4.34, 1.70
+        es = npz.get("ego_shape", None)
+        if es is not None and len(es) >= 3:
+            wb, length, width = float(es[0]), float(es[1]), float(es[2])
+        ro = (length - wb) / 2
+        ax.add_patch(Rectangle(
+            (-ro, -width / 2), length, width,
+            lw=2, ec="black", fc="#3366cc", alpha=0.9, zorder=20,
+        ))
+
+        # Reference trajectory (blue)
+        draw_trajectory(ax, traj_ref, "Reference", "blue", "-", zorder=10)
+        draw_footprints(ax, traj_ref, "blue", zorder=8)
+
+        # Guided trajectory (red)
+        draw_trajectory(ax, traj_guided, "Explorer-guided", "red", "--", zorder=12)
+        draw_footprints(ax, traj_guided, "red", zorder=11)
+
+        # Shift arrows at a few timesteps
+        T = min(80, traj_ref.shape[0], traj_guided.shape[0])
+        for t in [10, 20, 35, 55]:
+            if t < T:
+                dx = traj_guided[t, 0] - traj_ref[t, 0]
+                dy = traj_guided[t, 1] - traj_ref[t, 1]
+                if np.sqrt(dx ** 2 + dy ** 2) > 0.05:
+                    ax.annotate(
+                        "", xy=(traj_guided[t, 0], traj_guided[t, 1]),
+                        xytext=(traj_ref[t, 0], traj_ref[t, 1]),
+                        arrowprops=dict(arrowstyle="->", color="magenta", lw=1.5),
+                    )
+
+        # Auto-zoom
+        all_pts = np.vstack([
+            traj_ref[:, :2], traj_guided[:, :2], gt[:, :2], [[0, 0]],
+        ])
+        cx, cy = np.mean(all_pts[:, 0]), np.mean(all_pts[:, 1])
+        half = max(np.ptp(all_pts[:, 0]), np.ptp(all_pts[:, 1])) * 0.6 + 8
+        ax.set_xlim(cx - half, cx + half)
+        ax.set_ylim(cy - half, cy + half)
+        ax.set_aspect("equal")
+        ax.grid(True, alpha=0.15)
+        ax.legend(fontsize=7, loc="upper left")
+
+        # Annotation with eta values
+        lat_cm = res["eta_lat"] * args.lambda_lat * 100
+        lon_pct = res["eta_lon"] * args.lambda_lon * 100
+        ax.set_title(
+            f"[{res['si']}] {res['name'][-25:]}\n"
+            f"eta_lat={res['eta_lat']:+.3f} ({lat_cm:+.0f}cm)  "
+            f"eta_lon={res['eta_lon']:+.3f} ({lon_pct:+.1f}%)",
+            fontsize=9,
+        )
+
+    # Hide unused axes
+    for j in range(n, len(axes)):
+        axes[j].set_visible(False)
+
+    fig.suptitle(
+        "Exploration Policy: Reference (blue) vs Guided (red)\n"
+        f"lambda_lat={args.lambda_lat}, lambda_lon={args.lambda_lon}, "
+        f"guidance_scale={args.guidance_scale}",
+        fontsize=13,
+    )
+    fig.tight_layout()
+    out_path = args.output_dir / "explorer_trajectories.png"
+    fig.savefig(out_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    print(f"\nSaved grid: {out_path}")
+
+    # Also save individual per-scene images
+    for res in results:
+        fig_s, ax_s = plt.subplots(1, 1, figsize=(10, 10))
+        npz = draw_borders_and_lanes(ax_s, res["npz_path"])
+
+        gt = npz["ego_agent_future"]
+        ax_s.plot(gt[:, 0], gt[:, 1], "g-", lw=2, alpha=0.5, zorder=5)
+        ax_s.plot(gt[::3, 0], gt[::3, 1], "go", ms=3, alpha=0.7, mew=0,
+                  zorder=6, label="GT")
+
+        es = npz.get("ego_shape", None)
+        wb = float(es[0]) if es is not None and len(es) >= 1 else 2.75
+        length = float(es[1]) if es is not None and len(es) >= 2 else 4.34
+        width = float(es[2]) if es is not None and len(es) >= 3 else 1.70
+        ro = (length - wb) / 2
+        ax_s.add_patch(Rectangle(
+            (-ro, -width / 2), length, width,
+            lw=2, ec="black", fc="#3366cc", alpha=0.9, zorder=20,
+        ))
+
+        draw_trajectory(ax_s, res["traj_ref"], "Reference", "blue", "-", zorder=10)
+        draw_footprints(ax_s, res["traj_ref"], "blue", zorder=8)
+        draw_trajectory(ax_s, res["traj_guided"], "Explorer-guided", "red", "--", zorder=12)
+        draw_footprints(ax_s, res["traj_guided"], "red", zorder=11)
+
+        T = min(80, res["traj_ref"].shape[0], res["traj_guided"].shape[0])
+        for t in [10, 20, 35, 55]:
+            if t < T:
+                dx = res["traj_guided"][t, 0] - res["traj_ref"][t, 0]
+                dy = res["traj_guided"][t, 1] - res["traj_ref"][t, 1]
+                if np.sqrt(dx ** 2 + dy ** 2) > 0.05:
+                    ax_s.annotate(
+                        "", xy=(res["traj_guided"][t, 0], res["traj_guided"][t, 1]),
+                        xytext=(res["traj_ref"][t, 0], res["traj_ref"][t, 1]),
+                        arrowprops=dict(arrowstyle="->", color="magenta", lw=1.5),
+                    )
+
+        all_pts = np.vstack([
+            res["traj_ref"][:, :2], res["traj_guided"][:, :2], gt[:, :2], [[0, 0]],
+        ])
+        cx, cy = np.mean(all_pts[:, 0]), np.mean(all_pts[:, 1])
+        half = max(np.ptp(all_pts[:, 0]), np.ptp(all_pts[:, 1])) * 0.6 + 8
+        ax_s.set_xlim(cx - half, cx + half)
+        ax_s.set_ylim(cy - half, cy + half)
+        ax_s.set_aspect("equal")
+        ax_s.grid(True, alpha=0.15)
+        ax_s.legend(fontsize=9, loc="upper left")
+
+        lat_cm = res["eta_lat"] * args.lambda_lat * 100
+        lon_pct = res["eta_lon"] * args.lambda_lon * 100
+        ax_s.set_title(
+            f"Scene {res['si']}: {res['name']}\n"
+            f"eta_lat={res['eta_lat']:+.3f} ({lat_cm:+.0f}cm)  "
+            f"eta_lon={res['eta_lon']:+.3f} ({lon_pct:+.1f}%)",
+            fontsize=11,
+        )
+
+        fig_s.tight_layout()
+        scene_out = args.output_dir / f"scene_{res['si']:04d}.png"
+        fig_s.savefig(scene_out, dpi=150, bbox_inches="tight")
+        plt.close(fig_s)
+        print(f"  Saved: {scene_out}")
+
+    print(f"\nDone. {len(results)} scenes visualized in {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/viz_guidance_actual.py
+++ b/rlvr/autoresearch/tools/viz_guidance_actual.py
@@ -20,21 +20,22 @@ import json
 import sys
 from pathlib import Path
 
+import matplotlib
 import numpy as np
 import torch
-import matplotlib
+
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
-
-from preference_optimization.utils import load_npz_data
-from preference_optimization.lora_utils import load_lora_checkpoint
-from diffusion_planner.utils.config import Config
 from diffusion_planner.model.diffusion_planner import Diffusion_Planner
 from diffusion_planner.model.guidance.composer import GuidanceComposer
 from diffusion_planner.model.guidance.config import GuidanceConfig, GuidanceSetConfig
+from diffusion_planner.utils.config import Config
+
 from exploration_policy import ExplorationPolicy, ExplorationPolicyConfig
-from exploration_policy.utils import get_frozen_encoder, generate_reference_trajectory
+from exploration_policy.utils import generate_reference_trajectory, get_frozen_encoder
 from guidance_gui.generate_samples import generate_samples
+from preference_optimization.lora_utils import load_lora_checkpoint
+from preference_optimization.utils import load_npz_data
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 

--- a/rlvr/autoresearch/tools/viz_lane_departure.py
+++ b/rlvr/autoresearch/tools/viz_lane_departure.py
@@ -16,21 +16,23 @@ import argparse
 import json
 import os
 
+import matplotlib
 import numpy as np
 import torch
-import matplotlib
+
 matplotlib.use("Agg")
-import matplotlib.pyplot as plt
-from matplotlib.patches import Polygon as MplPolygon, Patch
 import matplotlib.cm as cmx
+import matplotlib.pyplot as plt
+from matplotlib.patches import Patch
+from matplotlib.patches import Polygon as MplPolygon
 
 from preference_optimization.utils import load_npz_data
 from rlvr.reward import (
+    _LANE_PTS_PER_SIDE,
     _build_lane_polygons,
     _classify_outer_boundaries,
     _point_in_polygons,
     _point_to_segments_dist,
-    _LANE_PTS_PER_SIDE,
 )
 
 
@@ -338,7 +340,8 @@ def main():
             print(f"  Saved: {fname}")
         except Exception as e:
             print(f"  FAILED: {e}")
-            import traceback; traceback.print_exc()
+            import traceback
+            traceback.print_exc()
 
 
 if __name__ == "__main__":

--- a/rlvr/autoresearch/visualize_scenes.py
+++ b/rlvr/autoresearch/visualize_scenes.py
@@ -28,6 +28,7 @@ import sys
 from pathlib import Path
 
 import matplotlib
+
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import matplotlib.transforms as mtransforms
@@ -39,11 +40,12 @@ _repo = str(Path(__file__).resolve().parent.parent.parent)
 if _repo not in sys.path:
     sys.path.insert(0, _repo)
 
-from preference_optimization.utils import load_npz_data
-from preference_optimization.lora_utils import load_lora_checkpoint
-from guidance_gui.generate_samples import generate_samples
-from diffusion_planner.utils.config import Config
 from diffusion_planner.model.diffusion_planner import Diffusion_Planner
+from diffusion_planner.utils.config import Config
+
+from guidance_gui.generate_samples import generate_samples
+from preference_optimization.lora_utils import load_lora_checkpoint
+from preference_optimization.utils import load_npz_data
 from rlvr.reward import RewardConfig, compute_reward_batch
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"

--- a/rlvr/closed_loop/__init__.py
+++ b/rlvr/closed_loop/__init__.py
@@ -15,9 +15,13 @@ def verify_lora_loaded(model, model_args, scene_path, device, label=""):
     Returns:
         True if LoRA has measurable effect, False otherwise.
     """
-    import torch, copy, numpy as np
-    from preference_optimization.utils import load_npz_data
+    import copy
+
+    import numpy as np
+    import torch
+
     from guidance_gui.generate_samples import generate_samples
+    from preference_optimization.utils import load_npz_data
 
     data = load_npz_data(scene_path, device)
     if "delay" not in data:

--- a/rlvr/closed_loop/batched_rollout.py
+++ b/rlvr/closed_loop/batched_rollout.py
@@ -16,10 +16,10 @@ from dataclasses import dataclass, field
 
 import numpy as np
 import torch
-from torch import nn
-
 from diffusion_planner.model.guidance.composer import GuidanceComposer
 from diffusion_planner.model.guidance.config import GuidanceConfig, GuidanceSetConfig
+from torch import nn
+
 from exploration_policy.model import ExplorationPolicy
 from preference_optimization.utils import load_npz_data as _load_npz_data_raw
 from rlvr.closed_loop.gae import compute_gae

--- a/rlvr/closed_loop/closed_loop_trainer.py
+++ b/rlvr/closed_loop/closed_loop_trainer.py
@@ -17,11 +17,11 @@ from pathlib import Path
 
 import numpy as np
 import torch
+from diffusion_planner.model.guidance.composer import GuidanceComposer
+from diffusion_planner.model.guidance.config import GuidanceConfig, GuidanceSetConfig
 from torch import nn, optim
 from tqdm import tqdm
 
-from diffusion_planner.model.guidance.composer import GuidanceComposer
-from diffusion_planner.model.guidance.config import GuidanceConfig, GuidanceSetConfig
 from exploration_policy.model import ExplorationPolicy, ExplorationPolicyConfig
 from exploration_policy.utils import generate_reference_trajectory, run_frozen_encoder
 from guidance_gui.generate_samples import generate_samples
@@ -181,7 +181,9 @@ class ClosedLoopExplorationTrainer:
         ~6x faster than sequential. Use sequential only for zi reproduction.
         """
         from rlvr.closed_loop.batched_rollout import (
-            _batched_encoder, _batched_generate, _batched_generate_varied_noise,
+            _batched_encoder,
+            _batched_generate,
+            _batched_generate_varied_noise,
         )
 
         if self.exploration_policy is not None:
@@ -569,7 +571,8 @@ class ClosedLoopExplorationTrainer:
         # --- Free rollout data from GPU before GRPO to avoid OOM ---
         # (eta stats already collected above from rollout_buffers)
         del rollout_buffers
-        import gc; gc.collect()
+        import gc
+        gc.collect()
         torch.cuda.empty_cache()
 
         # --- Reset RNG before GRPO to match zi's random state ---

--- a/rlvr/closed_loop/rollout.py
+++ b/rlvr/closed_loop/rollout.py
@@ -19,10 +19,10 @@ from dataclasses import dataclass, field
 
 import numpy as np
 import torch
-from torch import nn
-
 from diffusion_planner.model.guidance.composer import GuidanceComposer
 from diffusion_planner.model.guidance.config import GuidanceConfig, GuidanceSetConfig
+from torch import nn
+
 from exploration_policy.model import ExplorationPolicy
 from exploration_policy.utils import generate_reference_trajectory, run_frozen_encoder
 from guidance_gui.generate_samples import generate_samples

--- a/rlvr/closed_loop/state_update.py
+++ b/rlvr/closed_loop/state_update.py
@@ -8,7 +8,6 @@ in diffusion_planner/utils/data_augmentation.py.
 import math
 
 import torch
-
 from diffusion_planner.utils.data_augmentation import (
     heading_transform,
     vector_transform,

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -251,14 +251,17 @@ class GRPOConfig:
     # 1 = step every scene (original per-group), 4 = match DiT rhythm.
     exploration_grad_accum_groups: int = 1
 
-    # Explorer loss type: "reinforce" (default GRPO advantages), "rsft" (maximize
-    # log_prob of best eta only — ranked SFT for the explorer policy).
+    # Explorer loss type: "reinforce" (default GRPO advantages), "rsft" (MSE
+    # regression toward best eta — ranked SFT for the explorer policy).
     exploration_loss_type: str = "reinforce"
 
     # Use a pre-trained exploration policy during ranked SFT generation.
     # The explorer provides per-scene (eta_lat, eta_lon) guidance for trajectory generation.
-    # Set exploration_checkpoint_path to the .pth file. Explorer stays frozen during RSFT.
+    # Set exploration_checkpoint_path to the .pth file.
     ranked_sft_use_explorer: bool = False
+    # If True, explorer stays frozen during RSFT. If False, explorer trains jointly
+    # with DiT (explorer via REINFORCE/MSE on rewards, DiT via SFT loss).
+    ranked_sft_freeze_explorer: bool = True
 
     # Random guidance mode: replaces exploration policy with direct η sampling.
     # "explorer" (default): use learned exploration policy (Beta distributions).

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -127,10 +127,12 @@ class GRPOConfig:
     diffusion_t_range: list[float] = field(default_factory=lambda: [0.001, 0.1])
     diffusion_k_steps: int = 8  # K (noise, t) samples averaged per GRPO loss (matches DPO K=8)
 
-    # Log-probability GRPO (DDV2-style). When grpo_loss_type="logprob", the loss
-    # uses actual Gaussian log-probabilities from a truncated denoising rollout
-    # instead of MSE. This enables proper policy gradient for trajectory shape.
-    grpo_loss_type: str = "mse"  # "mse" (current) or "logprob" (DDV2-style)
+    # DiT GRPO loss type:
+    #   "advantage_mse" (default): advantage-weighted MSE diffusion loss.
+    #   "advantage_logprob": advantage-weighted Gaussian log-probabilities from
+    #       a truncated denoising rollout (DDV2-style). Enables proper policy
+    #       gradient for trajectory shape.
+    grpo_loss_type: str = "advantage_mse"
     logprob_num_steps: int = 10  # denoising steps for rollout
     logprob_t_start: float = 0.01  # starting noise level (truncated)
     logprob_discount: float = 0.8  # per-step advantage discount (DDV2 uses 0.8)
@@ -254,8 +256,9 @@ class GRPOConfig:
     # Explorer loss type:
     #   "advantage_logprob" (default): advantage-weighted negative log_prob of sampled etas.
     #       Pushes policy toward etas that got above-average reward.
-    #   "best_eta_mse": MSE regression of policy mean toward the best-reward eta.
+    #   "best_sample_mse": MSE regression of policy mean toward the best-reward eta.
     #       Directly supervises policy to output the best eta per scene.
+    #       Same principle as ranked SFT for the DiT (best trajectory MSE).
     exploration_loss_type: str = "advantage_logprob"
 
     # Use a pre-trained exploration policy during ranked SFT generation.
@@ -473,6 +476,21 @@ class GRPOConfig:
             if value is not None:
                 result[name] = value
         return result
+
+    def __post_init__(self):
+        """Normalize legacy loss type names to current names."""
+        _loss_renames = {
+            "mse": "advantage_mse",
+            "logprob": "advantage_logprob",
+            "reinforce": "advantage_logprob",
+            "rsft": "best_sample_mse",
+            "best_eta_mse": "best_sample_mse",
+            "grpo": "advantage_logprob",
+        }
+        if self.grpo_loss_type in _loss_renames:
+            self.grpo_loss_type = _loss_renames[self.grpo_loss_type]
+        if self.exploration_loss_type in _loss_renames:
+            self.exploration_loss_type = _loss_renames[self.exploration_loss_type]
 
     @property
     def uses_importance_sampling(self) -> bool:

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -251,6 +251,15 @@ class GRPOConfig:
     # 1 = step every scene (original per-group), 4 = match DiT rhythm.
     exploration_grad_accum_groups: int = 1
 
+    # Explorer loss type: "reinforce" (default GRPO advantages), "rsft" (maximize
+    # log_prob of best eta only — ranked SFT for the explorer policy).
+    exploration_loss_type: str = "reinforce"
+
+    # Use a pre-trained exploration policy during ranked SFT generation.
+    # The explorer provides per-scene (eta_lat, eta_lon) guidance for trajectory generation.
+    # Set exploration_checkpoint_path to the .pth file. Explorer stays frozen during RSFT.
+    ranked_sft_use_explorer: bool = False
+
     # Random guidance mode: replaces exploration policy with direct η sampling.
     # "explorer" (default): use learned exploration policy (Beta distributions).
     # "uniform": random η ~ U[-1, 1] (matches zero-init explorer output).

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -251,9 +251,12 @@ class GRPOConfig:
     # 1 = step every scene (original per-group), 4 = match DiT rhythm.
     exploration_grad_accum_groups: int = 1
 
-    # Explorer loss type: "reinforce" (default GRPO advantages), "rsft" (MSE
-    # regression toward best eta — ranked SFT for the explorer policy).
-    exploration_loss_type: str = "reinforce"
+    # Explorer loss type:
+    #   "advantage_logprob" (default): advantage-weighted negative log_prob of sampled etas.
+    #       Pushes policy toward etas that got above-average reward.
+    #   "best_eta_mse": MSE regression of policy mean toward the best-reward eta.
+    #       Directly supervises policy to output the best eta per scene.
+    exploration_loss_type: str = "advantage_logprob"
 
     # Use a pre-trained exploration policy during ranked SFT generation.
     # The explorer provides per-scene (eta_lat, eta_lon) guidance for trajectory generation.

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -491,6 +491,14 @@ class GRPOConfig:
             self.grpo_loss_type = _loss_renames[self.grpo_loss_type]
         if self.exploration_loss_type in _loss_renames:
             self.exploration_loss_type = _loss_renames[self.exploration_loss_type]
+        # Validate: best_sample_mse is not compatible with PPO (inner_epochs > 1)
+        if (self.exploration_loss_type == "best_sample_mse"
+                and self.exploration_inner_epochs > 1):
+            raise ValueError(
+                "exploration_loss_type='best_sample_mse' is not compatible with "
+                f"exploration_inner_epochs={self.exploration_inner_epochs} (PPO). "
+                "Use exploration_inner_epochs=1 or exploration_loss_type='advantage_logprob'."
+            )
 
     @property
     def uses_importance_sampling(self) -> bool:

--- a/rlvr/grpo_exploration_trainer.py
+++ b/rlvr/grpo_exploration_trainer.py
@@ -4,7 +4,8 @@ Extends the standard GRPO training with a learned exploration policy that
 outputs (eta_lat, eta_lon) from Beta distributions. The policy and DiT
 planner are trained simultaneously:
 
-- Policy: REINFORCE with GRPO group-relative advantages + entropy + KL
+- Policy: advantage-weighted log_prob (advantage_logprob) or MSE regression
+  toward best eta (best_eta_mse). Controlled by exploration_loss_type.
 - DiT: Standard GRPO diffusion loss (unchanged)
 
 The exploration policy samples K eta values from one distribution per scene,
@@ -47,16 +48,16 @@ def _load_npz(npz_path, device):
 
 
 class GRPOExplorationTrainer:
-    """Joint trainer for DiT planner (GRPO) + exploration policy (REINFORCE).
+    """Joint trainer for DiT planner (GRPO) + exploration policy.
 
     Per scene:
       1. Frozen encoder → scene_encoding
       2. LoRA-disabled DiT → x_ref (reference trajectory)
       3. Exploration policy(scene_encoding, x_ref) → Beta distributions
       4. Sample K η values → K trajectories (noise=0, lat+lon guidance)
-      5. Score → GRPO advantages
+      5. Score → group-relative advantages
       6. DiT loss: standard GRPO diffusion loss
-      7. Policy loss: REINFORCE + entropy + KL
+      7. Policy loss: advantage_logprob or best_eta_mse (see exploration_loss_type)
 
     Supports inverse KL scheduling: high DiT KL (stable planner) + low policy
     KL (free exploration) early, then swap as policy learns.
@@ -416,7 +417,7 @@ class GRPOExplorationTrainer:
                 self.dit_optimizer.zero_grad()
                 dit_accum = 0
 
-            # --- Exploration policy loss (REINFORCE or inner PPO) ---
+            # --- Exploration policy loss (advantage_logprob, best_eta_mse, or PPO) ---
             if self.use_explorer:
                 scene_encoding = group["scene_encoding"]
                 x_ref = group["x_ref"]
@@ -481,9 +482,9 @@ class GRPOExplorationTrainer:
                                 self.exploration_policy.parameters(), max_norm=1.0,
                             )
                             self.policy_optimizer.step()
-                    elif self.config.exploration_loss_type == "rsft":
+                    elif self.config.exploration_loss_type == "best_eta_mse":
                         # Ranked SFT for explorer: MSE regression of policy mean toward best eta.
-                        # Unlike REINFORCE which uses all K samples, this directly supervises
+                        # Unlike advantage_logprob which uses all K samples, this directly supervises
                         # the policy to output the best-reward eta for each scene.
                         best_idx = advantages_t.argmax()
                         best_eta_lat_01 = eta_lat_01[best_idx].detach()  # target (0,1)
@@ -517,7 +518,7 @@ class GRPOExplorationTrainer:
                             entropy_coef=self.config.exploration_entropy_coef,
                             kl_coef=self.config.exploration_kl_coef,
                         )
-                    # Backward pass for RSFT and REINFORCE paths
+                    # Backward pass for advantage_logprob and best_eta_mse paths
                     # (PPO path handles its own backward+step above)
                     if not policy_frozen and inner_epochs <= 1:
                         policy_loss.backward()
@@ -579,7 +580,7 @@ class GRPOExplorationTrainer:
             self.dit_optimizer.step()
             self.dit_optimizer.zero_grad()
 
-        # Policy optimizer step: only needed for REINFORCE (inner_epochs=1)
+        # Policy optimizer step: only needed for non-PPO (inner_epochs=1)
         # without per-group stepping. PPO and per-group both step above.
         if self.use_explorer and n_policy_accum > 0 and self.config.exploration_inner_epochs <= 1 and not policy_frozen:
             for p in self.exploration_policy.parameters():

--- a/rlvr/grpo_exploration_trainer.py
+++ b/rlvr/grpo_exploration_trainer.py
@@ -482,8 +482,9 @@ class GRPOExplorationTrainer:
                             )
                             self.policy_optimizer.step()
                     elif self.config.exploration_loss_type == "rsft":
-                        # Ranked SFT for explorer: MSE regression toward best eta
-                        # Find the best-reward trajectory's eta and regress toward it
+                        # Ranked SFT for explorer: MSE regression of policy mean toward best eta.
+                        # Unlike REINFORCE which uses all K samples, this directly supervises
+                        # the policy to output the best-reward eta for each scene.
                         best_idx = advantages_t.argmax()
                         best_eta_lat_01 = eta_lat_01[best_idx].detach()  # target (0,1)
                         best_eta_lon_01 = eta_lon_01[best_idx].detach()

--- a/rlvr/grpo_exploration_trainer.py
+++ b/rlvr/grpo_exploration_trainer.py
@@ -22,15 +22,15 @@ from pathlib import Path
 
 import numpy as np
 import torch
-from torch import nn, optim
-from tqdm import tqdm
-
 from diffusion_planner.model.guidance.composer import GuidanceComposer
 from diffusion_planner.model.guidance.config import GuidanceConfig, GuidanceSetConfig
-from exploration_policy.loss import compute_exploration_loss, _get_init_distributions
+from torch import nn, optim
+from torch.distributions import kl_divergence as kl_div
+from tqdm import tqdm
+
+from exploration_policy.loss import _get_init_distributions, compute_exploration_loss
 from exploration_policy.model import ExplorationPolicy, ExplorationPolicyConfig
 from exploration_policy.utils import generate_reference_trajectory, run_frozen_encoder
-from torch.distributions import kl_divergence as kl_div
 from guidance_gui.generate_samples import generate_samples
 from preference_optimization.utils import load_npz_data as _load_npz_data_raw
 from rlvr.grpo_config import GRPOConfig
@@ -481,6 +481,31 @@ class GRPOExplorationTrainer:
                                 self.exploration_policy.parameters(), max_norm=1.0,
                             )
                             self.policy_optimizer.step()
+                    elif self.config.exploration_loss_type == "rsft":
+                        # Ranked SFT for explorer: maximize log_prob of best eta only
+                        best_idx = advantages_t.argmax()
+                        best_log_prob = log_probs[best_idx]
+                        rsft_loss = -best_log_prob
+
+                        entropy_value = (lat_dist.entropy() + lon_dist.entropy()).mean()
+                        init_lat, init_lon = _get_init_distributions(self.device)
+                        kl_value = (kl_div(lat_dist, init_lat) + kl_div(lon_dist, init_lon)).mean()
+
+                        policy_loss = (
+                            rsft_loss
+                            + self.config.exploration_entropy_coef * (-entropy_value)
+                            + self.config.exploration_kl_coef * kl_value
+                        )
+                        policy_metrics = {
+                            "exploration_policy_loss": rsft_loss.item(),
+                            "exploration_entropy": entropy_value.item(),
+                            "exploration_kl": kl_value.item(),
+                            "exploration_total_loss": policy_loss.item(),
+                            "exploration_eta_lat_mean": lat_dist.mean.mean().item() * 2 - 1,
+                            "exploration_eta_lon_mean": lon_dist.mean.mean().item() * 2 - 1,
+                            "exploration_eta_lat_std": (lat_dist.variance.mean().item() * 4) ** 0.5,
+                            "exploration_eta_lon_std": (lon_dist.variance.mean().item() * 4) ** 0.5,
+                        }
                     else:
                         policy_loss, policy_metrics = compute_exploration_loss(
                             advantages=advantages_t,

--- a/rlvr/grpo_exploration_trainer.py
+++ b/rlvr/grpo_exploration_trainer.py
@@ -516,8 +516,9 @@ class GRPOExplorationTrainer:
                             entropy_coef=self.config.exploration_entropy_coef,
                             kl_coef=self.config.exploration_kl_coef,
                         )
-                    # Backward pass for both RSFT and REINFORCE paths
-                    if not policy_frozen:
+                    # Backward pass for RSFT and REINFORCE paths
+                    # (PPO path handles its own backward+step above)
+                    if not policy_frozen and inner_epochs <= 1:
                         policy_loss.backward()
                         if self.config.exploration_step_per_group:
                             n_policy_accum += 1

--- a/rlvr/grpo_exploration_trainer.py
+++ b/rlvr/grpo_exploration_trainer.py
@@ -5,7 +5,7 @@ outputs (eta_lat, eta_lon) from Beta distributions. The policy and DiT
 planner are trained simultaneously:
 
 - Policy: advantage-weighted log_prob (advantage_logprob) or MSE regression
-  toward best eta (best_eta_mse). Controlled by exploration_loss_type.
+  toward best eta (best_sample_mse). Controlled by exploration_loss_type.
 - DiT: Standard GRPO diffusion loss (unchanged)
 
 The exploration policy samples K eta values from one distribution per scene,
@@ -57,7 +57,7 @@ class GRPOExplorationTrainer:
       4. Sample K η values → K trajectories (noise=0, lat+lon guidance)
       5. Score → group-relative advantages
       6. DiT loss: standard GRPO diffusion loss
-      7. Policy loss: advantage_logprob or best_eta_mse (see exploration_loss_type)
+      7. Policy loss: advantage_logprob or best_sample_mse (see exploration_loss_type)
 
     Supports inverse KL scheduling: high DiT KL (stable planner) + low policy
     KL (free exploration) early, then swap as policy learns.
@@ -417,7 +417,7 @@ class GRPOExplorationTrainer:
                 self.dit_optimizer.zero_grad()
                 dit_accum = 0
 
-            # --- Exploration policy loss (advantage_logprob, best_eta_mse, or PPO) ---
+            # --- Exploration policy loss (advantage_logprob, best_sample_mse, or PPO) ---
             if self.use_explorer:
                 scene_encoding = group["scene_encoding"]
                 x_ref = group["x_ref"]
@@ -482,7 +482,7 @@ class GRPOExplorationTrainer:
                                 self.exploration_policy.parameters(), max_norm=1.0,
                             )
                             self.policy_optimizer.step()
-                    elif self.config.exploration_loss_type == "best_eta_mse":
+                    elif self.config.exploration_loss_type == "best_sample_mse":
                         # Ranked SFT for explorer: MSE regression of policy mean toward best eta.
                         # Unlike advantage_logprob which uses all K samples, this directly supervises
                         # the policy to output the best-reward eta for each scene.
@@ -518,7 +518,7 @@ class GRPOExplorationTrainer:
                             entropy_coef=self.config.exploration_entropy_coef,
                             kl_coef=self.config.exploration_kl_coef,
                         )
-                    # Backward pass for advantage_logprob and best_eta_mse paths
+                    # Backward pass for advantage_logprob and best_sample_mse paths
                     # (PPO path handles its own backward+step above)
                     if not policy_frozen and inner_epochs <= 1:
                         policy_loss.backward()

--- a/rlvr/grpo_exploration_trainer.py
+++ b/rlvr/grpo_exploration_trainer.py
@@ -482,25 +482,26 @@ class GRPOExplorationTrainer:
                             )
                             self.policy_optimizer.step()
                     elif self.config.exploration_loss_type == "rsft":
-                        # Ranked SFT for explorer: maximize log_prob of best eta only
+                        # Ranked SFT for explorer: MSE regression toward best eta
+                        # Find the best-reward trajectory's eta and regress toward it
                         best_idx = advantages_t.argmax()
-                        best_log_prob = log_probs[best_idx]
-                        rsft_loss = -best_log_prob
+                        best_eta_lat_01 = eta_lat_01[best_idx].detach()  # target (0,1)
+                        best_eta_lon_01 = eta_lon_01[best_idx].detach()
 
-                        entropy_value = (lat_dist.entropy() + lon_dist.entropy()).mean()
-                        init_lat, init_lon = _get_init_distributions(self.device)
-                        kl_value = (kl_div(lat_dist, init_lat) + kl_div(lon_dist, init_lon)).mean()
-
-                        policy_loss = (
-                            rsft_loss
-                            + self.config.exploration_entropy_coef * (-entropy_value)
-                            + self.config.exploration_kl_coef * kl_value
+                        # MSE between policy's deterministic mean and the best eta
+                        pred_lat_mean = lat_dist.mean.squeeze()  # policy's predicted mean in (0,1)
+                        pred_lon_mean = lon_dist.mean.squeeze()
+                        rsft_loss = (
+                            (pred_lat_mean - best_eta_lat_01) ** 2
+                            + (pred_lon_mean - best_eta_lon_01) ** 2
                         )
+
+                        policy_loss = rsft_loss
                         policy_metrics = {
                             "exploration_policy_loss": rsft_loss.item(),
-                            "exploration_entropy": entropy_value.item(),
-                            "exploration_kl": kl_value.item(),
-                            "exploration_total_loss": policy_loss.item(),
+                            "exploration_entropy": (lat_dist.entropy() + lon_dist.entropy()).mean().item(),
+                            "exploration_kl": 0.0,
+                            "exploration_total_loss": rsft_loss.item(),
                             "exploration_eta_lat_mean": lat_dist.mean.mean().item() * 2 - 1,
                             "exploration_eta_lon_mean": lon_dist.mean.mean().item() * 2 - 1,
                             "exploration_eta_lat_std": (lat_dist.variance.mean().item() * 4) ** 0.5,
@@ -515,17 +516,18 @@ class GRPOExplorationTrainer:
                             entropy_coef=self.config.exploration_entropy_coef,
                             kl_coef=self.config.exploration_kl_coef,
                         )
-                        if not policy_frozen:
-                            policy_loss.backward()
-                            if self.config.exploration_step_per_group:
-                                n_policy_accum += 1
-                                if n_policy_accum >= self.config.exploration_grad_accum_groups:
-                                    torch.nn.utils.clip_grad_norm_(
-                                        self.exploration_policy.parameters(), max_norm=1.0,
-                                    )
-                                    self.policy_optimizer.step()
-                                    self.policy_optimizer.zero_grad()
-                                    n_policy_accum = 0
+                    # Backward pass for both RSFT and REINFORCE paths
+                    if not policy_frozen:
+                        policy_loss.backward()
+                        if self.config.exploration_step_per_group:
+                            n_policy_accum += 1
+                            if n_policy_accum >= self.config.exploration_grad_accum_groups:
+                                torch.nn.utils.clip_grad_norm_(
+                                    self.exploration_policy.parameters(), max_norm=1.0,
+                                )
+                                self.policy_optimizer.step()
+                                self.policy_optimizer.zero_grad()
+                                n_policy_accum = 0
 
                 if not self.config.exploration_step_per_group:
                     n_policy_accum += 1

--- a/rlvr/grpo_logprob_loss.py
+++ b/rlvr/grpo_logprob_loss.py
@@ -15,7 +15,6 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 import torch
 import torch.nn.functional as F
-
 from diffusion_planner.model.diffusion_utils.sde import VPSDE_linear
 from diffusion_planner.model.module.decoder import generate_prefix_mask
 

--- a/rlvr/grpo_loss.py
+++ b/rlvr/grpo_loss.py
@@ -32,11 +32,9 @@ import contextlib
 import numpy as np
 import torch
 import torch.nn as nn
-
 import torch.nn.functional as F
 
 from preference_optimization.dpo_loss import compute_trajectory_loss as _compute_trajectory_loss_raw
-
 from rlvr.grpo_config import GRPOConfig
 
 
@@ -47,6 +45,7 @@ def compute_trajectory_loss(model, data, trajectory, model_args, noise, t, devic
     per-timestep t modulation, and clean prefix injection.
     """
     import random as _random
+
     from diffusion_planner.model.diffusion_utils.sde import VPSDE_linear
     from diffusion_planner.model.module.decoder import generate_prefix_mask
 
@@ -258,6 +257,7 @@ def compute_batched_trajectory_losses(
         [N] tensor of per-trajectory MSE losses.
     """
     import random as _random
+
     from diffusion_planner.model.diffusion_utils.sde import VPSDE_linear
     from diffusion_planner.model.module.decoder import generate_prefix_mask
 
@@ -506,6 +506,7 @@ def _compute_neighbor_reg_loss(
     per-scene processing loop. Will raise AssertionError if B>1.
     """
     import random as _random
+
     from diffusion_planner.model.diffusion_utils.sde import VPSDE_linear
     from diffusion_planner.model.module.decoder import generate_prefix_mask
 

--- a/rlvr/grpo_sampler.py
+++ b/rlvr/grpo_sampler.py
@@ -12,9 +12,9 @@ from pathlib import Path
 
 import numpy as np
 import torch
-
 from diffusion_planner.model.guidance.composer import GuidanceComposer
 from diffusion_planner.model.guidance.config import GuidanceConfig, GuidanceSetConfig
+
 from guidance_gui.generate_samples import generate_samples
 
 

--- a/rlvr/grpo_sampler_batched.py
+++ b/rlvr/grpo_sampler_batched.py
@@ -13,10 +13,10 @@ from __future__ import annotations
 import random
 
 import torch
-from torch import nn
-
 from diffusion_planner.model.guidance.composer import GuidanceComposer
 from diffusion_planner.model.guidance.config import GuidanceConfig, GuidanceSetConfig
+from torch import nn
+
 from guidance_gui.generate_samples import generate_samples
 from rlvr.closed_loop.batched_rollout import _batched_generate_varied_noise
 from rlvr.grpo_sampler import SamplerConfig

--- a/rlvr/grpo_sft_trainer.py
+++ b/rlvr/grpo_sft_trainer.py
@@ -569,7 +569,7 @@ def train_epoch_ranked_sft(
 
             advantages_t = torch.tensor(advantages, device=device, dtype=torch.float32)
 
-            if config.exploration_loss_type == "best_eta_mse":
+            if config.exploration_loss_type == "best_sample_mse":
                 best_idx = advantages_t.argmax()
                 pred_lat = policy_output.lat_dist.mean.squeeze()
                 pred_lon = policy_output.lon_dist.mean.squeeze()

--- a/rlvr/grpo_sft_trainer.py
+++ b/rlvr/grpo_sft_trainer.py
@@ -445,7 +445,7 @@ def train_epoch_ranked_sft(
                 norm_i["reference_trajectory"] = x_ref
 
                 # Get Beta distributions and sample K etas
-                output = exploration_policy(scene_enc, x_ref, deterministic=True)
+                output = exploration_policy(scene_enc, x_ref, deterministic=False)
                 eta_lat_01 = output.lat_dist.rsample((K,)).squeeze(-1)  # [K]
                 eta_lon_01 = output.lon_dist.rsample((K,)).squeeze(-1)  # [K]
                 eta_lat_vals = 2.0 * eta_lat_01 - 1.0  # map to [-1, 1]
@@ -583,7 +583,7 @@ def train_epoch_ranked_sft(
                     kl_coef=config.exploration_kl_coef,
                 )
 
-            (policy_loss / max(N, 1)).backward()
+            (policy_loss / N).backward()
             total_policy_loss += policy_loss.item()
             n_explorer += 1
 
@@ -782,4 +782,5 @@ def train_epoch_ranked_sft(
 
     avg_metrics = {k: v / max(n_scenes, 1) for k, v in all_metrics.items()}
     avg_metrics["mean_best_reward"] = mean_best_reward
+    avg_metrics.update(explorer_metrics)
     return avg_metrics

--- a/rlvr/grpo_sft_trainer.py
+++ b/rlvr/grpo_sft_trainer.py
@@ -308,6 +308,7 @@ def train_epoch_ranked_sft(
     reward_config: RewardConfig,
     device: torch.device,
     epoch: int,
+    exploration_policy=None,
 ) -> dict[str, float]:
     """GRPO-ranked SFT epoch: generate, rank, filter, train with SFT loss.
 
@@ -403,17 +404,91 @@ def train_epoch_ranked_sft(
     lon_lambda = scheduled.get("longitudinal_lambda", config.lambda_lon)
     lon_scale = scheduled.get("longitudinal_scale", 10.0)
 
-    # 3. Generate K trajectories for all scenes (batched)
-    print(f"  Generating {K} trajectories x {N} scenes (batched)...")
-    model.eval()
-    with torch.no_grad():
-        all_trajs = generate_all_scenes_batched(
-            model, model_args, norm_batch, K, config.noise_scale_range, device,
-            gt_max_speed=median_gt_speed,
-            longitudinal_eta=lon_eta,
-            longitudinal_lambda=lon_lambda,
-            longitudinal_scale=lon_scale,
-        )  # [N, K, T, 4]
+    # Extract lateral guidance params from schedule (default: off)
+    lat_eta = scheduled.get("lateral_eta", 0.0)
+    lat_lambda = scheduled.get("lateral_lambda", 2.0)
+    lat_scale = scheduled.get("lateral_scale", 5.0)
+
+    # 2c. Optionally use exploration policy to generate K diverse trajectories per scene
+    if exploration_policy is not None:
+        from diffusion_planner.model.guidance.composer import GuidanceComposer
+        from diffusion_planner.model.guidance.config import GuidanceConfig as _GC
+        from diffusion_planner.model.guidance.config import GuidanceSetConfig
+
+        from exploration_policy.utils import generate_reference_trajectory, run_frozen_encoder
+        from rlvr.closed_loop.batched_rollout import _batched_generate_varied_noise
+        print(f"  Explorer-guided generation: {K} samples from Beta distribution per scene...")
+        exploration_policy.eval()
+        model.eval()
+
+        _lat_lambda = config.exploration_lambda_lat
+        _lon_lambda = config.exploration_lambda_lon
+        _guide_scale = config.exploration_guidance_scale
+        noise_min, noise_max = config.noise_scale_range
+
+        all_scene_trajs = []  # will be [N, K, T, 4]
+        for i in range(N):
+            norm_i = {k: v[i:i+1] if isinstance(v, torch.Tensor) and v.dim() > 0 and v.shape[0] == N else v
+                      for k, v in norm_batch.items()}
+            with torch.no_grad():
+                scene_enc = run_frozen_encoder(model, norm_i)
+                x_ref_np = generate_reference_trajectory(model, model_args, norm_i, device)
+                x_ref = torch.from_numpy(x_ref_np).unsqueeze(0).to(device)
+                norm_i["reference_trajectory"] = x_ref
+
+                # Get Beta distributions and sample K etas
+                output = exploration_policy(scene_enc, x_ref, deterministic=True)
+                eta_lat_01 = output.lat_dist.rsample((K,)).squeeze(-1)  # [K]
+                eta_lon_01 = output.lon_dist.rsample((K,)).squeeze(-1)  # [K]
+                eta_lat_vals = 2.0 * eta_lat_01 - 1.0  # map to [-1, 1]
+                eta_lon_vals = 2.0 * eta_lon_01 - 1.0
+
+                # Expand scene data from B=1 to B=K
+                K_data = {}
+                for k_key, v in norm_i.items():
+                    if isinstance(v, torch.Tensor) and v.shape[0] == 1:
+                        K_data[k_key] = v.expand(K, *v.shape[1:]).contiguous()
+                    else:
+                        K_data[k_key] = v
+
+                # Build batched guidance with K different etas
+                guidance_fns = [
+                    _GC("lateral", enabled=True, scale=1.0,
+                         params={"lambda_lat": _lat_lambda, "eta_lat": eta_lat_vals}),
+                    _GC("longitudinal", enabled=True, scale=1.0,
+                         params={"lambda_lon": _lon_lambda, "eta_lon": eta_lon_vals}),
+                ]
+                composer = GuidanceComposer(GuidanceSetConfig(
+                    functions=guidance_fns, global_scale=_guide_scale))
+
+                # Generate K trajectories (first deterministic, rest with varied noise)
+                traj_tensor = _batched_generate_varied_noise(
+                    model, model_args, K_data,
+                    noise_min=noise_min, noise_max=noise_max,
+                    first_deterministic=True,
+                    composer=composer, device=device,
+                )  # [K, T, 4]
+                all_scene_trajs.append(traj_tensor)
+
+        all_trajs = torch.stack(all_scene_trajs)  # [N, K, T, 4]
+        print(f"  Explorer: K={K}, guide_scale={_guide_scale}, noise=[{noise_min},{noise_max}]")
+        torch.cuda.empty_cache()
+        gc.collect()
+    else:
+        # 3. Standard generation: K trajectories for all scenes (batched)
+        print(f"  Generating {K} trajectories x {N} scenes (batched)...")
+        model.eval()
+        with torch.no_grad():
+            all_trajs = generate_all_scenes_batched(
+                model, model_args, norm_batch, K, config.noise_scale_range, device,
+                gt_max_speed=median_gt_speed,
+                longitudinal_eta=lon_eta,
+                longitudinal_lambda=lon_lambda,
+                longitudinal_scale=lon_scale,
+                lateral_eta=lat_eta,
+                lateral_lambda=lat_lambda,
+                lateral_scale=lat_scale,
+            )  # [N, K, T, 4]
 
     torch.cuda.empty_cache()
     gc.collect()

--- a/rlvr/grpo_sft_trainer.py
+++ b/rlvr/grpo_sft_trainer.py
@@ -417,6 +417,9 @@ def train_epoch_ranked_sft(
 
         from exploration_policy.utils import generate_reference_trajectory, run_frozen_encoder
         from rlvr.closed_loop.batched_rollout import _batched_generate_varied_noise
+        # NOTE: per-scene loop matches grpo_exploration_trainer's generate_policy_guided_group.
+        # Batching across scenes would require handling per-scene Beta distributions in a single
+        # forward pass, which is complex. For 50-500 scenes this takes ~3 min, acceptable.
         print(f"  Explorer-guided generation: {K} samples from Beta distribution per scene...")
         exploration_policy.eval()
         model.eval()
@@ -433,7 +436,7 @@ def train_epoch_ranked_sft(
             with torch.no_grad():
                 scene_enc = run_frozen_encoder(model, norm_i)
                 x_ref_np = generate_reference_trajectory(model, model_args, norm_i, device)
-                x_ref = torch.from_numpy(x_ref_np).unsqueeze(0).to(device)
+                x_ref = torch.from_numpy(x_ref_np).unsqueeze(0).to(device=device, dtype=torch.float32)
                 norm_i["reference_trajectory"] = x_ref
 
                 # Get Beta distributions and sample K etas

--- a/rlvr/grpo_sft_trainer.py
+++ b/rlvr/grpo_sft_trainer.py
@@ -569,7 +569,7 @@ def train_epoch_ranked_sft(
 
             advantages_t = torch.tensor(advantages, device=device, dtype=torch.float32)
 
-            if config.exploration_loss_type == "rsft":
+            if config.exploration_loss_type == "best_eta_mse":
                 best_idx = advantages_t.argmax()
                 pred_lat = policy_output.lat_dist.mean.squeeze()
                 pred_lon = policy_output.lon_dist.mean.squeeze()

--- a/rlvr/grpo_sft_trainer.py
+++ b/rlvr/grpo_sft_trainer.py
@@ -309,6 +309,7 @@ def train_epoch_ranked_sft(
     device: torch.device,
     epoch: int,
     exploration_policy=None,
+    exploration_optimizer=None,
 ) -> dict[str, float]:
     """GRPO-ranked SFT epoch: generate, rank, filter, train with SFT loss.
 
@@ -406,7 +407,7 @@ def train_epoch_ranked_sft(
 
     # Extract lateral guidance params from schedule (default: off)
     lat_eta = scheduled.get("lateral_eta", 0.0)
-    lat_lambda = scheduled.get("lateral_lambda", 2.0)
+    lat_lambda = scheduled.get("lateral_lambda", config.lambda_lat)
     lat_scale = scheduled.get("lateral_scale", 5.0)
 
     # 2c. Optionally use exploration policy to generate K diverse trajectories per scene
@@ -428,8 +429,12 @@ def train_epoch_ranked_sft(
         _lon_lambda = config.exploration_lambda_lon
         _guide_scale = config.exploration_guidance_scale
         noise_min, noise_max = config.noise_scale_range
+        _train_explorer = exploration_optimizer is not None
 
         all_scene_trajs = []  # will be [N, K, T, 4]
+        # Store per-scene explorer data for training
+        _explorer_scenes = []  # list of dicts with distributions and sampled etas
+
         for i in range(N):
             norm_i = {k: v[i:i+1] if isinstance(v, torch.Tensor) and v.dim() > 0 and v.shape[0] == N else v
                       for k, v in norm_batch.items()}
@@ -445,6 +450,14 @@ def train_epoch_ranked_sft(
                 eta_lon_01 = output.lon_dist.rsample((K,)).squeeze(-1)  # [K]
                 eta_lat_vals = 2.0 * eta_lat_01 - 1.0  # map to [-1, 1]
                 eta_lon_vals = 2.0 * eta_lon_01 - 1.0
+
+                if _train_explorer:
+                    _explorer_scenes.append({
+                        "scene_enc": scene_enc.detach(),
+                        "x_ref": x_ref.detach(),
+                        "eta_lat_01": eta_lat_01.detach(),
+                        "eta_lon_01": eta_lon_01.detach(),
+                    })
 
                 # Expand scene data from B=1 to B=K
                 K_data = {}
@@ -521,6 +534,68 @@ def train_epoch_ranked_sft(
 
     mean_best_reward = float(np.mean(best_rewards_list))
     print(f"  Mean best-of-{K} reward: {mean_best_reward:.2f}")
+
+    # --- Train explorer on trajectory rewards (if optimizer provided) ---
+    explorer_metrics = {}
+    if exploration_policy is not None and exploration_optimizer is not None and _explorer_scenes:
+        from exploration_policy.loss import compute_exploration_loss
+        from rlvr.reward import compute_group_advantages
+        print(f"  Training explorer on {len(_explorer_scenes)} scenes...")
+        exploration_policy.train()
+        exploration_optimizer.zero_grad()
+        total_policy_loss = 0.0
+        n_explorer = 0
+
+        for i in range(N):
+            if i >= len(_explorer_scenes):
+                break
+            es = _explorer_scenes[i]
+            traj_K = all_trajs[i]  # [K, T, 4]
+            data_i = all_data[i]
+
+            # Compute rewards for this scene's K trajectories
+            rewards = compute_reward_batch(traj_K, data_i, reward_config)
+            advantages = compute_group_advantages(rewards)
+
+            if np.all(advantages == 0):
+                continue
+
+            # Recompute explorer distributions (with grad)
+            policy_output = exploration_policy(es["scene_enc"], es["x_ref"], deterministic=True)
+            log_probs = (policy_output.lat_dist.log_prob(es["eta_lat_01"])
+                         + policy_output.lon_dist.log_prob(es["eta_lon_01"]))
+            if log_probs.dim() > 1:
+                log_probs = log_probs.squeeze(-1)
+
+            advantages_t = torch.tensor(advantages, device=device, dtype=torch.float32)
+
+            if config.exploration_loss_type == "rsft":
+                best_idx = advantages_t.argmax()
+                pred_lat = policy_output.lat_dist.mean.squeeze()
+                pred_lon = policy_output.lon_dist.mean.squeeze()
+                policy_loss = (pred_lat - es["eta_lat_01"][best_idx].detach()) ** 2 \
+                            + (pred_lon - es["eta_lon_01"][best_idx].detach()) ** 2
+            else:
+                policy_loss, _ = compute_exploration_loss(
+                    advantages=advantages_t, log_probs=log_probs,
+                    lat_dist=policy_output.lat_dist, lon_dist=policy_output.lon_dist,
+                    entropy_coef=config.exploration_entropy_coef,
+                    kl_coef=config.exploration_kl_coef,
+                )
+
+            (policy_loss / max(N, 1)).backward()
+            total_policy_loss += policy_loss.item()
+            n_explorer += 1
+
+        if n_explorer > 0:
+            torch.nn.utils.clip_grad_norm_(exploration_policy.parameters(), max_norm=1.0)
+            exploration_optimizer.step()
+            exploration_optimizer.zero_grad()
+            explorer_metrics["explorer_loss"] = total_policy_loss / n_explorer
+            print(f"  Explorer loss: {explorer_metrics['explorer_loss']:.4f} ({n_explorer} scenes)")
+
+        exploration_policy.eval()
+        del _explorer_scenes
 
     # Free generation tensors
     del all_trajs

--- a/rlvr/grpo_trainer.py
+++ b/rlvr/grpo_trainer.py
@@ -22,9 +22,10 @@ from tqdm import tqdm
 from preference_optimization.utils import (
     calculate_ade,
     generate_deterministic_trajectory,
+)
+from preference_optimization.utils import (
     load_npz_data as _load_npz_data_raw,
 )
-
 from rlvr.grpo_config import GRPOConfig
 from rlvr.grpo_loss import compute_direct_best_loss, compute_grpo_loss, compute_log_probs
 from rlvr.grpo_sampler import SamplerConfig, generate_diverse_group
@@ -268,7 +269,7 @@ class GRPOTrainer:
         }
 
         # For logprob loss: also collect the denoising rollout chain
-        if self.config.grpo_loss_type == "logprob":
+        if self.config.grpo_loss_type == "advantage_logprob":
             from rlvr.grpo_logprob_loss import collect_logprob_rollout
             was_training = self.policy_model.training
             self.policy_model.eval()
@@ -301,9 +302,9 @@ class GRPOTrainer:
             return _empty_metrics()
 
         M = self.config.inner_epochs
-        if M > 1 and self.config.grpo_loss_type == "logprob":
+        if M > 1 and self.config.grpo_loss_type == "advantage_logprob":
             raise ValueError(
-                "inner_epochs > 1 is not supported with grpo_loss_type='logprob'. "
+                "inner_epochs > 1 is not supported with grpo_loss_type='advantage_logprob'. "
                 "Logprob GRPO uses on-policy REINFORCE without importance sampling."
             )
         all_metrics: dict[str, float] = {}
@@ -324,7 +325,7 @@ class GRPOTrainer:
                 if np.all(advantages == 0):
                     continue
 
-                if self.config.grpo_loss_type == "logprob":
+                if self.config.grpo_loss_type == "advantage_logprob":
                     # DDV2-style log-probability GRPO loss
                     from rlvr.grpo_logprob_loss import compute_logprob_grpo_loss
                     rollout = group.get("rollout")

--- a/rlvr/grpo_trainer_batched.py
+++ b/rlvr/grpo_trainer_batched.py
@@ -82,8 +82,6 @@ def generate_all_scenes_batched(
     lateral_eta: float = 0.0,
     lateral_lambda: float = 2.0,
     lateral_scale: float = 5.0,
-    per_scene_eta_lat: torch.Tensor | None = None,
-    per_scene_eta_lon: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Generate K trajectories for all N scenes in ~5 chunked-batched passes.
 
@@ -116,39 +114,39 @@ def generate_all_scenes_batched(
         norm_batch["reference_trajectory"] = det_trajs  # no clone needed, not mutated
 
     # --- Config 2-9: CL + SPD guidance sweep for lane keeping ---
-        # 8 guided trajectories at CL5-10 to ensure ~8-10/16 stay in-lane on curves.
-        cl_spd_configs = [
-            (5.0,  5.0,  0.0, 0.0),   # CL5+SPD5, deterministic
-            (8.0,  5.0,  0.0, 0.0),   # CL8+SPD5, deterministic
-            (10.0, 8.0,  0.0, 0.0),   # CL10+SPD8, deterministic
-            (10.0, 10.0, 0.0, 0.0),   # CL10+SPD10, deterministic
-            (5.0,  5.0,  0.3, 0.8),   # CL5+SPD5, noise
-            (8.0,  8.0,  0.3, 0.8),   # CL8+SPD8, noise
-            (10.0, 8.0,  0.3, 0.8),   # CL10+SPD8, noise
-            (10.0, 10.0, 0.5, 1.0),   # CL10+SPD10, noise
+    # 8 guided trajectories at CL5-10 to ensure ~8-10/16 stay in-lane on curves.
+    cl_spd_configs = [
+        (5.0,  5.0,  0.0, 0.0),   # CL5+SPD5, deterministic
+        (8.0,  5.0,  0.0, 0.0),   # CL8+SPD5, deterministic
+        (10.0, 8.0,  0.0, 0.0),   # CL10+SPD8, deterministic
+        (10.0, 10.0, 0.0, 0.0),   # CL10+SPD10, deterministic
+        (5.0,  5.0,  0.3, 0.8),   # CL5+SPD5, noise
+        (8.0,  8.0,  0.3, 0.8),   # CL8+SPD8, noise
+        (10.0, 8.0,  0.3, 0.8),   # CL10+SPD8, noise
+        (10.0, 10.0, 0.5, 1.0),   # CL10+SPD10, noise
+    ]
+    for cl_scale, spd_scale, n_min, n_max in cl_spd_configs:
+        fns = [
+            GuidanceConfig("centerline_following", enabled=True, scale=cl_scale),
+            GuidanceConfig("speed", enabled=True, scale=spd_scale,
+                           params={"v_high": gt_max_speed, "v_low": 0.5}),
         ]
-        for cl_scale, spd_scale, n_min, n_max in cl_spd_configs:
-            fns = [
-                GuidanceConfig("centerline_following", enabled=True, scale=cl_scale),
-                GuidanceConfig("speed", enabled=True, scale=spd_scale,
-                               params={"v_high": gt_max_speed, "v_low": 0.5}),
-            ]
-            if use_lon:
-                fns.append(GuidanceConfig(
-                    "longitudinal", enabled=True, scale=longitudinal_scale,
-                    params={"eta_lon": longitudinal_eta, "lambda_lon": longitudinal_lambda},
-                ))
-            if use_lat:
-                fns.append(GuidanceConfig(
-                    "lateral", enabled=True, scale=lateral_scale,
-                    params={"eta_lat": lateral_eta, "lambda_lat": lateral_lambda},
-                ))
-            comp = GuidanceComposer(GuidanceSetConfig(functions=fns, global_scale=1.0))
-            trajs = _chunked_generate(model, model_args, norm_batch, n_min, n_max, comp, device, gen_chunk_size)
-            all_k_trajs.append(trajs)
+        if use_lon:
+            fns.append(GuidanceConfig(
+                "longitudinal", enabled=True, scale=longitudinal_scale,
+                params={"eta_lon": longitudinal_eta, "lambda_lon": longitudinal_lambda},
+            ))
+        if use_lat:
+            fns.append(GuidanceConfig(
+                "lateral", enabled=True, scale=lateral_scale,
+                params={"eta_lat": lateral_eta, "lambda_lat": lateral_lambda},
+            ))
+        comp = GuidanceComposer(GuidanceSetConfig(functions=fns, global_scale=1.0))
+        trajs = _chunked_generate(model, model_args, norm_batch, n_min, n_max, comp, device, gen_chunk_size)
+        all_k_trajs.append(trajs)
 
-        # Clean up reference_trajectory before random passes (not needed, wastes VRAM on expand)
-        norm_batch.pop("reference_trajectory", None)
+    # Clean up reference_trajectory before random passes (not needed, wastes VRAM on expand)
+    norm_batch.pop("reference_trajectory", None)
 
     # --- Config 5+: Random guidance (no road_border to avoid OOM) ---
     n_fixed = len(all_k_trajs)

--- a/rlvr/grpo_trainer_batched.py
+++ b/rlvr/grpo_trainer_batched.py
@@ -19,17 +19,17 @@ from pathlib import Path
 
 import numpy as np
 import torch
+from diffusion_planner.model.guidance.composer import GuidanceComposer
+from diffusion_planner.model.guidance.config import GuidanceConfig, GuidanceSetConfig
 from torch import nn
 from tqdm import tqdm
 
-from diffusion_planner.model.guidance.composer import GuidanceComposer
-from diffusion_planner.model.guidance.config import GuidanceConfig, GuidanceSetConfig
 from guidance_gui.generate_samples import generate_samples
 from preference_optimization.utils import load_npz_data
 from rlvr.closed_loop.batched_rollout import _batched_generate_varied_noise
 from rlvr.grpo_config import GRPOConfig
 from rlvr.grpo_loss import compute_batched_grpo_loss
-from rlvr.reward import RewardConfig, compute_reward_batch, compute_group_advantages
+from rlvr.reward import RewardConfig, compute_group_advantages, compute_reward_batch
 
 
 def _stack_scene_data(all_data: list[dict], device: torch.device) -> dict[str, torch.Tensor]:
@@ -79,6 +79,11 @@ def generate_all_scenes_batched(
     longitudinal_eta: float = 0.0,
     longitudinal_lambda: float = 0.5,
     longitudinal_scale: float = 10.0,
+    lateral_eta: float = 0.0,
+    lateral_lambda: float = 2.0,
+    lateral_scale: float = 5.0,
+    per_scene_eta_lat: torch.Tensor | None = None,
+    per_scene_eta_lon: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Generate K trajectories for all N scenes in ~5 chunked-batched passes.
 
@@ -87,6 +92,10 @@ def generate_all_scenes_batched(
             Applied to CL-guided trajectories when nonzero.
         longitudinal_lambda: Speed scaling constant for longitudinal guidance.
         longitudinal_scale: Guidance scale for longitudinal guidance.
+        lateral_eta: Lateral guidance eta (0=off, >0=push left, <0=push right).
+            Applied to CL-guided trajectories when nonzero.
+        lateral_lambda: Maximum lateral offset in metres for lateral guidance.
+        lateral_scale: Guidance scale for lateral guidance.
 
     Returns:
         [N, K, T, 4] tensor.
@@ -99,41 +108,47 @@ def generate_all_scenes_batched(
     det_trajs = _chunked_generate(model, model_args, norm_batch, 0.0, 0.0, None, device, gen_chunk_size)
     all_k_trajs.append(det_trajs)
 
-    # Use deterministic trajectory as reference for longitudinal guidance.
+    # Use deterministic trajectory as reference for lon/lat guidance.
     # det_trajs is already in (x, y, cos_yaw, sin_yaw) format — no conversion needed.
     use_lon = abs(longitudinal_eta) > 1e-6
-    if use_lon:
+    use_lat = abs(lateral_eta) > 1e-6
+    if use_lon or use_lat:
         norm_batch["reference_trajectory"] = det_trajs  # no clone needed, not mutated
 
-    # --- Config 2-9: Strong CL + SPD guidance sweep for lane keeping ---
-    # 8 guided trajectories at CL5-10 to ensure ~8-10/16 stay in-lane on curves.
-    cl_spd_configs = [
-        (5.0,  5.0,  0.0, 0.0),   # CL5+SPD5, deterministic
-        (8.0,  5.0,  0.0, 0.0),   # CL8+SPD5, deterministic
-        (10.0, 8.0,  0.0, 0.0),   # CL10+SPD8, deterministic
-        (10.0, 10.0, 0.0, 0.0),   # CL10+SPD10, deterministic
-        (5.0,  5.0,  0.3, 0.8),   # CL5+SPD5, noise
-        (8.0,  8.0,  0.3, 0.8),   # CL8+SPD8, noise
-        (10.0, 8.0,  0.3, 0.8),   # CL10+SPD8, noise
-        (10.0, 10.0, 0.5, 1.0),   # CL10+SPD10, noise
-    ]
-    for cl_scale, spd_scale, n_min, n_max in cl_spd_configs:
-        fns = [
-            GuidanceConfig("centerline_following", enabled=True, scale=cl_scale),
-            GuidanceConfig("speed", enabled=True, scale=spd_scale,
-                           params={"v_high": gt_max_speed, "v_low": 0.5}),
+    # --- Config 2-9: CL + SPD guidance sweep for lane keeping ---
+        # 8 guided trajectories at CL5-10 to ensure ~8-10/16 stay in-lane on curves.
+        cl_spd_configs = [
+            (5.0,  5.0,  0.0, 0.0),   # CL5+SPD5, deterministic
+            (8.0,  5.0,  0.0, 0.0),   # CL8+SPD5, deterministic
+            (10.0, 8.0,  0.0, 0.0),   # CL10+SPD8, deterministic
+            (10.0, 10.0, 0.0, 0.0),   # CL10+SPD10, deterministic
+            (5.0,  5.0,  0.3, 0.8),   # CL5+SPD5, noise
+            (8.0,  8.0,  0.3, 0.8),   # CL8+SPD8, noise
+            (10.0, 8.0,  0.3, 0.8),   # CL10+SPD8, noise
+            (10.0, 10.0, 0.5, 1.0),   # CL10+SPD10, noise
         ]
-        if use_lon:
-            fns.append(GuidanceConfig(
-                "longitudinal", enabled=True, scale=longitudinal_scale,
-                params={"eta_lon": longitudinal_eta, "lambda_lon": longitudinal_lambda},
-            ))
-        comp = GuidanceComposer(GuidanceSetConfig(functions=fns, global_scale=1.0))
-        trajs = _chunked_generate(model, model_args, norm_batch, n_min, n_max, comp, device, gen_chunk_size)
-        all_k_trajs.append(trajs)
+        for cl_scale, spd_scale, n_min, n_max in cl_spd_configs:
+            fns = [
+                GuidanceConfig("centerline_following", enabled=True, scale=cl_scale),
+                GuidanceConfig("speed", enabled=True, scale=spd_scale,
+                               params={"v_high": gt_max_speed, "v_low": 0.5}),
+            ]
+            if use_lon:
+                fns.append(GuidanceConfig(
+                    "longitudinal", enabled=True, scale=longitudinal_scale,
+                    params={"eta_lon": longitudinal_eta, "lambda_lon": longitudinal_lambda},
+                ))
+            if use_lat:
+                fns.append(GuidanceConfig(
+                    "lateral", enabled=True, scale=lateral_scale,
+                    params={"eta_lat": lateral_eta, "lambda_lat": lateral_lambda},
+                ))
+            comp = GuidanceComposer(GuidanceSetConfig(functions=fns, global_scale=1.0))
+            trajs = _chunked_generate(model, model_args, norm_batch, n_min, n_max, comp, device, gen_chunk_size)
+            all_k_trajs.append(trajs)
 
-    # Clean up reference_trajectory before random passes (not needed, wastes VRAM on expand)
-    norm_batch.pop("reference_trajectory", None)
+        # Clean up reference_trajectory before random passes (not needed, wastes VRAM on expand)
+        norm_batch.pop("reference_trajectory", None)
 
     # --- Config 5+: Random guidance (no road_border to avoid OOM) ---
     n_fixed = len(all_k_trajs)

--- a/rlvr/grpo_trainer_batched.py
+++ b/rlvr/grpo_trainer_batched.py
@@ -329,7 +329,7 @@ def train_epoch_batched(
                 norm_i[k] = v
         kept_norm_data.append(norm_i)
         # Also keep raw data for logprob path (needs unnormalized data)
-        if config.grpo_loss_type == "logprob":
+        if config.grpo_loss_type == "advantage_logprob":
             kept_raw_data.append(data_i)
 
     N_kept = len(kept_trajs)
@@ -351,7 +351,7 @@ def train_epoch_batched(
         kept_mean_rewards = [kept_mean_rewards[j] for j in keep_idx]
         kept_lane_dep_fracs = [kept_lane_dep_fracs[j] for j in keep_idx]
         kept_norm_data = [kept_norm_data[j] for j in keep_idx]
-        if config.grpo_loss_type == "logprob":
+        if config.grpo_loss_type == "advantage_logprob":
             kept_raw_data = [kept_raw_data[j] for j in keep_idx]
         print(f"  Lane-dep trim: dropped {n_dropped} worst scenes "
               f"(avg_dep={avg_dep_dropped:.0%}), keeping {len(kept_trajs)} "
@@ -369,7 +369,7 @@ def train_epoch_batched(
         kept_advantages = [kept_advantages[j] for j in keep_idx]
         kept_mean_rewards = [kept_mean_rewards[j] for j in keep_idx]
         kept_norm_data = [kept_norm_data[j] for j in keep_idx]
-        if config.grpo_loss_type == "logprob":
+        if config.grpo_loss_type == "advantage_logprob":
             kept_raw_data = [kept_raw_data[j] for j in keep_idx]
         print(f"  Trimmed {2*n_trim} scenes, keeping {len(kept_trajs)}/{N_kept}")
         N_kept = len(kept_trajs)
@@ -381,7 +381,7 @@ def train_epoch_batched(
         config.kl_coef = scheduled_kl
 
     # 6. Training
-    if config.grpo_loss_type == "logprob":
+    if config.grpo_loss_type == "advantage_logprob":
         return _train_logprob(
             model, model_args, optimizer, config,
             kept_trajs, kept_advantages, kept_raw_data,

--- a/rlvr/reward.py
+++ b/rlvr/reward.py
@@ -11,7 +11,6 @@ from dataclasses import dataclass
 
 import numpy as np
 import torch
-
 from diffusion_planner.model.guidance.collision import (
     batch_signed_distance_rect,
     center_rect_to_points,

--- a/rlvr/test_lat_accel.py
+++ b/rlvr/test_lat_accel.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 import numpy as np
 import torch
+
 from rlvr.reward import _build_sg_diff_kernel
 
 # Add project root to path

--- a/rlvr/test_lateral_longitudinal_guidance.py
+++ b/rlvr/test_lateral_longitudinal_guidance.py
@@ -19,16 +19,18 @@ Usage:
 """
 
 import argparse
-import sys
 import os
+import sys
+
+import matplotlib
 import numpy as np
 import torch
 
-import matplotlib
 matplotlib.use("Agg")
+from pathlib import Path
+
 import matplotlib.pyplot as plt
 from matplotlib.collections import LineCollection
-from pathlib import Path
 
 _repo_root = os.path.join(os.path.dirname(__file__), "..")
 _dp_root = os.path.join(_repo_root, "diffusion_planner")

--- a/rlvr/test_neighbor_reg.py
+++ b/rlvr/test_neighbor_reg.py
@@ -204,8 +204,8 @@ class TestGRPONeighborReg:
 
     def test_b1_assertion(self):
         """Should raise AssertionError when B > 1."""
-        from rlvr.grpo_loss import _compute_neighbor_reg_loss
         from rlvr.grpo_config import GRPOConfig
+        from rlvr.grpo_loss import _compute_neighbor_reg_loss
 
         model = _StubDiT(P=5, T=80)
         data = _make_scene_data(B=2, P=5, T=80)  # B=2 should fail
@@ -220,8 +220,8 @@ class TestGRPONeighborReg:
 
     def test_reg_loss_nonzero(self):
         """Should produce non-zero loss for B=1."""
-        from rlvr.grpo_loss import _compute_neighbor_reg_loss
         from rlvr.grpo_config import GRPOConfig
+        from rlvr.grpo_loss import _compute_neighbor_reg_loss
 
         model = _StubDiT(P=5, T=80)
         data = _make_scene_data(B=1, P=5, T=80)
@@ -237,8 +237,8 @@ class TestGRPONeighborReg:
 
     def test_no_adapter_returns_zero(self):
         """Model without disable_adapter should return zero loss."""
-        from rlvr.grpo_loss import _compute_neighbor_reg_loss
         from rlvr.grpo_config import GRPOConfig
+        from rlvr.grpo_loss import _compute_neighbor_reg_loss
 
         model = nn.Linear(10, 10)
         data = _make_scene_data(B=1, P=5, T=80)

--- a/rlvr/test_reward.py
+++ b/rlvr/test_reward.py
@@ -29,7 +29,6 @@ from rlvr.reward import (
     compute_smoothness_score_batch,
 )
 
-
 T = 80
 CONFIG = RewardConfig()
 
@@ -848,7 +847,7 @@ def test_overprogress_underprogress_penalties():
 
 def test_advantage_absolute():
     """Absolute mode: no centering, positive reward → positive advantage."""
-    from rlvr.reward import compute_group_advantages, RewardBreakdown
+    from rlvr.reward import RewardBreakdown, compute_group_advantages
     rewards = [RewardBreakdown(safety=0, progress=0, smoothness=0, feasibility=0, centerline=0,
                                red_light=0, total=t, collision_step=None, off_road_fraction=0)
                for t in [+10, +5, -5, -20]]
@@ -863,7 +862,7 @@ def test_advantage_absolute():
 
 def test_advantage_softmax():
     """Softmax mode: rank 1 gets disproportionately high weight."""
-    from rlvr.reward import compute_group_advantages, RewardBreakdown
+    from rlvr.reward import RewardBreakdown, compute_group_advantages
     rewards = [RewardBreakdown(safety=0, progress=0, smoothness=0, feasibility=0, centerline=0,
                                red_light=0, total=t, collision_step=None, off_road_fraction=0)
                for t in [+20, +5, 0, -10, -30]]

--- a/rlvr/tests/test_logprob_loss.py
+++ b/rlvr/tests/test_logprob_loss.py
@@ -6,8 +6,8 @@ Run: python -m rlvr.tests.test_logprob_loss
 
 import torch
 import torch.nn.functional as F
-
 from diffusion_planner.model.diffusion_utils.sde import VPSDE_linear
+
 from rlvr.vpsde_logprob import (
     compute_discount_weights,
     create_timestep_schedule,

--- a/rlvr/tests/test_vpsde_logprob.py
+++ b/rlvr/tests/test_vpsde_logprob.py
@@ -5,8 +5,8 @@ Run: python -m rlvr.tests.test_vpsde_logprob
 
 import torch
 import torch.distributions as dist
-
 from diffusion_planner.model.diffusion_utils.sde import VPSDE_linear
+
 from rlvr.vpsde_logprob import (
     compute_discount_weights,
     create_timestep_schedule,

--- a/rlvr/train_grpo.py
+++ b/rlvr/train_grpo.py
@@ -236,10 +236,10 @@ def _run_gui_mode(
     config: GRPOConfig,
 ):
     from rlvr.trajectory_ranker_gui import (
+        _DEFAULT_PROTOTYPES_PATH,
         TrajectoryRanker,
         build_interface,
         ensure_prototypes,
-        _DEFAULT_PROTOTYPES_PATH,
     )
 
     prototypes_path = config.prototypes_path or _DEFAULT_PROTOTYPES_PATH

--- a/rlvr/trajectory_ranker_gui.py
+++ b/rlvr/trajectory_ranker_gui.py
@@ -37,11 +37,11 @@ import gradio as gr
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
-from matplotlib.figure import Figure
-
 from diffusion_planner.model.guidance.composer import GuidanceComposer
 from diffusion_planner.model.guidance.config import GuidanceConfig, GuidanceSetConfig
 from diffusion_planner.utils.visualize_input import visualize_inputs
+from matplotlib.figure import Figure
+
 from guidance_gui.generate_samples import generate_samples
 from guidance_gui.visualization import (
     _calculate_curvature,
@@ -52,8 +52,12 @@ from guidance_gui.visualization import (
 from preference_optimization.model_utils import load_model
 from preference_optimization.utils import load_npz_data
 from rlvr.grpo_sampler import SampledTrajectory
-from rlvr.reward import RewardBreakdown, RewardConfig, compute_group_advantages, compute_reward_batch
-
+from rlvr.reward import (
+    RewardBreakdown,
+    RewardConfig,
+    compute_group_advantages,
+    compute_reward_batch,
+)
 
 _DIVERGING_CMAP = plt.get_cmap("RdYlGn")
 
@@ -1311,7 +1315,9 @@ def main():
             print("Warning: no trainable parameters found. Use --use_lora or ensure model is not frozen.")
         else:
             from datetime import datetime
+
             from torch import optim
+
             from rlvr.grpo_trainer import GRPOTrainer
 
             timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")

--- a/rlvr/viz_policy_guidance.py
+++ b/rlvr/viz_policy_guidance.py
@@ -19,9 +19,10 @@ import json
 import sys
 from pathlib import Path
 
+import matplotlib
 import numpy as np
 import torch
-import matplotlib
+
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
@@ -31,9 +32,10 @@ sys.path.insert(0, str(PROJECT_ROOT / "diffusion_planner"))
 sys.path.insert(0, str(PROJECT_ROOT / "preference_optimization"))
 
 from model_utils import load_model
-from exploration_policy import ExplorationPolicy, ExplorationPolicyConfig
-from exploration_policy.utils import get_frozen_encoder, generate_reference_trajectory
 from utils import load_npz_data
+
+from exploration_policy import ExplorationPolicy, ExplorationPolicyConfig
+from exploration_policy.utils import generate_reference_trajectory, get_frozen_encoder
 
 
 def draw_road_borders(ax, data_raw, max_dist=25):

--- a/rlvr/vpsde_logprob.py
+++ b/rlvr/vpsde_logprob.py
@@ -13,7 +13,6 @@ import math
 from typing import Optional, Tuple
 
 import torch
-
 from diffusion_planner.model.diffusion_utils.sde import VPSDE_linear
 
 


### PR DESCRIPTION
## Summary

- Add exploration policy integration with ranked SFT: explorer provides per-scene lateral/longitudinal guidance for trajectory generation
- Add lateral guidance params to generate_all_scenes_batched for scheduled lateral guidance
- Unify loss type naming across DiT and explorer: advantage_mse, advantage_logprob, best_sample_mse
- Add best_sample_mse explorer loss (MSE regression toward best-reward eta)
- Add ranked_sft_use_explorer and ranked_sft_freeze_explorer config fields for explorer+DiT joint training
- Add visualization tools: viz_explorer_per_scene.py and viz_explorer_trajectories.py
- Backwards compatible: __post_init__ maps old names (mse, logprob, reinforce, rsft) to new names

## Loss Type Naming Convention

Pattern: `{selection_method}_{loss_function}`

| Loss Type | Description | Used By |
|-----------|-------------|---------|
| `advantage_mse` | Advantage-weighted MSE diffusion loss | DiT (GRPO) |
| `advantage_logprob` | Advantage-weighted log probability | DiT (GRPO) / Explorer |
| `best_sample_mse` | MSE regression toward best sample | Explorer (ranked SFT) |

## Test Plan

- [x] Smoke test: Ranked SFT (3 epochs, 5 scenes)
- [x] Smoke test: GRPO advantage_mse (3 epochs, 5 scenes)
- [x] Smoke test: GRPO advantage_logprob (3 epochs, 5 scenes)
- [x] Smoke test: Explorer advantage_logprob (3 epochs, 5 scenes)
- [x] Smoke test: Explorer best_sample_mse (3 epochs, 5 scenes)
- [x] Backwards compatibility: old config names auto-mapped via __post_init__
- [x] g_nolon reproduction: 0/50 LD at ep4-6 confirmed with latest code
- [x] Ruff lint: all files pass