### PR TITLE
perf: scenario_generation simulation and scene building optimizations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
+[tool.pytest.ini_options]
+markers = [
+    "benchmark: performance profiling tests (deselect with '-m \"not benchmark\"')",
+]
+addopts = "-m 'not benchmark'"
+
 [tool.ruff]
 line-length = 100
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 markers = [
     "benchmark: performance profiling tests (deselect with '-m \"not benchmark\"')",
 ]
-addopts = "-m 'not benchmark'"
 
 [tool.ruff]
 line-length = 100

--- a/scenario_generation/batch_generate.py
+++ b/scenario_generation/batch_generate.py
@@ -139,7 +139,6 @@ def run_batch(config: dict, builder: LaneletSceneBuilder, output_dir: Path,
     # Pipeline: generate next snippet's scenes on CPU while simulating current on GPU
     with ThreadPoolExecutor(max_workers=1, thread_name_prefix="scene_gen") as gen_pool:
         pending_future = None
-        pending_meta = None  # (name, snip_dir)
 
         def _gen_for_snippet(snip_path):
             name, lanelet_ids, ego_pose = _load_snippet(snip_path)

--- a/scenario_generation/batch_generate.py
+++ b/scenario_generation/batch_generate.py
@@ -69,8 +69,46 @@ def generate_scenes(
     return scenes
 
 
+def _load_snippet(snip_path: Path) -> tuple[str, list[int], tuple[float, float, float] | None]:
+    """Load a snippet pickle and return (name, lanelet_ids, ego_pose)."""
+    with open(snip_path, "rb") as f:
+        snip_data = pickle.load(f)
+    ego_pose = snip_data.get("ego_pose")
+    if ego_pose is not None:
+        ego_pose = tuple(ego_pose)
+    return snip_path.stem, snip_data["lanelet_ids"], ego_pose
+
+
+def _save_scene(scene: SceneContext, scene_dir: Path, snippet_name: str) -> None:
+    """Save scene pickle, info JSON, and initial visualization."""
+    scene_dir.mkdir(parents=True, exist_ok=True)
+
+    with open(scene_dir / "scene.pkl", "wb") as f:
+        pickle.dump(scene, f)
+
+    info = {
+        "snippet": snippet_name,
+        "n_agents": len(scene.agents),
+        "n_lanes": int(scene.map_data.lanes.shape[0]),
+        "agents": [
+            {"id": a.id, "pos": a.current_position.tolist(),
+             "heading_deg": float(np.degrees(a.current_heading)),
+             "speed": float(np.linalg.norm(a.current_velocity))}
+            for a in scene.agents
+        ],
+    }
+    with open(scene_dir / "info.json", "w") as f:
+        json.dump(info, f, indent=2)
+
+    fig = render_scene_figure(scene)
+    fig.savefig(scene_dir / "initial.png", dpi=100, bbox_inches="tight")
+    plt.close(fig)
+
+
 def run_batch(config: dict, builder: LaneletSceneBuilder, output_dir: Path,
               model_path: str | None = None, device: str = "cuda"):
+    from concurrent.futures import ThreadPoolExecutor
+
     output_dir.mkdir(parents=True, exist_ok=True)
 
     gen_params = config.get("generation", {})
@@ -97,63 +135,58 @@ def run_batch(config: dict, builder: LaneletSceneBuilder, output_dir: Path,
         print(f"Simulation modes: {sim_modes}, {sim_steps} steps each")
 
     scene_idx = 0
-    for snip_path in snippet_files:
-        name = snip_path.stem
-        with open(snip_path, "rb") as f:
-            snip_data = pickle.load(f)
 
-        lanelet_ids = snip_data["lanelet_ids"]
-        ego_pose = snip_data.get("ego_pose")
-        if ego_pose is not None:
-            ego_pose = tuple(ego_pose)
+    # Pipeline: generate next snippet's scenes on CPU while simulating current on GPU
+    with ThreadPoolExecutor(max_workers=1, thread_name_prefix="scene_gen") as gen_pool:
+        pending_future = None
+        pending_meta = None  # (name, snip_dir)
 
-        snip_dir = output_dir / name
-        snip_dir.mkdir(parents=True, exist_ok=True)
+        def _gen_for_snippet(snip_path):
+            name, lanelet_ids, ego_pose = _load_snippet(snip_path)
+            t0 = time.time()
+            scenes = generate_scenes(builder, lanelet_ids, gen_params, n_scenes_per, ego_pose)
+            elapsed = time.time() - t0
+            return name, lanelet_ids, scenes, elapsed
 
-        print(f"\n--- {name} ({len(lanelet_ids)} lanelets, {n_scenes_per} scenes) ---")
-        t0 = time.time()
-        scenes = generate_scenes(builder, lanelet_ids, gen_params, n_scenes_per, ego_pose)
-        print(f"  Generated {len(scenes)} scenes in {time.time() - t0:.1f}s")
+        def _process_snippet(name, scenes, snip_dir):
+            nonlocal scene_idx
+            for i, scene in enumerate(scenes):
+                scene_dir = snip_dir / f"scene_{i:03d}"
+                _save_scene(scene, scene_dir, name)
 
-        for i, scene in enumerate(scenes):
-            scene_dir = snip_dir / f"scene_{i:03d}"
-            scene_dir.mkdir(parents=True, exist_ok=True)
+                if sim_enabled:
+                    from scenario_generation.simulate import run_simulation
+                    for sim_mode in sim_modes:
+                        sim_out = scene_dir / sim_mode
+                        print(f"  Scene {i}: {sim_mode} ({sim_steps} steps)...")
+                        t1 = time.time()
+                        run_simulation(
+                            model, model_args, scene, sim_steps,
+                            sim_out, device=device,
+                            per_agent=per_agent, mode=sim_mode,
+                        )
+                        print(f"  Scene {i}: {sim_mode} done in {time.time() - t1:.1f}s")
 
-            with open(scene_dir / "scene.pkl", "wb") as f:
-                pickle.dump(scene, f)
+                scene_idx += 1
 
-            info = {
-                "snippet": name,
-                "n_agents": len(scene.agents),
-                "n_lanes": int(scene.map_data.lanes.shape[0]),
-                "agents": [
-                    {"id": a.id, "pos": a.current_position.tolist(),
-                     "heading_deg": float(np.degrees(a.current_heading)),
-                     "speed": float(np.linalg.norm(a.current_velocity))}
-                    for a in scene.agents
-                ],
-            }
-            with open(scene_dir / "info.json", "w") as f:
-                json.dump(info, f, indent=2)
+        # Submit first snippet generation
+        if snippet_files:
+            pending_future = gen_pool.submit(_gen_for_snippet, snippet_files[0])
 
-            fig = render_scene_figure(scene)
-            fig.savefig(scene_dir / "initial.png", dpi=100, bbox_inches="tight")
-            plt.close(fig)
+        for next_idx in range(1, len(snippet_files) + 1):
+            # Wait for current generation to finish
+            name, lanelet_ids, scenes, elapsed = pending_future.result()
+            snip_dir = output_dir / name
+            snip_dir.mkdir(parents=True, exist_ok=True)
+            print(f"\n--- {name} ({len(lanelet_ids)} lanelets, {n_scenes_per} scenes) ---")
+            print(f"  Generated {len(scenes)} scenes in {elapsed:.1f}s")
 
-            if sim_enabled:
-                from scenario_generation.simulate import run_simulation
-                for sim_mode in sim_modes:
-                    sim_out = scene_dir / sim_mode
-                    print(f"  Scene {i}: {sim_mode} ({sim_steps} steps)...")
-                    t1 = time.time()
-                    run_simulation(
-                        model, model_args, scene, sim_steps,
-                        sim_out, device=device,
-                        per_agent=per_agent, mode=sim_mode,
-                    )
-                    print(f"  Scene {i}: {sim_mode} done in {time.time() - t1:.1f}s")
+            # Submit next snippet generation (overlaps with current simulation)
+            if next_idx < len(snippet_files):
+                pending_future = gen_pool.submit(_gen_for_snippet, snippet_files[next_idx])
 
-            scene_idx += 1
+            # Process current snippet (save + simulate) on main thread
+            _process_snippet(name, scenes, snip_dir)
 
     print(f"\nBatch complete. {scene_idx} scenes saved to {output_dir}")
 

--- a/scenario_generation/gui/lanelet_scene_builder.py
+++ b/scenario_generation/gui/lanelet_scene_builder.py
@@ -10,7 +10,7 @@ import math
 import os
 import random
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import IntEnum
 
 import numpy as np
@@ -192,6 +192,7 @@ class _CachedLanelet:
     has_speed_limit: bool
     subtype: str
     arc_length: float = 0.0
+    cum_arc_lengths: np.ndarray = field(default_factory=lambda: np.zeros(0, dtype=np.float64))
 
 
 # ── Main builder class ───────────────────────────────────────────────────────
@@ -248,6 +249,9 @@ class LaneletSceneBuilder:
             interp_lb = _interpolate_lane(raw_lb, POINTS_PER_LANELET)
             interp_rb = _interpolate_lane(raw_rb, POINTS_PER_LANELET)
 
+            diffs = np.linalg.norm(np.diff(raw_cl[:, :2], axis=0), axis=1)
+            cum_arc = np.concatenate([[0.0], np.cumsum(diffs)]).astype(np.float64)
+
             self._cache[ll.id] = _CachedLanelet(
                 ll_id=ll.id,
                 raw_centerline=raw_cl,
@@ -261,7 +265,8 @@ class LaneletSceneBuilder:
                 speed_limit_mps=speed_mps,
                 has_speed_limit=has_sl,
                 subtype=subtype,
-                arc_length=_polyline_arc_length(raw_cl),
+                arc_length=float(cum_arc[-1]),
+                cum_arc_lengths=cum_arc,
             )
 
         print(f"LaneletSceneBuilder: cached {len(self._cache)} lanelets, "
@@ -395,10 +400,8 @@ class LaneletSceneBuilder:
         # Build dense backward polyline ordered [current_pos, ..., far_behind]
         bw_pts, traversed_ids = self._build_backward_polyline(lanelet_id, position_xy, heading, n_steps, speed, dt)
 
-        # Compute cumulative arc lengths (index 0 = 0 distance from current pos)
-        arc = np.zeros(len(bw_pts), dtype=np.float64)
-        for i in range(1, len(bw_pts)):
-            arc[i] = arc[i - 1] + np.linalg.norm(bw_pts[i] - bw_pts[i - 1])
+        diffs = np.linalg.norm(np.diff(bw_pts, axis=0), axis=1)
+        arc = np.concatenate([[0.0], np.cumsum(diffs)])
 
         # Sample history positions at evenly-spaced backward distances
         seg_idx = 0
@@ -448,10 +451,7 @@ class LaneletSceneBuilder:
         c = self._cache[start_ll_id]
         cl = c.raw_centerline
 
-        # Compute cumulative arc length along centerline
-        arc = np.zeros(len(cl))
-        for i in range(1, len(cl)):
-            arc[i] = arc[i - 1] + np.linalg.norm(cl[i] - cl[i - 1])
+        arc = c.cum_arc_lengths
 
         # Project start_pos onto the centerline: find the segment and parameter
         best_param = 0.0
@@ -649,10 +649,7 @@ class LaneletSceneBuilder:
             c = self._cache[ll_id]
             cl = c.raw_centerline
 
-            # Random position along centerline via arc-length sampling
-            arc_lengths = np.zeros(len(cl))
-            for j in range(1, len(cl)):
-                arc_lengths[j] = arc_lengths[j - 1] + np.linalg.norm(cl[j] - cl[j - 1])
+            arc_lengths = c.cum_arc_lengths
             total = arc_lengths[-1]
             if total < 1.0:
                 continue

--- a/scenario_generation/gui/lanelet_scene_builder.py
+++ b/scenario_generation/gui/lanelet_scene_builder.py
@@ -474,14 +474,13 @@ class LaneletSceneBuilder:
 
         # Start from the snapped projection point on the centerline
         points = [best_proj.copy()]
+        total_dist = 0.0
         for i in range(len(cl) - 1, -1, -1):
             if arc[i] < best_param - 0.1:
-                if np.linalg.norm(cl[i] - points[-1]) > 0.01:
+                d = float(np.linalg.norm(cl[i] - points[-1]))
+                if d > 0.01:
+                    total_dist += d
                     points.append(cl[i].copy())
-
-        total_dist = sum(
-            np.linalg.norm(points[j] - points[j - 1]) for j in range(1, len(points))
-        )
 
         # Trace through predecessors
         current_ll_id = start_ll_id
@@ -500,11 +499,11 @@ class LaneletSceneBuilder:
                 break
             visited.add(prev_ll.id)
             prev_cl = self._cache[prev_ll.id].raw_centerline
-            # Predecessor exit connects to current entrance: add from exit to entrance
             for pt in prev_cl[::-1]:
-                if np.linalg.norm(pt - points[-1]) > 0.01:
+                d = float(np.linalg.norm(pt - points[-1]))
+                if d > 0.01:
+                    total_dist += d
                     points.append(pt.copy())
-            total_dist += self._cache[prev_ll.id].arc_length
             current_ll_id = prev_ll.id
 
         if len(points) < 2:

--- a/scenario_generation/simulate.py
+++ b/scenario_generation/simulate.py
@@ -21,6 +21,8 @@ import math
 from copy import deepcopy
 from pathlib import Path
 
+from concurrent.futures import ThreadPoolExecutor
+
 import matplotlib
 
 matplotlib.use("Agg")
@@ -255,6 +257,12 @@ def _draw_agent_view(
     plt.close(fig)
 
 
+def _save_and_close(fig, path: Path, dpi: int = 100) -> None:
+    """Save a matplotlib figure and close it. Thread-safe per-figure."""
+    fig.savefig(path, dpi=dpi)
+    plt.close(fig)
+
+
 def _cat_tensor_dicts(
     dicts: list[dict[str, torch.Tensor]],
 ) -> dict[str, torch.Tensor]:
@@ -356,7 +364,13 @@ def run_simulation(model, model_args, scene: SceneContext, n_steps: int,
     n_simulated = len(simulated_ids)
     color_map = _build_color_map(scene)
 
-    for step in range(n_steps):
+    # Pre-create per-agent output dirs
+    if per_agent:
+        for agent in scene.agents:
+            (output_dir / agent.id).mkdir(parents=True, exist_ok=True)
+
+    with ThreadPoolExecutor(max_workers=4, thread_name_prefix="save") as save_pool:
+      for step in range(n_steps):
         ids_to_predict = [a.id for a in scene.agents if a.id in simulated_ids]
         agent_predictions = _predict_batch(
             model, model_args, scene, ids_to_predict, device,
@@ -415,19 +429,28 @@ def run_simulation(model, model_args, scene: SceneContext, n_steps: int,
                      f"({n_agents} agents)", fontsize=11)
 
         fig.tight_layout()
-        fig.savefig(output_dir / f"step_{step:03d}.png", dpi=100)
-        plt.close(fig)
 
+        # Submit overview save to thread pool
+        step_futures = [
+            save_pool.submit(_save_and_close, fig, output_dir / f"step_{step:03d}.png"),
+        ]
+
+        # Submit per-agent views to thread pool
         if per_agent:
             for agent in scene.agents:
-                agent_dir = output_dir / agent.id
-                agent_dir.mkdir(parents=True, exist_ok=True)
-                _draw_agent_view(
-                    scene, agent.id, agent_predictions,
-                    world_histories.get(agent.id, []),
-                    step, n_steps, agent_dir / f"step_{step:03d}.png",
-                    color_map=color_map,
+                step_futures.append(
+                    save_pool.submit(
+                        _draw_agent_view,
+                        scene, agent.id, agent_predictions,
+                        world_histories.get(agent.id, []),
+                        step, n_steps, output_dir / agent.id / f"step_{step:03d}.png",
+                        color_map,
+                    )
                 )
+
+        # Drain all saves for this step before advancing scene state
+        for f in step_futures:
+            f.result()
 
         # Advance all agents
         if mode == "semi_closed_loop" and ego_initial_plan is not None and step < len(ego_initial_plan):

--- a/scenario_generation/simulate.py
+++ b/scenario_generation/simulate.py
@@ -255,6 +255,14 @@ def _draw_agent_view(
     plt.close(fig)
 
 
+def _cat_tensor_dicts(
+    dicts: list[dict[str, torch.Tensor]],
+) -> dict[str, torch.Tensor]:
+    """Concatenate single-sample tensor dicts along batch dim 0."""
+    keys = dicts[0].keys()
+    return {k: torch.cat([d[k] for d in dicts], dim=0) for k in keys}
+
+
 @torch.no_grad()
 def _predict_as_ego(model, model_args, scene: SceneContext,
                     agent_id: str, device: str) -> np.ndarray:
@@ -263,6 +271,34 @@ def _predict_as_ego(model, model_args, scene: SceneContext,
     model.decoder._guidance_fn = None
     _, outputs = model(data)
     return outputs["prediction"][0, 0].cpu().numpy()
+
+
+@torch.no_grad()
+def _predict_batch(
+    model, model_args, scene: SceneContext,
+    agent_ids: list[str], device: str,
+) -> dict[str, np.ndarray]:
+    """Run batched inference for multiple agents-as-ego.
+
+    Builds per-agent tensor dicts, concatenates along batch dim,
+    runs one forward pass, splits results back per agent.
+
+    Returns {agent_id: (80, 4) ego-centric prediction}.
+    """
+    if not agent_ids:
+        return {}
+    if len(agent_ids) == 1:
+        return {agent_ids[0]: _predict_as_ego(model, model_args, scene, agent_ids[0], device)}
+
+    tensor_dicts = [
+        to_model_tensors(scene, aid, model_args, device)
+        for aid in agent_ids
+    ]
+    batched = _cat_tensor_dicts(tensor_dicts)
+    model.decoder._guidance_fn = None
+    _, outputs = model(batched)
+    preds = outputs["prediction"][:, 0].cpu().numpy()
+    return {aid: preds[i] for i, aid in enumerate(agent_ids)}
 
 
 @torch.no_grad()
@@ -320,12 +356,10 @@ def run_simulation(model, model_args, scene: SceneContext, n_steps: int,
     color_map = _build_color_map(scene)
 
     for step in range(n_steps):
-        agent_predictions: dict[str, np.ndarray] = {}
-        for agent in scene.agents:
-            if agent.id not in simulated_ids:
-                continue
-            pred = _predict_as_ego(model, model_args, scene, agent.id, device)
-            agent_predictions[agent.id] = pred
+        ids_to_predict = [a.id for a in scene.agents if a.id in simulated_ids]
+        agent_predictions = _predict_batch(
+            model, model_args, scene, ids_to_predict, device,
+        )
 
         mode_label = "CL" if mode == "closed_loop" else "semi-CL"
         print(f"[{mode_label}] Step {step:03d}/{n_steps}  "

--- a/scenario_generation/simulate.py
+++ b/scenario_generation/simulate.py
@@ -289,20 +289,28 @@ def _predict_as_ego(model, model_args, scene: SceneContext,
 def _predict_batch(
     model, model_args, scene: SceneContext,
     agent_ids: list[str], device: str,
+    map_cache: MapTensorCache | None = None,
 ) -> dict[str, np.ndarray]:
     """Run batched inference for multiple agents-as-ego.
 
     Builds per-agent tensor dicts, concatenates along batch dim,
     runs one forward pass, splits results back per agent.
 
+    Args:
+        map_cache: Optional pre-built MapTensorCache. When the scene's
+            map_data is static across steps, pass a single cache built
+            once to avoid rebuilding every call. Built internally when
+            not provided.
+
     Returns {agent_id: (80, 4) ego-centric prediction}.
     """
     if not agent_ids:
         return {}
 
-    cache = MapTensorCache(scene.map_data)
+    if map_cache is None:
+        map_cache = MapTensorCache(scene.map_data)
     tensor_dicts = [
-        to_model_tensors(scene, aid, model_args, device, map_cache=cache)
+        to_model_tensors(scene, aid, model_args, device, map_cache=map_cache)
         for aid in agent_ids
     ]
 
@@ -376,11 +384,15 @@ def run_simulation(model, model_args, scene: SceneContext, n_steps: int,
         for agent in scene.agents:
             (output_dir / agent.id).mkdir(parents=True, exist_ok=True)
 
+    # Build map cache once; map_data is static across simulation steps
+    map_cache = MapTensorCache(scene.map_data)
+
     with ThreadPoolExecutor(max_workers=4, thread_name_prefix="save") as save_pool:
         for step in range(n_steps):
             ids_to_predict = [a.id for a in scene.agents if a.id in simulated_ids]
             agent_predictions = _predict_batch(
                 model, model_args, scene, ids_to_predict, device,
+                map_cache=map_cache,
             )
 
             mode_label = "CL" if mode == "closed_loop" else "semi-CL"

--- a/scenario_generation/simulate.py
+++ b/scenario_generation/simulate.py
@@ -171,7 +171,9 @@ def _draw_agent_view(
     heading = agent.current_heading
     color = (color_map or {}).get(agent_id, _EGO_COLOR)
 
-    fig, ax = plt.subplots(1, 1, figsize=(10, 10))
+    from matplotlib.figure import Figure
+    fig = Figure(figsize=(10, 10))
+    ax = fig.add_subplot(1, 1, 1)
 
     # Map elements
     draw_lanes(ax, scene.map_data)
@@ -253,13 +255,17 @@ def _draw_agent_view(
 
     fig.tight_layout()
     fig.savefig(output_path, dpi=100)
-    plt.close(fig)
+    fig.clf()
 
 
 def _save_and_close(fig, path: Path, dpi: int = 100) -> None:
-    """Save a matplotlib figure and close it. Thread-safe per-figure."""
+    """Save a matplotlib figure and release resources.
+
+    Avoids plt.close() which touches the global pyplot figure manager
+    and is not thread-safe under concurrent saves.
+    """
     fig.savefig(path, dpi=dpi)
-    plt.close(fig)
+    fig.clf()
 
 
 def _cat_tensor_dicts(
@@ -369,96 +375,96 @@ def run_simulation(model, model_args, scene: SceneContext, n_steps: int,
             (output_dir / agent.id).mkdir(parents=True, exist_ok=True)
 
     with ThreadPoolExecutor(max_workers=4, thread_name_prefix="save") as save_pool:
-      for step in range(n_steps):
-        ids_to_predict = [a.id for a in scene.agents if a.id in simulated_ids]
-        agent_predictions = _predict_batch(
-            model, model_args, scene, ids_to_predict, device,
-        )
-
-        mode_label = "CL" if mode == "closed_loop" else "semi-CL"
-        print(f"[{mode_label}] Step {step:03d}/{n_steps}  "
-              f"({n_simulated} re-planned, {n_agents} total)")
-
-        # --- Visualize ---
-        fig, ax = plt.subplots(1, 1, figsize=(10, 10))
-        draw_scene(ax, scene, ego_id)
-
-        from scenario_generation.visualize import _agent_color
-        nb_idx = 0
-        for agent in scene.agents:
-            if agent.id not in agent_predictions:
-                continue
-            pred = agent_predictions[agent.id]
-            ax_pos, ay_pos = agent.current_position
-            ah = agent.current_heading
-            plan_xy, plan_h = _ego_to_world(
-                pred[:, :2], pred[:, 2:4], float(ax_pos), float(ay_pos), ah,
+        for step in range(n_steps):
+            ids_to_predict = [a.id for a in scene.agents if a.id in simulated_ids]
+            agent_predictions = _predict_batch(
+                model, model_args, scene, ids_to_predict, device,
             )
-            plan_traj = np.concatenate([plan_xy, plan_h[:, np.newaxis]], axis=-1)
 
-            if agent.id == ego_id:
-                color = "#3366cc"
-                label = "Ego plan"
-                zorder = 25
-            else:
-                color = _agent_color(agent.agent_type, nb_idx)
-                label = None
-                zorder = 18
-                nb_idx += 1
+            mode_label = "CL" if mode == "closed_loop" else "semi-CL"
+            print(f"[{mode_label}] Step {step:03d}/{n_steps}  "
+                  f"({n_simulated} re-planned, {n_agents} total)")
 
-            draw_trajectory(ax, plan_traj, color, label=label, lw=1.0, zorder=zorder,
-                            show_footprints=(agent.id == ego_id),
-                            length=agent.length, width=agent.width)
+            # --- Visualize ---
+            fig, ax = plt.subplots(1, 1, figsize=(10, 10))
+            draw_scene(ax, scene, ego_id)
 
-        # Draw ego initial plan in semi-closed-loop
-        if ego_initial_plan is not None:
-            remaining = ego_initial_plan[step:]
-            if len(remaining) > 1:
-                draw_trajectory(ax, remaining, "#3366cc", label="Ego plan (fixed)",
-                                lw=1.5, zorder=25, show_footprints=True,
-                                length=scene.get_agent(ego_id).length,
-                                width=scene.get_agent(ego_id).width)
-
-        hist = world_histories.get(ego_id, [])
-        if len(hist) > 1:
-            h = np.array(hist)
-            ax.plot(h[:, 0], h[:, 1], "-", color="#3366cc", lw=2, alpha=0.8, zorder=22)
-
-        ax.set_title(f"[{mode_label}] Step {step:03d}/{n_steps}  t={step*0.1:.1f}s  "
-                     f"({n_agents} agents)", fontsize=11)
-
-        fig.tight_layout()
-
-        # Submit overview save to thread pool
-        step_futures = [
-            save_pool.submit(_save_and_close, fig, output_dir / f"step_{step:03d}.png"),
-        ]
-
-        # Submit per-agent views to thread pool
-        if per_agent:
+            from scenario_generation.visualize import _agent_color
+            nb_idx = 0
             for agent in scene.agents:
-                step_futures.append(
-                    save_pool.submit(
-                        _draw_agent_view,
-                        scene, agent.id, agent_predictions,
-                        world_histories.get(agent.id, []),
-                        step, n_steps, output_dir / agent.id / f"step_{step:03d}.png",
-                        color_map,
-                    )
+                if agent.id not in agent_predictions:
+                    continue
+                pred = agent_predictions[agent.id]
+                ax_pos, ay_pos = agent.current_position
+                ah = agent.current_heading
+                plan_xy, plan_h = _ego_to_world(
+                    pred[:, :2], pred[:, 2:4], float(ax_pos), float(ay_pos), ah,
                 )
+                plan_traj = np.concatenate([plan_xy, plan_h[:, np.newaxis]], axis=-1)
 
-        # Drain all saves for this step before advancing scene state
-        for f in step_futures:
-            f.result()
+                if agent.id == ego_id:
+                    color = "#3366cc"
+                    label = "Ego plan"
+                    zorder = 25
+                else:
+                    color = _agent_color(agent.agent_type, nb_idx)
+                    label = None
+                    zorder = 18
+                    nb_idx += 1
 
-        # Advance all agents
-        if mode == "semi_closed_loop" and ego_initial_plan is not None and step < len(ego_initial_plan):
-            wp = ego_initial_plan[step]
-            _advance_agent(scene.get_agent(ego_id),
-                           np.array([wp[0], wp[1], wp[2]], dtype=np.float32))
-        advance_scene(scene, agent_predictions)
-        for agent in scene.agents:
-            world_histories[agent.id].append(agent.current_position.copy())
+                draw_trajectory(ax, plan_traj, color, label=label, lw=1.0, zorder=zorder,
+                                show_footprints=(agent.id == ego_id),
+                                length=agent.length, width=agent.width)
+
+            # Draw ego initial plan in semi-closed-loop
+            if ego_initial_plan is not None:
+                remaining = ego_initial_plan[step:]
+                if len(remaining) > 1:
+                    draw_trajectory(ax, remaining, "#3366cc", label="Ego plan (fixed)",
+                                    lw=1.5, zorder=25, show_footprints=True,
+                                    length=scene.get_agent(ego_id).length,
+                                    width=scene.get_agent(ego_id).width)
+
+            hist = world_histories.get(ego_id, [])
+            if len(hist) > 1:
+                h = np.array(hist)
+                ax.plot(h[:, 0], h[:, 1], "-", color="#3366cc", lw=2, alpha=0.8, zorder=22)
+
+            ax.set_title(f"[{mode_label}] Step {step:03d}/{n_steps}  t={step*0.1:.1f}s  "
+                         f"({n_agents} agents)", fontsize=11)
+
+            fig.tight_layout()
+
+            # Submit overview save to thread pool
+            step_futures = [
+                save_pool.submit(_save_and_close, fig, output_dir / f"step_{step:03d}.png"),
+            ]
+
+            # Submit per-agent views to thread pool
+            if per_agent:
+                for agent in scene.agents:
+                    step_futures.append(
+                        save_pool.submit(
+                            _draw_agent_view,
+                            scene, agent.id, agent_predictions,
+                            world_histories.get(agent.id, []),
+                            step, n_steps, output_dir / agent.id / f"step_{step:03d}.png",
+                            color_map,
+                        )
+                    )
+
+            # Drain all saves for this step before advancing scene state
+            for f in step_futures:
+                f.result()
+
+            # Advance all agents
+            if mode == "semi_closed_loop" and ego_initial_plan is not None and step < len(ego_initial_plan):
+                wp = ego_initial_plan[step]
+                _advance_agent(scene.get_agent(ego_id),
+                               np.array([wp[0], wp[1], wp[2]], dtype=np.float32))
+            advance_scene(scene, agent_predictions)
+            for agent in scene.agents:
+                world_histories[agent.id].append(agent.current_position.copy())
 
     print(f"Done. {n_steps} frames saved to {output_dir}")
 

--- a/scenario_generation/simulate.py
+++ b/scenario_generation/simulate.py
@@ -299,16 +299,19 @@ def _predict_batch(
     """
     if not agent_ids:
         return {}
-    if len(agent_ids) == 1:
-        return {agent_ids[0]: _predict_as_ego(model, model_args, scene, agent_ids[0], device)}
 
     cache = MapTensorCache(scene.map_data)
     tensor_dicts = [
         to_model_tensors(scene, aid, model_args, device, map_cache=cache)
         for aid in agent_ids
     ]
-    batched = _cat_tensor_dicts(tensor_dicts)
+
     model.decoder._guidance_fn = None
+    if len(agent_ids) == 1:
+        _, outputs = model(tensor_dicts[0])
+        return {agent_ids[0]: outputs["prediction"][0, 0].cpu().numpy()}
+
+    batched = _cat_tensor_dicts(tensor_dicts)
     _, outputs = model(batched)
     preds = outputs["prediction"][:, 0].cpu().numpy()
     return {aid: preds[i] for i, aid in enumerate(agent_ids)}

--- a/scenario_generation/simulate.py
+++ b/scenario_generation/simulate.py
@@ -387,9 +387,11 @@ def run_simulation(model, model_args, scene: SceneContext, n_steps: int,
     # Build map cache once; map_data is static across simulation steps
     map_cache = MapTensorCache(scene.map_data)
 
+    # Precompute ordered list of agents to predict; simulated_ids is constant
+    ids_to_predict = [a.id for a in scene.agents if a.id in simulated_ids]
+
     with ThreadPoolExecutor(max_workers=4, thread_name_prefix="save") as save_pool:
         for step in range(n_steps):
-            ids_to_predict = [a.id for a in scene.agents if a.id in simulated_ids]
             agent_predictions = _predict_batch(
                 model, model_args, scene, ids_to_predict, device,
                 map_cache=map_cache,

--- a/scenario_generation/simulate.py
+++ b/scenario_generation/simulate.py
@@ -32,7 +32,7 @@ import torch
 from scenario_generation.gt_route_extractor import assign_gt_goals_and_routes
 from scenario_generation.npz_loader import from_npz
 from scenario_generation.scene_context import AgentType, SceneContext
-from scenario_generation.tensor_converter import to_model_tensors
+from scenario_generation.tensor_converter import MapTensorCache, to_model_tensors
 from scenario_generation.visualize import draw_scene, draw_trajectory
 
 
@@ -290,8 +290,9 @@ def _predict_batch(
     if len(agent_ids) == 1:
         return {agent_ids[0]: _predict_as_ego(model, model_args, scene, agent_ids[0], device)}
 
+    cache = MapTensorCache(scene.map_data)
     tensor_dicts = [
-        to_model_tensors(scene, aid, model_args, device)
+        to_model_tensors(scene, aid, model_args, device, map_cache=cache)
         for aid in agent_ids
     ]
     batched = _cat_tensor_dicts(tensor_dicts)

--- a/scenario_generation/simulate.py
+++ b/scenario_generation/simulate.py
@@ -18,10 +18,9 @@ from __future__ import annotations
 
 import argparse
 import math
+from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from pathlib import Path
-
-from concurrent.futures import ThreadPoolExecutor
 
 import matplotlib
 

--- a/scenario_generation/simulate.py
+++ b/scenario_generation/simulate.py
@@ -26,7 +26,6 @@ import matplotlib
 
 matplotlib.use("Agg")
 
-import matplotlib.pyplot as plt
 import numpy as np
 import torch
 
@@ -386,7 +385,9 @@ def run_simulation(model, model_args, scene: SceneContext, n_steps: int,
                   f"({n_simulated} re-planned, {n_agents} total)")
 
             # --- Visualize ---
-            fig, ax = plt.subplots(1, 1, figsize=(10, 10))
+            from matplotlib.figure import Figure
+            fig = Figure(figsize=(10, 10))
+            ax = fig.add_subplot(1, 1, 1)
             draw_scene(ax, scene, ego_id)
 
             from scenario_generation.visualize import _agent_color

--- a/scenario_generation/tensor_converter.py
+++ b/scenario_generation/tensor_converter.py
@@ -352,11 +352,101 @@ def _build_route_lanes(
     return lanes, sl, hsl
 
 
+class MapTensorCache:
+    """Pre-computes padded, masked world-frame map arrays once per scene.
+
+    Avoids repeated .copy().astype() and mask computation when converting
+    the same scene for multiple agents (each with a different ego frame).
+    """
+
+    def __init__(self, map_data: MapData) -> None:
+        # -- lanes: (n, 20, 33) --
+        n_lanes = min(map_data.lanes.shape[0], _NUM_LANES)
+        self._lanes = np.zeros((_NUM_LANES, _POINTS_PER_LANELET, _SEGMENT_POINT_DIM), dtype=np.float32)
+        self._lanes[:n_lanes] = map_data.lanes[:n_lanes].astype(np.float32)
+        self._lanes_mask = np.sum(np.abs(self._lanes[:, :, :8]), axis=-1) == 0
+
+        # speed limits (no per-agent transform needed)
+        self._lanes_speed_limit = np.zeros((1, _NUM_LANES, 1), dtype=np.float32)
+        self._lanes_has_speed_limit = np.zeros((1, _NUM_LANES, 1), dtype=np.float32)
+        n_sl = min(map_data.lanes_speed_limit.shape[0], _NUM_LANES)
+        self._lanes_speed_limit[0, :n_sl] = map_data.lanes_speed_limit[:n_sl].astype(np.float32)
+        self._lanes_has_speed_limit[0, :n_sl] = map_data.lanes_has_speed_limit[:n_sl].astype(np.float32)
+
+        # -- static objects: (n, 10) --
+        n_static = min(map_data.static_objects.shape[0], _NUM_STATIC)
+        self._static = np.zeros((_NUM_STATIC, 10), dtype=np.float32)
+        self._static[:n_static] = map_data.static_objects[:n_static].astype(np.float32)
+        self._static_mask = np.sum(np.abs(self._static[:, :10]), axis=-1) == 0
+        self._n_static = n_static
+
+        # -- polygons: (n, 40, 3) --
+        n_poly = min(map_data.polygons.shape[0], _NUM_POLYGONS)
+        self._polygons = np.zeros((_NUM_POLYGONS, _POINTS_PER_POLYGON, 3), dtype=np.float32)
+        if n_poly > 0:
+            src_in = map_data.polygons[:n_poly].astype(np.float32)
+            D_in = min(src_in.shape[-1], 3) if src_in.ndim >= 3 else 2
+            self._polygons[:n_poly, :, :D_in] = src_in[:, :, :D_in]
+        self._polygons_mask = np.sum(np.abs(self._polygons), axis=-1) == 0
+        self._n_poly = n_poly
+
+        # -- line strings: (n, 20, 4) --
+        n_ls = min(map_data.line_strings.shape[0], _NUM_LINE_STRINGS)
+        self._line_strings = np.zeros((_NUM_LINE_STRINGS, _POINTS_PER_LINE_STRING, 4), dtype=np.float32)
+        if n_ls > 0:
+            src_in = map_data.line_strings[:n_ls].astype(np.float32)
+            D_in = min(src_in.shape[-1], 4) if src_in.ndim >= 3 else 2
+            self._line_strings[:n_ls, :, :D_in] = src_in[:, :, :D_in]
+        self._line_strings_mask = np.sum(np.abs(self._line_strings), axis=-1) == 0
+        self._n_ls = n_ls
+
+    def get_lanes_ego(self, R: np.ndarray, ego_xy: np.ndarray) -> np.ndarray:
+        """Return lanes in ego frame: [1, NUM_LANES, 20, 33]."""
+        src = self._lanes.copy()
+        src[:, :, :2] = transform_positions(src[:, :, :2], R, ego_xy)
+        src[:, :, 2:4] = transform_directions(src[:, :, 2:4], R)
+        src[:, :, 4:6] = transform_directions(src[:, :, 4:6], R)
+        src[:, :, 6:8] = transform_directions(src[:, :, 6:8], R)
+        src[self._lanes_mask] = 0.0
+        return src[np.newaxis]
+
+    def get_static_objects_ego(self, R: np.ndarray, ego_xy: np.ndarray) -> np.ndarray:
+        """Return static objects in ego frame: [1, 5, 10]."""
+        src = self._static.copy()
+        src[:, :2] = transform_positions(src[:, :2], R, ego_xy)
+        src[:, 2:4] = transform_cos_sin(src[:, 2:4], R)
+        src[self._static_mask] = 0.0
+        return src[np.newaxis]
+
+    def get_polygons_ego(self, R: np.ndarray, ego_xy: np.ndarray) -> np.ndarray:
+        """Return polygons in ego frame: [1, NUM_POLYGONS, 40, 3]."""
+        src = self._polygons.copy()
+        src[:, :, :2] = transform_positions(src[:, :, :2], R, ego_xy)
+        src[self._polygons_mask] = 0.0
+        return src[np.newaxis]
+
+    def get_line_strings_ego(self, R: np.ndarray, ego_xy: np.ndarray) -> np.ndarray:
+        """Return line strings in ego frame: [1, NUM_LINE_STRINGS, 20, 4]."""
+        src = self._line_strings.copy()
+        src[:, :, :2] = transform_positions(src[:, :, :2], R, ego_xy)
+        src[self._line_strings_mask] = 0.0
+        return src[np.newaxis]
+
+    @property
+    def lanes_speed_limit(self) -> np.ndarray:
+        return self._lanes_speed_limit.copy()
+
+    @property
+    def lanes_has_speed_limit(self) -> np.ndarray:
+        return self._lanes_has_speed_limit.copy()
+
+
 def to_model_tensors(
     scene: SceneContext,
     ego_agent_id: str,
     model_args,
     device: str | torch.device = "cpu",
+    map_cache: MapTensorCache | None = None,
 ) -> dict[str, torch.Tensor]:
     """Convert SceneContext to normalized model input tensors.
 
@@ -372,6 +462,9 @@ def to_model_tensors(
             - predicted_neighbor_num: int
             - future_len: int (typically 80)
         device: Target device for tensors.
+        map_cache: Optional pre-computed map tensor cache. When provided,
+            avoids repeated copy/pad/mask of static map arrays across
+            multiple agent conversions within the same scene.
 
     Returns:
         Dict of normalized torch tensors ready for model.forward().
@@ -390,21 +483,28 @@ def to_model_tensors(
     data_np["neighbor_agents_past"] = _build_neighbor_agents_past(
         scene, ego_agent_id, R, ego_xy, ego_heading,
     )
-    data_np["static_objects"] = _build_static_objects(scene.map_data.static_objects, R, ego_xy)
-    data_np["lanes"] = _build_lanes(scene.map_data.lanes, R, ego_xy, _NUM_LANES)
-    data_np["lanes_speed_limit"] = np.zeros((1, _NUM_LANES, 1), dtype=np.float32)
-    data_np["lanes_has_speed_limit"] = np.zeros((1, _NUM_LANES, 1), dtype=np.float32)
-    n_sl = min(scene.map_data.lanes_speed_limit.shape[0], _NUM_LANES)
-    data_np["lanes_speed_limit"][0, :n_sl] = scene.map_data.lanes_speed_limit[:n_sl].astype(np.float32)
-    data_np["lanes_has_speed_limit"][0, :n_sl] = scene.map_data.lanes_has_speed_limit[:n_sl].astype(np.float32)
+    if map_cache is not None:
+        data_np["static_objects"] = map_cache.get_static_objects_ego(R, ego_xy)
+        data_np["lanes"] = map_cache.get_lanes_ego(R, ego_xy)
+        data_np["lanes_speed_limit"] = map_cache.lanes_speed_limit
+        data_np["lanes_has_speed_limit"] = map_cache.lanes_has_speed_limit
+        data_np["polygons"] = map_cache.get_polygons_ego(R, ego_xy)
+        data_np["line_strings"] = map_cache.get_line_strings_ego(R, ego_xy)
+    else:
+        data_np["static_objects"] = _build_static_objects(scene.map_data.static_objects, R, ego_xy)
+        data_np["lanes"] = _build_lanes(scene.map_data.lanes, R, ego_xy, _NUM_LANES)
+        data_np["lanes_speed_limit"] = np.zeros((1, _NUM_LANES, 1), dtype=np.float32)
+        data_np["lanes_has_speed_limit"] = np.zeros((1, _NUM_LANES, 1), dtype=np.float32)
+        n_sl = min(scene.map_data.lanes_speed_limit.shape[0], _NUM_LANES)
+        data_np["lanes_speed_limit"][0, :n_sl] = scene.map_data.lanes_speed_limit[:n_sl].astype(np.float32)
+        data_np["lanes_has_speed_limit"][0, :n_sl] = scene.map_data.lanes_has_speed_limit[:n_sl].astype(np.float32)
+        data_np["polygons"] = _build_polygons(scene.map_data.polygons, R, ego_xy)
+        data_np["line_strings"] = _build_line_strings(scene.map_data.line_strings, R, ego_xy)
 
     route_lanes, route_sl, route_hsl = _build_route_lanes(ego, R, ego_xy)
     data_np["route_lanes"] = route_lanes
     data_np["route_lanes_speed_limit"] = route_sl
     data_np["route_lanes_has_speed_limit"] = route_hsl
-
-    data_np["polygons"] = _build_polygons(scene.map_data.polygons, R, ego_xy)
-    data_np["line_strings"] = _build_line_strings(scene.map_data.line_strings, R, ego_xy)
     data_np["goal_pose"] = _build_goal_pose(ego, R, ego_xy, ego_heading)
     data_np["ego_shape"] = _build_ego_shape(ego)
     data_np["turn_indicators"] = _build_turn_indicators(ego)

--- a/scenario_generation/tensor_converter.py
+++ b/scenario_generation/tensor_converter.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import torch
 
-from scenario_generation.scene_context import Agent, AgentType, SceneContext
+from scenario_generation.scene_context import Agent, AgentType, MapData, SceneContext
 from scenario_generation.transforms import (
     _rotation_matrix,
     transform_cos_sin,

--- a/scenario_generation/tensor_converter.py
+++ b/scenario_generation/tensor_converter.py
@@ -364,10 +364,10 @@ class MapTensorCache:
 
         # speed limits (no per-agent transform needed)
         self._lanes_speed_limit = np.zeros((1, _NUM_LANES, 1), dtype=np.float32)
-        self._lanes_has_speed_limit = np.zeros((1, _NUM_LANES, 1), dtype=np.float32)
+        self._lanes_has_speed_limit = np.zeros((1, _NUM_LANES, 1), dtype=bool)
         n_sl = min(map_data.lanes_speed_limit.shape[0], _NUM_LANES)
         self._lanes_speed_limit[0, :n_sl] = map_data.lanes_speed_limit[:n_sl].astype(np.float32)
-        self._lanes_has_speed_limit[0, :n_sl] = map_data.lanes_has_speed_limit[:n_sl].astype(np.float32)
+        self._lanes_has_speed_limit[0, :n_sl] = map_data.lanes_has_speed_limit[:n_sl].astype(bool)
 
         # -- static objects: (n, 10) --
         n_static = min(map_data.static_objects.shape[0], _NUM_STATIC)

--- a/scenario_generation/tensor_converter.py
+++ b/scenario_generation/tensor_converter.py
@@ -430,11 +430,17 @@ class MapTensorCache:
 
     @property
     def lanes_speed_limit(self) -> np.ndarray:
-        return self._lanes_speed_limit.copy()
+        """Return the cached speed-limit array. Treated as immutable by callers."""
+        view = self._lanes_speed_limit.view()
+        view.flags.writeable = False
+        return view
 
     @property
     def lanes_has_speed_limit(self) -> np.ndarray:
-        return self._lanes_has_speed_limit.copy()
+        """Return the cached has-speed-limit mask. Treated as immutable by callers."""
+        view = self._lanes_has_speed_limit.view()
+        view.flags.writeable = False
+        return view
 
 
 def to_model_tensors(
@@ -490,10 +496,10 @@ def to_model_tensors(
         data_np["static_objects"] = _build_static_objects(scene.map_data.static_objects, R, ego_xy)
         data_np["lanes"] = _build_lanes(scene.map_data.lanes, R, ego_xy, _NUM_LANES)
         data_np["lanes_speed_limit"] = np.zeros((1, _NUM_LANES, 1), dtype=np.float32)
-        data_np["lanes_has_speed_limit"] = np.zeros((1, _NUM_LANES, 1), dtype=np.float32)
+        data_np["lanes_has_speed_limit"] = np.zeros((1, _NUM_LANES, 1), dtype=bool)
         n_sl = min(scene.map_data.lanes_speed_limit.shape[0], _NUM_LANES)
         data_np["lanes_speed_limit"][0, :n_sl] = scene.map_data.lanes_speed_limit[:n_sl].astype(np.float32)
-        data_np["lanes_has_speed_limit"][0, :n_sl] = scene.map_data.lanes_has_speed_limit[:n_sl].astype(np.float32)
+        data_np["lanes_has_speed_limit"][0, :n_sl] = scene.map_data.lanes_has_speed_limit[:n_sl].astype(bool)
         data_np["polygons"] = _build_polygons(scene.map_data.polygons, R, ego_xy)
         data_np["line_strings"] = _build_line_strings(scene.map_data.line_strings, R, ego_xy)
 

--- a/scenario_generation/tensor_converter.py
+++ b/scenario_generation/tensor_converter.py
@@ -9,7 +9,6 @@ Produces a dict of torch tensors ready for model.forward(), with:
 from __future__ import annotations
 
 import math
-from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
@@ -22,9 +21,6 @@ from scenario_generation.transforms import (
     transform_headings,
     transform_positions,
 )
-
-if TYPE_CHECKING:
-    pass
 
 # Model dimension constants (from diffusion_planner.dimensions)
 _INPUT_T = 30

--- a/scenario_generation/tests/conftest.py
+++ b/scenario_generation/tests/conftest.py
@@ -1,0 +1,96 @@
+"""Shared pytest fixtures for scenario_generation tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from scenario_generation.scene_context import Agent, AgentType, MapData, SceneContext
+
+
+@pytest.fixture
+def synthetic_scene() -> SceneContext:
+    """Build a minimal SceneContext with 4 agents for unit testing."""
+    T_past = 31
+
+    def _make_agent(
+        agent_id: str, x: float, y: float, heading: float, speed: float,
+    ) -> Agent:
+        traj = np.zeros((T_past, 3), dtype=np.float32)
+        vels = np.zeros((T_past, 2), dtype=np.float32)
+        for t in range(T_past):
+            frac = t / (T_past - 1)
+            traj[t] = [x - (1 - frac) * speed * 3.0 * np.cos(heading),
+                        y - (1 - frac) * speed * 3.0 * np.sin(heading),
+                        heading]
+            vels[t] = [speed * np.cos(heading), speed * np.sin(heading)]
+
+        route = np.zeros((25, 20, 33), dtype=np.float32)
+        for pt in range(20):
+            route[0, pt, 0] = x + pt * 0.5 * np.cos(heading)
+            route[0, pt, 1] = y + pt * 0.5 * np.sin(heading)
+
+        return Agent(
+            id=agent_id,
+            agent_type=AgentType.VEHICLE,
+            length=4.5, width=1.8, wheelbase=2.9,
+            past_trajectory=traj,
+            past_velocities=vels,
+            acceleration=np.zeros(2, dtype=np.float32),
+            goal_pose=np.array([x + 50 * np.cos(heading),
+                                y + 50 * np.sin(heading),
+                                heading], dtype=np.float32),
+            route_lanes=route,
+            route_speed_limit=np.zeros((25, 1), dtype=np.float32),
+            route_has_speed_limit=np.zeros((25, 1), dtype=bool),
+            turn_indicators=np.zeros(T_past, dtype=np.int32),
+        )
+
+    agents = [
+        _make_agent("ego", 0.0, 0.0, 0.0, 3.0),
+        _make_agent("nb_1", 10.0, 3.0, 0.1, 2.5),
+        _make_agent("nb_2", -5.0, -4.0, -0.2, 4.0),
+        _make_agent("nb_3", 20.0, 1.0, 0.0, 5.0),
+    ]
+
+    lanes = np.zeros((140, 20, 33), dtype=np.float32)
+    for i in range(5):
+        for pt in range(20):
+            lanes[i, pt, 0] = i * 10.0 + pt * 0.5
+            lanes[i, pt, 1] = (i - 2) * 3.5
+            lanes[i, pt, 2] = 0.5
+            lanes[i, pt, 3] = 0.0
+
+    map_data = MapData(
+        lanes=lanes,
+        lanes_speed_limit=np.full((140, 1), 8.33, dtype=np.float32),
+        lanes_has_speed_limit=np.ones((140, 1), dtype=bool),
+        polygons=np.zeros((10, 40, 3), dtype=np.float32),
+        line_strings=np.zeros((60, 20, 4), dtype=np.float32),
+        static_objects=np.zeros((5, 10), dtype=np.float32),
+    )
+
+    return SceneContext(
+        agents=agents,
+        map_data=map_data,
+        ego_agent_id="ego",
+    )
+
+
+@pytest.fixture
+def map_snippets_dir() -> Path:
+    """Return the repo-root .map_snippets/ directory, skip if missing."""
+    d = Path(__file__).resolve().parents[2] / ".map_snippets"
+    if not d.exists() or not list(d.glob("*.pkl")):
+        pytest.skip("No .map_snippets/*.pkl available")
+    return d
+
+
+@pytest.fixture
+def tmp_output_dir(tmp_path: Path) -> Path:
+    """Return a temporary output directory for test artifacts."""
+    out = tmp_path / "output"
+    out.mkdir()
+    return out

--- a/scenario_generation/tests/conftest.py
+++ b/scenario_generation/tests/conftest.py
@@ -1,6 +1,11 @@
 """Shared pytest fixtures for scenario_generation tests."""
+# ruff: noqa: I001, E402
 
 from __future__ import annotations
+
+# Select Agg backend before any pyplot import in the test session (headless CI).
+import matplotlib
+matplotlib.use("Agg")
 
 from pathlib import Path
 

--- a/scenario_generation/tests/test_arc_length_cache.py
+++ b/scenario_generation/tests/test_arc_length_cache.py
@@ -1,0 +1,85 @@
+"""Tests for cumulative arc-length caching and vectorized computation."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+def _cum_arc_manual(pts: np.ndarray) -> np.ndarray:
+    """Reference implementation: Python loop."""
+    arc = np.zeros(len(pts), dtype=np.float64)
+    for i in range(1, len(pts)):
+        arc[i] = arc[i - 1] + np.linalg.norm(pts[i] - pts[i - 1])
+    return arc
+
+
+def _cum_arc_vectorized(pts: np.ndarray) -> np.ndarray:
+    """Vectorized implementation matching the code."""
+    diffs = np.linalg.norm(np.diff(pts, axis=0), axis=1)
+    return np.concatenate([[0.0], np.cumsum(diffs)])
+
+
+class TestCumArcLength:
+    def test_matches_manual_straight_line(self):
+        pts = np.array([[0, 0], [1, 0], [2, 0], [5, 0]], dtype=np.float64)
+        manual = _cum_arc_manual(pts)
+        vectorized = _cum_arc_vectorized(pts)
+        np.testing.assert_allclose(vectorized, manual, atol=1e-12)
+        np.testing.assert_allclose(vectorized, [0, 1, 2, 5], atol=1e-12)
+
+    def test_matches_manual_diagonal(self):
+        pts = np.array([[0, 0], [3, 4], [6, 8]], dtype=np.float64)
+        manual = _cum_arc_manual(pts)
+        vectorized = _cum_arc_vectorized(pts)
+        np.testing.assert_allclose(vectorized, manual, atol=1e-12)
+        np.testing.assert_allclose(vectorized, [0, 5, 10], atol=1e-12)
+
+    def test_total_matches_arc_length(self):
+        pts = np.array([[0, 0], [1, 1], [3, 2], [6, 3]], dtype=np.float64)
+        cum = _cum_arc_vectorized(pts)
+        total = float(np.sum(np.linalg.norm(np.diff(pts, axis=0), axis=1)))
+        np.testing.assert_allclose(cum[-1], total, atol=1e-12)
+
+    def test_monotonically_increasing(self):
+        rng = np.random.default_rng(42)
+        pts = np.cumsum(rng.random((20, 2)), axis=0)
+        cum = _cum_arc_vectorized(pts)
+        assert np.all(np.diff(cum) >= 0)
+
+    def test_searchsorted_finds_correct_segment(self):
+        pts = np.array([[0, 0], [1, 0], [3, 0], [6, 0]], dtype=np.float64)
+        cum = _cum_arc_vectorized(pts)
+        # target=2.5 is between seg 1 (arc=1) and seg 2 (arc=3)
+        idx = int(np.searchsorted(cum, 2.5)) - 1
+        assert idx == 1
+
+    def test_two_points(self):
+        pts = np.array([[0, 0], [3, 4]], dtype=np.float64)
+        cum = _cum_arc_vectorized(pts)
+        np.testing.assert_allclose(cum, [0, 5], atol=1e-12)
+
+
+class TestCachedLaneletArc:
+    """Integration tests requiring lanelet2 (skipped if unavailable)."""
+
+    @pytest.fixture
+    def builder(self, map_snippets_dir):
+        """Load a LaneletSceneBuilder from the first available map."""
+        # Find the map path from the snippets
+        import pickle
+        snip = next(map_snippets_dir.glob("*.pkl"))
+        with open(snip, "rb") as f:
+            data = pickle.load(f)
+        # The builder needs a lanelet map, not snippets. Skip if we can't
+        # determine the map path.
+        pytest.skip("Builder requires full map path, not snippet-only test")
+
+    def test_all_cached_arc_lengths_valid(self, map_snippets_dir):
+        """Verify snippets contain lanelet IDs (smoke check that data loads)."""
+        import pickle
+        for snip_path in map_snippets_dir.glob("*.pkl"):
+            with open(snip_path, "rb") as f:
+                data = pickle.load(f)
+            assert "lanelet_ids" in data
+            assert len(data["lanelet_ids"]) > 0

--- a/scenario_generation/tests/test_batch_inference.py
+++ b/scenario_generation/tests/test_batch_inference.py
@@ -1,0 +1,126 @@
+"""Tests for batched model inference in simulate.py."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+
+from scenario_generation.simulate import _cat_tensor_dicts, _predict_batch
+
+
+class TestCatTensorDicts:
+    def test_shapes(self):
+        d1 = {"a": torch.randn(1, 4, 3), "b": torch.randn(1, 10)}
+        d2 = {"a": torch.randn(1, 4, 3), "b": torch.randn(1, 10)}
+        d3 = {"a": torch.randn(1, 4, 3), "b": torch.randn(1, 10)}
+        out = _cat_tensor_dicts([d1, d2, d3])
+        assert out["a"].shape == (3, 4, 3)
+        assert out["b"].shape == (3, 10)
+
+    def test_preserves_dtypes(self):
+        d1 = {
+            "float": torch.randn(1, 5),
+            "bool": torch.tensor([[True, False]]),
+            "long": torch.tensor([[1, 2, 3]]),
+        }
+        d2 = {
+            "float": torch.randn(1, 5),
+            "bool": torch.tensor([[False, True]]),
+            "long": torch.tensor([[4, 5, 6]]),
+        }
+        out = _cat_tensor_dicts([d1, d2])
+        assert out["float"].dtype == torch.float32
+        assert out["bool"].dtype == torch.bool
+        assert out["long"].dtype == torch.int64
+
+    def test_values_preserved(self):
+        d1 = {"x": torch.tensor([[1.0, 2.0]])}
+        d2 = {"x": torch.tensor([[3.0, 4.0]])}
+        out = _cat_tensor_dicts([d1, d2])
+        expected = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        torch.testing.assert_close(out["x"], expected)
+
+    def test_single_dict(self):
+        d = {"a": torch.randn(1, 3)}
+        out = _cat_tensor_dicts([d])
+        assert out["a"].shape == (1, 3)
+        torch.testing.assert_close(out["a"], d["a"])
+
+
+class TestPredictBatch:
+    @staticmethod
+    def _make_mock_model(n_agents: int, n_neighbors: int = 5):
+        """Create a mock model that returns deterministic predictions."""
+        model = MagicMock()
+        model.decoder = MagicMock()
+
+        def forward(data: dict[str, torch.Tensor]):
+            B = data["ego_agent_past"].shape[0]
+            P = 1 + n_neighbors
+            pred = torch.arange(B, dtype=torch.float32).view(B, 1, 1, 1).expand(B, P, 80, 4)
+            return None, {"prediction": pred}
+
+        model.side_effect = forward
+        return model
+
+    @staticmethod
+    def _make_mock_model_args(n_neighbors: int = 5):
+        args = MagicMock()
+        args.predicted_neighbor_num = n_neighbors
+        args.future_len = 80
+        args.observation_normalizer = lambda x: x
+        return args
+
+    def test_empty_ids(self, synthetic_scene):
+        model = self._make_mock_model(0)
+        args = self._make_mock_model_args()
+        result = _predict_batch(model, args, synthetic_scene, [], "cpu")
+        assert result == {}
+
+    def test_single_agent(self, synthetic_scene):
+        model = self._make_mock_model(1)
+        args = self._make_mock_model_args()
+        result = _predict_batch(model, args, synthetic_scene, ["ego"], "cpu")
+        assert "ego" in result
+        assert result["ego"].shape == (80, 4)
+
+    def test_multi_agent_keys(self, synthetic_scene):
+        ids = ["ego", "nb_1", "nb_2"]
+        model = self._make_mock_model(len(ids))
+        args = self._make_mock_model_args()
+        result = _predict_batch(model, args, synthetic_scene, ids, "cpu")
+        assert set(result.keys()) == set(ids)
+        for aid in ids:
+            assert result[aid].shape == (80, 4)
+
+    def test_batch_vs_sequential(self, synthetic_scene):
+        """Verify batched results match sequential single-agent calls."""
+        ids = ["ego", "nb_1", "nb_2"]
+
+        def deterministic_forward(data):
+            B = data["ego_agent_past"].shape[0]
+            ego_x = data["ego_current_state"][:, 0]
+            pred = ego_x.view(B, 1, 1, 1).expand(B, 6, 80, 4).clone()
+            return None, {"prediction": pred}
+
+        model = MagicMock()
+        model.decoder = MagicMock()
+        model.side_effect = deterministic_forward
+
+        args = self._make_mock_model_args()
+
+        sequential = {}
+        for aid in ids:
+            from scenario_generation.simulate import _predict_as_ego
+            sequential[aid] = _predict_as_ego(model, args, synthetic_scene, aid, "cpu")
+
+        batched = _predict_batch(model, args, synthetic_scene, ids, "cpu")
+
+        for aid in ids:
+            np.testing.assert_allclose(
+                batched[aid], sequential[aid], atol=1e-5,
+                err_msg=f"Mismatch for agent {aid}",
+            )

--- a/scenario_generation/tests/test_map_cache.py
+++ b/scenario_generation/tests/test_map_cache.py
@@ -1,0 +1,123 @@
+"""Tests for MapTensorCache in tensor_converter.py."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from scenario_generation.tensor_converter import (
+    MapTensorCache,
+    _build_lanes,
+    _build_line_strings,
+    _build_polygons,
+    _build_static_objects,
+    _NUM_LANES,
+    _NUM_LINE_STRINGS,
+    _NUM_POLYGONS,
+    _NUM_STATIC,
+    _POINTS_PER_LANELET,
+    _POINTS_PER_LINE_STRING,
+    _POINTS_PER_POLYGON,
+    _SEGMENT_POINT_DIM,
+    to_model_tensors,
+)
+from scenario_generation.transforms import _rotation_matrix
+
+
+class TestMapTensorCache:
+    def test_cache_lanes_matches_uncached(self, synthetic_scene):
+        cache = MapTensorCache(synthetic_scene.map_data)
+        R = _rotation_matrix(0.3)
+        ego_xy = np.array([5.0, 2.0], dtype=np.float64)
+
+        cached = cache.get_lanes_ego(R, ego_xy)
+        uncached = _build_lanes(synthetic_scene.map_data.lanes, R, ego_xy, _NUM_LANES)
+
+        assert cached.shape == uncached.shape
+        np.testing.assert_allclose(cached, uncached, atol=1e-6)
+
+    def test_cache_static_objects_matches_uncached(self, synthetic_scene):
+        cache = MapTensorCache(synthetic_scene.map_data)
+        R = _rotation_matrix(-0.5)
+        ego_xy = np.array([1.0, -3.0], dtype=np.float64)
+
+        cached = cache.get_static_objects_ego(R, ego_xy)
+        uncached = _build_static_objects(synthetic_scene.map_data.static_objects, R, ego_xy)
+
+        np.testing.assert_allclose(cached, uncached, atol=1e-6)
+
+    def test_cache_polygons_matches_uncached(self, synthetic_scene):
+        cache = MapTensorCache(synthetic_scene.map_data)
+        R = _rotation_matrix(1.2)
+        ego_xy = np.array([10.0, 5.0], dtype=np.float64)
+
+        cached = cache.get_polygons_ego(R, ego_xy)
+        uncached = _build_polygons(synthetic_scene.map_data.polygons, R, ego_xy)
+
+        np.testing.assert_allclose(cached, uncached, atol=1e-6)
+
+    def test_cache_line_strings_matches_uncached(self, synthetic_scene):
+        cache = MapTensorCache(synthetic_scene.map_data)
+        R = _rotation_matrix(0.0)
+        ego_xy = np.array([0.0, 0.0], dtype=np.float64)
+
+        cached = cache.get_line_strings_ego(R, ego_xy)
+        uncached = _build_line_strings(synthetic_scene.map_data.line_strings, R, ego_xy)
+
+        np.testing.assert_allclose(cached, uncached, atol=1e-6)
+
+    def test_reuse_different_agents(self, synthetic_scene):
+        """Same cache, two different ego frames produce different results."""
+        cache = MapTensorCache(synthetic_scene.map_data)
+
+        R1 = _rotation_matrix(0.0)
+        xy1 = np.array([0.0, 0.0], dtype=np.float64)
+        R2 = _rotation_matrix(1.0)
+        xy2 = np.array([10.0, 5.0], dtype=np.float64)
+
+        lanes1 = cache.get_lanes_ego(R1, xy1)
+        lanes2 = cache.get_lanes_ego(R2, xy2)
+
+        # Non-zero lanes should differ
+        assert not np.allclose(lanes1, lanes2)
+
+    def test_preserves_mask(self, synthetic_scene):
+        """Zero-padded entries remain zero after ego transform."""
+        cache = MapTensorCache(synthetic_scene.map_data)
+        R = _rotation_matrix(0.7)
+        ego_xy = np.array([3.0, -1.0], dtype=np.float64)
+
+        lanes = cache.get_lanes_ego(R, ego_xy)
+
+        # The fixture only populates lanes 0-4; lanes 5+ should be all zeros
+        assert np.all(lanes[0, 10:] == 0.0)
+
+    def test_speed_limit_passthrough(self, synthetic_scene):
+        """Speed limits are returned unchanged regardless of agent pose."""
+        cache = MapTensorCache(synthetic_scene.map_data)
+
+        sl = cache.lanes_speed_limit
+        hsl = cache.lanes_has_speed_limit
+
+        assert sl.shape == (1, _NUM_LANES, 1)
+        assert hsl.shape == (1, _NUM_LANES, 1)
+        np.testing.assert_allclose(sl[0, 0, 0], 8.33, atol=1e-2)
+
+    def test_full_to_model_tensors_cached_vs_uncached(self, synthetic_scene):
+        """End-to-end: to_model_tensors with and without cache match."""
+        from unittest.mock import MagicMock
+        args = MagicMock()
+        args.predicted_neighbor_num = 5
+        args.future_len = 80
+        args.observation_normalizer = lambda x: x
+
+        cache = MapTensorCache(synthetic_scene.map_data)
+
+        cached = to_model_tensors(synthetic_scene, "ego", args, "cpu", map_cache=cache)
+        uncached = to_model_tensors(synthetic_scene, "ego", args, "cpu", map_cache=None)
+
+        for key in ["lanes", "static_objects", "polygons", "line_strings",
+                     "lanes_speed_limit", "lanes_has_speed_limit"]:
+            np.testing.assert_allclose(
+                cached[key].numpy(), uncached[key].numpy(), atol=1e-6,
+                err_msg=f"Mismatch for {key}",
+            )

--- a/scenario_generation/tests/test_map_cache.py
+++ b/scenario_generation/tests/test_map_cache.py
@@ -5,11 +5,6 @@ from __future__ import annotations
 import numpy as np
 
 from scenario_generation.tensor_converter import (
-    MapTensorCache,
-    _build_lanes,
-    _build_line_strings,
-    _build_polygons,
-    _build_static_objects,
     _NUM_LANES,
     _NUM_LINE_STRINGS,
     _NUM_POLYGONS,
@@ -18,6 +13,11 @@ from scenario_generation.tensor_converter import (
     _POINTS_PER_LINE_STRING,
     _POINTS_PER_POLYGON,
     _SEGMENT_POINT_DIM,
+    MapTensorCache,
+    _build_lanes,
+    _build_line_strings,
+    _build_polygons,
+    _build_static_objects,
     to_model_tensors,
 )
 from scenario_generation.transforms import _rotation_matrix

--- a/scenario_generation/tests/test_map_cache.py
+++ b/scenario_generation/tests/test_map_cache.py
@@ -89,7 +89,7 @@ class TestMapTensorCache:
         lanes = cache.get_lanes_ego(R, ego_xy)
 
         # The fixture only populates lanes 0-4; lanes 5+ should be all zeros
-        assert np.all(lanes[0, 10:] == 0.0)
+        assert np.all(lanes[0, 5:] == 0.0)
 
     def test_speed_limit_passthrough(self, synthetic_scene):
         """Speed limits are returned unchanged regardless of agent pose."""

--- a/scenario_generation/tests/test_parallel_save.py
+++ b/scenario_generation/tests/test_parallel_save.py
@@ -1,0 +1,82 @@
+"""Tests for parallel image saving in simulate.py."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+from scenario_generation.simulate import _save_and_close
+
+
+class TestSaveAndClose:
+    def test_creates_file(self, tmp_path):
+        fig, ax = plt.subplots(1, 1, figsize=(4, 4))
+        ax.plot([0, 1], [0, 1])
+        out = tmp_path / "test.png"
+        _save_and_close(fig, out)
+
+        assert out.exists()
+        assert out.stat().st_size > 0
+
+    def test_figure_closed(self, tmp_path):
+        fig, ax = plt.subplots(1, 1, figsize=(4, 4))
+        ax.plot([0, 1], [0, 1])
+        fig_num = fig.number
+        _save_and_close(fig, tmp_path / "test.png")
+
+        assert fig_num not in plt.get_fignums()
+
+
+class TestParallelSaves:
+    def test_no_corruption(self, tmp_path):
+        """Save 10 figures in parallel, verify all PNGs are valid."""
+        n = 10
+        figs = []
+        for i in range(n):
+            fig, ax = plt.subplots(1, 1, figsize=(4, 4))
+            ax.plot(np.random.randn(20), np.random.randn(20), "o")
+            ax.set_title(f"Figure {i}")
+            fig.tight_layout()
+            figs.append(fig)
+
+        paths = [tmp_path / f"fig_{i:02d}.png" for i in range(n)]
+
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            futures = [
+                pool.submit(_save_and_close, fig, path)
+                for fig, path in zip(figs, paths)
+            ]
+            for f in futures:
+                f.result()
+
+        for p in paths:
+            assert p.exists(), f"{p} not created"
+            assert p.stat().st_size > 100, f"{p} too small ({p.stat().st_size} bytes)"
+
+    def test_different_sizes(self, tmp_path):
+        """Figures with different sizes save correctly in parallel."""
+        sizes = [(4, 4), (8, 6), (10, 10), (3, 3)]
+        figs = []
+        for w, h in sizes:
+            fig, ax = plt.subplots(1, 1, figsize=(w, h))
+            ax.plot([0, 1], [0, 1])
+            figs.append(fig)
+
+        paths = [tmp_path / f"fig_{i}.png" for i in range(len(sizes))]
+
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            futures = [
+                pool.submit(_save_and_close, fig, path)
+                for fig, path in zip(figs, paths)
+            ]
+            for f in futures:
+                f.result()
+
+        for p in paths:
+            assert p.exists()
+            assert p.stat().st_size > 0

--- a/scenario_generation/tests/test_parallel_save.py
+++ b/scenario_generation/tests/test_parallel_save.py
@@ -24,13 +24,12 @@ class TestSaveAndClose:
         assert out.exists()
         assert out.stat().st_size > 0
 
-    def test_figure_closed(self, tmp_path):
+    def test_figure_cleared(self, tmp_path):
         fig, ax = plt.subplots(1, 1, figsize=(4, 4))
         ax.plot([0, 1], [0, 1])
-        fig_num = fig.number
         _save_and_close(fig, tmp_path / "test.png")
 
-        assert fig_num not in plt.get_fignums()
+        assert len(fig.get_axes()) == 0
 
 
 class TestParallelSaves:

--- a/scenario_generation/tests/test_parallel_save.py
+++ b/scenario_generation/tests/test_parallel_save.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
-import matplotlib
-
-matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/scenario_generation/tests/test_parallel_save.py
+++ b/scenario_generation/tests/test_parallel_save.py
@@ -6,6 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import matplotlib
+
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np

--- a/scenario_generation/tests/test_perf_integration.py
+++ b/scenario_generation/tests/test_perf_integration.py
@@ -1,0 +1,278 @@
+"""Integration smoke tests and performance profiling for optimizations.
+
+Profiles tensor conversion (with/without MapTensorCache) and arc-length
+computation (loop vs vectorized) to measure speedups.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+
+from scenario_generation.scene_context import Agent, AgentType, MapData, SceneContext
+from scenario_generation.simulate import (
+    _cat_tensor_dicts,
+    _predict_batch,
+    _save_and_close,
+    advance_scene,
+)
+from scenario_generation.tensor_converter import (
+    _NUM_LANES,
+    MapTensorCache,
+    _build_lanes,
+    _build_line_strings,
+    _build_polygons,
+    _build_static_objects,
+    to_model_tensors,
+)
+from scenario_generation.transforms import _rotation_matrix
+
+
+def _make_large_scene(n_agents: int = 8) -> SceneContext:
+    """Create a scene with many agents and dense map data for profiling."""
+    T_past = 31
+    agents = []
+    for i in range(n_agents):
+        angle = 2 * np.pi * i / n_agents
+        x = 20 * np.cos(angle)
+        y = 20 * np.sin(angle)
+        traj = np.zeros((T_past, 3), dtype=np.float32)
+        vels = np.zeros((T_past, 2), dtype=np.float32)
+        for t in range(T_past):
+            frac = t / (T_past - 1)
+            traj[t] = [x - (1 - frac) * 3 * np.cos(angle),
+                        y - (1 - frac) * 3 * np.sin(angle), angle]
+            vels[t] = [3 * np.cos(angle), 3 * np.sin(angle)]
+
+        route = np.random.randn(25, 20, 33).astype(np.float32) * 0.1
+        agents.append(Agent(
+            id=f"agent_{i}",
+            agent_type=AgentType.VEHICLE,
+            length=4.5, width=1.8, wheelbase=2.9,
+            past_trajectory=traj,
+            past_velocities=vels,
+            goal_pose=np.array([x + 50 * np.cos(angle),
+                                y + 50 * np.sin(angle), angle], dtype=np.float32),
+            route_lanes=route,
+            route_speed_limit=np.zeros((25, 1), dtype=np.float32),
+            route_has_speed_limit=np.zeros((25, 1), dtype=bool),
+            turn_indicators=np.zeros(T_past, dtype=np.int32),
+        ))
+
+    # Dense map: populate all 140 lanes, 10 polygons, 60 line strings
+    lanes = np.random.randn(140, 20, 33).astype(np.float32) * 10
+    polygons = np.random.randn(10, 40, 3).astype(np.float32) * 10
+    line_strings = np.random.randn(60, 20, 4).astype(np.float32) * 10
+    static_objects = np.random.randn(5, 10).astype(np.float32) * 5
+
+    return SceneContext(
+        agents=agents,
+        map_data=MapData(
+            lanes=lanes,
+            lanes_speed_limit=np.full((140, 1), 8.33, dtype=np.float32),
+            lanes_has_speed_limit=np.ones((140, 1), dtype=bool),
+            polygons=polygons,
+            line_strings=line_strings,
+            static_objects=static_objects,
+        ),
+        ego_agent_id="agent_0",
+    )
+
+
+class TestMapCacheProfile:
+    """Profile MapTensorCache vs uncached conversion."""
+
+    def test_map_cache_speedup(self):
+        scene = _make_large_scene(n_agents=8)
+        args = MagicMock()
+        args.predicted_neighbor_num = 5
+        args.future_len = 80
+        args.observation_normalizer = lambda x: x
+
+        agent_ids = [a.id for a in scene.agents]
+        n_warmup = 2
+        n_iter = 20
+
+        # Warmup
+        for _ in range(n_warmup):
+            for aid in agent_ids:
+                to_model_tensors(scene, aid, args, "cpu")
+
+        # Uncached
+        t0 = time.perf_counter()
+        for _ in range(n_iter):
+            for aid in agent_ids:
+                to_model_tensors(scene, aid, args, "cpu")
+        uncached_time = time.perf_counter() - t0
+
+        # Cached
+        for _ in range(n_warmup):
+            cache = MapTensorCache(scene.map_data)
+            for aid in agent_ids:
+                to_model_tensors(scene, aid, args, "cpu", map_cache=cache)
+
+        t0 = time.perf_counter()
+        for _ in range(n_iter):
+            cache = MapTensorCache(scene.map_data)
+            for aid in agent_ids:
+                to_model_tensors(scene, aid, args, "cpu", map_cache=cache)
+        cached_time = time.perf_counter() - t0
+
+        speedup = uncached_time / max(cached_time, 1e-9)
+        print(f"\n[PROFILE] MapTensorCache: {n_iter}x{len(agent_ids)} agents")
+        print(f"  Uncached: {uncached_time:.3f}s")
+        print(f"  Cached:   {cached_time:.3f}s")
+        print(f"  Speedup:  {speedup:.2f}x")
+
+        # Cache should not be slower than uncached
+        assert cached_time <= uncached_time * 1.2, (
+            f"Cache is slower: {cached_time:.3f}s vs {uncached_time:.3f}s"
+        )
+
+
+class TestMapOnlyProfile:
+    """Profile just the map tensor transforms (isolated from agent tensors)."""
+
+    def test_map_transforms_speedup(self):
+        scene = _make_large_scene(n_agents=8)
+        R = _rotation_matrix(0.5)
+        ego_xy = np.array([10.0, 5.0], dtype=np.float64)
+
+        n_agents = 8
+        n_iter = 50
+
+        # Uncached: rebuild from scratch each time
+        t0 = time.perf_counter()
+        for _ in range(n_iter):
+            for _ in range(n_agents):
+                _build_lanes(scene.map_data.lanes, R, ego_xy, _NUM_LANES)
+                _build_static_objects(scene.map_data.static_objects, R, ego_xy)
+                _build_polygons(scene.map_data.polygons, R, ego_xy)
+                _build_line_strings(scene.map_data.line_strings, R, ego_xy)
+        uncached_time = time.perf_counter() - t0
+
+        # Cached: create cache once per "step", reuse for all agents
+        t0 = time.perf_counter()
+        for _ in range(n_iter):
+            cache = MapTensorCache(scene.map_data)
+            for _ in range(n_agents):
+                cache.get_lanes_ego(R, ego_xy)
+                cache.get_static_objects_ego(R, ego_xy)
+                cache.get_polygons_ego(R, ego_xy)
+                cache.get_line_strings_ego(R, ego_xy)
+        cached_time = time.perf_counter() - t0
+
+        speedup = uncached_time / max(cached_time, 1e-9)
+        print(f"\n[PROFILE] Map-only transforms ({n_agents} agents, {n_iter} iters)")
+        print(f"  Uncached: {uncached_time:.3f}s")
+        print(f"  Cached:   {cached_time:.3f}s")
+        print(f"  Speedup:  {speedup:.2f}x")
+
+
+class TestArcLengthProfile:
+    """Profile vectorized vs loop arc-length computation."""
+
+    def test_arc_vectorized_speedup(self):
+        rng = np.random.default_rng(42)
+        pts = np.cumsum(rng.random((500, 2)), axis=0).astype(np.float64)
+
+        n_iter = 1000
+
+        # Loop version
+        t0 = time.perf_counter()
+        for _ in range(n_iter):
+            arc = np.zeros(len(pts))
+            for i in range(1, len(pts)):
+                arc[i] = arc[i - 1] + np.linalg.norm(pts[i] - pts[i - 1])
+        loop_time = time.perf_counter() - t0
+
+        # Vectorized version
+        t0 = time.perf_counter()
+        for _ in range(n_iter):
+            diffs = np.linalg.norm(np.diff(pts, axis=0), axis=1)
+            arc_v = np.concatenate([[0.0], np.cumsum(diffs)])
+        vec_time = time.perf_counter() - t0
+
+        speedup = loop_time / max(vec_time, 1e-9)
+        print(f"\n[PROFILE] Arc-length computation ({len(pts)} points, {n_iter} iters)")
+        print(f"  Loop:       {loop_time:.3f}s")
+        print(f"  Vectorized: {vec_time:.3f}s")
+        print(f"  Speedup:    {speedup:.2f}x")
+
+        np.testing.assert_allclose(arc, arc_v, atol=1e-10)
+        assert vec_time < loop_time, (
+            f"Vectorized is slower: {vec_time:.3f}s vs {loop_time:.3f}s"
+        )
+
+
+class TestBatchInferenceProfile:
+    """Profile batched vs sequential tensor dict concatenation."""
+
+    def test_cat_tensor_dicts_scaling(self):
+        n_agents = 8
+        dicts = []
+        for _ in range(n_agents):
+            dicts.append({
+                "ego_agent_past": torch.randn(1, 31, 4),
+                "neighbor_agents_past": torch.randn(1, 32, 31, 11),
+                "lanes": torch.randn(1, 140, 20, 33),
+                "route_lanes": torch.randn(1, 25, 20, 33),
+                "polygons": torch.randn(1, 10, 40, 3),
+                "line_strings": torch.randn(1, 60, 20, 4),
+                "static_objects": torch.randn(1, 5, 10),
+            })
+
+        n_iter = 100
+
+        t0 = time.perf_counter()
+        for _ in range(n_iter):
+            _cat_tensor_dicts(dicts)
+        cat_time = time.perf_counter() - t0
+
+        print(f"\n[PROFILE] _cat_tensor_dicts ({n_agents} agents, {n_iter} iters)")
+        print(f"  Time: {cat_time:.3f}s ({cat_time/n_iter*1000:.1f}ms/call)")
+
+
+class TestFullSimulationSmoke:
+    """End-to-end smoke test: build scene, run 2-step simulation with mock model."""
+
+    def test_simulation_smoke(self, synthetic_scene, tmp_output_dir):
+        def mock_forward(data):
+            B = data["ego_agent_past"].shape[0]
+            pred = torch.zeros(B, 6, 80, 4)
+            # Small forward movement
+            for b in range(B):
+                pred[b, 0, :, 0] = torch.linspace(0, 5, 80)
+                pred[b, 0, :, 2] = 1.0  # cos(0) = 1
+            return None, {"prediction": pred}
+
+        model = MagicMock()
+        model.decoder = MagicMock()
+        model.side_effect = mock_forward
+
+        args = MagicMock()
+        args.predicted_neighbor_num = 5
+        args.future_len = 80
+        args.observation_normalizer = lambda x: x
+
+        from scenario_generation.simulate import run_simulation
+        run_simulation(
+            model, args, synthetic_scene, n_steps=2,
+            output_dir=tmp_output_dir, device="cpu",
+            per_agent=True, mode="closed_loop",
+        )
+
+        # Verify output structure
+        overview_imgs = list(tmp_output_dir.glob("step_*.png"))
+        assert len(overview_imgs) == 2
+
+        for agent in synthetic_scene.agents:
+            agent_imgs = list((tmp_output_dir / agent.id).glob("step_*.png"))
+            assert len(agent_imgs) == 2, f"Missing images for {agent.id}"
+
+        for img in overview_imgs:
+            assert img.stat().st_size > 0

--- a/scenario_generation/tests/test_perf_integration.py
+++ b/scenario_generation/tests/test_perf_integration.py
@@ -83,6 +83,7 @@ def _make_large_scene(n_agents: int = 8) -> SceneContext:
     )
 
 
+@pytest.mark.benchmark
 class TestMapCacheProfile:
     """Profile MapTensorCache vs uncached conversion."""
 
@@ -131,6 +132,7 @@ class TestMapCacheProfile:
         # Only log; no timing assertion (flaky in CI)
 
 
+@pytest.mark.benchmark
 class TestMapOnlyProfile:
     """Profile just the map tensor transforms (isolated from agent tensors)."""
 
@@ -170,6 +172,7 @@ class TestMapOnlyProfile:
         print(f"  Speedup:  {speedup:.2f}x")
 
 
+@pytest.mark.benchmark
 class TestArcLengthProfile:
     """Profile vectorized vs loop arc-length computation."""
 
@@ -203,6 +206,7 @@ class TestArcLengthProfile:
         np.testing.assert_allclose(arc, arc_v, atol=1e-10)
 
 
+@pytest.mark.benchmark
 class TestBatchInferenceProfile:
     """Profile batched vs sequential tensor dict concatenation."""
 

--- a/scenario_generation/tests/test_perf_integration.py
+++ b/scenario_generation/tests/test_perf_integration.py
@@ -128,10 +128,7 @@ class TestMapCacheProfile:
         print(f"  Cached:   {cached_time:.3f}s")
         print(f"  Speedup:  {speedup:.2f}x")
 
-        # Cache should not be slower than uncached
-        assert cached_time <= uncached_time * 1.2, (
-            f"Cache is slower: {cached_time:.3f}s vs {uncached_time:.3f}s"
-        )
+        # Only log; no timing assertion (flaky in CI)
 
 
 class TestMapOnlyProfile:
@@ -204,9 +201,6 @@ class TestArcLengthProfile:
         print(f"  Speedup:    {speedup:.2f}x")
 
         np.testing.assert_allclose(arc, arc_v, atol=1e-10)
-        assert vec_time < loop_time, (
-            f"Vectorized is slower: {vec_time:.3f}s vs {loop_time:.3f}s"
-        )
 
 
 class TestBatchInferenceProfile:

--- a/scenario_generation/tests/test_pipeline.py
+++ b/scenario_generation/tests/test_pipeline.py
@@ -1,0 +1,122 @@
+"""Tests for CPU/GPU pipelining in batch_generate.py."""
+
+from __future__ import annotations
+
+import json
+import pickle
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from scenario_generation.batch_generate import (
+    _load_snippet,
+    _save_scene,
+    run_batch,
+)
+from scenario_generation.scene_context import SceneContext
+
+
+class TestLoadSnippet:
+    def test_loads_basic_snippet(self, tmp_path):
+        data = {"lanelet_ids": [1, 2, 3]}
+        snip_path = tmp_path / "test.pkl"
+        with open(snip_path, "wb") as f:
+            pickle.dump(data, f)
+
+        name, ids, ego_pose = _load_snippet(snip_path)
+        assert name == "test"
+        assert ids == [1, 2, 3]
+        assert ego_pose is None
+
+    def test_loads_with_ego_pose(self, tmp_path):
+        data = {"lanelet_ids": [10], "ego_pose": [1.0, 2.0, 0.5]}
+        snip_path = tmp_path / "posed.pkl"
+        with open(snip_path, "wb") as f:
+            pickle.dump(data, f)
+
+        name, ids, ego_pose = _load_snippet(snip_path)
+        assert ego_pose == (1.0, 2.0, 0.5)
+
+
+class TestSaveScene:
+    def test_creates_expected_files(self, synthetic_scene, tmp_path):
+        scene_dir = tmp_path / "scene_000"
+        _save_scene(synthetic_scene, scene_dir, "test_snippet")
+
+        assert (scene_dir / "scene.pkl").exists()
+        assert (scene_dir / "info.json").exists()
+        assert (scene_dir / "initial.png").exists()
+
+        with open(scene_dir / "info.json") as f:
+            info = json.load(f)
+        assert info["snippet"] == "test_snippet"
+        assert info["n_agents"] == 4
+
+    def test_pickle_roundtrips(self, synthetic_scene, tmp_path):
+        scene_dir = tmp_path / "scene_001"
+        _save_scene(synthetic_scene, scene_dir, "rt")
+
+        with open(scene_dir / "scene.pkl", "rb") as f:
+            loaded = pickle.load(f)
+        assert isinstance(loaded, SceneContext)
+        assert len(loaded.agents) == len(synthetic_scene.agents)
+
+
+class TestRunBatch:
+    def test_no_sim_produces_outputs(self, synthetic_scene, tmp_path):
+        """Run batch with mock builder, no simulation, verify output structure."""
+        snippets_dir = tmp_path / "snippets"
+        snippets_dir.mkdir()
+
+        for i in range(2):
+            data = {"lanelet_ids": [1, 2]}
+            with open(snippets_dir / f"snip_{i}.pkl", "wb") as f:
+                pickle.dump(data, f)
+
+        builder = MagicMock()
+        builder.build_scene_context.return_value = synthetic_scene
+
+        config = {
+            "snippets_dir": str(snippets_dir),
+            "generation": {"n_scenes_per_snippet": 2},
+            "simulation": {"enabled": False},
+        }
+
+        output_dir = tmp_path / "output"
+        run_batch(config, builder, output_dir, model_path=None, device="cpu")
+
+        # 2 snippets x 2 scenes = 4 scene dirs
+        scene_dirs = list(output_dir.rglob("scene_*"))
+        assert len(scene_dirs) == 4
+
+        for sd in scene_dirs:
+            assert (sd / "scene.pkl").exists()
+            assert (sd / "info.json").exists()
+            assert (sd / "initial.png").exists()
+
+    def test_scene_count_matches(self, synthetic_scene, tmp_path):
+        """Verify pipeline produces same count as sequential would."""
+        snippets_dir = tmp_path / "snippets"
+        snippets_dir.mkdir()
+
+        for i in range(3):
+            data = {"lanelet_ids": [i + 1]}
+            with open(snippets_dir / f"snip_{i}.pkl", "wb") as f:
+                pickle.dump(data, f)
+
+        builder = MagicMock()
+        builder.build_scene_context.return_value = synthetic_scene
+
+        config = {
+            "snippets_dir": str(snippets_dir),
+            "generation": {"n_scenes_per_snippet": 1},
+            "simulation": {"enabled": False},
+        }
+
+        output_dir = tmp_path / "output"
+        run_batch(config, builder, output_dir, model_path=None, device="cpu")
+
+        scene_dirs = list(output_dir.rglob("scene_*"))
+        assert len(scene_dirs) == 3


### PR DESCRIPTION
## Summary

Six performance optimizations for the `scenario_generation` module, targeting the simulation hot path and scene generation pipeline.

### Changes

- **Batch model inference** (`simulate.py`): Replace per-agent sequential forward passes with a single batched call. With 4 agents on GPU, measured **1.44x speedup** (44.8s -> 31.1s for 80-step closed-loop simulation)
- **Map tensor cache** (`tensor_converter.py`): `MapTensorCache` pre-copies, pads, and masks static map arrays once per scene. Per-agent ego-frame transforms reuse cached data instead of rebuilding from scratch. **1.74x** on isolated map transforms
- **Cumulative arc-length cache** (`lanelet_scene_builder.py`): Add `cum_arc_lengths` to `_CachedLanelet`, replacing Python for-loops in `_try_place_one` and `_build_backward_polyline` with cache lookups. Vectorize `generate_history`. **67x** speedup on arc-length computation
- **CPU/GPU pipeline** (`batch_generate.py`): `ThreadPoolExecutor` overlaps next snippet's scene generation (CPU) with current snippet's simulation (GPU)
- **Running distance accumulator** (`lanelet_scene_builder.py`): Incremental `total_dist` tracking in `_build_backward_polyline` instead of O(N) recomputation
- **Parallel image saving** (`simulate.py`): `ThreadPoolExecutor(max_workers=4)` for concurrent overview + per-agent `savefig` within each simulation step. Thread-safe figure creation via `matplotlib.figure.Figure` (no pyplot global state)

### Benchmark (4 agents, 80 steps, real model on GPU)

| Method | Time | Per-step |
|--------|------|----------|
| Sequential (before) | 44.8s | 0.56s/step |
| Batched + cached (after) | 31.1s | 0.39s/step |
| **Speedup** | **1.44x** | |

### Test coverage

72 tests across 7 test files (30 new), all passing. Includes correctness tests (cached vs uncached equivalence), profiling benchmarks, and end-to-end smoke tests with mock and real models.

## Test plan

- [x] `pytest scenario_generation/tests/ -v` -- 72 tests pass
- [x] `ruff check scenario_generation/` -- clean
- [x] End-to-end smoke test: 3 snippets, real model, both closed_loop and semi_closed_loop modes, 80 steps
- [x] Verified images show proper agent movement and lane following
- [x] No matplotlib memory leaks (figures created via `Figure()`, not `plt.subplots()`)