### PR TITLE
fix: rlvr bugs — neighbor reg crash, lateral guidance, data validation

### DIFF
--- a/rlvr/grpo_loss.py
+++ b/rlvr/grpo_loss.py
@@ -520,6 +520,14 @@ def _compute_neighbor_reg_loss(
 
     B = data["ego_current_state"].shape[0]
     if B > 1:
+        # All B entries must be the same scene (batched trainers expand per-scene
+        # data to B=keep_per). Bail out if different scenes are mixed in.
+        ego = data["ego_current_state"]
+        if not torch.allclose(ego[:1].expand_as(ego), ego):
+            raise ValueError(
+                f"_compute_neighbor_reg_loss: B={B} with mixed scenes. "
+                "Neighbor reg requires single-scene batches."
+            )
         data = {k: v[:1] if isinstance(v, torch.Tensor) else v for k, v in data.items()}
 
     inner = policy_model.module if hasattr(policy_model, "module") else policy_model

--- a/rlvr/grpo_loss.py
+++ b/rlvr/grpo_loss.py
@@ -246,7 +246,7 @@ def compute_batched_trajectory_losses(
 
     Args:
         model: Diffusion planner model (in train mode).
-        data: Scene observation dict with B=1.
+        data: Scene observation dict with B=1 or B=N.
         trajectories_tensor: [N, T, 4] tensor of trajectories.
         model_args: Config with state_normalizer, etc.
         noise: [1, P, T, 4] noise (will be expanded to [N, ...]).
@@ -266,11 +266,19 @@ def compute_batched_trajectory_losses(
     future_len = model_args.future_len
     eps = 1e-3
 
-    # Expand data from B=1 to B=N
+    # Expand data to B=N. Supports B=1 (expand) and B=N (pass through).
     batch_data = {}
     for k, v in data.items():
-        if isinstance(v, torch.Tensor) and v.shape[0] == 1:
-            batch_data[k] = v.expand(N, *v.shape[1:]).contiguous()
+        if isinstance(v, torch.Tensor):
+            B = v.shape[0]
+            if B == 1:
+                batch_data[k] = v.expand(N, *v.shape[1:]).contiguous()
+            elif B == N:
+                batch_data[k] = v
+            else:
+                raise ValueError(
+                    f"data['{k}'] has B={B}, expected 1 or N={N}"
+                )
         else:
             batch_data[k] = v
 
@@ -494,7 +502,7 @@ def _compute_batched_losses_and_ref(
 
 
 def _compute_neighbor_reg_loss(
-    policy_model, data, model_args, device, K, P, future_len, config,
+    policy_model, data, model_args, device, K, P, future_len,
 ):
     """Compute MSE between LoRA and base model neighbor outputs.
 
@@ -502,8 +510,8 @@ def _compute_neighbor_reg_loss(
     from the LoRA model vs the base model (LoRA disabled). Returns a scalar loss
     with gradients flowing only through the LoRA model.
 
-    NOTE: assumes B=1 (single scene per call), which matches the GRPO trainer's
-    per-scene processing loop. Will raise AssertionError if B>1.
+    When B>1 (batched trainers expand per-scene data), uses only the first
+    element since all B entries come from the same scene.
     """
     import random as _random
 
@@ -511,7 +519,8 @@ def _compute_neighbor_reg_loss(
     from diffusion_planner.model.module.decoder import generate_prefix_mask
 
     B = data["ego_current_state"].shape[0]
-    assert B == 1, f"_compute_neighbor_reg_loss requires B=1, got B={B}"
+    if B > 1:
+        data = {k: v[:1] if isinstance(v, torch.Tensor) else v for k, v in data.items()}
 
     inner = policy_model.module if hasattr(policy_model, "module") else policy_model
     if not hasattr(inner, "disable_adapter"):
@@ -642,10 +651,8 @@ def compute_batched_grpo_loss(
         zero = torch.tensor(0.0, device=device, requires_grad=True)
         return zero, _empty_metrics()
 
-    B = data["ego_current_state"].shape[0]  # should be 1
     P = 1 + model_args.predicted_neighbor_num
     future_len = model_args.future_len
-    eps = 1e-3
 
     # Average over K (noise, t) samples for stable gradients — matches DPO which
     # uses K=8. A single sample is dominated by noise at that specific timestep
@@ -686,7 +693,7 @@ def compute_batched_grpo_loss(
     neighbor_reg_loss_val = 0.0
     if neighbor_reg_w > 0 and P > 1:
         neighbor_reg_loss_val = _compute_neighbor_reg_loss(
-            policy_model, data, model_args, device, K, P, future_len, config,
+            policy_model, data, model_args, device, K, P, future_len,
         )
         total_loss = total_loss + neighbor_reg_w * neighbor_reg_loss_val
 

--- a/rlvr/grpo_loss.py
+++ b/rlvr/grpo_loss.py
@@ -267,17 +267,19 @@ def compute_batched_trajectory_losses(
     eps = 1e-3
 
     # Expand data to B=N. Supports B=1 (expand) and B=N (pass through).
+    # Only validate/expand tensors whose dim0 matches the scene batch size;
+    # non-batched metadata tensors (e.g. ego_shape [3], lane geometry) pass through.
+    B_scene = data["ego_current_state"].shape[0]
     batch_data = {}
     for k, v in data.items():
-        if isinstance(v, torch.Tensor):
-            B = v.shape[0]
-            if B == 1:
+        if isinstance(v, torch.Tensor) and v.dim() > 0 and v.shape[0] == B_scene:
+            if B_scene == 1:
                 batch_data[k] = v.expand(N, *v.shape[1:]).contiguous()
-            elif B == N:
+            elif B_scene == N:
                 batch_data[k] = v
             else:
                 raise ValueError(
-                    f"data['{k}'] has B={B}, expected 1 or N={N}"
+                    f"data['{k}'] has B={B_scene}, expected 1 or N={N}"
                 )
         else:
             batch_data[k] = v

--- a/rlvr/grpo_trainer_batched.py
+++ b/rlvr/grpo_trainer_batched.py
@@ -266,6 +266,9 @@ def train_epoch_batched(
     lon_eta = scheduled.get("longitudinal_eta", 0.0)
     lon_lambda = scheduled.get("longitudinal_lambda", config.lambda_lon)
     lon_scale = scheduled.get("longitudinal_scale", 10.0)
+    lat_eta = scheduled.get("lateral_eta", 0.0)
+    lat_lambda = scheduled.get("lateral_lambda", getattr(config, 'lambda_lat', 2.0))
+    lat_scale = scheduled.get("lateral_scale", 5.0)
 
     # 3. Generate K trajectories for all scenes (batched)
     print(f"  Generating {K} trajectories × {N} scenes (batched)...")
@@ -277,6 +280,9 @@ def train_epoch_batched(
             longitudinal_eta=lon_eta,
             longitudinal_lambda=lon_lambda,
             longitudinal_scale=lon_scale,
+            lateral_eta=lat_eta,
+            lateral_lambda=lat_lambda,
+            lateral_scale=lat_scale,
         )  # [N, K, T, 4]
 
     # Free generation memory before scoring + training

--- a/rlvr/grpo_trainer_batched.py
+++ b/rlvr/grpo_trainer_batched.py
@@ -267,7 +267,7 @@ def train_epoch_batched(
     lon_lambda = scheduled.get("longitudinal_lambda", config.lambda_lon)
     lon_scale = scheduled.get("longitudinal_scale", 10.0)
     lat_eta = scheduled.get("lateral_eta", 0.0)
-    lat_lambda = scheduled.get("lateral_lambda", getattr(config, 'lambda_lat', 2.0))
+    lat_lambda = scheduled.get("lateral_lambda", config.lambda_lat)
     lat_scale = scheduled.get("lateral_scale", 5.0)
 
     # 3. Generate K trajectories for all scenes (batched)

--- a/rlvr/test_neighbor_reg.py
+++ b/rlvr/test_neighbor_reg.py
@@ -5,7 +5,8 @@ Tests that:
 2. Gradients flow only through the LoRA model (base model is no_grad)
 3. neighbor_reg_only=True skips the neighbor SFT loss when reg is active
 4. neighbor_reg_only=True falls back to neighbor SFT loss when reg can't run
-5. B=1 assertion in GRPO path
+5. B>1 handling in GRPO path (same-scene slice, mixed-scene rejection)
+6. Batch dimension validation in compute_batched_trajectory_losses
 """
 
 from __future__ import annotations
@@ -202,12 +203,15 @@ class TestRankedSFTNeighborReg:
 class TestGRPONeighborReg:
     """Tests for _compute_neighbor_reg_loss in GRPO loss path."""
 
-    def test_b_gt1_slices_to_first(self):
-        """Should handle B > 1 by slicing to first element."""
+    def test_b_gt1_same_scene_slices_to_first(self):
+        """Should handle B > 1 by slicing to first element when all entries are same scene."""
         from rlvr.grpo_loss import _compute_neighbor_reg_loss
 
         model = _StubDiT(P=5, T=80)
-        data = _make_scene_data(B=4, P=5, T=80)  # B=4 should work
+        # Build B=1 data then expand to B=4 (same scene repeated)
+        data_b1 = _make_scene_data(B=1, P=5, T=80)
+        data = {k: v.expand(4, *v.shape[1:]).contiguous() if isinstance(v, torch.Tensor) else v
+                for k, v in data_b1.items()}
         model_args = _make_model_args(P=5, T=80)
 
         loss = _compute_neighbor_reg_loss(
@@ -215,6 +219,20 @@ class TestGRPONeighborReg:
             K=1, P=5, future_len=80,
         )
         assert isinstance(loss, torch.Tensor)
+
+    def test_b_gt1_mixed_scenes_raises(self):
+        """Should raise ValueError when B > 1 with different scenes."""
+        from rlvr.grpo_loss import _compute_neighbor_reg_loss
+
+        model = _StubDiT(P=5, T=80)
+        data = _make_scene_data(B=4, P=5, T=80)  # random data = different scenes
+        model_args = _make_model_args(P=5, T=80)
+
+        with pytest.raises(ValueError, match="mixed scenes"):
+            _compute_neighbor_reg_loss(
+                model, data, model_args, torch.device("cpu"),
+                K=1, P=5, future_len=80,
+            )
 
     def test_reg_loss_nonzero(self):
         """Should produce non-zero loss for B=1."""
@@ -244,6 +262,29 @@ class TestGRPONeighborReg:
             K=1, P=5, future_len=80,
         )
         assert loss.item() == 0.0
+
+
+class TestBatchedTrajectoryLossesValidation:
+    """Tests for data batch dimension validation in compute_batched_trajectory_losses."""
+
+    def test_invalid_batch_dim_raises(self):
+        """Should raise ValueError when data tensor has B != 1 and B != N."""
+        from rlvr.grpo_loss import compute_batched_trajectory_losses
+
+        model = _StubDiT(P=5, T=80)
+        model_args = _make_model_args(P=5, T=80)
+        N = 4
+        trajectories = torch.randn(N, 80, 4)
+        noise = torch.randn(1, 5, 80, 4)
+        t = torch.tensor([0.5])
+        # B=3 is neither 1 nor N=4
+        data = _make_scene_data(B=3, P=5, T=80)
+
+        with pytest.raises(ValueError, match="expected 1 or N=4"):
+            compute_batched_trajectory_losses(
+                model, data, trajectories, model_args, noise, t,
+                torch.device("cpu"),
+            )
 
 
 if __name__ == "__main__":

--- a/rlvr/test_neighbor_reg.py
+++ b/rlvr/test_neighbor_reg.py
@@ -202,52 +202,46 @@ class TestRankedSFTNeighborReg:
 class TestGRPONeighborReg:
     """Tests for _compute_neighbor_reg_loss in GRPO loss path."""
 
-    def test_b1_assertion(self):
-        """Should raise AssertionError when B > 1."""
-        from rlvr.grpo_config import GRPOConfig
+    def test_b_gt1_slices_to_first(self):
+        """Should handle B > 1 by slicing to first element."""
         from rlvr.grpo_loss import _compute_neighbor_reg_loss
 
         model = _StubDiT(P=5, T=80)
-        data = _make_scene_data(B=2, P=5, T=80)  # B=2 should fail
+        data = _make_scene_data(B=4, P=5, T=80)  # B=4 should work
         model_args = _make_model_args(P=5, T=80)
-        config = GRPOConfig(neighbor_reg_weight=1.0)
 
-        with pytest.raises(AssertionError, match="B=1"):
-            _compute_neighbor_reg_loss(
-                model, data, model_args, torch.device("cpu"),
-                K=1, P=5, future_len=80, config=config,
-            )
+        loss = _compute_neighbor_reg_loss(
+            model, data, model_args, torch.device("cpu"),
+            K=1, P=5, future_len=80,
+        )
+        assert isinstance(loss, torch.Tensor)
 
     def test_reg_loss_nonzero(self):
         """Should produce non-zero loss for B=1."""
-        from rlvr.grpo_config import GRPOConfig
         from rlvr.grpo_loss import _compute_neighbor_reg_loss
 
         model = _StubDiT(P=5, T=80)
         data = _make_scene_data(B=1, P=5, T=80)
         model_args = _make_model_args(P=5, T=80)
-        config = GRPOConfig(neighbor_reg_weight=1.0)
 
         loss = _compute_neighbor_reg_loss(
             model, data, model_args, torch.device("cpu"),
-            K=1, P=5, future_len=80, config=config,
+            K=1, P=5, future_len=80,
         )
         assert isinstance(loss, torch.Tensor)
         assert loss.item() > 0, "Reg loss should be non-zero when LoRA changes output"
 
     def test_no_adapter_returns_zero(self):
         """Model without disable_adapter should return zero loss."""
-        from rlvr.grpo_config import GRPOConfig
         from rlvr.grpo_loss import _compute_neighbor_reg_loss
 
         model = nn.Linear(10, 10)
         data = _make_scene_data(B=1, P=5, T=80)
         model_args = _make_model_args(P=5, T=80)
-        config = GRPOConfig(neighbor_reg_weight=1.0)
 
         loss = _compute_neighbor_reg_loss(
             model, data, model_args, torch.device("cpu"),
-            K=1, P=5, future_len=80, config=config,
+            K=1, P=5, future_len=80,
         )
         assert loss.item() == 0.0
 

--- a/rlvr/test_neighbor_reg.py
+++ b/rlvr/test_neighbor_reg.py
@@ -287,5 +287,27 @@ class TestBatchedTrajectoryLossesValidation:
             )
 
 
+    def test_non_batched_metadata_tensors_are_allowed(self):
+        """Non-batched metadata tensors should not be rejected or reshaped."""
+        from rlvr.grpo_loss import compute_batched_trajectory_losses
+
+        model = _StubDiT(P=5, T=80)
+        model_args = _make_model_args(P=5, T=80)
+        N = 4
+        trajectories = torch.randn(N, 80, 4)
+        noise = torch.randn(1, 5, 80, 4)
+        t = torch.tensor([0.5])
+
+        data = _make_scene_data(B=1, P=5, T=80)
+        data["ego_shape"] = torch.tensor([4.8, 2.0, 1.7])
+        data["lane_geometry"] = torch.randn(8, 20, 2)
+
+        losses = compute_batched_trajectory_losses(
+            model, data, trajectories, model_args, noise, t,
+            torch.device("cpu"),
+        )
+        assert losses is not None
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes 5 bugs found in the rlvr/ audit (BUGS_RLVR.md):

- **Bug 1 (HIGH):** `_compute_neighbor_reg_loss` crashes with `assert B==1` when called from batched trainers where `B=keep_per > 1`. Fixed by slicing data to first element (all B entries are same scene).
- **Bug 2 (MEDIUM):** Lateral guidance scheduling (`lateral_eta/lambda/scale`) was wired into ranked SFT but missing from standard batched GRPO trainer. Added schedule extraction and param passing in `train_epoch_batched`.
- **Bug 3 (LOW):** Removed dead variables `B` and `eps` in `compute_batched_grpo_loss`.
- **Bug 4 (LOW):** Removed unused `config` parameter from `_compute_neighbor_reg_loss`.
- **Bug 5 (LOW):** `compute_batched_trajectory_losses` silently passed through data with unexpected batch sizes. Added explicit validation — `B` must be 1 or N, raises `ValueError` otherwise.

## Test plan

- [x] `pytest rlvr/test_neighbor_reg.py` — 7/7 pass
- [x] `ruff check` clean