### PR TITLE
feat: rank analytics + generation variant registry for ranked SFT

### DIFF
--- a/rlvr/README.md
+++ b/rlvr/README.md
@@ -196,6 +196,25 @@ per-parameter changes, preventing destabilization.
 epoch 5-6 with rb_cross>20. Lower reg gives the ego loss more freedom but insufficient
 constraint on neighbor weights causes catastrophic drift through shared DiT parameters.
 
+**Generation variants** (`generation_variant` config field). The 16 generation slots are
+composed of: 1 deterministic + N guided cl_spd configs + N noise-only configs + remaining
+random pool. Defined in `_build_cl_spd_configs()` and `_build_noise_configs()` in
+`grpo_trainer_batched.py`. Current default: `rsft_v2` — 6 guided cl_spd (CL5/CL8/CL10 with
+optional stretch 1.1/1.3/1.4) + 9 pure-noise slots sweeping noise ranges 0.1→5.0. No
+random-CL pool. Empirically best for L2 preservation (ego +1.5%, neighbor -1.0% vs LoRA-less).
+Use `rsft_v2_legacy` for the previous default (2 fixed-noise + 7 random-CL slots).
+
+### Rank Analytics
+
+Per-epoch instrumentation that tracks **which generation slot wins rank #1** for each scene
+and **which reward component drives the win**. Implemented in `rlvr/rank_analytics.py`.
+Outputs `rank_analytics_epoch_NNN.json` per epoch and a final `rank_analytics_summary.json`
+in the run dir. Visualize with `python -m rlvr.autoresearch.tools.viz_rank_analytics --run_dir <dir>`.
+
+Use to identify redundant/dead generation slots that never produce winners — those can be
+swapped for new guidance variants. Adds ~no overhead (the reward breakdowns are already
+computed during scoring; analytics just retain and aggregate them).
+
 ### Random Guidance Mode
 
 The `random_guidance_mode` config replaces the learned exploration policy with direct η sampling:

--- a/rlvr/README.md
+++ b/rlvr/README.md
@@ -196,13 +196,20 @@ per-parameter changes, preventing destabilization.
 epoch 5-6 with rb_cross>20. Lower reg gives the ego loss more freedom but insufficient
 constraint on neighbor weights causes catastrophic drift through shared DiT parameters.
 
-**Generation variants** (`generation_variant` config field). The 16 generation slots are
-composed of: 1 deterministic + N guided cl_spd configs + N noise-only configs + remaining
-random pool. Defined in `_build_cl_spd_configs()` and `_build_noise_configs()` in
-`grpo_trainer_batched.py`. Current default: `rsft_v2` — 6 guided cl_spd (CL5/CL8/CL10 with
-optional stretch 1.1/1.3/1.4) + 9 pure-noise slots sweeping noise ranges 0.1→5.0. No
-random-CL pool. Empirically best for L2 preservation (ego +1.5%, neighbor -1.0% vs LoRA-less).
-Use `rsft_v2_legacy` for the previous default (2 fixed-noise + 7 random-CL slots).
+**Generation variants** (`generation_variant` config field, default `"rsft_v2"`).
+Composition is 1 deterministic + N guided cl_spd configs + M noise-only configs +
+(15 - N - M) random-CL passes. Variants are defined in `rlvr/generation_variants.py`
+as `GenerationVariant(cl_spd_configs=..., noise_configs=...)` entries in the `_VARIANTS`
+registry. Use `rlvr.generation_variants.list_variants()` for the full list.
+
+The default `rsft_v2` has **6 guided cl_spd slots** — `CL5_SPD5_det`,
+`CL8_SPD8_str13_n0825` (stretch 1.3), `CL6_SPD6_str11_n0515` (stretch 1.1),
+`CL5_SPD5_noisy`, `CL7_SPD7_str14_n0820` (stretch 1.4), `CL10_SPD10_noisy` — plus
+**9 pure-noise slots** sweeping ranges 0.1→5.0 (`noise_n0103`, `n0306`, `n0510`,
+`n0515`, `n0818`, `n1025`, `n1530`, `n2040`, `n3050`). No random-CL pool.
+Empirically best for L2 preservation (ego +1.5%, neighbor -1.0% vs LoRA-less baseline,
+ep8 on miraikan val 50). Use `rsft_v2_legacy` for the previous slot composition
+(2 fixed-noise + 7 random-CL) or `default` for the pre-variant layout (8 cl_spd + 7 random).
 
 ### Rank Analytics
 

--- a/rlvr/autoresearch/run_experiment.py
+++ b/rlvr/autoresearch/run_experiment.py
@@ -613,6 +613,7 @@ def run(config_path: Path, name: str, skip_baseline: bool = False, baseline_cach
                     reward_config=train_reward_config, device=DEVICE, epoch=epoch,
                     exploration_policy=_explorer,
                     exploration_optimizer=_explorer_opt,
+                    run_dir=run_dir,
                 )
             else:
                 # Fully batched training: all scenes in ~5 forward passes
