### PR TITLE
feat(scenario_generation,rlvr,scene_search): MPC-gen live metric logging + scene selector

### DIFF
--- a/rlvr/autoresearch/tools/profile_replay.py
+++ b/rlvr/autoresearch/tools/profile_replay.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""cProfile wrapper around ``scenario_generation.replay.run_route_replay``.
+
+Answers questions like "where is the MPC replay spending its wall clock?".
+Covers the full step loop (model inference, MPC solve per agent, map
+rebuild, PNG render submission, NPZ dump, live metric scoring). Run on a
+short horizon so the dump + profile stays manageable.
+
+Usage:
+    python -m rlvr.autoresearch.tools.profile_replay \\
+        --route /path/to/route.pkl \\
+        --model_path /path/to/model.pth \\
+        --config /path/to/spawn_config.json \\
+        --output_dir /path/to/profile_out/ \\
+        --steps 200 \\
+        [--top 40]
+"""
+
+from __future__ import annotations
+
+import argparse
+import cProfile
+import pstats
+import shutil
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--route", type=Path, required=True)
+    parser.add_argument("--model_path", type=Path, required=True)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--output_dir", type=Path, required=True)
+    parser.add_argument("--steps", type=int, default=200,
+                        help="Override spawn_config.max_steps for the profile run.")
+    parser.add_argument("--top", type=int, default=40,
+                        help="How many top consumers to print per sort order.")
+    parser.add_argument("--device", type=str, default="cuda")
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    # Lazy imports — keep argparse errors fast.
+    import torch
+
+    from scenario_generation.gui.lanelet_scene_builder import LaneletSceneBuilder
+    from scenario_generation.replay import SpawnConfig, run_route_replay
+    from scenario_generation.route import Route
+    from scenario_generation.simulate import load_model
+
+    print(f"Loading route from {args.route}")
+    route = Route.load(args.route)
+
+    print(f"Loading lanelet2 builder from {route.map_path}")
+    builder = LaneletSceneBuilder(route.map_path)
+
+    print(f"Loading model {args.model_path}")
+    device = args.device if torch.cuda.is_available() or args.device == "cpu" else "cpu"
+    model, model_args = load_model(str(args.model_path), device)
+
+    cfg = SpawnConfig.from_json(args.config)
+    cfg.max_steps = args.steps
+    cfg.seed = args.seed
+    cfg.validate()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    profile_path = args.output_dir / "replay.prof"
+
+    print(f"Profiling replay for {args.steps} steps → {profile_path}")
+    profiler = cProfile.Profile()
+    profiler.enable()
+    try:
+        run_route_replay(
+            model=model, model_args=model_args, builder=builder, route=route,
+            output_dir=args.output_dir, spawn_config=cfg, device=device,
+        )
+    finally:
+        profiler.disable()
+
+    profiler.dump_stats(str(profile_path))
+
+    stats = pstats.Stats(str(profile_path))
+    for sort_key, label in (
+        ("cumulative", "by cumulative time"),
+        ("tottime", "by self time"),
+    ):
+        print(f"\n─── Top {args.top} {label} ───")
+        stats.sort_stats(sort_key)
+        stats.print_stats(args.top)
+
+    print(f"\nFull profile: {profile_path}")
+    print(f"Inspect interactively with: python -m pstats {profile_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/rescore_replay_run.py
+++ b/rlvr/autoresearch/tools/rescore_replay_run.py
@@ -1,25 +1,54 @@
 #!/usr/bin/env python3
 """Recompute ``metrics_log.json`` for a ``scenario_generation.replay`` run.
 
-Motivation: when a reward component is added or its thresholds change, the
-training-time pipeline picks the new behaviour up immediately, but any
-already-dumped replay run keeps its old metrics log. Re-running the full
-MPC replay just to regenerate scores is wasteful — the NPZs the metrics
-depend on are already on disk. This tool reuses
-``scenario_generation.replay._score_step`` to rescore every NPZ in place
-and overwrite ``metrics_log.json``.
+Two modes, picked explicitly on the CLI — no fallbacks, no silent
+defaults:
+
+``--mode instant``
+    Scores each dumped NPZ against the reward primitives using only the
+    current ego pose (the same data the live sim already produces when
+    ``_score_step`` is called with ``prediction=None``). Fast, no model
+    needed. Use case: a reward component was added or a threshold
+    changed, and you want to regenerate the log without re-running the
+    MPC replay.
+
+``--mode full``
+    ``instant`` + the ``pred_*`` block produced by running model
+    inference on each NPZ and scoring the resulting 80-step prediction.
+    Requires ``--model_path``. Use case: evaluate how a DIFFERENT model
+    would have planned given the observations the baseline run dumped.
+    The instantaneous block is model-independent, so it stays identical
+    across model comparisons — only ``pred_*`` differs. Load two metrics
+    logs into scene_search (or diff them offline) to compare plan
+    quality at matching world positions.
+
+Important: the dumped NPZs are the closed-loop trajectory the *baseline*
+model actually drove. Post-hoc rescoring with a different model
+produces the single-step open-loop prediction that model would have
+emitted from the same observation — it does NOT simulate what the
+alternative model would have done if rolled out closed-loop from the
+same seed (that still requires ``scenario_generation.replay``).
 
 Usage:
     python -m rlvr.autoresearch.tools.rescore_replay_run \\
         --run_dir /path/to/mpc_gen_run/ \\
         --config  /path/to/grpo_config.json \\
-        [--output /path/to/new_metrics_log.json]  # default: run_dir/metrics_log.json
+        --mode    instant \\
+        [--output /path/to/new_metrics_log.json]
+
+    python -m rlvr.autoresearch.tools.rescore_replay_run \\
+        --run_dir /path/to/mpc_gen_run/ \\
+        --config  /path/to/grpo_config.json \\
+        --mode    full \\
+        --model_path /path/to/model.pth \\
+        [--output /path/to/new_metrics_log.json]
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import random
 import re
 from pathlib import Path
 
@@ -33,36 +62,7 @@ from scenario_generation.replay import SpawnConfig, _score_step
 _NPZ_RE = re.compile(r"replay_step_(\d+)\.npz$")
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--run_dir", type=Path, required=True,
-                        help="Replay output directory (must contain npz/).")
-    parser.add_argument("--config", type=Path, required=True,
-                        help="Reward config JSON (no silent defaults).")
-    parser.add_argument("--output", type=Path, default=None,
-                        help="Output metrics log path "
-                             "(default: <run_dir>/metrics_log.json).")
-    parser.add_argument("--device", type=str, default="cuda")
-    args = parser.parse_args()
-
-    run_dir = args.run_dir
-    npz_dir = run_dir / "npz"
-    if not npz_dir.is_dir():
-        raise SystemExit(f"{npz_dir} missing")
-
-    spawn_cfg_path = run_dir / "spawn_config.json"
-    if not spawn_cfg_path.exists():
-        raise SystemExit(f"{spawn_cfg_path} missing — needed for ego shape")
-    spawn_cfg = SpawnConfig.from_json(spawn_cfg_path)
-
-    reward_cfg = load_reward_config(args.config)
-
-    device = args.device if torch.cuda.is_available() or args.device == "cpu" else "cpu"
-
-    npz_paths = sorted(npz_dir.glob("replay_step_*.npz"))
-    if not npz_paths:
-        raise SystemExit(f"no replay_step_*.npz in {npz_dir}")
-
+def _score_instant(npz_paths, device, reward_cfg, spawn_cfg) -> list[dict]:
     steps: list[dict] = []
     for i, path in enumerate(npz_paths):
         m = _NPZ_RE.search(path.name)
@@ -73,7 +73,116 @@ def main() -> None:
             data = {k: raw[k] for k in raw.files if k != "version"}
         steps.append(_score_step(data, step, device, reward_cfg, spawn_cfg))
         if (i + 1) % 100 == 0:
-            print(f"  Scored {i+1}/{len(npz_paths)}")
+            print(f"  Scored {i+1}/{len(npz_paths)} (instant)")
+    return steps
+
+
+def _score_full(npz_paths, device, reward_cfg, spawn_cfg, model_path) -> list[dict]:
+    # Lazy imports: ROS / scene_context are only needed in full mode.
+    from scenario_generation.npz_loader import from_npz
+    from scenario_generation.simulate import _predict_batch, load_model
+
+    print(f"  Loading model {model_path}")
+    model, model_args = load_model(str(model_path), device)
+
+    steps: list[dict] = []
+    for i, path in enumerate(npz_paths):
+        m = _NPZ_RE.search(path.name)
+        if not m:
+            continue
+        step = int(m.group(1))
+        with np.load(path, allow_pickle=True) as raw:
+            data = {k: raw[k] for k in raw.files if k != "version"}
+
+        scene = from_npz(str(path))
+        preds = _predict_batch(
+            model, model_args, scene, [scene.ego_agent_id], device,
+            inference_delay=spawn_cfg.inference_delay,
+        )
+        ego_pred = preds.get(scene.ego_agent_id)
+        if ego_pred is None:
+            raise SystemExit(
+                f"Inference returned no prediction for ego at {path} — refusing "
+                f"to emit a partial metrics_log. Check that the NPZ has a valid "
+                f"ego_agent_past."
+            )
+        steps.append(_score_step(
+            data, step, device, reward_cfg, spawn_cfg, prediction=ego_pred,
+        ))
+        if (i + 1) % 50 == 0:
+            print(f"  Scored {i+1}/{len(npz_paths)} (full)")
+    return steps
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run_dir", type=Path, required=True,
+                        help="Replay output directory (must contain npz/).")
+    parser.add_argument("--config", type=Path, required=True,
+                        help="Reward config JSON (no silent defaults).")
+    parser.add_argument("--mode", choices=["instant", "full"], required=True,
+                        help="'instant' = current-pose metrics only (no model "
+                             "needed). 'full' = instantaneous + pred_* from a "
+                             "specified model (inference per NPZ).")
+    parser.add_argument("--model_path", type=Path, default=None,
+                        help="Model checkpoint. REQUIRED when --mode full; "
+                             "MUST NOT be supplied when --mode instant.")
+    parser.add_argument("--output", type=Path, default=None,
+                        help="Output metrics log path "
+                             "(default: <run_dir>/metrics_log.json).")
+    parser.add_argument("--device", type=str, default="cuda")
+    parser.add_argument("--seed", type=int, default=None,
+                        help="Seed torch / numpy / random before loading the "
+                             "model (full mode only). Match the sim's seed to "
+                             "make post-hoc predictions as close as possible "
+                             "to the live run — still not bit-identical "
+                             "because the live process advanced RNG state "
+                             "through map builds / MPC solves / etc. between "
+                             "inferences, which this tool doesn't replay.")
+    args = parser.parse_args()
+
+    if args.seed is not None:
+        torch.manual_seed(args.seed)
+        torch.cuda.manual_seed_all(args.seed)
+        np.random.seed(args.seed)
+        random.seed(args.seed)
+
+    # Mode / model_path consistency — explicit, no fallbacks.
+    if args.mode == "full" and args.model_path is None:
+        parser.error("--mode full requires --model_path")
+    if args.mode == "instant" and args.model_path is not None:
+        parser.error(
+            "--mode instant refuses --model_path (prediction scoring requires "
+            "--mode full; passing a model here would silently be ignored). "
+            "Drop --model_path or switch to --mode full."
+        )
+
+    run_dir = args.run_dir
+    npz_dir = run_dir / "npz"
+    if not npz_dir.is_dir():
+        raise SystemExit(f"{npz_dir} missing")
+
+    spawn_cfg_path = run_dir / "spawn_config.json"
+    if not spawn_cfg_path.exists():
+        raise SystemExit(
+            f"{spawn_cfg_path} missing — the tool needs the spawn config to "
+            f"read ego dimensions and inference_delay. Copy the one from the "
+            f"original run."
+        )
+    spawn_cfg = SpawnConfig.from_json(spawn_cfg_path)
+
+    reward_cfg = load_reward_config(args.config)
+
+    device = args.device if torch.cuda.is_available() or args.device == "cpu" else "cpu"
+
+    npz_paths = sorted(npz_dir.glob("replay_step_*.npz"))
+    if not npz_paths:
+        raise SystemExit(f"no replay_step_*.npz in {npz_dir}")
+
+    if args.mode == "instant":
+        steps = _score_instant(npz_paths, device, reward_cfg, spawn_cfg)
+    else:
+        steps = _score_full(npz_paths, device, reward_cfg, spawn_cfg, args.model_path)
 
     out_path = args.output or (run_dir / "metrics_log.json")
     payload = {
@@ -82,6 +191,8 @@ def main() -> None:
         "ego_shape": [
             spawn_cfg.ego_wheelbase, spawn_cfg.ego_length, spawn_cfg.ego_width,
         ],
+        "mode": args.mode,
+        "model_path": str(args.model_path) if args.model_path else None,
         "steps": steps,
     }
     with open(out_path, "w") as f:

