### PR TITLE
feat(scenario_generation): route-based closed-loop replay with NPC spawning, traffic lights, and trajectory tracking

### DIFF
--- a/scenario_generation/README.md
+++ b/scenario_generation/README.md
@@ -94,15 +94,23 @@ planner. A background NPC manager spawns and despawns neighbors around the
 ego as the simulation progresses.
 
 **Save a Route in the GUI.** Launch `python -m scenario_generation.gui
---map_path <lanelet2_map.osm>` and use:
+--map_path <lanelet2_map.osm>`. The left sidebar has a **Mode** radio
+(`Pan` / `Set Start` / `Set Goal` / `Add Waypoint`) that controls what a
+plain drag on the map places. Pan is the default. `Add Waypoint` stays
+active until you switch modes, so you can chain multiple waypoints.
 
-| Interaction | Modifier | Purpose | Visual |
+| Interaction | How to trigger | Purpose | Visual |
 |---|---|---|---|
-| Pan / zoom / rotate | drag, scroll, Alt+drag | navigate the map | |
-| Rectangle select | Ctrl+drag | existing snippet workflow | blue dashed box |
-| **Ego start pose** | Shift+drag | singular, overwrites | blue arrow |
-| **Ego goal pose** | Shift+Alt+drag | singular, overwrites | red arrow |
-| **Waypoint** | Ctrl+Shift+drag | appends to ordered list | yellow arrow, numbered |
+| Pan | drag (Mode = Pan) | navigate the map | grab cursor |
+| Zoom / rotate | scroll / Alt+drag | view controls | — |
+| Rectangle select | Ctrl+drag | existing snippet workflow (works in any mode) | blue dashed box |
+| **Ego start pose** | drag (Mode = Set Start) *or* Shift+drag | singular, overwrites | blue arrow |
+| **Ego goal pose** | drag (Mode = Set Goal) | singular, overwrites | red arrow |
+| **Waypoint** | drag (Mode = Add Waypoint) | appends to ordered list | yellow arrow, numbered |
+
+Shift+drag stays as a power-user shortcut for the start pose so the existing
+snippet workflow continues to work unchanged. Sidebar **Clear Start**,
+**Clear Goal** and **Clear Waypoints** buttons reset each part independently.
 
 The resolved route (`lanelet2.routing.RoutingGraph.shortestPathWithVia` under
 the hood) draws as a green polyline on the canvas every time start, goal, or
@@ -131,11 +139,17 @@ python -m scenario_generation.replay \
 ```
 
 Per-step PNG `step_NNNN.png` is written to `output_dir`. The simulation ends
-when either:
+when one of:
 
-- the ego reaches within `goal_tolerance_m` (default 2 m) of the goal, or
-- `max_steps` ticks have elapsed (default 6000 = 10 min of simulated data at
-  `dt = 0.1 s`).
+- The ego reaches within `goal_tolerance_m` (default 2 m) of the goal —
+  reason `goal_reached`.
+- The ego *passes* the goal (vector ego→goal points behind ego) AND its
+  closest-approach to the goal seen so far is within `goal_pass_window_m`
+  (default 25 m) — reason `goal_passed`. Catches the common case where the
+  diffusion planner doesn't perfectly stop at the goal but visibly drives
+  past it.
+- `max_steps` ticks have elapsed (default 6000 = 10 min of simulated data
+  at `dt = 0.1 s`) — reason `max_steps`.
 
 **NPC manager.** By default the manager holds the neighbor count in
 `[0, max_active_npcs]` (hard cap = 8), spawning with 30% per-tick probability