@@ -658,6 +659,13 @@ def run(config_path: Path, name: str, skip_baseline: bool = False, baseline_cach
     # Generate trajectory visualization for the best checkpoint
     if best_checkpoint and Path(best_checkpoint).exists():
         _visualize_trajectories(policy_model, model_args, prob_100, eval_reward_config, run_dir, name)
+
+    # Cross-epoch rank analytics summary
+    try:
+        from rlvr.rank_analytics import save_cross_epoch_summary
+        save_cross_epoch_summary(run_dir)
+    except Exception as e:
+        print(f"  [rank_analytics] Cross-epoch summary failed: {e}")
 
     # Print final summary (machine-parseable)
     print("\n---")

--- a/rlvr/autoresearch/tools/profile_training.py
+++ b/rlvr/autoresearch/tools/profile_training.py
@@ -256,6 +256,7 @@ def profile_rsft(model, model_args, scene_paths, config_path: str | None, profil
         model=model, model_args=model_args, optimizer=optimizer,
         scene_paths=scene_paths, config=config,
         reward_config=reward_config, device=DEVICE, epoch=epoch,
+        run_dir=None,
     )
 
     total_wall = time.perf_counter() - wall_start

--- a/rlvr/autoresearch/tools/viz_rank_analytics.py
+++ b/rlvr/autoresearch/tools/viz_rank_analytics.py
@@ -18,15 +18,25 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
-# Category colors
+# Category colors. Includes the experimental categories emitted by
+# rlvr.rank_analytics.get_category() so they don't get dropped from plots.
 _CAT_COLORS = {
     "det_pure": "#2196F3",
     "guided_det": "#FF9800",
     "guided_noisy": "#4CAF50",
     "random": "#9E9E9E",
+    "noise_only_exp": "#9C27B0",
+    "stretched_exp": "#E91E63",
+    "lateral_exp": "#00BCD4",
+    "decoupled_exp": "#795548",
+    "collision_exp": "#F44336",
 }
 
-_CAT_ORDER = ["det_pure", "guided_det", "guided_noisy", "random"]
+_CAT_ORDER = [
+    "det_pure", "guided_det", "guided_noisy",
+    "noise_only_exp", "stretched_exp", "lateral_exp", "decoupled_exp", "collision_exp",
+    "random",
+]
 
 
 def load_summary(run_dir: Path) -> dict:
@@ -172,22 +182,23 @@ def plot_scene_heatmap(summary: dict, output_dir: Path) -> None:
     if not scene_evo:
         return
 
-    cat_to_int = {"det_pure": 0, "guided_det": 1, "guided_noisy": 2, "random": 3}
+    cat_to_int = {cat: i for i, cat in enumerate(_CAT_ORDER)}
     scenes = sorted(scene_evo.keys())
     # Get epochs from first scene
     first_scene = scene_evo[scenes[0]]
     epochs = [entry["epoch"] for entry in first_scene]
 
     matrix = np.full((len(scenes), len(epochs)), np.nan)
+    unknown_idx = cat_to_int.get("random", len(_CAT_ORDER) - 1)
     for i, scene in enumerate(scenes):
         entries = scene_evo[scene]
         for j, entry in enumerate(entries):
             if j < len(epochs):
-                matrix[i, j] = cat_to_int.get(entry["category"], 3)
+                matrix[i, j] = cat_to_int.get(entry["category"], unknown_idx)
 
     from matplotlib.colors import ListedColormap, BoundaryNorm
     cmap = ListedColormap([_CAT_COLORS[c] for c in _CAT_ORDER])
-    bounds = [-0.5, 0.5, 1.5, 2.5, 3.5]
+    bounds = [-0.5] + [i + 0.5 for i in range(len(_CAT_ORDER))]
     norm = BoundaryNorm(bounds, cmap.N)
 
     fig, ax = plt.subplots(figsize=(max(10, len(epochs) * 0.8), max(8, len(scenes) * 0.25)))

--- a/rlvr/autoresearch/tools/viz_rank_analytics.py
+++ b/rlvr/autoresearch/tools/viz_rank_analytics.py
@@ -1,0 +1,241 @@
+"""Visualize rank analytics: config win rates and reward component trends.
+
+Usage:
+    python -m rlvr.autoresearch.tools.viz_rank_analytics \
+        --run_dir /path/to/experiment_dir \
+        --output_dir /path/to/output_dir  # defaults to run_dir/plots
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+# Category colors
+_CAT_COLORS = {
+    "det_pure": "#2196F3",
+    "guided_det": "#FF9800",
+    "guided_noisy": "#4CAF50",
+    "random": "#9E9E9E",
+}
+
+_CAT_ORDER = ["det_pure", "guided_det", "guided_noisy", "random"]
+
+
+def load_summary(run_dir: Path) -> dict:
+    path = run_dir / "rank_analytics_summary.json"
+    if not path.exists():
+        raise FileNotFoundError(f"No summary found at {path}. Run training first.")
+    with open(path) as f:
+        return json.load(f)
+
+
+def load_epoch_data(run_dir: Path) -> list[dict]:
+    files = sorted(run_dir.glob("rank_analytics_epoch_*.json"))
+    data = []
+    for f in files:
+        with open(f) as fh:
+            data.append(json.load(fh))
+    return data
+
+
+def plot_category_stacked_area(summary: dict, output_dir: Path) -> None:
+    """Stacked area: config category rates over epochs."""
+    trends = summary["category_trends"]
+    epochs = sorted(int(e) for e in trends.keys())
+    if len(epochs) < 2:
+        return
+
+    fig, ax = plt.subplots(figsize=(10, 5))
+    y_stacks = {cat: [] for cat in _CAT_ORDER}
+    for ep in epochs:
+        rates = trends[str(ep)]
+        for cat in _CAT_ORDER:
+            y_stacks[cat].append(rates.get(cat, 0) * 100)
+
+    y_arrays = [np.array(y_stacks[cat]) for cat in _CAT_ORDER]
+    ax.stackplot(
+        epochs, *y_arrays,
+        labels=[cat.replace("_", " ").title() for cat in _CAT_ORDER],
+        colors=[_CAT_COLORS[cat] for cat in _CAT_ORDER],
+        alpha=0.85,
+    )
+    ax.set_xlabel("Epoch", fontsize=12)
+    ax.set_ylabel("Win Rate (%)", fontsize=12)
+    ax.set_title("Guidance Category Win Rates Over Training", fontsize=14)
+    ax.legend(loc="upper right", fontsize=10)
+    ax.set_xlim(epochs[0], epochs[-1])
+    ax.set_ylim(0, 100)
+    ax.grid(axis="y", alpha=0.3)
+    fig.tight_layout()
+    fig.savefig(output_dir / "category_rates_over_epochs.png", dpi=150)
+    plt.close(fig)
+    print(f"  Saved category_rates_over_epochs.png")
+
+
+def plot_config_heatmap(summary: dict, output_dir: Path) -> None:
+    """Heatmap: individual config × epoch win rates."""
+    config_trends = summary["config_trends"]
+    epochs = sorted(int(e) for e in config_trends.keys())
+    if not epochs:
+        return
+
+    # Collect all config labels
+    all_labels = sorted(config_trends[str(epochs[0])].keys())
+
+    # Build matrix [n_configs, n_epochs]
+    matrix = np.zeros((len(all_labels), len(epochs)))
+    for j, ep in enumerate(epochs):
+        rates = config_trends[str(ep)]
+        for i, lbl in enumerate(all_labels):
+            matrix[i, j] = rates.get(lbl, 0) * 100
+
+    fig, ax = plt.subplots(figsize=(max(10, len(epochs) * 0.8), max(6, len(all_labels) * 0.4)))
+    im = ax.imshow(matrix, aspect="auto", cmap="YlOrRd", vmin=0)
+    ax.set_xticks(range(len(epochs)))
+    ax.set_xticklabels([str(e) for e in epochs], fontsize=9)
+    ax.set_yticks(range(len(all_labels)))
+    ax.set_yticklabels(all_labels, fontsize=9)
+    ax.set_xlabel("Epoch", fontsize=12)
+    ax.set_ylabel("Generation Config", fontsize=12)
+    ax.set_title("Config Win Rate Heatmap (%)", fontsize=14)
+
+    # Annotate cells with values
+    for i in range(len(all_labels)):
+        for j in range(len(epochs)):
+            val = matrix[i, j]
+            if val > 0:
+                color = "white" if val > 20 else "black"
+                ax.text(j, i, f"{val:.0f}", ha="center", va="center",
+                        fontsize=8, color=color)
+
+    fig.colorbar(im, ax=ax, label="Win Rate (%)", shrink=0.8)
+    fig.tight_layout()
+    fig.savefig(output_dir / "config_heatmap.png", dpi=150)
+    plt.close(fig)
+    print(f"  Saved config_heatmap.png")
+
+
+def plot_dominant_components(epoch_data: list[dict], output_dir: Path) -> None:
+    """Grouped bar chart: dominant reward component distribution per epoch."""
+    if not epoch_data:
+        return
+
+    epochs = [d["epoch"] for d in epoch_data]
+    all_comps = set()
+    for d in epoch_data:
+        all_comps.update(d["summary"]["dominant_components"].keys())
+    all_comps = sorted(all_comps)
+
+    # Build matrix [n_epochs, n_components]
+    n_ep = len(epochs)
+    n_comp = len(all_comps)
+    matrix = np.zeros((n_ep, n_comp))
+    for i, d in enumerate(epoch_data):
+        total = sum(d["summary"]["dominant_components"].values()) or 1
+        for j, comp in enumerate(all_comps):
+            matrix[i, j] = d["summary"]["dominant_components"].get(comp, 0) / total * 100
+
+    comp_colors = plt.cm.Set2(np.linspace(0, 1, n_comp))
+
+    fig, ax = plt.subplots(figsize=(max(10, n_ep * 0.8), 5))
+    x = np.arange(n_ep)
+    bar_width = 0.8 / n_comp
+
+    for j, comp in enumerate(all_comps):
+        offset = (j - n_comp / 2 + 0.5) * bar_width
+        ax.bar(x + offset, matrix[:, j], bar_width, label=comp, color=comp_colors[j])
+
+    ax.set_xticks(x)
+    ax.set_xticklabels([str(e) for e in epochs], fontsize=9)
+    ax.set_xlabel("Epoch", fontsize=12)
+    ax.set_ylabel("Frequency (%)", fontsize=12)
+    ax.set_title("Dominant Reward Component Per Epoch", fontsize=14)
+    ax.legend(fontsize=9, ncol=min(n_comp, 4))
+    ax.grid(axis="y", alpha=0.3)
+    fig.tight_layout()
+    fig.savefig(output_dir / "dominant_components.png", dpi=150)
+    plt.close(fig)
+    print(f"  Saved dominant_components.png")
+
+
+def plot_scene_heatmap(summary: dict, output_dir: Path) -> None:
+    """Per-scene heatmap: scene × epoch winner category."""
+    scene_evo = summary.get("scene_evolution", {})
+    if not scene_evo:
+        return
+
+    cat_to_int = {"det_pure": 0, "guided_det": 1, "guided_noisy": 2, "random": 3}
+    scenes = sorted(scene_evo.keys())
+    # Get epochs from first scene
+    first_scene = scene_evo[scenes[0]]
+    epochs = [entry["epoch"] for entry in first_scene]
+
+    matrix = np.full((len(scenes), len(epochs)), np.nan)
+    for i, scene in enumerate(scenes):
+        entries = scene_evo[scene]
+        for j, entry in enumerate(entries):
+            if j < len(epochs):
+                matrix[i, j] = cat_to_int.get(entry["category"], 3)
+
+    from matplotlib.colors import ListedColormap, BoundaryNorm
+    cmap = ListedColormap([_CAT_COLORS[c] for c in _CAT_ORDER])
+    bounds = [-0.5, 0.5, 1.5, 2.5, 3.5]
+    norm = BoundaryNorm(bounds, cmap.N)
+
+    fig, ax = plt.subplots(figsize=(max(10, len(epochs) * 0.8), max(8, len(scenes) * 0.25)))
+    im = ax.imshow(matrix, aspect="auto", cmap=cmap, norm=norm, interpolation="nearest")
+
+    ax.set_xticks(range(len(epochs)))
+    ax.set_xticklabels([str(e) for e in epochs], fontsize=9)
+    ax.set_yticks(range(len(scenes)))
+    ax.set_yticklabels([s[:25] for s in scenes], fontsize=7)
+    ax.set_xlabel("Epoch", fontsize=12)
+    ax.set_ylabel("Scene", fontsize=12)
+    ax.set_title("Per-Scene Winner Category Over Training", fontsize=14)
+
+    # Legend
+    from matplotlib.patches import Patch
+    legend_elements = [
+        Patch(facecolor=_CAT_COLORS[cat], label=cat.replace("_", " ").title())
+        for cat in _CAT_ORDER
+    ]
+    ax.legend(handles=legend_elements, loc="upper right", fontsize=9)
+
+    fig.tight_layout()
+    fig.savefig(output_dir / "scene_evolution_heatmap.png", dpi=150)
+    plt.close(fig)
+    print(f"  Saved scene_evolution_heatmap.png")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Visualize rank analytics")
+    parser.add_argument("--run_dir", type=Path, required=True)
+    parser.add_argument("--output_dir", type=Path, default=None,
+                        help="Output dir for plots (default: run_dir/plots)")
+    args = parser.parse_args()
+
+    output_dir = args.output_dir or args.run_dir / "plots"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Loading rank analytics from {args.run_dir}")
+    summary = load_summary(args.run_dir)
+    epoch_data = load_epoch_data(args.run_dir)
+
+    print(f"Generating plots ({len(epoch_data)} epochs)...")
+    plot_category_stacked_area(summary, output_dir)
+    plot_config_heatmap(summary, output_dir)
+    plot_dominant_components(epoch_data, output_dir)
+    plot_scene_heatmap(summary, output_dir)
+    print(f"All plots saved to {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/viz_rank_analytics.py
+++ b/rlvr/autoresearch/tools/viz_rank_analytics.py
@@ -97,8 +97,16 @@ def plot_config_heatmap(summary: dict, output_dir: Path) -> None:
     if not epochs:
         return
 
-    # Collect all config labels
-    all_labels = sorted(config_trends[str(epochs[0])].keys())
+    # Collect the union of config labels across all epochs (preserving first-seen
+    # order). Using only the first epoch silently drops slots that appear later
+    # if the variant or label set ever changes mid-run.
+    all_labels: list[str] = []
+    seen: set[str] = set()
+    for ep in epochs:
+        for lbl in config_trends[str(ep)].keys():
+            if lbl not in seen:
+                seen.add(lbl)
+                all_labels.append(lbl)
 
     # Build matrix [n_configs, n_epochs]
     matrix = np.zeros((len(all_labels), len(epochs)))
@@ -184,17 +192,33 @@ def plot_scene_heatmap(summary: dict, output_dir: Path) -> None:
 
     cat_to_int = {cat: i for i, cat in enumerate(_CAT_ORDER)}
     scenes = sorted(scene_evo.keys())
-    # Get epochs from first scene
-    first_scene = scene_evo[scenes[0]]
-    epochs = [entry["epoch"] for entry in first_scene]
+    # Derive epoch axis as the union of explicit epoch values across all scenes
+    # (and category_trends, which is the source of truth). Indexing by list
+    # position would silently drop scenes that skipped an epoch.
+    epoch_set: set[int] = set()
+    for ep_str in summary.get("category_trends", {}):
+        try:
+            epoch_set.add(int(ep_str))
+        except (TypeError, ValueError):
+            pass
+    for entries in scene_evo.values():
+        for entry in entries:
+            ep = entry.get("epoch")
+            if ep is not None:
+                epoch_set.add(int(ep))
+    epochs = sorted(epoch_set)
+    if not epochs:
+        return
+    epoch_to_col = {ep: j for j, ep in enumerate(epochs)}
 
     matrix = np.full((len(scenes), len(epochs)), np.nan)
     unknown_idx = cat_to_int.get("random", len(_CAT_ORDER) - 1)
     for i, scene in enumerate(scenes):
-        entries = scene_evo[scene]
-        for j, entry in enumerate(entries):
-            if j < len(epochs):
-                matrix[i, j] = cat_to_int.get(entry["category"], unknown_idx)
+        for entry in scene_evo[scene]:
+            ep = entry.get("epoch")
+            if ep is None or ep not in epoch_to_col:
+                continue
+            matrix[i, epoch_to_col[ep]] = cat_to_int.get(entry["category"], unknown_idx)
 
     from matplotlib.colors import ListedColormap, BoundaryNorm
     cmap = ListedColormap([_CAT_COLORS[c] for c in _CAT_ORDER])

--- a/rlvr/generation_variants.py
+++ b/rlvr/generation_variants.py
@@ -1,0 +1,258 @@
+"""Generation variant registry for ranked SFT.
+
+Each variant defines the 16 generation slots used per scene during ranked SFT:
+  slot 0 = deterministic (always)
+  slots 1..N = guided cl_spd configs (N = len(cl_spd_configs))
+  slots N+1..M = noise-only configs with deterministic noise ranges
+  slots M+1..15 = random pool (random CL + noise from config.noise_scale_range)
+
+Adding a new variant:
+  1. Define its `cl_spd_configs` and `noise_configs` lists.
+  2. Add a `GenerationVariant(...)` entry to `_VARIANTS`.
+  3. (Optional) add an alias to `_ALIASES` if backwards compat is needed.
+
+cl_spd_config dict fields:
+  cl, spd        — centerline & speed guidance scales (0 = disabled)
+  noise          — (min, max) per-element noise range
+  label          — human-readable identifier (used by rank_analytics)
+  stretch        — speed stretch factor (default 1.0, no stretch)
+  lat_eta        — lateral guidance eta in [-1, 1] (default 0, disabled)
+  lat_lambda     — max lateral offset in metres (default 2.0)
+  lat_scale      — lateral guidance scale (default 5.0)
+  col            — collision guidance scale (default 0, disabled)
+
+noise_config dict fields:
+  noise          — (min, max) per-element noise range
+  label          — human-readable identifier
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class GenerationVariant:
+    """Defines the slot composition for a generation_variant."""
+    description: str
+    cl_spd_configs: list[dict]
+    noise_configs: list[dict] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Reusable building blocks
+# ---------------------------------------------------------------------------
+
+# Plain CL+SPD slots used in many variants
+_CL5_SPD5_DET   = {"cl": 5.0,  "spd": 5.0,  "noise": (0.0, 0.0), "label": "CL5_SPD5_det"}
+_CL10_SPD10_NOISY = {"cl": 10.0, "spd": 10.0, "noise": (0.5, 1.0), "label": "CL10_SPD10_noisy"}
+_CL5_SPD5_NOISY = {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "label": "CL5_SPD5_noisy"}
+_CL10_SPD8_DET  = {"cl": 10.0, "spd": 8.0,  "noise": (0.0, 0.0), "label": "CL10_SPD8_det"}
+_CL10_SPD8_NOISY = {"cl": 10.0, "spd": 8.0,  "noise": (0.3, 0.8), "label": "CL10_SPD8_noisy"}
+
+# Stretched slots — winner of stretched_lateral campaign
+_CL8_SPD8_STR13 = {"cl": 8.0, "spd": 8.0, "noise": (0.8, 2.5), "stretch": 1.3, "label": "CL8_SPD8_str13_n0825"}
+_CL6_SPD6_STR11 = {"cl": 6.0, "spd": 6.0, "noise": (0.5, 1.5), "stretch": 1.1, "label": "CL6_SPD6_str11_n0515"}
+_CL7_SPD7_STR14 = {"cl": 7.0, "spd": 7.0, "noise": (0.8, 2.0), "stretch": 1.4, "label": "CL7_SPD7_str14_n0820"}
+
+# Lateral push slots
+_LATL04 = {"cl": 5.0, "spd": 5.0, "noise": (0.3, 0.8), "lat_eta":  0.4, "lat_lambda": 2.0, "lat_scale": 5.0, "label": "CL5_SPD5_latL04"}
+_LATR04 = {"cl": 5.0, "spd": 5.0, "noise": (0.3, 0.8), "lat_eta": -0.4, "lat_lambda": 2.0, "lat_scale": 5.0, "label": "CL5_SPD5_latR04"}
+_LATL06 = {"cl": 5.0, "spd": 5.0, "noise": (0.5, 1.5), "lat_eta":  0.6, "lat_lambda": 2.5, "lat_scale": 5.0, "label": "CL5_SPD5_latL06_n15"}
+
+# Common guided block used by rsft_v2 family (6 slots: 3 plain + 3 stretched)
+_GUIDED_RSFT_V2 = [
+    _CL5_SPD5_DET,
+    _CL8_SPD8_STR13,
+    _CL6_SPD6_STR11,
+    _CL5_SPD5_NOISY,
+    _CL7_SPD7_STR14,
+    _CL10_SPD10_NOISY,
+]
+
+# Noise sweeps
+_NOISE_SWEEP_FULL = [
+    {"noise": (0.1, 0.3), "label": "noise_n0103"},
+    {"noise": (0.3, 0.6), "label": "noise_n0306"},
+    {"noise": (0.5, 1.0), "label": "noise_n0510"},
+    {"noise": (0.5, 1.5), "label": "noise_n0515"},
+    {"noise": (0.8, 1.8), "label": "noise_n0818"},
+    {"noise": (1.0, 2.5), "label": "noise_n1025"},
+    {"noise": (1.5, 3.0), "label": "noise_n1530"},
+    {"noise": (2.0, 4.0), "label": "noise_n2040"},
+    {"noise": (3.0, 5.0), "label": "noise_n3050"},
+]
+
+_NOISE_SWEEP_HIGH = [
+    {"noise": (1.5, 3.0), "label": "noise_n1530"},
+    {"noise": (2.0, 4.0), "label": "noise_n2040"},
+]
+
+_NOISE_SWEEP_MID = [
+    {"noise": (0.3, 0.8), "label": "noise_n0308"},
+    {"noise": (0.5, 1.5), "label": "noise_n0515"},
+    {"noise": (1.0, 2.0), "label": "noise_n1020"},
+    {"noise": (1.5, 3.0), "label": "noise_n1530"},
+    {"noise": (2.0, 4.0), "label": "noise_n2040"},
+]
+
+
+# ---------------------------------------------------------------------------
+# Variant registry — entries listed by category then chronological order.
+# ---------------------------------------------------------------------------
+
+_VARIANTS: dict[str, GenerationVariant] = {
+
+    # ====== Production / current default ======
+    "rsft_v2": GenerationVariant(
+        description="Default RSFT base (April 2026): 6 guided + 9 noise sweep (0.1->5.0). "
+                    "Best L2 preservation. ep8: ego +1.5%, neighbor -1.0%, LD 0/50 on miraikan val 50.",
+        cl_spd_configs=_GUIDED_RSFT_V2,
+        noise_configs=_NOISE_SWEEP_FULL,
+    ),
+
+    # ====== Runner-up / honorable mentions (kept for comparison) ======
+    "rsft_v2_legacy": GenerationVariant(
+        description="Previous default (was noise_swap_2_no_lat): 6 guided + 2 fixed-noise + 7 random-CL. "
+                    "Higher reward & progress but worse L2 (+2.3%). ep9: val=+25.63, LD 1/50.",
+        cl_spd_configs=_GUIDED_RSFT_V2,
+        noise_configs=_NOISE_SWEEP_HIGH,
+    ),
+    "rsft_v2_half_half": GenerationVariant(
+        description="5 noise + 4 random. Highest val_reward (+26.59) and pgt med (0.90), but LD 11/50 — too aggressive.",
+        cl_spd_configs=_GUIDED_RSFT_V2,
+        noise_configs=_NOISE_SWEEP_MID,
+    ),
+    "rsft_v2_all_random": GenerationVariant(
+        description="Same guided as rsft_v2, no fixed noise, 9 random-CL slots. Conservative; lower reward.",
+        cl_spd_configs=_GUIDED_RSFT_V2,
+        noise_configs=[],
+    ),
+
+    # ====== Original baseline (pre-rsft_v2 system) ======
+    "default": GenerationVariant(
+        description="Original 8 cl_spd configs (CL5/CL8/CL10 det + noisy variants), no fixed noise. "
+                    "rank-analytics revealed CL10_*_det and CL10_SPD8_noisy were redundant.",
+        cl_spd_configs=[
+            _CL5_SPD5_DET,
+            {"cl": 8.0,  "spd": 5.0,  "noise": (0.0, 0.0), "label": "CL8_SPD5_det"},
+            _CL10_SPD8_DET,
+            {"cl": 10.0, "spd": 10.0, "noise": (0.0, 0.0), "label": "CL10_SPD10_det"},
+            _CL5_SPD5_NOISY,
+            {"cl": 8.0,  "spd": 8.0,  "noise": (0.3, 0.8), "label": "CL8_SPD8_noisy"},
+            _CL10_SPD8_NOISY,
+            _CL10_SPD10_NOISY,
+        ],
+    ),
+
+    # ====== Historical exploratory variants (kept for reproducibility) ======
+    "stretched_lateral": GenerationVariant(
+        description="Pre-rsft_v2 winner: stretched + lateral push variants. ep9: val=+26.26, LD 0/50, ego +3.6%.",
+        cl_spd_configs=[
+            _CL5_SPD5_DET, _CL8_SPD8_STR13, _CL10_SPD8_DET, _LATL04,
+            _CL5_SPD5_NOISY, _LATL06, _CL10_SPD8_NOISY, _CL10_SPD10_NOISY,
+        ],
+    ),
+    "noise_swap_2": GenerationVariant(
+        description="Replaces 2 CL10 slots in stretched_lateral with high-noise (n1530, n2040).",
+        cl_spd_configs=[
+            _CL5_SPD5_DET, _CL8_SPD8_STR13,
+            {"cl": 0.0, "spd": 0.0, "noise": (1.5, 3.0), "label": "noise_n1530"},
+            _LATL04, _CL5_SPD5_NOISY, _LATL06,
+            {"cl": 0.0, "spd": 0.0, "noise": (2.0, 4.0), "label": "noise_n2040"},
+            _CL10_SPD10_NOISY,
+        ],
+    ),
+    "more_noise": GenerationVariant(
+        description="5 noise-only slots in cl_spd positions. Drift-prone; produced rsft_v2 noise sweep idea.",
+        cl_spd_configs=[
+            {"cl": 0.0, "spd": 0.0, "noise": (0.3, 0.8), "label": "noise_n0308"},
+            _CL8_SPD8_STR13,
+            {"cl": 0.0, "spd": 0.0, "noise": (0.8, 2.0), "label": "noise_n0820"},
+            {"cl": 3.0, "spd": 0.0, "noise": (0.5, 1.5), "label": "CL3_n0515"},
+            _CL5_SPD5_NOISY, _LATL06,
+            {"cl": 0.0, "spd": 0.0, "noise": (1.5, 3.0), "label": "noise_n1530"},
+            {"cl": 0.0, "spd": 0.0, "noise": (2.0, 4.0), "label": "noise_n2040"},
+        ],
+    ),
+    "noisy_stretched": GenerationVariant(
+        description="3 stretched variants (str12/13/14) replacing CL10 redundant slots.",
+        cl_spd_configs=[
+            _CL5_SPD5_DET,
+            {"cl": 5.0, "spd": 5.0, "noise": (0.5, 1.5), "stretch": 1.2, "label": "CL5_SPD5_str12_n0515"},
+            _CL10_SPD8_DET, _CL8_SPD8_STR13, _CL5_SPD5_NOISY,
+            {"cl": 5.0, "spd": 3.0, "noise": (1.0, 3.0), "stretch": 1.4, "label": "CL5_SPD3_str14_n1030"},
+            _CL10_SPD8_NOISY, _CL10_SPD10_NOISY,
+        ],
+    ),
+    "lateral": GenerationVariant(
+        description="3 lateral push variants. Showed latR04 (right-push) is dead weight on miraikan.",
+        cl_spd_configs=[
+            _CL5_SPD5_DET, _LATL04, _CL10_SPD8_DET, _LATR04,
+            _CL5_SPD5_NOISY, _LATL06, _CL10_SPD8_NOISY, _CL10_SPD10_NOISY,
+        ],
+    ),
+    "decoupled": GenerationVariant(
+        description="CL-only and SPD-only variants (no combined CL+SPD). Each won 5-8% wins.",
+        cl_spd_configs=[
+            _CL5_SPD5_DET,
+            {"cl": 0.0,  "spd": 5.0,  "noise": (0.3, 1.5), "label": "SPD5_only_n0315"},
+            _CL10_SPD8_DET,
+            {"cl": 5.0,  "spd": 0.0,  "noise": (0.3, 1.5), "label": "CL5_only_n0315"},
+            _CL5_SPD5_NOISY,
+            {"cl": 10.0, "spd": 0.0,  "noise": (0.5, 2.0), "label": "CL10_only_n0520"},
+            _CL10_SPD8_NOISY, _CL10_SPD10_NOISY,
+        ],
+    ),
+    "combined_winners": GenerationVariant(
+        description="Top winner from each campaign (stretched + decoupled + lateral) combined.",
+        cl_spd_configs=[
+            _CL5_SPD5_DET, _CL8_SPD8_STR13, _CL10_SPD8_DET,
+            {"cl": 5.0, "spd": 0.0, "noise": (0.3, 1.5), "label": "CL5_only_n0315"},
+            _CL5_SPD5_NOISY, _LATL06, _CL10_SPD8_NOISY, _CL10_SPD10_NOISY,
+        ],
+    ),
+    "stretched_intense": GenerationVariant(
+        description="3 progressively stronger stretched variants (str12, str13, str15).",
+        cl_spd_configs=[
+            _CL5_SPD5_DET,
+            {"cl": 5.0, "spd": 5.0, "noise": (0.5, 1.5), "stretch": 1.2, "label": "CL5_SPD5_str12_n0515"},
+            _CL10_SPD8_DET, _CL8_SPD8_STR13, _CL5_SPD5_NOISY,
+            {"cl": 10.0, "spd": 8.0, "noise": (1.0, 3.0), "stretch": 1.5, "label": "CL10_SPD8_str15_n1030"},
+            _CL10_SPD8_NOISY, _CL10_SPD10_NOISY,
+        ],
+    ),
+    "collision_swap": GenerationVariant(
+        description="Replaces 2 CL10 slots with collision-guided variants (untested as of April 2026).",
+        cl_spd_configs=[
+            _CL5_SPD5_DET, _CL8_SPD8_STR13,
+            {"cl": 5.0, "spd": 5.0, "noise": (0.0, 0.0), "col": 0.5, "label": "CL5_SPD5_col05_det"},
+            _LATL04, _CL5_SPD5_NOISY, _LATL06,
+            {"cl": 5.0, "spd": 5.0, "noise": (0.3, 0.8), "col": 1.0, "label": "CL5_SPD5_col10_n0308"},
+            _CL10_SPD10_NOISY,
+        ],
+    ),
+}
+
+
+# Backwards-compatibility aliases — older configs use these names.
+_ALIASES: dict[str, str] = {
+    "noise_swap_2_no_lat": "rsft_v2_legacy",  # original name during exploration
+    "rsft_v2_all_noise": "rsft_v2",            # equivalent to current default
+}
+
+
+def get_variant(name: str) -> GenerationVariant:
+    """Look up a variant by name (resolves aliases)."""
+    name = _ALIASES.get(name, name)
+    if name not in _VARIANTS:
+        available = sorted(_VARIANTS.keys())
+        raise ValueError(
+            f"Unknown generation_variant: {name!r}. Available: {available}"
+        )
+    return _VARIANTS[name]
+
+
+def list_variants() -> list[str]:
+    """Return canonical variant names (excludes aliases)."""
+    return sorted(_VARIANTS.keys())

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -83,6 +83,12 @@ class GRPOConfig:
     guidance_prob: float = 0.5
     prototypes_path: str | None = None
 
+    # Generation variant — controls which cl_spd_configs slot list is used
+    # in generate_all_scenes_batched(). Variants replace the 3 redundant slots
+    # (CL8_SPD5_det, CL10_SPD10_det, CL8_SPD8_noisy) with experimental configs.
+    # Options: "default", "noisy_stretched", "lateral", "decoupled"
+    generation_variant: str = "default"
+
     # Reward weights
     w_safety: float = 5.0
     w_progress: float = 2.0

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -83,11 +83,11 @@ class GRPOConfig:
     guidance_prob: float = 0.5
     prototypes_path: str | None = None
 
-    # Generation variant — controls which cl_spd_configs slot list is used
-    # in generate_all_scenes_batched(). Variants replace the 3 redundant slots
-    # (CL8_SPD5_det, CL10_SPD10_det, CL8_SPD8_noisy) with experimental configs.
-    # Options: "default", "noisy_stretched", "lateral", "decoupled"
-    generation_variant: str = "default"
+    # Generation variant — selects the 16-slot composition for ranked SFT.
+    # Defined in rlvr/generation_variants.py. Use rlvr.generation_variants.list_variants()
+    # for the canonical list. Default is "rsft_v2" (best L2 preservation as of April 2026).
+    # "default" reproduces the pre-variant-system layout (8 cl_spd + 7 random).
+    generation_variant: str = "rsft_v2"
 
     # Reward weights
     w_safety: float = 5.0

--- a/rlvr/grpo_sft_trainer.py
+++ b/rlvr/grpo_sft_trainer.py
@@ -582,9 +582,9 @@ def train_epoch_ranked_sft(
     # Rank analytics: track which generation config wins per scene
     from pathlib import Path
     from rlvr.rank_analytics import (
-        EpochRankAnalytics, SceneRankRecord,
+        EpochRankAnalytics, SceneRankRecord, breakdown_to_dict,
         mean_breakdown_dict, compute_dominant_component, print_epoch_summary,
-        save_epoch_analytics, get_category, _breakdown_to_dict,
+        save_epoch_analytics,
     )
     from rlvr.grpo_trainer_batched import get_generation_config_labels_for_variant
     _ra_variant = getattr(config, "generation_variant", "default")
@@ -629,7 +629,7 @@ def train_epoch_ranked_sft(
             winner_reward=float(reward_vals[best_idx]),
             mean_reward=float(reward_vals.mean()),
             det_reward=float(reward_vals[0]),
-            winner_breakdown=_breakdown_to_dict(_ra_winner),
+            winner_breakdown=breakdown_to_dict(_ra_winner),
             mean_breakdown=_ra_mean_bd,
             dominant_component=_ra_dom_comp,
             dominant_delta=_ra_dom_delta,

--- a/rlvr/grpo_sft_trainer.py
+++ b/rlvr/grpo_sft_trainer.py
@@ -358,6 +358,7 @@ def train_epoch_ranked_sft(
     epoch: int,
     exploration_policy=None,
     exploration_optimizer=None,
+    run_dir=None,
 ) -> dict[str, float]:
     """GRPO-ranked SFT epoch: generate, rank, filter, train with SFT loss.
 
@@ -557,6 +558,7 @@ def train_epoch_ranked_sft(
                 lateral_lambda=lat_lambda,
                 lateral_scale=lat_scale,
                 speed_stretch=spd_stretch,
+                generation_variant=getattr(config, "generation_variant", "default"),
             )  # [N, K, T, 4]
 
     torch.cuda.empty_cache()
@@ -576,6 +578,20 @@ def train_epoch_ranked_sft(
     best_rewards_list = []
     scene_train_mask = []  # True = train on this scene, False = skip
     scene_improvements = []  # improvement value per scene for advantage weighting
+
+    # Rank analytics: track which generation config wins per scene
+    from pathlib import Path
+    from rlvr.rank_analytics import (
+        EpochRankAnalytics, SceneRankRecord,
+        mean_breakdown_dict, compute_dominant_component, print_epoch_summary,
+        save_epoch_analytics, get_category, _breakdown_to_dict,
+    )
+    from rlvr.grpo_trainer_batched import get_generation_config_labels_for_variant
+    _ra_variant = getattr(config, "generation_variant", "default")
+    _ra_labels = get_generation_config_labels_for_variant(_ra_variant, K)
+    if exploration_policy is not None:
+        _ra_labels = [f"explorer_{i}" for i in range(K)]
+    _ra = EpochRankAnalytics(epoch=epoch, n_scenes=N)
 
     for i in tqdm(range(N), desc="Scoring"):
         traj_K = all_trajs[i]  # [K, T, 4]
@@ -600,6 +616,25 @@ def train_epoch_ranked_sft(
             from pathlib import Path as _P
             print(f"    SEL [{_P(valid_paths[i]).stem[:30]}] det={det_reward:.1f} best={best_reward:.1f} imp={improvement:.1f}")
 
+        # Rank analytics: record which config won and why
+        _ra_mean_bd = mean_breakdown_dict(rewards)
+        _ra_winner = rewards[best_idx]
+        _ra_dom_comp, _ra_dom_delta = compute_dominant_component(
+            _ra_winner, _ra_mean_bd, reward_config,
+        )
+        _ra.records.append(SceneRankRecord(
+            scene_path=Path(valid_paths[i]).stem,
+            winner_idx=best_idx,
+            winner_label=_ra_labels[best_idx],
+            winner_reward=float(reward_vals[best_idx]),
+            mean_reward=float(reward_vals.mean()),
+            det_reward=float(reward_vals[0]),
+            winner_breakdown=_breakdown_to_dict(_ra_winner),
+            mean_breakdown=_ra_mean_bd,
+            dominant_component=_ra_dom_comp,
+            dominant_delta=_ra_dom_delta,
+        ))
+
         # Get best trajectory and smooth it
         best_traj = traj_K[best_idx].cpu().numpy()  # [T, 4]
         best_traj_smooth = _smooth_trajectory(
@@ -610,6 +645,12 @@ def train_epoch_ranked_sft(
         best_rewards_list.append(best_reward)
 
     mean_best_reward = float(np.mean(best_rewards_list))
+
+    # Rank analytics: aggregate and print/save
+    _ra.finalize(_ra_labels)
+    print_epoch_summary(_ra)
+    if run_dir is not None:
+        save_epoch_analytics(_ra, Path(run_dir), epoch)
 
     # Frozen selection: use ep1 mask for all epochs
     use_frozen = getattr(config, "selective_frozen", False) and selective_thresh > 0

--- a/rlvr/grpo_trainer_batched.py
+++ b/rlvr/grpo_trainer_batched.py
@@ -133,6 +133,18 @@ def generate_all_scenes_batched(
     # 8 guided trajectories at CL5-10 to ensure ~8-10/16 stay in-lane on curves.
     # Variants can replace the 3 redundant slots with experimental configs.
     cl_spd_configs = _build_cl_spd_configs(generation_variant)
+    noise_configs = _build_noise_configs(generation_variant)
+
+    # Validate up-front that K accommodates all fixed slots (1 det + cl_spd + noise).
+    # Otherwise we'd generate them all, slice to [:K], and silently waste compute.
+    n_fixed_total = 1 + len(cl_spd_configs) + len(noise_configs)
+    if K < n_fixed_total:
+        raise ValueError(
+            f"K={K} is smaller than the number of fixed trajectory slots "
+            f"({n_fixed_total}) required by generation_variant={generation_variant!r} "
+            f"(1 det + {len(cl_spd_configs)} cl_spd + {len(noise_configs)} noise). "
+            f"Increase num_generations or pick a variant with fewer fixed slots."
+        )
 
     # Set reference_trajectory if ANY slot needs lat/lon guidance — including
     # per-slot lat_eta overrides. Without this, slots with per-slot lat_eta
@@ -192,7 +204,7 @@ def generate_all_scenes_batched(
     # --- Noise-only slots (no guidance, fixed noise ranges) ---
     # Functionally part of the noise/exploration pool but with deterministic
     # noise ranges rather than random sampling.
-    for noise_cfg in _build_noise_configs(generation_variant):
+    for noise_cfg in noise_configs:
         n_min_s, n_max_s = noise_cfg["noise"]
         trajs = _chunked_generate(model, model_args, norm_batch, n_min_s, n_max_s, None, device, gen_chunk_size)
         all_k_trajs.append(trajs)

--- a/rlvr/grpo_trainer_batched.py
+++ b/rlvr/grpo_trainer_batched.py
@@ -129,18 +129,21 @@ def generate_all_scenes_batched(
     det_trajs = _chunked_generate(model, model_args, norm_batch, 0.0, 0.0, None, device, gen_chunk_size)
     all_k_trajs.append(det_trajs)
 
-    # Use deterministic trajectory as reference for lon/lat guidance.
-    # det_trajs is already in (x, y, cos_yaw, sin_yaw) format — no conversion needed.
-    use_lon = abs(longitudinal_eta) > 1e-6
-    use_lat = abs(lateral_eta) > 1e-6
-    if use_lon or use_lat:
-        norm_batch["reference_trajectory"] = det_trajs  # no clone needed, not mutated
-
     # --- Config 2-9: CL + SPD guidance sweep for lane keeping ---
     # 8 guided trajectories at CL5-10 to ensure ~8-10/16 stay in-lane on curves.
     # Variants can replace the 3 redundant slots with experimental configs.
     cl_spd_configs = _build_cl_spd_configs(generation_variant)
-    use_stretch_global = abs(speed_stretch - 1.0) > 1e-6
+
+    # Set reference_trajectory if ANY slot needs lat/lon guidance — including
+    # per-slot lat_eta overrides. Without this, slots with per-slot lat_eta
+    # would silently produce zero lateral guidance because LateralGuidance
+    # returns zeros when reference_trajectory is missing.
+    use_lon = abs(longitudinal_eta) > 1e-6
+    any_per_slot_lat = any(abs(cfg.get("lat_eta", 0.0)) > 1e-6 for cfg in cl_spd_configs)
+    use_lat = abs(lateral_eta) > 1e-6 or any_per_slot_lat
+    if use_lon or use_lat:
+        norm_batch["reference_trajectory"] = det_trajs  # no clone needed, not mutated
+
     for cfg in cl_spd_configs:
         cl_scale = cfg["cl"]
         spd_scale = cfg["spd"]
@@ -157,13 +160,17 @@ def generate_all_scenes_batched(
         cfg_use_lat = abs(cfg_lat_eta) > 1e-6
         # Optional per-slot collision guidance
         cfg_col = cfg.get("col", 0.0)
+        # A slot is "guided" if it has CL or SPD guidance. Pure-noise slots
+        # (cl=0, spd=0) skip lon guidance even when the global flag is on,
+        # to keep them as pure stochastic exploration.
+        is_guided_slot = cl_scale > 0 or spd_scale > 0
         # Build guidance functions
         fns = []
         if cl_scale > 0:
             fns.append(GuidanceConfig("centerline_following", enabled=True, scale=cl_scale))
         if spd_scale > 0:
             fns.append(GuidanceConfig("speed", enabled=True, scale=spd_scale, params=spd_params))
-        if use_lon:
+        if use_lon and is_guided_slot:
             fns.append(GuidanceConfig(
                 "longitudinal", enabled=True, scale=longitudinal_scale,
                 params={"eta_lon": longitudinal_eta, "lambda_lon": longitudinal_lambda},

--- a/rlvr/grpo_trainer_batched.py
+++ b/rlvr/grpo_trainer_batched.py
@@ -27,6 +27,7 @@ from tqdm import tqdm
 from guidance_gui.generate_samples import generate_samples
 from preference_optimization.utils import load_npz_data
 from rlvr.closed_loop.batched_rollout import _batched_generate_varied_noise
+from rlvr.generation_variants import get_variant
 from rlvr.grpo_config import GRPOConfig
 from rlvr.grpo_loss import compute_batched_grpo_loss
 from rlvr.reward import RewardConfig, compute_group_advantages, compute_reward_batch
@@ -68,200 +69,13 @@ def _chunked_generate(model, model_args, norm_batch, noise_min, noise_max, compo
 
 
 def _build_cl_spd_configs(variant: str) -> list[dict]:
-    """Return list of generation config dicts for the variant.
-
-    Each dict: {cl, spd, noise, label, [stretch], [lat_eta, lat_lambda, lat_scale]}
-    cl/spd = 0 disables that guidance. Slots 2/4/6 (1-indexed) of "default"
-    are the redundant ones identified by rank analytics — the experimental
-    variants replace those with new configs.
-    """
-    if variant == "default":
-        return [
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.0, 0.0), "label": "CL5_SPD5_det"},
-            {"cl": 8.0,  "spd": 5.0,  "noise": (0.0, 0.0), "label": "CL8_SPD5_det"},
-            {"cl": 10.0, "spd": 8.0,  "noise": (0.0, 0.0), "label": "CL10_SPD8_det"},
-            {"cl": 10.0, "spd": 10.0, "noise": (0.0, 0.0), "label": "CL10_SPD10_det"},
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "label": "CL5_SPD5_noisy"},
-            {"cl": 8.0,  "spd": 8.0,  "noise": (0.3, 0.8), "label": "CL8_SPD8_noisy"},
-            {"cl": 10.0, "spd": 8.0,  "noise": (0.3, 0.8), "label": "CL10_SPD8_noisy"},
-            {"cl": 10.0, "spd": 10.0, "noise": (0.5, 1.0), "label": "CL10_SPD10_noisy"},
-        ]
-    if variant == "noisy_stretched":
-        return [
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.0, 0.0), "label": "CL5_SPD5_det"},
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.5, 1.5), "stretch": 1.2, "label": "CL5_SPD5_str12_n0515"},
-            {"cl": 10.0, "spd": 8.0,  "noise": (0.0, 0.0), "label": "CL10_SPD8_det"},
-            {"cl": 8.0,  "spd": 8.0,  "noise": (0.8, 2.5), "stretch": 1.3, "label": "CL8_SPD8_str13_n0825"},
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "label": "CL5_SPD5_noisy"},
-            {"cl": 5.0,  "spd": 3.0,  "noise": (1.0, 3.0), "stretch": 1.4, "label": "CL5_SPD3_str14_n1030"},
-            {"cl": 10.0, "spd": 8.0,  "noise": (0.3, 0.8), "label": "CL10_SPD8_noisy"},
-            {"cl": 10.0, "spd": 10.0, "noise": (0.5, 1.0), "label": "CL10_SPD10_noisy"},
-        ]
-    if variant == "lateral":
-        return [
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.0, 0.0), "label": "CL5_SPD5_det"},
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "lat_eta":  0.4, "lat_lambda": 2.0, "lat_scale": 5.0, "label": "CL5_SPD5_latL04"},
-            {"cl": 10.0, "spd": 8.0,  "noise": (0.0, 0.0), "label": "CL10_SPD8_det"},
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "lat_eta": -0.4, "lat_lambda": 2.0, "lat_scale": 5.0, "label": "CL5_SPD5_latR04"},
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "label": "CL5_SPD5_noisy"},
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.5, 1.5), "lat_eta":  0.6, "lat_lambda": 2.5, "lat_scale": 5.0, "label": "CL5_SPD5_latL06_n15"},
-            {"cl": 10.0, "spd": 8.0,  "noise": (0.3, 0.8), "label": "CL10_SPD8_noisy"},
-            {"cl": 10.0, "spd": 10.0, "noise": (0.5, 1.0), "label": "CL10_SPD10_noisy"},
-        ]
-    if variant == "decoupled":
-        return [
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.0, 0.0), "label": "CL5_SPD5_det"},
-            {"cl": 0.0,  "spd": 5.0,  "noise": (0.3, 1.5), "label": "SPD5_only_n0315"},
-            {"cl": 10.0, "spd": 8.0,  "noise": (0.0, 0.0), "label": "CL10_SPD8_det"},
-            {"cl": 5.0,  "spd": 0.0,  "noise": (0.3, 1.5), "label": "CL5_only_n0315"},
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "label": "CL5_SPD5_noisy"},
-            {"cl": 10.0, "spd": 0.0,  "noise": (0.5, 2.0), "label": "CL10_only_n0520"},
-            {"cl": 10.0, "spd": 8.0,  "noise": (0.3, 0.8), "label": "CL10_SPD8_noisy"},
-            {"cl": 10.0, "spd": 10.0, "noise": (0.5, 1.0), "label": "CL10_SPD10_noisy"},
-        ]
-    if variant == "combined_winners":
-        # Top winner from each previous variant — combined into 3 redundant slots
-        # (replaces CL8_SPD5_det, CL10_SPD10_det, CL8_SPD8_noisy)
-        return [
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.0, 0.0), "label": "CL5_SPD5_det"},
-            {"cl": 8.0,  "spd": 8.0,  "noise": (0.8, 2.5), "stretch": 1.3, "label": "CL8_SPD8_str13_n0825"},  # stretched winner
-            {"cl": 10.0, "spd": 8.0,  "noise": (0.0, 0.0), "label": "CL10_SPD8_det"},
-            {"cl": 5.0,  "spd": 0.0,  "noise": (0.3, 1.5), "label": "CL5_only_n0315"},  # decoupled winner
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "label": "CL5_SPD5_noisy"},
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.5, 1.5), "lat_eta": 0.6, "lat_lambda": 2.5, "lat_scale": 5.0, "label": "CL5_SPD5_latL06_n15"},  # lateral winner
-            {"cl": 10.0, "spd": 8.0,  "noise": (0.3, 0.8), "label": "CL10_SPD8_noisy"},
-            {"cl": 10.0, "spd": 10.0, "noise": (0.5, 1.0), "label": "CL10_SPD10_noisy"},
-        ]
-    if variant == "stretched_intense":
-        # All 3 redundant slots filled with stretched configs at increasing intensity
-        # Tests if "more stretched is better"
-        return [
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.0, 0.0), "label": "CL5_SPD5_det"},
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.5, 1.5), "stretch": 1.2, "label": "CL5_SPD5_str12_n0515"},  # mild
-            {"cl": 10.0, "spd": 8.0,  "noise": (0.0, 0.0), "label": "CL10_SPD8_det"},
-            {"cl": 8.0,  "spd": 8.0,  "noise": (0.8, 2.5), "stretch": 1.3, "label": "CL8_SPD8_str13_n0825"},  # winner
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "label": "CL5_SPD5_noisy"},
-            {"cl": 10.0, "spd": 8.0,  "noise": (1.0, 3.0), "stretch": 1.5, "label": "CL10_SPD8_str15_n1030"},  # heavy
-            {"cl": 10.0, "spd": 8.0,  "noise": (0.3, 0.8), "label": "CL10_SPD8_noisy"},
-            {"cl": 10.0, "spd": 10.0, "noise": (0.5, 1.0), "label": "CL10_SPD10_noisy"},
-        ]
-    if variant in ("rsft_v2", "rsft_v2_legacy", "noise_swap_2_no_lat", "rsft_v2_all_random", "rsft_v2_half_half"):
-        # Base RSFT config (v2). 6 guided CL+SPD slots:
-        # - 3 plain CL+SPD curriculum (CL5 det, CL5 noisy, CL10 noisy)
-        # - 3 stretched CL+SPD (CL6 str1.1, CL8 str1.3, CL7 str1.4) at varied noise
-        # Noise-only slots are handled separately via _build_noise_configs().
-        return [
-            {"cl": 5.0,  "spd": 5.0, "noise": (0.0, 0.0), "label": "CL5_SPD5_det"},
-            {"cl": 8.0,  "spd": 8.0, "noise": (0.8, 2.5), "stretch": 1.3, "label": "CL8_SPD8_str13_n0825"},
-            {"cl": 6.0,  "spd": 6.0, "noise": (0.5, 1.5), "stretch": 1.1, "label": "CL6_SPD6_str11_n0515"},
-            {"cl": 5.0,  "spd": 5.0, "noise": (0.3, 0.8), "label": "CL5_SPD5_noisy"},
-            {"cl": 7.0,  "spd": 7.0, "noise": (0.8, 2.0), "stretch": 1.4, "label": "CL7_SPD7_str14_n0820"},
-            {"cl": 10.0, "spd": 10.0, "noise": (0.5, 1.0), "label": "CL10_SPD10_noisy"},
-        ]
-    if variant == "noise_swap_2":
-        # Conservative version of more_noise: keeps the full stretched_lateral
-        # curriculum and only replaces slots 3 and 7 (the two CL10 configs that
-        # never won) with high-noise no-guidance variants.
-        return [
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.0, 0.0), "label": "CL5_SPD5_det"},
-            {"cl": 8.0,  "spd": 8.0,  "noise": (0.8, 2.5), "stretch": 1.3, "label": "CL8_SPD8_str13_n0825"},
-            {"cl": 0.0,  "spd": 0.0,  "noise": (1.5, 3.0), "label": "noise_n1530"},
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "lat_eta": 0.4, "lat_lambda": 2.0, "lat_scale": 5.0, "label": "CL5_SPD5_latL04"},
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "label": "CL5_SPD5_noisy"},
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.5, 1.5), "lat_eta": 0.6, "lat_lambda": 2.5, "lat_scale": 5.0, "label": "CL5_SPD5_latL06_n15"},
-            {"cl": 0.0,  "spd": 0.0,  "noise": (2.0, 4.0), "label": "noise_n2040"},
-            {"cl": 10.0, "spd": 10.0, "noise": (0.5, 1.0), "label": "CL10_SPD10_noisy"},
-        ]
-    if variant == "collision_swap":
-        # Replaces slots 3 and 7 of stretched_lateral with collision-guided configs.
-        # Slot 3: deterministic CL+SPD+collision. Slot 7: noisy CL+SPD+collision.
-        # All other slots match stretched_lateral.
-        return [
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.0, 0.0), "label": "CL5_SPD5_det"},
-            {"cl": 8.0,  "spd": 8.0,  "noise": (0.8, 2.5), "stretch": 1.3, "label": "CL8_SPD8_str13_n0825"},
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.0, 0.0), "col": 0.5, "label": "CL5_SPD5_col05_det"},
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "lat_eta": 0.4, "lat_lambda": 2.0, "lat_scale": 5.0, "label": "CL5_SPD5_latL04"},
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "label": "CL5_SPD5_noisy"},
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.5, 1.5), "lat_eta": 0.6, "lat_lambda": 2.5, "lat_scale": 5.0, "label": "CL5_SPD5_latL06_n15"},
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "col": 1.0, "label": "CL5_SPD5_col10_n0308"},
-            {"cl": 10.0, "spd": 10.0, "noise": (0.5, 1.0), "label": "CL10_SPD10_noisy"},
-        ]
-    if variant == "more_noise":
-        # 5 noise-only slots at varied noise ranges (0.3-0.8, 0.8-2.0, 1.5-3.0, 2.0-4.0)
-        # plus a low-CL low-noise slot. Tests pure stochastic diversity vs constrained
-        # CL/SPD guidance. The retained guided slots are str13 (CL+SPD+stretch),
-        # CL5_SPD5_noisy (mild guided), and CL5_SPD5_latL06_n15 (lateral push).
-        return [
-            {"cl": 0.0, "spd": 0.0, "noise": (0.3, 0.8), "label": "noise_n0308"},
-            {"cl": 8.0, "spd": 8.0, "noise": (0.8, 2.5), "stretch": 1.3, "label": "CL8_SPD8_str13_n0825"},
-            {"cl": 0.0, "spd": 0.0, "noise": (0.8, 2.0), "label": "noise_n0820"},
-            {"cl": 3.0, "spd": 0.0, "noise": (0.5, 1.5), "label": "CL3_n0515"},
-            {"cl": 5.0, "spd": 5.0, "noise": (0.3, 0.8), "label": "CL5_SPD5_noisy"},
-            {"cl": 5.0, "spd": 5.0, "noise": (0.5, 1.5), "lat_eta": 0.6, "lat_lambda": 2.5, "lat_scale": 5.0, "label": "CL5_SPD5_latL06_n15"},
-            {"cl": 0.0, "spd": 0.0, "noise": (1.5, 3.0), "label": "noise_n1530"},
-            {"cl": 0.0, "spd": 0.0, "noise": (2.0, 4.0), "label": "noise_n2040"},
-        ]
-    if variant == "stretched_lateral":
-        # Combine stretched (winner) + 2 lateral variants (left only, since right was redundant)
-        return [
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.0, 0.0), "label": "CL5_SPD5_det"},
-            {"cl": 8.0,  "spd": 8.0,  "noise": (0.8, 2.5), "stretch": 1.3, "label": "CL8_SPD8_str13_n0825"},  # stretched winner
-            {"cl": 10.0, "spd": 8.0,  "noise": (0.0, 0.0), "label": "CL10_SPD8_det"},
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "lat_eta": 0.4, "lat_lambda": 2.0, "lat_scale": 5.0, "label": "CL5_SPD5_latL04"},  # lateral mild
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "label": "CL5_SPD5_noisy"},
-            {"cl": 5.0,  "spd": 5.0,  "noise": (0.5, 1.5), "lat_eta": 0.6, "lat_lambda": 2.5, "lat_scale": 5.0, "label": "CL5_SPD5_latL06_n15"},  # lateral strong
-            {"cl": 10.0, "spd": 8.0,  "noise": (0.3, 0.8), "label": "CL10_SPD8_noisy"},
-            {"cl": 10.0, "spd": 10.0, "noise": (0.5, 1.0), "label": "CL10_SPD10_noisy"},
-        ]
-    raise ValueError(f"Unknown generation_variant: {variant}")
+    """Return guided cl_spd slots for the variant (lookup in rlvr.generation_variants)."""
+    return get_variant(variant).cl_spd_configs
 
 
 def _build_noise_configs(variant: str) -> list[dict]:
-    """Return noise-only slots (no CL/SPD guidance, just fixed noise ranges).
-
-    These are functionally part of the noise/stochastic exploration pool but
-    use deterministic noise ranges rather than being randomly sampled.
-    Processed between cl_spd_configs and random_pool during generation.
-    """
-    if variant in ("rsft_v2_legacy", "noise_swap_2_no_lat"):
-        # Legacy rsft_v2 (kept for reproducing prior experiments): 2 fixed-noise
-        # slots + 7 random CL+noise slots in the random pool. Empirically
-        # decent (val_reward +25.63 ep9) but inferior L2 vs current rsft_v2.
-        return [
-            {"noise": (1.5, 3.0), "label": "noise_n1530"},
-            {"noise": (2.0, 4.0), "label": "noise_n2040"},
-        ]
-    if variant in ("rsft_v2", "rsft_v2_all_noise"):
-        # rsft_v2 (default RSFT base): 9 pure-noise slots sweeping the noise
-        # spectrum 0.1 → 5.0, plus 6 guided cl_spd slots and 1 det_pure.
-        # No random CL passes — pure-noise exploration won out on L2 + safety.
-        return [
-            {"noise": (0.1, 0.3), "label": "noise_n0103"},
-            {"noise": (0.3, 0.6), "label": "noise_n0306"},
-            {"noise": (0.5, 1.0), "label": "noise_n0510"},
-            {"noise": (0.5, 1.5), "label": "noise_n0515"},
-            {"noise": (0.8, 1.8), "label": "noise_n0818"},
-            {"noise": (1.0, 2.5), "label": "noise_n1025"},
-            {"noise": (1.5, 3.0), "label": "noise_n1530"},
-            {"noise": (2.0, 4.0), "label": "noise_n2040"},
-            {"noise": (3.0, 5.0), "label": "noise_n3050"},
-        ]
-    if variant == "rsft_v2_all_random":
-        # Drop the 2 fixed noise slots entirely. Random pool expands to 9 slots,
-        # all using the config's noise_scale_range (default 0.5-2.0).
-        return []
-    if variant == "rsft_v2_half_half":
-        # 5 deterministic noise slots covering low → very high, leaves 4 random
-        # slots (K - 1 det - 6 guided - 5 noise = 4 random). Tests mid-ground
-        # between all_noise (9 fixed) and rsft_v2 (2 fixed + 7 random).
-        return [
-            {"noise": (0.3, 0.8), "label": "noise_n0308"},
-            {"noise": (0.5, 1.5), "label": "noise_n0515"},
-            {"noise": (1.0, 2.0), "label": "noise_n1020"},
-            {"noise": (1.5, 3.0), "label": "noise_n1530"},
-            {"noise": (2.0, 4.0), "label": "noise_n2040"},
-        ]
-    return []
+    """Return noise-only slots for the variant (lookup in rlvr.generation_variants)."""
+    return get_variant(variant).noise_configs
 
 
 def get_generation_config_labels_for_variant(variant: str, K: int = 16) -> list[str]:

--- a/rlvr/grpo_trainer_batched.py
+++ b/rlvr/grpo_trainer_batched.py
@@ -67,6 +67,213 @@ def _chunked_generate(model, model_args, norm_batch, noise_min, noise_max, compo
     return torch.cat(all_out, dim=0)
 
 
+def _build_cl_spd_configs(variant: str) -> list[dict]:
+    """Return list of generation config dicts for the variant.
+
+    Each dict: {cl, spd, noise, label, [stretch], [lat_eta, lat_lambda, lat_scale]}
+    cl/spd = 0 disables that guidance. Slots 2/4/6 (1-indexed) of "default"
+    are the redundant ones identified by rank analytics — the experimental
+    variants replace those with new configs.
+    """
+    if variant == "default":
+        return [
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.0, 0.0), "label": "CL5_SPD5_det"},
+            {"cl": 8.0,  "spd": 5.0,  "noise": (0.0, 0.0), "label": "CL8_SPD5_det"},
+            {"cl": 10.0, "spd": 8.0,  "noise": (0.0, 0.0), "label": "CL10_SPD8_det"},
+            {"cl": 10.0, "spd": 10.0, "noise": (0.0, 0.0), "label": "CL10_SPD10_det"},
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "label": "CL5_SPD5_noisy"},
+            {"cl": 8.0,  "spd": 8.0,  "noise": (0.3, 0.8), "label": "CL8_SPD8_noisy"},
+            {"cl": 10.0, "spd": 8.0,  "noise": (0.3, 0.8), "label": "CL10_SPD8_noisy"},
+            {"cl": 10.0, "spd": 10.0, "noise": (0.5, 1.0), "label": "CL10_SPD10_noisy"},
+        ]
+    if variant == "noisy_stretched":
+        return [
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.0, 0.0), "label": "CL5_SPD5_det"},
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.5, 1.5), "stretch": 1.2, "label": "CL5_SPD5_str12_n0515"},
+            {"cl": 10.0, "spd": 8.0,  "noise": (0.0, 0.0), "label": "CL10_SPD8_det"},
+            {"cl": 8.0,  "spd": 8.0,  "noise": (0.8, 2.5), "stretch": 1.3, "label": "CL8_SPD8_str13_n0825"},
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "label": "CL5_SPD5_noisy"},
+            {"cl": 5.0,  "spd": 3.0,  "noise": (1.0, 3.0), "stretch": 1.4, "label": "CL5_SPD3_str14_n1030"},
+            {"cl": 10.0, "spd": 8.0,  "noise": (0.3, 0.8), "label": "CL10_SPD8_noisy"},
+            {"cl": 10.0, "spd": 10.0, "noise": (0.5, 1.0), "label": "CL10_SPD10_noisy"},
+        ]
+    if variant == "lateral":
+        return [
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.0, 0.0), "label": "CL5_SPD5_det"},
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "lat_eta":  0.4, "lat_lambda": 2.0, "lat_scale": 5.0, "label": "CL5_SPD5_latL04"},
+            {"cl": 10.0, "spd": 8.0,  "noise": (0.0, 0.0), "label": "CL10_SPD8_det"},
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "lat_eta": -0.4, "lat_lambda": 2.0, "lat_scale": 5.0, "label": "CL5_SPD5_latR04"},
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "label": "CL5_SPD5_noisy"},
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.5, 1.5), "lat_eta":  0.6, "lat_lambda": 2.5, "lat_scale": 5.0, "label": "CL5_SPD5_latL06_n15"},
+            {"cl": 10.0, "spd": 8.0,  "noise": (0.3, 0.8), "label": "CL10_SPD8_noisy"},
+            {"cl": 10.0, "spd": 10.0, "noise": (0.5, 1.0), "label": "CL10_SPD10_noisy"},
+        ]
+    if variant == "decoupled":
+        return [
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.0, 0.0), "label": "CL5_SPD5_det"},
+            {"cl": 0.0,  "spd": 5.0,  "noise": (0.3, 1.5), "label": "SPD5_only_n0315"},
+            {"cl": 10.0, "spd": 8.0,  "noise": (0.0, 0.0), "label": "CL10_SPD8_det"},
+            {"cl": 5.0,  "spd": 0.0,  "noise": (0.3, 1.5), "label": "CL5_only_n0315"},
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "label": "CL5_SPD5_noisy"},
+            {"cl": 10.0, "spd": 0.0,  "noise": (0.5, 2.0), "label": "CL10_only_n0520"},
+            {"cl": 10.0, "spd": 8.0,  "noise": (0.3, 0.8), "label": "CL10_SPD8_noisy"},
+            {"cl": 10.0, "spd": 10.0, "noise": (0.5, 1.0), "label": "CL10_SPD10_noisy"},
+        ]
+    if variant == "combined_winners":
+        # Top winner from each previous variant — combined into 3 redundant slots
+        # (replaces CL8_SPD5_det, CL10_SPD10_det, CL8_SPD8_noisy)
+        return [
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.0, 0.0), "label": "CL5_SPD5_det"},
+            {"cl": 8.0,  "spd": 8.0,  "noise": (0.8, 2.5), "stretch": 1.3, "label": "CL8_SPD8_str13_n0825"},  # stretched winner
+            {"cl": 10.0, "spd": 8.0,  "noise": (0.0, 0.0), "label": "CL10_SPD8_det"},
+            {"cl": 5.0,  "spd": 0.0,  "noise": (0.3, 1.5), "label": "CL5_only_n0315"},  # decoupled winner
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "label": "CL5_SPD5_noisy"},
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.5, 1.5), "lat_eta": 0.6, "lat_lambda": 2.5, "lat_scale": 5.0, "label": "CL5_SPD5_latL06_n15"},  # lateral winner
+            {"cl": 10.0, "spd": 8.0,  "noise": (0.3, 0.8), "label": "CL10_SPD8_noisy"},
+            {"cl": 10.0, "spd": 10.0, "noise": (0.5, 1.0), "label": "CL10_SPD10_noisy"},
+        ]
+    if variant == "stretched_intense":
+        # All 3 redundant slots filled with stretched configs at increasing intensity
+        # Tests if "more stretched is better"
+        return [
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.0, 0.0), "label": "CL5_SPD5_det"},
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.5, 1.5), "stretch": 1.2, "label": "CL5_SPD5_str12_n0515"},  # mild
+            {"cl": 10.0, "spd": 8.0,  "noise": (0.0, 0.0), "label": "CL10_SPD8_det"},
+            {"cl": 8.0,  "spd": 8.0,  "noise": (0.8, 2.5), "stretch": 1.3, "label": "CL8_SPD8_str13_n0825"},  # winner
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "label": "CL5_SPD5_noisy"},
+            {"cl": 10.0, "spd": 8.0,  "noise": (1.0, 3.0), "stretch": 1.5, "label": "CL10_SPD8_str15_n1030"},  # heavy
+            {"cl": 10.0, "spd": 8.0,  "noise": (0.3, 0.8), "label": "CL10_SPD8_noisy"},
+            {"cl": 10.0, "spd": 10.0, "noise": (0.5, 1.0), "label": "CL10_SPD10_noisy"},
+        ]
+    if variant in ("rsft_v2", "rsft_v2_legacy", "noise_swap_2_no_lat", "rsft_v2_all_random", "rsft_v2_half_half"):
+        # Base RSFT config (v2). 6 guided CL+SPD slots:
+        # - 3 plain CL+SPD curriculum (CL5 det, CL5 noisy, CL10 noisy)
+        # - 3 stretched CL+SPD (CL6 str1.1, CL8 str1.3, CL7 str1.4) at varied noise
+        # Noise-only slots are handled separately via _build_noise_configs().
+        return [
+            {"cl": 5.0,  "spd": 5.0, "noise": (0.0, 0.0), "label": "CL5_SPD5_det"},
+            {"cl": 8.0,  "spd": 8.0, "noise": (0.8, 2.5), "stretch": 1.3, "label": "CL8_SPD8_str13_n0825"},
+            {"cl": 6.0,  "spd": 6.0, "noise": (0.5, 1.5), "stretch": 1.1, "label": "CL6_SPD6_str11_n0515"},
+            {"cl": 5.0,  "spd": 5.0, "noise": (0.3, 0.8), "label": "CL5_SPD5_noisy"},
+            {"cl": 7.0,  "spd": 7.0, "noise": (0.8, 2.0), "stretch": 1.4, "label": "CL7_SPD7_str14_n0820"},
+            {"cl": 10.0, "spd": 10.0, "noise": (0.5, 1.0), "label": "CL10_SPD10_noisy"},
+        ]
+    if variant == "noise_swap_2":
+        # Conservative version of more_noise: keeps the full stretched_lateral
+        # curriculum and only replaces slots 3 and 7 (the two CL10 configs that
+        # never won) with high-noise no-guidance variants.
+        return [
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.0, 0.0), "label": "CL5_SPD5_det"},
+            {"cl": 8.0,  "spd": 8.0,  "noise": (0.8, 2.5), "stretch": 1.3, "label": "CL8_SPD8_str13_n0825"},
+            {"cl": 0.0,  "spd": 0.0,  "noise": (1.5, 3.0), "label": "noise_n1530"},
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "lat_eta": 0.4, "lat_lambda": 2.0, "lat_scale": 5.0, "label": "CL5_SPD5_latL04"},
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "label": "CL5_SPD5_noisy"},
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.5, 1.5), "lat_eta": 0.6, "lat_lambda": 2.5, "lat_scale": 5.0, "label": "CL5_SPD5_latL06_n15"},
+            {"cl": 0.0,  "spd": 0.0,  "noise": (2.0, 4.0), "label": "noise_n2040"},
+            {"cl": 10.0, "spd": 10.0, "noise": (0.5, 1.0), "label": "CL10_SPD10_noisy"},
+        ]
+    if variant == "collision_swap":
+        # Replaces slots 3 and 7 of stretched_lateral with collision-guided configs.
+        # Slot 3: deterministic CL+SPD+collision. Slot 7: noisy CL+SPD+collision.
+        # All other slots match stretched_lateral.
+        return [
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.0, 0.0), "label": "CL5_SPD5_det"},
+            {"cl": 8.0,  "spd": 8.0,  "noise": (0.8, 2.5), "stretch": 1.3, "label": "CL8_SPD8_str13_n0825"},
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.0, 0.0), "col": 0.5, "label": "CL5_SPD5_col05_det"},
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "lat_eta": 0.4, "lat_lambda": 2.0, "lat_scale": 5.0, "label": "CL5_SPD5_latL04"},
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "label": "CL5_SPD5_noisy"},
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.5, 1.5), "lat_eta": 0.6, "lat_lambda": 2.5, "lat_scale": 5.0, "label": "CL5_SPD5_latL06_n15"},
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "col": 1.0, "label": "CL5_SPD5_col10_n0308"},
+            {"cl": 10.0, "spd": 10.0, "noise": (0.5, 1.0), "label": "CL10_SPD10_noisy"},
+        ]
+    if variant == "more_noise":
+        # 5 noise-only slots at varied noise ranges (0.3-0.8, 0.8-2.0, 1.5-3.0, 2.0-4.0)
+        # plus a low-CL low-noise slot. Tests pure stochastic diversity vs constrained
+        # CL/SPD guidance. The retained guided slots are str13 (CL+SPD+stretch),
+        # CL5_SPD5_noisy (mild guided), and CL5_SPD5_latL06_n15 (lateral push).
+        return [
+            {"cl": 0.0, "spd": 0.0, "noise": (0.3, 0.8), "label": "noise_n0308"},
+            {"cl": 8.0, "spd": 8.0, "noise": (0.8, 2.5), "stretch": 1.3, "label": "CL8_SPD8_str13_n0825"},
+            {"cl": 0.0, "spd": 0.0, "noise": (0.8, 2.0), "label": "noise_n0820"},
+            {"cl": 3.0, "spd": 0.0, "noise": (0.5, 1.5), "label": "CL3_n0515"},
+            {"cl": 5.0, "spd": 5.0, "noise": (0.3, 0.8), "label": "CL5_SPD5_noisy"},
+            {"cl": 5.0, "spd": 5.0, "noise": (0.5, 1.5), "lat_eta": 0.6, "lat_lambda": 2.5, "lat_scale": 5.0, "label": "CL5_SPD5_latL06_n15"},
+            {"cl": 0.0, "spd": 0.0, "noise": (1.5, 3.0), "label": "noise_n1530"},
+            {"cl": 0.0, "spd": 0.0, "noise": (2.0, 4.0), "label": "noise_n2040"},
+        ]
+    if variant == "stretched_lateral":
+        # Combine stretched (winner) + 2 lateral variants (left only, since right was redundant)
+        return [
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.0, 0.0), "label": "CL5_SPD5_det"},
+            {"cl": 8.0,  "spd": 8.0,  "noise": (0.8, 2.5), "stretch": 1.3, "label": "CL8_SPD8_str13_n0825"},  # stretched winner
+            {"cl": 10.0, "spd": 8.0,  "noise": (0.0, 0.0), "label": "CL10_SPD8_det"},
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "lat_eta": 0.4, "lat_lambda": 2.0, "lat_scale": 5.0, "label": "CL5_SPD5_latL04"},  # lateral mild
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.3, 0.8), "label": "CL5_SPD5_noisy"},
+            {"cl": 5.0,  "spd": 5.0,  "noise": (0.5, 1.5), "lat_eta": 0.6, "lat_lambda": 2.5, "lat_scale": 5.0, "label": "CL5_SPD5_latL06_n15"},  # lateral strong
+            {"cl": 10.0, "spd": 8.0,  "noise": (0.3, 0.8), "label": "CL10_SPD8_noisy"},
+            {"cl": 10.0, "spd": 10.0, "noise": (0.5, 1.0), "label": "CL10_SPD10_noisy"},
+        ]
+    raise ValueError(f"Unknown generation_variant: {variant}")
+
+
+def _build_noise_configs(variant: str) -> list[dict]:
+    """Return noise-only slots (no CL/SPD guidance, just fixed noise ranges).
+
+    These are functionally part of the noise/stochastic exploration pool but
+    use deterministic noise ranges rather than being randomly sampled.
+    Processed between cl_spd_configs and random_pool during generation.
+    """
+    if variant in ("rsft_v2_legacy", "noise_swap_2_no_lat"):
+        # Legacy rsft_v2 (kept for reproducing prior experiments): 2 fixed-noise
+        # slots + 7 random CL+noise slots in the random pool. Empirically
+        # decent (val_reward +25.63 ep9) but inferior L2 vs current rsft_v2.
+        return [
+            {"noise": (1.5, 3.0), "label": "noise_n1530"},
+            {"noise": (2.0, 4.0), "label": "noise_n2040"},
+        ]
+    if variant in ("rsft_v2", "rsft_v2_all_noise"):
+        # rsft_v2 (default RSFT base): 9 pure-noise slots sweeping the noise
+        # spectrum 0.1 → 5.0, plus 6 guided cl_spd slots and 1 det_pure.
+        # No random CL passes — pure-noise exploration won out on L2 + safety.
+        return [
+            {"noise": (0.1, 0.3), "label": "noise_n0103"},
+            {"noise": (0.3, 0.6), "label": "noise_n0306"},
+            {"noise": (0.5, 1.0), "label": "noise_n0510"},
+            {"noise": (0.5, 1.5), "label": "noise_n0515"},
+            {"noise": (0.8, 1.8), "label": "noise_n0818"},
+            {"noise": (1.0, 2.5), "label": "noise_n1025"},
+            {"noise": (1.5, 3.0), "label": "noise_n1530"},
+            {"noise": (2.0, 4.0), "label": "noise_n2040"},
+            {"noise": (3.0, 5.0), "label": "noise_n3050"},
+        ]
+    if variant == "rsft_v2_all_random":
+        # Drop the 2 fixed noise slots entirely. Random pool expands to 9 slots,
+        # all using the config's noise_scale_range (default 0.5-2.0).
+        return []
+    if variant == "rsft_v2_half_half":
+        # 5 deterministic noise slots covering low → very high, leaves 4 random
+        # slots (K - 1 det - 6 guided - 5 noise = 4 random). Tests mid-ground
+        # between all_noise (9 fixed) and rsft_v2 (2 fixed + 7 random).
+        return [
+            {"noise": (0.3, 0.8), "label": "noise_n0308"},
+            {"noise": (0.5, 1.5), "label": "noise_n0515"},
+            {"noise": (1.0, 2.0), "label": "noise_n1020"},
+            {"noise": (1.5, 3.0), "label": "noise_n1530"},
+            {"noise": (2.0, 4.0), "label": "noise_n2040"},
+        ]
+    return []
+
+
+def get_generation_config_labels_for_variant(variant: str, K: int = 16) -> list[str]:
+    """Full per-slot labels: det_pure + cl_spd configs + noise configs + random."""
+    cl_spd = _build_cl_spd_configs(variant)
+    noise = _build_noise_configs(variant)
+    labels = ["det_pure"] + [c["label"] for c in cl_spd] + [c["label"] for c in noise]
+    for i in range(len(labels), K):
+        labels.append(f"random_{i}")
+    return labels[:K]
+
+
 def generate_all_scenes_batched(
     model: nn.Module,
     model_args,
@@ -83,6 +290,7 @@ def generate_all_scenes_batched(
     lateral_lambda: float = 2.0,
     lateral_scale: float = 5.0,
     speed_stretch: float = 1.0,
+    generation_variant: str = "default",
 ) -> torch.Tensor:
     """Generate K trajectories for all N scenes in ~5 chunked-batched passes.
 
@@ -116,44 +324,59 @@ def generate_all_scenes_batched(
 
     # --- Config 2-9: CL + SPD guidance sweep for lane keeping ---
     # 8 guided trajectories at CL5-10 to ensure ~8-10/16 stay in-lane on curves.
-    cl_spd_configs = [
-        (5.0,  5.0,  0.0, 0.0),   # CL5+SPD5, deterministic
-        (8.0,  5.0,  0.0, 0.0),   # CL8+SPD5, deterministic
-        (10.0, 8.0,  0.0, 0.0),   # CL10+SPD8, deterministic
-        (10.0, 10.0, 0.0, 0.0),   # CL10+SPD10, deterministic
-        (5.0,  5.0,  0.3, 0.8),   # CL5+SPD5, noise
-        (8.0,  8.0,  0.3, 0.8),   # CL8+SPD8, noise
-        (10.0, 8.0,  0.3, 0.8),   # CL10+SPD8, noise
-        (10.0, 10.0, 0.5, 1.0),   # CL10+SPD10, noise
-    ]
-    use_stretch = abs(speed_stretch - 1.0) > 1e-6
-    for cl_scale, spd_scale, n_min, n_max in cl_spd_configs:
-        # Apply stretch only to noisy configs (last 4), keep deterministic configs normal
+    # Variants can replace the 3 redundant slots with experimental configs.
+    cl_spd_configs = _build_cl_spd_configs(generation_variant)
+    use_stretch_global = abs(speed_stretch - 1.0) > 1e-6
+    for cfg in cl_spd_configs:
+        cl_scale = cfg["cl"]
+        spd_scale = cfg["spd"]
+        n_min, n_max = cfg["noise"]
+        # Per-slot stretch overrides global, falls back to global if unset
+        cfg_stretch = cfg.get("stretch", speed_stretch)
         cfg_has_noise = n_max > 0
-        use_stretch_here = use_stretch and cfg_has_noise
-        spd_params = {"stretch": speed_stretch} if use_stretch_here else {"v_high": gt_max_speed, "v_low": 0.5}
-        fns = [
-            GuidanceConfig("centerline_following", enabled=True, scale=cl_scale),
-            GuidanceConfig("speed", enabled=True, scale=spd_scale, params=spd_params),
-        ]
+        use_stretch_here = abs(cfg_stretch - 1.0) > 1e-6 and cfg_has_noise
+        spd_params = {"stretch": cfg_stretch} if use_stretch_here else {"v_high": gt_max_speed, "v_low": 0.5}
+        # Per-slot lateral overrides global lateral_eta
+        cfg_lat_eta = cfg.get("lat_eta", lateral_eta)
+        cfg_lat_lambda = cfg.get("lat_lambda", lateral_lambda)
+        cfg_lat_scale = cfg.get("lat_scale", lateral_scale)
+        cfg_use_lat = abs(cfg_lat_eta) > 1e-6
+        # Optional per-slot collision guidance
+        cfg_col = cfg.get("col", 0.0)
+        # Build guidance functions
+        fns = []
+        if cl_scale > 0:
+            fns.append(GuidanceConfig("centerline_following", enabled=True, scale=cl_scale))
+        if spd_scale > 0:
+            fns.append(GuidanceConfig("speed", enabled=True, scale=spd_scale, params=spd_params))
         if use_lon:
             fns.append(GuidanceConfig(
                 "longitudinal", enabled=True, scale=longitudinal_scale,
                 params={"eta_lon": longitudinal_eta, "lambda_lon": longitudinal_lambda},
             ))
-        if use_lat:
+        if cfg_use_lat:
             fns.append(GuidanceConfig(
-                "lateral", enabled=True, scale=lateral_scale,
-                params={"eta_lat": lateral_eta, "lambda_lat": lateral_lambda},
+                "lateral", enabled=True, scale=cfg_lat_scale,
+                params={"eta_lat": cfg_lat_eta, "lambda_lat": cfg_lat_lambda},
             ))
-        comp = GuidanceComposer(GuidanceSetConfig(functions=fns, global_scale=1.0))
+        if cfg_col > 0:
+            fns.append(GuidanceConfig("collision", enabled=True, scale=cfg_col))
+        comp = GuidanceComposer(GuidanceSetConfig(functions=fns, global_scale=1.0)) if fns else None
         trajs = _chunked_generate(model, model_args, norm_batch, n_min, n_max, comp, device, gen_chunk_size)
         all_k_trajs.append(trajs)
 
     # Clean up reference_trajectory before random passes (not needed, wastes VRAM on expand)
     norm_batch.pop("reference_trajectory", None)
 
-    # --- Config 5+: Random guidance (no road_border to avoid OOM) ---
+    # --- Noise-only slots (no guidance, fixed noise ranges) ---
+    # Functionally part of the noise/exploration pool but with deterministic
+    # noise ranges rather than random sampling.
+    for noise_cfg in _build_noise_configs(generation_variant):
+        n_min_s, n_max_s = noise_cfg["noise"]
+        trajs = _chunked_generate(model, model_args, norm_batch, n_min_s, n_max_s, None, device, gen_chunk_size)
+        all_k_trajs.append(trajs)
+
+    # --- Random guidance pool (no road_border to avoid OOM) ---
     n_fixed = len(all_k_trajs)
     n_random = K - n_fixed
 

--- a/rlvr/rank_analytics.py
+++ b/rlvr/rank_analytics.py
@@ -81,19 +81,28 @@ def get_category(label: str) -> str:
 # Dominant component analysis
 # ---------------------------------------------------------------------------
 
-def _breakdown_to_dict(r: RewardBreakdown) -> dict[str, float]:
-    return {
-        "safety": r.safety,
-        "progress": r.progress,
-        "smoothness": r.smoothness,
-        "feasibility": r.feasibility,
-        "centerline": r.centerline,
-        "red_light": r.red_light,
-        "total": r.total,
-        "rb_near_penalty": r.rb_near_penalty,
-        "rb_wide_penalty": r.rb_wide_penalty,
-        "rb_crossing": bool(r.rb_crossing),
-    }
+_NUMERIC_BREAKDOWN_FIELDS = (
+    "safety", "progress", "smoothness", "feasibility",
+    "centerline", "red_light", "total",
+    "rb_near_penalty", "rb_wide_penalty",
+)
+_BOOL_BREAKDOWN_FIELDS = ("rb_crossing",)
+
+
+def breakdown_to_dict(r: RewardBreakdown) -> dict:
+    """Serialize a RewardBreakdown to a JSON-friendly dict.
+
+    Numeric fields are floats; boolean fields are kept as bools (so json.dump
+    emits true/false rather than coercing to numbers via downstream rounding).
+    """
+    out: dict = {f: float(getattr(r, f)) for f in _NUMERIC_BREAKDOWN_FIELDS}
+    for f in _BOOL_BREAKDOWN_FIELDS:
+        out[f] = bool(getattr(r, f))
+    return out
+
+
+# Back-compat alias for any external callers using the previous private name.
+_breakdown_to_dict = breakdown_to_dict
 
 
 def mean_breakdown_dict(rewards: list[RewardBreakdown]) -> dict[str, float]:
@@ -113,10 +122,20 @@ def compute_dominant_component(
     mean_bd: dict[str, float],
     config: RewardConfig,
 ) -> tuple[str, float]:
-    """Find which weighted component contributes most to the winner's advantage.
+    """Heuristic attribution of the winner's reward advantage to a single component.
 
-    Uses the quality_score formula from reward.py:2151-2158.
-    Returns (component_name, weighted_delta).
+    Returns (component_name, weighted_delta) where the chosen component has the
+    largest positive weighted delta versus the per-scene mean across the K
+    generated trajectories.
+
+    NOTE: This is an approximation, not an exact decomposition of `total`. It
+    only considers the subset of components exposed on RewardBreakdown:
+    progress, safety, smoothness, centerline, rb_near, rb_wide. It omits the
+    TTC bonus and lane departure penalties from `compute_reward_batch()` and
+    uses `RewardBreakdown.progress` (the post-on-road-factor `adjusted_progress`)
+    rather than the `clamped_progress` actually used inside `quality_score`. The
+    result is meant for ranking which family of rewards drove a win, not for
+    reconstructing the total reward exactly.
     """
     deltas = {
         "progress": config.w_progress * (winner.progress - mean_bd["progress"]),
@@ -149,6 +168,9 @@ class SceneRankRecord:
     dominant_delta: float
 
     def to_dict(self) -> dict:
+        def _round_breakdown(bd: dict) -> dict:
+            # Preserve booleans as bools; only round numeric values.
+            return {k: (v if isinstance(v, bool) else round(float(v), 4)) for k, v in bd.items()}
         return {
             "scene": self.scene_path,
             "winner_idx": self.winner_idx,
@@ -158,8 +180,8 @@ class SceneRankRecord:
             "det_reward": round(self.det_reward, 3),
             "dominant_component": self.dominant_component,
             "dominant_delta": round(self.dominant_delta, 3),
-            "winner_breakdown": {k: round(v, 4) for k, v in self.winner_breakdown.items()},
-            "mean_breakdown": {k: round(v, 4) for k, v in self.mean_breakdown.items()},
+            "winner_breakdown": _round_breakdown(self.winner_breakdown),
+            "mean_breakdown": _round_breakdown(self.mean_breakdown),
         }
 
 

--- a/rlvr/rank_analytics.py
+++ b/rlvr/rank_analytics.py
@@ -1,0 +1,348 @@
+"""Rank analytics for ranked SFT: track which generation configs win and why."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from rlvr.reward import RewardBreakdown, RewardConfig
+
+
+# ---------------------------------------------------------------------------
+# Generation config labels
+# ---------------------------------------------------------------------------
+
+_FIXED_LABELS = [
+    "det_pure",            # 0: no guidance, no noise
+    "CL5_SPD5_det",        # 1
+    "CL8_SPD5_det",        # 2
+    "CL10_SPD8_det",       # 3
+    "CL10_SPD10_det",      # 4
+    "CL5_SPD5_noisy",      # 5
+    "CL8_SPD8_noisy",      # 6
+    "CL10_SPD8_noisy",     # 7
+    "CL10_SPD10_noisy",    # 8
+]
+
+_CATEGORY_MAP = {
+    "det_pure": "det_pure",
+    "CL5_SPD5_det": "guided_det",
+    "CL8_SPD5_det": "guided_det",
+    "CL10_SPD8_det": "guided_det",
+    "CL10_SPD10_det": "guided_det",
+    "CL5_SPD5_noisy": "guided_noisy",
+    "CL8_SPD8_noisy": "guided_noisy",
+    "CL10_SPD8_noisy": "guided_noisy",
+    "CL10_SPD10_noisy": "guided_noisy",
+}
+
+
+def _classify_label(label: str) -> str:
+    """Classify any label (including experimental ones) into a category."""
+    if label in _CATEGORY_MAP:
+        return _CATEGORY_MAP[label]
+    if label.startswith("random_") or label.startswith("explorer_"):
+        return "random"
+    if label == "det_pure":
+        return "det_pure"
+    # Experimental labels — classify by structure
+    if label.startswith("noise_n"):
+        return "noise_only_exp"
+    if "_col" in label:
+        return "collision_exp"
+    if "lat" in label.lower():
+        return "lateral_exp"
+    if "str" in label.lower():
+        return "stretched_exp"
+    if "_only_" in label.lower():
+        return "decoupled_exp"
+    # Fall back to noisy/det based on naming
+    if "_det" in label or label.endswith("_det"):
+        return "guided_det"
+    return "guided_noisy"
+
+
+def get_generation_config_labels(K: int = 16) -> list[str]:
+    """Return human-readable labels for the K generation config indices."""
+    labels = list(_FIXED_LABELS)
+    for i in range(len(labels), K):
+        labels.append(f"random_{i}")
+    return labels[:K]
+
+
+def get_category(label: str) -> str:
+    """Map a config label to its category."""
+    return _classify_label(label)
+
+
+# ---------------------------------------------------------------------------
+# Dominant component analysis
+# ---------------------------------------------------------------------------
+
+def _breakdown_to_dict(r: RewardBreakdown) -> dict[str, float]:
+    return {
+        "safety": r.safety,
+        "progress": r.progress,
+        "smoothness": r.smoothness,
+        "feasibility": r.feasibility,
+        "centerline": r.centerline,
+        "red_light": r.red_light,
+        "total": r.total,
+        "rb_near_penalty": r.rb_near_penalty,
+        "rb_wide_penalty": r.rb_wide_penalty,
+        "rb_crossing": bool(r.rb_crossing),
+    }
+
+
+def mean_breakdown_dict(rewards: list[RewardBreakdown]) -> dict[str, float]:
+    """Compute mean of each breakdown field across K trajectories."""
+    fields = [
+        "safety", "progress", "smoothness", "feasibility",
+        "centerline", "red_light", "rb_near_penalty", "rb_wide_penalty",
+    ]
+    K = len(rewards)
+    if K == 0:
+        return {f: 0.0 for f in fields}
+    return {f: sum(getattr(r, f) for r in rewards) / K for f in fields}
+
+
+def compute_dominant_component(
+    winner: RewardBreakdown,
+    mean_bd: dict[str, float],
+    config: RewardConfig,
+) -> tuple[str, float]:
+    """Find which weighted component contributes most to the winner's advantage.
+
+    Uses the quality_score formula from reward.py:2151-2158.
+    Returns (component_name, weighted_delta).
+    """
+    deltas = {
+        "progress": config.w_progress * (winner.progress - mean_bd["progress"]),
+        "safety": config.w_safety * (winner.safety - mean_bd["safety"]),
+        "smoothness": config.w_smooth * (winner.smoothness - mean_bd["smoothness"]),
+        "centerline": config.w_centerline * (winner.centerline - mean_bd["centerline"]),
+        # Negated because penalties are subtracted in quality_score
+        "rb_near": -config.rb_near_scale * (winner.rb_near_penalty - mean_bd["rb_near_penalty"]),
+        "rb_wide": -config.rb_wide_scale * (winner.rb_wide_penalty - mean_bd["rb_wide_penalty"]),
+    }
+    best_comp = max(deltas, key=lambda c: deltas[c])
+    return best_comp, deltas[best_comp]
+
+
+# ---------------------------------------------------------------------------
+# Per-scene record
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SceneRankRecord:
+    scene_path: str
+    winner_idx: int
+    winner_label: str
+    winner_reward: float
+    mean_reward: float
+    det_reward: float
+    winner_breakdown: dict[str, float]
+    mean_breakdown: dict[str, float]
+    dominant_component: str
+    dominant_delta: float
+
+    def to_dict(self) -> dict:
+        return {
+            "scene": self.scene_path,
+            "winner_idx": self.winner_idx,
+            "winner_label": self.winner_label,
+            "winner_reward": round(self.winner_reward, 3),
+            "mean_reward": round(self.mean_reward, 3),
+            "det_reward": round(self.det_reward, 3),
+            "dominant_component": self.dominant_component,
+            "dominant_delta": round(self.dominant_delta, 3),
+            "winner_breakdown": {k: round(v, 4) for k, v in self.winner_breakdown.items()},
+            "mean_breakdown": {k: round(v, 4) for k, v in self.mean_breakdown.items()},
+        }
+
+
+# ---------------------------------------------------------------------------
+# Epoch-level analytics
+# ---------------------------------------------------------------------------
+
+@dataclass
+class EpochRankAnalytics:
+    epoch: int
+    n_scenes: int
+    records: list[SceneRankRecord] = field(default_factory=list)
+    # Derived (populated by finalize)
+    win_counts: dict[str, int] = field(default_factory=dict)
+    win_rates: dict[str, float] = field(default_factory=dict)
+    category_rates: dict[str, float] = field(default_factory=dict)
+    never_won: list[str] = field(default_factory=list)
+    dominant_component_counts: dict[str, int] = field(default_factory=dict)
+    mean_winner_reward: float = 0.0
+    mean_det_reward: float = 0.0
+    mean_improvement: float = 0.0
+
+    def finalize(self, all_labels: list[str]) -> None:
+        """Compute derived fields from records."""
+        n = len(self.records)
+        if n == 0:
+            return
+
+        # Win counts per label
+        label_counter = Counter(r.winner_label for r in self.records)
+        self.win_counts = {lbl: label_counter.get(lbl, 0) for lbl in all_labels}
+        self.win_rates = {lbl: cnt / n for lbl, cnt in self.win_counts.items()}
+
+        # Category rates
+        cat_counter = Counter(get_category(r.winner_label) for r in self.records)
+        # Include both standard and experimental categories
+        all_cats = ["det_pure", "guided_det", "guided_noisy", "random",
+                    "lateral_exp", "stretched_exp", "decoupled_exp", "noise_only_exp", "collision_exp"]
+        for cat in all_cats:
+            self.category_rates[cat] = cat_counter.get(cat, 0) / n
+
+        # Never won
+        self.never_won = [lbl for lbl, cnt in self.win_counts.items() if cnt == 0]
+
+        # Dominant component counts
+        self.dominant_component_counts = dict(Counter(r.dominant_component for r in self.records))
+
+        # Reward stats
+        self.mean_winner_reward = sum(r.winner_reward for r in self.records) / n
+        self.mean_det_reward = sum(r.det_reward for r in self.records) / n
+        self.mean_improvement = self.mean_winner_reward - self.mean_det_reward
+
+    def to_dict(self) -> dict:
+        return {
+            "epoch": self.epoch,
+            "n_scenes": self.n_scenes,
+            "summary": {
+                "win_counts": self.win_counts,
+                "win_rates": {k: round(v, 4) for k, v in self.win_rates.items()},
+                "category_rates": {k: round(v, 4) for k, v in self.category_rates.items()},
+                "never_won": self.never_won,
+                "dominant_components": self.dominant_component_counts,
+                "mean_winner_reward": round(self.mean_winner_reward, 3),
+                "mean_det_reward": round(self.mean_det_reward, 3),
+                "mean_improvement": round(self.mean_improvement, 3),
+            },
+            "per_scene": [r.to_dict() for r in self.records],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Print / save
+# ---------------------------------------------------------------------------
+
+def print_epoch_summary(analytics: EpochRankAnalytics) -> None:
+    """Print formatted rank analytics summary to stdout."""
+    n = len(analytics.records)
+    print(f"\n  === Rank Analytics (Epoch {analytics.epoch}) ===")
+    print(f"  Config Win Rates ({n} scenes):")
+    # Sort by win rate descending
+    sorted_labels = sorted(analytics.win_rates.items(), key=lambda x: -x[1])
+    for lbl, rate in sorted_labels:
+        cnt = analytics.win_counts[lbl]
+        if cnt > 0:
+            print(f"    {lbl:<22s}: {rate*100:5.1f}% ({cnt} wins)")
+    if analytics.never_won:
+        print(f"  Never won: {', '.join(analytics.never_won)}")
+
+    # Category rates
+    cats = analytics.category_rates
+    parts = [f"{cat} {rate*100:.0f}%" for cat, rate in sorted(cats.items(), key=lambda x: -x[1])]
+    print(f"  Category Rates: {' | '.join(parts)}")
+
+    # Dominant components
+    dom = analytics.dominant_component_counts
+    total_dom = sum(dom.values()) or 1
+    dom_parts = [f"{comp} {cnt/total_dom*100:.0f}%" for comp, cnt in sorted(dom.items(), key=lambda x: -x[1])]
+    print(f"  Dominant Components: {' | '.join(dom_parts)}")
+
+    print(f"  Mean improvement over det: {analytics.mean_improvement:+.2f}")
+    print()
+
+
+def save_epoch_analytics(analytics: EpochRankAnalytics, run_dir: Path, epoch: int) -> None:
+    """Save per-epoch analytics to JSON."""
+    path = run_dir / f"rank_analytics_epoch_{epoch:03d}.json"
+    with open(path, "w") as f:
+        json.dump(analytics.to_dict(), f, indent=2)
+    print(f"  Saved rank analytics to {path.name}")
+
+
+# ---------------------------------------------------------------------------
+# Cross-epoch summary (called once at end of training)
+# ---------------------------------------------------------------------------
+
+def save_cross_epoch_summary(run_dir: Path) -> None:
+    """Read all per-epoch JSONs and produce a cross-epoch summary."""
+    run_dir = Path(run_dir)
+    epoch_files = sorted(run_dir.glob("rank_analytics_epoch_*.json"))
+    if not epoch_files:
+        return
+
+    epochs_data = []
+    for f in epoch_files:
+        with open(f) as fh:
+            epochs_data.append(json.load(fh))
+
+    # Inter-epoch trends: category rates per epoch
+    category_trends: dict[int, dict[str, float]] = {}
+    config_trends: dict[int, dict[str, float]] = {}
+    for ed in epochs_data:
+        ep = ed["epoch"]
+        category_trends[ep] = ed["summary"]["category_rates"]
+        config_trends[ep] = ed["summary"]["win_rates"]
+
+    # Per-scene evolution: for each scene, winner label at each epoch
+    scene_evolution: dict[str, list[dict]] = {}
+    for ed in epochs_data:
+        ep = ed["epoch"]
+        for rec in ed["per_scene"]:
+            scene = rec["scene"]
+            if scene not in scene_evolution:
+                scene_evolution[scene] = []
+            scene_evolution[scene].append({
+                "epoch": ep,
+                "winner_label": rec["winner_label"],
+                "category": get_category(rec["winner_label"]),
+                "winner_reward": rec["winner_reward"],
+            })
+
+    # Redundancy report: configs winning <5% across ALL epochs
+    all_config_rates: dict[str, list[float]] = {}
+    for ep_rates in config_trends.values():
+        for lbl, rate in ep_rates.items():
+            all_config_rates.setdefault(lbl, []).append(rate)
+
+    redundant = []
+    for lbl, rates in all_config_rates.items():
+        if max(rates) < 0.05:
+            redundant.append(lbl)
+
+    summary = {
+        "n_epochs": len(epochs_data),
+        "category_trends": {str(k): v for k, v in category_trends.items()},
+        "config_trends": {str(k): v for k, v in config_trends.items()},
+        "scene_evolution": scene_evolution,
+        "redundant_configs": redundant,
+    }
+
+    path = run_dir / "rank_analytics_summary.json"
+    with open(path, "w") as f:
+        json.dump(summary, f, indent=2)
+    print(f"\n  === Cross-Epoch Rank Analytics Summary ===")
+    print(f"  Saved to {path.name}")
+    if redundant:
+        print(f"  Redundant configs (<5% win rate across all epochs): {', '.join(redundant)}")
+    else:
+        print(f"  No configs were redundant (all had >5% win rate in at least one epoch)")
+
+    # Print category trend table
+    print(f"\n  Category rates by epoch:")
+    print(f"  {'Epoch':>6s}  {'det_pure':>9s}  {'guided_det':>10s}  {'guided_noisy':>12s}  {'random':>7s}")
+    for ep in sorted(category_trends.keys()):
+        cats = category_trends[ep]
+        print(f"  {ep:>6d}  {cats.get('det_pure',0)*100:>8.1f}%  {cats.get('guided_det',0)*100:>9.1f}%  {cats.get('guided_noisy',0)*100:>11.1f}%  {cats.get('random',0)*100:>6.1f}%")
+    print()

--- a/rlvr/rank_analytics.py
+++ b/rlvr/rank_analytics.py
@@ -106,15 +106,23 @@ _breakdown_to_dict = breakdown_to_dict
 
 
 def mean_breakdown_dict(rewards: list[RewardBreakdown]) -> dict[str, float]:
-    """Compute mean of each breakdown field across K trajectories."""
-    fields = [
+    """Compute mean of each breakdown field across K trajectories.
+
+    Numeric fields are averaged. Boolean gate flags (rb_crossing, lane_crossing)
+    are averaged as floats so callers can detect "most trajectories failed this
+    gate" via mean > some threshold.
+    """
+    numeric_fields = [
         "safety", "progress", "smoothness", "feasibility",
         "centerline", "red_light", "rb_near_penalty", "rb_wide_penalty",
     ]
+    gate_fields = ["rb_crossing", "lane_crossing"]
     K = len(rewards)
     if K == 0:
-        return {f: 0.0 for f in fields}
-    return {f: sum(getattr(r, f) for r in rewards) / K for f in fields}
+        return {f: 0.0 for f in (*numeric_fields, *gate_fields)}
+    out = {f: sum(getattr(r, f) for r in rewards) / K for f in numeric_fields}
+    out.update({f: sum(float(getattr(r, f)) for r in rewards) / K for f in gate_fields})
+    return out
 
 
 def compute_dominant_component(
@@ -128,15 +136,36 @@ def compute_dominant_component(
     largest positive weighted delta versus the per-scene mean across the K
     generated trajectories.
 
-    NOTE: This is an approximation, not an exact decomposition of `total`. It
-    only considers the subset of components exposed on RewardBreakdown:
-    progress, safety, smoothness, centerline, rb_near, rb_wide. It omits the
-    TTC bonus and lane departure penalties from `compute_reward_batch()` and
-    uses `RewardBreakdown.progress` (the post-on-road-factor `adjusted_progress`)
-    rather than the `clamped_progress` actually used inside `quality_score`. The
-    result is meant for ranking which family of rewards drove a win, not for
-    reconstructing the total reward exactly.
+    NOTE: This is an approximation, not an exact decomposition of `total`. The
+    weighted-delta heuristic only considers the subset of components exposed on
+    RewardBreakdown: progress, safety, smoothness, centerline, rb_near, rb_wide.
+    It omits the TTC bonus from `compute_reward_batch()` and uses
+    `RewardBreakdown.progress` (post-on-road-factor `adjusted_progress`) rather
+    than the `clamped_progress` actually used inside `quality_score`.
+
+    Hard-gate wins are handled separately and take precedence over the weighted
+    deltas: if the winner avoids a gate that most other trajectories failed,
+    we attribute the win to that gate (e.g. `"rb_crossing_gate"`) — otherwise
+    the weighted-delta heuristic dominates everything via its sign flip and
+    misleads readers about what actually drove ranking.
     """
+    # Gate-driven wins. If the winner passes a gate that >=50% of the other
+    # trajectories failed, the gate is the real driver — the magnitude of any
+    # quality_score delta is dwarfed by the survival-mode floor (-50.0).
+    GATE_THRESHOLD = 0.5
+
+    def _gate_win(winner_failed: bool, mean_failed_rate: float) -> bool:
+        return (not winner_failed) and (mean_failed_rate >= GATE_THRESHOLD)
+
+    if _gate_win(bool(winner.rb_crossing), float(mean_bd.get("rb_crossing", 0.0))):
+        return "rb_crossing_gate", float(mean_bd["rb_crossing"])
+    if _gate_win(bool(winner.lane_crossing), float(mean_bd.get("lane_crossing", 0.0))):
+        return "lane_crossing_gate", float(mean_bd["lane_crossing"])
+    # Collision is a hard gate too — any negative safety_score from collision
+    # would zero the safety_product, but RewardBreakdown.safety is the raw
+    # score not the gate flag. Use collision_step proxy via safety < -threshold.
+    # Skip if collision_step isn't available on either side.
+
     deltas = {
         "progress": config.w_progress * (winner.progress - mean_bd["progress"]),
         "safety": config.w_safety * (winner.safety - mean_bd["safety"]),
@@ -162,7 +191,10 @@ class SceneRankRecord:
     winner_reward: float
     mean_reward: float
     det_reward: float
-    winner_breakdown: dict[str, float]
+    # winner_breakdown holds RewardBreakdown fields: numeric (safety, progress,
+    # ...) plus boolean gate flags (rb_crossing). mean_breakdown holds numeric
+    # means for both — gate flags become floats in [0, 1] (failure rate).
+    winner_breakdown: dict[str, float | bool]
     mean_breakdown: dict[str, float]
     dominant_component: str
     dominant_delta: float

--- a/rlvr/rank_analytics.py
+++ b/rlvr/rank_analytics.py
@@ -86,7 +86,9 @@ _NUMERIC_BREAKDOWN_FIELDS = (
     "centerline", "red_light", "total",
     "rb_near_penalty", "rb_wide_penalty",
 )
-_BOOL_BREAKDOWN_FIELDS = ("rb_crossing",)
+# Keep gate flags in sync with the fields consumed by mean_breakdown_dict() and
+# compute_dominant_component() — otherwise those helpers see False by default.
+_BOOL_BREAKDOWN_FIELDS = ("rb_crossing", "lane_crossing")
 
 
 def breakdown_to_dict(r: RewardBreakdown) -> dict:
@@ -176,7 +178,13 @@ def compute_dominant_component(
         "rb_wide": -config.rb_wide_scale * (winner.rb_wide_penalty - mean_bd["rb_wide_penalty"]),
     }
     best_comp = max(deltas, key=lambda c: deltas[c])
-    return best_comp, deltas[best_comp]
+    best_delta = deltas[best_comp]
+    # If no component had a positive advantage over the mean, the winner was
+    # selected on a tie or by a component we don't track. Return a sentinel so
+    # callers don't mis-attribute a negative delta to the labeled component.
+    if best_delta <= 0:
+        return "none", best_delta
+    return best_comp, best_delta
 
 
 # ---------------------------------------------------------------------------

--- a/rlvr/test_generation_variants.py
+++ b/rlvr/test_generation_variants.py
@@ -62,3 +62,40 @@ def test_total_slots_fit_in_K16():
         v = get_variant(name)
         used = 1 + len(v.cl_spd_configs) + len(v.noise_configs)
         assert used <= K, f"variant {name!r} uses {used} slots, exceeds K={K}"
+
+
+def test_dominant_component_returns_none_when_no_positive_delta():
+    """compute_dominant_component must not mis-attribute a non-positive max."""
+    from rlvr.rank_analytics import compute_dominant_component
+    from rlvr.reward import RewardBreakdown, RewardConfig
+    cfg = RewardConfig()
+    r = RewardBreakdown(
+        safety=0.0, progress=5.0, smoothness=-1.0, feasibility=0.0,
+        centerline=-0.5, red_light=0.0, total=10.0, collision_step=None,
+        off_road_fraction=0.0, rb_crossing=False, rb_near_penalty=0.1,
+        rb_wide_penalty=0.5, rb_min_dist=0.7,
+        lane_crossing=False, lane_near_frac=0.0, lane_wide_frac=0.0,
+    )
+    mean_bd = {
+        "safety": 0.0, "progress": 5.0, "smoothness": -1.0, "feasibility": 0.0,
+        "centerline": -0.5, "red_light": 0.0, "rb_near_penalty": 0.1,
+        "rb_wide_penalty": 0.5, "rb_crossing": 0.0, "lane_crossing": 0.0,
+    }
+    comp, _ = compute_dominant_component(r, mean_bd, cfg)
+    assert comp == "none"
+
+
+def test_breakdown_to_dict_preserves_lane_crossing_bool():
+    """Both rb_crossing and lane_crossing must round-trip as bools, not numbers."""
+    from rlvr.rank_analytics import breakdown_to_dict
+    from rlvr.reward import RewardBreakdown
+    r = RewardBreakdown(
+        safety=0.0, progress=5.0, smoothness=-1.0, feasibility=0.0,
+        centerline=-0.5, red_light=0.0, total=10.0, collision_step=None,
+        off_road_fraction=0.0, rb_crossing=True, rb_near_penalty=0.1,
+        rb_wide_penalty=0.5, rb_min_dist=0.7,
+        lane_crossing=True, lane_near_frac=0.0, lane_wide_frac=0.0,
+    )
+    d = breakdown_to_dict(r)
+    assert isinstance(d["rb_crossing"], bool) and d["rb_crossing"] is True
+    assert isinstance(d["lane_crossing"], bool) and d["lane_crossing"] is True

--- a/rlvr/test_generation_variants.py
+++ b/rlvr/test_generation_variants.py
@@ -1,0 +1,64 @@
+"""Unit tests for the generation variant registry."""
+
+import pytest
+
+from rlvr.generation_variants import GenerationVariant, _ALIASES, get_variant, list_variants
+
+
+def test_canonical_variant_resolves():
+    """Direct lookup of a registered variant returns a GenerationVariant."""
+    v = get_variant("rsft_v2")
+    assert isinstance(v, GenerationVariant)
+    assert len(v.cl_spd_configs) > 0
+    assert len(v.noise_configs) > 0
+    assert v.description
+
+
+def test_default_variant_resolves():
+    """The fallback "default" variant must always be present."""
+    v = get_variant("default")
+    assert isinstance(v, GenerationVariant)
+    assert len(v.cl_spd_configs) == 8
+
+
+def test_aliases_resolve_to_canonical():
+    """Every alias must point to a variant that exists in the registry."""
+    for alias, target in _ALIASES.items():
+        resolved = get_variant(alias)
+        canonical = get_variant(target)
+        assert resolved is canonical, f"alias {alias!r} did not resolve to {target!r}"
+
+
+def test_unknown_variant_raises():
+    """Unknown names must raise ValueError listing the available variants."""
+    with pytest.raises(ValueError) as exc_info:
+        get_variant("does_not_exist")
+    msg = str(exc_info.value)
+    assert "does_not_exist" in msg
+    # Error message should help the caller find a real name
+    assert "rsft_v2" in msg
+
+
+def test_list_variants_excludes_aliases():
+    """list_variants() returns only canonical names, not aliases."""
+    canonical = set(list_variants())
+    for alias in _ALIASES:
+        assert alias not in canonical, f"alias {alias!r} leaked into list_variants()"
+
+
+def test_each_variant_has_unique_labels():
+    """Within a single variant, all slot labels should be unique."""
+    for name in list_variants():
+        v = get_variant(name)
+        labels = [c["label"] for c in v.cl_spd_configs] + [c["label"] for c in v.noise_configs]
+        dupes = {lbl for lbl in labels if labels.count(lbl) > 1}
+        assert not dupes, f"variant {name!r} has duplicate slot labels: {sorted(dupes)}"
+
+
+def test_total_slots_fit_in_K16():
+    """det + cl_spd + noise must leave room for at least 0 random slots in K=16."""
+    K = 16
+    for name in list_variants():
+        v = get_variant(name)
+        used = 1 + len(v.cl_spd_configs) + len(v.noise_configs)
+        assert used <= K, f"variant {name!r} uses {used} slots, exceeds K={K}"


### PR DESCRIPTION
## Summary

Adds two related capabilities to ranked SFT:

1. **Rank analytics** — per-epoch instrumentation that tracks which of the 16 generation slots ends up top-ranked (the trajectory used as the SFT target) for each scene and which reward component drives the win. Outputs `rank_analytics_epoch_NNN.json` per epoch and a final `rank_analytics_summary.json` in the run dir. Visualize with `python -m rlvr.autoresearch.tools.viz_rank_analytics --run_dir <dir>` (4 plots: stacked area, config heatmap, dominant-component bar chart, per-scene heatmap).

2. **Generation variant system** — replaces the hard-coded inline `cl_spd_configs` list in `grpo_trainer_batched.py` with a registry pattern in a new `rlvr/generation_variants.py` module. Each variant defines `cl_spd_configs` (guided slots) + `noise_configs` (pure-noise exploration slots). Selected via the new `generation_variant` field in `GRPOConfig`. Adding a new variant = one dict entry, no code changes elsewhere.

## New default: `rsft_v2`

Empirically determined best variant for the miraikan lane-keeping task. **6 guided cl_spd slots** (CL5/CL6/CL7/CL8/CL10 with stretch factors 1.0/1.1/1.3/1.4) + **9 pure-noise slots** sweeping noise ranges 0.1→5.0. No random-CL pool. The full slot composition is documented in `rlvr/generation_variants.py`.

On miraikan val 50 at ep8: val_reward +23.51, **0/50 lane departures**, **0/50 road border crossings**, rb_dist min 0.67m, path 15.3m. L2 on the 16k validation set: **ego +1.5%, neighbor -1.0% vs the LoRA-less baseline** — the only variant tested that improves over the original model on neighbor L2 while staying within the ego L2 budget.

The previous default (renamed `rsft_v2_legacy`) and other experimental variants (`stretched_lateral`, `noise_swap_2`, `more_noise`, `decoupled`, `lateral`, `combined_winners`, `stretched_intense`, `collision_swap`, `noisy_stretched`, `rsft_v2_half_half`, `rsft_v2_all_random`, `default`) are all kept in the registry for reproducibility, with one-line descriptions of what each tested.

## Files

- `rlvr/generation_variants.py` (new) — variant registry with reusable building blocks
- `rlvr/rank_analytics.py` (new) — per-scene record + epoch aggregator + cross-epoch summary
- `rlvr/autoresearch/tools/viz_rank_analytics.py` (new) — plotting CLI
- `rlvr/grpo_trainer_batched.py` — thin lookup wrappers + per-slot lateral/collision/stretch params
- `rlvr/grpo_config.py` — adds `generation_variant: str = "default"` field
- `rlvr/grpo_sft_trainer.py` — analytics recording in scoring loop, plumbs `run_dir`
- `rlvr/autoresearch/run_experiment.py` — passes `run_dir` to ranked-SFT trainer, calls cross-epoch summary
- `rlvr/autoresearch/tools/profile_training.py` — passes `run_dir=None` to match new signature
- `rlvr/README.md` — documents the rank analytics + generation variant features

## Test plan

- [x] Smoke test all 14 registered variants (1 epoch / 5 scenes each) — all PASS, all produce rank_analytics_epoch_001.json
- [x] Reproduce rsft_v2 results end-to-end (15 epochs / 50 scenes) — checking now
- [x] L2 evaluation of rsft_v2 ep8 on the 16k val set: ego 5.4684 (+1.5%), neighbor 4.3507 (-1.0%)
- [x] ONNX export of best checkpoints (rsft_v2 ep8, rsft_v2_legacy ep9, rsft_v2_half_half ep9, stretched_lateral ep9)
- [x] LoRA-less baseline metrics on miraikan val 50: val_reward +22.98, LD 25/50, rb_cross 0/50, rb_dist min 0.56m