--- a/rlvr/autoresearch/tools/rescore_replay_run.py
+++ b/rlvr/autoresearch/tools/rescore_replay_run.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Recompute ``metrics_log.json`` for a ``scenario_generation.replay`` run.
+
+Motivation: when a reward component is added or its thresholds change, the
+training-time pipeline picks the new behaviour up immediately, but any
+already-dumped replay run keeps its old metrics log. Re-running the full
+MPC replay just to regenerate scores is wasteful — the NPZs the metrics
+depend on are already on disk. This tool reuses
+``scenario_generation.replay._score_step`` to rescore every NPZ in place
+and overwrite ``metrics_log.json``.
+
+Usage:
+    python -m rlvr.autoresearch.tools.rescore_replay_run \\
+        --run_dir /path/to/mpc_gen_run/ \\
+        --config  /path/to/grpo_config.json \\
+        [--output /path/to/new_metrics_log.json]  # default: run_dir/metrics_log.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from rlvr.autoresearch.tools.reward_config_from_json import load_reward_config
+from scenario_generation.replay import SpawnConfig, _score_step
+
+
+_NPZ_RE = re.compile(r"replay_step_(\d+)\.npz$")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run_dir", type=Path, required=True,
+                        help="Replay output directory (must contain npz/).")
+    parser.add_argument("--config", type=Path, required=True,
+                        help="Reward config JSON (no silent defaults).")
+    parser.add_argument("--output", type=Path, default=None,
+                        help="Output metrics log path "
+                             "(default: <run_dir>/metrics_log.json).")
+    parser.add_argument("--device", type=str, default="cuda")
+    args = parser.parse_args()
+
+    run_dir = args.run_dir
+    npz_dir = run_dir / "npz"
+    if not npz_dir.is_dir():
+        raise SystemExit(f"{npz_dir} missing")
+
+    spawn_cfg_path = run_dir / "spawn_config.json"
+    if not spawn_cfg_path.exists():
+        raise SystemExit(f"{spawn_cfg_path} missing — needed for ego shape")
+    spawn_cfg = SpawnConfig.from_json(spawn_cfg_path)
+
+    reward_cfg = load_reward_config(args.config)
+
+    device = args.device if torch.cuda.is_available() or args.device == "cpu" else "cpu"
+
+    npz_paths = sorted(npz_dir.glob("replay_step_*.npz"))
+    if not npz_paths:
+        raise SystemExit(f"no replay_step_*.npz in {npz_dir}")
+
+    steps: list[dict] = []
+    for i, path in enumerate(npz_paths):
+        m = _NPZ_RE.search(path.name)
+        if not m:
+            continue
+        step = int(m.group(1))
+        with np.load(path, allow_pickle=True) as raw:
+            data = {k: raw[k] for k in raw.files if k != "version"}
+        steps.append(_score_step(data, step, device, reward_cfg, spawn_cfg))
+        if (i + 1) % 100 == 0:
+            print(f"  Scored {i+1}/{len(npz_paths)}")
+
+    out_path = args.output or (run_dir / "metrics_log.json")
+    payload = {
+        "reward_config_path": str(args.config),
+        "dump_npz_dir": str(npz_dir),
+        "ego_shape": [
+            spawn_cfg.ego_wheelbase, spawn_cfg.ego_length, spawn_cfg.ego_width,
+        ],
+        "steps": steps,
+    }
+    with open(out_path, "w") as f:
+        json.dump(payload, f)
+    print(f"Saved {len(steps)} step records to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/select_from_metrics_log.py
+++ b/rlvr/autoresearch/tools/select_from_metrics_log.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Pick pre-trigger replay NPZs from a live metrics log.
+
+``scenario_generation.replay`` writes ``metrics_log.json`` alongside the
+per-step NPZs whenever a reward config is supplied. Each record carries
+the step index + lane gate / near-frac / border-min-dist / centerline-score
+for that step. This tool reads that log, flags trigger steps (scenes where
+the ego is drifting) and keeps the ``--lookback`` steps *before* each
+trigger as training data — those are the frames where the model could
+still steer away.
+
+Trigger (OR — any fires):
+    1. ``lane_gate < 0.5``                (lane cross)
+    2. ``lane_near_frac > 0``             (within lane_near_thresh of edge;
+                                           threshold baked in at sim time)
+    3. ``rb_min_dist < --rb_min_dist``    (within N metres of a border)
+    4. ``abs(cl_score) > --cl_min_abs``   (off-center by more than N)
+
+Lookback does not cross NPZ-directory boundaries, so combining multiple
+replay runs into one log is safe.
+
+Usage:
+    python -m rlvr.autoresearch.tools.select_from_metrics_log \\
+        --metrics_log /path/to/metrics_log.json \\
+        --npz_dir     /path/to/replay_dump/ \\
+        --output      /path/to/kept_scenes.json \\
+        --diagnostics /path/to/diag.json \\
+        --cl_min_abs 0.35 --rb_min_dist 0.45 --lookback 20
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def _trigger_reasons(
+    rec: dict, rb_min_dist: float, cl_min_abs: float,
+) -> list[str]:
+    reasons: list[str] = []
+    if rec.get("lane_gate", 1.0) < 0.5:
+        reasons.append("lane_cross")
+    if rec.get("lane_near_frac", 0.0) > 0.0:
+        reasons.append("lane_near")
+    if rec.get("rb_min_dist", 99.0) < rb_min_dist:
+        reasons.append("rb_near")
+    if abs(rec.get("cl_score", 0.0)) > cl_min_abs:
+        reasons.append("cl_far")
+    return reasons
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--metrics_log", type=str, required=True,
+                        help="metrics_log.json written by scenario_generation.replay")
+    parser.add_argument("--npz_dir", type=str, required=True,
+                        help="Directory containing replay_step_NNNN.npz files")
+    parser.add_argument("--output", type=str, required=True,
+                        help="JSON list of kept (pre-trigger) NPZ paths")
+    parser.add_argument("--diagnostics", type=str, default=None,
+                        help="Optional per-step trigger/keep dump")
+    parser.add_argument("--rb_min_dist", type=float, required=True,
+                        help="Trigger if rb_min_dist < this (metres)")
+    parser.add_argument("--cl_min_abs", type=float, required=True,
+                        help="Trigger if |cl_score| > this")
+    parser.add_argument("--lookback", type=int, required=True,
+                        help="Number of pre-trigger scenes to keep")
+    parser.add_argument("--include_trigger", action="store_true",
+                        help="Also keep the trigger scenes (default: drop — "
+                             "the lookback is the preventable window)")
+    args = parser.parse_args()
+
+    with open(args.metrics_log) as f:
+        payload = json.load(f)
+    steps = payload["steps"] if isinstance(payload, dict) else payload
+
+    npz_dir = Path(args.npz_dir)
+
+    # Stamp trigger state on each record and collect the ordered step index.
+    for rec in steps:
+        reasons = _trigger_reasons(rec, args.rb_min_dist, args.cl_min_abs)
+        rec["reasons"] = reasons
+        rec["is_trigger"] = len(reasons) > 0
+
+    # Resolve NPZ paths once. Missing NPZs are dropped from the kept set but
+    # still scored in diagnostics so the user can tell why.
+    paths: list[Path | None] = []
+    for rec in steps:
+        p = npz_dir / f"replay_step_{rec['step']:04d}.npz"
+        paths.append(p if p.exists() else None)
+
+    kept_idx: set[int] = set()
+    for i, rec in enumerate(steps):
+        if not rec["is_trigger"]:
+            continue
+        lo = max(0, i - args.lookback)
+        for j in range(lo, i):
+            if paths[j] is not None:
+                kept_idx.add(j)
+        if args.include_trigger and paths[i] is not None:
+            kept_idx.add(i)
+
+    for i, rec in enumerate(steps):
+        rec["kept"] = i in kept_idx
+        rec["npz_path"] = str(paths[i]) if paths[i] is not None else None
+
+    kept_paths = [str(paths[i]) for i in sorted(kept_idx)]
+
+    reason_counts: dict[str, int] = {}
+    for rec in steps:
+        if rec["is_trigger"]:
+            for r in rec["reasons"]:
+                reason_counts[r] = reason_counts.get(r, 0) + 1
+
+    n_trigger = sum(1 for r in steps if r["is_trigger"])
+    n_missing = sum(1 for p in paths if p is None)
+    print(f"Total steps:      {len(steps)}")
+    print(f"Triggers:         {n_trigger}")
+    print(f"Missing NPZs:     {n_missing}")
+    print(f"Kept (lookback):  {len(kept_paths)}")
+    print("Trigger reasons (can overlap):")
+    for r, n in sorted(reason_counts.items(), key=lambda kv: -kv[1]):
+        print(f"  {r:10s} {n}")
+
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w") as f:
+        json.dump(kept_paths, f, indent=2)
+    print(f"\nSaved {len(kept_paths)} kept NPZ paths to {out_path}")
+
+    if args.diagnostics:
+        diag_path = Path(args.diagnostics)
+        diag_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(diag_path, "w") as f:
+            json.dump(steps, f, indent=2)
+        print(f"Saved per-step diagnostics to {diag_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/select_from_metrics_log.py
+++ b/rlvr/autoresearch/tools/select_from_metrics_log.py
@@ -21,11 +21,15 @@ replay runs into one log is safe.
 
 Usage:
     python -m rlvr.autoresearch.tools.select_from_metrics_log \\
-        --metrics_log /path/to/metrics_log.json \\
-        --npz_dir     /path/to/replay_dump/ \\
+        --metrics_log /path/to/replay_run/metrics_log.json \\
+        --npz_dir     /path/to/replay_run/npz/ \\
         --output      /path/to/kept_scenes.json \\
         --diagnostics /path/to/diag.json \\
         --cl_min_abs 0.35 --rb_min_dist 0.45 --lookback 20
+
+``--npz_dir`` must point at the ``npz/`` subdirectory of a replay run,
+not the run directory itself — the tool resolves each step's NPZ as
+``<npz_dir>/replay_step_NNNN.npz``.
 """
 
 from __future__ import annotations

--- a/scenario_generation/README.md
+++ b/scenario_generation/README.md
@@ -227,13 +227,18 @@ record carries `{step, lane_gate, lane_near_frac, lane_wide_frac, lane_cont,
 rb_min_dist, cl_score}`. Thresholds come from the training reward config, so
 the logged values speak the same semantics ranked-SFT uses.
 
-Downstream: `rlvr/autoresearch/tools/select_from_metrics_log.py` reads that
-log + the NPZ directory, flags drift-trigger steps (lane cross / lane-near /
-border-close / centerline-far), and keeps the N pre-trigger NPZs as training
-data — those are the frames where the model could still have recovered.
-Lookback does not cross NPZ-directory boundaries, so concatenating logs from
-multiple replay runs is safe. Reward thresholds for rb / cl are CLI flags on
-the selector so a single sim run can feed many threshold sweeps.
+Each metrics record carries two blocks: the **instantaneous** fields
+(ego-at-current-pose scores) and a `pred_*` block scoring the model's
+80-step prediction against the same reward primitives — produced with
+zero extra inference cost because replay already computed the
+prediction to hand it to the tracker.
+
+Downstream tools:
+
+| Tool | Purpose |
+|---|---|
+| `rlvr/autoresearch/tools/select_from_metrics_log.py` | Flags drift-trigger steps (lane cross / lane-near / border-close / centerline-far) and keeps the N pre-trigger NPZs as training data — the frames where the model could still have recovered. Lookback stays within one NPZ directory so concatenating logs from multiple replay runs is safe. Reward thresholds for rb / cl are CLI flags, so one sim run can feed many threshold sweeps. |
+| `rlvr/autoresearch/tools/rescore_replay_run.py` | Regenerate `metrics_log.json` from an existing replay dump without re-running MPC. Two explicit modes: `--mode instant` scores only the current pose (no model needed, use when a reward component or threshold changed); `--mode full` also scores the model's prediction (`--model_path REQUIRED` — no silent fallback). Swap `--model_path` to a different checkpoint to evaluate how that model would have planned at the same observations — the instantaneous block stays identical, only `pred_*` differs, so loading two metrics logs into scene_search gives a side-by-side plan-quality comparison at matching world positions. Caveat: post-hoc eval is single-step open-loop; it does NOT reproduce what the alternative model would have done if rolled out closed-loop from the same seed — that still requires a fresh `scenario_generation.replay` run. |
 
 Relevant modules:
 
@@ -247,6 +252,7 @@ Relevant modules:
 | `scenario_generation/traffic_light.py` | `TrafficLightController` + signal group state machines |
 | `scenario_generation/configs/replay_default.json` | Reference `SpawnConfig` template — not loaded automatically, `--config` is required |
 | `rlvr/autoresearch/tools/select_from_metrics_log.py` | Reads `metrics_log.json` + NPZ dir, emits pre-trigger scene list for training |
+| `rlvr/autoresearch/tools/rescore_replay_run.py` | Regenerate `metrics_log.json` from an existing run (no re-sim); `--mode instant` (no model) or `--mode full` (with model) — swap models to compare plans at the same observations |
 | `scenario_generation/tools/inspect_route.py` | CLI to dump a saved route pickle |
 | `scenario_generation/gui/app.py` | GUI panels + live route overlay wiring |
 | `scene_search/map_canvas_js.py` | JS canvas: start / goal / waypoint arrows + route polyline |

--- a/scenario_generation/README.md
+++ b/scenario_generation/README.md
@@ -129,14 +129,18 @@ python -m scenario_generation.tools.inspect_route my_route.pkl
 python -m scenario_generation.replay \
     --route my_route.pkl \
     --model_path /path/to/best_model.pth \
+    --config /path/to/spawn_config.json \
     --output_dir ./replay_out \
     [--map_path <override>] \
     [--steps 6000] \
     [--max_npcs 8] \
     [--spawn_probability 0.3] \
-    [--config scenario_generation/configs/replay_default.json] \
     [--seed 42]
 ```
+
+`--config` is required — replay refuses to run with `SpawnConfig` dataclass
+defaults because they don't match any production recipe. Author a JSON per
+run. `configs/replay_default.json` is a starting template, not a fallback.
 
 **Advance modes.** The `advance_mode` field in `SpawnConfig` (or the JSON
 config) controls how the vehicle moves each step:
@@ -210,6 +214,27 @@ perpendicular signals run in phase opposition. TL state is written into the
 5-dim one-hot block at lane-dim indices `[8:13]` of `scene.map_data.lanes`
 and into each agent's `route_lanes` tensor every step.
 
+Set `SpawnConfig.enable_traffic_lights = false` to skip TL construction and
+ticking entirely. Useful for MPC-gen data runs where TL-driven stops would
+bias the replay trajectory away from the steady-state driving the training
+set represents.
+
+**Live per-step metric logging.** When both `dump_npz_dir` and
+`reward_config_path` are set on the `SpawnConfig`, the replay loop scores
+the current ego pose against the dumped map tensors at every step it dumps
+an NPZ and writes `metrics_log.json` alongside `trajectory_log.json`. Each
+record carries `{step, lane_gate, lane_near_frac, lane_wide_frac, lane_cont,
+rb_min_dist, cl_score}`. Thresholds come from the training reward config, so
+the logged values speak the same semantics ranked-SFT uses.
+
+Downstream: `rlvr/autoresearch/tools/select_from_metrics_log.py` reads that
+log + the NPZ directory, flags drift-trigger steps (lane cross / lane-near /
+border-close / centerline-far), and keeps the N pre-trigger NPZs as training
+data — those are the frames where the model could still have recovered.
+Lookback does not cross NPZ-directory boundaries, so concatenating logs from
+multiple replay runs is safe. Reward thresholds for rb / cl are CLI flags on
+the selector so a single sim run can feed many threshold sweeps.
+
 Relevant modules:
 
 | Path | Role |
@@ -220,7 +245,8 @@ Relevant modules:
 | `scenario_generation/simulate.py` | `advance_scene`, `advance_scene_mpc`, model inference helpers |
 | `scenario_generation/mpc_tracker.py` | `MPCTracker`, `PerfectTracker`, `postprocess_reference` |
 | `scenario_generation/traffic_light.py` | `TrafficLightController` + signal group state machines |
-| `scenario_generation/configs/replay_default.json` | Default `SpawnConfig` values |
+| `scenario_generation/configs/replay_default.json` | Reference `SpawnConfig` template — not loaded automatically, `--config` is required |
+| `rlvr/autoresearch/tools/select_from_metrics_log.py` | Reads `metrics_log.json` + NPZ dir, emits pre-trigger scene list for training |
 | `scenario_generation/tools/inspect_route.py` | CLI to dump a saved route pickle |
 | `scenario_generation/gui/app.py` | GUI panels + live route overlay wiring |
 | `scene_search/map_canvas_js.py` | JS canvas: start / goal / waypoint arrows + route polyline |

--- a/scenario_generation/README.md
+++ b/scenario_generation/README.md
@@ -147,15 +147,15 @@ config) controls how the vehicle moves each step:
 
 | Mode | Description | Per-agent cost |
 |---|---|---|
-| `teleport` (default) | Snap to `pred[0]` each step. Original behaviour — fast but can produce aggressive driving (lane invasion, red-light running) because there are no kinematic constraints. | ~0 ms |
-| `perfect` | Euler integration with velocity from the reference trajectory and heading snap. Inspired by Autoware's `autoware_perfect_tracker`. Velocity limits how far the vehicle can move per step, preventing unphysical jumps. | ~0.01 ms |
-| `mpc` | Bicycle-model MPC via scipy L-BFGS-B. Optimises acceleration and steering over a 2 s lookahead horizon (20 steps, 5 control knots). Enforces kinematic constraints (max accel, steering limits, speed bounds). | ~13 ms |
+| `mpc` (**default**) | Bicycle-model MPC. numpy bicycle rollout + analytic reverse-mode gradient fed to scipy L-BFGS-B. Optimises acceleration and steering over a 2 s lookahead horizon (20 steps, 5 control knots). Enforces kinematic constraints (max accel, steering limits, speed bounds). When the ego is idle and the model's 8 s plan has meaningful forward intent, MPC time-compresses the full plan into its 2 s horizon and seeds the warm start with a resume-from-rest accel so the ego launches instead of staying parked. | ~5 ms |
+| `perfect` | Euler integration with velocity from the reference trajectory and heading snap. Inspired by Autoware's `autoware_perfect_tracker`. Velocity limits how far the vehicle can move per step, preventing unphysical jumps. Same full-plan avg speed resume-from-rest push as MPC. | ~0.01 ms |
+| `teleport` | Snap to `pred[0]` each step. Original behaviour — fast but can produce aggressive driving (lane invasion, red-light running) because there are no kinematic constraints. Useful only for bit-identical comparison with legacy `pred[0]` runs. | ~0 ms |
 
 Both `perfect` and `mpc` modes apply C++-style post-processing to the
 reference trajectory before tracking: velocity moving average (window=8) and
 force-stop logic (ported from the C++ `postprocessing_utils.cpp`).
 
-Example config enabling MPC:
+Example config pinning MPC explicitly (already the default):
 
 ```json
 {"advance_mode": "mpc", "seed": 42, "max_steps": 6000, "mpc_horizon_steps": 20, "mpc_n_knots": 5}

--- a/scenario_generation/mpc_tracker.py
+++ b/scenario_generation/mpc_tracker.py
@@ -231,18 +231,32 @@ class MPCTracker:
         idle_but_ref_moves = cur_speed < 0.1 and ref_reach > 0.5
 
         if self._prev_knots is not None and not idle_but_ref_moves:
-            init = np.roll(self._prev_knots, -1, axis=0).copy()
-            init[-1] = init[-2]
+            # Roll: the just-applied knot[0] is consumed, knots[1..n-1]
+            # become the leading knots of this solve. Old trailing knot
+            # approximates the terminal behaviour reasonably well, so
+            # reuse it for the freshly-opened tail slot (was: duplicate
+            # knots[-2], which drops one step of useful warm-start info
+            # when the old trajectory was smoothly decelerating).
+            init = np.empty_like(self._prev_knots)
+            init[:-1] = self._prev_knots[1:]
+            init[-1] = self._prev_knots[-1]
         else:
             init = np.zeros((self.n_knots, 2), dtype=np.float64)
 
+        # Tightened tolerance / iter caps. The smooth quadratic-ish cost
+        # converges long before maxiter=50 in the typical case; profiles
+        # showed ~47 cost evals per solve with the old caps, most of
+        # them after the gradient had already dropped below what ftol=1e-4
+        # would accept. Dropping the caps to maxiter=20 / ftol=1e-4
+        # trims cost evaluations without measurable trajectory drift
+        # (see A/B on 300-step TL+NPCs run — trajectory_log identical).
         result = minimize(
             self._cost,
             init.ravel(),
             args=(np.asarray(x0, dtype=np.float64), ref),
             method="L-BFGS-B",
             bounds=self._bounds,
-            options={"maxiter": 50, "ftol": 1e-6},
+            options={"maxiter": 20, "ftol": 1e-4, "gtol": 1e-4},
         )
         optimal_knots = result.x.reshape(self.n_knots, 2)
         self._prev_knots = optimal_knots.copy()

--- a/scenario_generation/mpc_tracker.py
+++ b/scenario_generation/mpc_tracker.py
@@ -336,26 +336,58 @@ class MPCTracker:
             new_pos: (3,) [x, y, yaw] after one dt step.
             new_speed: scalar speed after one dt step.
         """
-        # Pad or truncate reference to exactly *horizon* steps
-        ref = np.zeros((self.horizon, 3), dtype=np.float64)
-        n = min(len(ref_world), self.horizon)
-        ref[:n] = ref_world[:n, :3]
-        if n < self.horizon:
-            ref[n:] = ref[n - 1]
-
-        # Drop the warm start when we're idle at a stop but the reference
-        # wants meaningful forward motion. During a long decel the knots
-        # converge to all-zero controls; once the planner flips back to a
-        # forward prediction, the reference asks for a gentle
-        # "start-from-rest" ramp whose early-horizon position error is
-        # tiny. From the all-zero warm start the smoothness terms
-        # (w_jerk, w_steer_rate) dominate the gradient and L-BFGS-B can't
-        # escape the zero-knot basin — the ego ends up parked forever.
-        # Resetting the init lets the optimiser freely explore positive
-        # accelerations again, matching what a cold-started tracker does.
+        # Idle-recovery check uses the model's FULL prediction horizon,
+        # not the MPC's truncated window. Post-stop the model typically
+        # emits a back-loaded plan: near-zero motion in the first ~2 s
+        # (gentle start-from-rest) then real acceleration through 8 s.
+        # MPC's 2 s window would only see the flat start and command
+        # zero accel, leaving the ego parked indefinitely even though
+        # the planner has committed to 20+ m of forward motion over the
+        # full 8 s.
         cur_speed = float(x0[3]) if len(x0) > 3 else 0.0
-        ref_reach = float(np.hypot(ref[-1, 0] - x0[0], ref[-1, 1] - x0[1]))
-        idle_but_ref_moves = cur_speed < 0.1 and ref_reach > 0.5
+        full_n = len(ref_world)
+        full_tail_reach = float(
+            np.hypot(ref_world[-1, 0] - x0[0], ref_world[-1, 1] - x0[1])
+        ) if full_n > 0 else 0.0
+        full_horizon_time = full_n * self.dt
+        avg_plan_speed = (
+            full_tail_reach / full_horizon_time if full_horizon_time > 0 else 0.0
+        )
+        # Stay in recovery mode until the ego reaches a reasonable fraction
+        # of the plan's average speed — without this the push fires for one
+        # step (ego bumps from 0 → 0.3 m/s), then next step cur_speed > 0.1
+        # drops recovery off, MPC sees the flat near-horizon ref again,
+        # commands -accel, ego decelerates back to 0. Hysteresis via
+        # half-target gate keeps the launch continuous.
+        idle_but_plan_moves = (
+            cur_speed < max(0.1, 0.5 * avg_plan_speed)
+            and avg_plan_speed > 0.5
+        )
+
+        # Build the reference fed to MPC. Two modes:
+        # - normal: first `horizon` steps of the model's plan (truncate/pad).
+        # - idle-recovery: time-compress the full plan into the horizon
+        #   so MPC sees where the model wants the ego to be in 2 s if
+        #   it were following the plan's average pace. Once the ego
+        #   starts moving (cur_speed >= 0.1), we drop back to the normal
+        #   truncated view so the model's intended timing is respected.
+        ref = np.zeros((self.horizon, 3), dtype=np.float64)
+        if idle_but_plan_moves and full_n > self.horizon:
+            stride = full_n / self.horizon
+            indices = np.clip(
+                (np.arange(self.horizon) * stride).astype(int),
+                0, full_n - 1,
+            )
+            ref[:] = ref_world[indices, :3]
+        else:
+            n = min(full_n, self.horizon)
+            ref[:n] = ref_world[:n, :3]
+            if n < self.horizon:
+                ref[n:] = ref[n - 1]
+
+        # Keep the old flag name for the warm-start branch below — its
+        # semantics are the same: "ego idle AND we want motion".
+        idle_but_ref_moves = idle_but_plan_moves
 
         if self._prev_knots is not None and not idle_but_ref_moves:
             # Roll: the just-applied knot[0] is consumed, knots[1..n-1]
@@ -369,18 +401,12 @@ class MPCTracker:
             init[-1] = self._prev_knots[-1]
         elif idle_but_ref_moves:
             # Seed the warm start with an accel guess derived from the
-            # reference's desired terminal speed instead of all-zeros.
-            # Resetting alone lets the optimiser escape the zero-knot
-            # basin, but from init=0 it still has to discover positive
-            # accel via gradient descent over several L-BFGS-B steps —
-            # in closed loop that shows up as the ego taking a few sim
-            # ticks to actually start moving after a red.
-            # Give it a direct "push":
-            #   a_guess = (ref_reach / horizon_time) / horizon_time
-            # = avg accel needed to cover ref_reach from rest over the
-            # horizon. Clipped to the tracker's accel bounds.
+            # model's avg plan speed (not the tail-reach/horizon² formula
+            # used before — that blew up on back-loaded plans because it
+            # assumed the ref tail was close, when really the ref we NOW
+            # give MPC is the stretched full plan with a real far tail).
             horizon_time = self.horizon * self.dt
-            a_guess = ref_reach / (horizon_time * horizon_time)
+            a_guess = avg_plan_speed / horizon_time
             a_guess = max(self.min_accel, min(self.max_accel, a_guess))
             init = np.zeros((self.n_knots, 2), dtype=np.float64)
             init[:, 0] = a_guess
@@ -544,23 +570,23 @@ class PerfectTracker:
         dy = ref_world[0, 1] - x0[1]
         v_target = min(math.hypot(dx, dy) / self.dt, self.max_speed)
 
-        # Resume-from-rest push (mirrors the MPCTracker branch). After a
-        # red-light stop the reference's first step sits right on top of
-        # the current ego pose, so v_target ≈ 0 and PerfectTracker would
-        # creep out of the intersection over many ticks. When the tail
-        # of the reference is meaningfully forward of x0, override
-        # v_target with the average speed needed to cover that reach
-        # over the available horizon, so the ego actually launches.
+        # Resume-from-rest push (mirrors the MPCTracker branch). Use the
+        # model's FULL horizon (not the first 2 s) to decide whether to
+        # push — post-stop plans are back-loaded, so a short-horizon
+        # reach is near-zero while the 8 s reach is 20+ m. Push speed
+        # = avg over the full plan.
         cur_speed = float(x0[3]) if len(x0) > 3 else 0.0
-        tail_idx = min(len(ref_world) - 1, 20)  # ~2 s horizon on dt=0.1
-        tail_reach = math.hypot(
-            ref_world[tail_idx, 0] - x0[0],
-            ref_world[tail_idx, 1] - x0[1],
+        full_n = len(ref_world)
+        full_tail_reach = math.hypot(
+            ref_world[-1, 0] - x0[0],
+            ref_world[-1, 1] - x0[1],
+        ) if full_n > 0 else 0.0
+        full_horizon_time = full_n * self.dt
+        avg_plan_speed = (
+            full_tail_reach / full_horizon_time if full_horizon_time > 0 else 0.0
         )
-        if cur_speed < 0.1 and tail_reach > 0.5:
-            horizon_time = (tail_idx + 1) * self.dt
-            push_speed = tail_reach / horizon_time
-            v_target = max(v_target, min(self.max_speed, push_speed))
+        if cur_speed < 0.1 and avg_plan_speed > 0.5:
+            v_target = max(v_target, min(self.max_speed, avg_plan_speed))
 
         # Euler integration using current heading and target velocity
         x, y, yaw = float(x0[0]), float(x0[1]), float(x0[2])

--- a/scenario_generation/mpc_tracker.py
+++ b/scenario_generation/mpc_tracker.py
@@ -544,6 +544,24 @@ class PerfectTracker:
         dy = ref_world[0, 1] - x0[1]
         v_target = min(math.hypot(dx, dy) / self.dt, self.max_speed)
 
+        # Resume-from-rest push (mirrors the MPCTracker branch). After a
+        # red-light stop the reference's first step sits right on top of
+        # the current ego pose, so v_target ≈ 0 and PerfectTracker would
+        # creep out of the intersection over many ticks. When the tail
+        # of the reference is meaningfully forward of x0, override
+        # v_target with the average speed needed to cover that reach
+        # over the available horizon, so the ego actually launches.
+        cur_speed = float(x0[3]) if len(x0) > 3 else 0.0
+        tail_idx = min(len(ref_world) - 1, 20)  # ~2 s horizon on dt=0.1
+        tail_reach = math.hypot(
+            ref_world[tail_idx, 0] - x0[0],
+            ref_world[tail_idx, 1] - x0[1],
+        )
+        if cur_speed < 0.1 and tail_reach > 0.5:
+            horizon_time = (tail_idx + 1) * self.dt
+            push_speed = tail_reach / horizon_time
+            v_target = max(v_target, min(self.max_speed, push_speed))
+
         # Euler integration using current heading and target velocity
         x, y, yaw = float(x0[0]), float(x0[1]), float(x0[2])
         x_new = x + v_target * math.cos(yaw) * self.dt

--- a/scenario_generation/mpc_tracker.py
+++ b/scenario_generation/mpc_tracker.py
@@ -189,6 +189,133 @@ class MPCTracker:
 
         return float(J)
 
+    def _cost_and_grad(
+        self,
+        knot_flat: np.ndarray,
+        x0: np.ndarray,
+        ref: np.ndarray,
+    ) -> tuple[float, np.ndarray]:
+        """Scalar cost + analytic gradient w.r.t. knot_flat.
+
+        Reverse-mode through the bicycle rollout. The previous
+        ``_cost``-only path left scipy to compute a numerical Jacobian,
+        which on the profile was ~47 ``_cost`` evaluations per L-BFGS-B
+        step (one cold eval + one per control dim via forward
+        perturbation). With the exact gradient returned alongside the
+        cost the optimiser needs ~3-5 calls per step instead.
+
+        Verified against scipy's numerical gradient in the unit tests —
+        see ``test_mpc_tracker.py::TestMPCGradient``.
+        """
+        H = self.horizon
+        dt = self.dt
+        wb = self.wheelbase
+        v_max = self.max_speed
+        sk = self.steps_per_knot
+
+        knots = knot_flat.reshape(self.n_knots, 2)
+        controls = self._expand_knots(knots)
+
+        # ---- Forward rollout (same as _rollout, inlined so we can also
+        # cache per-step trig values used later in the backward sweep) ----
+        states = np.empty((H + 1, 4), dtype=np.float64)
+        states[0] = x0
+        clamped = np.zeros(H, dtype=bool)
+        for t in range(H):
+            x, y, yaw, v = states[t]
+            a = controls[t, 0]
+            delta = controls[t, 1]
+            states[t + 1, 0] = x + v * math.cos(yaw) * dt
+            states[t + 1, 1] = y + v * math.sin(yaw) * dt
+            states[t + 1, 2] = yaw + v * math.tan(delta) / wb * dt
+            v_new = v + a * dt
+            if v_new < 0.0:
+                clamped[t] = True
+                states[t + 1, 3] = 0.0
+            elif v_new > v_max:
+                clamped[t] = True
+                states[t + 1, 3] = v_max
+            else:
+                states[t + 1, 3] = v_new
+
+        pred = states[1:]
+        pos_err = pred[:, :2] - ref[:, :2]
+        dyaw = pred[:, 2] - ref[:, 2]
+
+        # Forward cost
+        J = self.w_pos * np.dot(pos_err.ravel(), pos_err.ravel())
+        J += self.w_head * np.sum(1.0 - np.cos(dyaw))
+        J += self.w_accel * np.dot(controls[:, 0], controls[:, 0])
+        J += self.w_steer * np.dot(controls[:, 1], controls[:, 1])
+        if self.n_knots > 1:
+            dk = np.diff(knots, axis=0)
+            J += self.w_jerk * np.dot(dk[:, 0], dk[:, 0])
+            J += self.w_steer_rate * np.dot(dk[:, 1], dk[:, 1])
+
+        # ---- Reverse sweep ----
+        # Direct contributions of the tracking cost to dJ/dstate[t] for t=1..H.
+        # (State[0] = x0 is a constant; tracking cost doesn't touch it.)
+        dJ_dstate_direct = np.zeros((H + 1, 4), dtype=np.float64)
+        dJ_dstate_direct[1:, 0] = 2.0 * self.w_pos * pos_err[:, 0]
+        dJ_dstate_direct[1:, 1] = 2.0 * self.w_pos * pos_err[:, 1]
+        dJ_dstate_direct[1:, 2] = self.w_head * np.sin(dyaw)
+
+        dJ_dctrl = np.zeros((H, 2), dtype=np.float64)
+        adj = dJ_dstate_direct[H].copy()  # adjoint at state[H]
+        for t in range(H - 1, -1, -1):
+            x, y, yaw, v = states[t]
+            a = controls[t, 0]
+            delta = controls[t, 1]
+            sin_yaw = math.sin(yaw)
+            cos_yaw = math.cos(yaw)
+            tan_d = math.tan(delta)
+            cos_d = math.cos(delta)
+            cos_d2 = cos_d * cos_d
+
+            ax, ay, ayaw, av = adj
+            dv_dv = 0.0 if clamped[t] else 1.0
+            dv_da = 0.0 if clamped[t] else dt
+
+            # df/dstate[t]^T @ adj
+            adj_x = ax
+            adj_y = ay
+            adj_yaw = (-v * sin_yaw * dt) * ax \
+                    + (v * cos_yaw * dt) * ay \
+                    + ayaw
+            adj_v = (cos_yaw * dt) * ax \
+                  + (sin_yaw * dt) * ay \
+                  + (tan_d / wb * dt) * ayaw \
+                  + dv_dv * av
+
+            # df/dctrl[t]^T @ adj — only a affects v, only delta affects yaw.
+            dJ_dctrl[t, 0] = dv_da * av
+            if cos_d2 > 1e-12:
+                dJ_dctrl[t, 1] = (v / (wb * cos_d2) * dt) * ayaw
+            # else leave 0 (delta at ±π/2 is excluded by bounds anyway).
+
+            adj = dJ_dstate_direct[t] + np.array([adj_x, adj_y, adj_yaw, adj_v])
+
+        # Direct control-cost contribution:
+        dJ_dctrl[:, 0] += 2.0 * self.w_accel * controls[:, 0]
+        dJ_dctrl[:, 1] += 2.0 * self.w_steer * controls[:, 1]
+
+        # Aggregate per-step control grads into per-knot grads. Each knot
+        # is held for ``sk`` steps of the rollout (_expand_knots uses
+        # ``np.repeat``), so dJ/dknot[i] is the sum of dJ/dctrl over that
+        # knot's span.
+        dJ_dknot = dJ_dctrl[: self.n_knots * sk].reshape(self.n_knots, sk, 2).sum(axis=1)
+
+        # Smoothness terms (closed-form on knot diffs).
+        if self.n_knots > 1:
+            dk0 = knots[1:, 0] - knots[:-1, 0]
+            dk1 = knots[1:, 1] - knots[:-1, 1]
+            dJ_dknot[:-1, 0] -= 2.0 * self.w_jerk * dk0
+            dJ_dknot[1:, 0] += 2.0 * self.w_jerk * dk0
+            dJ_dknot[:-1, 1] -= 2.0 * self.w_steer_rate * dk1
+            dJ_dknot[1:, 1] += 2.0 * self.w_steer_rate * dk1
+
+        return float(J), dJ_dknot.ravel()
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
@@ -251,11 +378,12 @@ class MPCTracker:
         # trims cost evaluations without measurable trajectory drift
         # (see A/B on 300-step TL+NPCs run — trajectory_log identical).
         result = minimize(
-            self._cost,
+            self._cost_and_grad,
             init.ravel(),
             args=(np.asarray(x0, dtype=np.float64), ref),
             method="L-BFGS-B",
             bounds=self._bounds,
+            jac=True,  # analytic gradient returned alongside the cost
             options={"maxiter": 20, "ftol": 1e-4, "gtol": 1e-4},
         )
         optimal_knots = result.x.reshape(self.n_knots, 2)

--- a/scenario_generation/mpc_tracker.py
+++ b/scenario_generation/mpc_tracker.py
@@ -367,6 +367,23 @@ class MPCTracker:
             init = np.empty_like(self._prev_knots)
             init[:-1] = self._prev_knots[1:]
             init[-1] = self._prev_knots[-1]
+        elif idle_but_ref_moves:
+            # Seed the warm start with an accel guess derived from the
+            # reference's desired terminal speed instead of all-zeros.
+            # Resetting alone lets the optimiser escape the zero-knot
+            # basin, but from init=0 it still has to discover positive
+            # accel via gradient descent over several L-BFGS-B steps —
+            # in closed loop that shows up as the ego taking a few sim
+            # ticks to actually start moving after a red.
+            # Give it a direct "push":
+            #   a_guess = (ref_reach / horizon_time) / horizon_time
+            # = avg accel needed to cover ref_reach from rest over the
+            # horizon. Clipped to the tracker's accel bounds.
+            horizon_time = self.horizon * self.dt
+            a_guess = ref_reach / (horizon_time * horizon_time)
+            a_guess = max(self.min_accel, min(self.max_accel, a_guess))
+            init = np.zeros((self.n_knots, 2), dtype=np.float64)
+            init[:, 0] = a_guess
         else:
             init = np.zeros((self.n_knots, 2), dtype=np.float64)
 

--- a/scenario_generation/mpc_tracker.py
+++ b/scenario_generation/mpc_tracker.py
@@ -216,8 +216,21 @@ class MPCTracker:
         if n < self.horizon:
             ref[n:] = ref[n - 1]
 
-        # Initial guess — warm-start from shifted previous solution
-        if self._prev_knots is not None:
+        # Drop the warm start when we're idle at a stop but the reference
+        # wants meaningful forward motion. During a long decel the knots
+        # converge to all-zero controls; once the planner flips back to a
+        # forward prediction, the reference asks for a gentle
+        # "start-from-rest" ramp whose early-horizon position error is
+        # tiny. From the all-zero warm start the smoothness terms
+        # (w_jerk, w_steer_rate) dominate the gradient and L-BFGS-B can't
+        # escape the zero-knot basin — the ego ends up parked forever.
+        # Resetting the init lets the optimiser freely explore positive
+        # accelerations again, matching what a cold-started tracker does.
+        cur_speed = float(x0[3]) if len(x0) > 3 else 0.0
+        ref_reach = float(np.hypot(ref[-1, 0] - x0[0], ref[-1, 1] - x0[1]))
+        idle_but_ref_moves = cur_speed < 0.1 and ref_reach > 0.5
+
+        if self._prev_knots is not None and not idle_but_ref_moves:
             init = np.roll(self._prev_knots, -1, axis=0).copy()
             init[-1] = init[-2]
         else:

--- a/scenario_generation/mpc_tracker.py
+++ b/scenario_generation/mpc_tracker.py
@@ -100,6 +100,14 @@ class MPCTracker:
         # Warm-start buffer (n_knots, 2)
         self._prev_knots: np.ndarray | None = None
 
+        # Last-step telemetry — populated by track(). Callers that want
+        # physically-correct accel / yaw_rate / steering (instead of the
+        # 5-step MA that _advance_agent derives from position history)
+        # read these after the track() call.
+        self.last_accel: float = 0.0
+        self.last_yaw_rate: float = 0.0
+        self.last_steering: float = 0.0
+
     # ------------------------------------------------------------------
     # Kinematic rollout
     # ------------------------------------------------------------------
@@ -236,6 +244,13 @@ class MPCTracker:
         yaw_new = yaw + v * math.tan(delta) / self.wheelbase * self.dt
         v_new = max(0.0, min(v + a * self.dt, self.max_speed))
 
+        # Stash the commanded control + kinematic yaw rate so callers can
+        # read the tracker's true physical state instead of MA-lagged
+        # estimates from position history.
+        self.last_accel = a
+        self.last_steering = delta
+        self.last_yaw_rate = v * math.tan(delta) / self.wheelbase
+
         new_pos = np.array([x_new, y_new, yaw_new], dtype=np.float32)
         return new_pos, v_new
 
@@ -325,6 +340,14 @@ class PerfectTracker:
     def __init__(self, dt: float = 0.1, max_speed: float = 20.0):
         self.dt = dt
         self.max_speed = max_speed
+        # Parallel to MPCTracker.last_*: perfect-tracker telemetry set by
+        # track(). PerfectTracker has no steering control — it snaps to
+        # the reference heading — so last_steering stays 0.0 and
+        # last_yaw_rate is derived from the heading change per step.
+        self.last_accel: float = 0.0
+        self.last_yaw_rate: float = 0.0
+        self.last_steering: float = 0.0
+        self._prev_speed: float = 0.0
 
     def track(
         self,
@@ -356,6 +379,23 @@ class PerfectTracker:
 
         # Snap heading directly to the reference orientation
         yaw_new = float(ref_world[0, 2])
+
+        # Telemetry for realistic agent-state propagation (same contract
+        # as MPCTracker.last_*).
+        dh = (yaw_new - yaw + math.pi) % (2 * math.pi) - math.pi
+        self.last_yaw_rate = dh / self.dt
+        v_prev = float(x0[3]) if len(x0) > 3 else self._prev_speed
+        self.last_accel = (v_target - v_prev) / self.dt
+        self._prev_speed = v_target
+        # PerfectTracker doesn't model a steering wheel; recover an
+        # equivalent bicycle-model δ from the observed yaw rate if speed
+        # is nontrivial (matches how _advance_agent used to derive it).
+        if v_target > 0.2:
+            # Wheelbase isn't on this class; leave last_steering at 0 and
+            # let _advance_agent compute it from (yaw_rate, speed, wheelbase).
+            self.last_steering = 0.0
+        else:
+            self.last_steering = 0.0
 
         new_pos = np.array([x_new, y_new, yaw_new], dtype=np.float32)
         return new_pos, v_target

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -564,7 +564,17 @@ class SceneNPCManager:
                 route_speed_limit=route_sl,
                 route_has_speed_limit=route_hsl,
                 turn_indicators=np.zeros(history.shape[0], dtype=np.int32),
-                age_steps=0,
+                # Expose the full synthesized history to the tensor
+                # converter. generate_history() backward-traces the
+                # lanelet centerline at the spawn speed and produces a
+                # physically coherent 31-step past; masking it to 1 real
+                # frame (age_steps=0) made the model see "appeared from
+                # nothing" and emit erratic first predictions that MPC
+                # then tracked into out-of-lane swerves. Setting
+                # age_steps to the buffer length lets the synthesized
+                # history pass through so the model gets a plausible
+                # past to condition on.
+                age_steps=history.shape[0],
                 route_lanelet_ids=route_ll_ids,
             )
             touched = list(set(route_ll_ids) | set(history_ll_ids) | {ll_id})

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -224,6 +224,10 @@ class SpawnConfig:
     # data runs where TL-driven speed drops would bias the replay ego
     # toward stop-and-go behaviour we don't want in training.
     enable_traffic_lights: bool = True
+    # Overlay the live metric values + closest road-border line on each
+    # per-step PNG. Requires dump_npz_dir + reward_config_path (so the
+    # metrics have actually been computed). Adds ~1 ms per frame.
+    overlay_metrics_on_png: bool = False
     # When set, per-step observations are dumped as training-style NPZs to
     # this directory. GT future is zeroed out (ranked-SFT generates its own).
     dump_npz_dir: str | None = None
@@ -725,6 +729,42 @@ def _draw_road_borders(ax, road_border_polylines, view_center=None, view_half_m=
     ))
 
 
+def _closest_border_point(
+    ego_xy: np.ndarray,
+    border_polylines: list[np.ndarray] | None,
+) -> tuple[np.ndarray, float] | None:
+    """Closest point on any road-border polyline to ``ego_xy`` (world frame).
+
+    Scans consecutive segments; returns (closest_xy, distance_m) or None if
+    no border segments are available.
+    """
+    if not border_polylines:
+        return None
+    best_pt: np.ndarray | None = None
+    best_d = float("inf")
+    ex, ey = float(ego_xy[0]), float(ego_xy[1])
+    for pl in border_polylines:
+        if pl is None or pl.shape[0] < 2:
+            continue
+        p1 = pl[:-1].astype(np.float64)  # (S, 2)
+        p2 = pl[1:].astype(np.float64)   # (S, 2)
+        seg = p2 - p1
+        seg_len2 = (seg * seg).sum(axis=1)
+        seg_len2[seg_len2 < 1e-9] = 1e-9
+        t = (((ex - p1[:, 0]) * seg[:, 0] + (ey - p1[:, 1]) * seg[:, 1])
+             / seg_len2)
+        t = np.clip(t, 0.0, 1.0)
+        closest = p1 + t[:, None] * seg  # (S, 2)
+        dists = np.hypot(closest[:, 0] - ex, closest[:, 1] - ey)
+        idx = int(dists.argmin())
+        if dists[idx] < best_d:
+            best_d = float(dists[idx])
+            best_pt = closest[idx]
+    if best_pt is None:
+        return None
+    return best_pt, best_d
+
+
 def _save_step_figure(
     scene: SceneContext,
     agent_predictions: dict,
@@ -737,6 +777,7 @@ def _save_step_figure(
     route_lanelet_ids: list[int] | None = None,
     sim_time: float = 0.0,
     road_border_polylines: list[np.ndarray] | None = None,
+    metrics: dict | None = None,
 ) -> None:
     """Render + save the overview PNG for a single replay step.
 
@@ -908,12 +949,36 @@ def _save_step_figure(
     )
     ti_label = _TI_NAMES.get(ti_cls, f"?{ti_cls}")
     steer_deg = math.degrees(ego.steering_angle)
-    ax.set_title(
+    title = (
         f"Step {step:04d}/{n_steps}  t={step * 0.1:.1f}s  agents={len(scene.agents)}"
         f"\nego  v={ego_speed:.1f} m/s ({ego_speed_kph:.0f} km/h)  "
-        f"steer={steer_deg:+.0f}°  turn={ti_label}  goal_d={goal_d:.1f} m",
-        fontsize=10,
+        f"steer={steer_deg:+.0f}°  turn={ti_label}  goal_d={goal_d:.1f} m"
     )
+
+    if metrics is not None:
+        gate_s = "IN" if metrics.get("lane_gate", 1.0) >= 0.5 else "CROSS"
+        title += (
+            f"\nrb_min={metrics.get('rb_min_dist', float('nan')):.2f} m  "
+            f"cl={metrics.get('cl_score', float('nan')):+.3f}  "
+            f"lane={gate_s}  "
+            f"lane_near={metrics.get('lane_near_frac', 0.0):.2f}"
+        )
+        closest = _closest_border_point(ego.current_position, road_border_polylines)
+        if closest is not None:
+            cb, cb_d = closest
+            ax.plot([ex, cb[0]], [ey, cb[1]], "k--", linewidth=1.3, alpha=0.7, zorder=29)
+            ax.plot(cb[0], cb[1], "ko", markersize=6, zorder=30,
+                    markeredgecolor="white", markeredgewidth=0.8)
+            mx, my = (ex + cb[0]) / 2, (ey + cb[1]) / 2
+            ax.annotate(f"{cb_d:.2f} m",
+                        xy=(mx, my), fontsize=8, color="black",
+                        ha="center", va="center",
+                        bbox=dict(boxstyle="round,pad=0.2",
+                                  facecolor="white", edgecolor="black",
+                                  alpha=0.7),
+                        zorder=31)
+
+    ax.set_title(title, fontsize=10)
     fig.tight_layout()
     _save_and_close(fig, output_path)
 
@@ -1335,12 +1400,18 @@ def run_route_replay(
 
             # Save PNG (concurrent with next step's compute).
             out_path = output_dir / f"step_{step:04d}.png"
+            overlay_metrics = (
+                metrics_log[-1]
+                if spawn_config.overlay_metrics_on_png and metrics_log
+                else None
+            )
             pending_saves.append(save_pool.submit(
                 _save_step_figure,
                 deepcopy(scene), agent_predictions, out_path,
                 step, spawn_config.max_steps, route_polylines,
                 _VIEW_HALF_M, tl_controller, _route_vis_ll_ids,
                 step * 0.1, road_border_polylines,
+                overlay_metrics,
             ))
 
             # Drain finished saves so memory doesn't balloon. Call

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -1020,6 +1020,7 @@ def _score_step(
     device: str,
     reward_cfg: RewardConfig,
     spawn_config: SpawnConfig,
+    prediction: np.ndarray | None = None,
 ) -> dict:
     """Score the current ego pose against the dumped map tensors.
 
@@ -1082,6 +1083,29 @@ def _score_step(
     out["collision"] = out.get("collision_step") is not None
     out["lane_gate"] = 0.0 if out.get("lane_crossing") else 1.0
     out["cl_score"] = float(cl_baselink[0].item())
+
+    # Prediction-trajectory scores. The model's 80-step output is already
+    # in ego frame (same frame as the dumped map tensors) so we can score
+    # it directly with no extra inference. Keys get prefixed with "pred_"
+    # so the heatmap / selector can toggle "here-and-now" vs
+    # "what-the-model-plans". Zero extra cost on the sim hot path.
+    if prediction is not None and prediction.shape[0] >= 2:
+        pred = torch.from_numpy(np.ascontiguousarray(prediction)).float().to(device)
+        pred = pred.unsqueeze(0)  # (1, T, 4)
+        br_p = compute_reward_batch(pred, d, reward_cfg)[0]
+        cl_p = compute_centerline_score_batch(
+            pred, ego_shape_cl, d,
+            usage_cap=reward_cfg.centerline_usage_cap,
+            usage_mode="baselink",
+        )
+        for k, v in asdict(br_p).items():
+            if isinstance(v, (bool, int, float)) or v is None:
+                out[f"pred_{k}"] = v
+            elif isinstance(v, torch.Tensor):
+                out[f"pred_{k}"] = float(v.item())
+        out["pred_collision"] = out.get("pred_collision_step") is not None
+        out["pred_lane_gate"] = 0.0 if out.get("pred_lane_crossing") else 1.0
+        out["pred_cl_score"] = float(cl_p[0].item())
     return out
 
 
@@ -1437,8 +1461,10 @@ def run_route_replay(
                 np.savez(npz_dir / f"replay_step_{step:04d}.npz", **data)
 
                 if reward_cfg is not None:
+                    ego_pred = agent_predictions.get(scene.ego_agent_id)
                     metrics_log.append(_score_step(
                         data, step, device, reward_cfg, spawn_config,
+                        prediction=ego_pred,
                     ))
 
             # Save PNG (concurrent with next step's compute).

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -344,20 +344,50 @@ class SceneNPCManager:
         # Updated every tick so NPC goals avoid untransited ego lanelets.
         self._ego_transited: set[int] = set()
         self._ego_untransited: set[int] = set(ego_route_ll_ids)
+        # Index into ``ego_route_ll_ids`` of the lanelet the ego snapped
+        # to last call. Used to restrict the ``snap_to_nearest_ll`` search
+        # to a tiny local window around the last known position — on the
+        # profile the full-map scan was 10 s of 114 s, and route progress
+        # only ever advances through adjacent entries in the fixed route.
+        self._last_ego_route_idx: int = 0
 
     def register_known_lanelets(self, lanelet_ids: list[int]) -> None:
         self._known_lanelet_ids.update(lanelet_ids)
 
     def update_ego_progress(self, ego_xy: np.ndarray) -> None:
-        """Mark the ego's current lanelet (and all prior) as transited."""
-        ll = self.builder.snap_to_nearest_ll(ego_xy)
+        """Mark the ego's current lanelet (and all prior) as transited.
+
+        Previously called ``snap_to_nearest_ll(ego_xy)`` with no filter,
+        which scanned every drivable lanelet on the map (O(N), ~40 ms
+        per call on dense Shinagawa). The ego only transits through its
+        own route, so we restrict the snap to ego route lanelets within a
+        sliding window around the last known index. Full-route fallback
+        is preserved for the (rare) case the ego strays outside the
+        window — we accept a miss as a no-op, not a silent wrong snap.
+        """
+        route = self.ego_route_ll_ids
+        if not route:
+            return
+
+        # Local window: current index ± a few slots covers the typical
+        # "advance at most a handful of lanelets per update" regime.
+        lo = max(0, self._last_ego_route_idx - 2)
+        hi = min(len(route), self._last_ego_route_idx + 8)
+        local_ids = route[lo:hi]
+        ll = self.builder.snap_to_nearest_ll(ego_xy, candidate_ids=local_ids)
+        if ll is None:
+            # Window missed — fall back to the full route list.
+            ll = self.builder.snap_to_nearest_ll(ego_xy, candidate_ids=route)
         if ll is None or ll not in self._ego_untransited:
             return
-        # Mark everything up to and including this lanelet as transited.
-        for rid in self.ego_route_ll_ids:
+
+        # Mark everything up to and including this lanelet as transited;
+        # cache the new window index so the next call stays local.
+        for i, rid in enumerate(route):
             self._ego_transited.add(rid)
             self._ego_untransited.discard(rid)
             if rid == ll:
+                self._last_ego_route_idx = i
                 break
 
     def tick(self, scene: SceneContext) -> None:

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -89,10 +89,11 @@ from scenario_generation.traffic_light import TrafficLightController
 # duplicating so the two pipelines stay in sync.
 from rlvr.grpo_sft_trainer import _smooth_trajectory as _sg_smooth_trajectory
 
-# Live per-step lane / border / centerline scoring (only loaded when
-# dump_npz_dir + reward_config_path are set). Matches the exact same
-# primitives ranked-SFT uses for its reward, so the metrics log here and
-# the training run speak the same thresholds.
+# Live per-step lane / border / centerline scoring. Imports are module-
+# level (unconditional); the scoring path itself only runs when both
+# dump_npz_dir and reward_config_path are set in SpawnConfig. Matches
+# the exact same primitives ranked-SFT uses for its reward, so the
+# metrics log here and the training run speak the same thresholds.
 from rlvr.autoresearch.tools.reward_config_from_json import load_reward_config
 from rlvr.reward import (
     RewardConfig,

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -729,40 +729,58 @@ def _draw_road_borders(ax, road_border_polylines, view_center=None, view_half_m=
     ))
 
 
-def _closest_border_point(
-    ego_xy: np.ndarray,
+def _nearest_border_point(
+    probe_xy: np.ndarray,
     border_polylines: list[np.ndarray] | None,
-) -> tuple[np.ndarray, float] | None:
-    """Closest point on any road-border polyline to ``ego_xy`` (world frame).
+) -> np.ndarray | None:
+    """Nearest point on any road-border polyline to ``probe_xy`` (world frame).
 
-    Scans consecutive segments; returns (closest_xy, distance_m) or None if
-    no border segments are available.
+    Pure geometry used only to position the viz pointer — the authoritative
+    body-to-border distance comes from ``rlvr.reward.compute_road_border_penalty``
+    via the per-step metrics log. Do not read the returned point's distance
+    as a metric.
     """
     if not border_polylines:
         return None
     best_pt: np.ndarray | None = None
     best_d = float("inf")
-    ex, ey = float(ego_xy[0]), float(ego_xy[1])
+    px, py = float(probe_xy[0]), float(probe_xy[1])
     for pl in border_polylines:
         if pl is None or pl.shape[0] < 2:
             continue
-        p1 = pl[:-1].astype(np.float64)  # (S, 2)
-        p2 = pl[1:].astype(np.float64)   # (S, 2)
+        p1 = pl[:-1].astype(np.float64)
+        p2 = pl[1:].astype(np.float64)
         seg = p2 - p1
         seg_len2 = (seg * seg).sum(axis=1)
         seg_len2[seg_len2 < 1e-9] = 1e-9
-        t = (((ex - p1[:, 0]) * seg[:, 0] + (ey - p1[:, 1]) * seg[:, 1])
+        t = (((px - p1[:, 0]) * seg[:, 0] + (py - p1[:, 1]) * seg[:, 1])
              / seg_len2)
         t = np.clip(t, 0.0, 1.0)
-        closest = p1 + t[:, None] * seg  # (S, 2)
-        dists = np.hypot(closest[:, 0] - ex, closest[:, 1] - ey)
+        closest = p1 + t[:, None] * seg
+        dists = np.hypot(closest[:, 0] - px, closest[:, 1] - py)
         idx = int(dists.argmin())
         if dists[idx] < best_d:
             best_d = float(dists[idx])
             best_pt = closest[idx]
-    if best_pt is None:
-        return None
-    return best_pt, best_d
+    return best_pt
+
+
+def _ego_obb_corners(
+    ex: float, ey: float, heading: float, length: float, width: float,
+) -> np.ndarray:
+    """Four OBB corners of the ego footprint in world frame (pure geometry).
+
+    Matches the rear-axle convention used by ``scenario_generation.visualize
+    .draw_agent_box``: baselink (ego x, y) sits rear_overhang behind the
+    back of the box.
+    """
+    rear_overhang = (length - length * 0.65) / 2
+    x0, x1 = -rear_overhang, length - rear_overhang
+    y0, y1 = -width / 2, width / 2
+    local = np.array([[x0, y0], [x0, y1], [x1, y1], [x1, y0]], dtype=np.float64)
+    c, s = math.cos(heading), math.sin(heading)
+    R = np.array([[c, -s], [s, c]], dtype=np.float64)
+    return (R @ local.T).T + np.array([ex, ey], dtype=np.float64)
 
 
 def _save_step_figure(
@@ -963,14 +981,26 @@ def _save_step_figure(
             f"lane={gate_s}  "
             f"lane_near={metrics.get('lane_near_frac', 0.0):.2f}"
         )
-        closest = _closest_border_point(ego.current_position, road_border_polylines)
-        if closest is not None:
-            cb, cb_d = closest
-            ax.plot([ex, cb[0]], [ey, cb[1]], "k--", linewidth=1.3, alpha=0.7, zorder=29)
-            ax.plot(cb[0], cb[1], "ko", markersize=6, zorder=30,
+        # Position the viz pointer using the nearest border point to the
+        # ego rear axle, then anchor the line on the nearest OBB corner
+        # (body edge, not baselink) so the visual length roughly tracks
+        # the body-to-border distance shown in the label.
+        border_pt = _nearest_border_point(ego.current_position, road_border_polylines)
+        if border_pt is not None:
+            corners = _ego_obb_corners(
+                ex, ey, ego.current_heading,
+                float(ego.length), float(ego.width),
+            )
+            d_corner = np.hypot(corners[:, 0] - border_pt[0],
+                                corners[:, 1] - border_pt[1])
+            start = corners[int(d_corner.argmin())]
+            body_d = metrics.get("rb_min_dist", float("nan"))
+            ax.plot([start[0], border_pt[0]], [start[1], border_pt[1]],
+                    "k--", linewidth=1.3, alpha=0.7, zorder=29)
+            ax.plot(border_pt[0], border_pt[1], "ko", markersize=6, zorder=30,
                     markeredgecolor="white", markeredgewidth=0.8)
-            mx, my = (ex + cb[0]) / 2, (ey + cb[1]) / 2
-            ax.annotate(f"{cb_d:.2f} m",
+            mx, my = (start[0] + border_pt[0]) / 2, (start[1] + border_pt[1]) / 2
+            ax.annotate(f"{body_d:.2f} m",
                         xy=(mx, my), fontsize=8, color="black",
                         ha="center", va="center",
                         bbox=dict(boxstyle="round,pad=0.2",
@@ -1031,10 +1061,17 @@ def _score_step(
     _, _, _, _, _, rb_per_ts_min = compute_road_border_penalty(
         traj, ego_shape, d, config=reward_cfg,
     )
+    # Centerline uses "baselink" regardless of what the training reward
+    # config specifies: the selection pipeline's drift signal is about
+    # where the rear-axle sits relative to the lane centerline, not about
+    # the full-body footprint — body-mode would inflate cl_score
+    # proportional to vehicle width and conflate width with drift.
+    # Road-border scoring above uses the body (perimeter), which is the
+    # physically-meaningful quantity for safety gating.
     cl = compute_centerline_score_batch(
         traj, ego_shape, d,
         usage_cap=reward_cfg.centerline_usage_cap,
-        usage_mode=reward_cfg.centerline_usage_mode,
+        usage_mode="baselink",
     )
 
     return {

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -88,6 +88,18 @@ from scenario_generation.traffic_light import TrafficLightController
 # replay time to suppress diffusion-sampler jitter. Importing rather than
 # duplicating so the two pipelines stay in sync.
 from rlvr.grpo_sft_trainer import _smooth_trajectory as _sg_smooth_trajectory
+
+# Live per-step lane / border / centerline scoring (only loaded when
+# dump_npz_dir + reward_config_path are set). Matches the exact same
+# primitives ranked-SFT uses for its reward, so the metrics log here and
+# the training run speak the same thresholds.
+from rlvr.autoresearch.tools.reward_config_from_json import load_reward_config
+from rlvr.reward import (
+    RewardConfig,
+    compute_centerline_score_batch,
+    compute_lane_departure_penalty,
+    compute_road_border_penalty,
+)
 from scenario_generation.visualize import (
     _agent_color,
     draw_agent_box,
@@ -211,6 +223,11 @@ class SpawnConfig:
     # When set, per-step observations are dumped as training-style NPZs to
     # this directory. GT future is zeroed out (ranked-SFT generates its own).
     dump_npz_dir: str | None = None
+    # Path to a training-style (GRPO) config JSON. Required when dump_npz_dir
+    # is set: per-step lane / border / centerline metrics are logged using
+    # the same thresholds the training run will use, so downstream scene
+    # selection can re-threshold without re-running the sim.
+    reward_config_path: str | None = None
     # Initial ego speed for history synthesis (m/s). Default uses midpoint
     # of NPC speed band (7.5), but real data may be much slower (e.g. 1.75
     # on low-speed exit curves). Set to match the scenario being replayed.
@@ -256,6 +273,12 @@ class SpawnConfig:
         if self.ego_init_speed is not None and self.ego_init_speed < 0:
             raise ValueError(
                 f"ego_init_speed must be >= 0 when set; got {self.ego_init_speed}"
+            )
+        if self.dump_npz_dir and not self.reward_config_path:
+            raise ValueError(
+                "reward_config_path is required when dump_npz_dir is set; "
+                "per-step metrics need thresholds that match the training "
+                "reward function (no silent defaults)."
             )
 
     @classmethod
@@ -892,6 +915,70 @@ def _save_step_figure(
 
 
 @torch.no_grad()
+@torch.no_grad()
+def _score_step(
+    npz_data: dict[str, np.ndarray],
+    step: int,
+    device: str,
+    reward_cfg: RewardConfig,
+    spawn_config: SpawnConfig,
+) -> dict:
+    """Score the current ego pose against the dumped map tensors.
+
+    The dumped NPZ has ``ego_agent_future`` zeroed, so the "trajectory" here
+    is a 1-step origin placeholder (t=0 + t=1 both at origin); this makes the
+    penalty primitives — which skip t=0 for near/wide fractions — evaluate
+    at least one timestep, and that one timestep is the current ego pose
+    (already centered in ego-frame by ``dump_step_npz``).
+
+    Metrics are logged raw where possible (``rb_min_dist``, ``cl_score``) so
+    the downstream selector can re-threshold without re-running the sim;
+    ``lane_gate`` and ``lane_near_frac`` use the training config's
+    thresholds directly.
+    """
+    def _to_t(arr: np.ndarray) -> torch.Tensor:
+        t = torch.from_numpy(np.asarray(arr)).float().to(device)
+        # Primitives accept either (S, P, D) or (1, S, P, D) — add batch dim
+        # for 3D map tensors so the broadcast path is unambiguous.
+        return t.unsqueeze(0) if t.dim() == 3 else t
+
+    d: dict[str, torch.Tensor] = {}
+    for k in ("lanes", "route_lanes", "line_strings"):
+        if k in npz_data:
+            d[k] = _to_t(npz_data[k])
+
+    ego_shape = torch.tensor(
+        [spawn_config.ego_wheelbase, spawn_config.ego_length, spawn_config.ego_width],
+        device=device, dtype=torch.float32,
+    )
+
+    # (1, 2, 4) origin traj — cos(0)=1 at both slots.
+    traj = torch.zeros(1, 2, 4, device=device)
+    traj[0, :, 2] = 1.0
+
+    lane_gate, lane_near, lane_wide, _, lane_cont = compute_lane_departure_penalty(
+        traj, ego_shape, d, config=reward_cfg,
+    )
+    _, _, _, _, _, rb_per_ts_min = compute_road_border_penalty(
+        traj, ego_shape, d, config=reward_cfg,
+    )
+    cl = compute_centerline_score_batch(
+        traj, ego_shape, d,
+        usage_cap=reward_cfg.centerline_usage_cap,
+        usage_mode=reward_cfg.centerline_usage_mode,
+    )
+
+    return {
+        "step": step,
+        "lane_gate": float(lane_gate[0].item()),
+        "lane_near_frac": float(lane_near[0].item()),
+        "lane_wide_frac": float(lane_wide[0].item()),
+        "lane_cont": float(lane_cont[0].item()),
+        "rb_min_dist": float(rb_per_ts_min[0].min().item()),
+        "cl_score": float(cl[0].item()),
+    }
+
+
 def run_route_replay(
     model,
     model_args,
@@ -1087,6 +1174,14 @@ def run_route_replay(
     # Per-step trajectory log for post-hoc evaluation.
     trajectory_log: list[dict] = []
 
+    # Live lane / border / centerline scoring, logged per step when NPZ dump
+    # + reward_config_path are both set. The downstream scene selector reads
+    # this log; no offline NPZ re-scoring needed.
+    metrics_log: list[dict] = []
+    reward_cfg: RewardConfig | None = None
+    if spawn_config.dump_npz_dir and spawn_config.reward_config_path:
+        reward_cfg = load_reward_config(spawn_config.reward_config_path)
+
     # Tracker state (lazy-init per agent inside advance_scene_mpc).
     _use_tracker = spawn_config.advance_mode in ("mpc", "perfect")
     mpc_trackers: dict = {}
@@ -1225,6 +1320,11 @@ def run_route_replay(
                 )
                 np.savez(npz_dir / f"replay_step_{step:04d}.npz", **data)
 
+                if reward_cfg is not None:
+                    metrics_log.append(_score_step(
+                        data, step, device, reward_cfg, spawn_config,
+                    ))
+
             # Save PNG (concurrent with next step's compute).
             out_path = output_dir / f"step_{step:04d}.png"
             pending_saves.append(save_pool.submit(
@@ -1340,13 +1440,34 @@ def run_route_replay(
     with open(traj_log_path, "w") as f:
         json.dump(trajectory_log, f)
 
-    return {
+    metrics_log_path: Path | None = None
+    if metrics_log:
+        metrics_log_path = output_dir / "metrics_log.json"
+        # Record the config source so the downstream selector knows which
+        # thresholds the stored lane_near_frac etc. were computed against.
+        payload = {
+            "reward_config_path": spawn_config.reward_config_path,
+            "dump_npz_dir": spawn_config.dump_npz_dir,
+            "ego_shape": [
+                spawn_config.ego_wheelbase,
+                spawn_config.ego_length,
+                spawn_config.ego_width,
+            ],
+            "steps": metrics_log,
+        }
+        with open(metrics_log_path, "w") as f:
+            json.dump(payload, f)
+
+    out = {
         "final_step": final_step,
         "goal_reached": goal_reached,
         "reason": reason,
         "n_npc_spawned": n_npc_spawned,
         "trajectory_log_path": str(traj_log_path),
     }
+    if metrics_log_path is not None:
+        out["metrics_log_path"] = str(metrics_log_path)
+    return out
 
 
 # ── CLI ──────────────────────────────────────────────────────────────────────

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -220,6 +220,10 @@ class SpawnConfig:
     # Model inference delay: number of initial timesteps kept fixed as prefix.
     # Matches the "delay" input tensor to the diffusion decoder.
     inference_delay: int = 0
+    # Skip traffic-light state propagation entirely. Useful for MPC-gen
+    # data runs where TL-driven speed drops would bias the replay ego
+    # toward stop-and-go behaviour we don't want in training.
+    enable_traffic_lights: bool = True
     # When set, per-step observations are dumped as training-style NPZs to
     # this directory. GT future is zeroed out (ranked-SFT generates its own).
     dump_npz_dir: str | None = None
@@ -1152,14 +1156,16 @@ def run_route_replay(
     ]
 
     # --- Traffic light controller. ---
-    tl_controller = TrafficLightController(
-        builder, ego_route_ids, seed=spawn_config.seed,
-    )
-    # Apply initial TL state to the freshly-built map_data AND ego route_lanes.
-    tl_controller.tick(scene, 0.0, builder._last_map_data_ids, ego_xy=snapped_xy)
-    tl_controller.write_to_route_lanes(
-        scene.ego_agent.route_lanes, initial_route_window, 0.0,
-    )
+    tl_controller: TrafficLightController | None = None
+    if spawn_config.enable_traffic_lights:
+        tl_controller = TrafficLightController(
+            builder, ego_route_ids, seed=spawn_config.seed,
+        )
+        # Apply initial TL state to the freshly-built map_data AND ego route_lanes.
+        tl_controller.tick(scene, 0.0, builder._last_map_data_ids, ego_xy=snapped_xy)
+        tl_controller.write_to_route_lanes(
+            scene.ego_agent.route_lanes, initial_route_window, 0.0,
+        )
 
     # --- NPC manager. ---
     npc_manager = SceneNPCManager(builder, ego_route_ids, spawn_config, tl_controller)
@@ -1241,10 +1247,11 @@ def run_route_replay(
             # always sees the current signal phase. The TL one-hot is
             # written directly into scene.map_data.lanes which the
             # map_cache references (shared underlying array).
-            tl_controller.tick(
-                scene, step * 0.1, builder._last_map_data_ids,
-                ego_xy=ego_xy,
-            )
+            if tl_controller is not None:
+                tl_controller.tick(
+                    scene, step * 0.1, builder._last_map_data_ids,
+                    ego_xy=ego_xy,
+                )
 
             # Refresh route_lanes for ALL agents (ego + NPCs) so the
             # sliding window stays centered on each agent's current
@@ -1259,7 +1266,8 @@ def run_route_replay(
                 )
                 if fwd:
                     rl, rsl, rhsl = builder._route_to_33dim(fwd)
-                    tl_controller.write_to_route_lanes(rl, fwd, step * 0.1)
+                    if tl_controller is not None:
+                        tl_controller.write_to_route_lanes(rl, fwd, step * 0.1)
                     a.route_lanes = rl
                     a.route_speed_limit = rsl
                     a.route_has_speed_limit = rhsl
@@ -1491,8 +1499,11 @@ def main() -> None:
                         help="Override hard cap on concurrent neighbors")
     parser.add_argument("--spawn_probability", type=float, default=None,
                         help="Override spawn probability per spawn tick")
-    parser.add_argument("--config", type=Path, default=None,
-                        help="JSON SpawnConfig overrides")
+    parser.add_argument("--config", type=Path, required=True,
+                        help="Path to a SpawnConfig JSON. Required — replay "
+                             "refuses to run with dataclass defaults because "
+                             "they don't match any production recipe. Author "
+                             "a config per run.")
     parser.add_argument("--device", type=str, default="cuda")
     parser.add_argument("--seed", type=int, default=None)
     args = parser.parse_args()
@@ -1502,10 +1513,7 @@ def main() -> None:
     print(f"Loading builder from {map_path}")
     builder = LaneletSceneBuilder(map_path)
 
-    if args.config is not None:
-        cfg = SpawnConfig.from_json(args.config)
-    else:
-        cfg = SpawnConfig()
+    cfg = SpawnConfig.from_json(args.config)
     if args.steps is not None:
         cfg.max_steps = args.steps
     if args.max_npcs is not None:

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -209,11 +209,16 @@ class SpawnConfig:
     sg_filter_window: int = 11
     sg_filter_order: int = 3
     # Advance mode: how the vehicle moves each step.
-    #   "teleport"  — original behaviour, snap to pred[0] (default)
     #   "mpc"       — bicycle-model MPC tracking with 2 s lookahead
+    #                 (default; numpy bicycle rollout + analytic gradient
+    #                 via scipy L-BFGS-B; respects kinematic bounds on
+    #                 accel / steering / speed)
     #   "perfect"   — Euler integration with velocity from reference
-    #                  (matches Autoware autoware_perfect_tracker)
-    advance_mode: str = "teleport"
+    #                 (matches Autoware autoware_perfect_tracker)
+    #   "teleport"  — original behaviour, snap to pred[0] each step
+    #                 (no physics; use only when comparing against
+    #                 legacy pred[0]-based runs)
+    advance_mode: str = "mpc"
     mpc_horizon_steps: int = 20
     mpc_n_knots: int = 5
     # Ego vehicle dimensions. Override for non-default vehicles (e.g. larger
@@ -1038,11 +1043,15 @@ def _save_step_figure(
         int(ego.turn_indicators[-1]) if ego.turn_indicators is not None else 0
     )
     ti_label = _TI_NAMES.get(ti_cls, f"?{ti_cls}")
+    # Display steering in degrees with 1-decimal precision. Under 0.5°
+    # the old :+.0f° rounded to "+0°" and was mistakable for radians.
     steer_deg = math.degrees(ego.steering_angle)
+    yaw_rate_deg = math.degrees(ego.yaw_rate)
     title = (
         f"Step {step:04d}/{n_steps}  t={step * 0.1:.1f}s  agents={len(scene.agents)}"
         f"\nego  v={ego_speed:.1f} m/s ({ego_speed_kph:.0f} km/h)  "
-        f"steer={steer_deg:+.0f}°  turn={ti_label}  goal_d={goal_d:.1f} m"
+        f"steer={steer_deg:+.1f}°  yawrate={yaw_rate_deg:+.1f}°/s  "
+        f"turn={ti_label}  goal_d={goal_d:.1f} m"
     )
 
     if metrics is not None:

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -299,6 +299,16 @@ class SpawnConfig:
                 "per-step metrics need thresholds that match the training "
                 "reward function (no silent defaults)."
             )
+        if self.overlay_metrics_on_png and (
+            not self.dump_npz_dir or not self.reward_config_path
+        ):
+            raise ValueError(
+                "overlay_metrics_on_png requires both dump_npz_dir and "
+                "reward_config_path; the overlay renders the live rb / cl "
+                "/ lane_gate values that only exist when the per-step "
+                "metrics log is being produced. Set both, or disable the "
+                "overlay."
+            )
 
     @classmethod
     def from_json(cls, path: str | Path) -> "SpawnConfig":

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -97,8 +97,7 @@ from rlvr.autoresearch.tools.reward_config_from_json import load_reward_config
 from rlvr.reward import (
     RewardConfig,
     compute_centerline_score_batch,
-    compute_lane_departure_penalty,
-    compute_road_border_penalty,
+    compute_reward_batch,
 )
 from scenario_generation.visualize import (
     _agent_color,
@@ -1025,28 +1024,33 @@ def _score_step(
     """Score the current ego pose against the dumped map tensors.
 
     The dumped NPZ has ``ego_agent_future`` zeroed, so the "trajectory" here
-    is a 1-step origin placeholder (t=0 + t=1 both at origin); this makes the
-    penalty primitives — which skip t=0 for near/wide fractions — evaluate
-    at least one timestep, and that one timestep is the current ego pose
-    (already centered in ego-frame by ``dump_step_npz``).
+    is a 1-step origin placeholder (t=0 + t=1 both at origin). The penalty
+    primitives skip t=0 for near/wide fractions; the duplicate t=1 slot
+    gives them one timestep to evaluate, representing the current pose.
 
-    Metrics are logged raw where possible (``rb_min_dist``, ``cl_score``) so
-    the downstream selector can re-threshold without re-running the sim;
-    ``lane_gate`` and ``lane_near_frac`` use the training config's
-    thresholds directly.
+    Dispatches to the full ``compute_reward_batch`` so every component the
+    training reward tracks (total, safety/collision, progress, smoothness,
+    feasibility, centerline-penalty, red_light, off_road, rb + lane sub-
+    fields) lands in the log. A separate ``compute_centerline_score_batch``
+    call with ``usage_mode="baselink"`` keeps a raw rear-axle cl magnitude
+    for the selection heatmap (independent of the training config's
+    usage_mode, which may be "body").
     """
     def _to_t(arr: np.ndarray) -> torch.Tensor:
         t = torch.from_numpy(np.asarray(arr)).float().to(device)
-        # Primitives accept either (S, P, D) or (1, S, P, D) — add batch dim
-        # for 3D map tensors so the broadcast path is unambiguous.
+        # compute_reward_batch handles either batched or unbatched tensors
+        # for lane / line_string / route_lanes; normalise to batched form
+        # so neighbor-future reshapes further down don't misinterpret the
+        # single ego dim.
         return t.unsqueeze(0) if t.dim() == 3 else t
 
     d: dict[str, torch.Tensor] = {}
-    for k in ("lanes", "route_lanes", "line_strings"):
+    for k in ("lanes", "route_lanes", "line_strings", "ego_shape",
+              "neighbor_agents_future", "neighbor_agents_past", "goal_pose"):
         if k in npz_data:
             d[k] = _to_t(npz_data[k])
 
-    ego_shape = torch.tensor(
+    ego_shape_cl = torch.tensor(
         [spawn_config.ego_wheelbase, spawn_config.ego_length, spawn_config.ego_width],
         device=device, dtype=torch.float32,
     )
@@ -1055,32 +1059,40 @@ def _score_step(
     traj = torch.zeros(1, 2, 4, device=device)
     traj[0, :, 2] = 1.0
 
-    lane_gate, lane_near, lane_wide, _, lane_cont = compute_lane_departure_penalty(
-        traj, ego_shape, d, config=reward_cfg,
-    )
-    _, _, _, _, _, rb_per_ts_min = compute_road_border_penalty(
-        traj, ego_shape, d, config=reward_cfg,
-    )
-    # Centerline uses "baselink" regardless of what the training reward
-    # config specifies: the selection pipeline's drift signal is about
-    # where the rear-axle sits relative to the lane centerline, not about
-    # the full-body footprint — body-mode would inflate cl_score
-    # proportional to vehicle width and conflate width with drift.
-    # Road-border scoring above uses the body (perimeter), which is the
-    # physically-meaningful quantity for safety gating.
+    breakdowns = compute_reward_batch(traj, d, reward_cfg)
+    br = breakdowns[0]
+
     cl = compute_centerline_score_batch(
-        traj, ego_shape, d,
+        traj, ego_shape_cl, d,
         usage_cap=reward_cfg.centerline_usage_cap,
         usage_mode="baselink",
     )
 
     return {
         "step": step,
-        "lane_gate": float(lane_gate[0].item()),
-        "lane_near_frac": float(lane_near[0].item()),
-        "lane_wide_frac": float(lane_wide[0].item()),
-        "lane_cont": float(lane_cont[0].item()),
-        "rb_min_dist": float(rb_per_ts_min[0].min().item()),
+        # Full RewardBreakdown — aggregate + per-component penalties /
+        # scores the selection heatmap can colour by.
+        "total": float(br.total),
+        "safety": float(br.safety),
+        "progress": float(br.progress),
+        "smoothness": float(br.smoothness),
+        "feasibility": float(br.feasibility),
+        "centerline_penalty": float(br.centerline),
+        "red_light": float(br.red_light),
+        "off_road_fraction": float(br.off_road_fraction),
+        "collision": br.collision_step is not None,
+        "collision_step": br.collision_step,
+        "rb_crossing": bool(br.rb_crossing),
+        "rb_near_penalty": float(br.rb_near_penalty),
+        "rb_wide_penalty": float(br.rb_wide_penalty),
+        "rb_min_dist": float(br.rb_min_dist),
+        "lane_crossing": bool(br.lane_crossing),
+        "lane_near_frac": float(br.lane_near_frac),
+        "lane_wide_frac": float(br.lane_wide_frac),
+        # Back-compat alias: downstream (selector, heatmap) reads lane_gate
+        # as a 0/1 rather than a bool crossing flag.
+        "lane_gate": 0.0 if br.lane_crossing else 1.0,
+        # Raw baselink centerline magnitude — independent of reward config.
         "cl_score": float(cl[0].item()),
     }
 

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -1347,13 +1347,19 @@ def run_route_replay(
 
             # TL state + route_lanes refresh EVERY step so the model
             # always sees the current signal phase. The TL one-hot is
-            # written directly into scene.map_data.lanes which the
-            # map_cache references (shared underlying array).
+            # written into scene.map_data.lanes AND synced into
+            # map_cache — the cache snapshots lanes at build time (via
+            # ``.astype(np.float32)`` which forces a copy), so without
+            # the sync the ``lanes`` channel the model reads from the
+            # cache stays at TL_NONE forever even while route_lanes
+            # carries the live TL colour. Missing this sync makes the
+            # ego ignore red lights at intersections.
             if tl_controller is not None:
                 tl_controller.tick(
                     scene, step * 0.1, builder._last_map_data_ids,
                     ego_xy=ego_xy,
                 )
+                map_cache.sync_tl_state(scene.map_data)
 
             # Refresh route_lanes for ALL agents (ego + NPCs) so the
             # sliding window stays centered on each agent's current

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -1013,7 +1013,6 @@ def _save_step_figure(
 
 
 @torch.no_grad()
-@torch.no_grad()
 def _score_step(
     npz_data: dict[str, np.ndarray],
     step: int,
@@ -1587,6 +1586,13 @@ def run_route_replay(
     traj_log_path = output_dir / "trajectory_log.json"
     with open(traj_log_path, "w") as f:
         json.dump(trajectory_log, f)
+
+    # Persist the effective SpawnConfig alongside the dumps so downstream
+    # tools (notably rlvr.autoresearch.tools.rescore_replay_run) can reload
+    # ego dimensions / inference_delay / reward_config_path without the
+    # user having to track the original JSON separately.
+    spawn_cfg_path = output_dir / "spawn_config.json"
+    spawn_config.to_json(spawn_cfg_path)
 
     metrics_log_path: Path | None = None
     if metrics_log:

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -179,6 +179,12 @@ class SpawnConfig:
     npc_min_speed: float = 3.0
     npc_max_speed: float = 12.0
     npc_route_length_m: float = 120.0
+    # Reject an NPC spawn if the chosen route's goal lands within this
+    # distance (metres) of any lanelet centerline on the ego route. Keeps
+    # NPCs from being born with goals on points the ego will pass
+    # through, which can cause them to swerve across the ego's path at
+    # the last moment. Set to 0 to disable.
+    npc_goal_min_dist_from_ego_route: float = 50.0
     curvature_threshold: float = 0.3
     # Closest-approach window: when the ego has been within this radius of
     # the goal AND now has the goal *behind* it (negative dot product
@@ -350,6 +356,22 @@ class SceneNPCManager:
         # profile the full-map scan was 10 s of 114 s, and route progress
         # only ever advances through adjacent entries in the fixed route.
         self._last_ego_route_idx: int = 0
+        # Flat (N, 2) world-frame stack of every valid centerline point
+        # across the ego route. Used to reject NPC spawns whose goal
+        # lands within ``cfg.npc_goal_min_dist_from_ego_route`` metres of
+        # the ego's path, so spawned NPCs can't plan toward a point the
+        # ego will pass through. Empty when the route has no cached
+        # lanelets (which makes the distance check a no-op).
+        ego_route_pts: list[np.ndarray] = []
+        for ll_id in ego_route_ll_ids:
+            if ll_id in builder._cache:
+                cl = builder._cache[ll_id].raw_centerline
+                if cl.shape[0] > 0:
+                    ego_route_pts.append(cl.astype(np.float32))
+        if ego_route_pts:
+            self._ego_route_pts: np.ndarray = np.concatenate(ego_route_pts, axis=0)
+        else:
+            self._ego_route_pts = np.zeros((0, 2), dtype=np.float32)
 
     def register_known_lanelets(self, lanelet_ids: list[int]) -> None:
         self._known_lanelet_ids.update(lanelet_ids)
@@ -543,6 +565,17 @@ class SceneNPCManager:
             # Route for this neighbor.
             route_ll_ids = self._pick_route(ll_id)
             goal = self.builder._route_goal(route_ll_ids)
+
+            # Reject if the goal lands too close to the ego's path. A
+            # close goal biases the NPC's plan toward the ego's route,
+            # which in turn produces the late-moment cross-through
+            # swerves we saw around step 1700 of the TL+NPC replay.
+            min_dist = self.cfg.npc_goal_min_dist_from_ego_route
+            if min_dist > 0 and self._ego_route_pts.shape[0] > 0 and goal is not None:
+                dxy = self._ego_route_pts - goal[:2]
+                if float(np.hypot(dxy[:, 0], dxy[:, 1]).min()) < min_dist:
+                    continue
+
             route_lanes, route_sl, route_hsl = self.builder._route_to_33dim(route_ll_ids)
             if self.tl_controller is not None:
                 self.tl_controller.write_to_route_lanes(

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -1083,8 +1083,23 @@ def _score_step(
     d: dict[str, torch.Tensor] = {}
     for k in ("lanes", "route_lanes", "line_strings", "ego_shape",
               "neighbor_agents_future", "neighbor_agents_past", "goal_pose"):
-        if k in npz_data:
-            d[k] = _to_t(npz_data[k])
+        if k not in npz_data:
+            continue
+        arr = npz_data[k]
+        # dump_step_npz stores goal_pose as (x, y, yaw_rad) length 3, but
+        # compute_reward_batch's progress term only reads goal_pose when
+        # it has >= 4 elements (expects x, y, cos, sin) and silently
+        # falls back to zeros otherwise. That made `progress` and `total`
+        # in the metrics log misleading. Convert to cos/sin on the fly.
+        if k == "goal_pose":
+            arr_np = np.asarray(arr)
+            if arr_np.shape[-1] == 3:
+                yaw = arr_np[..., 2]
+                arr = np.stack(
+                    (arr_np[..., 0], arr_np[..., 1], np.cos(yaw), np.sin(yaw)),
+                    axis=-1,
+                )
+        d[k] = _to_t(arr)
 
     ego_shape_cl = torch.tensor(
         [spawn_config.ego_wheelbase, spawn_config.ego_length, spawn_config.ego_width],

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -1028,20 +1028,16 @@ def _score_step(
     primitives skip t=0 for near/wide fractions; the duplicate t=1 slot
     gives them one timestep to evaluate, representing the current pose.
 
-    Dispatches to the full ``compute_reward_batch`` so every component the
-    training reward tracks (total, safety/collision, progress, smoothness,
-    feasibility, centerline-penalty, red_light, off_road, rb + lane sub-
-    fields) lands in the log. A separate ``compute_centerline_score_batch``
-    call with ``usage_mode="baselink"`` keeps a raw rear-axle cl magnitude
-    for the selection heatmap (independent of the training config's
-    usage_mode, which may be "body").
+    Everything dispatches to ``compute_reward_batch`` so that adding a new
+    field to ``rlvr.reward.RewardBreakdown`` automatically flows into the
+    log — no per-field mapping here to maintain. The one extra is an
+    explicit baselink-mode centerline score (the ``RewardBreakdown``
+    already holds a centerline term, but whether it used body or baselink
+    depends on the training config; the heatmap wants the rear-axle
+    version).
     """
     def _to_t(arr: np.ndarray) -> torch.Tensor:
         t = torch.from_numpy(np.asarray(arr)).float().to(device)
-        # compute_reward_batch handles either batched or unbatched tensors
-        # for lane / line_string / route_lanes; normalise to batched form
-        # so neighbor-future reshapes further down don't misinterpret the
-        # single ego dim.
         return t.unsqueeze(0) if t.dim() == 3 else t
 
     d: dict[str, torch.Tensor] = {}
@@ -1055,46 +1051,38 @@ def _score_step(
         device=device, dtype=torch.float32,
     )
 
-    # (1, 2, 4) origin traj — cos(0)=1 at both slots.
     traj = torch.zeros(1, 2, 4, device=device)
     traj[0, :, 2] = 1.0
 
     breakdowns = compute_reward_batch(traj, d, reward_cfg)
     br = breakdowns[0]
 
-    cl = compute_centerline_score_batch(
+    cl_baselink = compute_centerline_score_batch(
         traj, ego_shape_cl, d,
         usage_cap=reward_cfg.centerline_usage_cap,
         usage_mode="baselink",
     )
 
-    return {
-        "step": step,
-        # Full RewardBreakdown — aggregate + per-component penalties /
-        # scores the selection heatmap can colour by.
-        "total": float(br.total),
-        "safety": float(br.safety),
-        "progress": float(br.progress),
-        "smoothness": float(br.smoothness),
-        "feasibility": float(br.feasibility),
-        "centerline_penalty": float(br.centerline),
-        "red_light": float(br.red_light),
-        "off_road_fraction": float(br.off_road_fraction),
-        "collision": br.collision_step is not None,
-        "collision_step": br.collision_step,
-        "rb_crossing": bool(br.rb_crossing),
-        "rb_near_penalty": float(br.rb_near_penalty),
-        "rb_wide_penalty": float(br.rb_wide_penalty),
-        "rb_min_dist": float(br.rb_min_dist),
-        "lane_crossing": bool(br.lane_crossing),
-        "lane_near_frac": float(br.lane_near_frac),
-        "lane_wide_frac": float(br.lane_wide_frac),
-        # Back-compat alias: downstream (selector, heatmap) reads lane_gate
-        # as a 0/1 rather than a bool crossing flag.
-        "lane_gate": 0.0 if br.lane_crossing else 1.0,
-        # Raw baselink centerline magnitude — independent of reward config.
-        "cl_score": float(cl[0].item()),
-    }
+    # Dump every RewardBreakdown field by iterating the dataclass, so
+    # adding a new component only requires touching rlvr.reward — this
+    # function stays untouched.
+    out: dict = {"step": step}
+    for k, v in asdict(br).items():
+        if isinstance(v, (bool, int, float)) or v is None:
+            out[k] = v
+        elif isinstance(v, torch.Tensor):
+            out[k] = float(v.item())
+        # Anything else (should not happen for RewardBreakdown) gets dropped
+        # rather than breaking JSON serialization.
+
+    # Derived convenience fields not in RewardBreakdown:
+    #   collision: bool from collision_step
+    #   lane_gate: 0/1 alias of (not lane_crossing) — selector reads it
+    #   cl_score:  raw rear-axle centerline magnitude
+    out["collision"] = out.get("collision_step") is not None
+    out["lane_gate"] = 0.0 if out.get("lane_crossing") else 1.0
+    out["cl_score"] = float(cl_baselink[0].item())
+    return out
 
 
 def run_route_replay(

--- a/scenario_generation/simulate.py
+++ b/scenario_generation/simulate.py
@@ -292,12 +292,20 @@ def advance_scene_mpc(
         x0 = np.array([float(ax), float(ay), ah, speed], dtype=np.float64)
 
         new_pos, new_speed = tracker.track(x0, ref_world)
+        # Use None — not 0.0 — when a tracker lacks the telemetry
+        # attribute. _advance_agent treats None as "fall back to MA
+        # estimate"; 0.0 would be treated as a valid zero command and
+        # silently force accel/yaw_rate/steering to zero every step,
+        # defeating the whole point of the tracker-telemetry path.
+        last_accel = getattr(tracker, "last_accel", None)
+        last_yaw_rate = getattr(tracker, "last_yaw_rate", None)
+        last_steering = getattr(tracker, "last_steering", None)
         _advance_agent(
             agent, new_pos, dt,
             new_speed=float(new_speed),
-            new_accel=float(getattr(tracker, "last_accel", 0.0)),
-            new_yaw_rate=float(getattr(tracker, "last_yaw_rate", 0.0)),
-            new_steering=float(getattr(tracker, "last_steering", 0.0)),
+            new_accel=None if last_accel is None else float(last_accel),
+            new_yaw_rate=None if last_yaw_rate is None else float(last_yaw_rate),
+            new_steering=None if last_steering is None else float(last_steering),
         )
 
 

--- a/scenario_generation/simulate.py
+++ b/scenario_generation/simulate.py
@@ -83,28 +83,26 @@ def _advance_agent(
     new_world_pos: np.ndarray,
     dt: float = 0.1,
     new_speed: float | None = None,
+    new_accel: float | None = None,
+    new_yaw_rate: float | None = None,
+    new_steering: float | None = None,
 ):
     """Advance a single agent in-place given its new world position.
 
     Uses in-place shift + overwrite instead of concatenation to avoid
     allocations.
 
-    Velocity source:
-    - When ``new_speed`` is given (MPC / perfect tracker modes), use it
-      directly: ``v_world = new_speed * (cos(new_heading), sin(new_heading))``.
-      The tracker integrates the bicycle model and already produces the
-      physically correct instantaneous speed; applying a MA of position
-      diffs on top of that just introduces a 0.4 s lag visible both in
-      the PNG title speed AND in ``ego_current_state[4]`` fed back to the
-      model, which self-reinforces "slow down" plans that the lagged
-      speed never acknowledges.
-    - When ``new_speed`` is None (teleport mode, ``advance_scene``), fall
-      back to the 5-step MA of position diffs. At 10 Hz the one-step
-      numerical diff amplifies high-freq jitter from the diffusion
-      sampler ~10× on velocity, and the teleport path has no physics
-      filter to soften that, so the MA is still justified there.
-    Steering angle is derived from the bicycle model
-    (``δ = atan2(wheelbase * yaw_rate, speed)``).
+    The optional ``new_*`` kwargs carry the tracker's own physically-
+    correct telemetry (see ``MPCTracker.last_*`` / ``PerfectTracker.
+    last_*``). When given, they replace the corresponding 5-step MA
+    derivatives — those MAs were meant to denoise the jittery pred[0]
+    teleport output, but in MPC / perfect mode the tracker's bicycle
+    model already produces physically smooth signals, so the MA just
+    adds ~0.4 s of spurious lag. The lagged values end up in
+    ``ego_current_state`` and get fed back to the model, creating a
+    closed-loop feedback lag where "slow down" plans never settle.
+    Teleport-mode callers pass None for all of them and get the MA
+    fallback that's still justified there.
     """
     agent.past_trajectory[:-1] = agent.past_trajectory[1:]
     agent.past_trajectory[-1] = new_world_pos
@@ -133,10 +131,17 @@ def _advance_agent(
     else:
         old_smoothed_vel = smoothed_vel
 
-    # Acceleration: finite diff of the smoothed velocity series — this is
-    # far cleaner than `(new_vel_raw - old_vel_raw) / dt` which compounded
-    # jitter from both steps.
-    if agent.past_velocities is not None and agent.past_velocities.shape[0] >= W + 1:
+    # Acceleration: use the tracker's commanded accel when given (MPC /
+    # perfect); otherwise fall back to the 5-step MA of velocity diffs,
+    # which is what teleport mode needs to denoise the jittery pred[0]
+    # finite differences.
+    if new_accel is not None:
+        new_yaw = float(new_world_pos[2])
+        agent.acceleration = np.array(
+            [new_accel * math.cos(new_yaw), new_accel * math.sin(new_yaw)],
+            dtype=np.float32,
+        )
+    elif agent.past_velocities is not None and agent.past_velocities.shape[0] >= W + 1:
         vel_window = agent.past_velocities[-W - 1:]
         if vel_window.shape[0] >= 2:
             accel_diffs = np.diff(vel_window, axis=0) / dt
@@ -146,8 +151,10 @@ def _advance_agent(
     else:
         agent.acceleration = ((smoothed_vel - old_smoothed_vel) / dt).astype(np.float32)
 
-    # Heading rate via circular difference over the same window.
-    if T >= W + 1:
+    # Yaw rate: tracker's kinematic value when given, else MA over heading diffs.
+    if new_yaw_rate is not None:
+        agent.yaw_rate = float(new_yaw_rate)
+    elif T >= W + 1:
         head_window = traj[T - 1 - W: T, 2]
         dh_window = np.diff(head_window)
         dh_window = np.arctan2(np.sin(dh_window), np.cos(dh_window))
@@ -157,9 +164,14 @@ def _advance_agent(
         dh = (dh + math.pi) % (2 * math.pi) - math.pi
         agent.yaw_rate = dh / dt
 
-    # Steering angle from the bicycle model.
+    # Steering angle: MPC supplies the actual commanded δ; perfect tracker
+    # has no δ control (heading snaps to reference) so we derive it via
+    # the bicycle model from (yaw_rate, speed, wheelbase), same fallback
+    # teleport mode uses.
     speed = float(np.hypot(smoothed_vel[0], smoothed_vel[1]))
-    if speed > 0.2:
+    if new_steering is not None and abs(new_steering) > 1e-9:
+        agent.steering_angle = float(new_steering)
+    elif speed > 0.2:
         agent.steering_angle = float(math.atan2(agent.wheelbase * agent.yaw_rate, speed))
     else:
         agent.steering_angle = 0.0
@@ -280,7 +292,13 @@ def advance_scene_mpc(
         x0 = np.array([float(ax), float(ay), ah, speed], dtype=np.float64)
 
         new_pos, new_speed = tracker.track(x0, ref_world)
-        _advance_agent(agent, new_pos, dt, new_speed=float(new_speed))
+        _advance_agent(
+            agent, new_pos, dt,
+            new_speed=float(new_speed),
+            new_accel=float(getattr(tracker, "last_accel", 0.0)),
+            new_yaw_rate=float(getattr(tracker, "last_yaw_rate", 0.0)),
+            new_steering=float(getattr(tracker, "last_steering", 0.0)),
+        )
 
 
 def _build_color_map(scene: SceneContext) -> dict[str, str]:

--- a/scenario_generation/simulate.py
+++ b/scenario_generation/simulate.py
@@ -78,29 +78,48 @@ def _ego_to_world(pred_xy: np.ndarray, pred_cos_sin: np.ndarray,
     return world_xy, world_h
 
 
-def _advance_agent(agent, new_world_pos: np.ndarray, dt: float = 0.1):
+def _advance_agent(
+    agent,
+    new_world_pos: np.ndarray,
+    dt: float = 0.1,
+    new_speed: float | None = None,
+):
     """Advance a single agent in-place given its new world position.
 
     Uses in-place shift + overwrite instead of concatenation to avoid
-    allocations. Derivatives (velocity, acceleration, yaw_rate) are
-    computed from *smoothed* windows of the shifted past buffers instead
-    of raw one-step finite differences — at 10 Hz the one-step numerical
-    diff amplifies high-freq jitter from the diffusion sampler by ~10×
-    on velocity and ~100× on acceleration. A short 5-step central
-    average over the most recent window (past 0.4 s) suppresses that
-    without lag. Steering angle is derived from the bicycle model:
-    ``δ = atan2(wheelbase * yaw_rate, speed)``.
+    allocations.
+
+    Velocity source:
+    - When ``new_speed`` is given (MPC / perfect tracker modes), use it
+      directly: ``v_world = new_speed * (cos(new_heading), sin(new_heading))``.
+      The tracker integrates the bicycle model and already produces the
+      physically correct instantaneous speed; applying a MA of position
+      diffs on top of that just introduces a 0.4 s lag visible both in
+      the PNG title speed AND in ``ego_current_state[4]`` fed back to the
+      model, which self-reinforces "slow down" plans that the lagged
+      speed never acknowledges.
+    - When ``new_speed`` is None (teleport mode, ``advance_scene``), fall
+      back to the 5-step MA of position diffs. At 10 Hz the one-step
+      numerical diff amplifies high-freq jitter from the diffusion
+      sampler ~10× on velocity, and the teleport path has no physics
+      filter to soften that, so the MA is still justified there.
+    Steering angle is derived from the bicycle model
+    (``δ = atan2(wheelbase * yaw_rate, speed)``).
     """
     agent.past_trajectory[:-1] = agent.past_trajectory[1:]
     agent.past_trajectory[-1] = new_world_pos
 
-    # Velocity window: use the last 5 position differences to average out
-    # per-step noise. 5 steps = 0.4 s, short enough to react, long enough
-    # to denoise.
     traj = agent.past_trajectory
     T = traj.shape[0]
     W = min(5, T - 1) if T >= 2 else 0
-    if W >= 2:
+
+    if new_speed is not None:
+        new_yaw = float(new_world_pos[2])
+        smoothed_vel = np.array(
+            [new_speed * math.cos(new_yaw), new_speed * math.sin(new_yaw)],
+            dtype=np.float32,
+        )
+    elif W >= 2:
         diffs = np.diff(traj[T - 1 - W: T, :2], axis=0) / dt
         smoothed_vel = diffs.mean(axis=0).astype(np.float32)
     else:
@@ -260,8 +279,8 @@ def advance_scene_mpc(
         speed = max(speed, 0.0)
         x0 = np.array([float(ax), float(ay), ah, speed], dtype=np.float64)
 
-        new_pos, _new_speed = tracker.track(x0, ref_world)
-        _advance_agent(agent, new_pos, dt)
+        new_pos, new_speed = tracker.track(x0, ref_world)
+        _advance_agent(agent, new_pos, dt, new_speed=float(new_speed))
 
 
 def _build_color_map(scene: SceneContext) -> dict[str, str]:

--- a/scenario_generation/tensor_converter.py
+++ b/scenario_generation/tensor_converter.py
@@ -451,7 +451,14 @@ class MapTensorCache:
         """
         n = min(map_data.lanes.shape[0], self._lanes.shape[0])
         if n > 0:
-            self._lanes[:n, :, 8:13] = map_data.lanes[:n, :, 8:13].astype(np.float32)
+            # ``np.copyto`` with ``same_kind`` avoids the fresh allocation that
+            # ``.astype(np.float32)`` forces every tick — map_data.lanes is
+            # already float32 in the production path, so this is a pure memcpy.
+            np.copyto(
+                self._lanes[:n, :, 8:13],
+                map_data.lanes[:n, :, 8:13],
+                casting="same_kind",
+            )
 
     def get_lanes_ego(self, R: np.ndarray, ego_xy: np.ndarray) -> np.ndarray:
         """Return lanes in ego frame: [1, NUM_LANES, 20, 33]."""

--- a/scenario_generation/tensor_converter.py
+++ b/scenario_generation/tensor_converter.py
@@ -433,6 +433,26 @@ class MapTensorCache:
         self._line_strings_mask = np.sum(np.abs(self._line_strings), axis=-1) == 0
         self._n_ls = n_ls
 
+    def sync_tl_state(self, map_data: "MapData") -> None:
+        """Refresh the TL one-hot channels (``[:, :, 8:13]``) from ``map_data``.
+
+        ``MapTensorCache.__init__`` snapshots ``map_data.lanes`` (the
+        ``.astype(np.float32)`` forces a fresh allocation, so the cache
+        does NOT share storage with ``scene.map_data.lanes`` as earlier
+        replay comments implied). Callers that mutate the live lanes
+        tensor post-build — notably ``TrafficLightController.tick`` —
+        must call this after every mutation, or the model will keep
+        reading the snapshotted state (TL_NONE on every lanelet right
+        after a lanelet-set refresh, since ``lanelet_to_33dim`` defaults
+        to TL_NONE before the controller's first tick).
+
+        Only the 5-dim TL one-hot is synced; geometry (``[0:8]``) and
+        line-type channels (``[13:33]``) never change post-build.
+        """
+        n = min(map_data.lanes.shape[0], self._lanes.shape[0])
+        if n > 0:
+            self._lanes[:n, :, 8:13] = map_data.lanes[:n, :, 8:13].astype(np.float32)
+
     def get_lanes_ego(self, R: np.ndarray, ego_xy: np.ndarray) -> np.ndarray:
         """Return lanes in ego frame: [1, NUM_LANES, 20, 33]."""
         src = self._lanes.copy()

--- a/scenario_generation/tests/test_mpc_tracker.py
+++ b/scenario_generation/tests/test_mpc_tracker.py
@@ -205,7 +205,7 @@ class TestPostprocessReference:
 class TestMPCGradient:
     """Verify _cost_and_grad against scipy's numerical gradient.
 
-    scipy's ``approx_derivative`` with method='3-point' is accurate to
+    Central-difference gradient (step h=1e-6) is accurate to
     ~1e-6; we match within 1e-4 (the bicycle model's nonlinearity + the
     reverse-mode chain can accumulate single-digit relative error at
     this tolerance). Catches any sign/factor mistake in the hand-
@@ -241,22 +241,27 @@ class TestMPCGradient:
         ])
         return x0, ref, knot_flat
 
-    def test_gradient_matches_numerical(self):
-        import numpy as np
-        from scipy.optimize._numdiff import approx_derivative
+    @staticmethod
+    def _numerical_gradient(tracker, knot, x0, ref, h=1e-6):
+        """Central-difference gradient using only public numpy; avoids
+        scipy's private ``_numdiff.approx_derivative`` whose API isn't
+        stable across scipy versions."""
+        g = np.zeros_like(knot)
+        for i in range(len(knot)):
+            k_plus = knot.copy(); k_plus[i] += h
+            k_minus = knot.copy(); k_minus[i] -= h
+            g[i] = (tracker._cost(k_plus, x0, ref)
+                    - tracker._cost(k_minus, x0, ref)) / (2 * h)
+        return g
 
+    def test_gradient_matches_numerical(self):
         rng = np.random.default_rng(0)
         for _ in range(5):
             tracker = self._make_tracker()
             x0, ref, knot = self._rand_problem(rng)
 
-            # Analytic
             j_ana, g_ana = tracker._cost_and_grad(knot, x0, ref)
-            # Numerical (3-point central difference, ~1e-6 accuracy)
-            g_num = approx_derivative(
-                tracker._cost, knot, method="3-point",
-                args=(x0, ref), rel_step=1e-6,
-            )
+            g_num = self._numerical_gradient(tracker, knot, x0, ref)
 
             # Relative error, tolerant of scale
             scale = np.maximum(np.abs(g_ana), np.abs(g_num))

--- a/scenario_generation/tests/test_mpc_tracker.py
+++ b/scenario_generation/tests/test_mpc_tracker.py
@@ -197,3 +197,83 @@ class TestPostprocessReference:
         result = postprocess_reference(ref_xy, ref_h, stop_threshold=0.3)
         # Last position should NOT be frozen to earlier position
         assert result[-1, 0] > result[0, 0] + 10.0
+
+
+# ── Analytic gradient ──────────────────────────────────────────────────────
+
+
+class TestMPCGradient:
+    """Verify _cost_and_grad against scipy's numerical gradient.
+
+    scipy's ``approx_derivative`` with method='3-point' is accurate to
+    ~1e-6; we match within 1e-4 (the bicycle model's nonlinearity + the
+    reverse-mode chain can accumulate single-digit relative error at
+    this tolerance). Catches any sign/factor mistake in the hand-
+    derived Jacobian.
+    """
+
+    def _make_tracker(self):
+        return MPCTracker(wheelbase=2.79, horizon_steps=20, n_knots=5)
+
+    def _rand_problem(self, rng):
+        x0 = np.array([
+            float(rng.uniform(-10, 10)),
+            float(rng.uniform(-10, 10)),
+            float(rng.uniform(-1, 1)),
+            float(rng.uniform(0.5, 8.0)),
+        ])
+        ref = np.zeros((20, 3), dtype=np.float64)
+        for i in range(20):
+            ref[i, 0] = x0[0] + (i + 1) * 0.5
+            ref[i, 1] = x0[1] + (i + 1) * 0.05
+            ref[i, 2] = x0[2] + 0.01 * i
+        knot_flat = np.array([
+            rng.uniform(-1.0, 1.0),   # a0
+            rng.uniform(-0.2, 0.2),   # d0
+            rng.uniform(-1.0, 1.0),   # a1
+            rng.uniform(-0.2, 0.2),
+            rng.uniform(-1.0, 1.0),
+            rng.uniform(-0.2, 0.2),
+            rng.uniform(-1.0, 1.0),
+            rng.uniform(-0.2, 0.2),
+            rng.uniform(-1.0, 1.0),
+            rng.uniform(-0.2, 0.2),
+        ])
+        return x0, ref, knot_flat
+
+    def test_gradient_matches_numerical(self):
+        import numpy as np
+        from scipy.optimize._numdiff import approx_derivative
+
+        rng = np.random.default_rng(0)
+        for _ in range(5):
+            tracker = self._make_tracker()
+            x0, ref, knot = self._rand_problem(rng)
+
+            # Analytic
+            j_ana, g_ana = tracker._cost_and_grad(knot, x0, ref)
+            # Numerical (3-point central difference, ~1e-6 accuracy)
+            g_num = approx_derivative(
+                tracker._cost, knot, method="3-point",
+                args=(x0, ref), rel_step=1e-6,
+            )
+
+            # Relative error, tolerant of scale
+            scale = np.maximum(np.abs(g_ana), np.abs(g_num))
+            scale = np.where(scale < 1e-6, 1.0, scale)
+            rel_err = np.abs(g_ana - g_num) / scale
+            max_rel = float(rel_err.max())
+            assert max_rel < 1e-3, (
+                f"analytic vs numerical gradient diverges: max rel err = {max_rel:.2e}\n"
+                f"  analytic = {g_ana}\n  numerical= {g_num}"
+            )
+
+    def test_cost_value_unchanged(self):
+        """_cost_and_grad's cost value must match _cost alone bit-for-bit."""
+        rng = np.random.default_rng(42)
+        tracker = self._make_tracker()
+        for _ in range(5):
+            x0, ref, knot = self._rand_problem(rng)
+            j_ana, _ = tracker._cost_and_grad(knot, x0, ref)
+            j_ref = tracker._cost(knot, x0, ref)
+            assert j_ana == pytest.approx(j_ref, abs=1e-10)

--- a/scenario_generation/tests/test_tracker_telemetry.py
+++ b/scenario_generation/tests/test_tracker_telemetry.py
@@ -169,6 +169,28 @@ class TestWarmStartReset:
 # ── PerfectTracker.last_* telemetry ────────────────────────────────────────
 
 
+class TestPerfectTrackerPush:
+    def test_perfect_tracker_push_on_resume_from_rest(self):
+        """When the ego is at v≈0 and the reference's horizon tail is
+        meaningfully forward, PerfectTracker should boost v_target past
+        the first-step displacement so the ego launches instead of
+        creeping."""
+        pt = PerfectTracker(dt=0.1, max_speed=20.0)
+        # Reference has a near-zero first step but meaningful tail reach.
+        ref = np.zeros((20, 3), dtype=np.float64)
+        ref[0, 0] = 0.01  # almost co-located with x0
+        for i in range(1, 20):
+            ref[i, 0] = (i + 1) * 0.5  # tail ends at 10 m
+        x0 = np.array([0.0, 0.0, 0.0, 0.0], dtype=np.float64)
+        _, v_new = pt.track(x0, ref)
+        # Without push: v_target = 0.01 / 0.1 = 0.1 m/s → ego creeps.
+        # With push: v_target = tail_reach / horizon_time ≈ 10/2 = 5 m/s.
+        assert v_new > 1.0, (
+            f"expected push to override trivial first-step v_target, "
+            f"got v_new={v_new}"
+        )
+
+
 class TestPerfectTrackerTelemetry:
     def test_perfect_tracker_accel_from_delta(self):
         pt = PerfectTracker(dt=0.1)

--- a/scenario_generation/tests/test_tracker_telemetry.py
+++ b/scenario_generation/tests/test_tracker_telemetry.py
@@ -86,6 +86,44 @@ class TestWarmStartReset:
         )
         assert new_speed > 0.0
 
+    def test_warm_start_push_seeds_positive_accel(self):
+        """The idle-but-ref-moves warm start should seed ``init`` with a
+        non-zero accel guess (not all zeros), so the optimiser's first
+        iteration already has positive motion instead of having to
+        discover it from scratch. This reduces the multi-step
+        'barely-moving' creep after a red-light stop."""
+        tracker = MPCTracker(wheelbase=2.79, horizon_steps=20, n_knots=5)
+        # Reference with a meaningful long-horizon target speed
+        # (reach ≈ 10 m over 2 s → a_guess ≈ 2.5 m/s²).
+        ref = np.zeros((20, 3), dtype=np.float64)
+        for i in range(20):
+            ref[i, 0] = (i + 1) * 0.5
+        x0 = np.array([0.0, 0.0, 0.0, 0.0], dtype=np.float64)
+        # Poison warm start to force the idle-but-ref-moves branch.
+        tracker._prev_knots = np.zeros((5, 2), dtype=np.float64)
+
+        # After track(), compare with what the optimiser does with a
+        # cold start (fresh tracker, same x0 + ref). The "pushed" init
+        # should converge to similar or larger commanded accel in the
+        # same single call.
+        _, spd_push = tracker.track(x0, ref)
+        a_push = tracker.last_accel
+
+        # Baseline: tracker without the push — simulate by manually
+        # zeroing out _prev_knots ONLY (the reset-to-zero path fires
+        # when prev is None, same init shape). But our current code
+        # always takes the push branch when idle_but_ref_moves, so the
+        # only way to get the old behaviour is a tracker with the push
+        # disabled. We just assert the push's output is reasonable:
+        # - commanded accel in the right range for the ref (terminal
+        #   speed over the horizon),
+        # - new_speed > 0 (ego is moving by the end of this step).
+        expected_a = 10.0 / (2.0 * 2.0)  # ref_reach / horizon_time²
+        assert 0.8 * expected_a < a_push < 1.2 * 3.0, (
+            f"commanded accel {a_push} should be near expected {expected_a}"
+        )
+        assert spd_push > 0.0
+
     def test_warm_start_kept_when_not_idle(self):
         """Moving ego with valid warm start should keep it — no reset."""
         tracker = MPCTracker(wheelbase=2.79, horizon_steps=20, n_knots=5)

--- a/scenario_generation/tests/test_tracker_telemetry.py
+++ b/scenario_generation/tests/test_tracker_telemetry.py
@@ -1,0 +1,242 @@
+"""Tests for the tracker telemetry pass-through and the MPC warm-start
+reset heuristic added for the MPC-gen data pipeline.
+
+Pure-Python tests — no model, no GPU, no map needed.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from scenario_generation.mpc_tracker import MPCTracker, PerfectTracker
+
+
+# ── MPCTracker.last_* telemetry ────────────────────────────────────────────
+
+
+class TestMPCTrackerTelemetry:
+    def test_last_accel_matches_rollout_speed_delta(self):
+        """``last_accel`` must equal (new_speed - v) / dt for the applied step."""
+        tracker = MPCTracker(wheelbase=2.79, horizon_steps=20, n_knots=5)
+        x0 = np.array([0.0, 0.0, 0.0, 4.0], dtype=np.float64)  # heading east, 4 m/s
+        ref = np.zeros((30, 3), dtype=np.float64)
+        for i in range(30):
+            ref[i, 0] = 4.0 * 0.1 * (i + 1)  # forward at 4 m/s
+        _, new_speed = tracker.track(x0, ref)
+        # a = dv / dt; tolerate tiny numerical noise from L-BFGS-B convergence.
+        expected_a = (new_speed - x0[3]) / tracker.dt
+        assert math.isclose(tracker.last_accel, expected_a, abs_tol=1e-6)
+
+    def test_last_yaw_rate_matches_bicycle_model(self):
+        """``last_yaw_rate`` = v * tan(delta) / wheelbase for the applied control."""
+        tracker = MPCTracker(wheelbase=2.79, horizon_steps=20, n_knots=5)
+        # Set up a turning reference so the optimiser picks a non-zero steering.
+        x0 = np.array([0.0, 0.0, 0.0, 5.0], dtype=np.float64)
+        ref = np.zeros((20, 3), dtype=np.float64)
+        for i in range(20):
+            ref[i, 0] = 0.5 * (i + 1)
+            ref[i, 2] = 0.05 * (i + 1)  # increasing yaw
+        tracker.track(x0, ref)
+        v = x0[3]
+        expected_yaw_rate = v * math.tan(tracker.last_steering) / tracker.wheelbase
+        assert math.isclose(tracker.last_yaw_rate, expected_yaw_rate, abs_tol=1e-6)
+
+    def test_last_steering_within_bounds(self):
+        tracker = MPCTracker(wheelbase=2.79, horizon_steps=20, n_knots=5, max_steer=0.5)
+        x0 = np.array([0.0, 0.0, 0.0, 5.0], dtype=np.float64)
+        ref = np.zeros((20, 3), dtype=np.float64)
+        ref[:, 0] = np.arange(1, 21) * 0.5
+        tracker.track(x0, ref)
+        assert -0.5 - 1e-9 <= tracker.last_steering <= 0.5 + 1e-9
+
+
+# ── MPCTracker warm-start reset when idle + reference moves ────────────────
+
+
+class TestWarmStartReset:
+    def _stuck_from_rest_reference(self):
+        """A reference asking the ego to start from rest and accelerate
+        forward well past the horizon — mirrors the step-1465 stuck case
+        from the TL-on replay that motivated the fix."""
+        ref = np.zeros((20, 3), dtype=np.float64)
+        # first few steps barely move; later steps ramp up
+        for i in range(20):
+            ref[i, 0] = 0.01 * i + 0.002 * i * i  # monotonically increasing
+        return ref
+
+    def test_warm_start_reset_escapes_zero_basin(self):
+        """With ego at v=0 and a reference whose tail is > 0.5 m away, the
+        tracker must reset the warm-start and command a positive
+        acceleration even when the previous step converged to all-zero
+        knots (the bug this fix addresses)."""
+        tracker = MPCTracker(wheelbase=2.79, horizon_steps=20, n_knots=5)
+        # Poison the warm-start with all-zero knots, simulating what a long
+        # decel-to-stop leaves behind.
+        tracker._prev_knots = np.zeros((5, 2), dtype=np.float64)
+        ref = self._stuck_from_rest_reference()
+        x0 = np.array([0.0, 0.0, 0.0, 0.0], dtype=np.float64)  # stopped
+        _, new_speed = tracker.track(x0, ref)
+        # Reference reaches ref[-1, 0] = 0.01*19 + 0.002*361 ≈ 0.912 m > 0.5 m
+        # → warm start should have been reset; optimiser should now find a > 0.
+        assert tracker.last_accel > 0.0, (
+            f"expected positive accel after warm-start reset, got {tracker.last_accel}"
+        )
+        assert new_speed > 0.0
+
+    def test_warm_start_kept_when_not_idle(self):
+        """Moving ego with valid warm start should keep it — no reset."""
+        tracker = MPCTracker(wheelbase=2.79, horizon_steps=20, n_knots=5)
+        # Prime with a sensible warm start by running once.
+        ref = np.zeros((20, 3), dtype=np.float64)
+        ref[:, 0] = np.arange(1, 21) * 0.5
+        x0 = np.array([0.0, 0.0, 0.0, 5.0], dtype=np.float64)
+        tracker.track(x0, ref)
+        first_knots = tracker._prev_knots.copy()
+        # Next step with moving ego — warm start should evolve from the
+        # shifted previous solution, NOT reset to zeros.
+        x0_2 = np.array([0.5, 0.0, 0.0, 5.0], dtype=np.float64)
+        tracker.track(x0_2, ref)
+        # Shifted warm start means optimiser starts from rolled previous
+        # knots; after optimisation the result will differ but won't be
+        # identical to a cold-started optimiser's output on zero init.
+        # Assertion: the warm-start branch was taken (prev_knots remained
+        # non-None throughout the call). If reset had fired, first-call
+        # prev_knots would be overwritten to zeros before the minimize.
+        assert tracker._prev_knots is not None
+        # Sanity: at least one knot non-zero (we're not at rest).
+        assert np.any(tracker._prev_knots != 0)
+
+    def test_warm_start_not_reset_if_ref_static(self):
+        """Stopped ego + near-static reference (≤ 0.5 m reach) should NOT
+        trigger the reset — the ego is legitimately parked."""
+        tracker = MPCTracker(wheelbase=2.79, horizon_steps=20, n_knots=5)
+        # Poison warm start — but reference asks for ~no motion.
+        tracker._prev_knots = np.zeros((5, 2), dtype=np.float64)
+        ref = np.zeros((20, 3), dtype=np.float64)
+        # Tiny forward drift, well under 0.5 m over the horizon.
+        for i in range(20):
+            ref[i, 0] = 0.001 * i  # max ref[-1, 0] ≈ 0.019 m
+        x0 = np.array([0.0, 0.0, 0.0, 0.0], dtype=np.float64)
+        _, new_speed = tracker.track(x0, ref)
+        # Optimiser may command a tiny accel, but the key invariant is the
+        # warm-start RESET gate didn't fire (ref reach < 0.5 m). We assert
+        # by checking that the recovered controls stay near zero (i.e.
+        # optimiser saw a coherent "hold still" reference via warm start).
+        assert abs(tracker.last_accel) < 0.5
+
+
+# ── PerfectTracker.last_* telemetry ────────────────────────────────────────
+
+
+class TestPerfectTrackerTelemetry:
+    def test_perfect_tracker_accel_from_delta(self):
+        pt = PerfectTracker(dt=0.1)
+        x0 = np.array([0.0, 0.0, 0.0, 2.0], dtype=np.float64)
+        ref = np.array([[0.5, 0.0, 0.0]], dtype=np.float64)  # 5 m/s target
+        _, new_speed = pt.track(x0, ref)
+        # last_accel = (v_target - v_prev) / dt, here (5 - 2) / 0.1 = 30
+        assert math.isclose(pt.last_accel, (new_speed - x0[3]) / pt.dt, abs_tol=1e-6)
+
+    def test_perfect_tracker_yaw_rate_from_heading_snap(self):
+        pt = PerfectTracker(dt=0.1)
+        x0 = np.array([0.0, 0.0, 0.0, 5.0], dtype=np.float64)
+        ref = np.array([[0.5, 0.0, 0.2]], dtype=np.float64)  # snap yaw to 0.2 rad
+        pt.track(x0, ref)
+        # Heading change 0.0 → 0.2 over dt = 0.1 s → yaw rate = 2 rad/s
+        assert math.isclose(pt.last_yaw_rate, 2.0, abs_tol=1e-6)
+
+
+# ── _advance_agent tracker-telemetry pass-through ──────────────────────────
+
+
+class _StubAgent:
+    """Minimal agent stub for _advance_agent — matches the attributes the
+    function touches; past_velocities is the critical one we're validating."""
+    def __init__(self):
+        self.past_trajectory = np.zeros((21, 3), dtype=np.float32)
+        self.past_velocities = np.zeros((21, 2), dtype=np.float32)
+        self.acceleration = np.zeros(2, dtype=np.float32)
+        self.yaw_rate = 0.0
+        self.steering_angle = 0.0
+        self.wheelbase = 2.79
+        self.turn_indicators = None
+
+
+class TestAdvanceAgentTelemetry:
+    def test_new_speed_overrides_ma(self):
+        """Tracker-supplied new_speed should land in past_velocities[-1]
+        verbatim (projected onto new_heading), NOT an MA of positions."""
+        from scenario_generation.simulate import _advance_agent
+
+        agent = _StubAgent()
+        # Seed the past trajectory with a fast constant-speed history so the
+        # MA would otherwise report ~7.5 m/s, far from the tracker's value.
+        for i in range(21):
+            agent.past_trajectory[i, 0] = i * 0.75  # 7.5 m/s east
+        agent.past_velocities[:, 0] = 7.5
+
+        new_pos = np.array([15.5, 0.0, 0.0], dtype=np.float32)
+        _advance_agent(agent, new_pos, dt=0.1, new_speed=3.0)
+        vx, vy = agent.past_velocities[-1]
+        # heading=0 → vx = new_speed, vy = 0
+        assert math.isclose(vx, 3.0, abs_tol=1e-6)
+        assert math.isclose(vy, 0.0, abs_tol=1e-6)
+
+    def test_new_accel_overrides_ma(self):
+        from scenario_generation.simulate import _advance_agent
+
+        agent = _StubAgent()
+        for i in range(21):
+            agent.past_trajectory[i, 0] = i * 0.75
+        agent.past_velocities[:, 0] = 7.5
+
+        new_pos = np.array([15.5, 0.0, 0.0], dtype=np.float32)
+        _advance_agent(
+            agent, new_pos, dt=0.1,
+            new_speed=5.0, new_accel=-2.0, new_yaw_rate=0.0, new_steering=0.0,
+        )
+        # agent.acceleration = new_accel * (cos(new_yaw), sin(new_yaw))
+        ax, ay = agent.acceleration
+        assert math.isclose(ax, -2.0, abs_tol=1e-6)
+        assert math.isclose(ay, 0.0, abs_tol=1e-6)
+
+    def test_new_yaw_rate_and_steering_override_ma(self):
+        from scenario_generation.simulate import _advance_agent
+
+        agent = _StubAgent()
+        for i in range(21):
+            agent.past_trajectory[i, 0] = i * 0.5
+        agent.past_velocities[:, 0] = 5.0
+
+        new_pos = np.array([10.5, 0.0, 0.1], dtype=np.float32)
+        _advance_agent(
+            agent, new_pos, dt=0.1,
+            new_speed=5.0,
+            new_accel=0.0,
+            new_yaw_rate=0.4,
+            new_steering=0.12,
+        )
+        assert math.isclose(agent.yaw_rate, 0.4, abs_tol=1e-6)
+        assert math.isclose(agent.steering_angle, 0.12, abs_tol=1e-6)
+
+    def test_no_kwargs_falls_back_to_ma(self):
+        """Teleport-mode (no tracker kwargs) keeps the 5-step MA path."""
+        from scenario_generation.simulate import _advance_agent
+
+        agent = _StubAgent()
+        # Trajectory stride = 0.75 m/step → 7.5 m/s. The new position
+        # continues that stride so ALL 5 diffs in the MA window are 0.75,
+        # giving a mean of exactly 7.5 m/s (not the ~7.0 you'd get if
+        # new_pos lagged behind the established pattern by one step).
+        for i in range(21):
+            agent.past_trajectory[i, 0] = i * 0.75
+        agent.past_velocities[:, 0] = 7.5
+
+        new_pos = np.array([15.75, 0.0, 0.0], dtype=np.float32)  # 21*0.75
+        _advance_agent(agent, new_pos, dt=0.1)  # no tracker kwargs
+        vx, vy = agent.past_velocities[-1]
+        assert math.isclose(vx, 7.5, abs_tol=1e-3)
+        assert math.isclose(vy, 0.0, abs_tol=1e-6)

--- a/scene_search/README.md
+++ b/scene_search/README.md
@@ -14,6 +14,10 @@ source .venv/bin/activate
 
 ## Launch
 
+Two scene sources, freely combinable. At least one must be supplied.
+
+**Rosbag-extracted NPZs (sidecar-backed):**
+
 ```bash
 python -m scene_search.app \
   --map_path /path/to/lanelet2_map.osm \
@@ -21,12 +25,23 @@ python -m scene_search.app \
   [--port 7860]
 ```
 
-Example with shinagawa_odaiba map:
+**`scenario_generation.replay` output dirs (drift-metric heatmap enabled):**
+
 ```bash
 python -m scene_search.app \
-  --map_path ~/autoware_map/shinagawa_odaiba_stable/lanelet2_map.osm \
-  --npz_list /media/danielsanchez/2fb4af16-188c-4b7d-8ebb-4a7d0c90d207/xx1_grpo_v4_data/npz/
+  --map_path /path/to/lanelet2_map.osm \
+  --replay_runs /path/to/mpc_gen_run1/ /path/to/mpc_gen_run2/ \
+  [--port 7860]
 ```
+
+Replay mode reads `trajectory_log.json` + `metrics_log.json` from each run
+directory (no per-NPZ JSON sidecars are written by `dump_step_npz`). Every
+step becomes an index entry carrying the ego world pose **and** the live
+reward metrics — which light up the heatmap overlay and the
+`reward_threshold` constraint.
+
+`--npz_list` and `--replay_runs` can be combined in one session; replay
+scenes appear on the heatmap, sidecar scenes don't.
 
 ## Usage
 
@@ -44,6 +59,23 @@ python -m scene_search.app \
 6. Click **Keep Batch N** or **Keep All Batches** to add to kept collection
 7. Draw a new arrow elsewhere, search again, keep more batches
 8. Click **Save All Kept → JSON** to export
+
+### Heatmap (replay runs only)
+
+When the session was launched with `--replay_runs`, a **Heatmap** panel
+appears in the sidebar with an **Overlay metric** dropdown:
+
+| Option | What's coloured red (bad) vs blue (safe) |
+|---|---|
+| `off` | no overlay |
+| `rb_min_dist` | < ~0.5m ego-to-border = red, > 3m = blue |
+| `abs_cl_score` | `|cl|` ≥ 2 = red, ≈ 0 = blue |
+| `lane_gate` | gate=0 (cross) = red, gate=1 (in-lane) = blue |
+| `lane_near_frac` | near=1 = red, near=0 = blue |
+| `lane_wide_frac` | same idiom as near |
+
+Use it to spot hotspots, then Shift+drag over them to search, same as any
+other scene.
 
 ### Constraints
 Collapsible panels in the sidebar for filtering scenes:

--- a/scene_search/app.py
+++ b/scene_search/app.py
@@ -40,36 +40,61 @@ from scene_search.scene_previewer import (
 
 _HEATMAP_METRIC_CHOICES = [
     "off",
+    # Aggregate
+    "total",
+    # Safety
+    "collision",
     "rb_min_dist",
-    "abs_cl_score",
+    "rb_crossing",
+    "rb_near_penalty",
+    "rb_wide_penalty",
+    # Lane
     "lane_gate",
+    "lane_crossing",
     "lane_near_frac",
     "lane_wide_frac",
+    # Centerline
+    "abs_cl_score",
+    "centerline_penalty",
+    # Progress / dynamics
+    "progress",
+    "smoothness",
+    "feasibility",
+    "off_road_fraction",
+    "red_light",
 ]
 
 MAX_VISIBLE_BATCHES = 10
 
 MAP_CANVAS_JS = build_map_canvas_js(tool="arrow")
 
+_HEATMAP_METRIC_FIELDS = (
+    # Per-point fields the JS canvas may read for colour normalisation.
+    # Keep this list in sync with _heatmapT() in map_canvas_js.py so the
+    # dropdown only offers metrics that actually get transmitted.
+    "total", "collision", "rb_min_dist", "rb_crossing",
+    "rb_near_penalty", "rb_wide_penalty",
+    "lane_gate", "lane_crossing", "lane_near_frac", "lane_wide_frac",
+    "cl_score", "centerline_penalty",
+    "progress", "smoothness", "feasibility",
+    "off_road_fraction", "red_light",
+)
+
+
 def _heatmap_points(index: list[dict]) -> list[dict]:
     """Pick entries that carry per-step metrics (replay runs) and project to
-    the compact form the JS canvas consumes: x, y, and the subset of metric
-    fields driving the heatmap dropdown. Sidecar-backed entries have no
-    "metrics" key and are silently skipped."""
+    the compact form the JS canvas consumes. Sidecar-backed entries have
+    no "metrics" key and are silently skipped."""
     out = []
     for e in index:
         m = e.get("metrics") or {}
         if not m:
             continue
-        out.append({
-            "x": e["x"],
-            "y": e["y"],
-            "rb_min_dist": m.get("rb_min_dist"),
-            "cl_score": m.get("cl_score"),
-            "lane_gate": m.get("lane_gate"),
-            "lane_near_frac": m.get("lane_near_frac"),
-            "lane_wide_frac": m.get("lane_wide_frac"),
-        })
+        point = {"x": e["x"], "y": e["y"]}
+        for k in _HEATMAP_METRIC_FIELDS:
+            if k in m:
+                point[k] = m[k]
+        out.append(point)
     return out
 
 

--- a/scene_search/app.py
+++ b/scene_search/app.py
@@ -31,15 +31,47 @@ from scene_search.constraints import list_available as list_constraints
 from scene_search.constraints.registry import build as build_constraint
 from scene_search.map_canvas_js import build_map_canvas_js
 from scene_search.map_renderer import MapRenderer, Viewport
+from scene_search.replay_index import load_replay_runs
 from scene_search.scene_previewer import (
     render_batch_thumbnails,
     render_single_thumbnail,
     thumbnails_to_pil_images,
 )
 
+_HEATMAP_METRIC_CHOICES = [
+    "off",
+    "rb_min_dist",
+    "abs_cl_score",
+    "lane_gate",
+    "lane_near_frac",
+    "lane_wide_frac",
+]
+
 MAX_VISIBLE_BATCHES = 10
 
 MAP_CANVAS_JS = build_map_canvas_js(tool="arrow")
+
+def _heatmap_points(index: list[dict]) -> list[dict]:
+    """Pick entries that carry per-step metrics (replay runs) and project to
+    the compact form the JS canvas consumes: x, y, and the subset of metric
+    fields driving the heatmap dropdown. Sidecar-backed entries have no
+    "metrics" key and are silently skipped."""
+    out = []
+    for e in index:
+        m = e.get("metrics") or {}
+        if not m:
+            continue
+        out.append({
+            "x": e["x"],
+            "y": e["y"],
+            "rb_min_dist": m.get("rb_min_dist"),
+            "cl_score": m.get("cl_score"),
+            "lane_gate": m.get("lane_gate"),
+            "lane_near_frac": m.get("lane_near_frac"),
+            "lane_wide_frac": m.get("lane_wide_frac"),
+        })
+    return out
+
 
 def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | None = None):
     """Build the complete Gradio interface."""
@@ -50,6 +82,12 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
     full_map_b64 = renderer.render_viewport_base64(full_vp, dpi=100)
     full_bounds = full_vp.to_json()
     print(f"  Map image: {len(full_map_b64)//1024}KB base64")
+
+    heatmap_points = _heatmap_points(index)
+    heatmap_json = json.dumps(heatmap_points)
+    if heatmap_points:
+        print(f"  Heatmap: {len(heatmap_points)} scored points "
+              f"({len(heatmap_json)//1024}KB JSON)")
 
     def render_map(viewport_json: str) -> str:
         """Server function for hi-res tile at current zoom. Called from JS (debounced)."""
@@ -77,6 +115,17 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
                 n_before_slider = gr.Slider(0, 100, value=30, step=5, label="Frames before")
                 n_after_slider = gr.Slider(0, 200, value=80, step=5, label="Frames after")
                 search_btn = gr.Button("Search", variant="primary")
+
+                if heatmap_points:
+                    gr.Markdown("### Heatmap")
+                    heatmap_metric_dd = gr.Dropdown(
+                        choices=_HEATMAP_METRIC_CHOICES,
+                        value="off",
+                        label="Overlay metric",
+                        interactive=True,
+                    )
+                else:
+                    heatmap_metric_dd = None
 
                 gr.Markdown("### Constraints")
                 # Build toggle panels for each registered constraint
@@ -123,6 +172,8 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
                     map_bounds=json.dumps(full_bounds),
                     radius=50,
                     heading_tol=30,
+                    heatmap_json=heatmap_json,
+                    heatmap_metric="off",
                 )
 
                 gr.Markdown("### Search Results")
@@ -166,6 +217,13 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
         def on_heading_tol_change(val):
             return gr.update(heading_tol=val)
         heading_tol_slider.release(on_heading_tol_change, inputs=[heading_tol_slider], outputs=[map_canvas])
+
+        if heatmap_metric_dd is not None:
+            def on_heatmap_metric_change(val):
+                return gr.update(heatmap_metric=val)
+            heatmap_metric_dd.change(on_heatmap_metric_change,
+                                     inputs=[heatmap_metric_dd],
+                                     outputs=[map_canvas])
 
         # --- Build constraint input list for search ---
         # Order: [enable_1, param_1a, param_1b, ..., enable_2, param_2a, ...]
@@ -374,31 +432,49 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
 def main():
     parser = argparse.ArgumentParser(description="Scene Search GUI")
     parser.add_argument("--map_path", type=Path, required=True, help="Path to lanelet2 map (.osm)")
-    parser.add_argument("--npz_list", type=str, required=True, help="path_list.json or NPZ directory")
+    parser.add_argument("--npz_list", type=str, default=None,
+                        help="path_list.json or NPZ directory (sidecar-backed scenes)")
+    parser.add_argument("--replay_runs", type=str, nargs="+", default=None,
+                        help="One or more scenario_generation.replay output "
+                             "directories. Uses trajectory_log.json + "
+                             "metrics_log.json instead of per-NPZ sidecars; "
+                             "enables the drift heatmap overlay.")
     parser.add_argument("--index", type=str, default=None, help="Cached parquet index (requires pyarrow)")
     parser.add_argument("--port", type=int, default=7860)
     parser.add_argument("--share", action="store_true")
     args = parser.parse_args()
 
+    if not args.npz_list and not args.replay_runs:
+        parser.error("supply --npz_list and/or --replay_runs")
+
     print("Loading lanelet2 map...")
     renderer = MapRenderer(str(args.map_path))
 
-    if args.index and Path(args.index).exists():
-        print(f"Loading cached index from {args.index}")
-        index = load_index_parquet(args.index)
-    else:
-        print("Building spatial index from NPZ sidecars...")
-        p = Path(args.npz_list)
-        if p.is_file() and p.suffix == ".json":
-            with open(p) as f: npz_paths = json.load(f)
-        elif p.is_dir():
-            npz_paths = sorted(str(f) for f in p.rglob("*.npz"))
+    index: list[dict] = []
+    if args.npz_list:
+        if args.index and Path(args.index).exists():
+            print(f"Loading cached index from {args.index}")
+            index.extend(load_index_parquet(args.index))
         else:
-            raise ValueError(f"--npz_list must be .json or directory: {args.npz_list}")
-        index = build_index(npz_paths, workers=8)
-        if args.index:
-            save_index_parquet(index, args.index)
-            print(f"Saved index to {args.index}")
+            print("Building spatial index from NPZ sidecars...")
+            p = Path(args.npz_list)
+            if p.is_file() and p.suffix == ".json":
+                with open(p) as f: npz_paths = json.load(f)
+            elif p.is_dir():
+                npz_paths = sorted(str(f) for f in p.rglob("*.npz"))
+            else:
+                raise ValueError(f"--npz_list must be .json or directory: {args.npz_list}")
+            sidecar_index = build_index(npz_paths, workers=8)
+            index.extend(sidecar_index)
+            if args.index:
+                save_index_parquet(sidecar_index, args.index)
+                print(f"Saved sidecar index to {args.index}")
+
+    if args.replay_runs:
+        print(f"Loading {len(args.replay_runs)} replay run(s)...")
+        replay_entries = load_replay_runs(args.replay_runs)
+        index.extend(replay_entries)
+        print(f"  Replay entries: {len(replay_entries)}")
 
     print(f"Index: {len(index)} scenes")
     demo = build_interface(renderer, index, args.index)

--- a/scene_search/app.py
+++ b/scene_search/app.py
@@ -118,13 +118,20 @@ def _heatmap_metadata(points: list[dict]) -> dict:
             continue
         ranges[k] = [float(min(vals)), float(max(vals))]
     polarity = {k: _metric_polarity(k) for k in ranges}
-    # cl_score is a signed rear-axle offset; the magnitude reading is what
-    # users usually want, so offer a synthetic "abs_cl_score" entry on the
-    # dropdown whenever cl_score is present. The canvas handles the |·|
-    # and polarity flip for this one derived field.
-    metrics = sorted(ranges.keys())
+    # cl_score is a signed rear-axle offset with "safe" values near zero:
+    # both large-positive and large-negative magnitudes indicate drift.
+    # The generic min/max + monotonic polarity used by every other metric
+    # would colour the two tails differently (one as drift, one as safe),
+    # which is misleading. Hide the raw field from the dropdown and
+    # expose only the derived absolute-magnitude view — the canvas's
+    # abs_cl_score branch already does the |·| + polarity flip. Same
+    # pattern applies to pred_cl_score when it's present.
+    hidden_signed = {"cl_score", "pred_cl_score"}
+    metrics = sorted(k for k in ranges.keys() if k not in hidden_signed)
     if "cl_score" in ranges:
-        metrics.insert(metrics.index("cl_score") + 1, "abs_cl_score")
+        metrics.append("abs_cl_score")
+    if "pred_cl_score" in ranges:
+        metrics.append("abs_pred_cl_score")
     return {
         "metrics": metrics,
         "ranges": ranges,
@@ -502,19 +509,31 @@ def main():
                              "directories. Uses trajectory_log.json + "
                              "metrics_log.json instead of per-NPZ sidecars; "
                              "enables the drift heatmap overlay.")
-    parser.add_argument("--index", type=str, default=None, help="Cached parquet index (requires pyarrow)")
+    parser.add_argument("--index", type=str, default=None,
+                        help="Cached parquet index (requires pyarrow). Standalone "
+                             "when the parquet already contains every scene you "
+                             "want to browse; combine with --npz_list to also "
+                             "build / update the cache.")
     parser.add_argument("--port", type=int, default=7860)
     parser.add_argument("--share", action="store_true")
     args = parser.parse_args()
 
-    if not args.npz_list and not args.replay_runs:
-        parser.error("supply --npz_list and/or --replay_runs")
+    if not args.npz_list and not args.replay_runs and not (args.index and Path(args.index).exists()):
+        parser.error("supply at least one scene source: --npz_list, --replay_runs, "
+                     "or an existing --index parquet.")
 
     print("Loading lanelet2 map...")
     renderer = MapRenderer(str(args.map_path))
 
     index: list[dict] = []
-    if args.npz_list:
+    # --index alone is a valid scene source when the parquet already holds
+    # the scenes we want to browse. With --npz_list we either load the
+    # parquet if it exists or build + save one; without --npz_list we
+    # load the parquet read-only.
+    if args.index and Path(args.index).exists() and not args.npz_list:
+        print(f"Loading cached index from {args.index}")
+        index.extend(load_index_parquet(args.index))
+    elif args.npz_list:
         if args.index and Path(args.index).exists():
             print(f"Loading cached index from {args.index}")
             index.extend(load_index_parquet(args.index))

--- a/scene_search/app.py
+++ b/scene_search/app.py
@@ -510,10 +510,12 @@ def main():
                              "metrics_log.json instead of per-NPZ sidecars; "
                              "enables the drift heatmap overlay.")
     parser.add_argument("--index", type=str, default=None,
-                        help="Cached parquet index (requires pyarrow). Standalone "
-                             "when the parquet already contains every scene you "
-                             "want to browse; combine with --npz_list to also "
-                             "build / update the cache.")
+                        help="Cached parquet index (requires pyarrow). Valid as "
+                             "a standalone scene source when the parquet already "
+                             "contains every scene you want to browse. If the "
+                             "parquet exists it is loaded verbatim — passing "
+                             "--npz_list alongside an existing parquet does NOT "
+                             "refresh it; delete the parquet to force rebuild.")
     parser.add_argument("--port", type=int, default=7860)
     parser.add_argument("--share", action="store_true")
     args = parser.parse_args()

--- a/scene_search/app.py
+++ b/scene_search/app.py
@@ -38,64 +38,98 @@ from scene_search.scene_previewer import (
     thumbnails_to_pil_images,
 )
 
-_HEATMAP_METRIC_CHOICES = [
-    "off",
-    # Aggregate
-    "total",
-    # Safety
-    "collision",
-    "rb_min_dist",
-    "rb_crossing",
-    "rb_near_penalty",
-    "rb_wide_penalty",
-    # Lane
-    "lane_gate",
-    "lane_crossing",
-    "lane_near_frac",
-    "lane_wide_frac",
-    # Centerline
-    "abs_cl_score",
-    "centerline_penalty",
-    # Progress / dynamics
-    "progress",
-    "smoothness",
-    "feasibility",
-    "off_road_fraction",
-    "red_light",
-]
+## Heatmap metric auto-discovery
+#
+# The replay writes whatever the RewardBreakdown dataclass exposes — adding
+# a new reward component on the training side should "just work" here.
+# We derive the dropdown choices from the union of numeric fields across
+# loaded heatmap points, and transmit each metric's observed min/max range
+# to the canvas so the JS colour ramp can auto-scale.
+#
+# Polarity (is higher = good or bad?) can't be inferred from data alone,
+# so we fall back to a naming heuristic: metric names containing any of
+# these substrings are treated as "higher = worse". Everything else is
+# assumed "higher = better" (distance-, reward-, and score-style fields).
+_HIGHER_IS_WORSE_SUBSTRINGS = (
+    "penalty", "crossing", "collision", "off_road", "red_light",
+    "near_frac", "wide_frac",
+)
+
+
+def _metric_polarity(name: str) -> int:
+    """Return +1 if higher is better (safe), -1 if higher is worse (drift)."""
+    lo = name.lower()
+    for s in _HIGHER_IS_WORSE_SUBSTRINGS:
+        if s in lo:
+            return -1
+    return +1
 
 MAX_VISIBLE_BATCHES = 10
 
 MAP_CANVAS_JS = build_map_canvas_js(tool="arrow")
 
-_HEATMAP_METRIC_FIELDS = (
-    # Per-point fields the JS canvas may read for colour normalisation.
-    # Keep this list in sync with _heatmapT() in map_canvas_js.py so the
-    # dropdown only offers metrics that actually get transmitted.
-    "total", "collision", "rb_min_dist", "rb_crossing",
-    "rb_near_penalty", "rb_wide_penalty",
-    "lane_gate", "lane_crossing", "lane_near_frac", "lane_wide_frac",
-    "cl_score", "centerline_penalty",
-    "progress", "smoothness", "feasibility",
-    "off_road_fraction", "red_light",
-)
-
-
 def _heatmap_points(index: list[dict]) -> list[dict]:
     """Pick entries that carry per-step metrics (replay runs) and project to
-    the compact form the JS canvas consumes. Sidecar-backed entries have
-    no "metrics" key and are silently skipped."""
+    the compact form the JS canvas consumes. Every numeric/bool field from
+    ``metrics`` is copied verbatim — no per-field allowlist. Sidecar-backed
+    entries have no "metrics" key and are silently skipped."""
     out = []
     for e in index:
         m = e.get("metrics") or {}
         if not m:
             continue
         point = {"x": e["x"], "y": e["y"]}
-        for k in _HEATMAP_METRIC_FIELDS:
-            if k in m:
-                point[k] = m[k]
+        for k, v in m.items():
+            if isinstance(v, bool):
+                point[k] = 1.0 if v else 0.0
+            elif isinstance(v, (int, float)) and not isinstance(v, bool):
+                point[k] = float(v)
+            # Drop None / str / list — not colourable.
         out.append(point)
     return out
+
+
+def _heatmap_metadata(points: list[dict]) -> dict:
+    """Derive per-metric display metadata from the loaded heatmap points.
+
+    Returns::
+
+        {
+            "metrics": ["total", "rb_min_dist", ...],   # sorted field names
+            "ranges":  {"total": [min, max], ...},       # observed range
+            "polarity": {"total": 1, "rb_near_penalty": -1, ...},
+        }
+
+    The canvas uses this to auto-scale a colour ramp without any metric-
+    specific JS. Polarity comes from ``_metric_polarity`` (naming heuristic).
+    """
+    if not points:
+        return {"metrics": [], "ranges": {}, "polarity": {}}
+    field_names: set[str] = set()
+    for p in points:
+        for k in p.keys():
+            if k in ("x", "y"):
+                continue
+            field_names.add(k)
+    ranges: dict[str, list[float]] = {}
+    for k in field_names:
+        vals = [p[k] for p in points if k in p and p[k] is not None]
+        if not vals:
+            continue
+        ranges[k] = [float(min(vals)), float(max(vals))]
+    polarity = {k: _metric_polarity(k) for k in ranges}
+    # cl_score is a signed rear-axle offset; the magnitude reading is what
+    # users usually want, so offer a synthetic "abs_cl_score" entry on the
+    # dropdown whenever cl_score is present. The canvas handles the |·|
+    # and polarity flip for this one derived field.
+    metrics = sorted(ranges.keys())
+    if "cl_score" in ranges:
+        metrics.insert(metrics.index("cl_score") + 1, "abs_cl_score")
+    return {
+        "metrics": metrics,
+        "ranges": ranges,
+        "polarity": polarity,
+    }
 
 
 def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | None = None):
@@ -109,10 +143,13 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
     print(f"  Map image: {len(full_map_b64)//1024}KB base64")
 
     heatmap_points = _heatmap_points(index)
+    heatmap_meta = _heatmap_metadata(heatmap_points)
     heatmap_json = json.dumps(heatmap_points)
+    heatmap_meta_json = json.dumps(heatmap_meta)
     if heatmap_points:
-        print(f"  Heatmap: {len(heatmap_points)} scored points "
-              f"({len(heatmap_json)//1024}KB JSON)")
+        print(f"  Heatmap: {len(heatmap_points)} scored points across "
+              f"{len(heatmap_meta['metrics'])} metric(s) "
+              f"({len(heatmap_json)//1024}KB + {len(heatmap_meta_json)//1024}KB JSON)")
 
     def render_map(viewport_json: str) -> str:
         """Server function for hi-res tile at current zoom. Called from JS (debounced)."""
@@ -144,7 +181,7 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
                 if heatmap_points:
                     gr.Markdown("### Heatmap")
                     heatmap_metric_dd = gr.Dropdown(
-                        choices=_HEATMAP_METRIC_CHOICES,
+                        choices=["off"] + heatmap_meta["metrics"],
                         value="off",
                         label="Overlay metric",
                         interactive=True,
@@ -198,6 +235,7 @@ def build_interface(renderer: MapRenderer, index: list[dict], index_path: str | 
                     radius=50,
                     heading_tol=30,
                     heatmap_json=heatmap_json,
+                    heatmap_meta_json=heatmap_meta_json,
                     heatmap_metric="off",
                 )
 

--- a/scene_search/batch_search.py
+++ b/scene_search/batch_search.py
@@ -135,10 +135,13 @@ def find_batches(
     if not filtered:
         return []
 
-    # 3. Apply constraint filters. Pass the index entry through so
-    #    metric-based constraints (reward_threshold) can read precomputed
-    #    fields without re-reading the NPZ; legacy NPZ-backed constraints
-    #    just ignore the entry kwarg.
+    # 3. Apply constraint filters. Every entry still triggers an NPZ load
+    #    because legacy constraints (neighbor_count, speed_range,
+    #    travel_distance) read npz_data; the entry dict is passed through
+    #    for metric-based constraints (reward_threshold) that read
+    #    precomputed fields instead of deriving them from the NPZ.
+    #    Skipping the NPZ load when only entry-only constraints are active
+    #    is a follow-up (would need a capability flag on the constraint).
     if constraint_filters:
         passing = []
         for entry in filtered:

--- a/scene_search/batch_search.py
+++ b/scene_search/batch_search.py
@@ -135,14 +135,18 @@ def find_batches(
     if not filtered:
         return []
 
-    # 3. Apply constraint filters (load NPZ as needed)
+    # 3. Apply constraint filters. Pass the index entry through so
+    #    metric-based constraints (reward_threshold) can read precomputed
+    #    fields without re-reading the NPZ; legacy NPZ-backed constraints
+    #    just ignore the entry kwarg.
     if constraint_filters:
         passing = []
         for entry in filtered:
             with np.load(entry["npz_path"]) as npz_data:
                 passes_all = True
                 for constraint, params in constraint_filters:
-                    if not constraint.filter(entry["npz_path"], npz_data, params):
+                    if not constraint.filter(entry["npz_path"], npz_data,
+                                             params, entry=entry):
                         passes_all = False
                         break
             if passes_all:

--- a/scene_search/constraints/__init__.py
+++ b/scene_search/constraints/__init__.py
@@ -3,5 +3,7 @@
 Importing this package triggers @register decorators in all constraint modules.
 """
 
-from scene_search.constraints import neighbor_count, speed_range, travel_distance  # noqa: F401
+from scene_search.constraints import (  # noqa: F401
+    neighbor_count, reward_threshold, speed_range, travel_distance,
+)
 from scene_search.constraints.registry import build, list_available

--- a/scene_search/constraints/base.py
+++ b/scene_search/constraints/base.py
@@ -23,11 +23,21 @@ class BaseConstraint(ABC):
         """
 
     @abstractmethod
-    def filter(self, npz_path: str, npz_data: np.lib.npyio.NpzFile, params: dict) -> bool:
+    def filter(
+        self,
+        npz_path: str,
+        npz_data: np.lib.npyio.NpzFile,
+        params: dict,
+        entry: dict | None = None,
+    ) -> bool:
         """Return True if the scene passes this constraint.
 
         Args:
             npz_path: Path to the NPZ file.
             npz_data: Loaded NPZ data (numpy NpzFile).
             params: Dict of parameter values from UI.
+            entry: Optional index entry dict (carries precomputed fields like
+                replay ``metrics``). NPZ-only constraints can ignore it;
+                metric constraints read fields from here instead of
+                re-deriving them from the NPZ.
         """

--- a/scene_search/constraints/neighbor_count.py
+++ b/scene_search/constraints/neighbor_count.py
@@ -18,7 +18,8 @@ class NeighborCountConstraint(BaseConstraint):
             "within_radius": {"type": "float", "default": 30.0, "label": "Within radius (m)", "min": 1.0, "max": 100.0, "step": 1.0},
         }
 
-    def filter(self, npz_path: str, npz_data: np.lib.npyio.NpzFile, params: dict) -> bool:
+    def filter(self, npz_path: str, npz_data: np.lib.npyio.NpzFile,
+               params: dict, entry: dict | None = None) -> bool:
         neighbors = npz_data["neighbor_agents_past"]  # (32, 21, 11)
         current = neighbors[:, -1, :]  # (32, 11) — last timestep (t=0)
         # A neighbor is active if any of its features are nonzero

--- a/scene_search/constraints/reward_threshold.py
+++ b/scene_search/constraints/reward_threshold.py
@@ -54,18 +54,18 @@ class RewardThresholdConstraint(BaseConstraint):
         gate = metrics.get("lane_gate")
         near = metrics.get("lane_near_frac")
 
-        # A scene passes when it satisfies EVERY enabled (non-trivial) test.
-        # "Enabled" = the param is tighter than its no-op default:
-        #   rb_min_dist_max < 10.0   → rb must be ≤ max
-        #   abs_cl_score_min > 0.0   → |cl| must be ≥ min
-        #   require_lane_cross ≥ 0.5 → gate must be 0
-        #   lane_near_frac_min > 0.0 → near must be ≥ min
-        if params["rb_min_dist_max"] < 10.0:
-            if rb is None or rb > params["rb_min_dist_max"]:
-                return False
-        if params["abs_cl_score_min"] > 0.0:
-            if cl is None or abs(cl) < params["abs_cl_score_min"]:
-                return False
+        # A scene passes when it satisfies EVERY test below. The UI
+        # defaults for ``rb_min_dist_max`` (0.6) and ``abs_cl_score_min``
+        # (0.5) are already meaningful drift thresholds — treating the
+        # "default = no-op" pattern here would require the user to dial
+        # them to 10.0 / 0.0 to see the intended drift-only filter, which
+        # is surprising. The two fraction-style fields still use a >0
+        # gate because their no-op (0.0) IS the "don't filter on this"
+        # setting a user would naturally pick.
+        if rb is None or rb > params["rb_min_dist_max"]:
+            return False
+        if cl is None or abs(cl) < params["abs_cl_score_min"]:
+            return False
         if params["require_lane_cross"] >= 0.5:
             if gate is None or gate >= 0.5:
                 return False

--- a/scene_search/constraints/reward_threshold.py
+++ b/scene_search/constraints/reward_threshold.py
@@ -1,0 +1,75 @@
+"""Constraint: filter replay scenes by per-step drift metrics.
+
+Reads values straight from the index ``entry["metrics"]`` dict populated by
+``scene_search.replay_index.load_replay_run`` — NOT from the NPZ. This
+avoids duplicating the reward computation (which already lives in
+``rlvr.reward`` and was run at sim time by ``scenario_generation.replay``).
+
+Only fires on replay-backed scenes; entries without a metrics dict (i.e.
+sidecar-backed scenes from rosbag NPZs) are dropped when this constraint
+is enabled.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from scene_search.constraints.base import BaseConstraint
+from scene_search.constraints.registry import register
+
+
+@register("reward_threshold")
+class RewardThresholdConstraint(BaseConstraint):
+    name = "Reward Thresholds"
+    description = ("Filter replay scenes by live drift metrics (rb / cl / "
+                   "lane gate / lane_near_frac). Requires replay runs loaded "
+                   "via --replay_runs.")
+
+    def get_params_spec(self) -> dict:
+        return {
+            "rb_min_dist_max": {"type": "float", "default": 0.6,
+                                "label": "Max rb_min_dist (m)  [drift if ≤]",
+                                "min": 0.0, "max": 10.0, "step": 0.05},
+            "abs_cl_score_min": {"type": "float", "default": 0.5,
+                                 "label": "Min |cl_score|  [drift if ≥]",
+                                 "min": 0.0, "max": 3.0, "step": 0.05},
+            "require_lane_cross": {"type": "float", "default": 0.0,
+                                   "label": "Require lane_gate=0? (1=yes, 0=no)",
+                                   "min": 0.0, "max": 1.0, "step": 1.0},
+            "lane_near_frac_min": {"type": "float", "default": 0.0,
+                                   "label": "Min lane_near_frac  [drift if ≥]",
+                                   "min": 0.0, "max": 1.0, "step": 0.05},
+        }
+
+    def filter(self, npz_path: str, npz_data: np.lib.npyio.NpzFile,
+               params: dict, entry: dict | None = None) -> bool:
+        if entry is None:
+            return False  # not a replay entry; drop
+        metrics = entry.get("metrics") or {}
+        if not metrics:
+            return False
+
+        rb = metrics.get("rb_min_dist")
+        cl = metrics.get("cl_score")
+        gate = metrics.get("lane_gate")
+        near = metrics.get("lane_near_frac")
+
+        # A scene passes when it satisfies EVERY enabled (non-trivial) test.
+        # "Enabled" = the param is tighter than its no-op default:
+        #   rb_min_dist_max < 10.0   → rb must be ≤ max
+        #   abs_cl_score_min > 0.0   → |cl| must be ≥ min
+        #   require_lane_cross ≥ 0.5 → gate must be 0
+        #   lane_near_frac_min > 0.0 → near must be ≥ min
+        if params["rb_min_dist_max"] < 10.0:
+            if rb is None or rb > params["rb_min_dist_max"]:
+                return False
+        if params["abs_cl_score_min"] > 0.0:
+            if cl is None or abs(cl) < params["abs_cl_score_min"]:
+                return False
+        if params["require_lane_cross"] >= 0.5:
+            if gate is None or gate >= 0.5:
+                return False
+        if params["lane_near_frac_min"] > 0.0:
+            if near is None or near < params["lane_near_frac_min"]:
+                return False
+        return True

--- a/scene_search/constraints/reward_threshold.py
+++ b/scene_search/constraints/reward_threshold.py
@@ -12,8 +12,6 @@ is enabled.
 
 from __future__ import annotations
 
-import numpy as np
-
 from scene_search.constraints.base import BaseConstraint
 from scene_search.constraints.registry import register
 
@@ -41,8 +39,10 @@ class RewardThresholdConstraint(BaseConstraint):
                                    "min": 0.0, "max": 1.0, "step": 0.05},
         }
 
-    def filter(self, npz_path: str, npz_data: np.lib.npyio.NpzFile,
-               params: dict, entry: dict | None = None) -> bool:
+    def filter(self, npz_path: str, npz_data, params: dict,
+               entry: dict | None = None) -> bool:
+        # npz_data kept for BaseConstraint signature compatibility but
+        # unused here — reward_threshold reads from entry["metrics"] only.
         if entry is None:
             return False  # not a replay entry; drop
         metrics = entry.get("metrics") or {}

--- a/scene_search/constraints/speed_range.py
+++ b/scene_search/constraints/speed_range.py
@@ -17,7 +17,8 @@ class SpeedRangeConstraint(BaseConstraint):
             "max_speed_kmh": {"type": "float", "default": 100.0, "label": "Max speed (km/h)", "min": 0.0, "max": 100.0, "step": 1.0},
         }
 
-    def filter(self, npz_path: str, npz_data: np.lib.npyio.NpzFile, params: dict) -> bool:
+    def filter(self, npz_path: str, npz_data: np.lib.npyio.NpzFile,
+               params: dict, entry: dict | None = None) -> bool:
         # ego_current_state: [x, y, cos, sin, vx, vy, ax, ay, steer, yaw_rate]
         state = npz_data["ego_current_state"]  # (10,)
         vx, vy = state[4], state[5]

--- a/scene_search/constraints/travel_distance.py
+++ b/scene_search/constraints/travel_distance.py
@@ -17,7 +17,8 @@ class TravelDistanceConstraint(BaseConstraint):
             "max_distance": {"type": "float", "default": 200.0, "label": "Max distance (m)", "min": 0.0, "max": 200.0, "step": 1.0},
         }
 
-    def filter(self, npz_path: str, npz_data: np.lib.npyio.NpzFile, params: dict) -> bool:
+    def filter(self, npz_path: str, npz_data: np.lib.npyio.NpzFile,
+               params: dict, entry: dict | None = None) -> bool:
         fut = npz_data["ego_agent_future"]  # (80, 3) — [x, y, yaw_rad]
         dx = np.diff(fut[:, 0])
         dy = np.diff(fut[:, 1])

--- a/scene_search/map_canvas_js.py
+++ b/scene_search/map_canvas_js.py
@@ -253,8 +253,85 @@ ARROW_TOOL = {
     "state": """
     let arrowStartWorld = null, arrowEndWorld = null;
     let isDrawingArrow = false, arrowStartPx = null, arrowEndPx = null;
+
+    // Heatmap overlay (scored points from replay runs). Parsed once per
+    // prop update. Each point: {x, y, rb_min_dist, cl_score, lane_gate,
+    // lane_near_frac, lane_wide_frac}. Values may be null when absent.
+    let heatmapPoints = [];
+    let heatmapMetric = 'off';
+    let heatmapJsonCache = null;
+    function _parseHeatmap() {
+        const raw = props.heatmap_json || '[]';
+        if (raw === heatmapJsonCache) return;
+        heatmapJsonCache = raw;
+        try { heatmapPoints = JSON.parse(raw) || []; }
+        catch (e) { heatmapPoints = []; console.warn('bad heatmap_json', e); }
+    }
+    // Map a [0..1] score to a red→yellow→green→blue ramp (good at 0 = red,
+    // safe at 1 = blue). For metrics where LOW is bad (rb_min_dist), the
+    // caller first inverts via a range cutoff.
+    function _scoreColor(t) {
+        t = Math.max(0, Math.min(1, t));
+        // Red (1,0,0) → yellow (1,1,0) → green (0,1,0) → blue (0,0,1)
+        if (t < 0.33) {
+            const u = t / 0.33;
+            return 'rgba(' + Math.round(255) + ',' + Math.round(255*u) + ',0,0.85)';
+        } else if (t < 0.66) {
+            const u = (t - 0.33) / 0.33;
+            return 'rgba(' + Math.round(255*(1-u)) + ',255,0,0.85)';
+        } else {
+            const u = (t - 0.66) / 0.34;
+            return 'rgba(0,' + Math.round(255*(1-u)) + ',' + Math.round(255*u) + ',0.85)';
+        }
+    }
+    // Metric-specific normalisation to [0..1] where 1 = safe, 0 = bad.
+    function _heatmapT(point, metric) {
+        if (metric === 'rb_min_dist') {
+            const v = point.rb_min_dist;
+            if (v === null || v === undefined) return null;
+            // 0m = bad (red), >=3m = safe (blue). Clipped.
+            return Math.max(0, Math.min(1, v / 3.0));
+        }
+        if (metric === 'abs_cl_score') {
+            const v = point.cl_score;
+            if (v === null || v === undefined) return null;
+            // |cl|=0 = safe, |cl|>=2 = bad. Invert so 1=safe.
+            return 1.0 - Math.max(0, Math.min(1, Math.abs(v) / 2.0));
+        }
+        if (metric === 'lane_gate') {
+            const v = point.lane_gate;
+            if (v === null || v === undefined) return null;
+            return v >= 0.5 ? 1.0 : 0.0;
+        }
+        if (metric === 'lane_near_frac') {
+            const v = point.lane_near_frac;
+            if (v === null || v === undefined) return null;
+            return 1.0 - Math.max(0, Math.min(1, v));
+        }
+        if (metric === 'lane_wide_frac') {
+            const v = point.lane_wide_frac;
+            if (v === null || v === undefined) return null;
+            return 1.0 - Math.max(0, Math.min(1, v));
+        }
+        return null;
+    }
     """,
     "draw": """
+    // Heatmap dots — drawn below the arrow so the arrow always shows on top.
+    heatmapMetric = props.heatmap_metric || 'off';
+    if (heatmapMetric !== 'off') {
+        _parseHeatmap();
+        for (let i = 0; i < heatmapPoints.length; i++) {
+            const p = heatmapPoints[i];
+            const t = _heatmapT(p, heatmapMetric);
+            if (t === null) continue;
+            const pc = worldToCanvas(p.x, p.y);
+            if (pc.x < -10 || pc.x > W+10 || pc.y < -10 || pc.y > H+10) continue;
+            ctx.fillStyle = _scoreColor(t);
+            ctx.beginPath(); ctx.arc(pc.x, pc.y, 3, 0, Math.PI*2); ctx.fill();
+        }
+    }
+
     // Recompute arrow pixels from world coords
     if (arrowStartWorld && arrowEndWorld && !isDrawingArrow) {
         arrowStartPx = worldToCanvas(arrowStartWorld.x, arrowStartWorld.y);

--- a/scene_search/map_canvas_js.py
+++ b/scene_search/map_canvas_js.py
@@ -285,33 +285,50 @@ ARROW_TOOL = {
         }
     }
     // Metric-specific normalisation to [0..1] where 1 = safe, 0 = bad.
+    // Each case: read the field, map to [0..1], return null when missing.
     function _heatmapT(point, metric) {
+        const v = point[metric === 'abs_cl_score' ? 'cl_score' : metric];
+        if (v === null || v === undefined) return null;
+
+        // Distance / magnitude metrics with custom ranges
         if (metric === 'rb_min_dist') {
-            const v = point.rb_min_dist;
-            if (v === null || v === undefined) return null;
-            // 0m = bad (red), >=3m = safe (blue). Clipped.
+            // 0m = bad (red), >=3m = safe (blue).
             return Math.max(0, Math.min(1, v / 3.0));
         }
         if (metric === 'abs_cl_score') {
-            const v = point.cl_score;
-            if (v === null || v === undefined) return null;
-            // |cl|=0 = safe, |cl|>=2 = bad. Invert so 1=safe.
+            // |cl|>=2 = bad (red), 0 = safe.
             return 1.0 - Math.max(0, Math.min(1, Math.abs(v) / 2.0));
         }
+        if (metric === 'centerline_penalty') {
+            // Penalty is negative in baselink mode; more negative = worse.
+            // Clamp to [-2, 0] and invert so 0 = bad, -2 → 0, 0 → 1.
+            return 1.0 + Math.max(-1, Math.min(0, v / 2.0));
+        }
+        if (metric === 'total') {
+            // Total reward range is config-dependent; use a wide default
+            // [-30..+10] → t=[0..1] so typical runs span the whole ramp.
+            return Math.max(0, Math.min(1, (v + 30.0) / 40.0));
+        }
+        if (metric === 'progress' || metric === 'smoothness' || metric === 'feasibility') {
+            // Higher = better. Clamp to [0..1] with a soft cap.
+            return Math.max(0, Math.min(1, v));
+        }
+
+        // Inverted-penalty metrics: 0 = good, 1 = bad → flip so 1 = safe.
+        if (metric === 'collision' || metric === 'rb_crossing' || metric === 'lane_crossing') {
+            return v ? 0.0 : 1.0;  // bool or 0/1
+        }
         if (metric === 'lane_gate') {
-            const v = point.lane_gate;
-            if (v === null || v === undefined) return null;
             return v >= 0.5 ? 1.0 : 0.0;
         }
-        if (metric === 'lane_near_frac') {
-            const v = point.lane_near_frac;
-            if (v === null || v === undefined) return null;
+        if (metric === 'lane_near_frac' || metric === 'lane_wide_frac' ||
+            metric === 'off_road_fraction' ||
+            metric === 'rb_near_penalty' || metric === 'rb_wide_penalty') {
             return 1.0 - Math.max(0, Math.min(1, v));
         }
-        if (metric === 'lane_wide_frac') {
-            const v = point.lane_wide_frac;
-            if (v === null || v === undefined) return null;
-            return 1.0 - Math.max(0, Math.min(1, v));
+        if (metric === 'red_light') {
+            // 0 = no violation, >0 = violating. Treat >0.01 as bad.
+            return v > 0.01 ? 0.0 : 1.0;
         }
         return null;
     }

--- a/scene_search/map_canvas_js.py
+++ b/scene_search/map_canvas_js.py
@@ -300,18 +300,21 @@ ARROW_TOOL = {
     // Generic normalisation: auto-scale by the metric's observed [min, max]
     // and apply the polarity from _metric_polarity (Python side).
     // Adding a new reward component auto-appears here with no JS changes.
-    // 'abs_cl_score' is the sole exception — it reads |cl_score| rather
-    // than a separate field; if absent from ranges, fall back to cl_score
-    // and invert its polarity (low|cl|=safe, high|cl|=drift).
+    // 'abs_cl_score' / 'abs_pred_cl_score' are synthetic options — they
+    // read |cl_score| (or |pred_cl_score|) rather than a separate field
+    // since the signed cl_score has "safe" at 0 with both tails meaning
+    // drift. Magnitude view uses the auto-scaled range [0, max|·|] and
+    // inverts polarity (low |cl| = safe, high |cl| = drift).
     function _heatmapT(point, metric) {
         let v, range, polarity;
-        if (metric === 'abs_cl_score') {
-            const raw = point.cl_score;
+        if (metric === 'abs_cl_score' || metric === 'abs_pred_cl_score') {
+            const srcKey = metric === 'abs_cl_score' ? 'cl_score' : 'pred_cl_score';
+            const raw = point[srcKey];
             if (raw === null || raw === undefined) return null;
             v = Math.abs(raw);
-            range = heatmapRanges.cl_score;
+            range = heatmapRanges[srcKey];
             if (range) range = [0, Math.max(Math.abs(range[0]), Math.abs(range[1]))];
-            polarity = -1;  // higher |cl| = drift
+            polarity = -1;
         } else {
             v = point[metric];
             if (v === null || v === undefined) return null;

--- a/scene_search/map_canvas_js.py
+++ b/scene_search/map_canvas_js.py
@@ -255,27 +255,40 @@ ARROW_TOOL = {
     let isDrawingArrow = false, arrowStartPx = null, arrowEndPx = null;
 
     // Heatmap overlay (scored points from replay runs). Parsed once per
-    // prop update. Each point: {x, y, rb_min_dist, cl_score, lane_gate,
-    // lane_near_frac, lane_wide_frac}. Values may be null when absent.
+    // prop update. Each point: {x, y, ...metrics}. Metric set is auto-
+    // discovered from the data — no JS-side list to maintain.
     let heatmapPoints = [];
+    let heatmapRanges = {};    // {metric: [min, max]}
+    let heatmapPolarity = {};  // {metric: +1 (higher=safe) | -1 (higher=drift)}
     let heatmapMetric = 'off';
-    let heatmapJsonCache = null;
+    let heatmapJsonCache = null, heatmapMetaCache = null;
     function _parseHeatmap() {
         const raw = props.heatmap_json || '[]';
-        if (raw === heatmapJsonCache) return;
-        heatmapJsonCache = raw;
-        try { heatmapPoints = JSON.parse(raw) || []; }
-        catch (e) { heatmapPoints = []; console.warn('bad heatmap_json', e); }
+        if (raw !== heatmapJsonCache) {
+            heatmapJsonCache = raw;
+            try { heatmapPoints = JSON.parse(raw) || []; }
+            catch (e) { heatmapPoints = []; console.warn('bad heatmap_json', e); }
+        }
+        const metaRaw = props.heatmap_meta_json || '{}';
+        if (metaRaw !== heatmapMetaCache) {
+            heatmapMetaCache = metaRaw;
+            try {
+                const meta = JSON.parse(metaRaw) || {};
+                heatmapRanges = meta.ranges || {};
+                heatmapPolarity = meta.polarity || {};
+            } catch (e) {
+                heatmapRanges = {}; heatmapPolarity = {};
+                console.warn('bad heatmap_meta_json', e);
+            }
+        }
     }
-    // Map a [0..1] score to a red→yellow→green→blue ramp (good at 0 = red,
-    // safe at 1 = blue). For metrics where LOW is bad (rb_min_dist), the
-    // caller first inverts via a range cutoff.
+    // Red (1,0,0) → yellow (1,1,0) → green (0,1,0) → blue (0,0,1) ramp.
+    // t in [0..1] with 1 = safe (blue), 0 = drift (red).
     function _scoreColor(t) {
         t = Math.max(0, Math.min(1, t));
-        // Red (1,0,0) → yellow (1,1,0) → green (0,1,0) → blue (0,0,1)
         if (t < 0.33) {
             const u = t / 0.33;
-            return 'rgba(' + Math.round(255) + ',' + Math.round(255*u) + ',0,0.85)';
+            return 'rgba(255,' + Math.round(255*u) + ',0,0.85)';
         } else if (t < 0.66) {
             const u = (t - 0.33) / 0.33;
             return 'rgba(' + Math.round(255*(1-u)) + ',255,0,0.85)';
@@ -284,53 +297,32 @@ ARROW_TOOL = {
             return 'rgba(0,' + Math.round(255*(1-u)) + ',' + Math.round(255*u) + ',0.85)';
         }
     }
-    // Metric-specific normalisation to [0..1] where 1 = safe, 0 = bad.
-    // Each case: read the field, map to [0..1], return null when missing.
+    // Generic normalisation: auto-scale by the metric's observed [min, max]
+    // and apply the polarity from _metric_polarity (Python side).
+    // Adding a new reward component auto-appears here with no JS changes.
+    // 'abs_cl_score' is the sole exception — it reads |cl_score| rather
+    // than a separate field; if absent from ranges, fall back to cl_score
+    // and invert its polarity (low|cl|=safe, high|cl|=drift).
     function _heatmapT(point, metric) {
-        const v = point[metric === 'abs_cl_score' ? 'cl_score' : metric];
-        if (v === null || v === undefined) return null;
-
-        // Distance / magnitude metrics with custom ranges
-        if (metric === 'rb_min_dist') {
-            // 0m = bad (red), >=3m = safe (blue).
-            return Math.max(0, Math.min(1, v / 3.0));
-        }
+        let v, range, polarity;
         if (metric === 'abs_cl_score') {
-            // |cl|>=2 = bad (red), 0 = safe.
-            return 1.0 - Math.max(0, Math.min(1, Math.abs(v) / 2.0));
+            const raw = point.cl_score;
+            if (raw === null || raw === undefined) return null;
+            v = Math.abs(raw);
+            range = heatmapRanges.cl_score;
+            if (range) range = [0, Math.max(Math.abs(range[0]), Math.abs(range[1]))];
+            polarity = -1;  // higher |cl| = drift
+        } else {
+            v = point[metric];
+            if (v === null || v === undefined) return null;
+            range = heatmapRanges[metric];
+            polarity = heatmapPolarity[metric] || 1;
         }
-        if (metric === 'centerline_penalty') {
-            // Penalty is negative in baselink mode; more negative = worse.
-            // Clamp to [-2, 0] and invert so 0 = bad, -2 → 0, 0 → 1.
-            return 1.0 + Math.max(-1, Math.min(0, v / 2.0));
-        }
-        if (metric === 'total') {
-            // Total reward range is config-dependent; use a wide default
-            // [-30..+10] → t=[0..1] so typical runs span the whole ramp.
-            return Math.max(0, Math.min(1, (v + 30.0) / 40.0));
-        }
-        if (metric === 'progress' || metric === 'smoothness' || metric === 'feasibility') {
-            // Higher = better. Clamp to [0..1] with a soft cap.
-            return Math.max(0, Math.min(1, v));
-        }
-
-        // Inverted-penalty metrics: 0 = good, 1 = bad → flip so 1 = safe.
-        if (metric === 'collision' || metric === 'rb_crossing' || metric === 'lane_crossing') {
-            return v ? 0.0 : 1.0;  // bool or 0/1
-        }
-        if (metric === 'lane_gate') {
-            return v >= 0.5 ? 1.0 : 0.0;
-        }
-        if (metric === 'lane_near_frac' || metric === 'lane_wide_frac' ||
-            metric === 'off_road_fraction' ||
-            metric === 'rb_near_penalty' || metric === 'rb_wide_penalty') {
-            return 1.0 - Math.max(0, Math.min(1, v));
-        }
-        if (metric === 'red_light') {
-            // 0 = no violation, >0 = violating. Treat >0.01 as bad.
-            return v > 0.01 ? 0.0 : 1.0;
-        }
-        return null;
+        if (!range || range[1] <= range[0]) return 0.5;  // flat metric → neutral
+        let norm = (v - range[0]) / (range[1] - range[0]);  // [0..1]
+        norm = Math.max(0, Math.min(1, norm));
+        // Flip for drift-high metrics so red = bad regardless of polarity.
+        return polarity > 0 ? norm : 1.0 - norm;
     }
     """,
     "draw": """

--- a/scene_search/replay_index.py
+++ b/scene_search/replay_index.py
@@ -1,0 +1,95 @@
+"""Build a scene_search spatial index from a `scenario_generation.replay` run.
+
+A replay run does NOT emit per-NPZ JSON sidecars (``dump_step_npz`` writes
+observation tensors only); instead it writes ``trajectory_log.json`` and —
+when live metric logging is enabled — ``metrics_log.json`` alongside the
+``npz/`` dump. This module joins the two logs into the same index-entry
+format the rest of scene_search expects, plus an extra ``metrics`` field
+carrying the per-step drift scores that power the heatmap overlay and the
+reward-threshold constraint.
+
+Each entry mirrors ``search_scenes.read_sidecar``:
+    {
+        "npz_path": ...,
+        "x": ..., "y": ..., "heading_deg": ...,
+        "timestamp": ...,
+        "metrics": {lane_gate, lane_near_frac, rb_min_dist, cl_score, ...},
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+
+def _load_json(path: Path):
+    with open(path) as f:
+        return json.load(f)
+
+
+def load_replay_run(run_dir: str | Path) -> list[dict]:
+    """Load all per-step entries from one replay run directory.
+
+    Args:
+        run_dir: Output directory of ``scenario_generation.replay``. Must
+            contain ``trajectory_log.json``; ``metrics_log.json`` and
+            ``npz/replay_step_NNNN.npz`` are optional (steps with missing
+            NPZs are dropped, missing metrics default to None).
+
+    Returns:
+        List of per-step index entries.
+    """
+    run = Path(run_dir)
+    traj_path = run / "trajectory_log.json"
+    if not traj_path.exists():
+        raise FileNotFoundError(
+            f"{traj_path} missing; --replay_runs expects a run dir emitted "
+            f"by scenario_generation.replay."
+        )
+    trajectory = _load_json(traj_path)
+
+    metrics_by_step: dict[int, dict] = {}
+    metrics_path = run / "metrics_log.json"
+    if metrics_path.exists():
+        payload = _load_json(metrics_path)
+        # Newer replay writes {"steps": [...], ...}; older raw-list format
+        # is tolerated so old dumps still load.
+        steps = payload["steps"] if isinstance(payload, dict) else payload
+        for rec in steps:
+            s = int(rec["step"])
+            metrics_by_step[s] = {
+                k: rec[k] for k in (
+                    "lane_gate", "lane_near_frac", "lane_wide_frac",
+                    "lane_cont", "rb_min_dist", "cl_score",
+                ) if k in rec
+            }
+
+    npz_dir = run / "npz"
+    entries: list[dict] = []
+    for rec in trajectory:
+        step = int(rec["step"])
+        npz_path = npz_dir / f"replay_step_{step:04d}.npz"
+        if not npz_path.exists():
+            continue
+        entries.append({
+            "npz_path": str(npz_path),
+            "x": float(rec["x"]),
+            "y": float(rec["y"]),
+            "heading_deg": math.degrees(float(rec["heading"])),
+            "timestamp": float(step) * 0.1,  # dt=0.1 s per step
+            "metrics": metrics_by_step.get(step, {}),
+            "replay_run": str(run),
+            "replay_step": step,
+        })
+    return entries
+
+
+def load_replay_runs(run_dirs: list[str | Path]) -> list[dict]:
+    """Concatenate entries from multiple replay runs. Run dirs are disjoint
+    NPZ namespaces, so no de-duplication is needed."""
+    out: list[dict] = []
+    for rd in run_dirs:
+        out.extend(load_replay_run(rd))
+    return out

--- a/scene_search/replay_index.py
+++ b/scene_search/replay_index.py
@@ -75,7 +75,11 @@ def load_replay_run(run_dir: str | Path) -> list[dict]:
             "npz_path": str(npz_path),
             "x": float(rec["x"]),
             "y": float(rec["y"]),
-            "heading_deg": math.degrees(float(rec["heading"])),
+            # Normalise to [-180, 180) to match the convention in
+            # diffusion_planner/util_scripts/search_scenes.py — otherwise
+            # heading-range filters silently miss entries with raw
+            # headings outside that range.
+            "heading_deg": (math.degrees(float(rec["heading"])) + 180.0) % 360.0 - 180.0,
             "timestamp": float(step) * 0.1,  # dt=0.1 s per step
             "metrics": metrics_by_step.get(step, {}),
             "replay_run": str(run),

--- a/scene_search/replay_index.py
+++ b/scene_search/replay_index.py
@@ -36,7 +36,7 @@ def load_replay_run(run_dir: str | Path) -> list[dict]:
         run_dir: Output directory of ``scenario_generation.replay``. Must
             contain ``trajectory_log.json``; ``metrics_log.json`` and
             ``npz/replay_step_NNNN.npz`` are optional (steps with missing
-            NPZs are dropped, missing metrics default to None).
+            NPZs are dropped, missing metrics default to an empty dict).
 
     Returns:
         List of per-step index entries.

--- a/scene_search/replay_index.py
+++ b/scene_search/replay_index.py
@@ -59,12 +59,10 @@ def load_replay_run(run_dir: str | Path) -> list[dict]:
         steps = payload["steps"] if isinstance(payload, dict) else payload
         for rec in steps:
             s = int(rec["step"])
-            metrics_by_step[s] = {
-                k: rec[k] for k in (
-                    "lane_gate", "lane_near_frac", "lane_wide_frac",
-                    "lane_cont", "rb_min_dist", "cl_score",
-                ) if k in rec
-            }
+            # Copy every metric field the replay emits. Missing fields in
+            # older logs are simply absent from the dict; downstream code
+            # reads with .get() and treats None/missing as "no data".
+            metrics_by_step[s] = {k: v for k, v in rec.items() if k != "step"}
 
     npz_dir = run / "npz"
     entries: list[dict] = []


### PR DESCRIPTION
## Summary

MPC closed-loop data-generation pipeline (`scenario_generation.replay`) now produces rich, trustworthy metrics so we can build training scene sets without re-running the sim on every reward / model iteration. Also fixes four long-standing sim bugs that surfaced during testing (TL state stuck at `TL_NONE`, ego velocity / accel / yaw-rate / steering MA-lagged by 0.4 s, MPC warm-start locking the ego into a zero-knot basin after any stop).

20 signed commits on `mpc-gen-live-metrics`, branched from `tier4-main`.

## Demo

TL-on MPC replay over `bigcurve_route_20260422`, 2148 frames (214.8 s sim time), goal reached. The ego correctly decelerates at reds, stops, and resumes on green. Body-distance dashed line to the nearest road border + live metrics overlay in every frame's title.
[sim.webm](https://github.com/user-attachments/assets/f4cf93a6-9b0b-4861-b2a4-58e6af529fc6)


[sim.webm](https://github.com/user-attachments/assets/cd8bdca8-47af-4ce3-b638-a834d7b6c9bc)


## Sim correctness fixes

Real bugs the live sim had — all found and fixed during this work:

- **TL state stuck at TL_NONE.** `TrafficLightController.tick()` wrote the current signal phase into `scene.map_data.lanes`, but `MapTensorCache` held an independent copy (`.astype(np.float32)` forces a fresh allocation), so the model kept reading `TL_NONE` on every lanelet. Added `MapTensorCache.sync_tl_state()` and call it after every tick.
- **Ego velocity MA-lagged 0.4 s.** `advance_scene_mpc` discarded the tracker's integrated speed and recomputed velocity via a 5-step MA of position diffs — that MA was there to denoise the jittery teleport-mode `pred[0]`; applied to the already-smooth MPC output it just lagged the self-reported velocity, fed back into `ego_current_state[4]`, and locked the ego into self-reinforcing "slow down" plans. Same MA was also lagging accel, yaw rate, and steering. All four now come from the tracker's own telemetry (`last_accel`, `last_yaw_rate`, `last_steering`); the MA stays as the fallback for teleport mode where it's still justified.
- **MPC warm-start trap.** The tracker's warm-start persisted the all-zero knot solution through long decels; when the model flipped back to a forward prediction the reference's near-static first 2 s combined with the smoothness cost terms prevented L-BFGS-B from escaping the zero-knot basin — the ego stayed parked forever. Warm-start now resets whenever the ego is idle (< 0.1 m/s) AND the reference wants meaningful motion.

## Logging / scoring stack

- `_score_step` dispatches to `compute_reward_batch` + a baselink-mode `compute_centerline_score_batch`. Every field of `RewardBreakdown` lands in `metrics_log.json` via `dataclasses.asdict` — no hand-maintained mapping, so adding a new reward component automatically flows through.
- Added `pred_*` fields alongside the instantaneous block — they score the model's 80-step prediction against the same primitives, **zero extra inference** since replay already computes the prediction to feed the tracker.
- `SpawnConfig.reward_config_path` is required when `dump_npz_dir` is set (no silent defaults).
- `SpawnConfig.enable_traffic_lights` toggle; `SpawnConfig.overlay_metrics_on_png` draws live rb / cl / lane-state on every per-step PNG with a body-distance dashed line to the nearest road border.
- `replay.main()` now requires `--config`.
- Replay now writes `spawn_config.json` into `output_dir` at end so the rescore tool works on any dump.

## Downstream tooling

| Tool | Purpose |
|---|---|
| `rlvr/autoresearch/tools/select_from_metrics_log.py` | Trigger + lookback selector emitting pre-trigger NPZs for training. |
| `rlvr/autoresearch/tools/rescore_replay_run.py` | Regenerate `metrics_log.json` without re-running MPC. Two explicit modes, no fallbacks: `--mode instant` (current-pose only, no model needed) and `--mode full` (plus `pred_*` via inference, `--model_path` REQUIRED — crashes if missing). **Non-trivial capability:** swap `--model_path` to evaluate how a different checkpoint would have planned at the same observations. |
| `scene_search` | Gains `--replay_runs` and a **dynamic metric heatmap** — dropdown auto-populates from whatever numeric fields appear in the metrics log (polarity inferred from a metric-name heuristic, colour ramp auto-scaled). New `reward_threshold` constraint plugin filters scenes by metric thresholds. |

## Validation

- TL-on MPC replay over `bigcurve_route_20260422` reaches the goal at step 2148 (214.8 s sim time); ego correctly decelerates at reds, stops, and resumes on green. Compared to the TL-off run (1943 steps), the ~200 extra steps are real stop-and-go time at signals.
- Live vs post-hoc rescore (`--mode full` with matching seed): **instantaneous block is bit-identical** (all fields max|Δ|=0.0). `pred_*` correlates at **0.9999**; mean|Δ| is ~1 mm on `pred_rb_min_dist` and ~3×10⁻⁵ on `pred_cl_score`. Differences are bounded by RNG state drift between the two processes.
- 29/29 tracker tests pass (17 existing + 12 new covering the warm-start reset, tracker telemetry fields, and `_advance_agent`'s tracker-kwarg pass-through).

## Review-fix commit (bf037ee)

Addresses 7 of 9 Copilot review comments:

- Duplicate `@torch.no_grad()` dropped.
- Replay writes `spawn_config.json` at dump time so `rescore_replay_run` works on any dump out of the box.
- `sync_tl_state()` uses `np.copyto(casting="same_kind")` instead of per-tick allocation.
- Stale "without re-reading NPZ" comment corrected in `batch_search.py`.
- `replay_index` docstring matches behaviour (missing metrics → `{}`).
- 12 new tests for warm-start reset + tracker telemetry pass-through.

Deferred: heatmap perf downsampling (Copilot #9) — 2148 points renders fine; can revisit if we start loading many runs at once.

## Test plan

- [x] Existing `scenario_generation/tests/test_mpc_tracker.py` — all 17 pass.
- [x] New `scenario_generation/tests/test_tracker_telemetry.py` — all 12 pass (warm-start reset, `last_*` telemetry, `_advance_agent` kwarg override, MA fallback).
- [x] End-to-end MPC replay on `bigcurve_route_20260422`, TL off → 1943 frames, goal reached.
- [x] End-to-end MPC replay on same route, TL on → 2148 frames, goal reached, correct stop/resume at reds.
- [x] `select_from_metrics_log.py` on the TL-on run → trigger counts + lookback set emitted.
- [x] `scene_search --replay_runs <run_dir>` — heatmap dropdown auto-populates with all live + `pred_*` metrics, colour ramp auto-scales per field.
- [x] `rescore_replay_run --mode instant` → metrics identical to the live write.
- [x] `rescore_replay_run --mode full --model_path <base> --seed 42` → 0.9999 correlation with live pred_total, millimetre-level agreement on pred_rb_min_dist.
- [ ] Reviewer to drag the WebM into the Demo section.

## Out of scope

- Actually queueing an RSFT training run on the selected pre-trigger scenes.
- Eval on miraikan val 277 + MPC val 300 + psim scene 49.

## Jira

Tracks [T4DEV-52709](https://tier4.atlassian.net/browse/T4DEV-52709) (supersedes T4DEV-52690, which was filed as a Sub-task under an Epic and can't be added to a sprint in the T4DEV config).

[T4DEV-52709]: https://tier4.atlassian.net/browse/T4DEV-52709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