--- a/scenario_generation/README.md
+++ b/scenario_generation/README.md
@@ -138,6 +138,32 @@ python -m scenario_generation.replay \
     [--seed 42]
 ```
 
+**Advance modes.** The `advance_mode` field in `SpawnConfig` (or the JSON
+config) controls how the vehicle moves each step:
+
+| Mode | Description | Per-agent cost |
+|---|---|---|
+| `teleport` (default) | Snap to `pred[0]` each step. Original behaviour — fast but can produce aggressive driving (lane invasion, red-light running) because there are no kinematic constraints. | ~0 ms |
+| `perfect` | Euler integration with velocity from the reference trajectory and heading snap. Inspired by Autoware's `autoware_perfect_tracker`. Velocity limits how far the vehicle can move per step, preventing unphysical jumps. | ~0.01 ms |
+| `mpc` | Bicycle-model MPC via scipy L-BFGS-B. Optimises acceleration and steering over a 2 s lookahead horizon (20 steps, 5 control knots). Enforces kinematic constraints (max accel, steering limits, speed bounds). | ~13 ms |
+
+Both `perfect` and `mpc` modes apply C++-style post-processing to the
+reference trajectory before tracking: velocity moving average (window=8) and
+force-stop logic (ported from the C++ `postprocessing_utils.cpp`).
+
+Example config enabling MPC:
+
+```json
+{"advance_mode": "mpc", "seed": 42, "max_steps": 6000, "mpc_horizon_steps": 20, "mpc_n_knots": 5}
+```
+
+Key files for trajectory tracking:
+
+| File | Role |
+|---|---|
+| `mpc_tracker.py` | `MPCTracker` (bicycle MPC), `PerfectTracker` (Euler follower), `postprocess_reference` |
+| `simulate.py` | `advance_scene` (teleport), `advance_scene_mpc` (MPC/perfect tracked advance) |
+
 Per-step PNG `step_NNNN.png` is written to `output_dir`. The simulation ends
 when one of:
 
@@ -178,17 +204,11 @@ stale lane tensor as the ego moves across the map. Knobs:
   6 000-lanelet map, so lowering this is cheap if you want a stricter match
   to the ROS node's per-frame refresh.
 
-**Traffic lights.** Not wired today. The closed-loop loop accepts a
-`TrafficLightSource` protocol (`scenario_generation/traffic_light.py`) that
-defaults to "no traffic lights anywhere" (`AllNoneTLSource`). A follow-up
-session will ship a real source that mutates the 5-dim TL one-hot block at
-lane-dim indices `[8:13]` per step.
-
-**Known limitation (tracked as a future-session TODO).** The ego's
-`route_lanes` tensor is frozen at replay start. If the diffusion planner
-deviates far from `route.route_lanelet_ids`, the route context goes stale and
-the ego loses guidance. Future work: adaptive re-routing from the ego's
-current lanelet to the original goal once it drifts beyond a threshold.
+**Traffic lights.** A `TrafficLightController` manages signal group state
+machines per step. Route-facing groups cycle through green/yellow/red phases;
+perpendicular signals run in phase opposition. TL state is written into the
+5-dim one-hot block at lane-dim indices `[8:13]` of `scene.map_data.lanes`
+and into each agent's `route_lanes` tensor every step.
 
 Relevant modules:
 
@@ -196,7 +216,9 @@ Relevant modules:
 |---|---|
 | `scenario_generation/route.py` | `Route` dataclass + pickle save/load |
 | `scenario_generation/replay.py` | `run_route_replay`, `SceneNPCManager`, `SpawnConfig`, CLI |
-| `scenario_generation/traffic_light.py` | `TrafficLightSource` protocol + default "all none" |
+| `scenario_generation/simulate.py` | `advance_scene`, `advance_scene_mpc`, model inference helpers |
+| `scenario_generation/mpc_tracker.py` | `MPCTracker`, `PerfectTracker`, `postprocess_reference` |
+| `scenario_generation/traffic_light.py` | `TrafficLightController` + signal group state machines |
 | `scenario_generation/configs/replay_default.json` | Default `SpawnConfig` values |
 | `scenario_generation/tools/inspect_route.py` | CLI to dump a saved route pickle |
 | `scenario_generation/gui/app.py` | GUI panels + live route overlay wiring |

--- a/scenario_generation/README.md
+++ b/scenario_generation/README.md
@@ -86,6 +86,108 @@ Key modules in `gui/`:
 - `scene_renderer.py` -- Matplotlib rendering with all-agents and focus modes, with rotation support.
 - `app.py` -- Gradio web interface with shared interactive map canvas (also used by scene_search).
 
+### Route-based replay
+
+Pick a start, goal, and zero or more waypoints in the GUI; save the result as
+a reusable `Route` pickle; then replay it in closed-loop with the diffusion
+planner. A background NPC manager spawns and despawns neighbors around the
+ego as the simulation progresses.
+
+**Save a Route in the GUI.** Launch `python -m scenario_generation.gui
+--map_path <lanelet2_map.osm>` and use:
+
+| Interaction | Modifier | Purpose | Visual |
+|---|---|---|---|
+| Pan / zoom / rotate | drag, scroll, Alt+drag | navigate the map | |
+| Rectangle select | Ctrl+drag | existing snippet workflow | blue dashed box |
+| **Ego start pose** | Shift+drag | singular, overwrites | blue arrow |
+| **Ego goal pose** | Shift+Alt+drag | singular, overwrites | red arrow |
+| **Waypoint** | Ctrl+Shift+drag | appends to ordered list | yellow arrow, numbered |
+
+The resolved route (`lanelet2.routing.RoutingGraph.shortestPathWithVia` under
+the hood) draws as a green polyline on the canvas every time start, goal, or
+waypoints change. Click **Save Route** to pickle the full spec (including
+`route_lanelet_ids`) to disk.
+
+Inspect a saved route:
+
+```bash
+python -m scenario_generation.tools.inspect_route my_route.pkl
+```
+
+**Run closed-loop replay.**
+
+```bash
+python -m scenario_generation.replay \
+    --route my_route.pkl \
+    --model_path /path/to/best_model.pth \
+    --output_dir ./replay_out \
+    [--map_path <override>] \
+    [--steps 6000] \
+    [--max_npcs 8] \
+    [--spawn_probability 0.3] \
+    [--config scenario_generation/configs/replay_default.json] \
+    [--seed 42]
+```
+
+Per-step PNG `step_NNNN.png` is written to `output_dir`. The simulation ends
+when either:
+
+- the ego reaches within `goal_tolerance_m` (default 2 m) of the goal, or
+- `max_steps` ticks have elapsed (default 6000 = 10 min of simulated data at
+  `dt = 0.1 s`).
+
+**NPC manager.** By default the manager holds the neighbor count in
+`[0, max_active_npcs]` (hard cap = 8), spawning with 30% per-tick probability
+only when the count is below the cap. Neighbors further than
+`despawn_distance` (default 120 m) are dropped every tick. 70% of newly
+spawned neighbors get a random forward route; 30% are biased to share at
+least one lanelet with the ego's route. See
+`scenario_generation/configs/replay_default.json` for the full knob list.
+
+**Live map tensor refresh.** Every `map_refresh_steps` (default 5) ticks,
+`scene.map_data.lanes` is rebuilt from the closest lanelets to the ego plus
+the ego route + each alive NPC's current lanelet. This mirrors the
+Diffusion-Planner ROS node's per-frame lane filter — the model never sees a
+stale lane tensor as the ego moves across the map. Knobs:
+
+- `map_mask_range_m` (default 200): half-side of the AABB around the ego; a
+  lanelet passes when any of (center, first, last) centerline point is in
+  the square. The ROS node uses 100 m, but that yields only ~22 lanelets on
+  the Shinagawa map — below the training distribution (median 61). 200 m
+  matches the training median.
+- `max_map_lanelets` (default 140): hard cap, matches
+  `tensor_converter._NUM_LANES`. Ego-closest fill first; pinned ids (ego
+  route, history, NPC lanelets) fill the remaining slots.
+- `map_refresh_steps` (default 5 = 0.5 s at `dt=0.1`): refresh period. A
+  vectorised spatial query keeps the cost around 0.2 ms/call even on a
+  6 000-lanelet map, so lowering this is cheap if you want a stricter match
+  to the ROS node's per-frame refresh.
+
+**Traffic lights.** Not wired today. The closed-loop loop accepts a
+`TrafficLightSource` protocol (`scenario_generation/traffic_light.py`) that
+defaults to "no traffic lights anywhere" (`AllNoneTLSource`). A follow-up
+session will ship a real source that mutates the 5-dim TL one-hot block at
+lane-dim indices `[8:13]` per step.
+
+**Known limitation (tracked as a future-session TODO).** The ego's
+`route_lanes` tensor is frozen at replay start. If the diffusion planner
+deviates far from `route.route_lanelet_ids`, the route context goes stale and
+the ego loses guidance. Future work: adaptive re-routing from the ego's
+current lanelet to the original goal once it drifts beyond a threshold.
+
+Relevant modules:
+
+| Path | Role |
+|---|---|
+| `scenario_generation/route.py` | `Route` dataclass + pickle save/load |
+| `scenario_generation/replay.py` | `run_route_replay`, `SceneNPCManager`, `SpawnConfig`, CLI |
+| `scenario_generation/traffic_light.py` | `TrafficLightSource` protocol + default "all none" |
+| `scenario_generation/configs/replay_default.json` | Default `SpawnConfig` values |
+| `scenario_generation/tools/inspect_route.py` | CLI to dump a saved route pickle |
+| `scenario_generation/gui/app.py` | GUI panels + live route overlay wiring |
+| `scene_search/map_canvas_js.py` | JS canvas: start / goal / waypoint arrows + route polyline |
+
 ### Batch scene generation
 
 Generate N scenes per saved map snippet and run closed-loop + semi-closed-loop simulation:

--- a/scenario_generation/configs/replay_default.json
+++ b/scenario_generation/configs/replay_default.json
@@ -1,0 +1,27 @@
+{
+  "_comment_1": "Default SpawnConfig for scenario_generation.replay.run_route_replay.",
+  "_comment_2": "Matches the dataclass defaults in scenario_generation/replay.py::SpawnConfig.",
+  "_comment_3": "Distances are metres; time is simulation steps (dt=0.1 s per step).",
+
+  "spawn_period_steps": 10,
+  "max_active_npcs": 8,
+  "spawn_probability": 0.3,
+  "min_spawn_distance": 15.0,
+  "max_spawn_distance": 60.0,
+  "despawn_distance": 120.0,
+  "forward_bias": 0.8,
+  "min_npc_separation": 8.0,
+  "goal_tolerance_m": 2.0,
+  "max_steps": 6000,
+  "seed": null,
+  "ego_overlap_ratio": 0.3,
+  "npc_min_speed": 3.0,
+  "npc_max_speed": 12.0,
+  "npc_route_length_m": 120.0,
+  "curvature_threshold": 0.3,
+
+  "_comment_map": "Live map-tensor refresh. Matches the ROS node's live lane filter.",
+  "map_refresh_steps": 5,
+  "max_map_lanelets": 140,
+  "map_mask_range_m": 200.0
+}

--- a/scenario_generation/configs/replay_default.json
+++ b/scenario_generation/configs/replay_default.json
@@ -12,6 +12,7 @@
   "forward_bias": 0.8,
   "min_npc_separation": 8.0,
   "goal_tolerance_m": 2.0,
+  "goal_pass_window_m": 25.0,
   "max_steps": 6000,
   "seed": null,
   "ego_overlap_ratio": 0.3,

--- a/scenario_generation/gui/app.py
+++ b/scenario_generation/gui/app.py
@@ -194,7 +194,7 @@ def _waypoint_arrows_json(
 def _format_waypoints_md(waypoints: list, builder: LaneletSceneBuilder) -> str:
     """Render the waypoints list as a compact markdown block with snapped IDs."""
     if not waypoints:
-        return "*No waypoints. Ctrl+Shift+drag on the map to add one.*"
+        return "*No waypoints. Set Mode = **Add Waypoint** and drag on the map to add one.*"
     lines = ["| # | lanelet | x | y | heading |", "|---|---|---|---|---|"]
     for i, wp in enumerate(waypoints, 1):
         x, y, h = wp
@@ -380,9 +380,9 @@ def build_interface(
             * ``goal_pose``            → Set-Goal mode
             * ``waypoint_append``      → Add-Waypoint mode
 
-            After placing a start / goal / waypoint the mode is reset to
-            ``pan`` so the next drag doesn't accidentally re-place the same
-            thing. For rect events the mode is left untouched.
+            After placing a start or goal the mode is reset to ``pan``.
+            Waypoint mode stays active so multiple waypoints can be placed
+            in sequence. For rect events the mode is left untouched.
             """
             evt_type = getattr(evt, "type", "rect")
             no_change = gr.update()
@@ -429,7 +429,7 @@ def build_interface(
                     no_change, no_change, no_change, no_change, no_change,
                     no_change, no_change, no_change, no_change, no_change,
                     new_waypoints, _format_waypoints_md(new_waypoints, builder),
-                    reset_mode,
+                    no_change,
                 )
             else:  # rect
                 x1, y1 = evt.x1, evt.y1
@@ -570,7 +570,7 @@ def build_interface(
             at replay time.
             """
             if ego_pose is None or goal_pose is None:
-                return "Both start (Shift+drag) and goal (Shift+Alt+drag) required"
+                return "Both start and goal are required"
 
             start_pose = np.array(ego_pose, dtype=np.float32)
             goal_pose_arr = np.array(goal_pose, dtype=np.float32)

--- a/scenario_generation/gui/app.py
+++ b/scenario_generation/gui/app.py
@@ -22,16 +22,89 @@ import numpy as np
 
 from scenario_generation.gui.lanelet_scene_builder import LaneletSceneBuilder
 from scenario_generation.gui.scene_renderer import get_agent_info, render_scene_figure
+from scenario_generation.route import Route
 from scene_search.map_canvas_js import build_map_canvas_js
 from scene_search.map_renderer import MapRenderer, Viewport
+
+
+def _build_route_polyline_json(
+    builder: LaneletSceneBuilder, route_ll_ids: list[int] | None,
+) -> str:
+    """Serialise a lanelet-id sequence to the JSON format consumed by
+    ``window.__setRoute`` in the canvas JS: ``[[[x,y], ...], ...]`` — one
+    centerline polyline per resolved lanelet."""
+    if not route_ll_ids:
+        return "[]"
+    polylines = []
+    for ll_id in route_ll_ids:
+        if ll_id not in builder._cache:
+            continue
+        cl = builder._cache[ll_id].raw_centerline
+        polylines.append(cl[:, :2].tolist())
+    return json.dumps(polylines)
+
+
+def _recompute_route(
+    builder: LaneletSceneBuilder,
+    ego_pose,
+    goal_pose,
+    waypoints,
+) -> tuple[str, list[int] | None, str]:
+    """Resolve the route for the current start / goal / waypoints.
+
+    Returns ``(polyline_json, route_ll_ids, status_message)``. Returns an empty
+    polyline and ``None`` for ``route_ll_ids`` whenever the route cannot be
+    computed (missing start/goal, unreachable, off-map).
+    """
+    if ego_pose is None or goal_pose is None:
+        return "[]", None, ""
+    start_id = builder.snap_to_nearest_ll(np.asarray(ego_pose[:2], dtype=np.float32))
+    goal_id = builder.snap_to_nearest_ll(np.asarray(goal_pose[:2], dtype=np.float32))
+    if start_id is None or goal_id is None:
+        return "[]", None, "Could not snap start/goal to a drivable lanelet"
+    via_ids: list[int] = []
+    for wp in waypoints or []:
+        vid = builder.snap_to_nearest_ll(np.asarray(wp[:2], dtype=np.float32))
+        if vid is None:
+            return "[]", None, "Could not snap a waypoint to a drivable lanelet"
+        via_ids.append(vid)
+    route_ids = builder.route_with_waypoints(start_id, via_ids, goal_id)
+    if route_ids is None:
+        return "[]", None, (
+            f"Routing failed: no path from start ({start_id}) "
+            f"through {via_ids} to goal ({goal_id})"
+        )
+    poly_json = _build_route_polyline_json(builder, route_ids)
+    return poly_json, route_ids, f"Route: {len(route_ids)} lanelets"
+
+
+def _format_waypoints_md(waypoints: list, builder: LaneletSceneBuilder) -> str:
+    """Render the waypoints list as a compact markdown block with snapped IDs."""
+    if not waypoints:
+        return "*No waypoints. Ctrl+Shift+drag on the map to add one.*"
+    lines = ["| # | lanelet | x | y | heading |", "|---|---|---|---|---|"]
+    for i, wp in enumerate(waypoints, 1):
+        x, y, h = wp
+        ll = builder.snap_to_nearest_ll(np.asarray([x, y], dtype=np.float32))
+        ll_s = str(ll) if ll is not None else "?"
+        lines.append(f"| {i} | {ll_s} | {x:.1f} | {y:.1f} | {math.degrees(h):.0f}° |")
+    return "\n".join(lines)
 
 MAP_CANVAS_JS = build_map_canvas_js(tool="rectangle_and_arrow")
 
 def build_interface(
     renderer: MapRenderer,
     builder: LaneletSceneBuilder,
+    map_path_arg: str,
 ):
-    """Build the complete Gradio interface."""
+    """Build the complete Gradio interface.
+
+    Args:
+        renderer: Map tile renderer (base PNGs for the canvas).
+        builder: Lanelet scene builder used for routing + snapping.
+        map_path_arg: Absolute path to the lanelet2 ``.osm`` file. Persisted
+            into saved ``Route`` pickles so replay can re-open the same map.
+    """
 
     full_vp = renderer.initial_viewport(canvas_w=4000, canvas_h=3200)
     print("Pre-rendering full map image...")
@@ -49,6 +122,9 @@ def build_interface(
         rect_state = gr.State(value=None)   # (x1, y1, x2, y2)
         rotation_state = gr.State(value=0.0)  # map rotation angle (radians)
         ego_pose_state = gr.State(value=None)  # (x, y, heading_rad) or None
+        goal_pose_state = gr.State(value=None)  # (x, y, heading_rad) or None
+        waypoints_state = gr.State(value=[])  # list[(x, y, heading_rad)] — user order
+        route_ids_state = gr.State(value=None)  # list[int] resolved lanelet path
 
         gr.Markdown("# Scenario Generation")
 
@@ -63,12 +139,42 @@ def build_interface(
                     rect_x2 = gr.Number(label="X2", value=0, interactive=False)
                     rect_y2 = gr.Number(label="Y2", value=0, interactive=False)
                 rect_info = gr.Markdown("Ctrl+drag on map to select area")
-                gr.Markdown("### Ego Pose")
+                gr.Markdown("### Ego Start Pose")
                 with gr.Row():
                     ego_x = gr.Number(label="X", value=0, interactive=False)
                     ego_y = gr.Number(label="Y", value=0, interactive=False)
                 ego_heading = gr.Number(label="Heading (deg)", value=0, interactive=False)
-                ego_pose_info = gr.Markdown("Shift+drag to set ego pose (optional)")
+                ego_pose_info = gr.Markdown("Shift+drag to set start pose")
+
+                gr.Markdown("### Ego Goal Pose")
+                with gr.Row():
+                    goal_x = gr.Number(label="X", value=0, interactive=False)
+                    goal_y = gr.Number(label="Y", value=0, interactive=False)
+                goal_heading = gr.Number(label="Heading (deg)", value=0, interactive=False)
+                goal_pose_info = gr.Markdown("Shift+Alt+drag to set goal pose")
+
+                gr.Markdown("### Waypoints")
+                gr.Markdown(
+                    "Ctrl+Shift+drag on the map to add a waypoint. "
+                    "The resolved route is forced through them in order."
+                )
+                waypoints_display = gr.Markdown(
+                    "*No waypoints. Ctrl+Shift+drag on the map to add one.*"
+                )
+                clear_waypoints_btn = gr.Button("Clear Waypoints", variant="secondary", size="sm")
+
+                gr.Markdown("### Route")
+                route_status = gr.Markdown("*Set start + goal to resolve a route.*")
+                # Hidden textbox carrying the JSON polyline for the JS canvas.
+                route_polyline_json = gr.Textbox(value="[]", visible=False)
+
+                gr.Markdown("### Save Route")
+                route_save_path = gr.Textbox(
+                    label="Save path",
+                    value=str(Path.cwd() / "my_route.pkl"),
+                )
+                save_route_btn = gr.Button("Save Route", variant="primary")
+                save_route_status = gr.Markdown("")
 
                 gr.Markdown("### Generation Parameters")
                 n_neighbors = gr.Slider(0, 32, value=3, step=1, label="Neighbors")
@@ -121,45 +227,179 @@ def build_interface(
 
         # ===================== EVENT HANDLERS =====================
 
-        def on_canvas_click(evt: gr.EventData):
+        def on_canvas_click(evt: gr.EventData, current_waypoints):
+            """Handle a canvas click. Dispatches on evt.type:
+
+            * ``rect``                 → Ctrl+drag rectangle selection
+            * ``ego_pose``             → Shift+drag start pose (singular)
+            * ``goal_pose``            → Shift+Alt+drag goal pose (singular)
+            * ``waypoint_append``      → Ctrl+Shift+drag waypoint (appends)
+            """
             evt_type = getattr(evt, "type", "rect")
-            # All outputs: rect coords (4) + rect_info + rect_state + rotation +
-            #              ego coords (3) + ego_pose_info + ego_pose_state
-            # Use gr.update() for fields we don't change
             no_change = gr.update()
+            # Output order:
+            #   rect_x1, rect_y1, rect_x2, rect_y2, rect_info, rect_state, rotation_state,
+            #   ego_x, ego_y, ego_heading, ego_pose_info, ego_pose_state,
+            #   goal_x, goal_y, goal_heading, goal_pose_info, goal_pose_state,
+            #   waypoints_state, waypoints_display
 
             if evt_type == "ego_pose":
                 x, y = evt.x, evt.y
                 heading_deg = evt.heading
                 heading_rad = heading_deg * math.pi / 180
-                info = f"Ego: ({x:.0f}, {y:.0f}) heading={heading_deg:.0f} deg"
+                info = f"Start: ({x:.0f}, {y:.0f}) heading={heading_deg:.0f}°"
                 return (
                     no_change, no_change, no_change, no_change, no_change, no_change, no_change,
                     round(x, 1), round(y, 1), round(heading_deg, 1),
                     info, (x, y, heading_rad),
+                    no_change, no_change, no_change, no_change, no_change,
+                    no_change, no_change,
                 )
-            else:
+            elif evt_type == "goal_pose":
+                x, y = evt.x, evt.y
+                heading_deg = evt.heading
+                heading_rad = heading_deg * math.pi / 180
+                info = f"Goal: ({x:.0f}, {y:.0f}) heading={heading_deg:.0f}°"
+                return (
+                    no_change, no_change, no_change, no_change, no_change, no_change, no_change,
+                    no_change, no_change, no_change, no_change, no_change,
+                    round(x, 1), round(y, 1), round(heading_deg, 1),
+                    info, (x, y, heading_rad),
+                    no_change, no_change,
+                )
+            elif evt_type == "waypoint_append":
+                x, y = evt.x, evt.y
+                heading_rad = evt.heading * math.pi / 180
+                new_waypoints = list(current_waypoints or []) + [(x, y, heading_rad)]
+                return (
+                    no_change, no_change, no_change, no_change, no_change, no_change, no_change,
+                    no_change, no_change, no_change, no_change, no_change,
+                    no_change, no_change, no_change, no_change, no_change,
+                    new_waypoints, _format_waypoints_md(new_waypoints, builder),
+                )
+            else:  # rect
                 x1, y1 = evt.x1, evt.y1
                 x2, y2 = evt.x2, evt.y2
                 rot = getattr(evt, "rotation", 0.0) or 0.0
                 w = abs(x2 - x1)
                 h = abs(y2 - y1)
                 rot_deg = float(rot) * 180 / math.pi
-                info = f"Selected: {w:.0f}m x {h:.0f}m (rot: {rot_deg:.0f} deg)"
+                info = f"Selected: {w:.0f}m x {h:.0f}m (rot: {rot_deg:.0f}°)"
                 rect = (min(x1, x2), min(y1, y2), max(x1, x2), max(y1, y2))
                 return (
                     round(rect[0], 1), round(rect[1], 1),
                     round(rect[2], 1), round(rect[3], 1),
                     info, rect, float(rot),
                     no_change, no_change, no_change, no_change, no_change,
+                    no_change, no_change, no_change, no_change, no_change,
+                    no_change, no_change,
                 )
+
+        def refresh_route(ego_pose, goal_pose, waypoints):
+            """Recompute the route polyline + status string for the current
+            start/goal/waypoints triple. Updates the hidden textbox so the
+            downstream ``.then(None, js=...)`` can push it to the canvas."""
+            poly_json, route_ids, msg = _recompute_route(
+                builder, ego_pose, goal_pose, waypoints,
+            )
+            return poly_json, route_ids, msg or "*Set start + goal to resolve a route.*"
+
+        # JS that reads the polyline textbox and calls the canvas setter.
+        PUSH_ROUTE_JS = "(j) => { if (window.__setRoute) { window.__setRoute(j); } return []; }"
+        CLEAR_WAYPOINTS_JS = "() => { if (window.__clearWaypoints) { window.__clearWaypoints(); } return []; }"
 
         map_canvas.click(
             on_canvas_click,
+            inputs=[waypoints_state],
             outputs=[
                 rect_x1, rect_y1, rect_x2, rect_y2, rect_info, rect_state, rotation_state,
                 ego_x, ego_y, ego_heading, ego_pose_info, ego_pose_state,
+                goal_x, goal_y, goal_heading, goal_pose_info, goal_pose_state,
+                waypoints_state, waypoints_display,
             ],
+        ).then(
+            refresh_route,
+            inputs=[ego_pose_state, goal_pose_state, waypoints_state],
+            outputs=[route_polyline_json, route_ids_state, route_status],
+        ).then(
+            None, inputs=[route_polyline_json], outputs=[], js=PUSH_ROUTE_JS,
+        )
+
+        def on_clear_waypoints():
+            return [], _format_waypoints_md([], builder)
+
+        clear_waypoints_btn.click(
+            on_clear_waypoints,
+            outputs=[waypoints_state, waypoints_display],
+        ).then(
+            refresh_route,
+            inputs=[ego_pose_state, goal_pose_state, waypoints_state],
+            outputs=[route_polyline_json, route_ids_state, route_status],
+        ).then(
+            None, inputs=[route_polyline_json], outputs=[], js=PUSH_ROUTE_JS,
+        ).then(
+            None, inputs=[], outputs=[], js=CLEAR_WAYPOINTS_JS,
+        )
+
+        def on_save_route(ego_pose, goal_pose, waypoints, path):
+            """Persist the current route spec to ``path`` as a pickled ``Route``.
+
+            Computes a fresh resolved path via ``shortestPathWithVia`` so the
+            saved Route carries ``route_lanelet_ids`` without needing a re-query
+            at replay time.
+            """
+            if ego_pose is None or goal_pose is None:
+                return "Both start (Shift+drag) and goal (Shift+Alt+drag) required"
+
+            start_pose = np.array(ego_pose, dtype=np.float32)
+            goal_pose_arr = np.array(goal_pose, dtype=np.float32)
+
+            start_id = builder.snap_to_nearest_ll(start_pose[:2])
+            goal_id = builder.snap_to_nearest_ll(goal_pose_arr[:2])
+            if start_id is None or goal_id is None:
+                return "Could not snap start/goal to a drivable lanelet"
+
+            waypoint_poses = [np.array(w, dtype=np.float32) for w in (waypoints or [])]
+            waypoint_ids = [
+                builder.snap_to_nearest_ll(wp[:2]) for wp in waypoint_poses
+            ]
+            if any(wid is None for wid in waypoint_ids):
+                return "One or more waypoints did not snap to a drivable lanelet"
+
+            route_ids = builder.route_with_waypoints(start_id, waypoint_ids, goal_id)
+            if route_ids is None:
+                return (
+                    f"Routing failed: no path from start ({start_id}) "
+                    f"through {waypoint_ids} to goal ({goal_id})"
+                )
+            if route_ids[-1] != goal_id:
+                # shortestPathWithVia can land on a lane-change-adjacent lanelet;
+                # surface this loudly so users notice before running replay.
+                return (
+                    f"Routing warning: resolved path ends at {route_ids[-1]}, "
+                    f"not goal lanelet {goal_id}. Adjust start/waypoints/goal."
+                )
+
+            route = Route(
+                map_path=str(map_path_arg),
+                start_pose=start_pose,
+                goal_pose=goal_pose_arr,
+                start_lanelet_id=start_id,
+                goal_lanelet_id=goal_id,
+                waypoint_poses=waypoint_poses,
+                waypoint_lanelet_ids=waypoint_ids,
+                route_lanelet_ids=route_ids,
+            )
+            route.save(path)
+            return (
+                f"Saved to {path} — {len(route_ids)} lanelets, "
+                f"{len(waypoint_ids)} waypoints"
+            )
+
+        save_route_btn.click(
+            on_save_route,
+            inputs=[ego_pose_state, goal_pose_state, waypoints_state, route_save_path],
+            outputs=[save_route_status],
         )
 
         # Generate scene
@@ -300,7 +540,7 @@ def main():
     scene_builder = LaneletSceneBuilder(args.map_path)
     print("Starting GUI...")
 
-    demo = build_interface(map_renderer, scene_builder)
+    demo = build_interface(map_renderer, scene_builder, args.map_path)
     demo.launch(server_port=args.port, share=args.share, inbrowser=True)
 
 

--- a/scenario_generation/gui/app.py
+++ b/scenario_generation/gui/app.py
@@ -52,22 +52,48 @@ def _recompute_route(
 ) -> tuple[str, list[int] | None, str]:
     """Resolve the route for the current start / goal / waypoints.
 
+    Goal and waypoints are snapped with ``reachable_from=start_id`` so the
+    click never lands on a geometrically-close but topologically-disconnected
+    sub-network (common at overpass crossings on Shinagawa where two road
+    grids overlap but don't connect).
+
     Returns ``(polyline_json, route_ll_ids, status_message)``. Returns an empty
     polyline and ``None`` for ``route_ll_ids`` whenever the route cannot be
     computed (missing start/goal, unreachable, off-map).
     """
     if ego_pose is None or goal_pose is None:
         return "[]", None, ""
-    start_id = builder.snap_to_nearest_ll(np.asarray(ego_pose[:2], dtype=np.float32))
-    goal_id = builder.snap_to_nearest_ll(np.asarray(goal_pose[:2], dtype=np.float32))
-    if start_id is None or goal_id is None:
-        return "[]", None, "Could not snap start/goal to a drivable lanelet"
+    start_id = builder.snap_to_nearest_ll(
+        np.asarray(ego_pose[:2], dtype=np.float32),
+        heading_rad=float(ego_pose[2]),
+    )
+    if start_id is None:
+        return "[]", None, "Could not snap start to a routable lanelet"
+    goal_id = builder.snap_to_nearest_ll(
+        np.asarray(goal_pose[:2], dtype=np.float32),
+        reachable_from=start_id,
+        heading_rad=float(goal_pose[2]),
+    )
+    if goal_id is None:
+        return "[]", None, (
+            f"No routable lanelet near the goal is reachable from start "
+            f"({start_id}). Try clicking somewhere else or add a waypoint."
+        )
     via_ids: list[int] = []
-    for wp in waypoints or []:
-        vid = builder.snap_to_nearest_ll(np.asarray(wp[:2], dtype=np.float32))
+    prev_id = start_id
+    for i, wp in enumerate(waypoints or []):
+        vid = builder.snap_to_nearest_ll(
+            np.asarray(wp[:2], dtype=np.float32),
+            reachable_from=prev_id,
+            heading_rad=float(wp[2]),
+        )
         if vid is None:
-            return "[]", None, "Could not snap a waypoint to a drivable lanelet"
+            return "[]", None, (
+                f"Waypoint #{i + 1} has no routable lanelet reachable from "
+                f"the previous point."
+            )
         via_ids.append(vid)
+        prev_id = vid
     route_ids = builder.route_with_waypoints(start_id, via_ids, goal_id)
     if route_ids is None:
         return "[]", None, (
@@ -75,7 +101,94 @@ def _recompute_route(
             f"through {via_ids} to goal ({goal_id})"
         )
     poly_json = _build_route_polyline_json(builder, route_ids)
-    return poly_json, route_ids, f"Route: {len(route_ids)} lanelets"
+
+    # Diagnostic: how far did each click move to reach its snapped lanelet?
+    # Large snap distances indicate the click landed on an orphan / wrong-
+    # direction / non-routable lanelet and the snap had to walk away.
+    def _snap_dist(xy, ll_id):
+        cl = builder._cache[ll_id].raw_centerline
+        return float(np.linalg.norm(cl - np.asarray(xy, dtype=np.float32), axis=1).min())
+    ds = _snap_dist(ego_pose[:2], start_id)
+    dg = _snap_dist(goal_pose[:2], goal_id)
+    snap_note = ""
+    if ds > 10.0 or dg > 10.0:
+        snap_note = (
+            f" (snap: start {ds:.0f} m, goal {dg:.0f} m — click may be on "
+            f"an orphan / wrong-direction lanelet)"
+        )
+    return poly_json, route_ids, f"Route: {len(route_ids)} lanelets{snap_note}"
+
+
+_ARROW_LEN_M = 6.0
+
+
+def _snapped_arrow_json(
+    builder: LaneletSceneBuilder,
+    pose: tuple | None,
+    reachable_from: int | None = None,
+) -> tuple[str, int | None]:
+    """Snap a pose to a lanelet and return ``(arrow_json, snapped_ll_id)``.
+
+    The returned JSON matches the JS ``window.__setStartArrow`` /
+    ``__setGoalArrow`` format: ``{"start": [x, y], "end": [x + L*cos(h),
+    y + L*sin(h)]}`` with the start placed at the closest point on the
+    snapped lanelet's centerline (not the raw click xy) and the tip offset
+    ``_ARROW_LEN_M`` metres along the provided heading. This closes the
+    visual gap between the click position and where the route polyline
+    actually starts / ends.
+
+    Returns ``("null", None)`` when ``pose`` is ``None`` or no routable
+    lanelet is available. The JS setters interpret ``"null"`` as "erase".
+    """
+    if pose is None:
+        return "null", None
+    x, y, h = float(pose[0]), float(pose[1]), float(pose[2])
+    ll_id = builder.snap_to_nearest_ll(
+        np.asarray([x, y], dtype=np.float32),
+        reachable_from=reachable_from,
+        heading_rad=h,
+    )
+    if ll_id is None:
+        return "null", None
+    cl = builder._cache[ll_id].raw_centerline
+    dists = np.linalg.norm(cl - np.array([x, y], dtype=np.float32), axis=1)
+    closest = int(np.argmin(dists))
+    sx, sy = float(cl[closest, 0]), float(cl[closest, 1])
+    ex = sx + _ARROW_LEN_M * math.cos(h)
+    ey = sy + _ARROW_LEN_M * math.sin(h)
+    return json.dumps({"start": [sx, sy], "end": [ex, ey]}), ll_id
+
+
+def _waypoint_arrows_json(
+    builder: LaneletSceneBuilder,
+    waypoints: list,
+    start_id: int | None,
+) -> str:
+    """Return the ``window.__setWaypointArrows`` JSON for the current
+    waypoints list, each snapped to its reachable lanelet (sequentially
+    reachable from the previous point, starting with ``start_id``)."""
+    arrows = []
+    prev = start_id
+    for wp in waypoints or []:
+        x, y, h = float(wp[0]), float(wp[1]), float(wp[2])
+        ll_id = builder.snap_to_nearest_ll(
+            np.asarray([x, y], dtype=np.float32),
+            reachable_from=prev,
+            heading_rad=h,
+        )
+        if ll_id is None:
+            # Fall back to the raw click pose so the user still sees something.
+            sx, sy = x, y
+        else:
+            cl = builder._cache[ll_id].raw_centerline
+            dists = np.linalg.norm(cl - np.array([x, y], dtype=np.float32), axis=1)
+            closest = int(np.argmin(dists))
+            sx, sy = float(cl[closest, 0]), float(cl[closest, 1])
+            prev = ll_id
+        ex = sx + _ARROW_LEN_M * math.cos(h)
+        ey = sy + _ARROW_LEN_M * math.sin(h)
+        arrows.append({"start": [sx, sy], "end": [ex, ey]})
+    return json.dumps(arrows)
 
 
 def _format_waypoints_md(waypoints: list, builder: LaneletSceneBuilder) -> str:
@@ -85,7 +198,9 @@ def _format_waypoints_md(waypoints: list, builder: LaneletSceneBuilder) -> str:
     lines = ["| # | lanelet | x | y | heading |", "|---|---|---|---|---|"]
     for i, wp in enumerate(waypoints, 1):
         x, y, h = wp
-        ll = builder.snap_to_nearest_ll(np.asarray([x, y], dtype=np.float32))
+        ll = builder.snap_to_nearest_ll(
+            np.asarray([x, y], dtype=np.float32), heading_rad=float(h),
+        )
         ll_s = str(ll) if ll is not None else "?"
         lines.append(f"| {i} | {ll_s} | {x:.1f} | {y:.1f} | {math.degrees(h):.0f}° |")
     return "\n".join(lines)
@@ -139,34 +254,64 @@ def build_interface(
                     rect_x2 = gr.Number(label="X2", value=0, interactive=False)
                     rect_y2 = gr.Number(label="Y2", value=0, interactive=False)
                 rect_info = gr.Markdown("Ctrl+drag on map to select area")
+                gr.Markdown("### Mode")
+                mode_radio = gr.Radio(
+                    choices=[
+                        ("Pan", "pan"),
+                        ("Set Start", "start"),
+                        ("Set Goal", "goal"),
+                        ("Add Waypoint", "waypoint"),
+                    ],
+                    value="pan",
+                    label="Click mode",
+                    info=(
+                        "Pan = drag scrolls the map. Pick a mode, then plain "
+                        "drag on the map to place it. Ctrl+drag always = "
+                        "rectangle select (for map snippets). Shift+drag is "
+                        "a shortcut for Set Start. 'Add Waypoint' keeps "
+                        "appending waypoints until you switch mode."
+                    ),
+                )
+
                 gr.Markdown("### Ego Start Pose")
                 with gr.Row():
                     ego_x = gr.Number(label="X", value=0, interactive=False)
                     ego_y = gr.Number(label="Y", value=0, interactive=False)
                 ego_heading = gr.Number(label="Heading (deg)", value=0, interactive=False)
-                ego_pose_info = gr.Markdown("Shift+drag to set start pose")
+                ego_pose_info = gr.Markdown(
+                    "Select mode **Set Start** (or Shift+drag), then drag on the map."
+                )
+                clear_start_btn = gr.Button("Clear Start", variant="secondary", size="sm")
 
                 gr.Markdown("### Ego Goal Pose")
                 with gr.Row():
                     goal_x = gr.Number(label="X", value=0, interactive=False)
                     goal_y = gr.Number(label="Y", value=0, interactive=False)
                 goal_heading = gr.Number(label="Heading (deg)", value=0, interactive=False)
-                goal_pose_info = gr.Markdown("Shift+Alt+drag to set goal pose")
+                goal_pose_info = gr.Markdown(
+                    "Select mode **Set Goal**, then drag on the map."
+                )
+                clear_goal_btn = gr.Button("Clear Goal", variant="secondary", size="sm")
 
                 gr.Markdown("### Waypoints")
                 gr.Markdown(
-                    "Ctrl+Shift+drag on the map to add a waypoint. "
-                    "The resolved route is forced through them in order."
+                    "Select mode **Add Waypoint**, then drag on the map to "
+                    "append one. The resolved route is forced through them "
+                    "in drop order. Stays in waypoint mode until you switch."
                 )
                 waypoints_display = gr.Markdown(
-                    "*No waypoints. Ctrl+Shift+drag on the map to add one.*"
+                    "*No waypoints. Pick 'Add Waypoint' mode and drag on the map.*"
                 )
                 clear_waypoints_btn = gr.Button("Clear Waypoints", variant="secondary", size="sm")
 
                 gr.Markdown("### Route")
                 route_status = gr.Markdown("*Set start + goal to resolve a route.*")
-                # Hidden textbox carrying the JSON polyline for the JS canvas.
+                # Hidden textboxes carrying JSON state for the JS canvas
+                # (route polyline + arrow positions after snapping).
                 route_polyline_json = gr.Textbox(value="[]", visible=False)
+                start_arrow_json = gr.Textbox(value="null", visible=False)
+                goal_arrow_json = gr.Textbox(value="null", visible=False)
+                waypoint_arrows_json = gr.Textbox(value="[]", visible=False)
 
                 gr.Markdown("### Save Route")
                 route_save_path = gr.Textbox(
@@ -231,17 +376,23 @@ def build_interface(
             """Handle a canvas click. Dispatches on evt.type:
 
             * ``rect``                 → Ctrl+drag rectangle selection
-            * ``ego_pose``             → Shift+drag start pose (singular)
-            * ``goal_pose``            → Shift+Alt+drag goal pose (singular)
-            * ``waypoint_append``      → Ctrl+Shift+drag waypoint (appends)
+            * ``ego_pose``             → Set-Start mode or Shift+drag
+            * ``goal_pose``            → Set-Goal mode
+            * ``waypoint_append``      → Add-Waypoint mode
+
+            After placing a start / goal / waypoint the mode is reset to
+            ``pan`` so the next drag doesn't accidentally re-place the same
+            thing. For rect events the mode is left untouched.
             """
             evt_type = getattr(evt, "type", "rect")
             no_change = gr.update()
+            reset_mode = gr.update(value="pan")
             # Output order:
             #   rect_x1, rect_y1, rect_x2, rect_y2, rect_info, rect_state, rotation_state,
             #   ego_x, ego_y, ego_heading, ego_pose_info, ego_pose_state,
             #   goal_x, goal_y, goal_heading, goal_pose_info, goal_pose_state,
-            #   waypoints_state, waypoints_display
+            #   waypoints_state, waypoints_display,
+            #   mode_radio
 
             if evt_type == "ego_pose":
                 x, y = evt.x, evt.y
@@ -254,6 +405,7 @@ def build_interface(
                     info, (x, y, heading_rad),
                     no_change, no_change, no_change, no_change, no_change,
                     no_change, no_change,
+                    reset_mode,
                 )
             elif evt_type == "goal_pose":
                 x, y = evt.x, evt.y
@@ -266,6 +418,7 @@ def build_interface(
                     round(x, 1), round(y, 1), round(heading_deg, 1),
                     info, (x, y, heading_rad),
                     no_change, no_change,
+                    reset_mode,
                 )
             elif evt_type == "waypoint_append":
                 x, y = evt.x, evt.y
@@ -276,6 +429,7 @@ def build_interface(
                     no_change, no_change, no_change, no_change, no_change,
                     no_change, no_change, no_change, no_change, no_change,
                     new_waypoints, _format_waypoints_md(new_waypoints, builder),
+                    reset_mode,
                 )
             else:  # rect
                 x1, y1 = evt.x1, evt.y1
@@ -293,20 +447,44 @@ def build_interface(
                     no_change, no_change, no_change, no_change, no_change,
                     no_change, no_change, no_change, no_change, no_change,
                     no_change, no_change,
+                    no_change,
                 )
 
-        def refresh_route(ego_pose, goal_pose, waypoints):
-            """Recompute the route polyline + status string for the current
-            start/goal/waypoints triple. Updates the hidden textbox so the
-            downstream ``.then(None, js=...)`` can push it to the canvas."""
+        def refresh_route_and_arrows(ego_pose, goal_pose, waypoints):
+            """Recompute the route polyline + snapped arrow JSONs for the
+            current start / goal / waypoints triple.
+
+            Returns ``(route_polyline_json, start_arrow_json, goal_arrow_json,
+            waypoint_arrows_json, route_ids, status_message)``. The arrow
+            JSONs carry the *snapped* positions so the canvas viz sits on
+            the routable lanelet centerline, matching where the green route
+            polyline begins and ends — no visual gap to the raw click xy.
+            """
             poly_json, route_ids, msg = _recompute_route(
                 builder, ego_pose, goal_pose, waypoints,
             )
-            return poly_json, route_ids, msg or "*Set start + goal to resolve a route.*"
+            # Snap the three arrow sets. Start has no reachability constraint;
+            # goal and waypoints use reachable_from for consistency with the
+            # same snap logic used inside _recompute_route.
+            start_json, start_id = _snapped_arrow_json(builder, ego_pose)
+            goal_json, _ = _snapped_arrow_json(
+                builder, goal_pose, reachable_from=start_id,
+            )
+            wp_json = _waypoint_arrows_json(builder, waypoints, start_id)
+            return (
+                poly_json, start_json, goal_json, wp_json,
+                route_ids, msg or "*Set start + goal to resolve a route.*",
+            )
 
-        # JS that reads the polyline textbox and calls the canvas setter.
+        # JS hooks that read the hidden textboxes and call the canvas setters.
         PUSH_ROUTE_JS = "(j) => { if (window.__setRoute) { window.__setRoute(j); } return []; }"
-        CLEAR_WAYPOINTS_JS = "() => { if (window.__clearWaypoints) { window.__clearWaypoints(); } return []; }"
+        PUSH_START_JS = "(j) => { if (window.__setStartArrow) { window.__setStartArrow(j); } return []; }"
+        PUSH_GOAL_JS = "(j) => { if (window.__setGoalArrow) { window.__setGoalArrow(j); } return []; }"
+        PUSH_WAYPOINTS_JS = "(j) => { if (window.__setWaypointArrows) { window.__setWaypointArrows(j); } return []; }"
+        PUSH_MODE_JS = "(m) => { if (window.__setMode) { window.__setMode(m); } return []; }"
+
+        # Push the mode to the canvas JS whenever the radio changes.
+        mode_radio.change(None, inputs=[mode_radio], outputs=[], js=PUSH_MODE_JS)
 
         map_canvas.click(
             on_canvas_click,
@@ -316,14 +494,19 @@ def build_interface(
                 ego_x, ego_y, ego_heading, ego_pose_info, ego_pose_state,
                 goal_x, goal_y, goal_heading, goal_pose_info, goal_pose_state,
                 waypoints_state, waypoints_display,
+                mode_radio,
             ],
         ).then(
-            refresh_route,
+            refresh_route_and_arrows,
             inputs=[ego_pose_state, goal_pose_state, waypoints_state],
-            outputs=[route_polyline_json, route_ids_state, route_status],
-        ).then(
-            None, inputs=[route_polyline_json], outputs=[], js=PUSH_ROUTE_JS,
-        )
+            outputs=[
+                route_polyline_json, start_arrow_json, goal_arrow_json,
+                waypoint_arrows_json, route_ids_state, route_status,
+            ],
+        ).then(None, inputs=[route_polyline_json], outputs=[], js=PUSH_ROUTE_JS) \
+         .then(None, inputs=[start_arrow_json], outputs=[], js=PUSH_START_JS) \
+         .then(None, inputs=[goal_arrow_json], outputs=[], js=PUSH_GOAL_JS) \
+         .then(None, inputs=[waypoint_arrows_json], outputs=[], js=PUSH_WAYPOINTS_JS)
 
         def on_clear_waypoints():
             return [], _format_waypoints_md([], builder)
@@ -332,14 +515,52 @@ def build_interface(
             on_clear_waypoints,
             outputs=[waypoints_state, waypoints_display],
         ).then(
-            refresh_route,
+            refresh_route_and_arrows,
             inputs=[ego_pose_state, goal_pose_state, waypoints_state],
-            outputs=[route_polyline_json, route_ids_state, route_status],
+            outputs=[
+                route_polyline_json, start_arrow_json, goal_arrow_json,
+                waypoint_arrows_json, route_ids_state, route_status,
+            ],
+        ).then(None, inputs=[route_polyline_json], outputs=[], js=PUSH_ROUTE_JS) \
+         .then(None, inputs=[start_arrow_json], outputs=[], js=PUSH_START_JS) \
+         .then(None, inputs=[goal_arrow_json], outputs=[], js=PUSH_GOAL_JS) \
+         .then(None, inputs=[waypoint_arrows_json], outputs=[], js=PUSH_WAYPOINTS_JS)
+
+        def on_clear_start():
+            return None, 0, 0, 0, "Select mode **Set Start** (or Shift+drag), then drag on the map."
+
+        clear_start_btn.click(
+            on_clear_start,
+            outputs=[ego_pose_state, ego_x, ego_y, ego_heading, ego_pose_info],
         ).then(
-            None, inputs=[route_polyline_json], outputs=[], js=PUSH_ROUTE_JS,
+            refresh_route_and_arrows,
+            inputs=[ego_pose_state, goal_pose_state, waypoints_state],
+            outputs=[
+                route_polyline_json, start_arrow_json, goal_arrow_json,
+                waypoint_arrows_json, route_ids_state, route_status,
+            ],
+        ).then(None, inputs=[route_polyline_json], outputs=[], js=PUSH_ROUTE_JS) \
+         .then(None, inputs=[start_arrow_json], outputs=[], js=PUSH_START_JS) \
+         .then(None, inputs=[goal_arrow_json], outputs=[], js=PUSH_GOAL_JS) \
+         .then(None, inputs=[waypoint_arrows_json], outputs=[], js=PUSH_WAYPOINTS_JS)
+
+        def on_clear_goal():
+            return None, 0, 0, 0, "Select mode **Set Goal**, then drag on the map."
+
+        clear_goal_btn.click(
+            on_clear_goal,
+            outputs=[goal_pose_state, goal_x, goal_y, goal_heading, goal_pose_info],
         ).then(
-            None, inputs=[], outputs=[], js=CLEAR_WAYPOINTS_JS,
-        )
+            refresh_route_and_arrows,
+            inputs=[ego_pose_state, goal_pose_state, waypoints_state],
+            outputs=[
+                route_polyline_json, start_arrow_json, goal_arrow_json,
+                waypoint_arrows_json, route_ids_state, route_status,
+            ],
+        ).then(None, inputs=[route_polyline_json], outputs=[], js=PUSH_ROUTE_JS) \
+         .then(None, inputs=[start_arrow_json], outputs=[], js=PUSH_START_JS) \
+         .then(None, inputs=[goal_arrow_json], outputs=[], js=PUSH_GOAL_JS) \
+         .then(None, inputs=[waypoint_arrows_json], outputs=[], js=PUSH_WAYPOINTS_JS)
 
         def on_save_route(ego_pose, goal_pose, waypoints, path):
             """Persist the current route spec to ``path`` as a pickled ``Route``.
@@ -354,17 +575,38 @@ def build_interface(
             start_pose = np.array(ego_pose, dtype=np.float32)
             goal_pose_arr = np.array(goal_pose, dtype=np.float32)
 
-            start_id = builder.snap_to_nearest_ll(start_pose[:2])
-            goal_id = builder.snap_to_nearest_ll(goal_pose_arr[:2])
-            if start_id is None or goal_id is None:
-                return "Could not snap start/goal to a drivable lanelet"
+            start_id = builder.snap_to_nearest_ll(
+                start_pose[:2], heading_rad=float(start_pose[2]),
+            )
+            if start_id is None:
+                return "Could not snap start to a routable lanelet"
+            goal_id = builder.snap_to_nearest_ll(
+                goal_pose_arr[:2],
+                reachable_from=start_id,
+                heading_rad=float(goal_pose_arr[2]),
+            )
+            if goal_id is None:
+                return (
+                    f"No routable lanelet near the goal is reachable from "
+                    f"start ({start_id}). Try a different goal or add a waypoint."
+                )
 
             waypoint_poses = [np.array(w, dtype=np.float32) for w in (waypoints or [])]
-            waypoint_ids = [
-                builder.snap_to_nearest_ll(wp[:2]) for wp in waypoint_poses
-            ]
-            if any(wid is None for wid in waypoint_ids):
-                return "One or more waypoints did not snap to a drivable lanelet"
+            waypoint_ids: list[int] = []
+            prev_id = start_id
+            for i, wp in enumerate(waypoint_poses):
+                wid = builder.snap_to_nearest_ll(
+                    wp[:2],
+                    reachable_from=prev_id,
+                    heading_rad=float(wp[2]),
+                )
+                if wid is None:
+                    return (
+                        f"Waypoint #{i + 1} has no routable lanelet "
+                        f"reachable from the previous point."
+                    )
+                waypoint_ids.append(wid)
+                prev_id = wid
 
             route_ids = builder.route_with_waypoints(start_id, waypoint_ids, goal_id)
             if route_ids is None:

--- a/scenario_generation/gui/lanelet_scene_builder.py
+++ b/scenario_generation/gui/lanelet_scene_builder.py
@@ -29,6 +29,17 @@ for _p in _ROS_FALLBACK_PATHS:
 
 POINTS_PER_LANELET = 20
 
+# Polygon / LineString tensor constants — matched to the C++ Autoware planner
+# (~/pilot-auto.xx1/.../autoware_diffusion_planner/include/autoware/
+#  diffusion_planner/dimensions.hpp + conversion/lanelet.hpp).
+POINTS_PER_POLYGON = 40
+POINTS_PER_LINE_STRING = 20
+POLYGON_TYPE_INTERSECTION_AREA = 0
+POLYGON_TYPE_NUM = 1
+LINE_STRING_TYPE_STOP_LINE = 0
+LINE_STRING_TYPE_ROAD_BORDER = 1
+LINE_STRING_TYPE_NUM = 2
+
 
 # ── LineType enum (local copy to avoid ROS runtime dep) ──────────────────────
 
@@ -81,6 +92,61 @@ class AgentPlacement:
 
 
 # ── Geometry helpers ─────────────────────────────────────────────────────────
+
+def _resample_linestring_to_tiles(
+    pts: np.ndarray, num_points: int, max_step_m: float,
+) -> list[np.ndarray]:
+    """Mirror the C++ ``resample_line_string`` at
+    ``autoware_diffusion_planner/src/conversion/lanelet.cpp:109``.
+
+    A single polyline is split into N segments so that no sampled-point
+    step exceeds ``max_step_m``. Each segment becomes a ``(num_points, 2)``
+    tile interpolated uniformly along its arc length.
+
+    For a 500 m border with ``num_points=20`` and ``max_step_m=5.0``, the
+    unsplit step would be ``500 / 19 ≈ 26`` m — six times over. So we
+    split into ``ceil(26 / 5) = 6`` tiles of ~83 m each, each internally
+    spaced at ~4.4 m per sample. The output then carries six separate
+    tile entries in the line_strings tensor, each passing the AABB filter
+    independently, giving the model the same spatial resolution it saw
+    during training.
+    """
+    if len(pts) < 2 or num_points < 2:
+        return [pts.astype(np.float32)]
+
+    # Cumulative arc length along the polyline.
+    diffs = np.diff(pts, axis=0)
+    seg_lens = np.linalg.norm(diffs, axis=1)
+    arc = np.concatenate([[0.0], np.cumsum(seg_lens)])
+    total = float(arc[-1])
+    if total < 1e-6:
+        tile = np.tile(pts[:1].astype(np.float32), (num_points, 1))
+        return [tile]
+
+    step_m = total / (num_points - 1)
+    safe_max = max(max_step_m, 1e-6)
+    n_tiles = max(1, int(np.ceil(step_m / safe_max)))
+    tile_len = total / n_tiles
+
+    # Pre-build a linear interpolator over arc length.
+    def _point_at(s: float) -> np.ndarray:
+        s = max(0.0, min(total, s))
+        idx = int(np.searchsorted(arc, s) - 1)
+        idx = max(0, min(idx, len(arc) - 2))
+        seg = arc[idx + 1] - arc[idx]
+        t = 0.0 if seg < 1e-9 else (s - arc[idx]) / seg
+        return pts[idx] + t * (pts[idx + 1] - pts[idx])
+
+    tiles: list[np.ndarray] = []
+    for i in range(n_tiles):
+        s_start = i * tile_len
+        inner_step = tile_len / (num_points - 1)
+        tile = np.zeros((num_points, 2), dtype=np.float32)
+        for j in range(num_points):
+            tile[j] = _point_at(s_start + j * inner_step)
+        tiles.append(tile)
+    return tiles
+
 
 def _interpolate_lane(waypoints: np.ndarray, num_points: int = POINTS_PER_LANELET) -> np.ndarray:
     """Arc-length interpolation of a polyline to exactly num_points.
@@ -207,6 +273,23 @@ class LaneletSceneBuilder:
         projection = MGRSProjector(lanelet2.io.Origin(0.0, 0.0))
         self._lanelet_map = lanelet2.io.load(str(lanelet_path), projection)
 
+        # Japanese Autoware maps (e.g. Shinagawa-Odaiba) tag main driving
+        # lanes as ``subtype=road_shoulder`` — but the stock Germany/Vehicle
+        # traffic rules treat that subtype as non-drivable for vehicles,
+        # disconnecting them from the routing graph (0 successors / 0
+        # predecessors). Rewrite the subtype in-memory to ``road`` so the
+        # routing graph includes them. Geometry and all other attributes
+        # stay untouched.
+        n_promoted = 0
+        for ll in self._lanelet_map.laneletLayer:
+            if ("subtype" in ll.attributes
+                    and ll.attributes["subtype"] == "road_shoulder"):
+                ll.attributes["subtype"] = "road"
+                n_promoted += 1
+        if n_promoted:
+            print(f"LaneletSceneBuilder: promoted {n_promoted} "
+                  f"road_shoulder→road lanelets for routing")
+
         traffic_rules = lanelet2.traffic_rules.create(
             lanelet2.traffic_rules.Locations.Germany,
             lanelet2.traffic_rules.Participants.Vehicle,
@@ -217,6 +300,13 @@ class LaneletSceneBuilder:
         self._cache: dict[int, _CachedLanelet] = {}
         self._ll_by_id = {}  # lanelet2 objects by id
         self._vehicle_subtypes = {"road", "highway", "road_shoulder"}
+        # Subset of ``_vehicle_subtypes`` that actually has routing
+        # connections under Germany/Vehicle traffic rules. Used when snapping
+        # a user click to a lanelet the routing graph can plan through —
+        # ``road_shoulder`` is a vehicle-drivable geometry but has 0
+        # successors / predecessors so snapping a start or goal to it makes
+        # routing return None.
+        self._routable_subtypes = {"road", "highway"}
 
         for ll in self._lanelet_map.laneletLayer:
             subtype = ll.attributes["subtype"] if "subtype" in ll.attributes else ""
@@ -268,6 +358,52 @@ class LaneletSceneBuilder:
                 arc_length=float(cum_arc[-1]),
                 cum_arc_lengths=cum_arc,
             )
+
+        # ── Polygon + LineString cache (matches the C++ Autoware planner's
+        #    convert_to_internal_lanelet_map at ../diffusion_planner/src/
+        #    conversion/lanelet.cpp:294-317). Polygons are filtered to
+        #    ``intersection_area`` only; LineStrings to ``stop_line`` and
+        #    ``road_border`` (both populate channels 2/3 of the line_strings
+        #    tensor as one-hot LINE_STRING_TYPE_STOP_LINE=0 / _ROAD_BORDER=1).
+        self._polygons_cache: list[tuple[np.ndarray, int]] = []  # [(points (N,2), type)]
+        self._line_strings_cache: list[tuple[np.ndarray, int]] = []  # same shape
+
+        for poly in self._lanelet_map.polygonLayer:
+            ptype = poly.attributes["type"] if "type" in poly.attributes else ""
+            if ptype != "intersection_area":
+                continue
+            pts = np.array([(p.x, p.y) for p in poly], dtype=np.float32)
+            if len(pts) < 2:
+                continue
+            interp = _interpolate_lane(pts, POINTS_PER_POLYGON)
+            self._polygons_cache.append((interp, POLYGON_TYPE_INTERSECTION_AREA))
+
+        # Matches C++ resample_line_string (max_step_m = 5 m). A long border
+        # (e.g. 500 m) gets split into multiple 20-point tiles so no tile
+        # step exceeds 5 m. Without this, a 500 m border becomes a single
+        # 20-point coarse tile (26 m per step) — way below the model's
+        # training-time resolution and a likely cause of poor performance.
+        line_string_max_step_m = 5.0
+        for ls in self._lanelet_map.lineStringLayer:
+            lstype = ls.attributes["type"] if "type" in ls.attributes else ""
+            if lstype not in ("stop_line", "road_border"):
+                continue
+            pts = np.array([(p.x, p.y) for p in ls], dtype=np.float32)
+            if len(pts) < 2:
+                continue
+            type_idx = (
+                LINE_STRING_TYPE_STOP_LINE if lstype == "stop_line"
+                else LINE_STRING_TYPE_ROAD_BORDER
+            )
+            tiles = _resample_linestring_to_tiles(
+                pts, POINTS_PER_LINE_STRING, line_string_max_step_m,
+            )
+            for tile in tiles:
+                self._line_strings_cache.append((tile, type_idx))
+
+        print(f"LaneletSceneBuilder: cached {len(self._polygons_cache)} "
+              f"intersection polygons, {len(self._line_strings_cache)} line "
+              f"strings (stop_line + road_border)")
 
         # Pre-compute vectorised anchor arrays for fast spatial queries
         # (used by closest_lanelets). Rows align with ``self._vehicle_ll_ids``.
@@ -443,35 +579,104 @@ class LaneletSceneBuilder:
         return result
 
     def snap_to_nearest_ll(
-        self, xy: np.ndarray, candidate_ids: list[int] | None = None,
+        self,
+        xy: np.ndarray,
+        candidate_ids: list[int] | None = None,
+        routable_only: bool = True,
+        reachable_from: int | None = None,
+        reachable_range_m: float = 10000.0,
+        heading_rad: float | None = None,
+        heading_weight_m_per_deg: float = 0.5,
     ) -> int | None:
         """Snap a world-frame ``(x, y)`` position to the nearest drivable lanelet.
+
+        Scoring: when ``heading_rad`` is provided, the candidate score is
+        ``distance_m + heading_weight_m_per_deg * |delta_heading_deg|``. At
+        the default weight (0.5), a 180° mismatch adds 90 m to the distance —
+        so a slightly-farther lane pointing the right way wins over a
+        slightly-closer lane pointing the wrong way. This is critical for
+        dense maps (e.g. Shinagawa) where parallel opposite-direction roads
+        often lie within a few metres of each other.
 
         Args:
             xy: 2-element array-like ``[x, y]`` in MGRS world frame.
             candidate_ids: Optional restriction to a subset of lanelets. When
                 ``None``, all cached drivable lanelets are considered.
+            routable_only: When ``True`` (default), only lanelets with subtype
+                in ``self._routable_subtypes`` (``road`` / ``highway``) are
+                considered. This avoids snapping start/goal clicks onto
+                ``road_shoulder`` lanelets — those are drivable geometrically
+                but have no routing connections under Germany/Vehicle rules,
+                so ``route_between`` would return ``None``.
+            reachable_from: When set to a lanelet id, only candidates in
+                ``RoutingGraph.reachableSet(that_lanelet, reachable_range_m)``
+                are considered. Use this for snapping a goal / waypoint so
+                the click doesn't land on a geometrically-close but
+                topologically-disconnected sub-network.
+            reachable_range_m: Distance horizon for the reachable-set
+                computation (ignored when ``reachable_from`` is None).
+            heading_rad: Desired travel direction at the query point. When
+                provided, candidates with lane direction far from this are
+                penalised (see scoring formula above). ``None`` falls back
+                to pure nearest-distance snapping.
+            heading_weight_m_per_deg: Penalty weight applied to the heading
+                delta. 0.5 m/deg is a good default; raise it to snap more
+                aggressively along the click direction.
 
         Returns:
-            The lanelet id with the closest centerline point, or ``None`` when
-            no cached lanelet is available (e.g. empty ``candidate_ids``).
+            The lanelet id with the best combined score, or ``None`` when no
+            candidate passes the filters.
         """
         pos = np.asarray(xy, dtype=np.float32)[:2]
+        allowed_subtypes = (
+            self._routable_subtypes if routable_only else self._vehicle_subtypes
+        )
         if candidate_ids is None:
             candidate_ids = [
                 ll_id for ll_id, c in self._cache.items()
-                if c.subtype in self._vehicle_subtypes
+                if c.subtype in allowed_subtypes
+            ]
+        else:
+            candidate_ids = [
+                ll_id for ll_id in candidate_ids
+                if ll_id in self._cache
+                and self._cache[ll_id].subtype in allowed_subtypes
             ]
 
+        if reachable_from is not None and reachable_from in self._ll_by_id:
+            source_ll = self._ll_by_id[reachable_from]
+            reachable_ids = {
+                ll.id for ll in self._routing_graph.reachableSet(
+                    source_ll, reachable_range_m,
+                )
+            }
+            candidate_ids = [ll for ll in candidate_ids if ll in reachable_ids]
+
         best_ll_id = None
-        best_dist = float("inf")
+        best_score = float("inf")
         for ll_id in candidate_ids:
-            if ll_id not in self._cache:
-                continue
             cl = self._cache[ll_id].raw_centerline
-            d = float(np.linalg.norm(cl - pos, axis=1).min())
-            if d < best_dist:
-                best_dist = d
+            diff = cl - pos
+            dist2 = diff[:, 0] ** 2 + diff[:, 1] ** 2
+            idx = int(np.argmin(dist2))
+            dist = float(np.sqrt(dist2[idx]))
+
+            score = dist
+            if heading_rad is not None and len(cl) >= 2:
+                # Lane direction at the closest centerline point.
+                if idx < len(cl) - 1:
+                    dxdy = cl[idx + 1] - cl[idx]
+                else:
+                    dxdy = cl[idx] - cl[idx - 1]
+                lane_hdg = math.atan2(float(dxdy[1]), float(dxdy[0]))
+                delta = lane_hdg - heading_rad
+                # Wrap into [-pi, pi] and take absolute value (degrees).
+                delta = math.atan2(math.sin(delta), math.cos(delta))
+                delta_deg = abs(math.degrees(delta))
+                score += heading_weight_m_per_deg * delta_deg
+
+            if score < best_score:
+                best_score = score
                 best_ll_id = ll_id
         return best_ll_id
 
@@ -1051,11 +1256,184 @@ class LaneletSceneBuilder:
 
         return lanes, sl_arr, hsl_arr
 
-    def _build_map_data(self, ll_ids: list[int]) -> MapData:
+    # ── Polygon / LineString tensors (match C++ Autoware) ────────────────
+
+    def build_polygons_tensor(
+        self,
+        center_xy: np.ndarray,
+        max_n: int = 10,
+        mask_range: float = 100.0,
+    ) -> np.ndarray:
+        """Return a ``(max_n, POINTS_PER_POLYGON, 2 + POLYGON_TYPE_NUM)`` array
+        of intersection-area polygon points in **world frame** (not ego),
+        sorted by min-distance-to-``center_xy``.
+
+        The world-frame coordinates are written to channels [0:2]; channel
+        ``2 + type`` is set to 1.0 for the polygon's type. The
+        ``MapData.polygons`` field consumed by ``MapTensorCache`` carries the
+        world frame; the cache transforms to ego frame at inference time.
+
+        Mirrors C++
+        ``LaneSegmentContext::create_line_tensor<Polygon>(...)`` filter +
+        sort logic at
+        ``~/pilot-auto.xx1/.../autoware_diffusion_planner/src/preprocessing/
+        lane_segments.cpp:347``.
+        """
+        return self._build_line_or_polygon_tensor(
+            self._polygons_cache, center_xy, max_n,
+            POINTS_PER_POLYGON, POLYGON_TYPE_NUM, mask_range,
+        )
+
+    def build_line_strings_tensor(
+        self,
+        center_xy: np.ndarray,
+        max_n: int = 60,
+        mask_range: float = 100.0,
+    ) -> np.ndarray:
+        """Return a ``(max_n, POINTS_PER_LINE_STRING, 2 + LINE_STRING_TYPE_NUM)``
+        array of stop_line + road_border line-string points in **world frame**,
+        sorted by min-distance-to-``center_xy``. Channel layout matches
+        training NPZs:
+
+            [0]: x (world)
+            [1]: y (world)
+            [2]: one-hot stop_line
+            [3]: one-hot road_border
+        """
+        return self._build_line_or_polygon_tensor(
+            self._line_strings_cache, center_xy, max_n,
+            POINTS_PER_LINE_STRING, LINE_STRING_TYPE_NUM, mask_range,
+        )
+
+    def _build_line_or_polygon_tensor(
+        self,
+        cache: list[tuple[np.ndarray, int]],
+        center_xy: np.ndarray,
+        max_n: int,
+        num_points: int,
+        num_types: int,
+        mask_range: float,
+    ) -> np.ndarray:
+        """Shared implementation for ``build_polygons_tensor`` and
+        ``build_line_strings_tensor``. AABB pre-filter + min-distance sort +
+        top-N truncate, matching the C++ ``create_line_tensor`` template."""
+        cx, cy = float(center_xy[0]), float(center_xy[1])
+        x_min, x_max = cx - mask_range, cx + mask_range
+        y_min, y_max = cy - mask_range, cy + mask_range
+
+        scored: list[tuple[float, np.ndarray, int]] = []
+        for pts, type_idx in cache:
+            inside = (
+                ((pts[:, 0] > x_min) & (pts[:, 0] < x_max)
+                 & (pts[:, 1] > y_min) & (pts[:, 1] < y_max)).any()
+            )
+            if not inside:
+                continue
+            dx = pts[:, 0] - cx
+            dy = pts[:, 1] - cy
+            min_d = float(np.sqrt(dx * dx + dy * dy).min())
+            scored.append((min_d, pts, type_idx))
+        scored.sort(key=lambda t: t[0])
+
+        out = np.zeros((max_n, num_points, 2 + num_types), dtype=np.float32)
+        for i, (_, pts, type_idx) in enumerate(scored[:max_n]):
+            n = min(len(pts), num_points)
+            out[i, :n, 0] = pts[:n, 0]
+            out[i, :n, 1] = pts[:n, 1]
+            out[i, :n, 2 + type_idx] = 1.0
+        return out
+
+    # ── Route segment selection (match C++ Autoware) ─────────────────────
+
+    def select_route_segment_indices(
+        self,
+        route_lanelet_ids: list[int],
+        center_xy: np.ndarray,
+        max_segments: int = 25,
+        mask_range: float = 100.0,
+    ) -> list[int]:
+        """Return the forward-near-ego subset of a saved route, in the order
+        the ego will encounter them.
+
+        Algorithm matches the C++ Autoware planner
+        (``LaneSegmentContext::select_route_segment_indices`` at
+        ``~/pilot-auto.xx1/.../preprocessing/lane_segments.cpp:64``):
+
+        1. Find the route lanelet *closest* to ``center_xy`` by min
+           centerline-point distance — that's the ego's current "spot" on
+           the route.
+        2. Starting from that index, walk **forward** through the saved
+           route. For each next lanelet, check if any centerline point is
+           inside the AABB ``±mask_range`` around ``center_xy``.
+
+           - Lanelets outside the AABB *before* ego enters the valid region
+             are skipped (route hasn't started near ego yet).
+           - The first lanelet inside the AABB marks "entered valid region".
+           - Once entered, the first lanelet *outside* the AABB triggers a
+             break (we've gone past the relevant portion).
+        3. Cap at ``max_segments`` (default 25 = ``_NUM_ROUTE``).
+
+        This is what makes ``route_lanes`` a sliding window of forward
+        context that matches training distribution (median 4 non-zero
+        slots) instead of a frozen-at-init full route.
+        """
+        if not route_lanelet_ids:
+            return []
+        cx, cy = float(center_xy[0]), float(center_xy[1])
+
+        # Step 1: closest route lanelet to ego.
+        closest_idx = 0
+        closest_dist = float("inf")
+        for i, ll_id in enumerate(route_lanelet_ids):
+            if ll_id not in self._cache:
+                continue
+            cl = self._cache[ll_id].raw_centerline
+            dx = cl[:, 0] - cx
+            dy = cl[:, 1] - cy
+            d = float(np.sqrt(dx * dx + dy * dy).min())
+            if d < closest_dist:
+                closest_dist = d
+                closest_idx = i
+
+        # Step 2: walk forward from closest_idx with AABB gating.
+        selected: list[int] = []
+        has_entered = False
+        for i in range(closest_idx, len(route_lanelet_ids)):
+            ll_id = route_lanelet_ids[i]
+            if ll_id not in self._cache:
+                continue
+            cl = self._cache[ll_id].raw_centerline
+            inside = (
+                ((cl[:, 0] > cx - mask_range) & (cl[:, 0] < cx + mask_range)
+                 & (cl[:, 1] > cy - mask_range) & (cl[:, 1] < cy + mask_range)).any()
+            )
+            if not inside:
+                if has_entered:
+                    break
+                continue
+            has_entered = True
+            selected.append(ll_id)
+            if len(selected) >= max_segments:
+                break
+        return selected
+
+    def _build_map_data(
+        self,
+        ll_ids: list[int],
+        center_xy: np.ndarray | None = None,
+    ) -> MapData:
         """Build MapData from lanelet IDs.
 
         Includes ALL lanelets in the selection (no cap). At inference time the
         tensor converter selects the N closest lanelets per ego agent.
+
+        When ``center_xy`` is provided, ``polygons`` and ``line_strings`` are
+        populated with the closest 10 / 60 elements (intersection areas /
+        stop_line + road_border) within ±100 m of the center, sorted by
+        distance — matching the C++ Autoware planner's preprocessing. This
+        gives the model the road-border + intersection context it was
+        trained with. Without ``center_xy`` (legacy callers), they remain
+        zero-filled.
         """
         segments = []
         speed_limits = []
@@ -1081,11 +1459,18 @@ class LaneletSceneBuilder:
             sl_arr[j, 0] = speed_limits[j]
             hsl_arr[j, 0] = has_speed[j]
 
+        if center_xy is not None:
+            polygons = self.build_polygons_tensor(center_xy)
+            line_strings = self.build_line_strings_tensor(center_xy)
+        else:
+            polygons = np.zeros((10, POINTS_PER_POLYGON, 2 + POLYGON_TYPE_NUM), dtype=np.float32)
+            line_strings = np.zeros((60, POINTS_PER_LINE_STRING, 2 + LINE_STRING_TYPE_NUM), dtype=np.float32)
+
         return MapData(
             lanes=lanes,
             lanes_speed_limit=sl_arr,
             lanes_has_speed_limit=hsl_arr,
-            polygons=np.zeros((10, 40, 3), dtype=np.float32),
-            line_strings=np.zeros((60, 20, 4), dtype=np.float32),
+            polygons=polygons,
+            line_strings=line_strings,
             static_objects=np.zeros((5, 10), dtype=np.float32),
         )

--- a/scenario_generation/gui/lanelet_scene_builder.py
+++ b/scenario_generation/gui/lanelet_scene_builder.py
@@ -299,6 +299,10 @@ class LaneletSceneBuilder:
         # Cache per-lanelet geometry
         self._cache: dict[int, _CachedLanelet] = {}
         self._ll_by_id = {}  # lanelet2 objects by id
+        # Ordered lanelet IDs from the most recent _build_map_data call.
+        # The TrafficLightController reads this to map row indices in
+        # map_data.lanes back to lanelet IDs.
+        self._last_map_data_ids: list[int] = []
         self._vehicle_subtypes = {"road", "highway", "road_shoulder"}
         # Subset of ``_vehicle_subtypes`` that actually has routing
         # connections under Germany/Vehicle traffic rules. Used when snapping
@@ -468,6 +472,55 @@ class LaneletSceneBuilder:
 
         assert segment.shape == (POINTS_PER_LANELET, 33), f"Bad shape: {segment.shape}"
         return segment, c.speed_limit_mps, c.has_speed_limit
+
+    # ── Traffic light discovery ─────────────────────────────────────────
+
+    def get_traffic_light_groups(self) -> dict[int, int]:
+        """Return ``{lanelet_id: traffic_light_group_id}`` for all lanelets
+        with ``trafficLights()`` regulatory elements.
+
+        The group_id is the ``.id`` of the first traffic-light regulatory
+        element on each lanelet (mirrors the C++ planner's per-LaneSegment
+        traffic_light_id and ``route_traffic_light_publisher.py:172``).
+        """
+        result: dict[int, int] = {}
+        for ll_id, ll in self._ll_by_id.items():
+            try:
+                tl_list = ll.trafficLights()
+            except Exception:
+                continue
+            if tl_list:
+                result[ll_id] = tl_list[0].id
+        return result
+
+    def get_traffic_light_bulb_groups(self) -> dict[int, frozenset]:
+        """Return ``{reg_element_id: frozenset(light_bulb_linestring_ids)}``.
+
+        Two regulatory elements that share the same ``light_bulbs``
+        LineStrings are controlled by the same physical traffic light and
+        MUST show the same colour.
+        """
+        result: dict[int, frozenset] = {}
+        seen_regs: set[int] = set()
+        for ll in self._ll_by_id.values():
+            try:
+                tl_list = ll.trafficLights()
+            except Exception:
+                continue
+            for tl_reg in tl_list:
+                if tl_reg.id in seen_regs:
+                    continue
+                seen_regs.add(tl_reg.id)
+                bulb_ids: set[int] = set()
+                try:
+                    params = tl_reg.parameters
+                    if "light_bulbs" in params:
+                        for bulb_ls in params["light_bulbs"]:
+                            bulb_ids.add(bulb_ls.id)
+                except Exception:
+                    pass
+                result[tl_reg.id] = frozenset(bulb_ids)
+        return result
 
     # ── Spatial query ────────────────────────────────────────────────────
 
@@ -1438,6 +1491,7 @@ class LaneletSceneBuilder:
         segments = []
         speed_limits = []
         has_speed = []
+        used_ids: list[int] = []
 
         for ll_id in ll_ids:
             if ll_id not in self._cache:
@@ -1446,6 +1500,12 @@ class LaneletSceneBuilder:
             segments.append(seg)
             speed_limits.append(sl)
             has_speed.append(hsl)
+            used_ids.append(ll_id)
+
+        # Store the ordered lanelet IDs for external consumers (e.g.
+        # TrafficLightController) that need to map row indices back to
+        # lanelet IDs.
+        self._last_map_data_ids = used_ids
 
         n = len(segments)
         if n == 0:

--- a/scenario_generation/gui/lanelet_scene_builder.py
+++ b/scenario_generation/gui/lanelet_scene_builder.py
@@ -269,8 +269,26 @@ class LaneletSceneBuilder:
                 cum_arc_lengths=cum_arc,
             )
 
-        print(f"LaneletSceneBuilder: cached {len(self._cache)} lanelets, "
-              f"routing graph built")
+        # Pre-compute vectorised anchor arrays for fast spatial queries
+        # (used by closest_lanelets). Rows align with ``self._vehicle_ll_ids``.
+        self._vehicle_ll_ids: np.ndarray = np.array([
+            ll_id for ll_id, c in self._cache.items()
+            if c.subtype in self._vehicle_subtypes
+        ], dtype=np.int64)
+        n_v = len(self._vehicle_ll_ids)
+        self._vehicle_centers = np.zeros((n_v, 2), dtype=np.float32)
+        self._vehicle_firsts = np.zeros((n_v, 2), dtype=np.float32)
+        self._vehicle_lasts = np.zeros((n_v, 2), dtype=np.float32)
+        self._vehicle_backs = np.zeros((n_v, 2), dtype=np.float32)  # -2 index
+        for i, ll_id in enumerate(self._vehicle_ll_ids):
+            cl = self._cache[int(ll_id)].raw_centerline
+            self._vehicle_centers[i] = cl.mean(axis=0)
+            self._vehicle_firsts[i] = cl[0]
+            self._vehicle_lasts[i] = cl[-1]
+            self._vehicle_backs[i] = cl[-2] if len(cl) >= 2 else cl[-1]
+
+        print(f"LaneletSceneBuilder: cached {len(self._cache)} lanelets "
+              f"({n_v} drivable), routing graph built")
 
     # ── 33-dim conversion ────────────────────────────────────────────────
 
@@ -339,7 +357,204 @@ class LaneletSceneBuilder:
                 result.append(ll_id)
         return result
 
+    def closest_lanelets(
+        self, xy: np.ndarray, max_n: int, mask_range: float = 100.0,
+    ) -> list[int]:
+        """Return up to ``max_n`` drivable lanelet IDs around ``xy``, closest first.
+
+        Mirrors the lane-filter strategy used by the Autoware/Diffusion-Planner
+        ROS node (see ``diffusion_planner_ros/lanelet2_utils/lanelet_converter.py``):
+
+        1. **AABB pre-filter**: a lanelet passes when any of its center,
+           first centerline point, or last centerline point falls inside the
+           ``±mask_range`` square around ``xy``. The ROS node uses 100 m.
+        2. **Sort by min-endpoint-distance** to ``xy`` (the score used by
+           ``key_func`` in ``create_lane_tensor``: the smaller of the
+           distances from ``xy`` to the first and second-to-last centerline
+           points).
+        3. **Cap at ``max_n``**.
+
+        ``max_n`` should typically be ≤ ``tensor_converter._NUM_LANES``
+        (currently 140). The ROS node passes 70; training NPZs show ~65
+        non-zero slots per scene, so 70–140 is the sweet spot.
+
+        Args:
+            xy: 2-element world-frame query point ``[x, y]``.
+            max_n: Maximum number of lanelets to return.
+            mask_range: Half-side of the square AABB pre-filter in metres.
+
+        Returns:
+            Lanelet IDs sorted closest-first. Length ≤ ``max_n``.
+        """
+        pos = np.asarray(xy, dtype=np.float32)[:2]
+        if len(self._vehicle_ll_ids) == 0:
+            return []
+
+        # Vectorised AABB: accept when any of (center, first, last) is inside.
+        def _inside(points: np.ndarray) -> np.ndarray:
+            dx = np.abs(points[:, 0] - pos[0])
+            dy = np.abs(points[:, 1] - pos[1])
+            return (dx < mask_range) & (dy < mask_range)
+
+        mask = (
+            _inside(self._vehicle_centers)
+            | _inside(self._vehicle_firsts)
+            | _inside(self._vehicle_lasts)
+        )
+        if not mask.any():
+            return []
+
+        # Score by min-distance of first / second-to-last endpoint to xy
+        # (mirrors the ROS node's key_func in create_lane_tensor).
+        kept_ids = self._vehicle_ll_ids[mask]
+        d_first = np.sum((self._vehicle_firsts[mask] - pos) ** 2, axis=1)
+        d_back = np.sum((self._vehicle_backs[mask] - pos) ** 2, axis=1)
+        score = np.minimum(d_first, d_back)
+        if len(kept_ids) > max_n:
+            top_idx = np.argpartition(score, max_n)[:max_n]
+            top_idx = top_idx[np.argsort(score[top_idx])]
+        else:
+            top_idx = np.argsort(score)
+        return [int(kept_ids[i]) for i in top_idx]
+
+    def lanelets_near_point(
+        self, xy: np.ndarray, radius: float,
+    ) -> list[int]:
+        """Return drivable lanelet IDs whose centerline passes within ``radius``
+        metres of ``xy``.
+
+        Used by the NPC spawn manager to pick candidate lanelets near the ego.
+        First filters by an AABB of side ``2*radius`` (re-uses
+        :meth:`lanelets_in_rect`) then refines with exact centerline-point
+        distance so diagonal-corner false positives are rejected.
+        """
+        x, y = float(xy[0]), float(xy[1])
+        candidates = self.lanelets_in_rect(
+            x - radius, y - radius, x + radius, y + radius,
+        )
+        radius_sq = radius * radius
+        result = []
+        for ll_id in candidates:
+            cl = self._cache[ll_id].raw_centerline
+            dx = cl[:, 0] - x
+            dy = cl[:, 1] - y
+            if np.min(dx * dx + dy * dy) <= radius_sq:
+                result.append(ll_id)
+        return result
+
+    def snap_to_nearest_ll(
+        self, xy: np.ndarray, candidate_ids: list[int] | None = None,
+    ) -> int | None:
+        """Snap a world-frame ``(x, y)`` position to the nearest drivable lanelet.
+
+        Args:
+            xy: 2-element array-like ``[x, y]`` in MGRS world frame.
+            candidate_ids: Optional restriction to a subset of lanelets. When
+                ``None``, all cached drivable lanelets are considered.
+
+        Returns:
+            The lanelet id with the closest centerline point, or ``None`` when
+            no cached lanelet is available (e.g. empty ``candidate_ids``).
+        """
+        pos = np.asarray(xy, dtype=np.float32)[:2]
+        if candidate_ids is None:
+            candidate_ids = [
+                ll_id for ll_id, c in self._cache.items()
+                if c.subtype in self._vehicle_subtypes
+            ]
+
+        best_ll_id = None
+        best_dist = float("inf")
+        for ll_id in candidate_ids:
+            if ll_id not in self._cache:
+                continue
+            cl = self._cache[ll_id].raw_centerline
+            d = float(np.linalg.norm(cl - pos, axis=1).min())
+            if d < best_dist:
+                best_dist = d
+                best_ll_id = ll_id
+        return best_ll_id
+
+    def is_lanelet_straight(
+        self, ll_id: int, curvature_threshold: float = 0.3,
+    ) -> bool:
+        """Check if a lanelet is straight enough for NPC spawning.
+
+        Iterates consecutive centerline segments and returns False when the
+        maximum heading change between any two adjacent segments exceeds
+        ``curvature_threshold`` radians (default 0.3 rad ≈ 17°).
+
+        Ported from ``tier4_autoware_psim_scenarios.stopped_vehicle_utils.is_lanelet_straight``.
+        NPC history synthesis via :meth:`generate_history` can produce unnatural
+        trajectories on sharp curves, so the spawn manager rejects non-straight
+        candidates.
+        """
+        if ll_id not in self._cache:
+            return False
+        cl = self._cache[ll_id].raw_centerline
+        if len(cl) < 3:
+            return True  # too few points to measure curvature
+
+        diffs = np.diff(cl, axis=0)
+        seg_lens = np.linalg.norm(diffs, axis=1)
+        valid = seg_lens > 1e-6
+        if valid.sum() < 2:
+            return True
+        angles = np.arctan2(diffs[valid, 1], diffs[valid, 0])
+
+        delta = np.diff(angles)
+        # Wrap each delta into [-pi, pi].
+        delta = np.arctan2(np.sin(delta), np.cos(delta))
+        return bool(np.max(np.abs(delta)) <= curvature_threshold)
+
     # ── Routing ──────────────────────────────────────────────────────────
+
+    def route_between(
+        self, start_ll_id: int, goal_ll_id: int,
+    ) -> list[int] | None:
+        """Shortest path between two lanelet IDs using the lanelet2 routing graph.
+
+        Returns a list of lanelet IDs ``[start_ll_id, ..., goal_ll_id]`` or
+        ``None`` when start and goal are in disconnected components / reverse
+        directions. Wraps :class:`lanelet2.routing.RoutingGraph.shortestPath`.
+        """
+        if start_ll_id not in self._ll_by_id or goal_ll_id not in self._ll_by_id:
+            return None
+        start_ll = self._ll_by_id[start_ll_id]
+        goal_ll = self._ll_by_id[goal_ll_id]
+        path = self._routing_graph.shortestPath(start_ll, goal_ll)
+        if path is None:
+            return None
+        return [ll.id for ll in path]
+
+    def route_with_waypoints(
+        self,
+        start_ll_id: int,
+        via_ll_ids: list[int],
+        goal_ll_id: int,
+    ) -> list[int] | None:
+        """Shortest path forced through ``via_ll_ids`` in the given order.
+
+        Uses :class:`lanelet2.routing.RoutingGraph.shortestPathWithVia`. When
+        ``via_ll_ids`` is empty, delegates to :meth:`route_between`.
+
+        Returns the resolved lanelet id sequence or ``None`` when any
+        consecutive pair in ``[start, *via, goal]`` is unreachable.
+        """
+        if not via_ll_ids:
+            return self.route_between(start_ll_id, goal_ll_id)
+        if start_ll_id not in self._ll_by_id or goal_ll_id not in self._ll_by_id:
+            return None
+        for vid in via_ll_ids:
+            if vid not in self._ll_by_id:
+                return None
+        start_ll = self._ll_by_id[start_ll_id]
+        goal_ll = self._ll_by_id[goal_ll_id]
+        via_lls = [self._ll_by_id[i] for i in via_ll_ids]
+        path = self._routing_graph.shortestPathWithVia(start_ll, via_lls, goal_ll)
+        if path is None:
+            return None
+        return [ll.id for ll in path]
 
     def find_route(self, start_ll_id: int, min_length_m: float = 120.0) -> list[int]:
         """Find a forward route from start_lanelet of at least min_length_m.
@@ -591,19 +806,7 @@ class LaneletSceneBuilder:
         ex, ey, eheading = ego_pose
         pos = np.array([ex, ey], dtype=np.float32)
 
-        # Find nearest lanelet centerline
-        best_ll_id = None
-        best_dist = float("inf")
-        for ll_id in lanelet_ids:
-            if ll_id not in self._cache:
-                continue
-            cl = self._cache[ll_id].raw_centerline
-            dists = np.linalg.norm(cl - pos, axis=1)
-            d = float(dists.min())
-            if d < best_dist:
-                best_dist = d
-                best_ll_id = ll_id
-
+        best_ll_id = self.snap_to_nearest_ll(pos, candidate_ids=lanelet_ids)
         if best_ll_id is None:
             return None
 

--- a/scenario_generation/gui/lanelet_scene_builder.py
+++ b/scenario_generation/gui/lanelet_scene_builder.py
@@ -600,7 +600,7 @@ class LaneletSceneBuilder:
         d_back = np.sum((self._vehicle_backs[mask] - pos) ** 2, axis=1)
         score = np.minimum(d_first, d_back)
         if len(kept_ids) > max_n:
-            top_idx = np.argpartition(score, max_n)[:max_n]
+            top_idx = np.argpartition(score, max_n - 1)[:max_n]
             top_idx = top_idx[np.argsort(score[top_idx])]
         else:
             top_idx = np.argsort(score)

--- a/scenario_generation/mpc_tracker.py
+++ b/scenario_generation/mpc_tracker.py
@@ -1,0 +1,365 @@
+"""Simple MPC trajectory tracker using a bicycle kinematic model.
+
+Replaces the teleport-based advance in closed-loop replay with a
+physically plausible trajectory tracking controller. The MPC optimizes
+acceleration and steering angle over a 2-second horizon to follow the
+diffusion model's predicted trajectory through a kinematic bicycle
+model, enforcing physical constraints that prevent aggressive behavior
+(lane invasion, red-light running, unphysical heading jumps).
+
+Bicycle kinematic model:
+    dx/dt   = v * cos(yaw)
+    dy/dt   = v * sin(yaw)
+    dyaw/dt = v * tan(delta) / wheelbase
+    dv/dt   = a
+
+Velocity smoothing and force-stop logic ported from
+``autoware_diffusion_planner/src/postprocessing/postprocessing_utils.cpp``
+(lines 249-342).
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from scipy.optimize import minimize
+
+
+class MPCTracker:
+    """MPC trajectory tracker with bicycle kinematic model.
+
+    Optimises a short control sequence (acceleration + steering) via
+    scipy L-BFGS-B to track a reference trajectory produced by the
+    diffusion model.  Only the first control step is applied (receding
+    horizon), and the previous solution is warm-started into the next
+    call.
+
+    Parameters
+    ----------
+    wheelbase : float
+        Distance between front and rear axles (metres).
+    horizon_steps : int
+        Number of 0.1 s steps in the MPC horizon (default 20 = 2 s).
+    n_knots : int
+        Number of control decision points.  Controls are held constant
+        between knots (piecewise-constant parameterisation).  Fewer
+        knots = fewer decision variables = faster solve.
+    dt : float
+        Simulation timestep (seconds).
+    """
+
+    def __init__(
+        self,
+        wheelbase: float,
+        horizon_steps: int = 20,
+        n_knots: int = 5,
+        dt: float = 0.1,
+        # Physical bounds
+        max_accel: float = 3.0,
+        min_accel: float = -4.0,
+        max_steer: float = 0.6,
+        max_speed: float = 20.0,
+        # Cost weights
+        w_pos: float = 10.0,
+        w_head: float = 5.0,
+        w_accel: float = 0.1,
+        w_steer: float = 0.5,
+        w_jerk: float = 1.0,
+        w_steer_rate: float = 2.0,
+    ):
+        self.wheelbase = max(wheelbase, 0.5)  # safety floor
+        self.horizon = horizon_steps
+        self.n_knots = n_knots
+        self.dt = dt
+        if n_knots < 1 or horizon_steps < n_knots or horizon_steps % n_knots != 0:
+            raise ValueError(
+                f"horizon_steps ({horizon_steps}) must be a positive "
+                f"multiple of n_knots ({n_knots})"
+            )
+        self.steps_per_knot = horizon_steps // n_knots
+
+        self.max_accel = max_accel
+        self.min_accel = min_accel
+        self.max_steer = max_steer
+        self.max_speed = max_speed
+
+        self.w_pos = w_pos
+        self.w_head = w_head
+        self.w_accel = w_accel
+        self.w_steer = w_steer
+        self.w_jerk = w_jerk
+        self.w_steer_rate = w_steer_rate
+
+        # Bounds for the optimiser (interleaved [a0, d0, a1, d1, ...])
+        self._bounds = []
+        for _ in range(n_knots):
+            self._bounds.append((min_accel, max_accel))
+            self._bounds.append((-max_steer, max_steer))
+
+        # Warm-start buffer (n_knots, 2)
+        self._prev_knots: np.ndarray | None = None
+
+    # ------------------------------------------------------------------
+    # Kinematic rollout
+    # ------------------------------------------------------------------
+
+    def _expand_knots(self, knots: np.ndarray) -> np.ndarray:
+        """(n_knots, 2) -> (horizon, 2) via piecewise-constant hold."""
+        return np.repeat(knots, self.steps_per_knot, axis=0)[: self.horizon]
+
+    def _rollout(self, x0: np.ndarray, controls: np.ndarray) -> np.ndarray:
+        """Forward-integrate bicycle model for *horizon* steps.
+
+        Args:
+            x0: (4,) [x, y, yaw, v] initial state.
+            controls: (horizon, 2) [acceleration, steering] per step.
+
+        Returns:
+            (horizon+1, 4) state trajectory including x0.
+        """
+        H = self.horizon
+        states = np.empty((H + 1, 4), dtype=np.float64)
+        states[0] = x0
+        dt = self.dt
+        wb = self.wheelbase
+        v_max = self.max_speed
+
+        for t in range(H):
+            x, y, yaw, v = states[t]
+            a = controls[t, 0]
+            delta = controls[t, 1]
+            # Euler integration
+            states[t + 1, 0] = x + v * math.cos(yaw) * dt
+            states[t + 1, 1] = y + v * math.sin(yaw) * dt
+            states[t + 1, 2] = yaw + v * math.tan(delta) / wb * dt
+            states[t + 1, 3] = max(0.0, min(v + a * dt, v_max))
+
+        return states
+
+    # ------------------------------------------------------------------
+    # Cost function
+    # ------------------------------------------------------------------
+
+    def _cost(
+        self,
+        knot_flat: np.ndarray,
+        x0: np.ndarray,
+        ref: np.ndarray,
+    ) -> float:
+        """Scalar cost evaluated by L-BFGS-B.
+
+        Args:
+            knot_flat: (2*n_knots,) decision variables.
+            x0: (4,) current state.
+            ref: (horizon, 3) reference [x, y, yaw] world frame.
+        """
+        knots = knot_flat.reshape(self.n_knots, 2)
+        controls = self._expand_knots(knots)
+        states = self._rollout(x0, controls)
+
+        # Predicted states at t=1..H aligned with ref at t=0..H-1
+        pred = states[1:]
+
+        # Position tracking  ||pos - ref||^2
+        pos_err = pred[:, :2] - ref[:, :2]
+        J = self.w_pos * np.dot(pos_err.ravel(), pos_err.ravel())
+
+        # Heading tracking  (1 - cos(Δyaw))  — smooth, no wrapping issues
+        dyaw = pred[:, 2] - ref[:, 2]
+        J += self.w_head * np.sum(1.0 - np.cos(dyaw))
+
+        # Control effort
+        J += self.w_accel * np.dot(controls[:, 0], controls[:, 0])
+        J += self.w_steer * np.dot(controls[:, 1], controls[:, 1])
+
+        # Smoothness between consecutive knots
+        if self.n_knots > 1:
+            dk = np.diff(knots, axis=0)
+            J += self.w_jerk * np.dot(dk[:, 0], dk[:, 0])
+            J += self.w_steer_rate * np.dot(dk[:, 1], dk[:, 1])
+
+        return float(J)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def track(
+        self,
+        x0: np.ndarray,
+        ref_world: np.ndarray,
+    ) -> tuple[np.ndarray, float]:
+        """Run one MPC step: optimise controls, apply first step.
+
+        Args:
+            x0: (4,) [x, y, yaw, v] current state in world frame.
+            ref_world: (N, 3) reference [x, y, yaw] in world frame.
+                At least *horizon* rows; extras are ignored.
+
+        Returns:
+            new_pos: (3,) [x, y, yaw] after one dt step.
+            new_speed: scalar speed after one dt step.
+        """
+        # Pad or truncate reference to exactly *horizon* steps
+        ref = np.zeros((self.horizon, 3), dtype=np.float64)
+        n = min(len(ref_world), self.horizon)
+        ref[:n] = ref_world[:n, :3]
+        if n < self.horizon:
+            ref[n:] = ref[n - 1]
+
+        # Initial guess — warm-start from shifted previous solution
+        if self._prev_knots is not None:
+            init = np.roll(self._prev_knots, -1, axis=0).copy()
+            init[-1] = init[-2]
+        else:
+            init = np.zeros((self.n_knots, 2), dtype=np.float64)
+
+        result = minimize(
+            self._cost,
+            init.ravel(),
+            args=(np.asarray(x0, dtype=np.float64), ref),
+            method="L-BFGS-B",
+            bounds=self._bounds,
+            options={"maxiter": 50, "ftol": 1e-6},
+        )
+        optimal_knots = result.x.reshape(self.n_knots, 2)
+        self._prev_knots = optimal_knots.copy()
+
+        # Apply first control through the bicycle model (single step)
+        a = float(optimal_knots[0, 0])
+        delta = float(np.clip(optimal_knots[0, 1], -self.max_steer, self.max_steer))
+
+        x, y, yaw, v = float(x0[0]), float(x0[1]), float(x0[2]), float(x0[3])
+        x_new = x + v * math.cos(yaw) * self.dt
+        y_new = y + v * math.sin(yaw) * self.dt
+        yaw_new = yaw + v * math.tan(delta) / self.wheelbase * self.dt
+        v_new = max(0.0, min(v + a * self.dt, self.max_speed))
+
+        new_pos = np.array([x_new, y_new, yaw_new], dtype=np.float32)
+        return new_pos, v_new
+
+    def reset(self):
+        """Clear warm-start state (call on agent respawn)."""
+        self._prev_knots = None
+
+
+# ----------------------------------------------------------------------
+# Reference trajectory post-processing
+# ----------------------------------------------------------------------
+
+def postprocess_reference(
+    ref_xy: np.ndarray,
+    ref_h: np.ndarray,
+    dt: float = 0.1,
+    vel_smooth_window: int = 8,
+    stop_threshold: float = 0.3,
+) -> np.ndarray:
+    """Velocity smoothing + force-stop on a world-frame reference trajectory.
+
+    Ports the two key post-processing passes from the C++ diffusion
+    planner (``postprocessing_utils.cpp`` lines 249-342):
+
+    1. Compute velocity from position differences, then apply a
+       forward-looking moving average (window = ``vel_smooth_window``).
+    2. Force-stop: once smoothed velocity drops below
+       ``stop_threshold`` m/s after having been above it, freeze all
+       subsequent positions and headings.  This ensures the MPC
+       receives a clean stop reference instead of slow drift.
+
+    Args:
+        ref_xy: (N, 2) world-frame positions [x, y].
+        ref_h: (N,) headings in radians.
+        dt: timestep (seconds).
+        vel_smooth_window: moving-average window for velocity.
+        stop_threshold: force-stop trigger velocity (m/s).
+
+    Returns:
+        (N, 3) post-processed reference [x, y, yaw].
+    """
+    N = len(ref_xy)
+    ref = np.column_stack([ref_xy, ref_h]).copy()
+    if N < 2:
+        return ref
+
+    # Step 1: velocity from position differences
+    diffs = np.diff(ref_xy, axis=0)
+    velocities = np.hypot(diffs[:, 0], diffs[:, 1]) / dt
+    velocities = np.concatenate([[velocities[0]], velocities])  # prepend for index alignment
+
+    # Step 2: forward-looking moving average
+    smoothed = velocities.copy()
+    w = vel_smooth_window
+    for i in range(N - w + 1):
+        smoothed[i] = velocities[i : i + w].mean()
+
+    # Step 3: force-stop
+    force_stop = False
+    for i in range(1, N):
+        if not force_stop:
+            if smoothed[i - 1] > stop_threshold and smoothed[i] <= stop_threshold:
+                force_stop = True
+        if force_stop:
+            ref[i, :2] = ref[i - 1, :2]
+            ref[i, 2] = ref[i - 1, 2]
+
+    return ref
+
+
+# ----------------------------------------------------------------------
+# Perfect tracker (simple Euler integration, no optimisation)
+# ----------------------------------------------------------------------
+
+class PerfectTracker:
+    """Velocity-limited Euler trajectory follower.
+
+    Reads the target velocity from the reference trajectory's position
+    differences, integrates position via Euler step, and snaps heading
+    to the reference.  No optimisation, no feedback control — pure
+    open-loop trajectory following with physics-limited steps.
+
+    Much faster than :class:`MPCTracker` (~0.01 ms vs ~13 ms per call)
+    but has no lookahead or kinematic steering model.
+    """
+
+    def __init__(self, dt: float = 0.1, max_speed: float = 20.0):
+        self.dt = dt
+        self.max_speed = max_speed
+
+    def track(
+        self,
+        x0: np.ndarray,
+        ref_world: np.ndarray,
+    ) -> tuple[np.ndarray, float]:
+        """Advance one step along the reference trajectory.
+
+        Args:
+            x0: (4,) [x, y, yaw, v] current state in world frame.
+            ref_world: (N, 3) reference [x, y, yaw] in world frame.
+
+        Returns:
+            new_pos: (3,) [x, y, yaw] after one dt step.
+            new_speed: scalar speed after one dt step.
+        """
+        if len(ref_world) < 1:
+            return np.array([x0[0], x0[1], x0[2]], dtype=np.float32), 0.0
+
+        # Target velocity from reference step 0 displacement
+        dx = ref_world[0, 0] - x0[0]
+        dy = ref_world[0, 1] - x0[1]
+        v_target = min(math.hypot(dx, dy) / self.dt, self.max_speed)
+
+        # Euler integration using current heading and target velocity
+        x, y, yaw = float(x0[0]), float(x0[1]), float(x0[2])
+        x_new = x + v_target * math.cos(yaw) * self.dt
+        y_new = y + v_target * math.sin(yaw) * self.dt
+
+        # Snap heading directly to the reference orientation
+        yaw_new = float(ref_world[0, 2])
+
+        new_pos = np.array([x_new, y_new, yaw_new], dtype=np.float32)
+        return new_pos, v_target
+
+    def reset(self):
+        """No-op (no internal state to clear)."""
+        pass

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -1,0 +1,871 @@
+"""Closed-loop replay of a saved :class:`scenario_generation.route.Route`.
+
+High-level flow
+---------------
+
+1. Load the Route and rebuild a ``LaneletSceneBuilder`` from ``route.map_path``.
+2. Build an initial ``SceneContext`` containing just the ego (no neighbors),
+   placed at ``route.start_pose`` with its 31-step history synthesised
+   backwards along the lanelet centerlines (see
+   ``LaneletSceneBuilder.generate_history``).
+3. Enter the closed-loop: each simulation tick we
+
+   * Run batched inference on every currently-alive agent as ego (reusing
+     :func:`scenario_generation.simulate._predict_batch` — a single forward
+     pass with all agents concatenated along the batch dim, no sequential
+     per-agent calls).
+   * Advance every agent one physical step via
+     :func:`scenario_generation.simulate.advance_scene`.
+   * Periodically run the NPC spawn manager:
+
+     - **Despawn** any neighbor farther than ``despawn_distance`` m from ego.
+     - **Spawn** up to ``max_active_npcs`` (hard cap) neighbors near the ego
+       with a small per-tick probability, using a realistic synthesised
+       history and a route that is sometimes biased to overlap the ego's
+       own route (see ``SpawnConfig.ego_overlap_ratio``).
+   * Save an overview PNG per tick.
+
+4. Terminate when the ego arrives within ``goal_tolerance_m`` of
+   ``route.goal_pose`` or after ``n_steps`` ticks.
+
+Traffic lights are explicitly out of scope. ``traffic_light_source`` is
+accepted but ignored today; see :mod:`scenario_generation.traffic_light` for
+the intended seam.
+
+Batched inference note
+----------------------
+
+Each alive agent is a separate scene dict (different ego-centric coordinate
+frames) but ``_predict_batch`` concatenates them along ``batch_dim=0`` for a
+single ``model(data)`` call. This is the point the user emphasised: we never
+loop inference sequentially; even spawned neighbors enter the same batch on
+the very next tick.
+
+The ``MapTensorCache`` is rebuilt whenever a new lanelet is added to
+``scene.map_data`` during NPC spawning (there is no ``invalidate()`` method —
+see CLAUDE.md and the cache definition in ``tensor_converter.py``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import random
+from concurrent.futures import ThreadPoolExecutor
+from copy import deepcopy
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import numpy as np
+import torch
+
+from scenario_generation.gui.lanelet_scene_builder import (
+    LaneletSceneBuilder,
+    _obb_collides,
+    _obb_corners,
+)
+from scenario_generation.route import Route
+from scenario_generation.scene_context import Agent, AgentType, SceneContext
+from scenario_generation.simulate import (
+    _ego_to_world,
+    _predict_batch,
+    _save_and_close,
+    advance_scene,
+    load_model,
+)
+from scenario_generation.tensor_converter import MapTensorCache
+from scenario_generation.traffic_light import AllNoneTLSource, TrafficLightSource
+from scenario_generation.visualize import (
+    _agent_color,
+    draw_agent_box,
+    draw_trajectory,
+)
+
+
+# ── Config ───────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class SpawnConfig:
+    """Controls the NPC spawn/despawn manager.
+
+    All distances in metres, all times in simulation steps (each step = 0.1 s).
+
+    Attributes:
+        spawn_period_steps: Run the spawn/despawn tick every N steps.
+            ``10`` ≈ once per simulated second.
+        max_active_npcs: Hard upper bound on the number of concurrent
+            neighbors. Neighbor count is not kept constant — it drifts in
+            ``[0, max_active_npcs]`` driven by ``spawn_probability`` and
+            despawn distance.
+        spawn_probability: Per-tick chance of attempting a spawn when the
+            active count is below the cap.
+        min_spawn_distance: A spawn candidate must sit at least this far
+            from ego.
+        max_spawn_distance: A spawn candidate must sit no further than this
+            from ego.
+        despawn_distance: Any neighbor farther than this from ego is dropped.
+            Default 120 m matches the user's spec.
+        forward_bias: Probability that a spawn candidate is restricted to
+            lanelets in front of the ego (vs. free directional choice).
+        min_npc_separation: Minimum centre-to-centre distance between a new
+            spawn and any existing agent's OBB. Matches tier4 npc_manager's
+            constant.
+        goal_tolerance_m: Ego-to-goal distance that triggers a
+            "goal reached" termination.
+        max_steps: Maximum simulation ticks before forced termination.
+            6000 ticks = 600 s = 10 minutes of simulated time.
+        seed: RNG seed used for spawn candidate selection, vehicle
+            dimensions, speeds, route choices. ``None`` for non-deterministic.
+        ego_overlap_ratio: Fraction of spawned NPCs that are routed to
+            overlap with the ego's route_lanelet_ids. Per user: 0.30 (30%
+            overlap, 70% random forward routes).
+        npc_min_speed: Floor for a spawned NPC's initial speed (m/s).
+        npc_max_speed: Ceiling for a spawned NPC's initial speed (m/s).
+        npc_route_length_m: Minimum arc-length fed to ``find_route`` for each
+            new NPC — drives how many lanelets of route_lanes it gets.
+        curvature_threshold: Max allowable |Δheading| between consecutive
+            centerline segments for a lanelet to be spawnable. Matches the
+            default used by ``is_lanelet_straight``.
+        map_refresh_steps: Rebuild ``scene.map_data`` with the closest
+            lanelets to the ego every this many steps. Matches the training
+            distribution where the ``(140, 20, 33)`` lane tensor is packed
+            with the closest lanelets to ego — not a fixed pre-baked subset.
+        max_map_lanelets: Upper bound on the number of lanelets packed into
+            ``map_data.lanes``. Must match / not exceed
+            ``tensor_converter._NUM_LANES`` (currently 140).
+        map_mask_range_m: Half-side of the AABB lane-filter around ego.
+            Matches the Diffusion-Planner ROS node's ``judge_inside``
+            (``mask_range = 100.0``). A lanelet passes the filter when its
+            center, first, or last centerline point is within this square.
+    """
+
+    spawn_period_steps: int = 10
+    max_active_npcs: int = 8
+    spawn_probability: float = 0.3
+    min_spawn_distance: float = 15.0
+    max_spawn_distance: float = 60.0
+    despawn_distance: float = 120.0
+    forward_bias: float = 0.8
+    min_npc_separation: float = 8.0
+    goal_tolerance_m: float = 2.0
+    max_steps: int = 6000
+    seed: int | None = None
+    ego_overlap_ratio: float = 0.3
+    npc_min_speed: float = 3.0
+    npc_max_speed: float = 12.0
+    npc_route_length_m: float = 120.0
+    curvature_threshold: float = 0.3
+    map_refresh_steps: int = 5
+    max_map_lanelets: int = 140
+    # ROS node uses 100 m; empirical survey of our training NPZs shows
+    # ~23 (min) – 89 (max) non-zero lanes per scene, median 61. 100 m on the
+    # Shinagawa map tops out at ~22 lanelets — at the bottom of training
+    # distribution. 200 m yields ~62, matching the median.
+    map_mask_range_m: float = 200.0
+
+    @classmethod
+    def from_json(cls, path: str | Path) -> "SpawnConfig":
+        """Load a SpawnConfig from a JSON file.
+
+        Unknown keys (including ``_comment_*`` keys used as inline JSON
+        comments) are silently dropped so configs can carry documentation
+        without tripping the dataclass constructor.
+        """
+        with open(path) as f:
+            data = json.load(f)
+        valid_fields = {f.name for f in cls.__dataclass_fields__.values()}
+        filtered = {k: v for k, v in data.items() if k in valid_fields}
+        return cls(**filtered)
+
+    def to_json(self, path: str | Path) -> None:
+        with open(path, "w") as f:
+            json.dump(asdict(self), f, indent=2)
+
+
+# ── NPC spawn manager ────────────────────────────────────────────────────────
+
+
+class SceneNPCManager:
+    """Spawns and despawns ``Agent`` objects inside a running ``SceneContext``.
+
+    This class intentionally owns no state that outlives a single replay —
+    construct a fresh one per ``run_route_replay`` invocation.
+
+    The manager does **not** call the model. Inference for every agent
+    (including freshly spawned neighbors) happens in the main replay loop via
+    the shared ``_predict_batch`` one-forward-pass.
+    """
+
+    def __init__(
+        self,
+        builder: LaneletSceneBuilder,
+        ego_route_ll_ids: list[int],
+        spawn_config: SpawnConfig,
+    ) -> None:
+        self.builder = builder
+        self.ego_route_ll_ids = ego_route_ll_ids
+        self.cfg = spawn_config
+        self._rng = random.Random(spawn_config.seed)
+        self._np_rng = np.random.default_rng(spawn_config.seed)
+        self._next_id = 0
+        # Set of lanelet ids currently present in ``scene.map_data``. Tracked
+        # incrementally so we only rebuild the MapTensorCache when new
+        # lanelets actually appear.
+        self._known_lanelet_ids: set[int] = set()
+
+    def register_known_lanelets(self, lanelet_ids: list[int]) -> None:
+        self._known_lanelet_ids.update(lanelet_ids)
+
+    def tick(self, scene: SceneContext) -> None:
+        """Run one spawn/despawn cycle.
+
+        The map_data rebuild is owned by the main replay loop (it refreshes
+        periodically based on ego position + closest lanelets). This method
+        only mutates ``scene.agents``.
+        """
+        ego_agent = scene.ego_agent
+        if ego_agent is None:
+            return
+        ego_pos = ego_agent.current_position
+
+        # --- Despawn pass ---
+        kept_agents: list[Agent] = []
+        removed = 0
+        for agent in scene.agents:
+            if agent.id == scene.ego_agent_id:
+                kept_agents.append(agent)
+                continue
+            d = float(np.linalg.norm(agent.current_position - ego_pos))
+            if d > self.cfg.despawn_distance:
+                removed += 1
+                continue
+            kept_agents.append(agent)
+        scene.agents = kept_agents
+        if removed > 0:
+            print(f"  [NPCManager] despawned {removed} (beyond {self.cfg.despawn_distance:.0f} m)")
+
+        # --- Spawn pass ---
+        active_nb = sum(1 for a in scene.agents if a.id != scene.ego_agent_id)
+        if active_nb >= self.cfg.max_active_npcs:
+            return
+        if self._rng.random() >= self.cfg.spawn_probability:
+            return
+
+        new_agent, _added_ll_ids = self._try_spawn_one(scene)
+        if new_agent is None:
+            return
+        scene.agents.append(new_agent)
+        print(f"  [NPCManager] spawned {new_agent.id}")
+
+    # -- internals --------------------------------------------------------
+
+    def _try_spawn_one(self, scene: SceneContext) -> tuple[Agent | None, list[int]]:
+        """Attempt to synthesise one valid NPC near the ego. Returns
+        ``(agent_or_None, list_of_lanelet_ids_the_new_agent_touches)``."""
+        ego = scene.ego_agent
+        ego_pos = ego.current_position
+        ego_heading = ego.current_heading
+        ego_forward = np.array([math.cos(ego_heading), math.sin(ego_heading)], dtype=np.float32)
+
+        candidate_ids = self.builder.lanelets_near_point(
+            ego_pos, self.cfg.max_spawn_distance,
+        )
+        # Drop lanelets that are too curved for history synthesis.
+        candidate_ids = [
+            ll_id for ll_id in candidate_ids
+            if self.builder.is_lanelet_straight(ll_id, self.cfg.curvature_threshold)
+        ]
+        if not candidate_ids:
+            return None, []
+
+        forward_only = self._rng.random() < self.cfg.forward_bias
+        if forward_only:
+            filtered = []
+            for ll_id in candidate_ids:
+                cl = self.builder._cache[ll_id].raw_centerline
+                mid = cl[len(cl) // 2]
+                to_mid = mid - ego_pos
+                if np.dot(to_mid, ego_forward) > 0:
+                    filtered.append(ll_id)
+            candidate_ids = filtered or candidate_ids  # fall back if forward filter empties
+
+        # Existing agents' OBBs to collision-test against.
+        existing_corners = [
+            _obb_corners(
+                a.current_position[0], a.current_position[1],
+                a.current_heading, a.length, a.width,
+            )
+            for a in scene.agents
+        ]
+
+        for _ in range(20):  # up to 20 attempts
+            ll_id = self._rng.choice(candidate_ids)
+            c = self.builder._cache[ll_id]
+            cl = c.raw_centerline
+            # Pick an arc-length away from the lanelet endpoints.
+            total = float(c.arc_length)
+            if total < 1.0:
+                continue
+            margin = min(3.0, total * 0.1)
+            target_arc = self._rng.uniform(margin, total - margin)
+            arc_lengths = c.cum_arc_lengths
+            seg_idx = int(np.searchsorted(arc_lengths, target_arc)) - 1
+            seg_idx = max(0, min(seg_idx, len(cl) - 2))
+            seg_len = arc_lengths[seg_idx + 1] - arc_lengths[seg_idx]
+            if seg_len < 1e-6:
+                continue
+            t = (target_arc - arc_lengths[seg_idx]) / max(seg_len, 1e-6)
+            pos = cl[seg_idx] + t * (cl[seg_idx + 1] - cl[seg_idx])
+            pos = pos.astype(np.float32)
+
+            # Range check against ego.
+            d_ego = float(np.linalg.norm(pos - ego_pos))
+            if d_ego < self.cfg.min_spawn_distance or d_ego > self.cfg.max_spawn_distance:
+                continue
+
+            # Lane heading at this point.
+            if seg_idx < len(cl) - 1:
+                dxdy = cl[seg_idx + 1] - cl[seg_idx]
+            else:
+                dxdy = cl[seg_idx] - cl[seg_idx - 1]
+            heading = float(math.atan2(dxdy[1], dxdy[0]))
+
+            length = float(self._rng.uniform(4.0, 5.0))
+            width = float(self._rng.uniform(1.7, 2.0))
+            wheelbase = length * 0.65
+
+            corners = _obb_corners(pos[0], pos[1], heading, length, width)
+            collides = False
+            for ec in existing_corners:
+                ec_center = ec.mean(axis=0)
+                if np.linalg.norm(pos - ec_center) < self.cfg.min_npc_separation:
+                    collides = True
+                    break
+                if _obb_collides(corners, ec):
+                    collides = True
+                    break
+            if collides:
+                continue
+
+            speed = float(self._rng.uniform(self.cfg.npc_min_speed, self.cfg.npc_max_speed))
+
+            # Route for this neighbor. 30% of spawns are biased to share at
+            # least one lanelet with the ego's route (see user spec 70/30).
+            route_ll_ids = self._pick_route(ll_id)
+            goal = self.builder._route_goal(route_ll_ids)
+            route_lanes, route_sl, route_hsl = self.builder._route_to_33dim(route_ll_ids)
+
+            history, history_ll_ids = self.builder.generate_history(
+                pos, heading, speed, ll_id,
+            )
+            velocities = np.zeros((history.shape[0], 2), dtype=np.float32)
+            for k in range(1, history.shape[0]):
+                velocities[k] = (history[k, :2] - history[k - 1, :2]) / 0.1
+            velocities[0] = velocities[1]
+
+            agent_id = f"npc_{self._next_id}"
+            self._next_id += 1
+            agent = Agent(
+                id=agent_id,
+                agent_type=AgentType.VEHICLE,
+                length=length,
+                width=width,
+                wheelbase=wheelbase,
+                past_trajectory=history,
+                past_velocities=velocities,
+                acceleration=np.zeros(2, dtype=np.float32),
+                steering_angle=0.0,
+                yaw_rate=0.0,
+                goal_pose=goal,
+                route_lanes=route_lanes,
+                route_speed_limit=route_sl,
+                route_has_speed_limit=route_hsl,
+            )
+            touched = list(set(route_ll_ids) | set(history_ll_ids) | {ll_id})
+            return agent, touched
+
+        return None, []
+
+    def _pick_route(self, start_ll_id: int) -> list[int]:
+        """Select a forward route for a freshly-spawned NPC.
+
+        With probability ``ego_overlap_ratio`` we retry ``find_route`` a few
+        times searching for a candidate that shares at least one lanelet with
+        the ego's route — more interactions with ego, less natural traffic
+        diversity. Otherwise a single random forward route.
+        """
+        want_overlap = self._rng.random() < self.cfg.ego_overlap_ratio
+        ego_set = set(self.ego_route_ll_ids)
+        best = self.builder.find_route(start_ll_id, self.cfg.npc_route_length_m)
+        if want_overlap and not (set(best) & ego_set):
+            for _ in range(5):
+                candidate = self.builder.find_route(start_ll_id, self.cfg.npc_route_length_m)
+                if set(candidate) & ego_set:
+                    return candidate
+        return best
+
+
+# ── Replay loop ──────────────────────────────────────────────────────────────
+
+
+_LANE_COLOR = "#bbbbbb"
+_LANE_BORDER_COLOR = "#888888"
+_EGO_COLOR = "#3366cc"
+_ROUTE_COLOR = "#00aa44"
+_VIEW_HALF_M = 50.0  # ±50 m window around ego keeps lane detail legible
+
+
+def _draw_lane_network(ax, map_data, alpha: float = 0.7) -> None:
+    """Draw lane centerlines **and** left/right borders from the 33-dim tensor.
+
+    Borders are reconstructed via ``centerline + lane[:, 4:6]`` (left) and
+    ``centerline + lane[:, 6:8]`` (right). ``map_data.line_strings`` stays
+    zero-filled in replay scenes so we can't rely on it; the borders we draw
+    here come from the lane tensor which is always populated.
+    """
+    from matplotlib.collections import LineCollection
+
+    lanes = map_data.lanes
+    centerlines, lefts, rights = [], [], []
+    for i in range(lanes.shape[0]):
+        lane = lanes[i]
+        if np.abs(lane[:, :2]).sum() < 1e-6:
+            continue
+        pts = lane[:, :2]
+        valid = np.abs(pts).sum(axis=1) > 0.1
+        if valid.sum() < 2:
+            continue
+        centerlines.append(pts[valid])
+        if lane.shape[1] > 7:
+            lefts.append((pts + lane[:, 4:6])[valid])
+            rights.append((pts + lane[:, 6:8])[valid])
+
+    if centerlines:
+        ax.add_collection(LineCollection(
+            centerlines, colors=_LANE_COLOR, linewidths=0.6,
+            alpha=alpha * 0.4, zorder=1,
+        ))
+    if lefts:
+        ax.add_collection(LineCollection(
+            lefts, colors=_LANE_BORDER_COLOR, linewidths=1.1,
+            alpha=alpha, zorder=2,
+        ))
+    if rights:
+        ax.add_collection(LineCollection(
+            rights, colors=_LANE_BORDER_COLOR, linewidths=1.1,
+            alpha=alpha, zorder=2,
+        ))
+
+
+def _save_step_figure(
+    scene: SceneContext,
+    agent_predictions: dict,
+    output_path: Path,
+    step: int,
+    n_steps: int,
+    route_polylines: list[np.ndarray] | None = None,
+    view_half_m: float = _VIEW_HALF_M,
+) -> None:
+    """Render + save the overview PNG for a single replay step.
+
+    Viewport is fixed to ``±view_half_m`` metres around the ego, so lane
+    borders stay visible and NPC detail remains readable at every step.
+    """
+    from matplotlib.figure import Figure
+
+    ego = scene.ego_agent
+    if ego is None:
+        return
+    ex, ey = ego.current_position
+
+    fig = Figure(figsize=(10, 10))
+    ax = fig.add_subplot(1, 1, 1)
+    fig.patch.set_facecolor("#f8f8f8")
+
+    # 1) Lane network (centerlines + left / right borders).
+    _draw_lane_network(ax, scene.map_data)
+
+    # 2) Ego route polyline (drawn below agents but above lanes).
+    if route_polylines:
+        for pl in route_polylines:
+            if pl.shape[0] >= 2:
+                ax.plot(
+                    pl[:, 0], pl[:, 1], "-", color=_ROUTE_COLOR,
+                    lw=2.5, alpha=0.6, zorder=3,
+                )
+
+    # 3) Agents + per-agent predicted trajectories.
+    nb_idx = 0
+    for agent in scene.agents:
+        is_ego = agent.id == scene.ego_agent_id
+        if is_ego:
+            color = _EGO_COLOR
+        else:
+            color = _agent_color(agent.agent_type, nb_idx)
+            nb_idx += 1
+
+        pos = agent.current_position
+        heading = agent.current_heading
+
+        # Past trail (dashed, light).
+        past = agent.past_trajectory
+        valid = np.abs(past[:, :2]).sum(axis=1) > 1e-6
+        if valid.sum() > 1:
+            ax.plot(
+                past[valid, 0], past[valid, 1], "--", color=color,
+                lw=0.9, alpha=0.5, zorder=7,
+            )
+
+        # Bounding box + heading arrow.
+        draw_agent_box(
+            ax, pos[0], pos[1], heading, agent.length, agent.width,
+            color, alpha=0.85 if is_ego else 0.55, lw=2 if is_ego else 1,
+            zorder=20 if is_ego else 15,
+        )
+        arrow_len = max(agent.length, 2.5)
+        ax.annotate(
+            "",
+            xy=(pos[0] + arrow_len * math.cos(heading),
+                pos[1] + arrow_len * math.sin(heading)),
+            xytext=(pos[0], pos[1]),
+            arrowprops=dict(arrowstyle="-|>", color=color, lw=1.5, mutation_scale=12),
+            zorder=21 if is_ego else 16,
+        )
+        ax.annotate(
+            agent.id, (pos[0], pos[1]), fontsize=7, color=color,
+            ha="center", va="bottom", xytext=(0, 6), textcoords="offset points",
+            zorder=22,
+        )
+
+        # Predicted trajectory from the model (in that agent's ego frame).
+        if agent.id in agent_predictions:
+            pred = agent_predictions[agent.id]
+            plan_xy, plan_h = _ego_to_world(
+                pred[:, :2], pred[:, 2:4],
+                float(pos[0]), float(pos[1]), heading,
+            )
+            plan_traj = np.concatenate([plan_xy, plan_h[:, np.newaxis]], axis=-1)
+            draw_trajectory(
+                ax, plan_traj, color,
+                lw=1.8 if is_ego else 1.0,
+                zorder=25 if is_ego else 18,
+                show_footprints=is_ego,
+                length=agent.length, width=agent.width,
+            )
+
+    # 4) Ego goal marker (if within viewport).
+    if ego.goal_pose is not None:
+        gx, gy = float(ego.goal_pose[0]), float(ego.goal_pose[1])
+        if abs(gx - ex) <= view_half_m and abs(gy - ey) <= view_half_m:
+            ax.plot(gx, gy, "*", color="#d62728", ms=18, zorder=30,
+                    markeredgecolor="black", markeredgewidth=0.8)
+
+    # 5) Viewport: fixed square around ego.
+    ax.set_xlim(ex - view_half_m, ex + view_half_m)
+    ax.set_ylim(ey - view_half_m, ey + view_half_m)
+    ax.set_aspect("equal")
+    ax.grid(True, alpha=0.15)
+    ax.set_xlabel("X (m)")
+    ax.set_ylabel("Y (m)")
+
+    goal_d = float(np.linalg.norm(ego.current_position - ego.goal_pose[:2])) \
+        if ego.goal_pose is not None else float("nan")
+    ax.set_title(
+        f"Step {step:04d}/{n_steps}  t={step * 0.1:.1f}s  "
+        f"agents={len(scene.agents)}  goal_d={goal_d:.1f} m",
+        fontsize=11,
+    )
+    fig.tight_layout()
+    _save_and_close(fig, output_path)
+
+
+@torch.no_grad()
+def run_route_replay(
+    model,
+    model_args,
+    builder: LaneletSceneBuilder,
+    route: Route,
+    output_dir: Path,
+    spawn_config: SpawnConfig | None = None,
+    device: str = "cuda",
+    traffic_light_source: TrafficLightSource | None = None,
+) -> dict:
+    """Run closed-loop replay of ``route`` with dynamic NPC spawning.
+
+    Args:
+        model: Loaded Diffusion-Planner (``eval()`` already called).
+        model_args: ``Config`` instance returned alongside ``model`` by
+            :func:`scenario_generation.simulate.load_model`.
+        builder: Lanelet scene builder for the map ``route.map_path`` points
+            at (rebuild one fresh per call — cheap vs. GPU inference).
+        route: Authored route spec. Must be resolved (``route_lanelet_ids``
+            non-empty); falls back to greedy ``find_route`` with a warning
+            when unresolved.
+        output_dir: Directory for per-step PNGs. Created if missing.
+        spawn_config: NPC manager tuning. Defaults to :class:`SpawnConfig()`.
+        device: Torch device.
+        traffic_light_source: Reserved seam for a future TL source. Ignored
+            today; see :mod:`scenario_generation.traffic_light`.
+
+    Returns:
+        Dict with ``final_step``, ``goal_reached`` (bool), ``reason`` (str),
+        and ``n_npc_spawned`` for downstream scripting.
+    """
+    if spawn_config is None:
+        spawn_config = SpawnConfig()
+    if traffic_light_source is None:
+        traffic_light_source = AllNoneTLSource()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # --- Step 0: build the initial scene from the Route. ---
+    ego_route_ids = route.route_lanelet_ids
+    if not ego_route_ids:
+        if route.start_lanelet_id is None:
+            raise ValueError("Route has no start_lanelet_id and no resolved path")
+        print("  [WARN] Route.route_lanelet_ids is empty; falling back to find_route")
+        ego_route_ids = builder.find_route(
+            route.start_lanelet_id, spawn_config.npc_route_length_m,
+        )
+
+    # Snap the ego to a lanelet on the saved route (prevents the initial lane
+    # from drifting to a parallel lane that isn't part of the route).
+    start_pose = route.start_pose
+    start_ll_id = builder.snap_to_nearest_ll(
+        start_pose[:2], candidate_ids=ego_route_ids,
+    ) or route.start_lanelet_id
+    if start_ll_id is None:
+        raise ValueError("Could not determine start lanelet for the ego")
+
+    # Snap the ego's x,y onto the chosen lanelet's centerline for stability.
+    cl = builder._cache[start_ll_id].raw_centerline
+    dists = np.linalg.norm(cl - start_pose[:2], axis=1)
+    closest = int(np.argmin(dists))
+    snapped_xy = cl[closest].astype(np.float32)
+    heading = float(start_pose[2])
+    # Reasonable initial speed: midpoint of NPC speed band. The diffusion
+    # planner recovers from this quickly since it sees 31 steps of history.
+    init_speed = 0.5 * (spawn_config.npc_min_speed + spawn_config.npc_max_speed)
+
+    # Synthesise realistic history along the route's predecessor lanelets.
+    history, history_ll_ids = builder.generate_history(
+        snapped_xy, heading, init_speed, start_ll_id,
+    )
+    # Override history[-1] with the user-specified heading so the ego faces
+    # the right way at t=0 even when the lane heading differs slightly.
+    history[-1, 2] = heading
+    velocities = np.zeros((history.shape[0], 2), dtype=np.float32)
+    for k in range(1, history.shape[0]):
+        velocities[k] = (history[k, :2] - history[k - 1, :2]) / 0.1
+    velocities[0] = velocities[1]
+
+    # Build map_data to mirror the Diffusion-Planner ROS node:
+    # - closest lanelets to ego via a ±100 m AABB pre-filter + distance sort
+    # - ego route + history pinned (route context never drops, even when the
+    #   ego approaches a dense junction where the closest-N would saturate)
+    # - each alive NPC's current lanelet pinned so neighbors always have
+    #   lane context even when outside the ego bbox (NPCs can live up to
+    #   despawn_distance = 120 m > bbox = 100 m from ego)
+    # - final hard cap at ``max_map_lanelets`` (140 = tensor_converter._NUM_LANES).
+    def _compute_map_lanelet_ids(
+        ego_xy: np.ndarray,
+        neighbor_positions: list[np.ndarray],
+    ) -> list[int]:
+        closest = builder.closest_lanelets(
+            ego_xy, spawn_config.max_map_lanelets,
+            mask_range=spawn_config.map_mask_range_m,
+        )
+        pinned: list[int] = list(ego_route_ids) + list(history_ll_ids)
+        for nb_xy in neighbor_positions:
+            ll = builder.snap_to_nearest_ll(nb_xy)
+            if ll is not None:
+                pinned.append(ll)
+
+        # Deduplicate while preserving priority: closest-first, then pins.
+        seen: set[int] = set()
+        ordered: list[int] = []
+        for ll_id in list(closest) + pinned:
+            if ll_id in seen:
+                continue
+            seen.add(ll_id)
+            ordered.append(ll_id)
+            if len(ordered) >= spawn_config.max_map_lanelets:
+                break
+        return ordered
+
+    all_lanelet_ids = _compute_map_lanelet_ids(snapped_xy, [])
+    map_data = builder._build_map_data(all_lanelet_ids)
+
+    route_lanes, route_sl, route_hsl = builder._route_to_33dim(ego_route_ids)
+    ego = Agent(
+        id="ego",
+        agent_type=AgentType.VEHICLE,
+        length=4.5, width=1.9, wheelbase=4.5 * 0.65,
+        past_trajectory=history,
+        past_velocities=velocities,
+        acceleration=np.zeros(2, dtype=np.float32),
+        steering_angle=0.0,
+        yaw_rate=0.0,
+        goal_pose=route.goal_pose.astype(np.float32),
+        route_lanes=route_lanes,
+        route_speed_limit=route_sl,
+        route_has_speed_limit=route_hsl,
+    )
+    scene = SceneContext(agents=[ego], map_data=map_data, ego_agent_id="ego", dt=0.1)
+
+    # Route polyline (world frame) for per-step visualisation.
+    route_polylines = [
+        builder._cache[ll_id].raw_centerline[:, :2]
+        for ll_id in ego_route_ids if ll_id in builder._cache
+    ]
+
+    # --- NPC manager. ---
+    npc_manager = SceneNPCManager(builder, ego_route_ids, spawn_config)
+    npc_manager.register_known_lanelets(all_lanelet_ids)
+
+    map_cache = MapTensorCache(scene.map_data)
+    n_npc_spawned = 0
+    goal_reached = False
+    reason = "max_steps"
+
+    # --- Main loop. ---
+    with ThreadPoolExecutor(max_workers=4, thread_name_prefix="save") as save_pool:
+        pending_saves: list = []
+        for step in range(spawn_config.max_steps):
+            # Run the NPC manager (after step 0 so the ego has a meaningful
+            # ``current_position`` — always true by construction here).
+            if step > 0 and step % spawn_config.spawn_period_steps == 0:
+                before = sum(1 for a in scene.agents if a.id != scene.ego_agent_id)
+                npc_manager.tick(scene)
+                after = sum(1 for a in scene.agents if a.id != scene.ego_agent_id)
+                if after > before:
+                    n_npc_spawned += (after - before)
+
+            # Refresh map_data to include the closest lanelets to ego + NPC
+            # anchors. Mirrors the Diffusion-Planner ROS node, which rebuilds
+            # the lane tensor every inference frame. We throttle to
+            # ``map_refresh_steps`` (default 5 = 0.5 s at dt=0.1) since the
+            # cost (~few ms on a 6k-lanelet map) adds up over 6000 steps.
+            if step == 0 or step % spawn_config.map_refresh_steps == 0:
+                ego_xy = scene.ego_agent.current_position
+                neighbor_xys = [
+                    a.current_position for a in scene.agents
+                    if a.id != scene.ego_agent_id
+                ]
+                new_ids = _compute_map_lanelet_ids(ego_xy, neighbor_xys)
+                scene.map_data = builder._build_map_data(new_ids)
+                npc_manager._known_lanelet_ids = set(new_ids)
+                map_cache = MapTensorCache(scene.map_data)
+
+            # Inference for every alive agent, in one batched forward pass.
+            ids_to_predict = [a.id for a in scene.agents if a.agent_type == AgentType.VEHICLE]
+            agent_predictions = _predict_batch(
+                model, model_args, scene, ids_to_predict, device,
+                map_cache=map_cache,
+            )
+
+            # Save PNG (concurrent with next step's compute).
+            out_path = output_dir / f"step_{step:04d}.png"
+            pending_saves.append(save_pool.submit(
+                _save_step_figure,
+                deepcopy(scene), agent_predictions, out_path,
+                step, spawn_config.max_steps, route_polylines,
+            ))
+
+            # Drain any finished saves so memory doesn't balloon.
+            if step % 50 == 0:
+                pending_saves = [f for f in pending_saves if not f.done()]
+
+            # Goal check (BEFORE advancing — measures arrival accurately).
+            ego_pos = scene.ego_agent.current_position
+            goal_xy = route.goal_pose[:2]
+            if float(np.linalg.norm(ego_pos - goal_xy)) <= spawn_config.goal_tolerance_m:
+                goal_reached = True
+                reason = "goal_reached"
+                print(f"  Goal reached at step {step} (distance {np.linalg.norm(ego_pos - goal_xy):.2f} m)")
+                break
+
+            advance_scene(scene, agent_predictions)
+
+            if step % 50 == 0:
+                print(
+                    f"  step {step:04d}/{spawn_config.max_steps}  "
+                    f"agents={len(scene.agents)}  "
+                    f"ego=({ego_pos[0]:.1f}, {ego_pos[1]:.1f})  "
+                    f"goal_d={np.linalg.norm(ego_pos - goal_xy):.1f} m"
+                )
+
+        for f in pending_saves:
+            f.result()
+
+    final_step = step
+    print(f"Done. {final_step + 1} frames saved to {output_dir}; reason={reason}")
+    return {
+        "final_step": final_step,
+        "goal_reached": goal_reached,
+        "reason": reason,
+        "n_npc_spawned": n_npc_spawned,
+    }
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Closed-loop replay of a saved scenario_generation Route "
+                    "with dynamic NPC spawning.",
+    )
+    parser.add_argument("--map_path", type=str, default=None,
+                        help="Override the map path stored in the Route pickle")
+    parser.add_argument("--route", type=Path, required=True, help="Path to route.pkl")
+    parser.add_argument("--model_path", type=Path, required=True, help="Path to best_model.pth")
+    parser.add_argument("--output_dir", type=Path, required=True,
+                        help="Directory for per-step PNGs")
+    parser.add_argument("--steps", type=int, default=None,
+                        help="Max simulation steps (overrides config.max_steps; "
+                             "default from config = 6000 = 10 min at dt=0.1)")
+    parser.add_argument("--max_npcs", type=int, default=None,
+                        help="Override hard cap on concurrent neighbors")
+    parser.add_argument("--spawn_probability", type=float, default=None,
+                        help="Override spawn probability per spawn tick")
+    parser.add_argument("--config", type=Path, default=None,
+                        help="JSON SpawnConfig overrides")
+    parser.add_argument("--device", type=str, default="cuda")
+    parser.add_argument("--seed", type=int, default=None)
+    args = parser.parse_args()
+
+    route = Route.load(args.route)
+    map_path = args.map_path or route.map_path
+    print(f"Loading builder from {map_path}")
+    builder = LaneletSceneBuilder(map_path)
+
+    if args.config is not None:
+        cfg = SpawnConfig.from_json(args.config)
+    else:
+        cfg = SpawnConfig()
+    if args.steps is not None:
+        cfg.max_steps = args.steps
+    if args.max_npcs is not None:
+        cfg.max_active_npcs = args.max_npcs
+    if args.spawn_probability is not None:
+        cfg.spawn_probability = args.spawn_probability
+    if args.seed is not None:
+        cfg.seed = args.seed
+
+    device = args.device if torch.cuda.is_available() or args.device == "cpu" else "cpu"
+    print(f"Loading model from {args.model_path}")
+    model, model_args = load_model(args.model_path, device)
+
+    run_route_replay(
+        model=model, model_args=model_args, builder=builder, route=route,
+        output_dir=args.output_dir, spawn_config=cfg, device=device,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -76,14 +76,11 @@ from scenario_generation.simulate import (
     _predict_batch,
     _save_and_close,
     advance_scene,
+    advance_scene_mpc,
     load_model,
 )
 from scenario_generation.tensor_converter import MapTensorCache
-from scenario_generation.traffic_light import (
-    AllNoneTLSource,
-    TrafficLightController,
-    TrafficLightSource,
-)
+from scenario_generation.traffic_light import TrafficLightController
 
 # Reuse the Savitzky-Golay smoother from the RL pipeline. Used there by
 # ranked-SFT to smooth diffusion-planner outputs before the SFT loss; same
@@ -194,6 +191,18 @@ class SpawnConfig:
     sg_smooth_enabled: bool = True
     sg_filter_window: int = 11
     sg_filter_order: int = 3
+    # Advance mode: how the vehicle moves each step.
+    #   "teleport"  — original behaviour, snap to pred[0] (default)
+    #   "mpc"       — bicycle-model MPC tracking with 2 s lookahead
+    #   "perfect"   — Euler integration with velocity from reference
+    #                  (matches Autoware autoware_perfect_tracker)
+    advance_mode: str = "teleport"
+    mpc_horizon_steps: int = 20
+    mpc_n_knots: int = 5
+    # Run model inference one agent at a time instead of batching all
+    # agents into a single forward pass. Slower but useful for diagnosing
+    # whether batched inference affects trajectory quality.
+    sequential_inference: bool = False
 
     @classmethod
     def from_json(cls, path: str | Path) -> "SpawnConfig":
@@ -247,9 +256,25 @@ class SceneNPCManager:
         # incrementally so we only rebuild the MapTensorCache when new
         # lanelets actually appear.
         self._known_lanelet_ids: set[int] = set()
+        # Ego route lanelets the ego has already driven through.
+        # Updated every tick so NPC goals avoid untransited ego lanelets.
+        self._ego_transited: set[int] = set()
+        self._ego_untransited: set[int] = set(ego_route_ll_ids)
 
     def register_known_lanelets(self, lanelet_ids: list[int]) -> None:
         self._known_lanelet_ids.update(lanelet_ids)
+
+    def update_ego_progress(self, ego_xy: np.ndarray) -> None:
+        """Mark the ego's current lanelet (and all prior) as transited."""
+        ll = self.builder.snap_to_nearest_ll(ego_xy)
+        if ll is None or ll not in self._ego_untransited:
+            return
+        # Mark everything up to and including this lanelet as transited.
+        for rid in self.ego_route_ll_ids:
+            self._ego_transited.add(rid)
+            self._ego_untransited.discard(rid)
+            if rid == ll:
+                break
 
     def tick(self, scene: SceneContext) -> None:
         """Run one spawn/despawn cycle.
@@ -392,10 +417,16 @@ class SceneNPCManager:
             if collides:
                 continue
 
-            speed = float(self._rng.uniform(self.cfg.npc_min_speed, self.cfg.npc_max_speed))
+            # Speed from lane speed limit (±20%), falling back to config range.
+            cache_entry = self.builder._cache[ll_id]
+            if cache_entry.has_speed_limit and cache_entry.speed_limit_mps > 0:
+                sl = cache_entry.speed_limit_mps
+                speed = float(self._rng.uniform(sl * 0.8, sl * 1.2))
+                speed = max(speed, 0.5)  # floor to avoid near-zero spawns
+            else:
+                speed = float(self._rng.uniform(self.cfg.npc_min_speed, self.cfg.npc_max_speed))
 
-            # Route for this neighbor. 30% of spawns are biased to share at
-            # least one lanelet with the ego's route (see user spec 70/30).
+            # Route for this neighbor.
             route_ll_ids = self._pick_route(ll_id)
             goal = self.builder._route_goal(route_ll_ids)
             route_lanes, route_sl, route_hsl = self.builder._route_to_33dim(route_ll_ids)
@@ -477,17 +508,32 @@ class SceneNPCManager:
             gid = tl.get_group_for_lanelet(rid)
             if gid is None:
                 continue
-            color = tl._color_for_group(gid, self._sim_time)
+            color = tl.color_for_group(gid, self._sim_time)
             if color not in (TL_RED, TL_YELLOW):
-                return False  # first TL is green, fine to spawn
-            # First TL is red/yellow — check distance to its start.
+                continue  # green TL, check remaining
+            # Red/yellow TL — check distance to its start.
             if rid not in self.builder._cache:
                 return True
             tl_start = self.builder._cache[rid].raw_centerline[0]
             dist = float(np.linalg.norm(spawn_pos - tl_start))
-            return dist < min_dist
+            if dist < min_dist:
+                return True
 
         return False
+
+    def _trim_route_off_ego(self, route: list[int]) -> list[int]:
+        """Trim route so its goal lanelet is not on an untransited ego lanelet.
+
+        Walks backward from the end of the route, dropping lanelets that
+        belong to the ego's future path, until a safe goal is found.
+        Returns at least the first lanelet (the spawn lanelet).
+        """
+        if not self._ego_untransited:
+            return route
+        end = len(route)
+        while end > 1 and route[end - 1] in self._ego_untransited:
+            end -= 1
+        return route[:end]
 
     def _pick_route(self, start_ll_id: int) -> list[int]:
         """Select a forward route for a freshly-spawned NPC.
@@ -496,6 +542,9 @@ class SceneNPCManager:
         times searching for a candidate that shares at least one lanelet with
         the ego's route — more interactions with ego, less natural traffic
         diversity. Otherwise a single random forward route.
+
+        The route is trimmed so its goal does not land on an ego route
+        lanelet that the ego has not yet transited.
         """
         want_overlap = self._rng.random() < self.cfg.ego_overlap_ratio
         ego_set = set(self.ego_route_ll_ids)
@@ -504,8 +553,9 @@ class SceneNPCManager:
             for _ in range(5):
                 candidate = self.builder.find_route(start_ll_id, self.cfg.npc_route_length_m)
                 if set(candidate) & ego_set:
-                    return candidate
-        return best
+                    best = candidate
+                    break
+        return self._trim_route_off_ego(best)
 
 
 # ── Replay loop ──────────────────────────────────────────────────────────────
@@ -757,7 +807,6 @@ def run_route_replay(
     output_dir: Path,
     spawn_config: SpawnConfig | None = None,
     device: str = "cuda",
-    traffic_light_source: TrafficLightSource | None = None,
 ) -> dict:
     """Run closed-loop replay of ``route`` with dynamic NPC spawning.
 
@@ -773,8 +822,6 @@ def run_route_replay(
         output_dir: Directory for per-step PNGs. Created if missing.
         spawn_config: NPC manager tuning. Defaults to :class:`SpawnConfig()`.
         device: Torch device.
-        traffic_light_source: Legacy parameter (unused). Traffic lights are
-            now managed by :class:`TrafficLightController` internally.
 
     Returns:
         Dict with ``final_step``, ``goal_reached`` (bool), ``reason`` (str),
@@ -782,8 +829,6 @@ def run_route_replay(
     """
     if spawn_config is None:
         spawn_config = SpawnConfig()
-    if traffic_light_source is None:
-        traffic_light_source = AllNoneTLSource()
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # Seed ALL random sources for full reproducibility across runs.
@@ -856,10 +901,10 @@ def run_route_replay(
             if ll is not None:
                 pinned.append(ll)
 
-        # Deduplicate while preserving priority: closest-first, then pins.
+        # Deduplicate: pinned IDs first (always included), then closest.
         seen: set[int] = set()
         ordered: list[int] = []
-        for ll_id in list(closest) + pinned:
+        for ll_id in pinned + list(closest):
             if ll_id in seen:
                 continue
             seen.add(ll_id)
@@ -940,12 +985,25 @@ def run_route_replay(
     reason = "max_steps"
     min_goal_d = float("inf")  # closest approach to goal seen so far
 
+    # Tracker state (lazy-init per agent inside advance_scene_mpc).
+    _use_tracker = spawn_config.advance_mode in ("mpc", "perfect")
+    mpc_trackers: dict = {}
+    if _use_tracker:
+        print(f"  Advance mode: {spawn_config.advance_mode}"
+              + (f" (horizon={spawn_config.mpc_horizon_steps}, "
+                 f"knots={spawn_config.mpc_n_knots})"
+                 if spawn_config.advance_mode == "mpc" else ""))
+
     # --- Main loop. ---
     with ThreadPoolExecutor(max_workers=4, thread_name_prefix="save") as save_pool:
         pending_saves: list = []
         for step in range(spawn_config.max_steps):
             # Keep NPC manager's sim time in sync for TL writes on spawn.
             npc_manager._sim_time = step * 0.1
+
+            # Track which ego route lanelets have been transited so NPC
+            # goals avoid landing on the ego's future path.
+            npc_manager.update_ego_progress(scene.ego_agent.current_position)
 
             # Run the NPC manager (after step 0 so the ego has a meaningful
             # ``current_position`` — always true by construction here).
@@ -955,6 +1013,11 @@ def run_route_replay(
                 after = sum(1 for a in scene.agents if a.id != scene.ego_agent_id)
                 if after > before:
                     n_npc_spawned += (after - before)
+                # Prune trackers for despawned agents.
+                if _use_tracker:
+                    alive_ids = {a.id for a in scene.agents}
+                    for stale_id in list(mpc_trackers.keys() - alive_ids):
+                        del mpc_trackers[stale_id]
 
             # Refresh map_data + ego.route_lanes. Mirrors the C++ Autoware
             # planner, which rebuilds these every inference frame. We
@@ -975,14 +1038,16 @@ def run_route_replay(
                 new_ids = _compute_map_lanelet_ids(ego_xy, neighbor_xys)
                 scene.map_data = builder._build_map_data(new_ids, center_xy=ego_xy)
                 npc_manager._known_lanelet_ids = set(new_ids)
+                map_cache = MapTensorCache(scene.map_data)
 
             # TL state + route_lanes refresh EVERY step so the model
-            # always sees the current signal phase.
+            # always sees the current signal phase. The TL one-hot is
+            # written directly into scene.map_data.lanes which the
+            # map_cache references (shared underlying array).
             tl_controller.tick(
                 scene, step * 0.1, builder._last_map_data_ids,
                 ego_xy=ego_xy,
             )
-            map_cache = MapTensorCache(scene.map_data)
 
             # Refresh route_lanes for ALL agents (ego + NPCs) so the
             # sliding window stays centered on each agent's current
@@ -1008,10 +1073,22 @@ def run_route_replay(
             # turn_indicators history on the next frame — mirrors the C++
             # ``TurnIndicatorManager`` control loop.
             ids_to_predict = [a.id for a in scene.agents if a.agent_type == AgentType.VEHICLE]
-            agent_predictions, agent_turn_indicators = _predict_batch(
-                model, model_args, scene, ids_to_predict, device,
-                map_cache=map_cache, return_turn_indicators=True,
-            )
+            if spawn_config.sequential_inference:
+                # One forward pass per agent (batch_size=1 each).
+                agent_predictions: dict[str, np.ndarray] = {}
+                agent_turn_indicators: dict[str, int] = {}
+                for aid in ids_to_predict:
+                    p, ti = _predict_batch(
+                        model, model_args, scene, [aid], device,
+                        map_cache=map_cache, return_turn_indicators=True,
+                    )
+                    agent_predictions.update(p)
+                    agent_turn_indicators.update(ti)
+            else:
+                agent_predictions, agent_turn_indicators = _predict_batch(
+                    model, model_args, scene, ids_to_predict, device,
+                    map_cache=map_cache, return_turn_indicators=True,
+                )
 
             # Optional Savitzky-Golay smoothing on each agent's predicted
             # trajectory. Reuses the same smoother the RL ranked-SFT
@@ -1037,9 +1114,16 @@ def run_route_replay(
                 step * 0.1,
             ))
 
-            # Drain any finished saves so memory doesn't balloon.
+            # Drain finished saves so memory doesn't balloon. Call
+            # .result() to surface any exceptions from background saves.
             if step % 50 == 0:
-                pending_saves = [f for f in pending_saves if not f.done()]
+                still_pending = []
+                for f in pending_saves:
+                    if f.done():
+                        f.result()  # raises if save thread failed
+                    else:
+                        still_pending.append(f)
+                pending_saves = still_pending
 
             # Goal check (BEFORE advancing — measures arrival accurately).
             # Two termination conditions:
@@ -1073,7 +1157,15 @@ def run_route_replay(
                 )
                 break
 
-            advance_scene(scene, agent_predictions)
+            if spawn_config.advance_mode in ("mpc", "perfect"):
+                advance_scene_mpc(
+                    scene, agent_predictions, mpc_trackers,
+                    tracker_type=spawn_config.advance_mode,
+                    mpc_horizon_steps=spawn_config.mpc_horizon_steps,
+                    mpc_n_knots=spawn_config.mpc_n_knots,
+                )
+            else:
+                advance_scene(scene, agent_predictions)
 
             # Increment age for all agents so the tensor converter knows
             # how many history frames are "real" vs pre-spawn fabrication.

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -79,6 +79,13 @@ from scenario_generation.simulate import (
 )
 from scenario_generation.tensor_converter import MapTensorCache
 from scenario_generation.traffic_light import AllNoneTLSource, TrafficLightSource
+
+# Reuse the Savitzky-Golay smoother from the RL pipeline. Used there by
+# ranked-SFT to smooth diffusion-planner outputs before the SFT loss; same
+# defaults (window=11, order=3) and cos/sin-renormalisation logic apply at
+# replay time to suppress diffusion-sampler jitter. Importing rather than
+# duplicating so the two pipelines stay in sync.
+from rlvr.grpo_sft_trainer import _smooth_trajectory as _sg_smooth_trajectory
 from scenario_generation.visualize import (
     _agent_color,
     draw_agent_box,
@@ -160,6 +167,12 @@ class SpawnConfig:
     npc_max_speed: float = 12.0
     npc_route_length_m: float = 120.0
     curvature_threshold: float = 0.3
+    # Closest-approach window: when the ego has been within this radius of
+    # the goal AND now has the goal *behind* it (negative dot product
+    # against ego-forward), terminate as "goal_passed". The diffusion
+    # planner doesn't stop at the goal, so without this it can pass within
+    # 5-15 m of the goal then drive off into the horizon.
+    goal_pass_window_m: float = 25.0
     map_refresh_steps: int = 5
     max_map_lanelets: int = 140
     # ROS node uses 100 m; empirical survey of our training NPZs shows
@@ -167,6 +180,15 @@ class SpawnConfig:
     # Shinagawa map tops out at ~22 lanelets — at the bottom of training
     # distribution. 200 m yields ~62, matching the median.
     map_mask_range_m: float = 200.0
+    # Savitzky-Golay smoothing applied to each agent's predicted
+    # trajectory before ``advance_scene`` uses its first step. Matches the
+    # defaults from ``rlvr.grpo_sft_trainer._smooth_trajectory`` (ranked
+    # SFT uses the same smoother on generated trajectories before the SFT
+    # loss). Set ``sg_smooth_enabled=False`` to disable (e.g. for A/B
+    # comparison).
+    sg_smooth_enabled: bool = True
+    sg_filter_window: int = 11
+    sg_filter_order: int = 3
 
     @classmethod
     def from_json(cls, path: str | Path) -> "SpawnConfig":
@@ -368,6 +390,21 @@ class SceneNPCManager:
                 velocities[k] = (history[k, :2] - history[k - 1, :2]) / 0.1
             velocities[0] = velocities[1]
 
+            # Realistic kinematic initialisation from the synthesised
+            # history — lanelet centerline tracing already gives curvature,
+            # so yaw_rate / steering / acceleration are computable rather
+            # than the zero placeholders we had before.
+            dh_spawn = np.arctan2(
+                np.sin(np.diff(history[-5:, 2])),
+                np.cos(np.diff(history[-5:, 2])),
+            )
+            yaw_rate_spawn = float(dh_spawn.mean() / 0.1) if len(dh_spawn) > 0 else 0.0
+            speed_spawn = float(np.linalg.norm(velocities[-1]))
+            accel_spawn = (velocities[-1] - velocities[-3]) / (2 * 0.1) \
+                if len(velocities) >= 3 else np.zeros(2, dtype=np.float32)
+            steering_spawn = float(math.atan2(wheelbase * yaw_rate_spawn, max(speed_spawn, 0.2))) \
+                if speed_spawn > 0.2 else 0.0
+
             agent_id = f"npc_{self._next_id}"
             self._next_id += 1
             agent = Agent(
@@ -378,13 +415,14 @@ class SceneNPCManager:
                 wheelbase=wheelbase,
                 past_trajectory=history,
                 past_velocities=velocities,
-                acceleration=np.zeros(2, dtype=np.float32),
-                steering_angle=0.0,
-                yaw_rate=0.0,
+                acceleration=accel_spawn.astype(np.float32),
+                steering_angle=steering_spawn,
+                yaw_rate=yaw_rate_spawn,
                 goal_pose=goal,
                 route_lanes=route_lanes,
                 route_speed_limit=route_sl,
                 route_has_speed_limit=route_hsl,
+                turn_indicators=np.zeros(history.shape[0], dtype=np.int32),
             )
             touched = list(set(route_ll_ids) | set(history_ll_ids) | {ll_id})
             return agent, touched
@@ -500,14 +538,28 @@ def _save_step_figure(
                 )
 
     # 3) Agents + per-agent predicted trajectories.
-    nb_idx = 0
+    # Assign colors by hashing the agent id (or extracting a stable numeric
+    # suffix from ``npc_N``) so a given neighbor keeps the same color even
+    # when other NPCs spawn / despawn and reshuffle the iteration order.
+    # Previously we indexed the palette by iteration rank, which made
+    # colors jump on every spawn / despawn tick.
+    def _stable_color(agent) -> str:
+        if agent.id == scene.ego_agent_id:
+            return _EGO_COLOR
+        # npc_5 → 5; falls back to Python hash otherwise.
+        sid = agent.id
+        idx = None
+        if "_" in sid:
+            suffix = sid.rsplit("_", 1)[-1]
+            if suffix.isdigit():
+                idx = int(suffix)
+        if idx is None:
+            idx = abs(hash(sid))
+        return _agent_color(agent.agent_type, idx)
+
     for agent in scene.agents:
         is_ego = agent.id == scene.ego_agent_id
-        if is_ego:
-            color = _EGO_COLOR
-        else:
-            color = _agent_color(agent.agent_type, nb_idx)
-            nb_idx += 1
+        color = _stable_color(agent)
 
         pos = agent.current_position
         heading = agent.current_heading
@@ -575,10 +627,21 @@ def _save_step_figure(
 
     goal_d = float(np.linalg.norm(ego.current_position - ego.goal_pose[:2])) \
         if ego.goal_pose is not None else float("nan")
+
+    # Ego state readout: speed, steering, current turn-signal class.
+    ego_speed = float(np.hypot(ego.current_velocity[0], ego.current_velocity[1]))
+    ego_speed_kph = ego_speed * 3.6
+    _TI_NAMES = {0: "NONE", 1: "DISABLE", 2: "LEFT", 3: "RIGHT", 4: "KEEP"}
+    ti_cls = (
+        int(ego.turn_indicators[-1]) if ego.turn_indicators is not None else 0
+    )
+    ti_label = _TI_NAMES.get(ti_cls, f"?{ti_cls}")
+    steer_deg = math.degrees(ego.steering_angle)
     ax.set_title(
-        f"Step {step:04d}/{n_steps}  t={step * 0.1:.1f}s  "
-        f"agents={len(scene.agents)}  goal_d={goal_d:.1f} m",
-        fontsize=11,
+        f"Step {step:04d}/{n_steps}  t={step * 0.1:.1f}s  agents={len(scene.agents)}"
+        f"\nego  v={ego_speed:.1f} m/s ({ego_speed_kph:.0f} km/h)  "
+        f"steer={steer_deg:+.0f}°  turn={ti_label}  goal_d={goal_d:.1f} m",
+        fontsize=10,
     )
     fig.tight_layout()
     _save_and_close(fig, output_path)
@@ -698,22 +761,43 @@ def run_route_replay(
         return ordered
 
     all_lanelet_ids = _compute_map_lanelet_ids(snapped_xy, [])
-    map_data = builder._build_map_data(all_lanelet_ids)
+    map_data = builder._build_map_data(all_lanelet_ids, center_xy=snapped_xy)
 
-    route_lanes, route_sl, route_hsl = builder._route_to_33dim(ego_route_ids)
+    # Initial route_lanes uses the C++-style forward window (not the full
+    # saved route — training data has median 4 non-zero route slots, so
+    # packing all 25 over-provides context). Refreshed every
+    # ``map_refresh_steps`` in the main loop as the ego advances.
+    initial_route_window = builder.select_route_segment_indices(
+        ego_route_ids, snapped_xy, max_segments=25,
+    ) or ego_route_ids[:25]
+    route_lanes, route_sl, route_hsl = builder._route_to_33dim(initial_route_window)
+    # Initial kinematic derivatives from the synthesized history so the
+    # first inference call sees realistic non-zero yaw_rate + steering +
+    # acceleration (otherwise the model's first ~1-2 steps behave as if
+    # the ego just teleported in with zero state).
+    dh_init = np.arctan2(
+        np.sin(np.diff(history[-5:, 2])),
+        np.cos(np.diff(history[-5:, 2])),
+    )
+    yaw_rate_init = float(dh_init.mean() / 0.1) if len(dh_init) > 0 else 0.0
+    speed_init = float(np.linalg.norm(velocities[-1]))
+    accel_init = (velocities[-1] - velocities[-3]) / (2 * 0.1) if len(velocities) >= 3 else np.zeros(2, dtype=np.float32)
+    steering_init = float(math.atan2(4.5 * 0.65 * yaw_rate_init, max(speed_init, 0.2))) if speed_init > 0.2 else 0.0
+
     ego = Agent(
         id="ego",
         agent_type=AgentType.VEHICLE,
         length=4.5, width=1.9, wheelbase=4.5 * 0.65,
         past_trajectory=history,
         past_velocities=velocities,
-        acceleration=np.zeros(2, dtype=np.float32),
-        steering_angle=0.0,
-        yaw_rate=0.0,
+        acceleration=accel_init.astype(np.float32),
+        steering_angle=steering_init,
+        yaw_rate=yaw_rate_init,
         goal_pose=route.goal_pose.astype(np.float32),
         route_lanes=route_lanes,
         route_speed_limit=route_sl,
         route_has_speed_limit=route_hsl,
+        turn_indicators=np.zeros(history.shape[0], dtype=np.int32),
     )
     scene = SceneContext(agents=[ego], map_data=map_data, ego_agent_id="ego", dt=0.1)
 
@@ -731,6 +815,7 @@ def run_route_replay(
     n_npc_spawned = 0
     goal_reached = False
     reason = "max_steps"
+    min_goal_d = float("inf")  # closest approach to goal seen so far
 
     # --- Main loop. ---
     with ThreadPoolExecutor(max_workers=4, thread_name_prefix="save") as save_pool:
@@ -745,11 +830,13 @@ def run_route_replay(
                 if after > before:
                     n_npc_spawned += (after - before)
 
-            # Refresh map_data to include the closest lanelets to ego + NPC
-            # anchors. Mirrors the Diffusion-Planner ROS node, which rebuilds
-            # the lane tensor every inference frame. We throttle to
-            # ``map_refresh_steps`` (default 5 = 0.5 s at dt=0.1) since the
-            # cost (~few ms on a 6k-lanelet map) adds up over 6000 steps.
+            # Refresh map_data + ego.route_lanes. Mirrors the C++ Autoware
+            # planner, which rebuilds these every inference frame. We
+            # throttle to ``map_refresh_steps`` (default 5 = 0.5 s at
+            # dt=0.1). The refresh now also populates polygons +
+            # line_strings (intersection areas + road borders + stop lines)
+            # via center_xy, and slides the route window forward via
+            # select_route_segment_indices.
             if step == 0 or step % spawn_config.map_refresh_steps == 0:
                 ego_xy = scene.ego_agent.current_position
                 neighbor_xys = [
@@ -757,16 +844,47 @@ def run_route_replay(
                     if a.id != scene.ego_agent_id
                 ]
                 new_ids = _compute_map_lanelet_ids(ego_xy, neighbor_xys)
-                scene.map_data = builder._build_map_data(new_ids)
+                scene.map_data = builder._build_map_data(new_ids, center_xy=ego_xy)
                 npc_manager._known_lanelet_ids = set(new_ids)
                 map_cache = MapTensorCache(scene.map_data)
 
+                # Slide the ego's route window forward — drop already-passed
+                # lanelets, keep the next ~25 ahead. Matches training
+                # distribution (median 4 non-zero) and keeps the model's
+                # route context fresh as ego advances.
+                fwd_route_ids = builder.select_route_segment_indices(
+                    ego_route_ids, ego_xy, max_segments=25,
+                )
+                if fwd_route_ids:
+                    rl, rsl, rhsl = builder._route_to_33dim(fwd_route_ids)
+                    scene.ego_agent.route_lanes = rl
+                    scene.ego_agent.route_speed_limit = rsl
+                    scene.ego_agent.route_has_speed_limit = rhsl
+
             # Inference for every alive agent, in one batched forward pass.
+            # Also returns per-agent argmax of the model's turn-indicator
+            # logit head so we can feed it back into each agent's
+            # turn_indicators history on the next frame — mirrors the C++
+            # ``TurnIndicatorManager`` control loop.
             ids_to_predict = [a.id for a in scene.agents if a.agent_type == AgentType.VEHICLE]
-            agent_predictions = _predict_batch(
+            agent_predictions, agent_turn_indicators = _predict_batch(
                 model, model_args, scene, ids_to_predict, device,
-                map_cache=map_cache,
+                map_cache=map_cache, return_turn_indicators=True,
             )
+
+            # Optional Savitzky-Golay smoothing on each agent's predicted
+            # trajectory. Reuses the same smoother the RL ranked-SFT
+            # pipeline applies before its SFT loss (rlvr/grpo_sft_trainer.
+            # _smooth_trajectory). Helps when the diffusion sampler emits
+            # jitter at the first step; benign at worst when the output is
+            # already clean.
+            if spawn_config.sg_smooth_enabled:
+                for aid, traj in agent_predictions.items():
+                    agent_predictions[aid] = _sg_smooth_trajectory(
+                        traj,
+                        spawn_config.sg_filter_window,
+                        spawn_config.sg_filter_order,
+                    )
 
             # Save PNG (concurrent with next step's compute).
             out_path = output_dir / f"step_{step:04d}.png"
@@ -781,15 +899,50 @@ def run_route_replay(
                 pending_saves = [f for f in pending_saves if not f.done()]
 
             # Goal check (BEFORE advancing — measures arrival accurately).
+            # Two termination conditions:
+            #   (a) within ``goal_tolerance_m`` of the goal — clean arrival
+            #   (b) ego *passed* the goal: goal is behind ego AND was within
+            #       ``goal_pass_window_m`` recently. The diffusion planner
+            #       isn't a goal-stop controller, so a perfect-arrival check
+            #       at small radius (e.g. 2 m) often misses by a few metres
+            #       and the ego then drives away. (b) catches that case.
             ego_pos = scene.ego_agent.current_position
+            ego_heading = scene.ego_agent.current_heading
             goal_xy = route.goal_pose[:2]
-            if float(np.linalg.norm(ego_pos - goal_xy)) <= spawn_config.goal_tolerance_m:
+            d_goal = float(np.linalg.norm(ego_pos - goal_xy))
+            min_goal_d = min(min_goal_d, d_goal)
+            if d_goal <= spawn_config.goal_tolerance_m:
                 goal_reached = True
                 reason = "goal_reached"
-                print(f"  Goal reached at step {step} (distance {np.linalg.norm(ego_pos - goal_xy):.2f} m)")
+                print(f"  Goal reached at step {step} (distance {d_goal:.2f} m)")
+                break
+            # Has the ego passed the goal? Vector ego→goal vs ego forward.
+            ego_forward = np.array([math.cos(ego_heading), math.sin(ego_heading)], dtype=np.float32)
+            to_goal = goal_xy - ego_pos
+            dot = float(np.dot(to_goal, ego_forward))
+            if dot < 0 and min_goal_d <= spawn_config.goal_pass_window_m:
+                goal_reached = True
+                reason = "goal_passed"
+                print(
+                    f"  Ego passed the goal at step {step} (current d={d_goal:.1f} m, "
+                    f"closest approach was {min_goal_d:.1f} m within "
+                    f"{spawn_config.goal_pass_window_m:.0f} m of goal)"
+                )
                 break
 
             advance_scene(scene, agent_predictions)
+
+            # Closed-loop turn-indicator feedback: overwrite the freshly-
+            # rolled last slot of each agent's turn_indicators history
+            # with the argmax of the model's turn_indicator_logit. Matches
+            # the C++ TurnIndicatorManager (minus the hold-duration
+            # filter, which we skip for now — can be added later).
+            for a in scene.agents:
+                if a.turn_indicators is None:
+                    continue
+                ti_cls = agent_turn_indicators.get(a.id)
+                if ti_cls is not None:
+                    a.turn_indicators[-1] = int(ti_cls)
 
             if step % 50 == 0:
                 print(

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -28,9 +28,10 @@ High-level flow
 4. Terminate when the ego arrives within ``goal_tolerance_m`` of
    ``route.goal_pose`` or after ``n_steps`` ticks.
 
-Traffic lights are explicitly out of scope. ``traffic_light_source`` is
-accepted but ignored today; see :mod:`scenario_generation.traffic_light` for
-the intended seam.
+Traffic lights are managed by :class:`TrafficLightController`
+(``scenario_generation.traffic_light``), which discovers TL regulatory
+elements from the lanelet2 map, builds cycle groups, and writes the 5-dim
+one-hot into ``scene.map_data.lanes[:, :, 8:13]`` every map refresh.
 
 Batched inference note
 ----------------------
@@ -78,7 +79,11 @@ from scenario_generation.simulate import (
     load_model,
 )
 from scenario_generation.tensor_converter import MapTensorCache
-from scenario_generation.traffic_light import AllNoneTLSource, TrafficLightSource
+from scenario_generation.traffic_light import (
+    AllNoneTLSource,
+    TrafficLightController,
+    TrafficLightSource,
+)
 
 # Reuse the Savitzky-Golay smoother from the RL pipeline. Used there by
 # ranked-SFT to smooth diffusion-planner outputs before the SFT loss; same
@@ -228,10 +233,13 @@ class SceneNPCManager:
         builder: LaneletSceneBuilder,
         ego_route_ll_ids: list[int],
         spawn_config: SpawnConfig,
+        tl_controller: TrafficLightController | None = None,
     ) -> None:
         self.builder = builder
         self.ego_route_ll_ids = ego_route_ll_ids
         self.cfg = spawn_config
+        self.tl_controller = tl_controller
+        self._sim_time: float = 0.0
         self._rng = random.Random(spawn_config.seed)
         self._np_rng = np.random.default_rng(spawn_config.seed)
         self._next_id = 0
@@ -327,6 +335,12 @@ class SceneNPCManager:
 
         for _ in range(20):  # up to 20 attempts
             ll_id = self._rng.choice(candidate_ids)
+            # Skip lanelets that ARE traffic-light-controlled (inside the
+            # intersection). Spawning is allowed on lanelets *before* the
+            # intersection; speed is adjusted below based on TL state.
+            if self.tl_controller is not None and \
+               self.tl_controller.get_group_for_lanelet(ll_id) is not None:
+                continue
             c = self.builder._cache[ll_id]
             cl = c.raw_centerline
             # Pick an arc-length away from the lanelet endpoints.
@@ -345,9 +359,13 @@ class SceneNPCManager:
             pos = cl[seg_idx] + t * (cl[seg_idx + 1] - cl[seg_idx])
             pos = pos.astype(np.float32)
 
-            # Range check against ego.
+            # Range check against ego. Dynamic minimum: at higher ego
+            # speeds, push the min distance out to ego_speed * 3 s to
+            # prevent NPCs from popping in dangerously close.
             d_ego = float(np.linalg.norm(pos - ego_pos))
-            if d_ego < self.cfg.min_spawn_distance or d_ego > self.cfg.max_spawn_distance:
+            ego_speed = float(np.linalg.norm(ego.current_velocity))
+            dynamic_min = max(self.cfg.min_spawn_distance, ego_speed * 3.0)
+            if d_ego < dynamic_min or d_ego > self.cfg.max_spawn_distance:
                 continue
 
             # Lane heading at this point.
@@ -381,6 +399,14 @@ class SceneNPCManager:
             route_ll_ids = self._pick_route(ll_id)
             goal = self.builder._route_goal(route_ll_ids)
             route_lanes, route_sl, route_hsl = self.builder._route_to_33dim(route_ll_ids)
+            if self.tl_controller is not None:
+                self.tl_controller.write_to_route_lanes(
+                    route_lanes, route_ll_ids, self._sim_time,
+                )
+
+            # Reject spawn if too close to a red light on its route.
+            if self._too_close_to_red_tl(pos, route_ll_ids):
+                continue
 
             history, history_ll_ids = self.builder.generate_history(
                 pos, heading, speed, ll_id,
@@ -423,11 +449,45 @@ class SceneNPCManager:
                 route_speed_limit=route_sl,
                 route_has_speed_limit=route_hsl,
                 turn_indicators=np.zeros(history.shape[0], dtype=np.int32),
+                age_steps=0,
+                route_lanelet_ids=route_ll_ids,
             )
             touched = list(set(route_ll_ids) | set(history_ll_ids) | {ll_id})
             return agent, touched
 
         return None, []
+
+    def _too_close_to_red_tl(
+        self,
+        spawn_pos: np.ndarray,
+        route_ll_ids: list[int],
+        min_dist: float = 30.0,
+    ) -> bool:
+        """Return True if the spawn is within ``min_dist`` of a RED/YELLOW TL
+        on the NPC's route. Such spawns are rejected outright — a vehicle
+        appearing 10 m before a red light with full speed is unrealistic
+        and confuses the ego.
+        """
+        from scenario_generation.traffic_light import TL_RED, TL_YELLOW
+        tl = self.tl_controller
+        if tl is None:
+            return False
+
+        for rid in route_ll_ids:
+            gid = tl.get_group_for_lanelet(rid)
+            if gid is None:
+                continue
+            color = tl._color_for_group(gid, self._sim_time)
+            if color not in (TL_RED, TL_YELLOW):
+                return False  # first TL is green, fine to spawn
+            # First TL is red/yellow — check distance to its start.
+            if rid not in self.builder._cache:
+                return True
+            tl_start = self.builder._cache[rid].raw_centerline[0]
+            dist = float(np.linalg.norm(spawn_pos - tl_start))
+            return dist < min_dist
+
+        return False
 
     def _pick_route(self, start_ll_id: int) -> list[int]:
         """Select a forward route for a freshly-spawned NPC.
@@ -454,7 +514,7 @@ class SceneNPCManager:
 _LANE_COLOR = "#bbbbbb"
 _LANE_BORDER_COLOR = "#888888"
 _EGO_COLOR = "#3366cc"
-_ROUTE_COLOR = "#00aa44"
+_ROUTE_COLOR = "#3366cc"
 _VIEW_HALF_M = 50.0  # ±50 m window around ego keeps lane detail legible
 
 
@@ -508,6 +568,9 @@ def _save_step_figure(
     n_steps: int,
     route_polylines: list[np.ndarray] | None = None,
     view_half_m: float = _VIEW_HALF_M,
+    tl_controller: TrafficLightController | None = None,
+    route_lanelet_ids: list[int] | None = None,
+    sim_time: float = 0.0,
 ) -> None:
     """Render + save the overview PNG for a single replay step.
 
@@ -536,6 +599,44 @@ def _save_step_figure(
                     pl[:, 0], pl[:, 1], "-", color=_ROUTE_COLOR,
                     lw=2.5, alpha=0.6, zorder=3,
                 )
+
+    # 2b) Traffic-light coloured overlay on ALL lanes in map_data that have
+    #     active TL state (route, parallel, and perpendicular). Read
+    #     centerline XY directly from the lane tensor [0:2].
+    if tl_controller is not None:
+        from matplotlib.collections import LineCollection
+        tl_segments: dict[str, list[np.ndarray]] = {}  # hex → list of polylines
+        lanes = scene.map_data.lanes
+        # Use the map_data_ll_ids that were stored when building map_data.
+        # They are passed via route_lanelet_ids for the route overlay, but
+        # for ALL lanes we need the builder's _last_map_data_ids — which
+        # we can't access here. Instead, read the TL one-hot directly from
+        # the lane tensor channels [8:13].
+        for i in range(lanes.shape[0]):
+            lane = lanes[i]
+            pts = lane[:, :2]
+            if np.abs(pts).sum() < 1e-6:
+                continue
+            tl_onehot = lane[0, 8:13]
+            if tl_onehot.sum() < 0.5:
+                continue
+            ch = int(np.argmax(tl_onehot))
+            from scenario_generation.traffic_light import TL_HEX, TL_NONE
+            if ch == TL_NONE:
+                continue
+            hex_color = TL_HEX.get(ch)
+            if hex_color is None:
+                continue
+            valid = np.abs(pts).sum(axis=1) > 0.1
+            if valid.sum() < 2:
+                continue
+            tl_segments.setdefault(hex_color, []).append(pts[valid])
+
+        for hex_color, segs in tl_segments.items():
+            ax.add_collection(LineCollection(
+                segs, colors=hex_color, linewidths=2.5,
+                alpha=0.85, zorder=4,
+            ))
 
     # 3) Agents + per-agent predicted trajectories.
     # Assign colors by hashing the agent id (or extracting a stable numeric
@@ -672,8 +773,8 @@ def run_route_replay(
         output_dir: Directory for per-step PNGs. Created if missing.
         spawn_config: NPC manager tuning. Defaults to :class:`SpawnConfig()`.
         device: Torch device.
-        traffic_light_source: Reserved seam for a future TL source. Ignored
-            today; see :mod:`scenario_generation.traffic_light`.
+        traffic_light_source: Legacy parameter (unused). Traffic lights are
+            now managed by :class:`TrafficLightController` internally.
 
     Returns:
         Dict with ``final_step``, ``goal_reached`` (bool), ``reason`` (str),
@@ -684,6 +785,13 @@ def run_route_replay(
     if traffic_light_source is None:
         traffic_light_source = AllNoneTLSource()
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Seed ALL random sources for full reproducibility across runs.
+    if spawn_config.seed is not None:
+        torch.manual_seed(spawn_config.seed)
+        torch.cuda.manual_seed_all(spawn_config.seed)
+        np.random.seed(spawn_config.seed)
+        random.seed(spawn_config.seed)
 
     # --- Step 0: build the initial scene from the Route. ---
     ego_route_ids = route.route_lanelet_ids
@@ -798,17 +906,32 @@ def run_route_replay(
         route_speed_limit=route_sl,
         route_has_speed_limit=route_hsl,
         turn_indicators=np.zeros(history.shape[0], dtype=np.int32),
+        route_lanelet_ids=list(ego_route_ids),
     )
     scene = SceneContext(agents=[ego], map_data=map_data, ego_agent_id="ego", dt=0.1)
 
-    # Route polyline (world frame) for per-step visualisation.
+    # Route polyline (world frame) for per-step visualisation. Keep the
+    # lanelet ID list in sync so the TL overlay can colour each segment.
+    _route_vis_ll_ids: list[int] = [
+        ll_id for ll_id in ego_route_ids if ll_id in builder._cache
+    ]
     route_polylines = [
         builder._cache[ll_id].raw_centerline[:, :2]
-        for ll_id in ego_route_ids if ll_id in builder._cache
+        for ll_id in _route_vis_ll_ids
     ]
 
+    # --- Traffic light controller. ---
+    tl_controller = TrafficLightController(
+        builder, ego_route_ids, seed=spawn_config.seed,
+    )
+    # Apply initial TL state to the freshly-built map_data AND ego route_lanes.
+    tl_controller.tick(scene, 0.0, builder._last_map_data_ids, ego_xy=snapped_xy)
+    tl_controller.write_to_route_lanes(
+        scene.ego_agent.route_lanes, initial_route_window, 0.0,
+    )
+
     # --- NPC manager. ---
-    npc_manager = SceneNPCManager(builder, ego_route_ids, spawn_config)
+    npc_manager = SceneNPCManager(builder, ego_route_ids, spawn_config, tl_controller)
     npc_manager.register_known_lanelets(all_lanelet_ids)
 
     map_cache = MapTensorCache(scene.map_data)
@@ -821,6 +944,9 @@ def run_route_replay(
     with ThreadPoolExecutor(max_workers=4, thread_name_prefix="save") as save_pool:
         pending_saves: list = []
         for step in range(spawn_config.max_steps):
+            # Keep NPC manager's sim time in sync for TL writes on spawn.
+            npc_manager._sim_time = step * 0.1
+
             # Run the NPC manager (after step 0 so the ego has a meaningful
             # ``current_position`` — always true by construction here).
             if step > 0 and step % spawn_config.spawn_period_steps == 0:
@@ -837,8 +963,11 @@ def run_route_replay(
             # line_strings (intersection areas + road borders + stop lines)
             # via center_xy, and slides the route window forward via
             # select_route_segment_indices.
+            ego_xy = scene.ego_agent.current_position
+
+            # Rebuild map_data periodically (expensive: closest-lanelet
+            # query + polygon/line_string tensors).
             if step == 0 or step % spawn_config.map_refresh_steps == 0:
-                ego_xy = scene.ego_agent.current_position
                 neighbor_xys = [
                     a.current_position for a in scene.agents
                     if a.id != scene.ego_agent_id
@@ -846,20 +975,32 @@ def run_route_replay(
                 new_ids = _compute_map_lanelet_ids(ego_xy, neighbor_xys)
                 scene.map_data = builder._build_map_data(new_ids, center_xy=ego_xy)
                 npc_manager._known_lanelet_ids = set(new_ids)
-                map_cache = MapTensorCache(scene.map_data)
 
-                # Slide the ego's route window forward — drop already-passed
-                # lanelets, keep the next ~25 ahead. Matches training
-                # distribution (median 4 non-zero) and keeps the model's
-                # route context fresh as ego advances.
-                fwd_route_ids = builder.select_route_segment_indices(
-                    ego_route_ids, ego_xy, max_segments=25,
+            # TL state + route_lanes refresh EVERY step so the model
+            # always sees the current signal phase.
+            tl_controller.tick(
+                scene, step * 0.1, builder._last_map_data_ids,
+                ego_xy=ego_xy,
+            )
+            map_cache = MapTensorCache(scene.map_data)
+
+            # Refresh route_lanes for ALL agents (ego + NPCs) so the
+            # sliding window stays centered on each agent's current
+            # position. Without this, NPC route context goes stale and
+            # the model plans trajectories in the wrong direction.
+            for a in scene.agents:
+                if a.route_lanelet_ids is None:
+                    continue
+                a_xy = a.current_position
+                fwd = builder.select_route_segment_indices(
+                    a.route_lanelet_ids, a_xy, max_segments=25,
                 )
-                if fwd_route_ids:
-                    rl, rsl, rhsl = builder._route_to_33dim(fwd_route_ids)
-                    scene.ego_agent.route_lanes = rl
-                    scene.ego_agent.route_speed_limit = rsl
-                    scene.ego_agent.route_has_speed_limit = rhsl
+                if fwd:
+                    rl, rsl, rhsl = builder._route_to_33dim(fwd)
+                    tl_controller.write_to_route_lanes(rl, fwd, step * 0.1)
+                    a.route_lanes = rl
+                    a.route_speed_limit = rsl
+                    a.route_has_speed_limit = rhsl
 
             # Inference for every alive agent, in one batched forward pass.
             # Also returns per-agent argmax of the model's turn-indicator
@@ -892,6 +1033,8 @@ def run_route_replay(
                 _save_step_figure,
                 deepcopy(scene), agent_predictions, out_path,
                 step, spawn_config.max_steps, route_polylines,
+                _VIEW_HALF_M, tl_controller, _route_vis_ll_ids,
+                step * 0.1,
             ))
 
             # Drain any finished saves so memory doesn't balloon.
@@ -931,6 +1074,11 @@ def run_route_replay(
                 break
 
             advance_scene(scene, agent_predictions)
+
+            # Increment age for all agents so the tensor converter knows
+            # how many history frames are "real" vs pre-spawn fabrication.
+            for a in scene.agents:
+                a.age_steps += 1
 
             # Closed-loop turn-indicator feedback: overwrite the freshly-
             # rolled last slot of each agent's turn_indicators history

--- a/scenario_generation/route.py
+++ b/scenario_generation/route.py
@@ -2,11 +2,11 @@
 
 A ``Route`` captures an ego vehicle's driving intent on a Lanelet2 map:
 
-* A start pose (picked in the GUI via Shift+drag)
-* A goal pose (Shift+Alt+drag)
-* Zero or more intermediate waypoints (Ctrl+Shift+drag), each forcing the
-  route to pass through a specific lanelet even when it is off the shortest
-  path from start to goal.
+* A start pose (picked in the GUI by selecting Start mode and dragging)
+* A goal pose (picked by selecting Goal mode and dragging)
+* Zero or more intermediate waypoints (picked by selecting Waypoint mode and
+  dragging), each forcing the route to pass through a specific lanelet even
+  when it is off the shortest path from start to goal.
 * The resolved lanelet sequence connecting start → waypoints → goal, computed
   via ``lanelet2.routing.RoutingGraph.shortestPathWithVia``.
 

--- a/scenario_generation/route.py
+++ b/scenario_generation/route.py
@@ -1,0 +1,105 @@
+"""Route specification for closed-loop replay.
+
+A ``Route`` captures an ego vehicle's driving intent on a Lanelet2 map:
+
+* A start pose (picked in the GUI via Shift+drag)
+* A goal pose (Shift+Alt+drag)
+* Zero or more intermediate waypoints (Ctrl+Shift+drag), each forcing the
+  route to pass through a specific lanelet even when it is off the shortest
+  path from start to goal.
+* The resolved lanelet sequence connecting start → waypoints → goal, computed
+  via ``lanelet2.routing.RoutingGraph.shortestPathWithVia``.
+
+The Route is intentionally lightweight — no SceneContext, no neighbors.
+Neighbors are synthesized on the fly at replay time by ``replay.py`` so that
+saved routes stay reusable under different traffic densities and seeds.
+
+Coordinate frame: all poses are in MGRS local Cartesian (the world frame used
+throughout ``scenario_generation/``), matching the lanelet2 map origin
+``MGRSProjector(Origin(0.0, 0.0))``.
+
+Persistence uses pickle to match the existing ``.map_snippets/*.pkl`` format
+(see ``batch_generate._load_snippet``).
+"""
+
+from __future__ import annotations
+
+import pickle
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+
+
+@dataclass
+class Route:
+    """A reusable route spec for closed-loop replay.
+
+    Attributes:
+        map_path: Absolute path to the ``lanelet2_map.osm`` file used when the
+            route was authored. The replay loader rebuilds the ``LaneletSceneBuilder``
+            from this path, so the map must exist at replay time.
+        start_pose: ``(3,)`` float32 ``[x, y, heading_rad]`` in world frame.
+        goal_pose: ``(3,)`` float32 ``[x, y, heading_rad]`` in world frame.
+        start_lanelet_id: Snapped lanelet id at save time; can be ``None`` when
+            the start could not be snapped to a drivable lanelet (in which case
+            the route should not have been saved).
+        goal_lanelet_id: Snapped lanelet id for the goal. Same ``None`` caveat.
+        waypoint_poses: Ordered list of ``(3,)`` float32 ``[x, y, heading_rad]``
+            world-frame poses, one per waypoint. Empty when no waypoints were
+            dropped.
+        waypoint_lanelet_ids: Snapped lanelet ids, parallel to
+            ``waypoint_poses``. Same length.
+        route_lanelet_ids: Full resolved lanelet path ``[start, ..., goal]``.
+            Set at save time via ``shortestPathWithVia``. ``None`` indicates
+            the author explicitly skipped resolution (e.g. the map changed);
+            replay will fall back to ``builder.find_route`` with a warning.
+    """
+
+    map_path: str
+    start_pose: np.ndarray
+    goal_pose: np.ndarray
+    start_lanelet_id: int | None
+    goal_lanelet_id: int | None
+    waypoint_poses: list[np.ndarray] = field(default_factory=list)
+    waypoint_lanelet_ids: list[int] = field(default_factory=list)
+    route_lanelet_ids: list[int] | None = None
+
+    def __post_init__(self) -> None:
+        if self.start_pose.shape != (3,):
+            raise ValueError(f"start_pose must be shape (3,), got {self.start_pose.shape}")
+        if self.goal_pose.shape != (3,):
+            raise ValueError(f"goal_pose must be shape (3,), got {self.goal_pose.shape}")
+        if len(self.waypoint_poses) != len(self.waypoint_lanelet_ids):
+            raise ValueError(
+                f"waypoint_poses ({len(self.waypoint_poses)}) and "
+                f"waypoint_lanelet_ids ({len(self.waypoint_lanelet_ids)}) "
+                "must have the same length"
+            )
+        for i, wp in enumerate(self.waypoint_poses):
+            if wp.shape != (3,):
+                raise ValueError(f"waypoint_poses[{i}] must be shape (3,), got {wp.shape}")
+
+    def save(self, path: str | Path) -> None:
+        """Pickle the Route to disk. Parent directories are created as needed."""
+        p = Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with open(p, "wb") as f:
+            pickle.dump(self, f)
+
+    @classmethod
+    def load(cls, path: str | Path) -> "Route":
+        """Load a Route previously written with :meth:`save`."""
+        with open(path, "rb") as f:
+            obj = pickle.load(f)
+        if not isinstance(obj, cls):
+            raise TypeError(f"Expected pickled Route, got {type(obj).__name__}")
+        return obj
+
+    def num_waypoints(self) -> int:
+        """Convenience accessor for the number of intermediate waypoints."""
+        return len(self.waypoint_lanelet_ids)
+
+    def is_resolved(self) -> bool:
+        """Whether ``route_lanelet_ids`` has been computed."""
+        return self.route_lanelet_ids is not None and len(self.route_lanelet_ids) > 0

--- a/scenario_generation/scene_context.py
+++ b/scenario_generation/scene_context.py
@@ -69,6 +69,16 @@ class Agent:
     route_speed_limit: np.ndarray | None = None
     route_has_speed_limit: np.ndarray | None = None
     turn_indicators: np.ndarray | None = None
+    # Number of simulation steps this agent has been alive. Used by the
+    # tensor converter to zero-out history frames that predate the spawn
+    # so other agents see the NPC as "just appeared" rather than having
+    # a fabricated past. The agent's OWN inference still uses its full
+    # synthesised history (age is ignored for the ego-as-self path).
+    age_steps: int = 999
+    # Ordered lanelet IDs for this agent's route. Stored at spawn time
+    # so the replay loop can refresh route_lanes as the agent advances
+    # (same sliding-window logic as the ego's route refresh).
+    route_lanelet_ids: list | None = None
 
     @property
     def current_position(self) -> np.ndarray:

--- a/scenario_generation/scene_context.py
+++ b/scenario_generation/scene_context.py
@@ -78,7 +78,7 @@ class Agent:
     # Ordered lanelet IDs for this agent's route. Stored at spawn time
     # so the replay loop can refresh route_lanes as the agent advances
     # (same sliding-window logic as the ego's route refresh).
-    route_lanelet_ids: list | None = None
+    route_lanelet_ids: list[int] | None = None
 
     @property
     def current_position(self) -> np.ndarray:

--- a/scenario_generation/simulate.py
+++ b/scenario_generation/simulate.py
@@ -118,7 +118,7 @@ def _advance_agent(agent, new_world_pos: np.ndarray, dt: float = 0.1):
     # far cleaner than `(new_vel_raw - old_vel_raw) / dt` which compounded
     # jitter from both steps.
     if agent.past_velocities is not None and agent.past_velocities.shape[0] >= W + 1:
-        vel_window = agent.past_velocities[-W - 1: -1]
+        vel_window = agent.past_velocities[-W - 1:]
         if vel_window.shape[0] >= 2:
             accel_diffs = np.diff(vel_window, axis=0) / dt
             agent.acceleration = accel_diffs.mean(axis=0).astype(np.float32)
@@ -180,6 +180,84 @@ def advance_scene(scene: SceneContext, agent_predictions: dict[str, np.ndarray],
             float(ax), float(ay), ah,
         )
         new_pos = np.array([new_xy[0, 0], new_xy[0, 1], new_h[0]], dtype=np.float32)
+        _advance_agent(agent, new_pos, dt)
+
+
+def advance_scene_mpc(
+    scene: SceneContext,
+    agent_predictions: dict[str, np.ndarray],
+    trackers: dict,
+    dt: float = 0.1,
+    apply_postprocessing: bool = True,
+    tracker_type: str = "mpc",
+    mpc_horizon_steps: int = 20,
+    mpc_n_knots: int = 5,
+) -> None:
+    """Advance the scene using trajectory tracking (in-place).
+
+    Instead of teleporting each agent to ``pred[0]``, transforms the
+    full 80-step reference trajectory to world frame and feeds it to a
+    per-agent tracker which produces physically plausible steps.
+
+    Args:
+        scene: SceneContext to modify in-place.
+        agent_predictions: Maps agent_id -> (80, 4) ego-centric prediction
+            [x, y, cos_h, sin_h].
+        trackers: Maps agent_id -> tracker instance.  Missing entries are
+            created lazily.
+        dt: Timestep duration.
+        apply_postprocessing: When True, apply velocity smoothing and
+            force-stop to the reference before tracking (see
+            ``mpc_tracker.postprocess_reference``).
+        tracker_type: ``"mpc"`` for bicycle-model MPC, ``"perfect"``
+            for Euler velocity-limited follower.
+    """
+    from scenario_generation.mpc_tracker import (
+        MPCTracker,
+        PerfectTracker,
+        postprocess_reference,
+    )
+
+    for agent in scene.agents:
+        if agent.id not in agent_predictions:
+            continue
+
+        pred = agent_predictions[agent.id]  # (80, 4) ego-centric
+
+        # Transform full trajectory to world frame
+        ax, ay = agent.current_position
+        ah = agent.current_heading
+        world_xy, world_h = _ego_to_world(
+            pred[:, :2], pred[:, 2:4], float(ax), float(ay), ah,
+        )
+
+        # Build world-frame reference (N, 3) [x, y, yaw]
+        ref_world = np.column_stack([world_xy, world_h])
+
+        if apply_postprocessing:
+            ref_world = postprocess_reference(world_xy, world_h, dt=dt)
+
+        # Lazy-init tracker for this agent
+        if agent.id not in trackers:
+            if tracker_type == "mpc":
+                trackers[agent.id] = MPCTracker(
+                    wheelbase=agent.wheelbase, dt=dt,
+                    horizon_steps=mpc_horizon_steps, n_knots=mpc_n_knots,
+                )
+            elif tracker_type == "perfect":
+                trackers[agent.id] = PerfectTracker(dt=dt)
+            else:
+                raise ValueError(f"Unknown tracker_type {tracker_type!r}")
+
+        tracker = trackers[agent.id]
+
+        # Current state: [x, y, yaw, speed]
+        vel = agent.current_velocity
+        speed = float(vel[0] * math.cos(ah) + vel[1] * math.sin(ah))
+        speed = max(speed, 0.0)
+        x0 = np.array([float(ax), float(ay), ah, speed], dtype=np.float64)
+
+        new_pos, _new_speed = tracker.track(x0, ref_world)
         _advance_agent(agent, new_pos, dt)
 
 

--- a/scenario_generation/simulate.py
+++ b/scenario_generation/simulate.py
@@ -81,24 +81,78 @@ def _ego_to_world(pred_xy: np.ndarray, pred_cos_sin: np.ndarray,
 def _advance_agent(agent, new_world_pos: np.ndarray, dt: float = 0.1):
     """Advance a single agent in-place given its new world position.
 
-    Uses in-place shift + overwrite instead of concatenation to avoid allocations.
+    Uses in-place shift + overwrite instead of concatenation to avoid
+    allocations. Derivatives (velocity, acceleration, yaw_rate) are
+    computed from *smoothed* windows of the shifted past buffers instead
+    of raw one-step finite differences — at 10 Hz the one-step numerical
+    diff amplifies high-freq jitter from the diffusion sampler by ~10×
+    on velocity and ~100× on acceleration. A short 5-step central
+    average over the most recent window (past 0.4 s) suppresses that
+    without lag. Steering angle is derived from the bicycle model:
+    ``δ = atan2(wheelbase * yaw_rate, speed)``.
     """
-    old_vel = agent.current_velocity
-    old_heading = agent.current_heading
-    new_vel = ((new_world_pos[:2] - agent.current_position) / dt).astype(np.float32)
-    new_accel = ((new_vel - old_vel) / dt).astype(np.float32)
-    dh = float(new_world_pos[2] - old_heading)
-    dh = (dh + math.pi) % (2 * math.pi) - math.pi
-
     agent.past_trajectory[:-1] = agent.past_trajectory[1:]
     agent.past_trajectory[-1] = new_world_pos
 
-    if agent.past_velocities is not None:
-        agent.past_velocities[:-1] = agent.past_velocities[1:]
-        agent.past_velocities[-1] = new_vel
+    # Velocity window: use the last 5 position differences to average out
+    # per-step noise. 5 steps = 0.4 s, short enough to react, long enough
+    # to denoise.
+    traj = agent.past_trajectory
+    T = traj.shape[0]
+    W = min(5, T - 1) if T >= 2 else 0
+    if W >= 2:
+        diffs = np.diff(traj[T - 1 - W: T, :2], axis=0) / dt
+        smoothed_vel = diffs.mean(axis=0).astype(np.float32)
+    else:
+        smoothed_vel = ((new_world_pos[:2] - traj[-2, :2]) / dt).astype(np.float32) \
+            if T >= 2 else np.zeros(2, dtype=np.float32)
 
-    agent.acceleration = new_accel
-    agent.yaw_rate = dh / dt
+    if agent.past_velocities is not None:
+        old_smoothed_vel = agent.past_velocities[-1].copy()
+        agent.past_velocities[:-1] = agent.past_velocities[1:]
+        agent.past_velocities[-1] = smoothed_vel
+    else:
+        old_smoothed_vel = smoothed_vel
+
+    # Acceleration: finite diff of the smoothed velocity series — this is
+    # far cleaner than `(new_vel_raw - old_vel_raw) / dt` which compounded
+    # jitter from both steps.
+    if agent.past_velocities is not None and agent.past_velocities.shape[0] >= W + 1:
+        vel_window = agent.past_velocities[-W - 1: -1]
+        if vel_window.shape[0] >= 2:
+            accel_diffs = np.diff(vel_window, axis=0) / dt
+            agent.acceleration = accel_diffs.mean(axis=0).astype(np.float32)
+        else:
+            agent.acceleration = ((smoothed_vel - old_smoothed_vel) / dt).astype(np.float32)
+    else:
+        agent.acceleration = ((smoothed_vel - old_smoothed_vel) / dt).astype(np.float32)
+
+    # Heading rate via circular difference over the same window.
+    if T >= W + 1:
+        head_window = traj[T - 1 - W: T, 2]
+        dh_window = np.diff(head_window)
+        dh_window = np.arctan2(np.sin(dh_window), np.cos(dh_window))
+        agent.yaw_rate = float(dh_window.mean() / dt)
+    else:
+        dh = float(new_world_pos[2] - traj[-2, 2]) if T >= 2 else 0.0
+        dh = (dh + math.pi) % (2 * math.pi) - math.pi
+        agent.yaw_rate = dh / dt
+
+    # Steering angle from the bicycle model.
+    speed = float(np.hypot(smoothed_vel[0], smoothed_vel[1]))
+    if speed > 0.2:
+        agent.steering_angle = float(math.atan2(agent.wheelbase * agent.yaw_rate, speed))
+    else:
+        agent.steering_angle = 0.0
+
+    # Roll the per-step turn-indicator history forward by one slot. The
+    # newest slot (index -1) is filled in by the replay loop after
+    # reading the model's turn_indicator_logit output for this agent —
+    # we just leave index -1 at 0 (NONE) here so callers that don't have
+    # the model output still get a valid-shaped buffer.
+    if agent.turn_indicators is not None:
+        agent.turn_indicators[:-1] = agent.turn_indicators[1:]
+        agent.turn_indicators[-1] = 0
 
 
 def advance_scene(scene: SceneContext, agent_predictions: dict[str, np.ndarray],
@@ -290,7 +344,8 @@ def _predict_batch(
     model, model_args, scene: SceneContext,
     agent_ids: list[str], device: str,
     map_cache: MapTensorCache | None = None,
-) -> dict[str, np.ndarray]:
+    return_turn_indicators: bool = False,
+) -> dict[str, np.ndarray] | tuple[dict[str, np.ndarray], dict[str, int]]:
     """Run batched inference for multiple agents-as-ego.
 
     Builds per-agent tensor dicts, concatenates along batch dim,
@@ -301,11 +356,19 @@ def _predict_batch(
             map_data is static across steps, pass a single cache built
             once to avoid rebuilding every call. Built internally when
             not provided.
+        return_turn_indicators: When True, also returns a per-agent
+            ``{id: class_idx}`` dict with the argmax of each agent's
+            ``turn_indicator_logit`` output (class index in
+            {0=NONE, 1=DISABLE, 2=LEFT, 3=RIGHT, 4=KEEP}). Used by the
+            closed-loop replay to feed model-predicted turn signals back
+            into the next frame's ``turn_indicators`` history, matching
+            the C++ ``TurnIndicatorManager`` control flow.
 
-    Returns {agent_id: (80, 4) ego-centric prediction}.
+    Returns ``{agent_id: (80, 4) ego-centric prediction}``, or a tuple
+    ``(preds, turn_idx)`` when ``return_turn_indicators=True``.
     """
     if not agent_ids:
-        return {}
+        return ({}, {}) if return_turn_indicators else {}
 
     if map_cache is None:
         map_cache = MapTensorCache(scene.map_data)
@@ -317,12 +380,28 @@ def _predict_batch(
     model.decoder._guidance_fn = None
     if len(agent_ids) == 1:
         _, outputs = model(tensor_dicts[0])
-        return {agent_ids[0]: outputs["prediction"][0, 0].cpu().numpy()}
+        preds = {agent_ids[0]: outputs["prediction"][0, 0].cpu().numpy()}
+        if not return_turn_indicators:
+            return preds
+        ti_logit = outputs.get("turn_indicator_logit")
+        ti = {}
+        if ti_logit is not None:
+            ti[agent_ids[0]] = int(ti_logit[0].argmax(dim=-1).cpu().item())
+        return preds, ti
 
     batched = _cat_tensor_dicts(tensor_dicts)
     _, outputs = model(batched)
-    preds = outputs["prediction"][:, 0].cpu().numpy()
-    return {aid: preds[i] for i, aid in enumerate(agent_ids)}
+    preds_arr = outputs["prediction"][:, 0].cpu().numpy()
+    preds = {aid: preds_arr[i] for i, aid in enumerate(agent_ids)}
+    if not return_turn_indicators:
+        return preds
+    ti_logit = outputs.get("turn_indicator_logit")
+    ti: dict[str, int] = {}
+    if ti_logit is not None:
+        ti_cls = ti_logit.argmax(dim=-1).cpu().numpy()
+        for i, aid in enumerate(agent_ids):
+            ti[aid] = int(ti_cls[i])
+    return preds, ti
 
 
 @torch.no_grad()

--- a/scenario_generation/tensor_converter.py
+++ b/scenario_generation/tensor_converter.py
@@ -86,22 +86,36 @@ def _build_ego_current_state(
     ego: Agent,
     R: np.ndarray,
 ) -> np.ndarray:
-    """Build ego_current_state: [1, 10] all zeros for position (at origin)."""
-    vel = ego.current_velocity
-    vel_ego = transform_directions(vel.reshape(1, 2), R).flatten()
+    """Build ego_current_state: ``[1, 10]`` in ego frame.
 
-    accel = ego.acceleration
+    Convention matches the training data / C++ Autoware:
+    - position (x, y) is (0, 0) — self-frame
+    - heading (cos, sin) is (1, 0) — self-frame
+    - **vx carries the full global speed magnitude**, vy is exactly 0
+    - ax is the longitudinal projection of world-frame acceleration onto
+      ego forward, ay is exactly 0
+    - steering_angle and yaw_rate are scalars set by the physics updater
+
+    Forcing vy=ay=0 matches the training NPZ convention — the car's motion
+    is canonicalized to its own heading axis so the lateral dimension is
+    only a kinematics cue (rate of heading change), never a velocity.
+    """
+    vel = ego.current_velocity  # world frame [Vx_w, Vy_w]
+    speed = float(np.sqrt(vel[0] ** 2 + vel[1] ** 2))
+
+    # Longitudinal acceleration = projection onto ego forward. Lateral = 0.
+    accel = ego.acceleration  # world frame
     accel_ego = transform_directions(accel.reshape(1, 2), R).flatten()
 
     state = np.zeros(10, dtype=np.float32)
-    state[0] = 0.0  # x (at origin)
-    state[1] = 0.0  # y (at origin)
-    state[2] = 1.0  # cos(0)
-    state[3] = 0.0  # sin(0)
-    state[4] = vel_ego[0]
-    state[5] = vel_ego[1]
-    state[6] = accel_ego[0]
-    state[7] = accel_ego[1]
+    state[0] = 0.0           # x
+    state[1] = 0.0           # y
+    state[2] = 1.0           # cos(0)
+    state[3] = 0.0           # sin(0)
+    state[4] = speed         # vx = |V| (full magnitude in ego frame)
+    state[5] = 0.0           # vy = 0 (canonicalized to forward axis)
+    state[6] = accel_ego[0]  # ax = longitudinal accel
+    state[7] = 0.0           # ay = 0
     state[8] = ego.steering_angle
     state[9] = ego.yaw_rate
     return state[np.newaxis]  # [1, 10]
@@ -143,14 +157,30 @@ def _build_neighbor_agents_past(
         cos_h = np.cos(h_ego).astype(np.float32)
         sin_h = np.sin(h_ego).astype(np.float32)
 
-        # Transform velocities
+        # Velocity, canonicalized to each neighbor's own heading axis — this
+        # matches the C++ Autoware convention in
+        # ``autoware_diffusion_planner/src/conversion/agent.cpp::as_array``
+        # (lines 73-76): velocity_norm = hypot(vx_world, vy_world); then
+        # (velocity_x, velocity_y) = velocity_norm * (cos(θ), sin(θ)) with θ
+        # being the neighbor's own yaw. This zeros any lateral drift
+        # (skid) and only encodes forward speed. We then rotate into ego
+        # frame via R.
         if agent.past_velocities is not None:
-            vel = transform_directions(agent.past_velocities, R)
+            raw_vel = agent.past_velocities
+        elif T_agent >= 2:
+            raw_vel = np.zeros((T_agent, 2), dtype=np.float32)
+            raw_vel[1:] = np.diff(traj[:, :2], axis=0) / scene.dt
         else:
-            vel = np.zeros((T_agent, 2), dtype=np.float32)
-            if T_agent >= 2:
-                diffs = np.diff(traj[:, :2], axis=0) / scene.dt
-                vel[1:] = transform_directions(diffs, R)
+            raw_vel = np.zeros((T_agent, 2), dtype=np.float32)
+        speed = np.linalg.norm(raw_vel, axis=1).astype(np.float32)  # (T,)
+        # Canonical world-frame velocity pointing along the neighbor's own
+        # heading. traj[:, 2] is heading_rad.
+        cos_hw = np.cos(traj[:, 2]).astype(np.float32)
+        sin_hw = np.sin(traj[:, 2]).astype(np.float32)
+        vel_world_canonical = np.stack(
+            [speed * cos_hw, speed * sin_hw], axis=1,
+        )
+        vel = transform_directions(vel_world_canonical, R)
 
         # Agent type one-hot
         type_vec = np.zeros(3, dtype=np.float32)

--- a/scenario_generation/tensor_converter.py
+++ b/scenario_generation/tensor_converter.py
@@ -207,6 +207,13 @@ def _build_neighbor_agents_past(
         orig_invalid = np.sum(np.abs(traj[:, :2]), axis=-1) == 0
         feats[orig_invalid] = 0.0
 
+        # Zero out pre-spawn history so other agents see the neighbor as
+        # "just appeared". age_steps=0 means only the current frame (last
+        # row) is real; age_steps>=T_agent means the full history is valid.
+        if hasattr(agent, "age_steps") and agent.age_steps < T_agent:
+            n_valid = max(1, agent.age_steps + 1)  # at least current frame
+            feats[:T_agent - n_valid] = 0.0
+
         feats = _pad_or_truncate(feats, T_needed, axis=0)
         out[0, slot_idx] = feats
 

--- a/scenario_generation/tests/test_mpc_tracker.py
+++ b/scenario_generation/tests/test_mpc_tracker.py
@@ -1,0 +1,199 @@
+"""Tests for :mod:`scenario_generation.mpc_tracker`.
+
+Pure-Python tests — no model, no GPU, no map needed.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from scenario_generation.mpc_tracker import (
+    MPCTracker,
+    PerfectTracker,
+    postprocess_reference,
+)
+
+
+# ── MPCTracker ──────────────────────────────────────────────────────────────
+
+
+class TestMPCTracker:
+    def test_straight_line_tracks_reference(self):
+        """Vehicle going straight should stay on the straight reference."""
+        tracker = MPCTracker(wheelbase=2.79, horizon_steps=20, n_knots=5)
+        x0 = np.array([0.0, 0.0, 0.0, 5.0])  # heading east, 5 m/s
+        ref = np.zeros((80, 3))
+        for i in range(80):
+            ref[i, 0] = 0.5 * (i + 1)
+        new_pos, new_speed = tracker.track(x0, ref)
+        assert np.isfinite(new_pos).all()
+        assert new_pos[0] > 0  # moved forward
+        assert abs(new_pos[1]) < 0.1  # stayed on line
+        assert new_speed > 0
+
+    def test_output_respects_speed_bounds(self):
+        tracker = MPCTracker(wheelbase=2.79, max_speed=10.0)
+        x0 = np.array([0.0, 0.0, 0.0, 9.0])
+        # Reference demanding very high speed
+        ref = np.zeros((80, 3))
+        for i in range(80):
+            ref[i, 0] = 5.0 * (i + 1)  # 50 m/s reference
+        _, speed = tracker.track(x0, ref)
+        assert speed <= 10.0 + 1e-6
+
+    def test_output_no_reverse(self):
+        tracker = MPCTracker(wheelbase=2.79)
+        x0 = np.array([0.0, 0.0, 0.0, 2.0])
+        # Reference behind the vehicle
+        ref = np.zeros((80, 3))
+        ref[:, 0] = -10.0
+        _, speed = tracker.track(x0, ref)
+        assert speed >= 0.0
+
+    def test_steering_bounded(self):
+        tracker = MPCTracker(wheelbase=2.79, max_steer=0.6)
+        x0 = np.array([0.0, 0.0, 0.0, 5.0])
+        # Sharp left turn reference
+        ref = np.zeros((80, 3))
+        for i in range(80):
+            ref[i, 0] = 0.0
+            ref[i, 1] = 2.0 * (i + 1)  # hard left
+            ref[i, 2] = math.pi / 2
+        new_pos, _ = tracker.track(x0, ref)
+        assert np.isfinite(new_pos).all()
+
+    def test_warm_start_produces_valid_output(self):
+        tracker = MPCTracker(wheelbase=2.79)
+        x0 = np.array([0.0, 0.0, 0.0, 5.0])
+        ref = np.zeros((80, 3))
+        for i in range(80):
+            ref[i, 0] = 0.5 * (i + 1)
+        pos1, spd1 = tracker.track(x0, ref)
+        x1 = np.array([pos1[0], pos1[1], pos1[2], spd1])
+        pos2, spd2 = tracker.track(x1, ref)
+        assert np.isfinite(pos2).all()
+        assert spd2 >= 0.0
+
+    def test_reset_clears_warm_start(self):
+        tracker = MPCTracker(wheelbase=2.79)
+        x0 = np.array([0.0, 0.0, 0.0, 5.0])
+        ref = np.zeros((80, 3))
+        ref[:, 0] = np.arange(1, 81) * 0.5
+        tracker.track(x0, ref)
+        assert tracker._prev_knots is not None
+        tracker.reset()
+        assert tracker._prev_knots is None
+
+    def test_invalid_knots_raises(self):
+        with pytest.raises(ValueError):
+            MPCTracker(wheelbase=2.79, horizon_steps=20, n_knots=7)
+        with pytest.raises(ValueError):
+            MPCTracker(wheelbase=2.79, horizon_steps=5, n_knots=10)
+        with pytest.raises(ValueError):
+            MPCTracker(wheelbase=2.79, horizon_steps=20, n_knots=0)
+
+    def test_short_reference_padded(self):
+        """Reference shorter than horizon should be padded, not crash."""
+        tracker = MPCTracker(wheelbase=2.79, horizon_steps=20, n_knots=5)
+        x0 = np.array([0.0, 0.0, 0.0, 3.0])
+        ref = np.array([[1.0, 0.0, 0.0], [2.0, 0.0, 0.0]])  # only 2 steps
+        pos, speed = tracker.track(x0, ref)
+        assert np.isfinite(pos).all()
+
+
+# ── PerfectTracker ──────────────────────────────────────────────────────────
+
+
+class TestPerfectTracker:
+    def test_straight_advance(self):
+        tracker = PerfectTracker(dt=0.1)
+        x0 = np.array([0.0, 0.0, 0.0, 5.0])
+        ref = np.array([[0.5, 0.0, 0.0]])  # 0.5m ahead = 5 m/s
+        pos, speed = tracker.track(x0, ref)
+        assert pos[0] == pytest.approx(0.5, abs=0.05)
+        assert abs(pos[1]) < 1e-6
+        assert speed == pytest.approx(5.0, abs=0.5)
+
+    def test_heading_snapped_to_reference(self):
+        tracker = PerfectTracker(dt=0.1)
+        x0 = np.array([0.0, 0.0, 0.0, 5.0])  # heading east
+        ref = np.array([[0.5, 0.0, math.pi / 4]])  # ref heading NE
+        pos, _ = tracker.track(x0, ref)
+        assert pos[2] == pytest.approx(math.pi / 4, abs=1e-6)
+
+    def test_speed_capped(self):
+        tracker = PerfectTracker(dt=0.1, max_speed=10.0)
+        x0 = np.array([0.0, 0.0, 0.0, 5.0])
+        ref = np.array([[50.0, 0.0, 0.0]])  # 500 m/s implied
+        _, speed = tracker.track(x0, ref)
+        assert speed <= 10.0 + 1e-6
+
+    def test_empty_reference(self):
+        tracker = PerfectTracker(dt=0.1)
+        x0 = np.array([0.0, 0.0, 0.0, 5.0])
+        pos, speed = tracker.track(x0, np.zeros((0, 3)))
+        assert pos[0] == pytest.approx(0.0)
+        assert speed == 0.0
+
+    def test_reset_is_noop(self):
+        tracker = PerfectTracker()
+        tracker.reset()  # should not raise
+
+
+# ── postprocess_reference ───────────────────────────────────────────────────
+
+
+class TestPostprocessReference:
+    def test_force_stop_freezes_positions(self):
+        """After velocity drops below threshold, positions must freeze."""
+        N = 20
+        ref_xy = np.zeros((N, 2), dtype=np.float64)
+        ref_h = np.zeros(N, dtype=np.float64)
+        # Constant speed for first 10 steps, then stop
+        for i in range(N):
+            if i < 10:
+                ref_xy[i, 0] = i * 0.5
+            else:
+                ref_xy[i, 0] = 10 * 0.5  # freeze
+        result = postprocess_reference(ref_xy, ref_h, stop_threshold=0.3)
+        # After force-stop triggers, all positions should be identical
+        stop_idx = None
+        for i in range(11, N):
+            if result[i, 0] == result[i - 1, 0]:
+                stop_idx = i
+                break
+        assert stop_idx is not None, "Force-stop should have frozen positions"
+        for i in range(stop_idx, N):
+            np.testing.assert_array_equal(result[i, :2], result[stop_idx - 1, :2])
+
+    def test_velocity_smoothing_reduces_jitter(self):
+        """Moving average should smooth velocity spikes."""
+        N = 30
+        ref_xy = np.zeros((N, 2), dtype=np.float64)
+        for i in range(N):
+            ref_xy[i, 0] = i * 0.5
+        # Inject a spike
+        ref_xy[10, 0] += 2.0
+        result = postprocess_reference(ref_xy, np.zeros(N), vel_smooth_window=8)
+        assert np.isfinite(result).all()
+
+    def test_single_point_reference(self):
+        ref_xy = np.array([[1.0, 2.0]])
+        ref_h = np.array([0.5])
+        result = postprocess_reference(ref_xy, ref_h)
+        assert result.shape == (1, 3)
+        assert result[0, 0] == pytest.approx(1.0)
+
+    def test_constant_velocity_no_stop(self):
+        """Constant-velocity reference should not trigger force-stop."""
+        N = 40
+        ref_xy = np.zeros((N, 2), dtype=np.float64)
+        for i in range(N):
+            ref_xy[i, 0] = i * 1.0  # 10 m/s constant
+        ref_h = np.zeros(N)
+        result = postprocess_reference(ref_xy, ref_h, stop_threshold=0.3)
+        # Last position should NOT be frozen to earlier position
+        assert result[-1, 0] > result[0, 0] + 10.0

--- a/scenario_generation/tests/test_replay_spawn.py
+++ b/scenario_generation/tests/test_replay_spawn.py
@@ -56,6 +56,7 @@ def test_spawn_config_defaults_match_user_spec() -> None:
     assert c.goal_tolerance_m == 2.0       # user: "within 2 meters"
     assert c.max_steps == 6000             # user: "more than 6000 timesteps"
     assert c.ego_overlap_ratio == 0.3      # user: "mixed 70/30"
+    assert c.goal_pass_window_m == 25.0    # added when v3 showed ego passing goal at d=16.5m
 
 
 # ── SceneNPCManager with a real map ──────────────────────────────────────────

--- a/scenario_generation/tests/test_replay_spawn.py
+++ b/scenario_generation/tests/test_replay_spawn.py
@@ -1,0 +1,209 @@
+"""Tests for :class:`scenario_generation.replay.SceneNPCManager` and
+:class:`SpawnConfig`.
+
+These exercise the spawn-manager logic without the diffusion model — there is
+no ``_predict_batch`` call here. ``run_route_replay`` is covered by a
+manual end-to-end run (task #13); unit tests stay lightweight.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from scenario_generation.replay import (
+    SceneNPCManager,
+    SpawnConfig,
+)
+from scenario_generation.scene_context import Agent, AgentType, SceneContext
+
+MAP_PATH = Path("/home/danielsanchez/autoware_map/shinagawa_odaiba_stable/lanelet2_map.osm")
+
+
+# ── SpawnConfig ──────────────────────────────────────────────────────────────
+
+
+def test_spawn_config_json_round_trip(tmp_path: Path) -> None:
+    c = SpawnConfig(max_active_npcs=12, goal_tolerance_m=1.5, max_steps=1000)
+    p = tmp_path / "cfg.json"
+    c.to_json(p)
+    c2 = SpawnConfig.from_json(p)
+    assert c == c2
+
+
+def test_spawn_config_ignores_unknown_keys(tmp_path: Path) -> None:
+    """Comment-style underscore-prefixed keys in a config JSON must not
+    crash the constructor."""
+    raw = {
+        "_comment": "example comment",
+        "max_active_npcs": 4,
+        "_note": "another",
+    }
+    p = tmp_path / "cfg.json"
+    p.write_text(json.dumps(raw))
+    c = SpawnConfig.from_json(p)
+    assert c.max_active_npcs == 4
+
+
+def test_spawn_config_defaults_match_user_spec() -> None:
+    """User-required values from the April 2026 planning session."""
+    c = SpawnConfig()
+    assert c.max_active_npcs == 8          # user confirmed default
+    assert c.despawn_distance == 120.0     # user-required
+    assert c.goal_tolerance_m == 2.0       # user: "within 2 meters"
+    assert c.max_steps == 6000             # user: "more than 6000 timesteps"
+    assert c.ego_overlap_ratio == 0.3      # user: "mixed 70/30"
+
+
+# ── SceneNPCManager with a real map ──────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def builder():
+    if not MAP_PATH.exists():
+        pytest.skip(f"Lanelet2 map not found at {MAP_PATH}")
+    from scenario_generation.gui.lanelet_scene_builder import LaneletSceneBuilder
+    return LaneletSceneBuilder(str(MAP_PATH))
+
+
+def _make_ego_scene(builder, start_ll_id: int) -> tuple[SceneContext, list[int]]:
+    """Build a minimal scene containing just an ego on the given lanelet."""
+    cl = builder._cache[start_ll_id].raw_centerline
+    pos = cl[len(cl) // 2].astype(np.float32)
+    heading = 0.0
+    history, history_ids = builder.generate_history(pos, heading, 5.0, start_ll_id)
+    route_ll_ids = builder.find_route(start_ll_id, 120.0)
+    route_lanes, rsl, rhsl = builder._route_to_33dim(route_ll_ids)
+    ego = Agent(
+        id="ego",
+        agent_type=AgentType.VEHICLE,
+        length=4.5, width=1.9, wheelbase=2.9,
+        past_trajectory=history,
+        past_velocities=np.zeros((history.shape[0], 2), dtype=np.float32),
+        acceleration=np.zeros(2, dtype=np.float32),
+        goal_pose=np.array([pos[0] + 20, pos[1], heading], dtype=np.float32),
+        route_lanes=route_lanes,
+        route_speed_limit=rsl,
+        route_has_speed_limit=rhsl,
+    )
+    all_ids = sorted(set(route_ll_ids) | set(history_ids))
+    map_data = builder._build_map_data(all_ids)
+    scene = SceneContext(agents=[ego], map_data=map_data, ego_agent_id="ego")
+    return scene, route_ll_ids
+
+
+def test_spawn_one_produces_valid_neighbor(builder) -> None:
+    # Pick a lanelet that's likely to have neighbors nearby.
+    all_ids = list(builder._cache.keys())
+    start_id = all_ids[len(all_ids) // 2]
+    scene, ego_route = _make_ego_scene(builder, start_id)
+
+    cfg = SpawnConfig(
+        max_active_npcs=4, spawn_probability=1.0, seed=42,
+        min_spawn_distance=5.0, max_spawn_distance=80.0,
+        forward_bias=0.5,
+    )
+    mgr = SceneNPCManager(builder, ego_route, cfg)
+    mgr.register_known_lanelets(ego_route)
+
+    mgr.tick(scene)
+    # At least one spawn attempt at prob=1.0 should succeed on a dense map.
+    npcs = [a for a in scene.agents if a.id != "ego"]
+    if not npcs:
+        # Dense-map assumption can fail at some lanelets; retry a few times.
+        for _ in range(10):
+            mgr.tick(scene)
+            npcs = [a for a in scene.agents if a.id != "ego"]
+            if npcs:
+                break
+    assert npcs, "spawn manager never produced a neighbor even after 10 ticks"
+
+    nb = npcs[0]
+    # Valid 31-step history with the current pose at index -1.
+    assert nb.past_trajectory.shape == (31, 3)
+    # Non-degenerate speed.
+    v = nb.past_velocities[-1]
+    assert np.linalg.norm(v) > 0.0
+    # Distance to ego within spawn bounds.
+    d = float(np.linalg.norm(nb.current_position - scene.ego_agent.current_position))
+    assert cfg.min_spawn_distance - 1.0 <= d <= cfg.max_spawn_distance + 1.0
+
+
+def test_despawn_drops_far_neighbors(builder) -> None:
+    all_ids = list(builder._cache.keys())
+    start_id = all_ids[len(all_ids) // 2]
+    scene, ego_route = _make_ego_scene(builder, start_id)
+
+    cfg = SpawnConfig(despawn_distance=50.0, spawn_probability=0.0, seed=1)
+    mgr = SceneNPCManager(builder, ego_route, cfg)
+    mgr.register_known_lanelets(ego_route)
+
+    # Inject a synthetic far-away neighbor.
+    ego_pos = scene.ego_agent.current_position
+    far_pos = np.array([ego_pos[0] + 200.0, ego_pos[1] + 0.0, 0.0], dtype=np.float32)
+    far_history = np.tile(far_pos, (31, 1))
+    near_pos = np.array([ego_pos[0] + 10.0, ego_pos[1] + 0.0, 0.0], dtype=np.float32)
+    near_history = np.tile(near_pos, (31, 1))
+    for label, hist in (("far", far_history), ("near", near_history)):
+        scene.agents.append(Agent(
+            id=label,
+            agent_type=AgentType.VEHICLE,
+            length=4.5, width=1.9, wheelbase=2.9,
+            past_trajectory=hist,
+            past_velocities=np.zeros((31, 2), dtype=np.float32),
+            acceleration=np.zeros(2, dtype=np.float32),
+        ))
+
+    mgr.tick(scene)
+    ids = [a.id for a in scene.agents]
+    assert "ego" in ids
+    assert "near" in ids
+    assert "far" not in ids, "neighbor > despawn_distance must be removed"
+
+
+def test_overlap_ratio_biases_neighbor_routes(builder) -> None:
+    """With ``ego_overlap_ratio`` = 1.0 every spawned NPC route should share
+    at least one lanelet with the ego route (when reachable). This does not
+    require any statistical power beyond a handful of successful spawns."""
+    all_ids = list(builder._cache.keys())
+    start_id = all_ids[len(all_ids) // 2]
+    scene, ego_route = _make_ego_scene(builder, start_id)
+    ego_set = set(ego_route)
+
+    cfg = SpawnConfig(
+        max_active_npcs=6, spawn_probability=1.0, seed=7,
+        ego_overlap_ratio=1.0,
+    )
+    mgr = SceneNPCManager(builder, ego_route, cfg)
+    mgr.register_known_lanelets(ego_route)
+
+    # Try many ticks to get several spawned neighbors.
+    for _ in range(30):
+        mgr.tick(scene)
+
+    npcs = [a for a in scene.agents if a.id != "ego"]
+    # We cannot assert every neighbor overlaps (the map may have candidates
+    # where no forward route touches the ego route after 5 retries — the
+    # code falls back to a random route). But at least one should overlap.
+    route_sets = []
+    for nb in npcs:
+        # Walk the non-zero centerline points of nb.route_lanes back to ids by
+        # matching against the cache.
+        lanes_xy = nb.route_lanes[:, 0, :2]  # first-point of each route slot
+        found_ids = set()
+        for xy in lanes_xy:
+            if abs(xy[0]) < 1e-6 and abs(xy[1]) < 1e-6:
+                continue
+            snapped = builder.snap_to_nearest_ll(xy)
+            if snapped is not None:
+                found_ids.add(snapped)
+        route_sets.append(found_ids)
+
+    any_overlap = any((rs & ego_set) for rs in route_sets)
+    assert npcs and any_overlap, (
+        f"ego_overlap_ratio=1.0 produced no neighbor with overlapping route "
+        f"across {len(npcs)} spawns"
+    )

--- a/scenario_generation/tests/test_route.py
+++ b/scenario_generation/tests/test_route.py
@@ -1,0 +1,238 @@
+"""Tests for :class:`scenario_generation.route.Route` and the routing
+helpers on :class:`~scenario_generation.gui.lanelet_scene_builder.LaneletSceneBuilder`.
+
+Tests that require the lanelet2 map are skipped when the expected
+shinagawa_odaiba_stable map is not available on disk, so CI can still run
+the pure-Python Route round-trip coverage.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from scenario_generation.route import Route
+
+MAP_PATH = Path("/home/danielsanchez/autoware_map/shinagawa_odaiba_stable/lanelet2_map.osm")
+
+
+# ── Pure Route round-trip ────────────────────────────────────────────────────
+
+
+def test_route_save_load_round_trip(tmp_path: Path) -> None:
+    r = Route(
+        map_path="/tmp/example.osm",
+        start_pose=np.array([1.0, 2.0, 0.5], dtype=np.float32),
+        goal_pose=np.array([10.0, 20.0, 1.5], dtype=np.float32),
+        start_lanelet_id=100,
+        goal_lanelet_id=200,
+        waypoint_poses=[np.array([5.0, 5.0, 1.0], dtype=np.float32)],
+        waypoint_lanelet_ids=[150],
+        route_lanelet_ids=[100, 150, 200],
+    )
+    r.save(tmp_path / "r.pkl")
+    loaded = Route.load(tmp_path / "r.pkl")
+
+    assert loaded.map_path == r.map_path
+    np.testing.assert_array_equal(loaded.start_pose, r.start_pose)
+    np.testing.assert_array_equal(loaded.goal_pose, r.goal_pose)
+    assert loaded.start_lanelet_id == 100
+    assert loaded.goal_lanelet_id == 200
+    assert loaded.waypoint_lanelet_ids == [150]
+    assert loaded.route_lanelet_ids == [100, 150, 200]
+    assert loaded.num_waypoints() == 1
+    assert loaded.is_resolved()
+
+
+def test_route_validates_start_pose_shape() -> None:
+    with pytest.raises(ValueError, match="start_pose must be shape"):
+        Route(
+            map_path="x",
+            start_pose=np.array([1.0, 2.0], dtype=np.float32),
+            goal_pose=np.array([3.0, 4.0, 0.0], dtype=np.float32),
+            start_lanelet_id=1, goal_lanelet_id=2,
+        )
+
+
+def test_route_validates_parallel_waypoint_lengths() -> None:
+    with pytest.raises(ValueError, match="must have the same length"):
+        Route(
+            map_path="x",
+            start_pose=np.zeros(3, dtype=np.float32),
+            goal_pose=np.zeros(3, dtype=np.float32),
+            start_lanelet_id=1, goal_lanelet_id=2,
+            waypoint_poses=[np.zeros(3, dtype=np.float32)],
+            waypoint_lanelet_ids=[],  # mismatched
+        )
+
+
+def test_route_unresolved_is_flagged() -> None:
+    r = Route(
+        map_path="x",
+        start_pose=np.zeros(3, dtype=np.float32),
+        goal_pose=np.zeros(3, dtype=np.float32),
+        start_lanelet_id=1, goal_lanelet_id=2,
+        route_lanelet_ids=None,
+    )
+    assert not r.is_resolved()
+
+
+# ── Routing helpers ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def builder():
+    """Cached LaneletSceneBuilder for the shinagawa map.
+
+    Scoped to the module so we pay the ~6000-lanelet load cost once.
+    """
+    if not MAP_PATH.exists():
+        pytest.skip(f"Lanelet2 map not found at {MAP_PATH}")
+    if os.environ.get("SKIP_LANELET_TESTS"):
+        pytest.skip("SKIP_LANELET_TESTS set")
+    from scenario_generation.gui.lanelet_scene_builder import LaneletSceneBuilder
+    return LaneletSceneBuilder(str(MAP_PATH))
+
+
+def _chain_of_length(builder, min_length: int) -> list[int]:
+    """Return a connected successor chain of at least ``min_length`` lanelets."""
+    for ll in list(builder._ll_by_id.values())[:500]:
+        curr = ll
+        chain = [curr.id]
+        for _ in range(20):
+            fol = list(builder._routing_graph.following(curr))
+            if not fol:
+                break
+            curr = fol[0]
+            chain.append(curr.id)
+        if len(chain) >= min_length:
+            return chain
+    pytest.skip(f"No successor chain of length >= {min_length} in this map")
+
+
+def test_snap_to_nearest_ll(builder) -> None:
+    ll_id = next(iter(builder._cache))
+    cl = builder._cache[ll_id].raw_centerline
+    # Snap a point exactly on the centerline — the expected closest is some
+    # lanelet whose centerline passes through / very near here.
+    snapped = builder.snap_to_nearest_ll(cl[len(cl) // 2])
+    assert snapped is not None
+    # The snapped lanelet's centerline must be within a few metres of the query.
+    snapped_cl = builder._cache[snapped].raw_centerline
+    min_d = np.min(np.linalg.norm(snapped_cl - cl[len(cl) // 2], axis=1))
+    assert min_d <= 5.0
+
+
+def test_lanelets_near_point(builder) -> None:
+    ll_id = next(iter(builder._cache))
+    cl = builder._cache[ll_id].raw_centerline
+    near = builder.lanelets_near_point(cl[len(cl) // 2], 30.0)
+    assert ll_id in near or any(
+        np.min(np.linalg.norm(builder._cache[x].raw_centerline - cl[len(cl) // 2], axis=1)) <= 30.0
+        for x in near
+    )
+    # All returned lanelets actually satisfy the radius constraint.
+    for x in near:
+        d = np.min(
+            np.linalg.norm(builder._cache[x].raw_centerline - cl[len(cl) // 2], axis=1),
+        )
+        assert d <= 30.0 + 1e-3  # float slack
+
+
+def test_route_between_recovers_connected_chain(builder) -> None:
+    chain = _chain_of_length(builder, min_length=5)
+    start, end = chain[0], chain[-1]
+    route = builder.route_between(start, end)
+    assert route is not None
+    assert route[0] == start and route[-1] == end
+
+
+def test_route_with_waypoints_empty_equals_route_between(builder) -> None:
+    chain = _chain_of_length(builder, min_length=5)
+    start, end = chain[0], chain[-1]
+    base = builder.route_between(start, end)
+    with_via = builder.route_with_waypoints(start, [], end)
+    assert base == with_via
+
+
+def test_route_with_waypoints_passes_through_via(builder) -> None:
+    chain = _chain_of_length(builder, min_length=5)
+    start, end = chain[0], chain[-1]
+    via = chain[len(chain) // 2]
+    route = builder.route_with_waypoints(start, [via], end)
+    assert route is not None
+    assert via in route
+
+
+def test_route_with_waypoints_preserves_order(builder) -> None:
+    chain = _chain_of_length(builder, min_length=5)
+    start, end = chain[0], chain[-1]
+    via1, via2 = chain[1], chain[-2]
+    route = builder.route_with_waypoints(start, [via1, via2], end)
+    assert route is not None
+    assert route.index(via1) < route.index(via2)
+
+
+def test_route_with_waypoints_reversed_is_infeasible(builder) -> None:
+    """Providing via-points in reverse order on a directed chain is unreachable
+    — the API must surface that as None rather than silently misroute."""
+    chain = _chain_of_length(builder, min_length=5)
+    start, end = chain[0], chain[-1]
+    via1, via2 = chain[1], chain[-2]
+    route = builder.route_with_waypoints(start, [via2, via1], end)
+    assert route is None
+
+
+def test_is_lanelet_straight_on_short_lanelet(builder) -> None:
+    # Pick a lanelet with few points — the short-circuit in is_lanelet_straight
+    # should return True without crashing.
+    short_ids = [i for i, c in builder._cache.items() if len(c.raw_centerline) < 3]
+    if not short_ids:
+        pytest.skip("No short (<3 points) lanelet in this map")
+    assert builder.is_lanelet_straight(short_ids[0]) is True
+
+
+def test_closest_lanelets_respects_bbox_and_cap(builder) -> None:
+    """closest_lanelets must: (1) stay within the mask range, (2) cap length,
+    (3) return closest-first order (by min-endpoint-to-query score)."""
+    ll_id = next(iter(builder._cache))
+    cl = builder._cache[ll_id].raw_centerline
+    query = cl[len(cl) // 2]
+
+    tight = builder.closest_lanelets(query, max_n=50, mask_range=50.0)
+    loose = builder.closest_lanelets(query, max_n=50, mask_range=200.0)
+    assert len(loose) >= len(tight)  # wider bbox = at least as many hits
+    assert len(loose) <= 50            # cap respected
+
+    # All returned lanelets have at least one anchor point inside the bbox.
+    for lid in loose:
+        c = builder._cache[lid].raw_centerline
+        center = c.mean(axis=0)
+        hits = (
+            (np.abs(c[0] - query) < 200).all()
+            or (np.abs(c[-1] - query) < 200).all()
+            or (np.abs(center - query) < 200).all()
+        )
+        assert hits, f"lanelet {lid} is outside the 200 m bbox"
+
+
+def test_closest_lanelets_cap_at_max_n(builder) -> None:
+    ll_id = next(iter(builder._cache))
+    cl = builder._cache[ll_id].raw_centerline
+    query = cl[len(cl) // 2]
+    # A huge bbox + small cap — the cap must truncate.
+    res = builder.closest_lanelets(query, max_n=5, mask_range=1000.0)
+    assert len(res) <= 5
+
+
+def test_is_lanelet_straight_rejects_sharp_curves(builder) -> None:
+    """Curve detection: when the threshold is tight most lanelets with any
+    turn register as non-straight; when loose, most register as straight."""
+    sample = list(builder._cache.keys())[:200]
+    tight = sum(1 for i in sample if builder.is_lanelet_straight(i, 0.01))
+    loose = sum(1 for i in sample if builder.is_lanelet_straight(i, 3.14))
+    assert tight <= loose
+    assert loose == len(sample)  # every lanelet is straight under a huge threshold

--- a/scenario_generation/tests/test_traffic_light.py
+++ b/scenario_generation/tests/test_traffic_light.py
@@ -1,0 +1,174 @@
+"""Tests for :mod:`scenario_generation.traffic_light`.
+
+Pure-Python tests — no lanelet2 map, no ROS, no GPU.
+Uses mock objects to isolate TL logic from the LaneletSceneBuilder.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from scenario_generation.traffic_light import (
+    PERP_GREEN_AFTER_DELAY,
+    TL_GREEN,
+    TL_NONE,
+    TL_RED,
+    TL_YELLOW,
+    _GroupState,
+    _opposite_color,
+)
+
+
+# ── _opposite_color ─────────────────────────────────────────────────────────
+
+
+class TestOppositeColor:
+    def test_green_gives_red(self):
+        assert _opposite_color(TL_GREEN, 0.0) == TL_RED
+
+    def test_yellow_gives_red(self):
+        assert _opposite_color(TL_YELLOW, 0.0) == TL_RED
+
+    def test_red_short_time_gives_red(self):
+        """Perpendicular stays red for PERP_GREEN_AFTER_DELAY seconds."""
+        assert _opposite_color(TL_RED, 0.0) == TL_RED
+        assert _opposite_color(TL_RED, PERP_GREEN_AFTER_DELAY - 0.1) == TL_RED
+
+    def test_red_after_delay_gives_green(self):
+        assert _opposite_color(TL_RED, PERP_GREEN_AFTER_DELAY + 0.1) == TL_GREEN
+
+
+# ── _GroupState transitions ─────────────────────────────────────────────────
+
+
+class TestGroupState:
+    def test_green_to_yellow_to_red_to_green(self):
+        """State machine must cycle green → yellow → red → green."""
+        state = _GroupState(color=TL_GREEN, last_change_time=0.0, duration=5.0)
+
+        # Still green before duration
+        assert state.color == TL_GREEN
+
+        # Transition to yellow
+        state.color = TL_YELLOW
+        state.last_change_time = 5.0
+        state.duration = 3.0
+        assert state.color == TL_YELLOW
+
+        # Transition to red
+        state.color = TL_RED
+        state.last_change_time = 8.0
+        state.duration = 5.0
+        assert state.color == TL_RED
+
+        # Transition back to green
+        state.color = TL_GREEN
+        state.last_change_time = 13.0
+        assert state.color == TL_GREEN
+
+
+# ── Signal group merging (transitive) ──────────────────────────────────────
+
+
+class TestSignalGroupMerge:
+    """Test the transitive bulb-group merge logic in TrafficLightController.__init__.
+
+    We replicate the merge algorithm from traffic_light.py rather than
+    instantiating a full TrafficLightController (which requires a real
+    LaneletSceneBuilder). This ensures the algorithm itself is correct.
+    """
+
+    @staticmethod
+    def _merge(bulb_map: dict[int, frozenset]) -> dict[frozenset, set[int]]:
+        """Replicate the transitive merge from TrafficLightController.__init__."""
+        signal_groups: dict[frozenset, set[int]] = {}
+        for reg_id, bulbs in bulb_map.items():
+            if not bulbs:
+                continue
+            overlapping_bulbs = bulbs
+            overlapping_regs: set[int] = {reg_id}
+            keys_to_remove: list[frozenset] = []
+            for existing_bulbs, existing_regs in signal_groups.items():
+                if overlapping_bulbs & existing_bulbs:
+                    overlapping_bulbs = overlapping_bulbs | existing_bulbs
+                    overlapping_regs |= existing_regs
+                    keys_to_remove.append(existing_bulbs)
+            for k in keys_to_remove:
+                del signal_groups[k]
+            signal_groups[overlapping_bulbs] = overlapping_regs
+        return signal_groups
+
+    def test_no_overlap_separate_groups(self):
+        result = self._merge({
+            1: frozenset({10, 11}),
+            2: frozenset({20, 21}),
+        })
+        assert len(result) == 2
+
+    def test_direct_overlap_merges(self):
+        result = self._merge({
+            1: frozenset({10, 11}),
+            2: frozenset({11, 12}),
+        })
+        assert len(result) == 1
+        group = list(result.values())[0]
+        assert group == {1, 2}
+
+    def test_transitive_overlap_merges_all(self):
+        """A shares with B, B shares with C → all three merge."""
+        result = self._merge({
+            1: frozenset({10, 11}),
+            2: frozenset({20, 21}),
+            3: frozenset({11, 20}),  # bridges group 1 and 2
+        })
+        assert len(result) == 1
+        group = list(result.values())[0]
+        assert group == {1, 2, 3}
+        bulbs = list(result.keys())[0]
+        assert bulbs == frozenset({10, 11, 20, 21})
+
+    def test_empty_bulbs_skipped(self):
+        result = self._merge({
+            1: frozenset(),
+            2: frozenset({10}),
+        })
+        assert len(result) == 1
+        assert list(result.values())[0] == {2}
+
+    def test_chain_of_three(self):
+        """A-B, B-C, C-D chain should all merge into one group."""
+        result = self._merge({
+            1: frozenset({1, 2}),
+            2: frozenset({2, 3}),
+            3: frozenset({3, 4}),
+            4: frozenset({4, 5}),
+        })
+        assert len(result) == 1
+        assert list(result.values())[0] == {1, 2, 3, 4}
+
+
+# ── Lane tensor one-hot encoding ───────────────────────────────────────────
+
+
+class TestLaneTensorEncoding:
+    """Verify TL one-hot is written to the correct channels in lane tensors."""
+
+    def test_one_hot_channels(self):
+        """Each TL color should set exactly one of the 5 channels [8:13]."""
+        for color, expected_idx in [
+            (TL_GREEN, 0), (TL_YELLOW, 1), (TL_RED, 2),
+        ]:
+            one_hot = np.zeros(5, dtype=np.float32)
+            one_hot[color] = 1.0
+            assert one_hot[expected_idx] == 1.0
+            assert one_hot.sum() == 1.0
+
+    def test_no_tl_channel(self):
+        one_hot = np.zeros(5, dtype=np.float32)
+        one_hot[TL_NONE] = 1.0
+        assert one_hot[4] == 1.0
+        assert one_hot.sum() == 1.0

--- a/scenario_generation/tools/__init__.py
+++ b/scenario_generation/tools/__init__.py
@@ -1,0 +1,6 @@
+"""User-facing command-line helpers for scenario_generation.
+
+Each tool is runnable via ``python -m scenario_generation.tools.<name>``.
+Tools must remain thin wrappers — algorithmic logic belongs in the top-level
+``scenario_generation`` modules, not here.
+"""

--- a/scenario_generation/tools/inspect_route.py
+++ b/scenario_generation/tools/inspect_route.py
@@ -1,0 +1,61 @@
+"""Pretty-print the contents of a saved ``Route`` pickle.
+
+Usage::
+
+    python -m scenario_generation.tools.inspect_route path/to/my_route.pkl
+
+Prints:
+
+* map path the route was authored against
+* start / goal world poses and snapped lanelet ids
+* waypoints (ordered) with snapped lanelet ids
+* resolved lanelet path length and first/last 5 lanelet ids
+
+Does not require the map or a model — pure pickle inspection.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+from pathlib import Path
+
+from scenario_generation.route import Route
+
+
+def _fmt_pose(pose) -> str:
+    x, y, h = pose
+    return f"({x:.2f}, {y:.2f}, {math.degrees(float(h)):.1f}°)"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("route", type=Path, help="Route pickle file")
+    args = parser.parse_args()
+
+    route = Route.load(args.route)
+
+    print(f"Route from {args.route}")
+    print(f"  map_path:          {route.map_path}")
+    print(f"  start_pose:        {_fmt_pose(route.start_pose)}  "
+          f"lanelet_id={route.start_lanelet_id}")
+    print(f"  goal_pose:         {_fmt_pose(route.goal_pose)}  "
+          f"lanelet_id={route.goal_lanelet_id}")
+    print(f"  waypoints:         {route.num_waypoints()}")
+    for i, (wp, wl) in enumerate(zip(route.waypoint_poses, route.waypoint_lanelet_ids), 1):
+        print(f"    #{i}: {_fmt_pose(wp)}  lanelet_id={wl}")
+    if route.is_resolved():
+        ids = route.route_lanelet_ids
+        head = ids[:5]
+        tail = ids[-5:] if len(ids) > 5 else []
+        print(f"  route_lanelet_ids: {len(ids)} lanelets")
+        print(f"    first 5: {head}")
+        if tail and tail != head:
+            print(f"    last 5:  {tail}")
+    else:
+        print("  route_lanelet_ids: *unresolved* "
+              "(replay will fall back to find_route)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scenario_generation/traffic_light.py
+++ b/scenario_generation/traffic_light.py
@@ -136,20 +136,19 @@ class TrafficLightController:
         for reg_id, bulbs in bulb_map.items():
             if not bulbs:
                 continue
-            # Find or create the signal group for these bulbs
-            merged = False
-            for existing_bulbs, existing_regs in list(self._signal_groups.items()):
-                if bulbs & existing_bulbs:  # any shared bulb
-                    # Merge: union the bulbs and reg_ids
-                    new_bulbs = existing_bulbs | bulbs
-                    existing_regs.add(reg_id)
-                    if new_bulbs != existing_bulbs:
-                        del self._signal_groups[existing_bulbs]
-                        self._signal_groups[new_bulbs] = existing_regs
-                    merged = True
-                    break
-            if not merged:
-                self._signal_groups[bulbs] = {reg_id}
+            # Collect ALL existing groups that share any bulb with this
+            # reg (transitive: A∩C and B∩C means A, B, C all merge).
+            overlapping_bulbs = bulbs
+            overlapping_regs: set[int] = {reg_id}
+            keys_to_remove: list[frozenset] = []
+            for existing_bulbs, existing_regs in self._signal_groups.items():
+                if overlapping_bulbs & existing_bulbs:
+                    overlapping_bulbs = overlapping_bulbs | existing_bulbs
+                    overlapping_regs |= existing_regs
+                    keys_to_remove.append(existing_bulbs)
+            for k in keys_to_remove:
+                del self._signal_groups[k]
+            self._signal_groups[overlapping_bulbs] = overlapping_regs
 
         # reg_element_id → canonical signal_id (use min reg_id in the group)
         self._group_to_signal: dict[int, int] = {}
@@ -323,6 +322,10 @@ class TrafficLightController:
             self._advance_group(rgid, sim_time_s)
 
         self._write_to_lanes(scene.map_data, map_data_ll_ids, sim_time_s)
+
+    def color_for_group(self, gid: int, t: float) -> int:
+        """Public accessor for the current colour of a signal group."""
+        return self._color_for_group(gid, t)
 
     def _color_for_group(self, gid: int, t: float) -> int:
         """Return the current colour for a group.

--- a/scenario_generation/traffic_light.py
+++ b/scenario_generation/traffic_light.py
@@ -1,26 +1,29 @@
-"""Traffic-light source Protocol for closed-loop replay.
+"""Traffic-light controller for closed-loop replay.
 
-This module exists purely to reserve the interface for a future session that
-wires real traffic-light state into ``replay.py``. Today ``replay.py`` ignores
-the source; the map-data lane tensor's 5-dim traffic-light one-hot block at
-channel indices ``[8:13]`` (see :class:`scenario_generation.scene_context.MapData`
-docstring) stays at its default "none" value.
+Discovers traffic lights from the lanelet2 map via ``lanelet.trafficLights()``
+regulatory elements and runs independent per-group state machines (green →
+amber → red → green) for TL groups along the ego's forward route.
 
-When a real source is added:
+Follows the same pattern as ``route_traffic_light_publisher.py``:
+  1. Walk the ego route from the closest lanelet forward (not-yet-passed).
+  2. For each lanelet with a TL, lazily initialise a per-group-id state
+     machine with randomised timing.
+  3. Every tick, advance each active group's state machine and write the
+     5-dim one-hot into ``scene.map_data.lanes[:, :, 8:13]``.
 
-* Read each lanelet's ``trafficLights()`` regulatory elements on the map.
-* Run a cycle state-machine (green/amber/red) per group_id.
-* Per step, for every lanelet in ``scene.map_data``, write the corresponding
-  one-hot into ``scene.map_data.lanes[ll_idx, :, 8:13]`` — same value for all
-  20 points of that lanelet.
-
-The writes propagate automatically to both the ego and NPC-as-ego inferences
-because they read from the same shared ``MapData``.
+Perpendicular groups (cross-traffic at the same intersection) are discovered
+by proximity and given the opposite phase of the route-direction group.
 """
 
 from __future__ import annotations
 
+import random
+from dataclasses import dataclass
 from typing import Protocol
+
+import numpy as np
+
+from scenario_generation.scene_context import MapData, SceneContext
 
 
 # Channel indices inside the 5-dim traffic-light one-hot block at lane dims
@@ -31,37 +34,409 @@ TL_RED = 2
 TL_WHITE = 3
 TL_NONE = 4
 
+# Hex colours for the visualisation overlay.
+TL_HEX = {
+    TL_GREEN: "#22bb22",
+    TL_YELLOW: "#ddaa00",
+    TL_RED: "#dd2222",
+}
+
 
 class TrafficLightSource(Protocol):
     """A callable-shaped object supplying the traffic-light colour for a given
-    lanelet at a given simulation time.
+    lanelet at a given simulation time."""
 
-    Implementations must be deterministic given their internal state so that
-    replays are reproducible with a fixed seed.
-    """
-
-    def color_for_lanelet(self, lanelet_id: int, t_sec: float) -> int:
-        """Return the active traffic-light channel index for ``lanelet_id``.
-
-        Args:
-            lanelet_id: Target lanelet, as stored in ``MapData``'s index-to-id
-                mapping.
-            t_sec: Simulation time in seconds since replay start.
-
-        Returns:
-            One of ``TL_GREEN``, ``TL_YELLOW``, ``TL_RED``, ``TL_WHITE``,
-            ``TL_NONE``.
-        """
-        ...
+    def color_for_lanelet(self, lanelet_id: int, t_sec: float) -> int: ...
 
 
 class AllNoneTLSource:
-    """Default source that returns ``TL_NONE`` for every lanelet at every time.
-
-    Matches the pre-existing behaviour of the scenario_generation pipeline
-    (lane tensors built by ``_route_to_33dim`` default the traffic block to
-    "none"). Use this as the replay default until a real source is wired in.
-    """
+    """Default source that returns ``TL_NONE`` for every lanelet at every time."""
 
     def color_for_lanelet(self, lanelet_id: int, t_sec: float) -> int:
         return TL_NONE
+
+
+# ── Cycle timing defaults (from route_traffic_light_publisher.py) ───────────
+
+AMBER_DURATION_RANGE = (3.0, 5.0)
+GREEN_RED_DURATION_RANGE = (10.0, 30.0)
+# Perpendicular lights turn GREEN this many seconds after the route light
+# turns RED (reverse-sync delay from route_traffic_light_publisher.py:636).
+PERP_GREEN_AFTER_DELAY = 2.0
+
+
+@dataclass
+class _GroupState:
+    """Per-TL-group independent state machine (mirrors route_traffic_light_publisher.py)."""
+    color: int
+    last_change_time: float
+    duration: float
+
+
+def _opposite_color(color: int, time_in_color: float) -> int:
+    """Return the perpendicular colour using the reverse-sync pattern from
+    ``route_traffic_light_publisher.py:_update_crosswalk_light_state``.
+
+    When route is GREEN → perp is RED.
+    When route is AMBER → perp is RED.
+    When route is RED → perp stays RED for ``PERP_GREEN_AFTER_DELAY``
+    seconds, then turns GREEN.
+    """
+    if color == TL_GREEN:
+        return TL_RED
+    if color == TL_YELLOW:
+        return TL_RED
+    # Route is RED.
+    if time_in_color < PERP_GREEN_AFTER_DELAY:
+        return TL_RED
+    return TL_GREEN
+
+
+class TrafficLightController:
+    """Manages traffic light state for closed-loop replay.
+
+    Only controls TL groups along the ego's route (forward from ego) and
+    their perpendicular counterparts. Each group runs its own independent
+    state machine, lazily initialised the first time it appears.
+    """
+
+    def __init__(
+        self,
+        builder,  # LaneletSceneBuilder
+        route_lanelet_ids: list[int],
+        seed: int | None = None,
+    ) -> None:
+        self._rng = random.Random(seed)
+
+        # Full map: {lanelet_id → TL reg_element_id (group_id)}.
+        self._ll_to_group: dict[int, int] = builder.get_traffic_light_groups()
+
+        # group_id → set of lanelet_ids
+        self._group_to_lls: dict[int, set[int]] = {}
+        for ll_id, gid in self._ll_to_group.items():
+            self._group_to_lls.setdefault(gid, set()).add(ll_id)
+
+        # group_id → geometric center (for proximity)
+        self._group_centers: dict[int, np.ndarray] = {}
+        for gid, ll_ids in self._group_to_lls.items():
+            pts = []
+            for ll_id in ll_ids:
+                if ll_id in builder._cache:
+                    pts.append(builder._cache[ll_id].raw_centerline.mean(axis=0))
+            if pts:
+                self._group_centers[gid] = np.mean(pts, axis=0)
+
+        # Build signal groups from shared light_bulbs. Regulatory elements
+        # that reference the same physical bulbs ARE the same signal and
+        # MUST show the same colour. This replaces the broken heading-
+        # based parallel/perpendicular heuristic.
+        bulb_map = builder.get_traffic_light_bulb_groups()
+        # bulbs_key → set of reg_element_ids that share those bulbs
+        self._signal_groups: dict[frozenset, set[int]] = {}
+        for reg_id, bulbs in bulb_map.items():
+            if not bulbs:
+                continue
+            # Find or create the signal group for these bulbs
+            merged = False
+            for existing_bulbs, existing_regs in list(self._signal_groups.items()):
+                if bulbs & existing_bulbs:  # any shared bulb
+                    # Merge: union the bulbs and reg_ids
+                    new_bulbs = existing_bulbs | bulbs
+                    existing_regs.add(reg_id)
+                    if new_bulbs != existing_bulbs:
+                        del self._signal_groups[existing_bulbs]
+                        self._signal_groups[new_bulbs] = existing_regs
+                    merged = True
+                    break
+            if not merged:
+                self._signal_groups[bulbs] = {reg_id}
+
+        # reg_element_id → canonical signal_id (use min reg_id in the group)
+        self._group_to_signal: dict[int, int] = {}
+        for _bulbs, reg_ids in self._signal_groups.items():
+            canonical = min(reg_ids)
+            for rid in reg_ids:
+                self._group_to_signal[rid] = canonical
+
+        # Route group discovery: ordered list of unique TL group_ids on the
+        # ego's route, preserving encounter order.
+        self._route_group_ids: list[int] = []
+        seen: set[int] = set()
+        for ll_id in route_lanelet_ids:
+            gid = self._ll_to_group.get(ll_id)
+            if gid is not None and gid not in seen:
+                self._route_group_ids.append(gid)
+                seen.add(gid)
+
+        # Route signal IDs (canonical IDs for the physical lights on the route)
+        self._route_signal_ids: set[int] = set()
+        for rgid in self._route_group_ids:
+            sig = self._group_to_signal.get(rgid, rgid)
+            self._route_signal_ids.add(sig)
+
+        # For each route signal, find nearby signals that are DIFFERENT
+        # physical lights → those are perpendicular (cross-traffic).
+        # Same-signal groups automatically get the same colour via
+        # _group_to_signal lookup.
+        proximity_m = 50.0
+        self._perp_signals: dict[int, set[int]] = {}  # route_signal → {perp signals}
+        for rgid in self._route_group_ids:
+            rc = self._group_centers.get(rgid)
+            if rc is None:
+                continue
+            route_sig = self._group_to_signal.get(rgid, rgid)
+            perp_sigs: set[int] = set()
+            for ogid, oc in self._group_centers.items():
+                if ogid == rgid:
+                    continue
+                other_sig = self._group_to_signal.get(ogid, ogid)
+                if other_sig == route_sig or other_sig in self._route_signal_ids:
+                    continue
+                if float(np.linalg.norm(rc - oc)) < proximity_m:
+                    perp_sigs.add(other_sig)
+            if perp_sigs:
+                self._perp_signals.setdefault(route_sig, set()).update(perp_sigs)
+
+        # Inverse: perp_signal → route_signal
+        self._perp_to_route_signal: dict[int, int] = {}
+        for rsig, perps in self._perp_signals.items():
+            for psig in perps:
+                self._perp_to_route_signal.setdefault(psig, rsig)
+
+        # Per-group state machines. Lazily initialised in _ensure_state().
+        self._group_states: dict[int, _GroupState] = {}
+
+        # Forward-route tracking: index into route_lanelet_ids of the closest
+        # lanelet to ego. Updated each tick via _update_forward_index().
+        self._route_ll_ids = list(route_lanelet_ids)
+        self._route_ll_centers: list[np.ndarray] = []
+        for ll_id in self._route_ll_ids:
+            if ll_id in builder._cache:
+                self._route_ll_centers.append(
+                    builder._cache[ll_id].raw_centerline.mean(axis=0)
+                )
+            else:
+                self._route_ll_centers.append(np.zeros(2, dtype=np.float32))
+        self._forward_idx: int = 0
+
+        n_total = len(self._ll_to_group)
+        n_route = len(self._route_group_ids)
+        n_signals = len(self._signal_groups)
+        n_route_sigs = len(self._route_signal_ids)
+        n_perp_sigs = sum(len(v) for v in self._perp_signals.values())
+        print(
+            f"  [TrafficLightController] {n_total} lanelets with TLs, "
+            f"{n_signals} physical signals, {n_route} groups on route "
+            f"({n_route_sigs} signals), {n_perp_sigs} perpendicular signals"
+        )
+
+    # ── State machine helpers ─────────────────────────────────────────────
+
+    def _ensure_state(self, gid: int, t: float) -> _GroupState:
+        """Lazily initialise a group's state machine (random initial colour)."""
+        if gid not in self._group_states:
+            initial = self._rng.choice([TL_GREEN, TL_RED])
+            self._group_states[gid] = _GroupState(
+                color=initial,
+                last_change_time=t,
+                duration=self._duration_for(initial),
+            )
+        return self._group_states[gid]
+
+    def _duration_for(self, color: int) -> float:
+        if color == TL_YELLOW:
+            return self._rng.uniform(*AMBER_DURATION_RANGE)
+        return self._rng.uniform(*GREEN_RED_DURATION_RANGE)
+
+    def _advance_group(self, gid: int, t: float) -> None:
+        """Advance one group's independent state machine (green→amber→red→green).
+
+        Mirrors ``route_traffic_light_publisher.py:_update_traffic_light_state``.
+        """
+        state = self._ensure_state(gid, t)
+        if t - state.last_change_time < state.duration:
+            return
+        if state.color == TL_GREEN:
+            nxt = TL_YELLOW
+        elif state.color == TL_YELLOW:
+            nxt = TL_RED
+        else:
+            nxt = TL_GREEN
+        state.color = nxt
+        state.last_change_time = t
+        state.duration = self._duration_for(nxt)
+
+    # ── Forward-route tracking ────────────────────────────────────────────
+
+    def _update_forward_index(self, ego_xy: np.ndarray) -> None:
+        """Move ``_forward_idx`` to the closest route lanelet to ego."""
+        if not self._route_ll_centers:
+            return
+        best_d = float("inf")
+        best_i = self._forward_idx
+        # Only search forward from current index (no going backwards).
+        for i in range(self._forward_idx, len(self._route_ll_centers)):
+            d = float(np.linalg.norm(self._route_ll_centers[i] - ego_xy))
+            if d < best_d:
+                best_d = d
+                best_i = i
+            elif d > best_d + 50.0:
+                break  # past the closest, stop searching
+        self._forward_idx = best_i
+
+    def _forward_route_groups(self) -> list[int]:
+        """Return route group_ids from the ego's current position forward."""
+        seen: set[int] = set()
+        result: list[int] = []
+        for i in range(self._forward_idx, len(self._route_ll_ids)):
+            gid = self._ll_to_group.get(self._route_ll_ids[i])
+            if gid is not None and gid not in seen:
+                result.append(gid)
+                seen.add(gid)
+        return result
+
+    # ── Per-step update ───────────────────────────────────────────────────
+
+    def tick(
+        self,
+        scene: SceneContext,
+        sim_time_s: float,
+        map_data_ll_ids: list[int],
+        ego_xy: np.ndarray | None = None,
+    ) -> None:
+        """Advance TL states and write into ``scene.map_data.lanes[:, :, 8:13]``.
+
+        Args:
+            scene: Current scene context (``map_data.lanes`` is mutated).
+            sim_time_s: Simulation time in seconds since replay start.
+            map_data_ll_ids: Ordered list of lanelet IDs corresponding to
+                rows of ``scene.map_data.lanes``.
+            ego_xy: Current ego XY position for forward-route tracking.
+        """
+        if ego_xy is not None:
+            self._update_forward_index(ego_xy)
+
+        # Advance state machines for forward route groups only.
+        # Perpendicular groups derive their colour from the route group
+        # via _opposite_color() — they have no independent state machine.
+        for rgid in self._forward_route_groups():
+            self._advance_group(rgid, sim_time_s)
+
+        self._write_to_lanes(scene.map_data, map_data_ll_ids, sim_time_s)
+
+    def _color_for_group(self, gid: int, t: float) -> int:
+        """Return the current colour for a group.
+
+        Three cases:
+        1. Route group with its own state machine → return state.color
+        2. Same-signal group (shares light_bulbs with a route group) →
+           same colour as the route group
+        3. Perpendicular signal (different physical light, nearby) →
+           opposite colour with safety delay
+        """
+        # Case 1: route group with active state machine
+        state = self._group_states.get(gid)
+        if state is not None:
+            return state.color
+
+        # Resolve to canonical signal ID
+        sig = self._group_to_signal.get(gid, gid)
+
+        # Case 2: same physical signal as a route group
+        if sig in self._route_signal_ids:
+            # Find the route group that shares this signal and use its state
+            for rgid in self._route_group_ids:
+                if self._group_to_signal.get(rgid, rgid) == sig:
+                    rs = self._group_states.get(rgid)
+                    if rs is not None:
+                        return rs.color
+                    break
+
+        # Case 3: perpendicular signal
+        parent_rsig = self._perp_to_route_signal.get(sig)
+        if parent_rsig is not None:
+            # Find the route group driving this parent signal
+            for rgid in self._route_group_ids:
+                if self._group_to_signal.get(rgid, rgid) == parent_rsig:
+                    rs = self._group_states.get(rgid)
+                    if rs is not None:
+                        time_in_color = t - rs.last_change_time
+                        return _opposite_color(rs.color, time_in_color)
+                    break
+
+        return TL_NONE
+
+    def _write_to_lanes(
+        self,
+        map_data: MapData,
+        map_data_ll_ids: list[int],
+        t: float,
+    ) -> None:
+        """Write TL one-hot into ``map_data.lanes[:, :, 8:13]``.
+
+        Matches the C++ encoding at ``lane_segments.cpp:267-292``:
+        - Lanelet has no TL regulatory element → NO_TRAFFIC_LIGHT (ch 4)
+        - Lanelet has TL but we have no state for it → WHITE (ch 3)
+        - Lanelet has TL and we know the color → GREEN/YELLOW/RED
+        """
+        lanes = map_data.lanes  # (N, 20, 33)
+        for row_idx, ll_id in enumerate(map_data_ll_ids):
+            if row_idx >= lanes.shape[0]:
+                break
+            gid = self._ll_to_group.get(ll_id)
+            if gid is None:
+                # No TL regulatory element on this lanelet.
+                lanes[row_idx, :, 8:13] = 0.0
+                lanes[row_idx, :, 12] = 1.0  # NO_TRAFFIC_LIGHT
+                continue
+            color = self._color_for_group(gid, t)
+            if color == TL_NONE:
+                # TL exists but we don't control this group (not on route
+                # or perpendicular). C++ encodes this as WHITE ("TL exists
+                # but perception has no data").
+                lanes[row_idx, :, 8:13] = 0.0
+                lanes[row_idx, :, 8 + TL_WHITE] = 1.0
+            else:
+                lanes[row_idx, :, 8:13] = 0.0
+                lanes[row_idx, :, 8 + color] = 1.0
+
+    def write_to_route_lanes(
+        self,
+        route_lanes: np.ndarray,
+        route_ll_ids: list[int],
+        t: float,
+    ) -> None:
+        """Write TL one-hot into a route_lanes array ``[:, :, 8:13]``.
+
+        Same logic as ``_write_to_lanes`` but for the per-agent route tensor
+        (shape ``(max_segments, 20, 33)``). Call this after every
+        ``_route_to_33dim`` build so the model sees TL state in route context.
+        """
+        for row_idx, ll_id in enumerate(route_ll_ids):
+            if row_idx >= route_lanes.shape[0]:
+                break
+            gid = self._ll_to_group.get(ll_id)
+            if gid is None:
+                continue  # no TL regulatory element, keep NO_TRAFFIC_LIGHT
+            color = self._color_for_group(gid, t)
+            if color == TL_NONE:
+                # TL exists but uncontrolled → WHITE (matches C++)
+                route_lanes[row_idx, :, 8:13] = 0.0
+                route_lanes[row_idx, :, 8 + TL_WHITE] = 1.0
+            else:
+                route_lanes[row_idx, :, 8:13] = 0.0
+                route_lanes[row_idx, :, 8 + color] = 1.0
+
+    # ── Query API (for visualisation) ─────────────────────────────────────
+
+    def get_lanelet_color(self, ll_id: int, t: float = 0.0) -> str | None:
+        """Return hex colour string for a TL-affected lanelet, or None."""
+        gid = self._ll_to_group.get(ll_id)
+        if gid is None:
+            return None
+        color = self._color_for_group(gid, t)
+        return TL_HEX.get(color)
+
+    def get_group_for_lanelet(self, ll_id: int) -> int | None:
+        """Return TL group_id for a lanelet, or None if no TL."""
+        return self._ll_to_group.get(ll_id)

--- a/scenario_generation/traffic_light.py
+++ b/scenario_generation/traffic_light.py
@@ -1,0 +1,67 @@
+"""Traffic-light source Protocol for closed-loop replay.
+
+This module exists purely to reserve the interface for a future session that
+wires real traffic-light state into ``replay.py``. Today ``replay.py`` ignores
+the source; the map-data lane tensor's 5-dim traffic-light one-hot block at
+channel indices ``[8:13]`` (see :class:`scenario_generation.scene_context.MapData`
+docstring) stays at its default "none" value.
+
+When a real source is added:
+
+* Read each lanelet's ``trafficLights()`` regulatory elements on the map.
+* Run a cycle state-machine (green/amber/red) per group_id.
+* Per step, for every lanelet in ``scene.map_data``, write the corresponding
+  one-hot into ``scene.map_data.lanes[ll_idx, :, 8:13]`` — same value for all
+  20 points of that lanelet.
+
+The writes propagate automatically to both the ego and NPC-as-ego inferences
+because they read from the same shared ``MapData``.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+# Channel indices inside the 5-dim traffic-light one-hot block at lane dims
+# [8:13] per ``scene_context.MapData``.
+TL_GREEN = 0
+TL_YELLOW = 1
+TL_RED = 2
+TL_WHITE = 3
+TL_NONE = 4
+
+
+class TrafficLightSource(Protocol):
+    """A callable-shaped object supplying the traffic-light colour for a given
+    lanelet at a given simulation time.
+
+    Implementations must be deterministic given their internal state so that
+    replays are reproducible with a fixed seed.
+    """
+
+    def color_for_lanelet(self, lanelet_id: int, t_sec: float) -> int:
+        """Return the active traffic-light channel index for ``lanelet_id``.
+
+        Args:
+            lanelet_id: Target lanelet, as stored in ``MapData``'s index-to-id
+                mapping.
+            t_sec: Simulation time in seconds since replay start.
+
+        Returns:
+            One of ``TL_GREEN``, ``TL_YELLOW``, ``TL_RED``, ``TL_WHITE``,
+            ``TL_NONE``.
+        """
+        ...
+
+
+class AllNoneTLSource:
+    """Default source that returns ``TL_NONE`` for every lanelet at every time.
+
+    Matches the pre-existing behaviour of the scenario_generation pipeline
+    (lane tensors built by ``_route_to_33dim`` default the traffic block to
+    "none"). Use this as the replay default until a real source is wired in.
+    """
+
+    def color_for_lanelet(self, lanelet_id: int, t_sec: float) -> int:
+        return TL_NONE

--- a/scene_search/map_canvas_js.py
+++ b/scene_search/map_canvas_js.py
@@ -443,7 +443,15 @@ RECTANGLE_AND_ARROW_TOOL = {
     window.__setWaypointArrows = function(json) {
         try {
             const parsed = typeof json === 'string' ? JSON.parse(json) : (json || []);
-            waypointArrows = Array.isArray(parsed) ? parsed : [];
+            const normalizePoint = function(pt) {
+                if (Array.isArray(pt) && pt.length >= 2) return {x: pt[0], y: pt[1]};
+                if (pt && typeof pt.x !== 'undefined' && typeof pt.y !== 'undefined') return pt;
+                return null;
+            };
+            waypointArrows = Array.isArray(parsed) ? parsed.map(function(w) {
+                const s = normalizePoint(w && w.start), e = normalizePoint(w && w.end);
+                return (s && e) ? {start: s, end: e} : null;
+            }).filter(function(w) { return w !== null; }) : [];
         } catch (e) { waypointArrows = []; console.warn('bad waypoints json', e); }
         redraw();
     };
@@ -673,7 +681,7 @@ RECTANGLE_AND_ARROW_TOOL = {
         redraw();
     } else if (isDrawingWaypoint && waypointDragStartPx && waypointDragEndPx) {
         isDrawingWaypoint = false;
-        canvas.style.cursor = 'grab';
+        canvas.style.cursor = (currentMode === 'waypoint') ? 'crosshair' : 'grab';
         const ws = canvasToWorld(waypointDragStartPx.x, waypointDragStartPx.y);
         const we = canvasToWorld(waypointDragEndPx.x, waypointDragEndPx.y);
         const hdeg = Math.atan2(we.y - ws.y, we.x - ws.x) * 180 / Math.PI;

--- a/scene_search/map_canvas_js.py
+++ b/scene_search/map_canvas_js.py
@@ -399,36 +399,86 @@ RECTANGLE_TOOL = {
 
 RECTANGLE_AND_ARROW_TOOL = {
     "help": (
-        " | <b>Ctrl+drag=rectangle</b> | <b>Shift+drag=start</b> | "
-        "<b>Shift+Alt+drag=goal</b> | <b>Ctrl+Shift+drag=waypoint</b>"
+        " | <b>Ctrl+drag=rectangle</b> | Use the <b>Mode</b> buttons "
+        "to pick what a plain drag places (Pan / Start / Goal / Waypoint)"
     ),
     "state": """
     let rectWorld = null;
     let isDrawingRect = false;
     let rectStartPx = null, rectEndPx = null;
-    // Start (blue) arrow — set via Shift+drag.
+    // Start (blue) arrow — placed by mode="start" or Shift+drag (legacy).
     let egoArrowStartWorld = null, egoArrowEndWorld = null;
     let isDrawingEgoArrow = false, egoArrowStartPx = null, egoArrowEndPx = null;
-    // Goal (red) arrow — set via Shift+Alt+drag.
+    // Goal (red) arrow — placed by mode="goal".
     let goalArrowStartWorld = null, goalArrowEndWorld = null;
     let isDrawingGoalArrow = false, goalArrowStartPx = null, goalArrowEndPx = null;
-    // Waypoint (yellow) arrows — appended via Ctrl+Shift+drag.
+    // Waypoint (yellow) arrows — appended by mode="waypoint".
     let waypointArrows = [];  // array of {start: {x,y}, end: {x,y}}
     let isDrawingWaypoint = false, waypointDragStartPx = null, waypointDragEndPx = null;
     // Route polyline for visualization — set via window.__setRoute(json).
     // Format: [[[x0,y0],[x1,y1],...], ...] one polyline per resolved lanelet.
     let routePolylines = [];
-    // Expose setters so Python can push updates via Gradio's `.then(None, js=...)`.
+    // Mode-selector state. Valid values: "pan" (default) | "start" | "goal" |
+    // "waypoint". Python pushes updates via window.__setMode(mode).
+    let currentMode = "pan";
+    window.__setMode = function(mode) {
+        currentMode = mode || "pan";
+        // Cursor hint so the user sees the mode is active.
+        if (currentMode === "pan") {
+            canvas.style.cursor = 'grab';
+        } else {
+            canvas.style.cursor = 'crosshair';
+        }
+    };
     window.__setRoute = function(json) {
         try {
             routePolylines = typeof json === 'string' ? JSON.parse(json) : (json || []);
         } catch (e) { routePolylines = []; console.warn('bad route json', e); }
         redraw();
     };
-    window.__clearWaypoints = function() {
-        waypointArrows = [];
+    // Python is the source of truth for all arrow positions — these setters
+    // overwrite the JS-local state after every change so the viz is always
+    // consistent with the Gradio state (fixes the stale-arrow bug where
+    // clearing waypoints didn't wipe their viz).
+    window.__setWaypointArrows = function(json) {
+        try {
+            const parsed = typeof json === 'string' ? JSON.parse(json) : (json || []);
+            waypointArrows = Array.isArray(parsed) ? parsed : [];
+        } catch (e) { waypointArrows = []; console.warn('bad waypoints json', e); }
         redraw();
     };
+    window.__setStartArrow = function(json) {
+        try {
+            const d = typeof json === 'string' ? JSON.parse(json) : json;
+            if (d && d.start && d.end) {
+                egoArrowStartWorld = {x: d.start[0], y: d.start[1]};
+                egoArrowEndWorld = {x: d.end[0], y: d.end[1]};
+                egoArrowStartPx = null; egoArrowEndPx = null; // force recompute from world
+            } else {
+                egoArrowStartWorld = null; egoArrowEndWorld = null;
+                egoArrowStartPx = null; egoArrowEndPx = null;
+            }
+        } catch (e) { console.warn('bad start-arrow json', e); }
+        redraw();
+    };
+    window.__setGoalArrow = function(json) {
+        try {
+            const d = typeof json === 'string' ? JSON.parse(json) : json;
+            if (d && d.start && d.end) {
+                goalArrowStartWorld = {x: d.start[0], y: d.start[1]};
+                goalArrowEndWorld = {x: d.end[0], y: d.end[1]};
+                goalArrowStartPx = null; goalArrowEndPx = null;
+            } else {
+                goalArrowStartWorld = null; goalArrowEndWorld = null;
+                goalArrowStartPx = null; goalArrowEndPx = null;
+            }
+        } catch (e) { console.warn('bad goal-arrow json', e); }
+        redraw();
+    };
+    // Back-compat aliases — kept so old handlers still work.
+    window.__clearWaypoints = function() { window.__setWaypointArrows('[]'); };
+    window.__clearStart = function() { window.__setStartArrow('null'); };
+    window.__clearGoal = function() { window.__setGoalArrow('null'); };
     """,
     "draw": """
     // Reusable arrow renderer: colour, start, end (all in canvas pixels), label.
@@ -523,33 +573,35 @@ RECTANGLE_AND_ARROW_TOOL = {
     }
     """,
     "mousedown": """
-    // Modifier priority: Ctrl+Shift (waypoint) > Alt+Shift (goal) > Shift (start)
-    //                    > Ctrl (rectangle). Alt alone = rotation, handled above.
-    if ((e.ctrlKey || e.metaKey) && e.shiftKey) {
-        isDrawingWaypoint = true;
-        waypointDragStartPx = {x: cx, y: cy};
-        waypointDragEndPx = {x: cx, y: cy};
-        canvas.style.cursor = 'crosshair';
-        toolHandled = true;
-    } else if (e.altKey && e.shiftKey) {
-        isDrawingGoalArrow = true;
-        goalArrowStartPx = {x: cx, y: cy};
-        goalArrowEndPx = {x: cx, y: cy};
-        canvas.style.cursor = 'crosshair';
-        toolHandled = true;
-    } else if (e.shiftKey) {
-        isDrawingEgoArrow = true;
-        egoArrowStartPx = {x: cx, y: cy};
-        egoArrowEndPx = {x: cx, y: cy};
-        canvas.style.cursor = 'crosshair';
-        toolHandled = true;
-    } else if (e.ctrlKey || e.metaKey) {
+    // Ctrl+drag always = rectangle (legacy snippet flow). Everything else
+    // routes through the Mode radio (Pan / Start / Goal / Waypoint).
+    // Shift+drag stays as a power-user shortcut for start, regardless of mode.
+    if (e.ctrlKey || e.metaKey) {
         isDrawingRect = true;
         rectStartPx = {x: cx, y: cy};
         rectEndPx = {x: cx, y: cy};
         canvas.style.cursor = 'crosshair';
         toolHandled = true;
+    } else if (e.shiftKey || currentMode === "start") {
+        isDrawingEgoArrow = true;
+        egoArrowStartPx = {x: cx, y: cy};
+        egoArrowEndPx = {x: cx, y: cy};
+        canvas.style.cursor = 'crosshair';
+        toolHandled = true;
+    } else if (currentMode === "goal") {
+        isDrawingGoalArrow = true;
+        goalArrowStartPx = {x: cx, y: cy};
+        goalArrowEndPx = {x: cx, y: cy};
+        canvas.style.cursor = 'crosshair';
+        toolHandled = true;
+    } else if (currentMode === "waypoint") {
+        isDrawingWaypoint = true;
+        waypointDragStartPx = {x: cx, y: cy};
+        waypointDragEndPx = {x: cx, y: cy};
+        canvas.style.cursor = 'crosshair';
+        toolHandled = true;
     }
+    // Else (currentMode === "pan"): fall through to base pan handler.
     """,
     "mousemove": """
     if (isDrawingRect) {

--- a/scene_search/map_canvas_js.py
+++ b/scene_search/map_canvas_js.py
@@ -398,15 +398,79 @@ RECTANGLE_TOOL = {
 }
 
 RECTANGLE_AND_ARROW_TOOL = {
-    "help": " | <b>Ctrl+drag=rectangle</b> | <b>Shift+drag=ego pose</b>",
+    "help": (
+        " | <b>Ctrl+drag=rectangle</b> | <b>Shift+drag=start</b> | "
+        "<b>Shift+Alt+drag=goal</b> | <b>Ctrl+Shift+drag=waypoint</b>"
+    ),
     "state": """
     let rectWorld = null;
     let isDrawingRect = false;
     let rectStartPx = null, rectEndPx = null;
+    // Start (blue) arrow — set via Shift+drag.
     let egoArrowStartWorld = null, egoArrowEndWorld = null;
     let isDrawingEgoArrow = false, egoArrowStartPx = null, egoArrowEndPx = null;
+    // Goal (red) arrow — set via Shift+Alt+drag.
+    let goalArrowStartWorld = null, goalArrowEndWorld = null;
+    let isDrawingGoalArrow = false, goalArrowStartPx = null, goalArrowEndPx = null;
+    // Waypoint (yellow) arrows — appended via Ctrl+Shift+drag.
+    let waypointArrows = [];  // array of {start: {x,y}, end: {x,y}}
+    let isDrawingWaypoint = false, waypointDragStartPx = null, waypointDragEndPx = null;
+    // Route polyline for visualization — set via window.__setRoute(json).
+    // Format: [[[x0,y0],[x1,y1],...], ...] one polyline per resolved lanelet.
+    let routePolylines = [];
+    // Expose setters so Python can push updates via Gradio's `.then(None, js=...)`.
+    window.__setRoute = function(json) {
+        try {
+            routePolylines = typeof json === 'string' ? JSON.parse(json) : (json || []);
+        } catch (e) { routePolylines = []; console.warn('bad route json', e); }
+        redraw();
+    };
+    window.__clearWaypoints = function() {
+        waypointArrows = [];
+        redraw();
+    };
     """,
     "draw": """
+    // Reusable arrow renderer: colour, start, end (all in canvas pixels), label.
+    function drawArrow(color, sx, sy, ex, ey, label) {
+        const adx = ex - sx, ady = ey - sy;
+        const len = Math.sqrt(adx*adx + ady*ady);
+        ctx.strokeStyle = color; ctx.lineWidth = 3;
+        ctx.beginPath(); ctx.moveTo(sx, sy); ctx.lineTo(ex, ey); ctx.stroke();
+        if (len > 3) {
+            const ang = Math.atan2(ady, adx);
+            const hl = Math.min(18, len*0.3);
+            ctx.fillStyle = color; ctx.beginPath();
+            ctx.moveTo(ex, ey);
+            ctx.lineTo(ex - hl*Math.cos(ang-0.4), ey - hl*Math.sin(ang-0.4));
+            ctx.lineTo(ex - hl*Math.cos(ang+0.4), ey - hl*Math.sin(ang+0.4));
+            ctx.closePath(); ctx.fill();
+        }
+        ctx.fillStyle = color; ctx.beginPath(); ctx.arc(sx, sy, 5, 0, Math.PI*2); ctx.fill();
+        if (label) {
+            ctx.fillStyle = color; ctx.font = 'bold 11px monospace';
+            ctx.fillText(label, sx + 8, sy - 8);
+        }
+    }
+
+    // Route polyline (drawn underneath arrows and rectangle so arrows stay visible)
+    if (routePolylines && routePolylines.length > 0) {
+        ctx.strokeStyle = 'rgba(0, 170, 68, 0.85)';  // green
+        ctx.lineWidth = 4;
+        ctx.setLineDash([]);
+        for (const line of routePolylines) {
+            if (!line || line.length < 2) continue;
+            ctx.beginPath();
+            const p0 = worldToCanvas(line[0][0], line[0][1]);
+            ctx.moveTo(p0.x, p0.y);
+            for (let i = 1; i < line.length; i++) {
+                const p = worldToCanvas(line[i][0], line[i][1]);
+                ctx.lineTo(p.x, p.y);
+            }
+            ctx.stroke();
+        }
+    }
+
     // Rectangle
     if (rectStartPx && rectEndPx) {
         const rx = Math.min(rectStartPx.x, rectEndPx.x);
@@ -423,44 +487,66 @@ RECTANGLE_AND_ARROW_TOOL = {
             ctx.fillText(wm.toFixed(0) + 'm x ' + hm.toFixed(0) + 'm', rx + 4, ry + 14);
         }
     }
-    // Ego arrow
+
+    // Ego start arrow (blue)
     if (egoArrowStartWorld && egoArrowEndWorld && !isDrawingEgoArrow) {
         egoArrowStartPx = worldToCanvas(egoArrowStartWorld.x, egoArrowStartWorld.y);
         egoArrowEndPx = worldToCanvas(egoArrowEndWorld.x, egoArrowEndWorld.y);
     }
     if (egoArrowStartPx && egoArrowEndPx) {
-        const adx = egoArrowEndPx.x - egoArrowStartPx.x;
-        const ady = egoArrowEndPx.y - egoArrowStartPx.y;
-        const len = Math.sqrt(adx*adx + ady*ady);
-        if (len > 3) {
-            const ang = Math.atan2(ady, adx);
-            ctx.strokeStyle = '#3366cc'; ctx.lineWidth = 3;
-            ctx.beginPath(); ctx.moveTo(egoArrowStartPx.x, egoArrowStartPx.y);
-            ctx.lineTo(egoArrowEndPx.x, egoArrowEndPx.y); ctx.stroke();
-            const hl = Math.min(18, len*0.3);
-            ctx.fillStyle = '#3366cc'; ctx.beginPath();
-            ctx.moveTo(egoArrowEndPx.x, egoArrowEndPx.y);
-            ctx.lineTo(egoArrowEndPx.x - hl*Math.cos(ang-0.4), egoArrowEndPx.y - hl*Math.sin(ang-0.4));
-            ctx.lineTo(egoArrowEndPx.x - hl*Math.cos(ang+0.4), egoArrowEndPx.y - hl*Math.sin(ang+0.4));
-            ctx.closePath(); ctx.fill();
-        }
-        ctx.fillStyle = '#3366cc'; ctx.beginPath();
-        ctx.arc(egoArrowStartPx.x, egoArrowStartPx.y, 5, 0, Math.PI*2); ctx.fill();
-        ctx.fillStyle = '#3366cc'; ctx.font = '11px monospace';
-        ctx.fillText('ego', egoArrowStartPx.x + 8, egoArrowStartPx.y - 8);
+        drawArrow('#3366cc', egoArrowStartPx.x, egoArrowStartPx.y,
+                  egoArrowEndPx.x, egoArrowEndPx.y, 'start');
+    }
+
+    // Goal arrow (red)
+    if (goalArrowStartWorld && goalArrowEndWorld && !isDrawingGoalArrow) {
+        goalArrowStartPx = worldToCanvas(goalArrowStartWorld.x, goalArrowStartWorld.y);
+        goalArrowEndPx = worldToCanvas(goalArrowEndWorld.x, goalArrowEndWorld.y);
+    }
+    if (goalArrowStartPx && goalArrowEndPx) {
+        drawArrow('#cc3333', goalArrowStartPx.x, goalArrowStartPx.y,
+                  goalArrowEndPx.x, goalArrowEndPx.y, 'goal');
+    }
+
+    // Waypoint arrows (yellow, numbered)
+    for (let i = 0; i < waypointArrows.length; i++) {
+        const w = waypointArrows[i];
+        const sp = worldToCanvas(w.start.x, w.start.y);
+        const ep = worldToCanvas(w.end.x, w.end.y);
+        drawArrow('#e6a400', sp.x, sp.y, ep.x, ep.y, (i + 1).toString());
+    }
+    // Waypoint in-progress drag
+    if (isDrawingWaypoint && waypointDragStartPx && waypointDragEndPx) {
+        drawArrow('#e6a400', waypointDragStartPx.x, waypointDragStartPx.y,
+                  waypointDragEndPx.x, waypointDragEndPx.y,
+                  (waypointArrows.length + 1).toString());
     }
     """,
     "mousedown": """
-    if (e.ctrlKey || e.metaKey) {
-        isDrawingRect = true;
-        rectStartPx = {x: cx, y: cy};
-        rectEndPx = {x: cx, y: cy};
+    // Modifier priority: Ctrl+Shift (waypoint) > Alt+Shift (goal) > Shift (start)
+    //                    > Ctrl (rectangle). Alt alone = rotation, handled above.
+    if ((e.ctrlKey || e.metaKey) && e.shiftKey) {
+        isDrawingWaypoint = true;
+        waypointDragStartPx = {x: cx, y: cy};
+        waypointDragEndPx = {x: cx, y: cy};
+        canvas.style.cursor = 'crosshair';
+        toolHandled = true;
+    } else if (e.altKey && e.shiftKey) {
+        isDrawingGoalArrow = true;
+        goalArrowStartPx = {x: cx, y: cy};
+        goalArrowEndPx = {x: cx, y: cy};
         canvas.style.cursor = 'crosshair';
         toolHandled = true;
     } else if (e.shiftKey) {
         isDrawingEgoArrow = true;
         egoArrowStartPx = {x: cx, y: cy};
         egoArrowEndPx = {x: cx, y: cy};
+        canvas.style.cursor = 'crosshair';
+        toolHandled = true;
+    } else if (e.ctrlKey || e.metaKey) {
+        isDrawingRect = true;
+        rectStartPx = {x: cx, y: cy};
+        rectEndPx = {x: cx, y: cy};
         canvas.style.cursor = 'crosshair';
         toolHandled = true;
     }
@@ -480,6 +566,12 @@ RECTANGLE_AND_ARROW_TOOL = {
         redraw();
     } else if (isDrawingEgoArrow) {
         egoArrowEndPx = {x: cx, y: cy};
+        redraw();
+    } else if (isDrawingGoalArrow) {
+        goalArrowEndPx = {x: cx, y: cy};
+        redraw();
+    } else if (isDrawingWaypoint) {
+        waypointDragEndPx = {x: cx, y: cy};
         redraw();
     }
     """,
@@ -513,6 +605,30 @@ RECTANGLE_AND_ARROW_TOOL = {
         trigger('click', {
             type: 'ego_pose',
             x: egoArrowStartWorld.x, y: egoArrowStartWorld.y, heading: hdeg
+        });
+        redraw();
+    } else if (isDrawingGoalArrow && goalArrowStartPx && goalArrowEndPx) {
+        isDrawingGoalArrow = false;
+        canvas.style.cursor = 'grab';
+        goalArrowStartWorld = canvasToWorld(goalArrowStartPx.x, goalArrowStartPx.y);
+        goalArrowEndWorld = canvasToWorld(goalArrowEndPx.x, goalArrowEndPx.y);
+        const hdeg = Math.atan2(goalArrowEndWorld.y - goalArrowStartWorld.y,
+                                 goalArrowEndWorld.x - goalArrowStartWorld.x) * 180 / Math.PI;
+        trigger('click', {
+            type: 'goal_pose',
+            x: goalArrowStartWorld.x, y: goalArrowStartWorld.y, heading: hdeg
+        });
+        redraw();
+    } else if (isDrawingWaypoint && waypointDragStartPx && waypointDragEndPx) {
+        isDrawingWaypoint = false;
+        canvas.style.cursor = 'grab';
+        const ws = canvasToWorld(waypointDragStartPx.x, waypointDragStartPx.y);
+        const we = canvasToWorld(waypointDragEndPx.x, waypointDragEndPx.y);
+        const hdeg = Math.atan2(we.y - ws.y, we.x - ws.x) * 180 / Math.PI;
+        waypointArrows.push({start: ws, end: we});
+        trigger('click', {
+            type: 'waypoint_append',
+            x: ws.x, y: ws.y, heading: hdeg
         });
         redraw();
     }


### PR DESCRIPTION
## Summary

End-to-end closed-loop replay pipeline for the diffusion planner: author a route in the GUI, save it as a pickle, and replay it with dynamic NPC spawning, traffic light state injection, and configurable vehicle advance modes.

- **Route authoring in GUI**: place start/goal/waypoints via mode radio, resolved route rendered as a green polyline, saved as `Route` pickle
- **Closed-loop replay** (`replay.py`): NPC spawn/despawn manager, live map tensor refresh, turn-indicator feedback loop, per-step PNG output
- **Traffic light controller**: signal group state machines with green/yellow/red cycling, perpendicular phase opposition, one-hot encoding into lane tensors
- **Trajectory tracking modes** (`mpc_tracker.py`):
  - `teleport` (default): snap to pred[0] each step
  - `perfect`: Euler integration with velocity from reference trajectory
  - `mpc`: bicycle-model MPC with 2s lookahead horizon via scipy L-BFGS-B
- **Tensor pipeline fixes**: canonicalized ego velocity/acceleration, smoothed derivatives, spawn-age history masking
- **Sequential inference option**: run model one agent at a time for diagnostics

## Example


https://github.com/user-attachments/assets/430472b6-1652-41be-b43f-77874e50ed00



## Test plan

- [x] Full replay with `advance_mode=teleport` (1570 frames, goal reached)
- [x] Full replay with `advance_mode=perfect` (1647 frames, goal reached)
- [x] Full replay with `advance_mode=mpc` (2095 frames, goal reached)
- [x] Full replay with `sequential_inference=true` (1548 frames, goal reached)
- [x] MPC smoke test and multi-agent timing (~13ms/agent)
- [x] SpawnConfig JSON round-trip
- [x] Visual inspection of trajectory quality across modes