### PR TITLE
feat: optional wandb logging for RLVR training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ program.md
 ros_scripts/convert_all_v4.sh
 .claude/
 CLAUDE.md
+wandb/

--- a/rlvr/autoresearch/run_experiment.py
+++ b/rlvr/autoresearch/run_experiment.py
@@ -464,6 +464,16 @@ def run(config_path: Path, name: str, skip_baseline: bool = False, baseline_cach
         },
     )
 
+    # Initialize before try so finally block never hits UnboundLocalError
+    start_time = time.time()
+    best_epoch = 0
+    best_prob_reward = float("-inf")
+    best_prob_rb_crossings = 999
+    best_val_reward = float("-inf")
+    best_val_collision = 1.0
+    duration = 0.0
+    best_checkpoint = ""
+
     try:
         # Load model
         policy_model, model_args = load_model(checkpoint_path, DEVICE)
@@ -561,15 +571,11 @@ def run(config_path: Path, name: str, skip_baseline: bool = False, baseline_cach
 
         trainer._eval_scene_paths = val_50
 
-        # Training loop
-        start_time = time.time()
-        best_epoch = 0
+        # Update best trackers from baseline eval
         best_prob_reward = base_prob["reward_mean"]
         best_prob_rb_crossings = base_prob["rb_crossings"]
         best_val_reward = base_val["reward_mean"]
         best_val_collision = base_val["collision_rate"]
-        duration = 0.0
-        best_checkpoint = ""
 
         args_dict = {"exp_name": name}
 

--- a/rlvr/autoresearch/run_experiment.py
+++ b/rlvr/autoresearch/run_experiment.py
@@ -450,6 +450,20 @@ def run(config_path: Path, name: str, skip_baseline: bool = False, baseline_cach
     with open(run_dir / "train_scenes.json", "w") as f:
         json.dump(train_paths, f)
 
+    # Initialize wandb logging (no-op if disabled in config)
+    from rlvr.wandb_logger import WandbLogger
+    wandb_log = WandbLogger.from_config(
+        grpo_config,
+        run_dir=str(run_dir),
+        run_name=name,
+        extra_tags=["autoresearch"],
+        extra_config={
+            "n_prob_scenes": n_prob,
+            "n_normal_scenes": n_normal,
+            "n_train_scenes": len(train_paths),
+        },
+    )
+
     # Load model
     policy_model, model_args = load_model(checkpoint_path, DEVICE)
 
@@ -553,6 +567,7 @@ def run(config_path: Path, name: str, skip_baseline: bool = False, baseline_cach
     best_prob_rb_crossings = base_prob["rb_crossings"]
     best_val_reward = base_val["reward_mean"]
     best_val_collision = base_val["collision_rate"]
+    duration = 0.0
     best_checkpoint = ""
 
     args_dict = {"exp_name": name}
@@ -631,6 +646,14 @@ def run(config_path: Path, name: str, skip_baseline: bool = False, baseline_cach
         prob_result = evaluate_checkpoint(policy_model, model_args, prob_eval, eval_reward_config, f"epoch{epoch}-prob", baseline_cache=baseline_cache)
         val_eval = evaluate_checkpoint(policy_model, model_args, val_50, eval_reward_config, f"epoch{epoch}-val", baseline_cache=baseline_cache)
 
+        # Log to wandb
+        wandb_log.log_training(epoch, metrics)
+        wandb_log.log_eval(epoch, prob_result=prob_result, val_result=val_eval)
+        _ra_path = run_dir / f"rank_analytics_epoch_{epoch:03d}.json"
+        if _ra_path.exists():
+            with open(_ra_path) as _f:
+                wandb_log.log_rank_analytics(epoch, json.load(_f))
+
         # Track best: highest prob deterministic reward (with val sanity check > -5)
         is_better = (prob_result["reward_mean"] > best_prob_reward
                      and val_eval["reward_mean"] > -5)
@@ -666,6 +689,15 @@ def run(config_path: Path, name: str, skip_baseline: bool = False, baseline_cach
         save_cross_epoch_summary(run_dir)
     except Exception as e:
         print(f"  [rank_analytics] Cross-epoch summary failed: {e}")
+
+    # Finalize wandb run
+    wandb_log.finish({
+        "best_epoch": best_epoch,
+        "best_prob_reward": best_prob_reward,
+        "best_prob_rb_crossings": best_prob_rb_crossings,
+        "best_val_reward": best_val_reward,
+        "duration_min": duration,
+    })
 
     # Print final summary (machine-parseable)
     print("\n---")

--- a/rlvr/autoresearch/run_experiment.py
+++ b/rlvr/autoresearch/run_experiment.py
@@ -572,132 +572,131 @@ def run(config_path: Path, name: str, skip_baseline: bool = False, baseline_cach
 
     args_dict = {"exp_name": name}
 
-    for epoch in range(1, grpo_config.train_epochs + 1):
-        print(f"\n--- Epoch {epoch}/{grpo_config.train_epochs} ---")
-
-        if epoch == 1 and hasattr(trainer, 'save_epoch1_baselines'):
-            trainer.save_epoch1_baselines(train_paths)
-
-        if not grpo_config.use_exploration_policy and not grpo_config.use_closed_loop:
-            if grpo_config.ranked_sft_mode != "none":
-                # Ranked SFT: generate N trajs, pick best, SFT on it
-                from rlvr.grpo_sft_trainer import train_epoch_ranked_sft
-
-                # Optionally load a pre-trained exploration policy for guided generation
-                _explorer = None
-                if grpo_config.ranked_sft_use_explorer and grpo_config.exploration_checkpoint_path:
-                    from pathlib import Path as _P
-
-                    from exploration_policy.model import ExplorationPolicy, ExplorationPolicyConfig
-                    _ckpt = _P(grpo_config.exploration_checkpoint_path)
-                    if not _ckpt.exists():
-                        print(f"  WARNING: exploration_checkpoint_path not found: {_ckpt}")
-                        print(f"  Falling back to standard generation (no explorer)")
-                    elif not hasattr(run, '_cached_explorer') or getattr(run, '_cached_explorer_path', None) != str(_ckpt):
-                        _ep_cfg = ExplorationPolicyConfig(
-                            hidden_dim=grpo_config.exploration_hidden_dim,
-                            n_mixer_layers=grpo_config.exploration_n_mixer_layers,
-                            n_attn_heads=grpo_config.exploration_n_attn_heads,
-                            dropout=grpo_config.exploration_dropout,
-                            encoder_hidden_dim=model_args.hidden_dim,
-                            head_init=grpo_config.exploration_head_init,
-                            head_raw_scale=grpo_config.exploration_head_raw_scale,
-                        )
-                        run._cached_explorer = ExplorationPolicy(
-                            _ep_cfg, ref_seq_len=model_args.future_len,
-                        ).to(DEVICE)
-                        _state = torch.load(_ckpt, map_location=DEVICE, weights_only=False)
-                        run._cached_explorer.load_state_dict(_state, strict=False)
-                        run._cached_explorer.eval()
-                        run._cached_explorer_path = str(_ckpt)
-                        print(f"  Loaded frozen explorer from {_ckpt}")
-                    _explorer = getattr(run, '_cached_explorer', None)
-
-                # Create explorer optimizer if training jointly
-                _explorer_opt = None
-                if _explorer is not None and not grpo_config.ranked_sft_freeze_explorer:
-                    if not hasattr(run, '_cached_explorer_opt'):
-                        run._cached_explorer_opt = torch.optim.AdamW(
-                            _explorer.parameters(), lr=grpo_config.exploration_lr,
-                        )
-                    _explorer_opt = run._cached_explorer_opt
-
-                metrics = train_epoch_ranked_sft(
-                    model=policy_model, model_args=model_args, optimizer=optimizer,
-                    scene_paths=train_paths, config=grpo_config,
-                    reward_config=train_reward_config, device=DEVICE, epoch=epoch,
-                    exploration_policy=_explorer,
-                    exploration_optimizer=_explorer_opt,
-                    run_dir=run_dir,
-                )
-            else:
-                # Fully batched training: all scenes in ~5 forward passes
-                from rlvr.grpo_trainer_batched import train_epoch_batched
-                metrics = train_epoch_batched(
-                    model=policy_model, model_args=model_args, optimizer=optimizer,
-                    scene_paths=train_paths, config=grpo_config,
-                    reward_config=train_reward_config, device=DEVICE, epoch=epoch,
-                )
-        else:
-            metrics = trainer.train_epoch(train_paths, epoch)
-        trainer.log_metrics(epoch, metrics)
-        trainer.save_checkpoint(epoch, args_dict)
-
-        prob_result = evaluate_checkpoint(policy_model, model_args, prob_eval, eval_reward_config, f"epoch{epoch}-prob", baseline_cache=baseline_cache)
-        val_eval = evaluate_checkpoint(policy_model, model_args, val_50, eval_reward_config, f"epoch{epoch}-val", baseline_cache=baseline_cache)
-
-        # Log to wandb
-        wandb_log.log_training(epoch, metrics)
-        wandb_log.log_eval(epoch, prob_result=prob_result, val_result=val_eval)
-        _ra_path = run_dir / f"rank_analytics_epoch_{epoch:03d}.json"
-        if _ra_path.exists():
-            with open(_ra_path) as _f:
-                wandb_log.log_rank_analytics(epoch, json.load(_f))
-
-        # Track best: highest prob deterministic reward (with val sanity check > -5)
-        is_better = (prob_result["reward_mean"] > best_prob_reward
-                     and val_eval["reward_mean"] > -5)
-
-        if is_better:
-            best_prob_reward = prob_result["reward_mean"]
-            best_prob_rb_crossings = prob_result["rb_crossings"]
-            best_val_reward = val_eval["reward_mean"]
-            best_val_collision = val_eval["collision_rate"]
-            best_epoch = epoch
-            if grpo_config.use_lora:
-                best_checkpoint = str(run_dir / f"lora_epoch_{epoch:03d}")
-            else:
-                best_checkpoint = str(run_dir / "latest.pth")
-
-        # Early stopping: val collapsed
-        if val_eval["reward_mean"] < -20:
-            print(f"  Val collapsed ({val_eval['reward_mean']:.1f}), stopping early")
-            break
-
-    duration = (time.time() - start_time) / 60
-
-    # Keep ALL checkpoints — don't delete anything. Disk space is cheap,
-    # losing the best checkpoint is not.
-
-    # Generate trajectory visualization for the best checkpoint
-    if best_checkpoint and Path(best_checkpoint).exists():
-        _visualize_trajectories(policy_model, model_args, prob_100, eval_reward_config, run_dir, name)
-
-    # Cross-epoch rank analytics summary
     try:
-        from rlvr.rank_analytics import save_cross_epoch_summary
-        save_cross_epoch_summary(run_dir)
-    except Exception as e:
-        print(f"  [rank_analytics] Cross-epoch summary failed: {e}")
+        for epoch in range(1, grpo_config.train_epochs + 1):
+            print(f"\n--- Epoch {epoch}/{grpo_config.train_epochs} ---")
 
-    # Finalize wandb run
-    wandb_log.finish({
-        "best_epoch": best_epoch,
-        "best_prob_reward": best_prob_reward,
-        "best_prob_rb_crossings": best_prob_rb_crossings,
-        "best_val_reward": best_val_reward,
-        "duration_min": duration,
-    })
+            if epoch == 1 and hasattr(trainer, 'save_epoch1_baselines'):
+                trainer.save_epoch1_baselines(train_paths)
+
+            if not grpo_config.use_exploration_policy and not grpo_config.use_closed_loop:
+                if grpo_config.ranked_sft_mode != "none":
+                    # Ranked SFT: generate N trajs, pick best, SFT on it
+                    from rlvr.grpo_sft_trainer import train_epoch_ranked_sft
+
+                    # Optionally load a pre-trained exploration policy for guided generation
+                    _explorer = None
+                    if grpo_config.ranked_sft_use_explorer and grpo_config.exploration_checkpoint_path:
+                        from pathlib import Path as _P
+
+                        from exploration_policy.model import ExplorationPolicy, ExplorationPolicyConfig
+                        _ckpt = _P(grpo_config.exploration_checkpoint_path)
+                        if not _ckpt.exists():
+                            print(f"  WARNING: exploration_checkpoint_path not found: {_ckpt}")
+                            print(f"  Falling back to standard generation (no explorer)")
+                        elif not hasattr(run, '_cached_explorer') or getattr(run, '_cached_explorer_path', None) != str(_ckpt):
+                            _ep_cfg = ExplorationPolicyConfig(
+                                hidden_dim=grpo_config.exploration_hidden_dim,
+                                n_mixer_layers=grpo_config.exploration_n_mixer_layers,
+                                n_attn_heads=grpo_config.exploration_n_attn_heads,
+                                dropout=grpo_config.exploration_dropout,
+                                encoder_hidden_dim=model_args.hidden_dim,
+                                head_init=grpo_config.exploration_head_init,
+                                head_raw_scale=grpo_config.exploration_head_raw_scale,
+                            )
+                            run._cached_explorer = ExplorationPolicy(
+                                _ep_cfg, ref_seq_len=model_args.future_len,
+                            ).to(DEVICE)
+                            _state = torch.load(_ckpt, map_location=DEVICE, weights_only=False)
+                            run._cached_explorer.load_state_dict(_state, strict=False)
+                            run._cached_explorer.eval()
+                            run._cached_explorer_path = str(_ckpt)
+                            print(f"  Loaded frozen explorer from {_ckpt}")
+                        _explorer = getattr(run, '_cached_explorer', None)
+
+                    # Create explorer optimizer if training jointly
+                    _explorer_opt = None
+                    if _explorer is not None and not grpo_config.ranked_sft_freeze_explorer:
+                        if not hasattr(run, '_cached_explorer_opt'):
+                            run._cached_explorer_opt = torch.optim.AdamW(
+                                _explorer.parameters(), lr=grpo_config.exploration_lr,
+                            )
+                        _explorer_opt = run._cached_explorer_opt
+
+                    metrics = train_epoch_ranked_sft(
+                        model=policy_model, model_args=model_args, optimizer=optimizer,
+                        scene_paths=train_paths, config=grpo_config,
+                        reward_config=train_reward_config, device=DEVICE, epoch=epoch,
+                        exploration_policy=_explorer,
+                        exploration_optimizer=_explorer_opt,
+                        run_dir=run_dir,
+                    )
+                else:
+                    # Fully batched training: all scenes in ~5 forward passes
+                    from rlvr.grpo_trainer_batched import train_epoch_batched
+                    metrics = train_epoch_batched(
+                        model=policy_model, model_args=model_args, optimizer=optimizer,
+                        scene_paths=train_paths, config=grpo_config,
+                        reward_config=train_reward_config, device=DEVICE, epoch=epoch,
+                    )
+            else:
+                metrics = trainer.train_epoch(train_paths, epoch)
+            trainer.log_metrics(epoch, metrics)
+            trainer.save_checkpoint(epoch, args_dict)
+
+            prob_result = evaluate_checkpoint(policy_model, model_args, prob_eval, eval_reward_config, f"epoch{epoch}-prob", baseline_cache=baseline_cache)
+            val_eval = evaluate_checkpoint(policy_model, model_args, val_50, eval_reward_config, f"epoch{epoch}-val", baseline_cache=baseline_cache)
+
+            # Log to wandb
+            wandb_log.log_training(epoch, metrics)
+            wandb_log.log_eval(epoch, prob_result=prob_result, val_result=val_eval)
+            _ra_path = run_dir / f"rank_analytics_epoch_{epoch:03d}.json"
+            if _ra_path.exists():
+                with open(_ra_path) as _f:
+                    wandb_log.log_rank_analytics(epoch, json.load(_f))
+
+            # Track best: highest prob deterministic reward (with val sanity check > -5)
+            is_better = (prob_result["reward_mean"] > best_prob_reward
+                         and val_eval["reward_mean"] > -5)
+
+            if is_better:
+                best_prob_reward = prob_result["reward_mean"]
+                best_prob_rb_crossings = prob_result["rb_crossings"]
+                best_val_reward = val_eval["reward_mean"]
+                best_val_collision = val_eval["collision_rate"]
+                best_epoch = epoch
+                if grpo_config.use_lora:
+                    best_checkpoint = str(run_dir / f"lora_epoch_{epoch:03d}")
+                else:
+                    best_checkpoint = str(run_dir / "latest.pth")
+
+            # Early stopping: val collapsed
+            if val_eval["reward_mean"] < -20:
+                print(f"  Val collapsed ({val_eval['reward_mean']:.1f}), stopping early")
+                break
+
+        # Keep ALL checkpoints — don't delete anything. Disk space is cheap,
+        # losing the best checkpoint is not.
+
+        # Generate trajectory visualization for the best checkpoint
+        if best_checkpoint and Path(best_checkpoint).exists():
+            _visualize_trajectories(policy_model, model_args, prob_100, eval_reward_config, run_dir, name)
+
+        # Cross-epoch rank analytics summary
+        try:
+            from rlvr.rank_analytics import save_cross_epoch_summary
+            save_cross_epoch_summary(run_dir)
+        except Exception as e:
+            print(f"  [rank_analytics] Cross-epoch summary failed: {e}")
+    finally:
+        duration = (time.time() - start_time) / 60
+        wandb_log.finish({
+            "best_epoch": best_epoch,
+            "best_prob_reward": best_prob_reward,
+            "best_prob_rb_crossings": best_prob_rb_crossings,
+            "best_val_reward": best_val_reward,
+            "duration_min": duration,
+        })
 
     # Print final summary (machine-parseable)
     print("\n---")

--- a/rlvr/autoresearch/run_experiment.py
+++ b/rlvr/autoresearch/run_experiment.py
@@ -464,115 +464,115 @@ def run(config_path: Path, name: str, skip_baseline: bool = False, baseline_cach
         },
     )
 
-    # Load model
-    policy_model, model_args = load_model(checkpoint_path, DEVICE)
-
-    if grpo_config.use_lora:
-        if seed_lora_path and Path(seed_lora_path).exists():
-            from preference_optimization.lora_utils import load_lora_checkpoint
-            policy_model = load_lora_checkpoint(policy_model, seed_lora_path, is_trainable=True)
-            print(f"Seeded from LoRA: {seed_lora_path}")
-        else:
-            from preference_optimization.lora_utils import (
-                LORA_TARGET_BLOCKS_01_REGEX,
-                LORA_TARGET_FIRST_BLOCK_REGEX,
-                LORA_TARGET_LAST_BLOCK_REGEX,
-                apply_lora,
-            )
-            from preference_optimization.lora_utils import LORA_TARGET_BLOCKS_02_REGEX
-            target = {"last": LORA_TARGET_LAST_BLOCK_REGEX, "first": LORA_TARGET_FIRST_BLOCK_REGEX, "blocks01": LORA_TARGET_BLOCKS_01_REGEX, "blocks02": LORA_TARGET_BLOCKS_02_REGEX}.get(grpo_config.lora_target)
-            kwargs = dict(r=grpo_config.lora_rank, lora_alpha=grpo_config.lora_alpha,
-                         lora_dropout=grpo_config.lora_dropout)
-            if target:
-                kwargs["target_modules"] = target
-            policy_model = apply_lora(policy_model, **kwargs)
-
-    trainable_params = [p for p in policy_model.parameters() if p.requires_grad]
-    optimizer = torch.optim.AdamW(trainable_params, lr=grpo_config.learning_rate)
-
-    # Training reward config uses the configured weights (may boost w_progress
-    # to prevent reward hacking where the model learns to stop instead of drive)
-    train_reward_config = RewardConfig(
-        w_safety=grpo_config.w_safety, w_progress=grpo_config.w_progress,
-        w_smooth=grpo_config.w_smooth, w_feasibility=grpo_config.w_feasibility,
-        w_centerline=grpo_config.w_centerline,
-        rb_near_scale=grpo_config.rb_near_scale,
-        rb_wide_scale=grpo_config.rb_wide_scale,
-        rb_cont_scale=grpo_config.rb_cont_scale,
-        rb_gate_enabled=grpo_config.rb_gate_enabled,
-        rb_penalty_mode=grpo_config.rb_penalty_mode,
-        rb_cross_thresh=grpo_config.rb_cross_thresh,
-        rb_near_thresh=grpo_config.rb_near_thresh,
-        rb_wide_thresh=grpo_config.rb_wide_thresh,
-        rb_cont_thresh=grpo_config.rb_cont_thresh,
-        max_lat_accel=grpo_config.max_lat_accel,
-        lat_accel_scale=grpo_config.lat_accel_scale,
-        enable_overprogress=grpo_config.enable_overprogress,
-        overprogress_margin=grpo_config.overprogress_margin,
-        overprogress_penalty=grpo_config.overprogress_penalty,
-        stopped_penalty=grpo_config.stopped_penalty,
-        underprogress_penalty=grpo_config.underprogress_penalty,
-        underprogress_threshold=grpo_config.underprogress_threshold,
-        progress_norm_scale=grpo_config.progress_norm_scale,
-        enable_lane_departure=grpo_config.enable_lane_departure,
-        lane_gate_enabled=grpo_config.lane_gate_enabled,
-        lane_near_scale=grpo_config.lane_near_scale,
-        lane_wide_scale=grpo_config.lane_wide_scale,
-        lane_cont_scale=grpo_config.lane_cont_scale,
-        lane_near_thresh=grpo_config.lane_near_thresh,
-        lane_wide_thresh=grpo_config.lane_wide_thresh,
-        lane_cont_thresh=grpo_config.lane_cont_thresh,
-        reward_mode=grpo_config.reward_mode,
-    )
-    # Eval reward config: standard weights but always check lane departure for metrics
-    eval_reward_config = RewardConfig(enable_lane_departure=True)
-
-    if grpo_config.use_closed_loop:
-        from rlvr.closed_loop.closed_loop_trainer import ClosedLoopExplorationTrainer
-        trainer = ClosedLoopExplorationTrainer(
-            policy_model=policy_model, model_args=model_args,
-            dit_optimizer=optimizer, device=DEVICE, run_dir=run_dir,
-            config=grpo_config, use_lora=grpo_config.use_lora,
-        )
-    elif grpo_config.use_exploration_policy:
-        from rlvr.grpo_exploration_trainer import GRPOExplorationTrainer
-        trainer = GRPOExplorationTrainer(
-            policy_model=policy_model, model_args=model_args,
-            dit_optimizer=optimizer, device=DEVICE, run_dir=run_dir,
-            config=grpo_config, use_lora=grpo_config.use_lora,
-        )
-    else:
-        trainer = GRPOTrainer(
-            policy_model=policy_model, model_args=model_args,
-            optimizer=optimizer, device=DEVICE, run_dir=run_dir,
-            config=grpo_config, use_lora=grpo_config.use_lora,
-        )
-
-    # Evaluate base model (can skip if baseline numbers are already known)
-    if skip_baseline:
-        print("\nSkipping base model evaluation (--skip_baseline)")
-        base_prob = {"reward_mean": float("-inf"), "rb_crossings": 999, "collision_rate": 1.0}
-        base_val = {"reward_mean": float("-inf"), "rb_crossings": 999, "collision_rate": 1.0}
-    else:
-        print("\nBase model evaluation:")
-        base_prob = evaluate_checkpoint(policy_model, model_args, prob_eval, eval_reward_config, "base-prob")
-        base_val = evaluate_checkpoint(policy_model, model_args, val_50, eval_reward_config, "base-val")
-
-    trainer._eval_scene_paths = val_50
-
-    # Training loop
-    start_time = time.time()
-    best_epoch = 0
-    best_prob_reward = base_prob["reward_mean"]
-    best_prob_rb_crossings = base_prob["rb_crossings"]
-    best_val_reward = base_val["reward_mean"]
-    best_val_collision = base_val["collision_rate"]
-    duration = 0.0
-    best_checkpoint = ""
-
-    args_dict = {"exp_name": name}
-
     try:
+        # Load model
+        policy_model, model_args = load_model(checkpoint_path, DEVICE)
+
+        if grpo_config.use_lora:
+            if seed_lora_path and Path(seed_lora_path).exists():
+                from preference_optimization.lora_utils import load_lora_checkpoint
+                policy_model = load_lora_checkpoint(policy_model, seed_lora_path, is_trainable=True)
+                print(f"Seeded from LoRA: {seed_lora_path}")
+            else:
+                from preference_optimization.lora_utils import (
+                    LORA_TARGET_BLOCKS_01_REGEX,
+                    LORA_TARGET_FIRST_BLOCK_REGEX,
+                    LORA_TARGET_LAST_BLOCK_REGEX,
+                    apply_lora,
+                )
+                from preference_optimization.lora_utils import LORA_TARGET_BLOCKS_02_REGEX
+                target = {"last": LORA_TARGET_LAST_BLOCK_REGEX, "first": LORA_TARGET_FIRST_BLOCK_REGEX, "blocks01": LORA_TARGET_BLOCKS_01_REGEX, "blocks02": LORA_TARGET_BLOCKS_02_REGEX}.get(grpo_config.lora_target)
+                kwargs = dict(r=grpo_config.lora_rank, lora_alpha=grpo_config.lora_alpha,
+                             lora_dropout=grpo_config.lora_dropout)
+                if target:
+                    kwargs["target_modules"] = target
+                policy_model = apply_lora(policy_model, **kwargs)
+
+        trainable_params = [p for p in policy_model.parameters() if p.requires_grad]
+        optimizer = torch.optim.AdamW(trainable_params, lr=grpo_config.learning_rate)
+
+        # Training reward config uses the configured weights (may boost w_progress
+        # to prevent reward hacking where the model learns to stop instead of drive)
+        train_reward_config = RewardConfig(
+            w_safety=grpo_config.w_safety, w_progress=grpo_config.w_progress,
+            w_smooth=grpo_config.w_smooth, w_feasibility=grpo_config.w_feasibility,
+            w_centerline=grpo_config.w_centerline,
+            rb_near_scale=grpo_config.rb_near_scale,
+            rb_wide_scale=grpo_config.rb_wide_scale,
+            rb_cont_scale=grpo_config.rb_cont_scale,
+            rb_gate_enabled=grpo_config.rb_gate_enabled,
+            rb_penalty_mode=grpo_config.rb_penalty_mode,
+            rb_cross_thresh=grpo_config.rb_cross_thresh,
+            rb_near_thresh=grpo_config.rb_near_thresh,
+            rb_wide_thresh=grpo_config.rb_wide_thresh,
+            rb_cont_thresh=grpo_config.rb_cont_thresh,
+            max_lat_accel=grpo_config.max_lat_accel,
+            lat_accel_scale=grpo_config.lat_accel_scale,
+            enable_overprogress=grpo_config.enable_overprogress,
+            overprogress_margin=grpo_config.overprogress_margin,
+            overprogress_penalty=grpo_config.overprogress_penalty,
+            stopped_penalty=grpo_config.stopped_penalty,
+            underprogress_penalty=grpo_config.underprogress_penalty,
+            underprogress_threshold=grpo_config.underprogress_threshold,
+            progress_norm_scale=grpo_config.progress_norm_scale,
+            enable_lane_departure=grpo_config.enable_lane_departure,
+            lane_gate_enabled=grpo_config.lane_gate_enabled,
+            lane_near_scale=grpo_config.lane_near_scale,
+            lane_wide_scale=grpo_config.lane_wide_scale,
+            lane_cont_scale=grpo_config.lane_cont_scale,
+            lane_near_thresh=grpo_config.lane_near_thresh,
+            lane_wide_thresh=grpo_config.lane_wide_thresh,
+            lane_cont_thresh=grpo_config.lane_cont_thresh,
+            reward_mode=grpo_config.reward_mode,
+        )
+        # Eval reward config: standard weights but always check lane departure for metrics
+        eval_reward_config = RewardConfig(enable_lane_departure=True)
+
+        if grpo_config.use_closed_loop:
+            from rlvr.closed_loop.closed_loop_trainer import ClosedLoopExplorationTrainer
+            trainer = ClosedLoopExplorationTrainer(
+                policy_model=policy_model, model_args=model_args,
+                dit_optimizer=optimizer, device=DEVICE, run_dir=run_dir,
+                config=grpo_config, use_lora=grpo_config.use_lora,
+            )
+        elif grpo_config.use_exploration_policy:
+            from rlvr.grpo_exploration_trainer import GRPOExplorationTrainer
+            trainer = GRPOExplorationTrainer(
+                policy_model=policy_model, model_args=model_args,
+                dit_optimizer=optimizer, device=DEVICE, run_dir=run_dir,
+                config=grpo_config, use_lora=grpo_config.use_lora,
+            )
+        else:
+            trainer = GRPOTrainer(
+                policy_model=policy_model, model_args=model_args,
+                optimizer=optimizer, device=DEVICE, run_dir=run_dir,
+                config=grpo_config, use_lora=grpo_config.use_lora,
+            )
+
+        # Evaluate base model (can skip if baseline numbers are already known)
+        if skip_baseline:
+            print("\nSkipping base model evaluation (--skip_baseline)")
+            base_prob = {"reward_mean": float("-inf"), "rb_crossings": 999, "collision_rate": 1.0}
+            base_val = {"reward_mean": float("-inf"), "rb_crossings": 999, "collision_rate": 1.0}
+        else:
+            print("\nBase model evaluation:")
+            base_prob = evaluate_checkpoint(policy_model, model_args, prob_eval, eval_reward_config, "base-prob")
+            base_val = evaluate_checkpoint(policy_model, model_args, val_50, eval_reward_config, "base-val")
+
+        trainer._eval_scene_paths = val_50
+
+        # Training loop
+        start_time = time.time()
+        best_epoch = 0
+        best_prob_reward = base_prob["reward_mean"]
+        best_prob_rb_crossings = base_prob["rb_crossings"]
+        best_val_reward = base_val["reward_mean"]
+        best_val_collision = base_val["collision_rate"]
+        duration = 0.0
+        best_checkpoint = ""
+
+        args_dict = {"exp_name": name}
+
         for epoch in range(1, grpo_config.train_epochs + 1):
             print(f"\n--- Epoch {epoch}/{grpo_config.train_epochs} ---")
 

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -360,7 +360,7 @@ class GRPOConfig:
     # Weights & Biases logging
     wandb_enabled: bool = False
     wandb_project: str = "rlvr-training"
-    wandb_entity: str = ""  # empty = default entity
+    wandb_entity: str = ""  # empty = resolved from WANDB_ENTITY env var
 
     # Backward compat: old field names → new field names
     _FIELD_RENAMES: ClassVar[dict[str, str]] = {

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -357,6 +357,11 @@ class GRPOConfig:
     #   }
     schedules: dict = field(default_factory=dict)
 
+    # Weights & Biases logging
+    wandb_enabled: bool = False
+    wandb_project: str = "rlvr-training"
+    wandb_entity: str = ""  # empty = default entity
+
     # Backward compat: old field names → new field names
     _FIELD_RENAMES: ClassVar[dict[str, str]] = {
         "near_edge_scale": "rb_near_scale",

--- a/rlvr/test_wandb_logger.py
+++ b/rlvr/test_wandb_logger.py
@@ -1,0 +1,107 @@
+"""Tests for WandbLogger no-op and auto-disable behavior."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rlvr.grpo_config import GRPOConfig
+from rlvr.wandb_logger import WandbLogger
+
+
+def test_disabled_by_default():
+    """Logger is a no-op when wandb_enabled=False."""
+    config = GRPOConfig(wandb_enabled=False)
+    logger = WandbLogger.from_config(config)
+    assert not logger._enabled
+    assert logger._run is None
+    # All calls are no-ops
+    logger.log_training(1, {"loss": 0.5})
+    logger.log_eval(1, prob_result={"reward_mean": 10.0})
+    logger.log_rank_analytics(1, {"summary": {"win_rates": {"a": 0.5}}})
+    logger.finish({"best_epoch": 1})
+
+
+def test_disabled_when_wandb_import_fails():
+    """Logger auto-disables when wandb is not installed."""
+    config = GRPOConfig(wandb_enabled=True)
+    with patch.dict("sys.modules", {"wandb": None}):
+        logger = WandbLogger.from_config(config)
+    assert not logger._enabled
+
+
+def test_disabled_when_wandb_init_fails():
+    """Logger auto-disables when wandb.init() raises."""
+    config = GRPOConfig(wandb_enabled=True)
+    mock_wandb = MagicMock()
+    mock_wandb.init.side_effect = RuntimeError("network error")
+    with patch.dict("sys.modules", {"wandb": mock_wandb}):
+        logger = WandbLogger.from_config(config)
+    assert not logger._enabled
+    assert logger._run is None
+
+
+def test_safe_log_disables_on_failure():
+    """_safe_log catches errors and disables logging."""
+    logger = WandbLogger(enabled=True)
+    logger._run = MagicMock()
+    mock_wandb = MagicMock()
+    mock_wandb.log.side_effect = RuntimeError("upload failed")
+    with patch.dict("sys.modules", {"wandb": mock_wandb}):
+        logger.log_training(1, {"loss": 0.5})
+    assert not logger._enabled
+
+
+def test_finish_clears_run_and_disables():
+    """finish() sets _run=None and _enabled=False."""
+    logger = WandbLogger(enabled=True)
+    logger._run = MagicMock()
+    mock_wandb = MagicMock()
+    with patch.dict("sys.modules", {"wandb": mock_wandb}):
+        logger.finish({"best_epoch": 3})
+    assert logger._run is None
+    assert not logger._enabled
+    mock_wandb.finish.assert_called_once()
+
+
+def test_finish_noop_when_no_run():
+    """finish() is a no-op when no run was ever started."""
+    logger = WandbLogger(enabled=False)
+    logger.finish({"best_epoch": 1})  # should not raise
+    assert not logger._enabled
+
+
+def test_finish_best_effort_after_disable():
+    """finish() still closes the run even if _enabled was set to False by _safe_log."""
+    logger = WandbLogger(enabled=False)
+    logger._run = MagicMock()  # run was started but logging got disabled
+    mock_wandb = MagicMock()
+    with patch.dict("sys.modules", {"wandb": mock_wandb}):
+        logger.finish({"best_epoch": 5})
+    assert logger._run is None
+    assert not logger._enabled
+    mock_wandb.finish.assert_called_once()
+
+
+def test_finish_handles_wandb_finish_error():
+    """finish() doesn't crash if wandb.finish() itself raises."""
+    logger = WandbLogger(enabled=True)
+    logger._run = MagicMock()
+    mock_wandb = MagicMock()
+    mock_wandb.finish.side_effect = RuntimeError("cleanup error")
+    with patch.dict("sys.modules", {"wandb": mock_wandb}):
+        logger.finish()  # should not raise
+    assert logger._run is None
+    assert not logger._enabled
+
+
+def test_tags_from_config():
+    """Auto-tags are set based on config fields."""
+    config = GRPOConfig(wandb_enabled=True, ranked_sft_mode="gt_neighbor")
+    mock_wandb = MagicMock()
+    with patch.dict("sys.modules", {"wandb": mock_wandb}):
+        WandbLogger.from_config(config, extra_tags=["test"])
+    call_kwargs = mock_wandb.init.call_args[1]
+    assert "ranked_sft" in call_kwargs["tags"]
+    assert "test" in call_kwargs["tags"]

--- a/rlvr/train_grpo.py
+++ b/rlvr/train_grpo.py
@@ -212,30 +212,31 @@ def _run_rule_mode(
     print(f"\nStarting GRPO training for {trainer.config.train_epochs} epochs...")
     print("=" * 60)
 
-    total_epochs = trainer.config.train_epochs
-    for epoch in range(1, total_epochs + 1):
-        print(f"\nEpoch {epoch}/{total_epochs}")
-        print("-" * 60)
+    try:
+        total_epochs = trainer.config.train_epochs
+        for epoch in range(1, total_epochs + 1):
+            print(f"\nEpoch {epoch}/{total_epochs}")
+            print("-" * 60)
 
-        if drift_info:
-            print(f"  {drift_info}")
+            if drift_info:
+                print(f"  {drift_info}")
 
-        if epoch == 1:
-            trainer.save_epoch1_baselines(train_npz_paths)
+            if epoch == 1:
+                trainer.save_epoch1_baselines(train_npz_paths)
 
-        metrics = trainer.train_epoch(train_npz_paths, epoch)
+            metrics = trainer.train_epoch(train_npz_paths, epoch)
 
-        drift_info = trainer.compute_trajectory_drift()
-        trainer.log_metrics(epoch, metrics)
-        trainer.save_checkpoint(epoch, args_dict)
-        eval_result = trainer.evaluate_rewards(epoch)
+            drift_info = trainer.compute_trajectory_drift()
+            trainer.log_metrics(epoch, metrics)
+            trainer.save_checkpoint(epoch, args_dict)
+            eval_result = trainer.evaluate_rewards(epoch)
 
-        wandb_log.log_training(epoch, metrics)
-        wandb_log.log_eval(epoch, val_result=eval_result)
+            wandb_log.log_training(epoch, metrics)
+            wandb_log.log_eval(epoch, val_result=eval_result)
 
-        print("-" * 60)
-
-    wandb_log.finish()
+            print("-" * 60)
+    finally:
+        wandb_log.finish()
 
     print("\n" + "=" * 60)
     print("Training complete!")

--- a/rlvr/train_grpo.py
+++ b/rlvr/train_grpo.py
@@ -196,6 +196,15 @@ def _run_rule_mode(
     # Fix evaluation scenes from validation set (sampled once, reused every epoch)
     trainer.setup_eval_scenes(valid_npz_paths, n_scenes=50)
 
+    # Initialize wandb logging (no-op if disabled in config)
+    from rlvr.wandb_logger import WandbLogger
+    wandb_log = WandbLogger.from_config(
+        trainer.config,
+        run_dir=str(trainer.run_dir),
+        run_name=args.exp_name,
+        extra_tags=["standalone"],
+    )
+
     # Evaluate base model before any training (epoch 0)
     print("\nEvaluating base model (epoch 0)...")
     trainer.evaluate_rewards(epoch=0)
@@ -219,9 +228,14 @@ def _run_rule_mode(
         drift_info = trainer.compute_trajectory_drift()
         trainer.log_metrics(epoch, metrics)
         trainer.save_checkpoint(epoch, args_dict)
-        trainer.evaluate_rewards(epoch)
+        eval_result = trainer.evaluate_rewards(epoch)
+
+        wandb_log.log_training(epoch, metrics)
+        wandb_log.log_eval(epoch, val_result=eval_result)
 
         print("-" * 60)
+
+    wandb_log.finish()
 
     print("\n" + "=" * 60)
     print("Training complete!")

--- a/rlvr/train_grpo.py
+++ b/rlvr/train_grpo.py
@@ -205,14 +205,14 @@ def _run_rule_mode(
         extra_tags=["standalone"],
     )
 
-    # Evaluate base model before any training (epoch 0)
-    print("\nEvaluating base model (epoch 0)...")
-    trainer.evaluate_rewards(epoch=0)
-
-    print(f"\nStarting GRPO training for {trainer.config.train_epochs} epochs...")
-    print("=" * 60)
-
     try:
+        # Evaluate base model before any training (epoch 0)
+        print("\nEvaluating base model (epoch 0)...")
+        trainer.evaluate_rewards(epoch=0)
+
+        print(f"\nStarting GRPO training for {trainer.config.train_epochs} epochs...")
+        print("=" * 60)
+
         total_epochs = trainer.config.train_epochs
         for epoch in range(1, total_epochs + 1):
             print(f"\nEpoch {epoch}/{total_epochs}")

--- a/rlvr/wandb_logger.py
+++ b/rlvr/wandb_logger.py
@@ -134,13 +134,23 @@ class WandbLogger:
 
     def finish(self, summary: dict[str, Any] | None = None) -> None:
         """Finalize the wandb run with optional summary metrics."""
-        if not self._enabled:
+        if self._run is None:
+            self._enabled = False
             return
-        import wandb
 
-        if summary and self._run:
-            for k, v in summary.items():
-                self._run.summary[k] = v
-        wandb.finish()
-        self._run = None
-        self._enabled = False
+        try:
+            if summary:
+                for k, v in summary.items():
+                    self._run.summary[k] = v
+        except Exception as e:
+            print(f"[wandb] failed to update summary during finish: {e}")
+
+        try:
+            import wandb
+
+            wandb.finish()
+        except Exception as e:
+            print(f"[wandb] finish failed: {e}")
+        finally:
+            self._run = None
+            self._enabled = False

--- a/rlvr/wandb_logger.py
+++ b/rlvr/wandb_logger.py
@@ -1,0 +1,141 @@
+"""Lightweight wandb integration for RLVR training.
+
+Provides a WandbLogger class that wraps wandb.init / wandb.log / wandb.finish
+with graceful no-op behavior when wandb is disabled or unavailable.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import asdict
+from typing import Any
+
+from rlvr.grpo_config import GRPOConfig
+
+
+class WandbLogger:
+    """Thin wrapper around wandb with no-op fallback."""
+
+    def __init__(self, enabled: bool = False):
+        self._enabled = enabled
+        self._run = None
+
+    @classmethod
+    def from_config(
+        cls,
+        config: GRPOConfig,
+        run_dir: str | None = None,
+        run_name: str | None = None,
+        extra_tags: list[str] | None = None,
+        extra_config: dict | None = None,
+    ) -> WandbLogger:
+        """Create logger from GRPOConfig. Returns no-op logger if disabled."""
+        instance = cls(enabled=config.wandb_enabled)
+        if not instance._enabled:
+            return instance
+
+        try:
+            import wandb
+        except ImportError:
+            print("[wandb] wandb not installed, disabling logging")
+            instance._enabled = False
+            return instance
+
+        tags = []
+        if config.ranked_sft_mode != "none":
+            tags.append("ranked_sft")
+        if config.use_exploration_policy:
+            tags.append("exploration")
+        if config.use_closed_loop:
+            tags.append("closed_loop")
+        if extra_tags:
+            tags.extend(extra_tags)
+
+        wandb_config = asdict(config)
+        if extra_config:
+            wandb_config.update(extra_config)
+
+        try:
+            instance._run = wandb.init(
+                project=config.wandb_project,
+                entity=config.wandb_entity or os.environ.get("WANDB_ENTITY") or None,
+                name=run_name,
+                dir=run_dir,
+                config=wandb_config,
+                tags=tags,
+                reinit="finish_previous",
+            )
+        except Exception as e:
+            print(f"[wandb] init failed: {e}, disabling logging")
+            instance._enabled = False
+
+        return instance
+
+    def log_training(self, epoch: int, metrics: dict[str, float]) -> None:
+        """Log per-epoch training metrics."""
+        if not self._enabled:
+            return
+        import wandb
+
+        wandb.log({f"train/{k}": v for k, v in metrics.items()}, step=epoch)
+
+    def log_eval(
+        self,
+        epoch: int,
+        prob_result: dict[str, Any] | None = None,
+        val_result: dict[str, Any] | None = None,
+    ) -> None:
+        """Log per-epoch evaluation results."""
+        if not self._enabled:
+            return
+        import wandb
+
+        payload: dict[str, Any] = {}
+        if prob_result:
+            for k, v in prob_result.items():
+                if isinstance(v, (int, float)):
+                    payload[f"eval_prob/{k}"] = v
+        if val_result:
+            for k, v in val_result.items():
+                if isinstance(v, (int, float)):
+                    payload[f"eval_val/{k}"] = v
+        if payload:
+            wandb.log(payload, step=epoch)
+
+    def log_rank_analytics(self, epoch: int, analytics: dict) -> None:
+        """Log rank analytics (win rates, category rates, dominant components)."""
+        if not self._enabled:
+            return
+        import wandb
+
+        payload: dict[str, Any] = {}
+        summary = analytics.get("summary", analytics)
+
+        for label, rate in summary.get("win_rates", {}).items():
+            payload[f"rank/win_rate/{label}"] = rate
+        for cat, rate in summary.get("category_rates", {}).items():
+            payload[f"rank/category/{cat}"] = rate
+
+        dom = summary.get("dominant_components", {})
+        total_dom = sum(dom.values()) or 1
+        for comp, cnt in dom.items():
+            payload[f"rank/dominant/{comp}"] = cnt / total_dom
+
+        for key in ("mean_winner_reward", "mean_det_reward", "mean_improvement"):
+            if key in summary:
+                payload[f"rank/{key}"] = summary[key]
+
+        if payload:
+            wandb.log(payload, step=epoch)
+
+    def finish(self, summary: dict[str, Any] | None = None) -> None:
+        """Finalize the wandb run with optional summary metrics."""
+        if not self._enabled:
+            return
+        import wandb
+
+        if summary and self._run:
+            for k, v in summary.items():
+                self._run.summary[k] = v
+        wandb.finish()
+        self._run = None

--- a/rlvr/wandb_logger.py
+++ b/rlvr/wandb_logger.py
@@ -71,13 +71,21 @@ class WandbLogger:
 
         return instance
 
+    def _safe_log(self, payload: dict[str, Any], step: int) -> None:
+        """Log to wandb, disabling on failure so training continues."""
+        try:
+            import wandb
+
+            wandb.log(payload, step=step)
+        except Exception as e:
+            print(f"[wandb] log failed: {e}, disabling logging")
+            self._enabled = False
+
     def log_training(self, epoch: int, metrics: dict[str, float]) -> None:
         """Log per-epoch training metrics."""
         if not self._enabled:
             return
-        import wandb
-
-        wandb.log({f"train/{k}": v for k, v in metrics.items()}, step=epoch)
+        self._safe_log({f"train/{k}": v for k, v in metrics.items()}, step=epoch)
 
     def log_eval(
         self,
@@ -88,8 +96,6 @@ class WandbLogger:
         """Log per-epoch evaluation results."""
         if not self._enabled:
             return
-        import wandb
-
         payload: dict[str, Any] = {}
         if prob_result:
             for k, v in prob_result.items():
@@ -100,14 +106,12 @@ class WandbLogger:
                 if isinstance(v, (int, float)):
                     payload[f"eval_val/{k}"] = v
         if payload:
-            wandb.log(payload, step=epoch)
+            self._safe_log(payload, step=epoch)
 
     def log_rank_analytics(self, epoch: int, analytics: dict) -> None:
         """Log rank analytics (win rates, category rates, dominant components)."""
         if not self._enabled:
             return
-        import wandb
-
         payload: dict[str, Any] = {}
         summary = analytics.get("summary", analytics)
 
@@ -126,7 +130,7 @@ class WandbLogger:
                 payload[f"rank/{key}"] = summary[key]
 
         if payload:
-            wandb.log(payload, step=epoch)
+            self._safe_log(payload, step=epoch)
 
     def finish(self, summary: dict[str, Any] | None = None) -> None:
         """Finalize the wandb run with optional summary metrics."""
@@ -139,3 +143,4 @@ class WandbLogger:
                 self._run.summary[k] = v
         wandb.finish()
         self._run = None
+        self._enabled = False


### PR DESCRIPTION
## Summary

Migrate W&B visualization for closed-loop evaluation results from HTML-based charts to **W&B CustomChart**, and add **cross-run comparison** support.

## Changes

### 1. Use W&B CustomChart Instead of HTML

**Problem**: Previous stacked bar charts used `wandb.Html` with inline ECharts, requiring manual Vega spec registration.

**Solution**: Switch to W&B CustomChart API, which creates reusable chart templates directly on the W&B platform with zero extra configuration.

### 2. Enable Cross-Run Comparison

New feature allowing users to compare closed-loop metrics across multiple training runs in the W&B Workspace:

- Each run automatically includes a `Run` column
- Dynamic comparison via W&B CustomChart's shared axes feature
- Toggle runs on/off in the left panel

## Visual Preview

W&B Workspace sample: [KEM-Closed-Loop-Evaluation](https://wandb.ai/advanced-technology-department/KEM-Closed-Loop-Evaluation/workspace?nw=nwusertemkeikem)

## Usage

1. Run closed-loop tests — results are automatically uploaded to W&B
2. Open W&B Workspace to view the `cross_run_chart` panel
3. Toggle different runs in the left panel for comparison

## Files Changed

- `diffusion_planner/run_all_groups_closed_loop.py`: Refactor `_log_to_wandb` → `log_closed_loop_to_wandb`
- `diffusion_planner/tests/test_closed_loop_cli.py`: Update function reference in test
- `scenario_generation/wandb_closed_loop.py`: Core changes, add CustomChart support

## Test Plan

- [ ] Run closed-loop tests and verify W&B displays correctly
- [ ] Run multiple tests with different configs and verify cross-run comparison
- [ ] Ensure backward compatibility with existing HTML visualization
