### PR TITLE
feat(rlvr): route-lanes centerline guidance + progress-penalty bugfix

### DIFF
--- a/diffusion_planner/diffusion_planner/model/guidance/__init__.py
+++ b/diffusion_planner/diffusion_planner/model/guidance/__init__.py
@@ -22,6 +22,7 @@ from . import lane_keeping  # noqa: F401
 from . import lateral_guidance  # noqa: F401
 from . import longitudinal_guidance  # noqa: F401
 from . import road_border  # noqa: F401
+from . import route_centerline_following  # noqa: F401
 from . import route_following  # noqa: F401
 from . import speed_guidance  # noqa: F401
 

--- a/diffusion_planner/diffusion_planner/model/guidance/route_centerline_following.py
+++ b/diffusion_planner/diffusion_planner/model/guidance/route_centerline_following.py
@@ -1,0 +1,99 @@
+"""Route-centerline-following guidance for the diffusion planner.
+
+Identical to ``centerline_following.py`` except it uses the planned
+``route_lanes`` tensor instead of all ``lanes``. This matches
+``rlvr.reward.compute_centerline_score_batch`` which scores against
+route_lanes, so guidance and ranking are aligned.
+
+For each future ego position:
+  1. Find the nearest point among all valid route-lane polyline points.
+  2. Project the ego offset onto the route-lane LATERAL direction
+     (perpendicular to the route tangent).
+  3. Penalise lateral_offset^2 (quadratic pull toward the route centerline).
+
+Points farther than ``_MAX_LANE_DIST`` are masked out to avoid pulling
+ego toward distant/disconnected route pieces.
+"""
+
+import torch
+
+from .base import BaseGuidance
+from .registry import register
+
+_X, _Y = 0, 1
+_DX, _DY = 2, 3
+
+_MAX_LANE_DIST = 30.0
+
+
+@register
+class RouteCenterlineFollowingGuidance(BaseGuidance):
+    """Quadratic penalty for lateral deviation from the nearest ROUTE lane centerline.
+
+    Identical to ``CenterlineFollowingGuidance`` but reads ``route_lanes``
+    from ``inputs`` so the guidance and the reward (which also uses
+    ``route_lanes``) are aligned.
+
+    _energy_scale = 0.1 matches CenterlineFollowingGuidance — gradient of
+    ego_lat^2 at 1 m offset is ~40 in normalised trajectory coordinates so
+    scale=0.1 gives a ~4 unit correction.
+    """
+
+    name = "route_centerline_following"
+    _energy_scale = 0.1
+
+    def _compute(self, x: torch.Tensor, inputs: dict) -> torch.Tensor:
+        """
+        x: [B, P, T+1, 4] physical ego-centric metres.
+        inputs: observation dict in physical units (must contain route_lanes).
+
+        Returns [B] unscaled reward (higher = closer to route centerline).
+        """
+        B, P, T_plus1, _ = x.shape
+        T = T_plus1 - 1
+
+        ego_pos = x[:, 0, 1:, :2]  # [B, T, 2]
+
+        # route_lanes shape: [B, 25, 20, 33] (25 segments × 20 points each)
+        route_lanes = inputs["route_lanes"]
+        N = route_lanes.shape[1] * route_lanes.shape[2]
+
+        lane_centers = route_lanes[..., _X:_Y + 1].reshape(B, N, 2)
+        lane_dirs    = route_lanes[..., _DX:_DY + 1].reshape(B, N, 2)
+
+        lane_dirs_n = lane_dirs / (lane_dirs.norm(dim=-1, keepdim=True) + 1e-6)
+        lane_lat = torch.stack([-lane_dirs_n[..., 1], lane_dirs_n[..., 0]], dim=-1)
+
+        lane_valid = lane_centers.norm(dim=-1) > 1e-3
+
+        dist = (ego_pos.unsqueeze(2) - lane_centers.unsqueeze(1)).norm(dim=-1)
+        dist = dist.masked_fill(~lane_valid.unsqueeze(1).expand(-1, T, -1), 1e6)
+        nearest   = dist.argmin(dim=-1)
+        min_dist  = dist.min(dim=-1).values
+
+        def gather2(tensor):
+            idx = nearest.unsqueeze(-1).expand(-1, -1, 2)
+            return tensor.unsqueeze(1).expand(-1, T, -1, -1) \
+                         .gather(2, idx.unsqueeze(2)).squeeze(2)
+
+        c   = gather2(lane_centers)
+        lat = gather2(lane_lat)
+
+        ego_lat = ((ego_pos - c) * lat).sum(dim=-1)  # [B, T]
+
+        no_lane = min_dist > _MAX_LANE_DIST
+        ego_lat = ego_lat.masked_fill(no_lane, 0.0)
+
+        reward = -(ego_lat ** 2).sum(dim=-1)  # [B]
+        return reward
+
+
+# ---------------------------------------------------------------------------
+# Backward-compatible module-level function alias
+# ---------------------------------------------------------------------------
+
+def route_centerline_following_fn(x, t, cond, inputs, *args, **kwargs) -> torch.Tensor:
+    """Deprecated. Use RouteCenterlineFollowingGuidance via GuidanceComposer."""
+    from .config import GuidanceConfig
+    fn = RouteCenterlineFollowingGuidance(GuidanceConfig(name="route_centerline_following"))
+    return fn.energy(x, t, inputs)

--- a/rlvr/autoresearch/run_experiment.py
+++ b/rlvr/autoresearch/run_experiment.py
@@ -282,9 +282,10 @@ def _visualize_trajectories(model, model_args, prob_scenes, reward_config, run_d
 
     model.eval()
 
-    # Find scenes where base model goes offroad
+    # Find scenes where base model goes offroad (scan all scenes — don't
+    # subsample, that would hide worst-offroad scenes past index 100).
     offroad_indices = []
-    for i, path in enumerate(prob_scenes[:100]):
+    for i, path in enumerate(prob_scenes):
         try:
             data = load_npz_data(path, DEVICE)
             norm = {k: v.clone() if isinstance(v, torch.Tensor) else v for k, v in data.items()}
@@ -516,6 +517,7 @@ def run(config_path: Path, name: str, skip_baseline: bool = False, baseline_cach
             w_centerline=grpo_config.w_centerline,
             centerline_usage_cap=grpo_config.centerline_usage_cap,
             centerline_usage_mode=grpo_config.centerline_usage_mode,
+            centerline_time_weight_min=grpo_config.centerline_time_weight_min,
             rb_near_scale=grpo_config.rb_near_scale,
             rb_wide_scale=grpo_config.rb_wide_scale,
             rb_cont_scale=grpo_config.rb_cont_scale,

--- a/rlvr/autoresearch/tools/eval_centerline_metrics.py
+++ b/rlvr/autoresearch/tools/eval_centerline_metrics.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Report the centerline-reward distribution over scenes + lat-offset-to-nearest-route-lane (m).
+
+Uses rlvr.reward.compute_centerline_score_batch — the exact function the training
+reward calls — so numbers here are what the training signal actually sees.
+
+Optional --sanity_compare runs a parallel naive reimplementation (same formula,
+no caps, no time-weight, no route-deviation branch) and reports where the two
+diverge. Useful for surfacing cases the reward is hiding (saturation, time-decay).
+
+Outputs per tag:
+  * centerline score distribution: mean, p5, p25, p50, p75, p95  (score is negative; p5 = worst 5%)
+  * |lat_offset| (baselink → nearest route lane centerline point, meters): mean, p25, p50, p75, p95
+  * fraction of scenes where score hits the cap floor (-1.0)
+  * fraction of scenes with any off-route drift
+
+Usage:
+    source .venv/bin/activate
+    python -m rlvr.autoresearch.tools.eval_centerline_metrics \
+        --model_path /path/to/best_model.pth \
+        --scenes /path/to/scenes.json \
+        [--lora_path /path/to/lora_epoch_NNN] \
+        [--tag ep4] [--out_json out.json] [--sanity_compare]
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from preference_optimization.model_utils import load_model
+from preference_optimization.utils import load_npz_data
+from rlvr.reward import RewardConfig, compute_centerline_score_batch
+
+
+@torch.no_grad()
+def generate_trajectory(model, model_args, data, device):
+    B = data["ego_current_state"].shape[0]
+    P = 1 + model_args.predicted_neighbor_num
+    future_len = model_args.future_len
+    norm_data = {k: v.clone() for k, v in data.items()}
+    norm_data = model_args.observation_normalizer(norm_data)
+    norm_data["sampled_trajectories"] = torch.zeros(B, P, future_len + 1, 4, device=device)
+    _orig = model.decoder._guidance_fn
+    model.decoder._guidance_fn = None
+    _, outputs = model(norm_data)
+    model.decoder._guidance_fn = _orig
+    return outputs["prediction"][0, 0]  # [T, 4] on device
+
+
+@torch.no_grad()
+def lat_offset_and_naive_score(traj: torch.Tensor, data: dict, ego_half_w: float):
+    """Per-scene per-timestep quantities used for sanity-compare + lat_offset stats.
+
+    Mirrors compute_centerline_score_batch lines 985-1017 to get |lat_offset|
+    (m) from nearest route-lane centerline point, plus a NAIVE score:
+    -mean(lane_usage²) with no cap, no time-weight, no route-deviation branch.
+    """
+    device = traj.device
+    lanes = data.get("route_lanes", data.get("lanes"))
+    if lanes is None:
+        return None
+    if lanes.dim() == 4:
+        lanes = lanes[0]
+    S_P = lanes.shape[0] * lanes.shape[1]
+    centers = lanes[..., 0:2].reshape(S_P, 2)
+    dirs = lanes[..., 2:4].reshape(S_P, 2)
+    left = lanes[..., 4:6].reshape(S_P, 2)
+    right = lanes[..., 6:8].reshape(S_P, 2)
+    valid = centers.norm(dim=-1) > 1e-3
+    dirs_n = dirs / (dirs.norm(dim=-1, keepdim=True) + 1e-6)
+    lat_dir = torch.stack([-dirs_n[..., 1], dirs_n[..., 0]], dim=-1)
+    left_hw = (left * lat_dir).sum(dim=-1)
+    right_hw = (right * lat_dir).sum(dim=-1)
+
+    ego_pos = traj[:, :2]
+    T = ego_pos.shape[0]
+    diff = ego_pos.unsqueeze(1) - centers.unsqueeze(0)
+    dist = diff.norm(dim=-1)
+    dist = dist.masked_fill(~valid.view(1, -1).expand(T, -1), 1e6)
+    min_dist, nearest = dist.min(dim=-1)
+
+    c = centers[nearest]
+    lat_vec = lat_dir[nearest]
+    ego_lat = ((ego_pos - c) * lat_vec).sum(dim=-1)
+    lhw = left_hw[nearest]
+    rhw = right_hw[nearest]
+    side_hw = torch.where(ego_lat >= 0, lhw.clamp(min=0.5), (-rhw).clamp(min=0.5))
+    lane_usage = (ego_lat.abs() + ego_half_w) / side_hw  # body mode, uncapped
+
+    naive_score = -(lane_usage ** 2).mean().item()  # uniform-weight, no cap, no route-dev
+    any_off_route = bool(((min_dist > 5.0).cummax(dim=0).values & (min_dist > 5.0)).any().item())
+    return {
+        "lat_offset_m": ego_lat.abs().cpu().numpy(),  # [T]
+        "lane_usage_uncapped": lane_usage.cpu().numpy(),  # [T]
+        "naive_score": naive_score,
+        "any_off_route": any_off_route,
+    }
+
+
+def _q(a, p): return float(np.percentile(a, p))
+
+
+def report(tag, cl_scores, lat_offset_means, lat_offset_maxes, cap_floor_count, off_route_count):
+    n = len(cl_scores)
+    cl = np.asarray(cl_scores)
+    lom = np.asarray(lat_offset_means)
+    lomx = np.asarray(lat_offset_maxes)
+
+    print(f"\n=== Centerline — {tag} ({n} scenes) ===")
+    print(f"centerline_score (from compute_centerline_score_batch; negative, 0=best):")
+    print(f"  mean={cl.mean():+.3f}  p5={_q(cl,5):+.3f}  p25={_q(cl,25):+.3f}  "
+          f"p50={_q(cl,50):+.3f}  p75={_q(cl,75):+.3f}  p95={_q(cl,95):+.3f}  min={cl.min():+.3f}")
+    print(f"  (p5 and p25 are worst-case tails; min = worst scene)")
+    print(f"  hit cap floor (score ≤ -0.999): {cap_floor_count}/{n} "
+          f"({100*cap_floor_count/n:.1f}%) — reward is saturating")
+
+    print(f"|lat_offset|_mean-per-scene (baselink → nearest route-lane centerline point, m):")
+    print(f"  mean={lom.mean():.2f}  p25={_q(lom,25):.2f}  p50={_q(lom,50):.2f}  "
+          f"p75={_q(lom,75):.2f}  p95={_q(lom,95):.2f}  max={lom.max():.2f}")
+    print(f"|lat_offset|_max-per-scene (worst timestep in each scene, m):")
+    print(f"  mean={lomx.mean():.2f}  p25={_q(lomx,25):.2f}  p50={_q(lomx,50):.2f}  "
+          f"p75={_q(lomx,75):.2f}  p95={_q(lomx,95):.2f}  max={lomx.max():.2f}")
+    print(f"off-route scenes: {off_route_count}/{n} ({100*off_route_count/n:.1f}%)")
+
+    return {
+        "tag": tag, "n_scenes": n,
+        "cl_score_mean": float(cl.mean()),
+        "cl_score_p5": _q(cl, 5), "cl_score_p25": _q(cl, 25), "cl_score_p50": _q(cl, 50),
+        "cl_score_p75": _q(cl, 75), "cl_score_p95": _q(cl, 95), "cl_score_min": float(cl.min()),
+        "cl_score_capped_frac": float(cap_floor_count / n),
+        "lat_off_mean_mean_m": float(lom.mean()),
+        "lat_off_mean_p25_m": _q(lom, 25), "lat_off_mean_p50_m": _q(lom, 50),
+        "lat_off_mean_p75_m": _q(lom, 75), "lat_off_mean_p95_m": _q(lom, 95),
+        "lat_off_max_mean_m": float(lomx.mean()), "lat_off_max_p95_m": _q(lomx, 95),
+        "off_route_frac": float(off_route_count / n),
+    }
+
+
+def sanity_compare(cl_scores_reward, naive_scores):
+    """Compare reward-function score vs a naive uniform-weight no-cap no-route-dev score.
+
+    Large gaps reveal where the reward is hiding signal (cap saturation, time-decay,
+    route-deviation overriding raw offset).
+    """
+    reward = np.asarray(cl_scores_reward)
+    naive = np.asarray(naive_scores)
+    diff = reward - naive  # reward is typically less negative than naive (cap + time-weight)
+    print(f"\n=== Sanity: reward vs. naive (uniform-weight, uncapped, no route-dev) ===")
+    print(f"reward (from compute_centerline_score_batch): mean={reward.mean():+.3f}  min={reward.min():+.3f}")
+    print(f"naive  (uniform-mean(lane_usage²), uncapped): mean={naive.mean():+.3f}  min={naive.min():+.3f}")
+    print(f"diff=(reward - naive): mean={diff.mean():+.3f}  p5={_q(diff, 5):+.3f}  p95={_q(diff, 95):+.3f}")
+    # scenes where reward is much LESS negative than naive → reward is hiding the pain
+    hidden = int((diff > 1.0).sum())
+    print(f"scenes where reward >> naive (diff > 1.0, reward hiding pain): {hidden}/{len(reward)}")
+
+
+@torch.no_grad()
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_path", type=str, required=True)
+    parser.add_argument("--scenes", type=str, required=True)
+    parser.add_argument("--lora_path", type=str, default=None)
+    parser.add_argument("--tag", type=str, default="model")
+    parser.add_argument("--out_json", type=str, default=None)
+    parser.add_argument("--sanity_compare", action="store_true",
+                        help="Also compute naive score and report divergence vs reward")
+    parser.add_argument("--usage_cap", type=float, default=None,
+                        help="Override centerline usage cap (default: RewardConfig's 1.0)")
+    parser.add_argument("--time_weight_min", type=float, default=None,
+                        help="Override centerline time_weight_min (1.0 = flat; default: 0.3)")
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model, model_args = load_model(Path(args.model_path), device)
+    model.eval()
+    if args.lora_path:
+        from preference_optimization.lora_utils import load_lora_checkpoint
+        model = load_lora_checkpoint(model, args.lora_path)
+        model.eval()
+        print(f"Loaded LoRA from {args.lora_path}")
+
+    with open(args.scenes) as f:
+        scene_paths = json.load(f)
+    print(f"Evaluating centerline on {len(scene_paths)} scenes [{args.tag}]")
+
+    cfg = RewardConfig()  # defaults: usage_cap=1.0, usage_mode="body", time_weight_min=0.3
+    if args.usage_cap is not None:
+        cfg.centerline_usage_cap = args.usage_cap
+    if args.time_weight_min is not None:
+        cfg.centerline_time_weight_min = args.time_weight_min
+    print(f"Reward: usage_cap={cfg.centerline_usage_cap}, usage_mode={cfg.centerline_usage_mode}, "
+          f"time_weight_min={cfg.centerline_time_weight_min}")
+    cl_scores, naive_scores = [], []
+    lat_off_means, lat_off_maxes = [], []
+    cap_floor = 0
+    off_route = 0
+
+    for i, p in enumerate(scene_paths):
+        data = load_npz_data(p, device)
+        traj = generate_trajectory(model, model_args, data, device)  # [T, 4]
+        ego_shape = data["ego_shape"][0] if data["ego_shape"].dim() > 1 else data["ego_shape"]
+        ego_half_w = float(ego_shape[2]) / 2
+
+        # OFFICIAL: the reward function the training sees.
+        score = compute_centerline_score_batch(
+            traj.unsqueeze(0),              # (N=1, T, 4)
+            ego_shape,                      # (3,)
+            data,
+            usage_cap=cfg.centerline_usage_cap,
+            usage_mode=cfg.centerline_usage_mode,
+            time_weight_min=cfg.centerline_time_weight_min,
+        )[0].item()
+        cl_scores.append(score)
+        # "capped" = clamped at the current cap → no gradient past this
+        if score <= -(cfg.centerline_usage_cap ** 2) * 0.999:
+            cap_floor += 1
+
+        # SIDE-CHANNEL: lat_offset_m distribution + naive score for sanity_compare.
+        aux = lat_offset_and_naive_score(traj, data, ego_half_w)
+        if aux is not None:
+            lat_off_means.append(float(aux["lat_offset_m"].mean()))
+            lat_off_maxes.append(float(aux["lat_offset_m"].max()))
+            naive_scores.append(aux["naive_score"])
+            if aux["any_off_route"]:
+                off_route += 1
+
+        if (i + 1) % 50 == 0:
+            print(f"  processed {i+1}/{len(scene_paths)}")
+
+    summary = report(args.tag, cl_scores, lat_off_means, lat_off_maxes, cap_floor, off_route)
+
+    if args.sanity_compare:
+        sanity_compare(cl_scores, naive_scores)
+
+    if args.out_json:
+        Path(args.out_json).parent.mkdir(parents=True, exist_ok=True)
+        json.dump(summary, open(args.out_json, "w"), indent=2)
+        print(f"\nSaved summary to {args.out_json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/viz_cl_recovery.py
+++ b/rlvr/autoresearch/tools/viz_cl_recovery.py
@@ -50,7 +50,8 @@ DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 
 
 def draw_scene_base(ax, npz_path):
-    """Lane centerlines (grey) + lane boundaries (blue) + road borders (black)."""
+    """Lane centerlines (grey dashed) + lane boundaries (blue) + road borders (black)
+    + route_lanes centerline (bold orange — the scene's planned path, what CL reward scores against)."""
     npz = np.load(npz_path, allow_pickle=True)
     lanes = npz["lanes"]
     for i in range(lanes.shape[0]):
@@ -63,6 +64,19 @@ def draw_scene_base(ax, npz_path):
             ax.plot(pts[:, 0] + lb[:, 0], pts[:, 1] + lb[:, 1], "-", color="#6a9ec9", lw=0.6, alpha=0.6)
             ax.plot(pts[:, 0] + rb[:, 0], pts[:, 1] + rb[:, 1], "-", color="#6a9ec9", lw=0.6, alpha=0.6)
         ax.plot(pts[:, 0], pts[:, 1], "--", color="grey", lw=0.4, alpha=0.5)
+
+    # Route_lanes: the scene's planned path — this is what `compute_centerline_score_batch` scores against
+    if "route_lanes" in npz.files:
+        rl = npz["route_lanes"]
+        for i in range(rl.shape[0]):
+            lane = rl[i]
+            if np.abs(lane[:, :2]).sum() < 1e-6:
+                continue
+            pts = lane[:, :2]
+            valid = np.linalg.norm(pts, axis=-1) > 1e-3
+            if valid.sum() >= 2:
+                ax.plot(pts[valid, 0], pts[valid, 1], "-", color="#ff7f0e", lw=2.0, alpha=0.85,
+                        label="ROUTE centerline" if i == 0 else None, zorder=8)
 
     if "line_strings" in npz.files:
         ls = npz["line_strings"]
@@ -131,8 +145,15 @@ def main():
     parser.add_argument("--usage_cap", type=float, default=1.0,
                         help="Centerline usage cap for reward ranking (>1.0 makes "
                              "past-boundary trajs more penalized).")
+    parser.add_argument("--seed", type=int, default=0,
+                        help="Set torch RNG seed for reproducible generation.")
     args = parser.parse_args()
     Path(args.output_dir).mkdir(parents=True, exist_ok=True)
+
+    torch.manual_seed(args.seed)
+    np.random.seed(args.seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(args.seed)
 
     device = torch.device(DEVICE)
     model_dir = Path(args.model_path).parent
@@ -217,11 +238,39 @@ def main():
             # Replace default-cap centerline with cap-aware one in total
             total_no_cl = r.total - rcfg.w_centerline * r.centerline
             new_total = total_no_cl + rcfg.w_centerline * cl_capped[k_i]
-            per_k.append({"k": k_i, "total": new_total, "cl": cl_capped[k_i]})
+            # Mark trajectory as valid (no gate violation) for BestCL filtering
+            valid = (
+                not r.rb_crossing
+                and not r.lane_crossing
+                and r.kinematic_gate  # True = pass
+                and (r.collision_step is None or r.collision_step < 0)
+            )
+            per_k.append({"k": k_i, "total": new_total, "cl": cl_capped[k_i], "valid": valid})
+        # Also include DET as a candidate for BestCL (not just among K generated)
+        det_traj_tensor = torch.tensor(det_traj[None], device=device, dtype=torch.float32)
+        det_cl_capped = compute_centerline_score_batch(
+            det_traj_tensor, ego_shape, data, usage_cap=args.usage_cap
+        )[0].item()
+        det_valid = (
+            not r_det.rb_crossing
+            and not r_det.lane_crossing
+            and r_det.kinematic_gate
+            and (r_det.collision_step is None or r_det.collision_step < 0)
+        )
+        per_k_with_det = per_k + [{"k": -1, "total": None, "cl": det_cl_capped,
+                                    "is_det": True, "valid": det_valid}]
         top1 = max(per_k, key=lambda x: x["total"])
-        best_cl_e = max(per_k, key=lambda x: x["cl"])
+        # BestCL: only consider valid trajectories (no gate violations)
+        valid_candidates = [p for p in per_k_with_det if p["valid"]]
+        if valid_candidates:
+            best_cl_e = max(valid_candidates, key=lambda x: x["cl"])
+            best_cl_label_prefix = ""
+        else:
+            best_cl_e = max(per_k_with_det, key=lambda x: x["cl"])
+            best_cl_label_prefix = "[NO VALID] "
         top1_traj = trajs[top1["k"]].cpu().numpy()
-        best_traj = trajs[best_cl_e["k"]].cpu().numpy()
+        best_traj = det_traj if best_cl_e.get("is_det") else trajs[best_cl_e["k"]].cpu().numpy()
+        best_cl_label = "DET" if best_cl_e.get("is_det") else slot_labels[best_cl_e["k"]][:14]
 
         # Draw
         draw_scene_base(ax, path)
@@ -231,7 +280,7 @@ def main():
                   f"Top1 k={top1['k']} {slot_labels[top1['k']][:14]} (tot={top1['total']:+.1f} cl={top1['cl']:+.2f})",
                   "#d62728", path)
         draw_traj(ax, best_traj,
-                  f"BestCL k={best_cl_e['k']} {slot_labels[best_cl_e['k']][:14]} (cl={best_cl_e['cl']:+.2f})",
+                  f"{best_cl_label_prefix}BestCL[valid] {best_cl_label} (cl={best_cl_e['cl']:+.2f})",
                   "#2ca02c", path)
 
         # Frame on trajectory area

--- a/rlvr/autoresearch/tools/viz_rb_cross_scenes.py
+++ b/rlvr/autoresearch/tools/viz_rb_cross_scenes.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Visualize the val scenes where a model's DET trajectory crosses the road border.
+
+For a given base model + LoRA checkpoint, runs deterministic inference on every
+scene in the val list, scores it with the training reward config, filters the
+scenes where `r.rb_crossing=True`, and draws the worst N (by `rb_min_dist`) on
+a grid with: lane boundaries / road borders / route centerline / GT / DET
+trajectory + ego OBB rendered at the FIRST crossing step.
+
+Usage:
+    python -m rlvr.autoresearch.tools.viz_rb_cross_scenes \
+        --model_path <base.pth> \
+        --lora_dir <run_dir>/lora_epoch_NNN \
+        --scenes <val.json> \
+        --config <grpo_config.json> \
+        --output_dir <out_dir> \
+        [--max_scenes 16] \
+        [--cols 4]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from diffusion_planner.model.diffusion_planner import Diffusion_Planner
+from diffusion_planner.utils.config import Config
+
+from guidance_gui.generate_samples import generate_samples
+from preference_optimization.lora_utils import load_lora_checkpoint
+from preference_optimization.utils import load_npz_data
+from rlvr.autoresearch.tools.reward_config_from_json import load_reward_config
+from rlvr.autoresearch.tools.viz_cl_recovery import draw_scene_base
+from rlvr.reward import _build_ego_bbox_corners, compute_reward_batch
+
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+
+
+def _draw_ego_obb(ax, xy_yaw_4, ego_shape, color="red", lw=2.0, label=None):
+    """Draw a single ego bounding box at given [x, y, cos, sin] pose."""
+    traj = torch.tensor(xy_yaw_4, dtype=torch.float32).reshape(1, 1, 4)
+    corners = _build_ego_bbox_corners(traj, ego_shape)[0, 0].cpu().numpy()
+    corners_closed = np.vstack([corners, corners[:1]])
+    ax.plot(corners_closed[:, 0], corners_closed[:, 1],
+            color=color, lw=lw, label=label, zorder=15)
+
+
+def _draw_gt(ax, path):
+    d = np.load(path, allow_pickle=True)
+    gt = d["ego_agent_future"][:, :2]
+    valid = ~((gt[:, 0] == 0) & (gt[:, 1] == 0))
+    if valid.sum() >= 2:
+        ax.plot(gt[valid, 0], gt[valid, 1], "--",
+                color="black", lw=1.2, alpha=0.6, label="GT")
+
+
+def _draw_traj(ax, traj, label, color):
+    ax.plot(traj[:, 0], traj[:, 1], "-", color=color, lw=2.0, label=label, zorder=10)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--model_path", type=Path, required=True)
+    p.add_argument("--lora_dir", type=Path, default=None)
+    p.add_argument("--scenes", type=Path, required=True)
+    p.add_argument("--config", type=Path, required=True)
+    p.add_argument("--output_dir", type=Path, required=True)
+    p.add_argument("--max_scenes", type=int, default=16,
+                   help="Plot at most N rb-cross scenes (worst by rb_min_dist first)")
+    p.add_argument("--cols", type=int, default=4)
+    p.add_argument("--seed", type=int, default=42)
+    args = p.parse_args()
+
+    torch.manual_seed(args.seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(args.seed)
+
+    device = torch.device(DEVICE)
+
+    # Load model + LoRA
+    model_dir = args.model_path.parent
+    args_json = model_dir / "args.json"
+    if not args_json.exists():
+        args_json = model_dir.parent / "args.json"
+    model_args = Config(str(args_json))
+    model = Diffusion_Planner(model_args)
+    ckpt = torch.load(args.model_path, map_location=device, weights_only=False)
+    state = ckpt.get("model", ckpt)
+    state = {k.replace("module.", ""): v for k, v in state.items()}
+    model.load_state_dict(state)
+    model.to(device).eval()
+    if args.lora_dir:
+        model = load_lora_checkpoint(model, args.lora_dir)
+        model.eval()
+
+    rcfg = load_reward_config(args.config)
+    with open(args.scenes) as f:
+        scenes = json.load(f)
+    print(f"Loaded {len(scenes)} val scenes. Scanning for rb_crossing=True...")
+
+    offenders = []  # (scene_idx, rb_min_dist, first_cross_step, det_traj, path)
+    for si, path in enumerate(scenes):
+        data = load_npz_data(path, device)
+        det_norm = {k: v.clone() if isinstance(v, torch.Tensor) else v for k, v in data.items()}
+        det_norm = model_args.observation_normalizer(det_norm)
+        det_traj = generate_samples(model, model_args, det_norm, 0.0, 1, None, device)[0]
+        det_t = torch.tensor(det_traj[None], device=device, dtype=torch.float32)
+        r = compute_reward_batch(det_t, data, rcfg)[0]
+        if r.rb_crossing:
+            # Find first crossing step — traj pose with min rb distance across t
+            # r.rb_min_dist is the scalar min across t>=1
+            offenders.append((si, float(r.rb_min_dist), det_traj, path))
+        if (si + 1) % 50 == 0:
+            print(f"  ... scanned {si+1}/{len(scenes)}, offenders so far: {len(offenders)}")
+
+    print(f"Total rb_crossing scenes: {len(offenders)}/{len(scenes)} "
+          f"({100*len(offenders)/len(scenes):.1f}%)")
+
+    # Sort by rb_min_dist ascending (worst first — min distance is most negative/zero)
+    offenders.sort(key=lambda x: x[1])
+    offenders = offenders[:args.max_scenes]
+    if not offenders:
+        print("No rb_crossing scenes found. Exiting.")
+        return
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    n = len(offenders)
+    cols = min(args.cols, n)
+    rows = (n + cols - 1) // cols
+    fig, axes = plt.subplots(rows, cols, figsize=(7 * cols, 7 * rows))
+    if rows == 1 and cols == 1: axes = np.array([[axes]])
+    elif rows == 1: axes = axes[None, :]
+    elif cols == 1: axes = axes[:, None]
+    axes_flat = axes.flatten()
+
+    # Ego shape from first scene (consistent across all scenes)
+    data0 = load_npz_data(offenders[0][3], device)
+    es = data0.get("ego_shape")
+    ego_shape = (es[0] if es is not None and es.dim() > 1 else es).cpu()
+
+    for plot_idx, (si, rb_min_d, det_traj, path) in enumerate(offenders):
+        ax = axes_flat[plot_idx]
+        # Map background
+        draw_scene_base(ax, path)
+        _draw_gt(ax, path)
+        _draw_traj(ax, det_traj, f"DET (scene {si})", "#d62728")
+        # Ego OBB at t=0 (start)
+        _draw_ego_obb(ax, [0.0, 0.0, 1.0, 0.0], ego_shape, color="blue", lw=1.5,
+                      label="ego t=0")
+        # Ego OBB at the worst step (min rb_dist) — approximate by finding step in
+        # det_traj where the ego-to-border distance is smallest. Compute per-step
+        # using compute_reward_batch once more with the single traj.
+        data = load_npz_data(path, device)
+        det_t = torch.tensor(det_traj[None], device=device, dtype=torch.float32)
+        r = compute_reward_batch(det_t, data, rcfg)[0]
+        # Use first crossing step via rb_per_ts recomputation from reward internals:
+        # We don't expose per-step easily; just use argmin over stepwise rb approximation.
+        # Use t=40 (mid) as a reasonable proxy ego OBB marker for the worst area,
+        # OR: evaluate per-step using direct call.
+        try:
+            from rlvr.reward import compute_road_border_penalty
+            gate, _, _, _, per_ts_min, _ = compute_road_border_penalty(
+                det_t, ego_shape.to(device), data,
+            )
+            worst_t = int(per_ts_min[0].argmin().item())
+        except Exception:
+            worst_t = 40
+        if 0 < worst_t < det_traj.shape[0]:
+            pose = det_traj[worst_t]  # [x, y, cos, sin]
+            _draw_ego_obb(ax, pose.tolist(), ego_shape, color="red", lw=2.2,
+                          label=f"ego t={worst_t} (worst)")
+
+        # Frame
+        pts = np.vstack([det_traj[:, :2], [[0, 0]]])
+        cx, cy = np.mean(pts[:, 0]), np.mean(pts[:, 1])
+        half = max(np.ptp(pts[:, 0]), np.ptp(pts[:, 1])) * 0.6 + 8
+        ax.set_xlim(cx - half, cx + half); ax.set_ylim(cy - half, cy + half)
+        ax.set_aspect("equal")
+        ax.legend(fontsize=6, loc="upper left")
+        ax.set_title(
+            f"scene {si}  rb_min={rb_min_d:.2f}m  worst_t={worst_t}",
+            fontsize=9,
+        )
+
+    for j in range(n, len(axes_flat)):
+        axes_flat[j].axis("off")
+
+    fig.tight_layout()
+    ckpt_tag = args.lora_dir.name if args.lora_dir else "base"
+    out = args.output_dir / f"rb_cross_{ckpt_tag}.png"
+    fig.savefig(out, dpi=110, bbox_inches="tight")
+    print(f"Saved: {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/viz_rb_cross_scenes.py
+++ b/rlvr/autoresearch/tools/viz_rb_cross_scenes.py
@@ -166,7 +166,7 @@ def main():
         # OR: evaluate per-step using direct call.
         try:
             from rlvr.reward import compute_road_border_penalty
-            gate, _, _, _, per_ts_min, _ = compute_road_border_penalty(
+            _, _, _, _, _, per_ts_min = compute_road_border_penalty(
                 det_t, ego_shape.to(device), data,
             )
             worst_t = int(per_ts_min[0].argmin().item())

--- a/rlvr/autoresearch/tools/viz_rb_cross_scenes.py
+++ b/rlvr/autoresearch/tools/viz_rb_cross_scenes.py
@@ -5,7 +5,8 @@ For a given base model + LoRA checkpoint, runs deterministic inference on every
 scene in the val list, scores it with the training reward config, filters the
 scenes where `r.rb_crossing=True`, and draws the worst N (by `rb_min_dist`) on
 a grid with: lane boundaries / road borders / route centerline / GT / DET
-trajectory + ego OBB rendered at the FIRST crossing step.
+trajectory + ego OBB rendered at the WORST (min-distance) step, computed as
+argmin of the per-timestep ego-to-border distance.
 
 Usage:
     python -m rlvr.autoresearch.tools.viz_rb_cross_scenes \
@@ -104,7 +105,7 @@ def main():
         scenes = json.load(f)
     print(f"Loaded {len(scenes)} val scenes. Scanning for rb_crossing=True...")
 
-    offenders = []  # (scene_idx, rb_min_dist, first_cross_step, det_traj, path)
+    offenders = []  # (scene_idx, rb_min_dist, det_traj, path)
     for si, path in enumerate(scenes):
         data = load_npz_data(path, device)
         det_norm = {k: v.clone() if isinstance(v, torch.Tensor) else v for k, v in data.items()}
@@ -113,8 +114,9 @@ def main():
         det_t = torch.tensor(det_traj[None], device=device, dtype=torch.float32)
         r = compute_reward_batch(det_t, data, rcfg)[0]
         if r.rb_crossing:
-            # Find first crossing step — traj pose with min rb distance across t
-            # r.rb_min_dist is the scalar min across t>=1
+            # Keep the scalar min distance (r.rb_min_dist = min across t>=1) for
+            # sorting offenders worst-first below; the exact worst-step index is
+            # recomputed later via compute_road_border_penalty when plotting.
             offenders.append((si, float(r.rb_min_dist), det_traj, path))
         if (si + 1) % 50 == 0:
             print(f"  ... scanned {si+1}/{len(scenes)}, offenders so far: {len(offenders)}")

--- a/rlvr/generation_variants.py
+++ b/rlvr/generation_variants.py
@@ -184,12 +184,11 @@ _VARIANTS: dict[str, GenerationVariant] = {
         ],
     ),
     "rl_cl_soft_sweep": GenerationVariant(
-        description="Soft route-lanes-centerline (rl_cl) sweep — all scale ≤ 3.0, "
-                    "no pure-noise slots. GUI tuning found scale=2.4 as the sweet "
-                    "spot; this variant sweeps ∈ {1.5, 2.0, 2.5, 3.0} so training "
-                    "picks the winning strength per scene via rank analytics. "
-                    "Always uses route_centerline_following (rl_cl). K=8: "
-                    "1 det + 4 det-sweep + 3 low-noise-sweep, no pure noise.",
+        description="Low-scale CL sweep (scale ∈ {1.5, 2.0, 2.5, 3.0}) with no "
+                    "pure-noise slots. K=8: 1 det + 4 det-sweep + 3 low-noise-sweep. "
+                    "Targets route_lanes centerline when the caller passes "
+                    "use_route_cl_guidance=True (otherwise these slots emit the "
+                    "legacy nearest-lane centerline_following guidance).",
         cl_spd_configs=[
             _RL_CL_1_5_SPD1_5_DET,       # rl_cl=1.5, no noise
             _RL_CL_2_0_SPD2_0_DET,       # rl_cl=2.0, no noise

--- a/rlvr/generation_variants.py
+++ b/rlvr/generation_variants.py
@@ -377,7 +377,9 @@ def clean_slot_mask(variant: str, K: int, noise_max_threshold: float = 1.0) -> l
       * pure-noise slots: NOT clean (noise dominates the signal)
       * random filler slots: NOT clean
 
-    Used by grpo_sft_trainer when `sft_target_clean_slots_only=True` in config.
+    Utility helper for callers that want to restrict ranked-SFT's winner
+    selection to slots whose winning trajectory will transfer cleanly to
+    deterministic inference. Not currently wired into any trainer.
     """
     v = get_variant(variant)
     n_cl = len(v.cl_spd_configs)

--- a/rlvr/generation_variants.py
+++ b/rlvr/generation_variants.py
@@ -59,6 +59,30 @@ _CL7_SPD7_STR14 = {"cl": 7.0, "spd": 7.0, "noise": (0.8, 2.0), "stretch": 1.4, "
 _CL20_SPD10_STR13 = {"cl": 20.0, "spd": 10.0, "noise": (0.8, 2.0), "stretch": 1.3, "label": "CL20_SPD10_str13_n0820"}
 _CL30_SPD15_STR15 = {"cl": 30.0, "spd": 15.0, "noise": (1.0, 2.5), "stretch": 1.5, "label": "CL30_SPD15_str15_n1025"}
 
+_CL12_SPD8_STR12 = {"cl": 12.0, "spd": 8.0, "noise": (0.5, 1.5), "stretch": 1.2, "label": "CL12_SPD8_str12_n0515"}
+_CL15_SPD10_STR13 = {"cl": 15.0, "spd": 10.0, "noise": (0.8, 2.0), "stretch": 1.3, "label": "CL15_SPD10_str13_n0820"}
+
+# Low-noise clean variants — SFT targets that transfer cleanly to deterministic val.
+# Same CL strengths but noise_max <= 1.0 so the winner trajectory isn't noise-contaminated.
+_CL10_SPD8_DET = {"cl": 10.0, "spd": 8.0, "noise": (0.0, 0.0), "label": "CL10_SPD8_det"}
+_CL12_SPD8_STR12_CLEAN = {"cl": 12.0, "spd": 8.0, "noise": (0.3, 0.8), "stretch": 1.2, "label": "CL12_SPD8_str12_n0308"}
+_CL15_SPD10_STR13_CLEAN = {"cl": 15.0, "spd": 10.0, "noise": (0.3, 0.8), "stretch": 1.3, "label": "CL15_SPD10_str13_n0308"}
+
+# Clean low-noise slots for route-guidance variant (cl ≤ 10, noise max ≤ 1.0).
+_CL7_SPD7_LOWNOISE = {"cl": 7.0, "spd": 7.0, "noise": (0.3, 0.8), "label": "CL7_SPD7_n0308"}
+_CL8_SPD8_LOWNOISE = {"cl": 8.0, "spd": 8.0, "noise": (0.5, 1.0), "label": "CL8_SPD8_n0510"}
+
+# Low-scale route-lanes-centerline (rl_cl) sweep slots. scale ≤ 3.0 with
+# matching spd, no stretch. Paired with use_route_cl_guidance=True to target
+# route_lanes centerline instead of the nearest-lane centerline.
+_RL_CL_1_5_SPD1_5_DET   = {"cl": 1.5, "spd": 1.5, "noise": (0.0, 0.0), "label": "RL_CL1.5_SPD1.5_det"}
+_RL_CL_2_0_SPD2_0_DET   = {"cl": 2.0, "spd": 2.0, "noise": (0.0, 0.0), "label": "RL_CL2.0_SPD2.0_det"}
+_RL_CL_2_5_SPD2_5_DET   = {"cl": 2.5, "spd": 2.5, "noise": (0.0, 0.0), "label": "RL_CL2.5_SPD2.5_det"}
+_RL_CL_3_0_SPD3_0_DET   = {"cl": 3.0, "spd": 3.0, "noise": (0.0, 0.0), "label": "RL_CL3.0_SPD3.0_det"}
+_RL_CL_2_0_SPD2_0_NOISY = {"cl": 2.0, "spd": 2.0, "noise": (0.3, 0.8), "label": "RL_CL2.0_SPD2.0_n0308"}
+_RL_CL_2_5_SPD2_5_NOISY = {"cl": 2.5, "spd": 2.5, "noise": (0.3, 0.8), "label": "RL_CL2.5_SPD2.5_n0308"}
+_RL_CL_3_0_SPD3_0_NOISY = {"cl": 3.0, "spd": 3.0, "noise": (0.3, 0.8), "label": "RL_CL3.0_SPD3.0_n0308"}
+
 # Lateral push slots
 _LATL04 = {"cl": 5.0, "spd": 5.0, "noise": (0.3, 0.8), "lat_eta":  0.4, "lat_lambda": 2.0, "lat_scale": 5.0, "label": "CL5_SPD5_latL04"}
 _LATR04 = {"cl": 5.0, "spd": 5.0, "noise": (0.3, 0.8), "lat_eta": -0.4, "lat_lambda": 2.0, "lat_scale": 5.0, "label": "CL5_SPD5_latR04"}
@@ -135,6 +159,63 @@ _VARIANTS: dict[str, GenerationVariant] = {
                     "Replaces 2 low-noise slots to keep K=16.",
         cl_spd_configs=_GUIDED_RSFT_V2 + [_CL20_SPD10_STR13, _CL30_SPD15_STR15],
         noise_configs=_NOISE_SWEEP_FULL[2:],  # drop n0103 and n0306 to keep K=16 (6+2 guided + 7 noise + det = 16)
+    ),
+    "strong_cl_stretch_v2": GenerationVariant(
+        description="rsft_v2 guided + 2 mid-strong CL+stretch slots (cl=12 / cl=15).",
+        cl_spd_configs=_GUIDED_RSFT_V2 + [_CL12_SPD8_STR12, _CL15_SPD10_STR13],
+        noise_configs=_NOISE_SWEEP_FULL[2:],
+    ),
+    "route_cl_low_noise": GenerationVariant(
+        description="Route-centerline guidance (uses route_lanes matching reward) + "
+                    "ALL slots have noise_max <= 1.0 + cl values capped at 10. "
+                    "Requires use_route_cl_guidance=True in config to swap "
+                    "centerline_following → route_centerline_following. K=8: "
+                    "1 det + 6 route-guided + 1 noise-only-low-noise.",
+        cl_spd_configs=[
+            _CL5_SPD5_DET,           # cl=5, no noise
+            _CL5_SPD5_NOISY,         # cl=5, noise (0.3, 0.8)
+            _CL7_SPD7_LOWNOISE,      # cl=7, noise (0.3, 0.8)
+            _CL8_SPD8_LOWNOISE,      # cl=8, noise (0.5, 1.0)
+            _CL10_SPD8_DET,          # cl=10, no noise
+            _CL10_SPD10_NOISY,       # cl=10, noise (0.5, 1.0)
+        ],
+        noise_configs=[
+            {"noise": (0.5, 1.0), "label": "noise_n0510"},  # only low-noise exploration slot
+        ],
+    ),
+    "rl_cl_soft_sweep": GenerationVariant(
+        description="Soft route-lanes-centerline (rl_cl) sweep — all scale ≤ 3.0, "
+                    "no pure-noise slots. GUI tuning found scale=2.4 as the sweet "
+                    "spot; this variant sweeps ∈ {1.5, 2.0, 2.5, 3.0} so training "
+                    "picks the winning strength per scene via rank analytics. "
+                    "Always uses route_centerline_following (rl_cl). K=8: "
+                    "1 det + 4 det-sweep + 3 low-noise-sweep, no pure noise.",
+        cl_spd_configs=[
+            _RL_CL_1_5_SPD1_5_DET,       # rl_cl=1.5, no noise
+            _RL_CL_2_0_SPD2_0_DET,       # rl_cl=2.0, no noise
+            _RL_CL_2_5_SPD2_5_DET,       # rl_cl=2.5, no noise
+            _RL_CL_3_0_SPD3_0_DET,       # rl_cl=3.0, no noise
+            _RL_CL_2_0_SPD2_0_NOISY,     # rl_cl=2.0, noise (0.3, 0.8)
+            _RL_CL_2_5_SPD2_5_NOISY,     # rl_cl=2.5, noise (0.3, 0.8)
+            _RL_CL_3_0_SPD3_0_NOISY,     # rl_cl=3.0, noise (0.3, 0.8)
+        ],
+        noise_configs=[],
+    ),
+    "clean_cl_only": GenerationVariant(
+        description="Only clean CL-guided slots — no pure-noise, no high-noise variants. "
+                    "All cl_spd slots have noise_max <= 1.0 so SFT-to-winner produces "
+                    "trajectories that transfer cleanly to deterministic val. "
+                    "K = 1 det + 7 clean guided = 8. CL range 5-15.",
+        cl_spd_configs=[
+            _CL5_SPD5_DET,              # cl=5, noise=(0,0)          — pure CL det
+            _CL5_SPD5_NOISY,            # cl=5, noise=(0.3,0.8)      — low noise
+            _CL10_SPD8_DET,             # cl=10, noise=(0,0)          — mid CL det
+            _CL10_SPD10_NOISY,          # cl=10, noise=(0.5,1.0)      — mid CL low-noise
+            _CL6_SPD6_STR11,            # cl=6, stretch=1.1, noise=(0.5,1.5)  <-- kept at 1.5 max (borderline)
+            _CL12_SPD8_STR12_CLEAN,     # cl=12, stretch=1.2, noise=(0.3,0.8)
+            _CL15_SPD10_STR13_CLEAN,    # cl=15, stretch=1.3, noise=(0.3,0.8)
+        ],
+        noise_configs=[],
     ),
 
     # ====== Original baseline (pre-rsft_v2 system) ======
@@ -266,6 +347,7 @@ _VARIANTS: dict[str, GenerationVariant] = {
 _ALIASES: dict[str, str] = {
     "noise_swap_2_no_lat": "rsft_v2_legacy",  # original name during exploration
     "rsft_v2_all_noise": "rsft_v2",            # equivalent to current default
+    "route_cl_soft_sweep": "rl_cl_soft_sweep", # renamed 2026-04-24 → rl_cl naming
 }
 
 
@@ -283,3 +365,33 @@ def get_variant(name: str) -> GenerationVariant:
 def list_variants() -> list[str]:
     """Return canonical variant names (excludes aliases)."""
     return sorted(_VARIANTS.keys())
+
+
+def clean_slot_mask(variant: str, K: int, noise_max_threshold: float = 1.0) -> list[bool]:
+    """Return a K-length bool mask of slots suitable as clean SFT targets.
+
+    A slot is "clean" when it carries useful CL signal without heavy noise
+    contamination — so that MSE SFT against the winner trajectory actually
+    transfers to a deterministic val-time output. Criteria:
+      * slot 0 (det_pure): always clean
+      * cl_spd slots with cl>0 AND noise_max <= threshold: clean
+      * pure-noise slots: NOT clean (noise dominates the signal)
+      * random filler slots: NOT clean
+
+    Used by grpo_sft_trainer when `sft_target_clean_slots_only=True` in config.
+    """
+    v = get_variant(variant)
+    n_cl = len(v.cl_spd_configs)
+    n_noise = len(v.noise_configs)
+    mask = [False] * K
+    mask[0] = True  # det_pure is always clean
+    for i, c in enumerate(v.cl_spd_configs, start=1):
+        if i >= K:
+            break
+        noise = c.get("noise", (0.0, 0.0))
+        noise_max = float(noise[1]) if len(noise) >= 2 else 0.0
+        cl_val = float(c.get("cl", 0.0))
+        if cl_val > 0 and noise_max <= noise_max_threshold:
+            mask[i] = True
+    # cl_spd_configs slice ends at 1+n_cl; noise slots and randoms are NOT clean
+    return mask

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -104,6 +104,16 @@ class GRPOConfig:
     #   "body" (default): lane_usage = (|baselink_lat| + ego_half_w) / side_hw
     #   "baselink": lane_usage = |baselink_lat| / side_hw (ignores ego width)
     centerline_usage_mode: str = "body"
+    # Centerline time-weight floor (passed to RewardConfig). Per-step penalty is
+    # averaged with linspace(1.0, centerline_time_weight_min, T). Default 0.3 matches
+    # historical behavior; 1.0 = flat uniform average. Raise when late-curve lane
+    # following matters as much as early and the decay is compressing the signal.
+    centerline_time_weight_min: float = 0.3
+    # Use `route_centerline_following` guidance (reads `route_lanes`) instead of
+    # `centerline_following` (reads all `lanes`). Aligns generation-time pull
+    # with the reward function — both score against route_lanes. Default False
+    # preserves old behavior.
+    use_route_cl_guidance: bool = False
 
     # Reward tuning (passed to RewardConfig for training)
     # Road border penalty scales and thresholds
@@ -152,7 +162,7 @@ class GRPOConfig:
     stopped_penalty: float = 5.0
     underprogress_penalty: float = 0.0  # penalize model driving << reference (0=disabled)
     underprogress_threshold: float = 0.5  # penalize if model_path/reference < threshold
-    underprogress_reference: str = "det"  # "det" = deterministic (adaptive); "baseline" = frozen LoRA-less baseline
+    underprogress_reference: str = "baseline"  # "baseline" = frozen LoRA-less baseline (default; anchors threshold); "det" = deterministic (adaptive, moves with training — can miss collapse)
     progress_norm_scale: float = 20.0  # max progress points at 100% GT match
 
     # Reward aggregation mode (passed to RewardConfig):

--- a/rlvr/grpo_sft_trainer.py
+++ b/rlvr/grpo_sft_trainer.py
@@ -599,6 +599,7 @@ def train_epoch_ranked_sft(
                 lateral_scale=lat_scale,
                 speed_stretch=spd_stretch,
                 generation_variant=getattr(config, "generation_variant", "default"),
+                use_route_cl_guidance=getattr(config, "use_route_cl_guidance", False),
             )  # [N, K, T, 4]
 
     torch.cuda.empty_cache()

--- a/rlvr/grpo_trainer.py
+++ b/rlvr/grpo_trainer.py
@@ -799,7 +799,14 @@ class GRPOTrainer:
         )
 
     def save_epoch1_baselines(self, npz_paths: list[str]) -> None:
-        """Save deterministic trajectories as epoch-1 reference for drift tracking."""
+        """Save deterministic trajectories as epoch-1 reference for drift tracking.
+
+        Saves ALL scenes — downstream consumers include
+        `underprogress_reference="baseline"` path-length lookup
+        (rlvr/grpo_sft_trainer.py), which needs every training scene to have
+        an anchor; subsampling causes unfixed scenes to fall back to the "det"
+        reference and mask path-collapse behavior.
+        """
         baseline_path = self.run_dir / "epoch1_baselines.npz"
         if baseline_path.exists():
             return
@@ -808,7 +815,7 @@ class GRPOTrainer:
         paths_list: list[str] = []
         trajs_list: list[np.ndarray] = []
 
-        for npz_path in npz_paths[:100]:
+        for npz_path in npz_paths:
             try:
                 obs = load_npz_data(npz_path, self.device)
                 traj = generate_deterministic_trajectory(

--- a/rlvr/grpo_trainer_batched.py
+++ b/rlvr/grpo_trainer_batched.py
@@ -105,6 +105,7 @@ def generate_all_scenes_batched(
     lateral_scale: float = 5.0,
     speed_stretch: float = 1.0,
     generation_variant: str = "default",
+    use_route_cl_guidance: bool = False,
 ) -> torch.Tensor:
     """Generate K trajectories for all N scenes in ~5 chunked-batched passes.
 
@@ -179,7 +180,8 @@ def generate_all_scenes_batched(
         # Build guidance functions
         fns = []
         if cl_scale > 0:
-            fns.append(GuidanceConfig("centerline_following", enabled=True, scale=cl_scale))
+            cl_name = "route_centerline_following" if use_route_cl_guidance else "centerline_following"
+            fns.append(GuidanceConfig(cl_name, enabled=True, scale=cl_scale))
         if spd_scale > 0:
             fns.append(GuidanceConfig("speed", enabled=True, scale=spd_scale, params=spd_params))
         if use_lon and is_guided_slot:
@@ -223,7 +225,8 @@ def generate_all_scenes_batched(
     for n_pass in n_per_pass:
         fns = []
         if random.random() < 0.7:
-            fns.append(GuidanceConfig("centerline_following", enabled=True,
+            cl_name = "route_centerline_following" if use_route_cl_guidance else "centerline_following"
+            fns.append(GuidanceConfig(cl_name, enabled=True,
                                        scale=random.uniform(2.0, 8.0)))
         # Skip road_border guidance in generation (causes OOM with large batches)
         # Road border avoidance is handled by the reward function instead

--- a/rlvr/grpo_trainer_batched.py
+++ b/rlvr/grpo_trainer_batched.py
@@ -349,6 +349,8 @@ def train_epoch_batched(
             lateral_lambda=lat_lambda,
             lateral_scale=lat_scale,
             speed_stretch=spd_stretch,
+            generation_variant=config.generation_variant,
+            use_route_cl_guidance=getattr(config, "use_route_cl_guidance", False),
         )  # [N, K, T, 4]
 
     # Free generation memory before scoring + training

--- a/rlvr/reward.py
+++ b/rlvr/reward.py
@@ -2944,6 +2944,12 @@ def compute_reward_batch(
         + config.sc_cont_scale * sc_cont_pen
     )
 
+    # Penalty magnitude preserves legacy behavior for configs with w_progress >= 1
+    # (historical default range: w_progress ∈ {2.0, 7.0}), where the old code
+    # effectively multiplied the penalty by w_progress via the clamped_progress
+    # sum. For w_progress < 1 we floor at 1.0 so penalties still fire on
+    # CL-only / reward-sculpted configs (w_progress=0 was the original bug).
+    penalty_mult = max(float(config.w_progress), 1.0)
     quality_score = (
         config.w_progress * clamped_progress
         + config.w_safety * safety_scores
@@ -2953,7 +2959,7 @@ def compute_reward_batch(
         - rb_penalty
         - lane_penalty
         - sc_penalty
-        - progress_penalty
+        - penalty_mult * progress_penalty
     )
 
     _OFFROAD_FLOOR = -50.0

--- a/rlvr/reward.py
+++ b/rlvr/reward.py
@@ -39,6 +39,13 @@ class RewardConfig:
     #       Use when you want the reward to track centering distance directly
     #       rather than body-to-edge clearance.
     centerline_usage_mode: str = "body"
+    # Centerline time-weight floor. The per-step centerline penalty is averaged
+    # with weights torch.linspace(1.0, centerline_time_weight_min, T). The default
+    # 0.3 matches the historical behavior (late timesteps count 30% of early).
+    # Set to 1.0 for a flat (uniform) time-average — recommended when late-curve
+    # lane-following matters as much as early, and the training signal is being
+    # compressed by the decay.
+    centerline_time_weight_min: float = 0.3
     collision_penalty: float = -10.0
     red_light_penalty: float = -10.0
     max_accel: float = 8.0  # m/s^2
@@ -110,12 +117,13 @@ class RewardConfig:
     underprogress_penalty: float = 0.0   # scale (0=disabled). Penalty = scale * max(0, threshold - ratio)
     underprogress_threshold: float = 0.5  # fire when ratio < threshold
     # Reference for underprogress:
-    #   "det"      — deterministic traj (traj[0]) path length. Adaptive but can
-    #                collapse when model output itself collapses.
-    #   "baseline" — frozen LoRA-less baseline det path, passed via
+    #   "baseline" — (default) frozen LoRA-less baseline det path, passed via
     #                data["baseline_path_len"]. Anchors ratio regardless of
-    #                training drift.
-    underprogress_reference: str = "det"
+    #                training drift — recommended.
+    #   "det"      — deterministic traj (traj[0]) path length. Adaptive but can
+    #                collapse when model output itself collapses (path shrinks
+    #                while threshold follows it → penalty never fires).
+    underprogress_reference: str = "baseline"
 
     # Progress normalization scale: when enable_overprogress=True, progress is
     # normalized to [0, 1] as fraction of GT, then multiplied by this scale.
@@ -958,6 +966,7 @@ def compute_centerline_score_batch(
     data: dict[str, torch.Tensor],
     usage_cap: float = 1.0,
     usage_mode: str = "body",
+    time_weight_min: float = 0.3,
 ) -> torch.Tensor:
     """Batched normalized lane-usage penalty from nearest route lane centerline.
 
@@ -1077,8 +1086,9 @@ def compute_centerline_score_batch(
         ),
     )  # (N, T)
 
-    # Time-weighted mean: early deviations penalized more
-    time_weights = torch.linspace(1.0, 0.3, T, device=device).unsqueeze(0)
+    # Time-weighted mean: early deviations penalized more by default (min=0.3).
+    # Raise time_weight_min to 1.0 for flat uniform averaging.
+    time_weights = torch.linspace(1.0, time_weight_min, T, device=device).unsqueeze(0)
     penalty = per_step_penalty * time_weights
     return -(penalty.sum(dim=-1) / time_weights.sum())  # (N,)
 
@@ -2749,6 +2759,7 @@ def compute_reward_batch(
         ego_trajs, ego_shape, data,
         usage_cap=config.centerline_usage_cap,
         usage_mode=config.centerline_usage_mode,
+        time_weight_min=config.centerline_time_weight_min,
     )
     red_light_scores = compute_red_light_score_batch(ego_trajs, data, config)
     ttc_scores = compute_ttc_score_batch(
@@ -2841,6 +2852,12 @@ def compute_reward_batch(
     # Safety score includes proximity penalty to NPCs (closer = more negative).
     clamped_progress = progress_scores.clamp(min=0)
 
+    # Progress-related penalties (overprogress, stopped, underprogress) are floors,
+    # not progress rewards — they must apply even when w_progress=0. Accumulate
+    # them into `progress_penalty` and subtract from quality_score directly,
+    # bypassing the w_progress multiplier.
+    progress_penalty = torch.zeros(N, device=device)
+
     # Normalize progress as percentage of GT path length, then apply
     # overprogress/underprogress/stopped penalties.
     # This ensures a 10m path on a 12m GT scene and a 10m path on a 22m GT scene
@@ -2870,13 +2887,13 @@ def compute_reward_batch(
             # Configs must use ratio-scale penalties (e.g. 100.0), not meter-scale (e.g. 0.3).
             # E.g., margin=1.0, penalty=100: at 1.5x GT → 100*(1.5-1.0)=50 penalty.
             overprogress = torch.relu(path_ratio - config.overprogress_margin)
-            clamped_progress = clamped_progress - config.overprogress_penalty * overprogress
+            progress_penalty = progress_penalty + config.overprogress_penalty * overprogress
 
             # Stopped penalty: if GT drives (>5m) but model barely moves (<1m),
             # apply extra negative progress to discourage stopping.
             if gt_path_len > 5.0:
                 is_stopped = (model_path_lens < 1.0).float()
-                clamped_progress = clamped_progress - config.stopped_penalty * is_stopped
+                progress_penalty = progress_penalty + config.stopped_penalty * is_stopped
 
             # Underprogress: penalize trajectories shorter than deterministic traj.
             # Reference = deterministic trajectory (traj[0]) path length, NOT GT.
@@ -2908,7 +2925,7 @@ def compute_reward_batch(
                     ref_path_len = model_path_lens[0].clamp(min=1e-3)
                 ratio = model_path_lens / ref_path_len
                 underprogress = torch.relu(config.underprogress_threshold - ratio.clamp(max=1.0))
-                clamped_progress = clamped_progress - config.underprogress_penalty * underprogress
+                progress_penalty = progress_penalty + config.underprogress_penalty * underprogress
 
     # TTC as quality bonus
     ttc_bonus = config.w_safety * (ttc_scores - 0.5) * 2
@@ -2936,6 +2953,7 @@ def compute_reward_batch(
         - rb_penalty
         - lane_penalty
         - sc_penalty
+        - progress_penalty
     )
 
     _OFFROAD_FLOOR = -50.0

--- a/rlvr/test_progress_penalty_bugfix.py
+++ b/rlvr/test_progress_penalty_bugfix.py
@@ -140,7 +140,8 @@ def test_penalties_still_apply_with_nonzero_w_progress():
     totals_one = _totals(cfg_one, trajs, data)
 
     # w_progress=1 adds positive progress (progress_frac*20=20 for det, 0.5*20=10 for short)
-    # so absolute totals shift up; but the relative gap from underprogress is identical.
+    # so absolute totals shift up; but the relative gap from underprogress is identical
+    # (both at the floor penalty_mult = max(w_progress, 1.0) = 1.0).
     gap_zero = totals_zero[1] - totals_zero[0]
     gap_one = totals_one[1] - totals_one[0]
 
@@ -148,6 +149,43 @@ def test_penalties_still_apply_with_nonzero_w_progress():
     assert gap_one == pytest.approx(gap_zero - 10.0, abs=0.5), (
         f"relative underprogress magnitude changed with w_progress. "
         f"gap_zero={gap_zero}, gap_one={gap_one}"
+    )
+
+
+def test_penalty_magnitude_scales_with_w_progress_above_one():
+    """With w_progress=2 the underprogress penalty should fire at 2x magnitude
+    (matching legacy behavior where penalties lived inside the w_progress sum).
+    With w_progress=7 it should fire at 7x. This guards the penalty_mult floor
+    that preserves backward compat for configs with w_progress in {2, 7}."""
+    trajs, data = _make_scene([60.0, 30.0], gt_len=60.0)
+    cfg_base = _cfg_cl_only(w_progress=1.0)
+    cfg_2 = _cfg_cl_only(w_progress=2.0)
+    cfg_7 = _cfg_cl_only(w_progress=7.0)
+
+    totals_1 = _totals(cfg_base, trajs, data)
+    totals_2 = _totals(cfg_2, trajs, data)
+    totals_7 = _totals(cfg_7, trajs, data)
+
+    # Underprogress: ratio = 30/60 = 0.5, thresh 0.85 → underprogress = 0.35.
+    # penalty_at_w1 = 50 * 0.35 = 17.5 on traj[1].
+    # penalty_at_w2 = 2 * 17.5 = 35.0 on traj[1] → extra 17.5 swing vs w=1.
+    # Positive progress contribution also scales: det gets 1*20→2*20 (+20),
+    # short gets 1*10→2*10 (+10), so gap-from-progress changes by -10.
+    # Net gap change (w=2 vs w=1): -17.5 (penalty) + -10 (progress) = -27.5.
+    gap_1 = totals_1[1] - totals_1[0]
+    gap_2 = totals_2[1] - totals_2[0]
+    gap_7 = totals_7[1] - totals_7[0]
+
+    # At w=2: expect gap shift of −27.5 vs w=1.
+    assert (gap_2 - gap_1) == pytest.approx(-27.5, abs=1.0), (
+        f"penalty did not scale to 2x at w_progress=2. "
+        f"gap_1={gap_1:.2f} gap_2={gap_2:.2f} delta={gap_2 - gap_1:.2f} (expected -27.5)"
+    )
+    # At w=7: penalty 7*17.5=122.5 (extra 105 vs w=1), progress 7*(10)=70 (extra 60 vs w=1).
+    # Net gap shift: -105 + -60 = -165.
+    assert (gap_7 - gap_1) == pytest.approx(-165.0, abs=2.0), (
+        f"penalty did not scale to 7x at w_progress=7. "
+        f"gap_1={gap_1:.2f} gap_7={gap_7:.2f} delta={gap_7 - gap_1:.2f} (expected -165)"
     )
 
 

--- a/rlvr/test_progress_penalty_bugfix.py
+++ b/rlvr/test_progress_penalty_bugfix.py
@@ -1,0 +1,181 @@
+"""Smoke test: underprogress / overprogress / stopped penalties must fire
+regardless of w_progress.
+
+Regression for the 2026-04-24 path-collapse bug: these penalties were
+accumulated into `clamped_progress`, which got multiplied by `w_progress`
+in `quality_score`. When `w_progress=0` (CL-only configs), the penalties
+silently evaporated and path collapsed unchecked.
+"""
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from rlvr.reward import (
+    RewardConfig,
+    compute_reward_batch,
+)
+
+
+def _make_scene(
+    path_lens: list[float],
+    gt_len: float = 60.0,
+    T: int = 80,
+    dt: float = 0.1,
+) -> tuple[torch.Tensor, dict]:
+    """Build N straight-line ego trajectories of given path lengths + GT.
+
+    Each traj is a straight line along +x starting from origin, yaw=0.
+    No neighbors, no lanes (no-op for this test).
+    """
+    N = len(path_lens)
+    trajs = torch.zeros(N, T, 4)
+    for i, L in enumerate(path_lens):
+        v = L / ((T - 1) * dt)  # constant speed to cover L over T-1 steps
+        xs = torch.arange(T, dtype=torch.float32) * v * dt
+        trajs[i, :, 0] = xs
+        trajs[i, :, 2] = 1.0  # cos(0) = 1, yaw = 0
+
+    # GT: straight line of length gt_len along +x, T=80 points
+    gt_future = torch.zeros(T, 3)
+    v_gt = gt_len / ((T - 1) * dt)
+    gt_future[:, 0] = torch.arange(T, dtype=torch.float32) * v_gt * dt
+
+    data = {
+        "ego_agent_future": gt_future.unsqueeze(0),  # (1, T, 3)
+        "ego_shape": torch.tensor([[2.79, 4.34, 1.70]]),
+    }
+    return trajs, data
+
+
+def _cfg_cl_only(**overrides) -> RewardConfig:
+    """CL-only config mirroring the RUN J-v2 setup."""
+    base = dict(
+        w_progress=0.0,
+        w_safety=0.0,
+        w_smooth=0.0,
+        w_centerline=0.0,
+        progress_norm_scale=20.0,
+        # gates off so survival floor is the only other moving piece
+        rb_gate_enabled=False,
+        lane_gate_enabled=False,
+        enable_lane_departure=False,
+        static_collision_enabled=False,
+        reward_mode="direct",  # skip survival so totals = quality_score
+        # penalty settings under test
+        enable_overprogress=True,
+        underprogress_penalty=50.0,
+        underprogress_threshold=0.85,
+        underprogress_reference="det",
+        overprogress_penalty=30.0,
+        overprogress_margin=1.1,
+        stopped_penalty=100.0,
+    )
+    base.update(overrides)
+    return RewardConfig(**base)
+
+
+def _totals(cfg, trajs, data):
+    return [float(r.total) for r in compute_reward_batch(trajs, data, cfg)]
+
+
+def test_underprogress_fires_with_w_progress_zero():
+    """Core regression: w_progress=0, short traj must score worse than long traj."""
+    # det = 60m (matches GT), test traj = 30m (half, < 0.85*60=51)
+    trajs, data = _make_scene([60.0, 30.0], gt_len=60.0)
+    cfg = _cfg_cl_only()
+    totals = _totals(cfg, trajs, data)
+
+    # Short traj underprogress = relu(0.85 - 30/60) = 0.35 → penalty = 50*0.35 = 17.5
+    # Det traj underprogress = relu(0.85 - 1.0) = 0 → no penalty
+    # Expected gap: totals[1] - totals[0] ≈ -17.5
+    gap = totals[1] - totals[0]
+    assert gap == pytest.approx(-17.5, abs=0.5), (
+        f"underprogress did not fire with w_progress=0. "
+        f"totals={totals}, gap={gap}, expected ~-17.5"
+    )
+
+
+def test_stopped_fires_with_w_progress_zero():
+    """Stopped traj (<1m) when GT moves (>5m) must trigger stopped_penalty=100."""
+    trajs, data = _make_scene([60.0, 0.5], gt_len=60.0)  # 2nd is stopped
+    cfg = _cfg_cl_only(underprogress_penalty=0.0)  # isolate stopped penalty
+    totals = _totals(cfg, trajs, data)
+
+    # stopped_penalty=100 hit exactly once for traj[1]
+    gap = totals[1] - totals[0]
+    assert gap == pytest.approx(-100.0, abs=1.0), (
+        f"stopped penalty did not fire with w_progress=0. "
+        f"totals={totals}, gap={gap}, expected ~-100"
+    )
+
+
+def test_overprogress_fires_with_w_progress_zero():
+    """Overprogress (path > margin*GT) must trigger penalty regardless of w_progress."""
+    # GT≈60m (t=0 filtered by gt_valid → effective ~59.24m), margin=1.1.
+    # Traj 1 = 80m → overprogress ≈ relu(80/59.24 - 1.1) ≈ 0.250 → penalty ≈ 7.5.
+    # Traj 0 = 60m → overprogress = relu(60/59.24 - 1.1) = 0 → no penalty.
+    # Main assertion: gap is meaningfully negative and in the expected ballpark.
+    trajs, data = _make_scene([60.0, 80.0], gt_len=60.0)
+    cfg = _cfg_cl_only(underprogress_penalty=0.0)  # isolate overprogress
+    totals = _totals(cfg, trajs, data)
+
+    gap = totals[1] - totals[0]
+    # Accept ~7.0 (using nominal GT=60) through ~7.6 (using effective GT=59.24).
+    assert -8.5 < gap < -6.0, (
+        f"overprogress did not fire with w_progress=0. "
+        f"totals={totals}, gap={gap}, expected -8.5 < gap < -6.0"
+    )
+
+
+def test_penalties_still_apply_with_nonzero_w_progress():
+    """Sanity: the refactor must not break the w_progress>0 case."""
+    trajs, data = _make_scene([60.0, 30.0], gt_len=60.0)
+    cfg_zero = _cfg_cl_only(w_progress=0.0)
+    cfg_one = _cfg_cl_only(w_progress=1.0)
+
+    totals_zero = _totals(cfg_zero, trajs, data)
+    totals_one = _totals(cfg_one, trajs, data)
+
+    # w_progress=1 adds positive progress (progress_frac*20=20 for det, 0.5*20=10 for short)
+    # so absolute totals shift up; but the relative gap from underprogress is identical.
+    gap_zero = totals_zero[1] - totals_zero[0]
+    gap_one = totals_one[1] - totals_one[0]
+
+    # gap_one = gap_zero + (10 - 20) = gap_zero - 10 (short has less positive progress)
+    assert gap_one == pytest.approx(gap_zero - 10.0, abs=0.5), (
+        f"relative underprogress magnitude changed with w_progress. "
+        f"gap_zero={gap_zero}, gap_one={gap_one}"
+    )
+
+
+def test_underprogress_uses_baseline_ref_when_configured():
+    """underprogress_reference='baseline' reads data['baseline_path_len']."""
+    # det=30m (short!), test=30m, but baseline_path_len=60m frozen anchor.
+    # With det reference: ratio=30/30=1.0 → no penalty. Both trajs score identical.
+    # With baseline reference: ratio=30/60=0.5 → penalty fires on BOTH (including det).
+    trajs, data = _make_scene([30.0, 30.0], gt_len=60.0)
+    data["baseline_path_len"] = torch.tensor(60.0)
+
+    cfg_det = _cfg_cl_only(underprogress_reference="det")
+    cfg_base = _cfg_cl_only(underprogress_reference="baseline")
+
+    totals_det = _totals(cfg_det, trajs, data)
+    totals_base = _totals(cfg_base, trajs, data)
+
+    # det reference: neither traj penalized (det is traj[0], ratio=1.0)
+    # baseline reference: both penalized by 50*(0.85-0.5) = 17.5
+    assert totals_det[0] == pytest.approx(totals_det[1], abs=0.1), (
+        f"det ref: trajs should be equal, got {totals_det}"
+    )
+    # baseline shift: totals_base should be ~17.5 lower than totals_det for BOTH trajs
+    shift_0 = totals_det[0] - totals_base[0]
+    shift_1 = totals_det[1] - totals_base[1]
+    assert shift_0 == pytest.approx(17.5, abs=0.5), f"traj[0] shift: {shift_0}"
+    assert shift_1 == pytest.approx(17.5, abs=0.5), f"traj[1] shift: {shift_1}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/rlvr/test_progress_penalty_bugfix.py
+++ b/rlvr/test_progress_penalty_bugfix.py
@@ -63,7 +63,9 @@ def _cfg_cl_only(**overrides) -> RewardConfig:
         lane_gate_enabled=False,
         enable_lane_departure=False,
         static_collision_enabled=False,
-        reward_mode="direct",  # skip survival so totals = quality_score
+        # reward_mode: stick to default "gate" branch (collision_gate + red_light_gate
+        # both pass with neutral data → totals = quality_score, same as survival w/o
+        # failures). Avoids relying on any unsupported mode value.
         # penalty settings under test
         enable_overprogress=True,
         underprogress_penalty=50.0,

--- a/rlvr/test_reward_gates.py
+++ b/rlvr/test_reward_gates.py
@@ -215,8 +215,8 @@ def test_reward_config_no_dead_fields():
 
 def test_reward_config_baseline_reference_default():
     cfg = RewardConfig()
-    # Default reference is adaptive "det"; "baseline" is opt-in.
-    assert cfg.underprogress_reference == "det"
+    # Default reference is "baseline" (frozen anchor, doesn't collapse with training).
+    assert cfg.underprogress_reference == "baseline"
 
 
 # ---------------------------------------------------------------------------

--- a/rlvr/trajectory_ranker_gui.py
+++ b/rlvr/trajectory_ranker_gui.py
@@ -30,7 +30,7 @@ import json
 import random
 import subprocess
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields as dc_fields, replace as dc_replace
 from pathlib import Path
 
 import gradio as gr
@@ -66,6 +66,7 @@ _GENERATE_SCRIPT = Path(__file__).parent.parent / "guidance_gui" / "scripts" / "
 
 ALL_GUIDANCE_NAMES = [
     "centerline_following",
+    "route_centerline_following",
     "speed",
     "lane_keeping",
     "road_border",
@@ -76,9 +77,13 @@ ALL_GUIDANCE_NAMES = [
     "longitudinal",
 ]
 
-# Short display names for labels
+# Short display names for labels.
+# Note: `rl_cl` = route_lanes centerline (our curve-training default).
+#       `cl` = nearest-lane centerline (legacy, kept for back-compat).
+#       `rb` = road_border guidance (distinct from rl_cl — borders vs centerline).
 _SHORT_NAMES = {
     "centerline_following": "cl",
+    "route_centerline_following": "rl_cl",
     "speed": "spd",
     "lane_keeping": "lk",
     "road_border": "rb",
@@ -304,6 +309,10 @@ class TrajectoryRanker:
         self.saved_scenes: list[dict] = []
 
         self.reward_config = RewardConfig()
+        # Base template preserved so _apply_reward_config can override only the
+        # slider-controlled fields without resetting penalty / threshold settings
+        # that the training config carries.
+        self.reward_config_base = RewardConfig()
         self.accepted_groups: list[dict] = []
 
     def _compute_gt_speed_bounds(self) -> None:
@@ -424,6 +433,34 @@ class TrajectoryRanker:
 
         data_cpu = {k: v.cpu() for k, v in self.current_data.items()}
         visualize_inputs(data_cpu, save_path=None, ax=ax, view_ranges=[120])
+
+        # Overlay route_lanes centerline in bold orange — this is what
+        # compute_centerline_score_batch scores against when route_lanes exist,
+        # and what route_centerline_following guidance pulls toward. Drawn on
+        # top of visualize_inputs which only shows nearest-lane centerlines.
+        if "route_lanes" in data_cpu:
+            rl = data_cpu["route_lanes"]
+            if hasattr(rl, "numpy"):
+                rl = rl.numpy()
+            rl = np.asarray(rl)
+            if rl.ndim == 4:
+                rl = rl[0]
+            route_label_done = False
+            for i in range(rl.shape[0]):
+                lane = rl[i]
+                if np.abs(lane[:, :2]).sum() < 1e-6:
+                    continue
+                pts = lane[:, :2]
+                valid = np.linalg.norm(pts, axis=-1) > 1e-3
+                if valid.sum() < 2:
+                    continue
+                ax.plot(
+                    pts[valid, 0], pts[valid, 1],
+                    "-", color="#ff7f0e", lw=2.2, alpha=0.9,
+                    label="ROUTE centerline" if not route_label_done else None,
+                    zorder=8,
+                )
+                route_label_done = True
 
         if not self.sampled_trajectories:
             return fig
@@ -811,15 +848,26 @@ def build_interface(
                     label="Jump to index", value=0, minimum=0, precision=0,
                 )
                 n_traj_sl = gr.Slider(
-                    4, 32, value=ranker.n_trajectories, step=1, label="N trajectories",
+                    1, 32, value=ranker.n_trajectories, step=1, label="N trajectories",
                 )
 
+                _rc0 = ranker.reward_config_base  # initial defaults from loaded config (or RewardConfig())
                 gr.Markdown("### Reward Weights")
-                w_safety = gr.Slider(0.0, 20.0, value=5.0, step=0.5, label="w_safety")
-                w_progress = gr.Slider(0.0, 10.0, value=2.0, step=0.1, label="w_progress")
-                w_smooth = gr.Slider(0.0, 10.0, value=0.5, step=0.1, label="w_smooth")
-                w_feasibility = gr.Slider(0.0, 10.0, value=5.0, step=0.1, label="w_feasibility")
-                w_centerline = gr.Slider(0.0, 10.0, value=5.0, step=0.1, label="w_centerline")
+                w_safety = gr.Slider(0.0, 20.0, value=_rc0.w_safety, step=0.5, label="w_safety")
+                w_progress = gr.Slider(0.0, 10.0, value=_rc0.w_progress, step=0.1, label="w_progress")
+                w_smooth = gr.Slider(0.0, 10.0, value=_rc0.w_smooth, step=0.1, label="w_smooth")
+                w_feasibility = gr.Slider(0.0, 10.0, value=_rc0.w_feasibility, step=0.1, label="w_feasibility")
+                w_centerline = gr.Slider(0.0, 15.0, value=_rc0.w_centerline, step=0.1, label="w_centerline")
+
+                with gr.Accordion("Reward Penalties & Options", open=False):
+                    up_pen_sl = gr.Slider(0.0, 200.0, value=_rc0.underprogress_penalty, step=1.0, label="underprogress_penalty")
+                    up_thr_sl = gr.Slider(0.0, 1.0, value=_rc0.underprogress_threshold, step=0.05, label="underprogress_threshold")
+                    op_pen_sl = gr.Slider(0.0, 200.0, value=_rc0.overprogress_penalty, step=1.0, label="overprogress_penalty")
+                    op_mar_sl = gr.Slider(1.0, 1.5, value=_rc0.overprogress_margin, step=0.01, label="overprogress_margin")
+                    stop_pen_sl = gr.Slider(0.0, 200.0, value=_rc0.stopped_penalty, step=1.0, label="stopped_penalty")
+                    cl_cap_sl = gr.Slider(0.1, 5.0, value=_rc0.centerline_usage_cap, step=0.1, label="centerline_usage_cap (m)")
+                    rb_near_sl = gr.Slider(0.0, 20.0, value=_rc0.rb_near_scale, step=0.5, label="rb_near_scale")
+                    rb_wide_sl = gr.Slider(0.0, 5.0, value=_rc0.rb_wide_scale, step=0.1, label="rb_wide_scale")
 
                 gr.Markdown("### Display")
                 zoom_sl = gr.Slider(1, 10, value=5, step=1, label="Zoom")
@@ -884,8 +932,11 @@ def build_interface(
 
                 gr.Markdown("#### Guidance Functions")
                 # 9 guidance types: each gets a checkbox + scale slider
-                cb_cl = gr.Checkbox(value=False, label="Centerline following")
+                cb_cl = gr.Checkbox(value=False, label="Centerline following (nearest lane)")
                 sl_cl = gr.Slider(0.1, 15.0, value=5.0, step=0.1, label="CL scale")
+
+                cb_rcl = gr.Checkbox(value=False, label="Route-Lanes Centerline (rl_cl)")
+                sl_rcl = gr.Slider(0.1, 15.0, value=2.5, step=0.1, label="rl_cl scale")
 
                 cb_spd = gr.Checkbox(value=False, label="Speed")
                 sl_spd = gr.Slider(0.1, 15.0, value=5.0, step=0.1, label="SPD scale")
@@ -921,12 +972,16 @@ def build_interface(
 
         # --- Component lists for callbacks ---
         editor_guidance_components = [
-            cb_cl, sl_cl, cb_spd, sl_spd, spd_stretch, cb_lk, sl_lk,
+            cb_cl, sl_cl, cb_rcl, sl_rcl, cb_spd, sl_spd, spd_stretch, cb_lk, sl_lk,
             cb_rb, sl_rb, cb_rf, sl_rf, cb_col, sl_col,
             cb_anc, sl_anc, cb_lat, sl_lat, eta_lat, cb_lon, sl_lon, eta_lon,
         ]
         editor_components = [noise_sl, global_g_sl, det_cb] + editor_guidance_components
-        reward_inputs = [w_safety, w_progress, w_smooth, w_feasibility, w_centerline]
+        reward_inputs = [
+            w_safety, w_progress, w_smooth, w_feasibility, w_centerline,
+            up_pen_sl, up_thr_sl, op_pen_sl, op_mar_sl, stop_pen_sl,
+            cl_cap_sl, rb_near_sl, rb_wide_sl,
+        ]
         display_inputs = [zoom_sl, time_sl]
         main_outputs = [traj_plot, reward_table, speed_curv_plot, sample_info]
 
@@ -948,6 +1003,8 @@ def build_interface(
                 slot.is_deterministic,
                 g.get("centerline_following", (False, 1.0, {}))[0],
                 g.get("centerline_following", (False, 5.0, {}))[1],
+                g.get("route_centerline_following", (False, 1.0, {}))[0],
+                g.get("route_centerline_following", (False, 5.0, {}))[1],
                 g.get("speed", (False, 1.0, {}))[0],
                 g.get("speed", (False, 5.0, {}))[1],
                 g.get("speed", (False, 1.0, {}))[2].get("stretch", 1.0),
@@ -972,7 +1029,7 @@ def build_interface(
         # --- Helper: read editor into slot config ---
         def _read_editor_into_slot(
             noise_val, global_g_val, is_det,
-            cl_on, cl_s, spd_on, spd_s, spd_stretch_val, lk_on, lk_s,
+            cl_on, cl_s, rcl_on, rcl_s, spd_on, spd_s, spd_stretch_val, lk_on, lk_s,
             rb_on, rb_s, rf_on, rf_s, col_on, col_s,
             anc_on, anc_s, lat_on, lat_s, eta_lat_val, lon_on, lon_s, eta_lon_val,
         ) -> TrajectorySlotConfig:
@@ -982,6 +1039,7 @@ def build_interface(
                 is_deterministic=bool(is_det),
             )
             slot.guidance["centerline_following"] = (bool(cl_on), float(cl_s), {})
+            slot.guidance["route_centerline_following"] = (bool(rcl_on), float(rcl_s), {})
             slot.guidance["speed"] = (bool(spd_on), float(spd_s), {
                 "stretch": float(spd_stretch_val),
             })
@@ -1020,13 +1078,27 @@ def build_interface(
             return "\n".join(lines)
 
         # --- Render helpers ---
-        def _apply_reward_config(ws, wp, wm, wf, wc):
-            ranker.reward_config = RewardConfig(
+        def _apply_reward_config(
+            ws, wp, wm, wf, wc,
+            up_pen, up_thr, op_pen, op_mar, stop_pen, cl_cap, rb_near, rb_wide,
+        ):
+            # Preserve all non-slider fields from the loaded base config
+            # (gt_*, thresholds, modes, etc.) — only override slider-controlled ones.
+            ranker.reward_config = dc_replace(
+                ranker.reward_config_base,
                 w_safety=float(ws),
                 w_progress=float(wp),
                 w_smooth=float(wm),
                 w_feasibility=float(wf),
                 w_centerline=float(wc),
+                underprogress_penalty=float(up_pen),
+                underprogress_threshold=float(up_thr),
+                overprogress_penalty=float(op_pen),
+                overprogress_margin=float(op_mar),
+                stopped_penalty=float(stop_pen),
+                centerline_usage_cap=float(cl_cap),
+                rb_near_scale=float(rb_near),
+                rb_wide_scale=float(rb_wide),
             )
 
         def _render(sel_idx, zoom, ts):
@@ -1043,9 +1115,14 @@ def build_interface(
             return _format_dropdown_choices(ranker.slot_configs, ranker.reward_breakdowns)
 
         # --- Full run: load scene, generate all, render ---
-        def _full_run(n_traj, ws, wp, wm, wf, wc, zoom, ts):
+        def _full_run(
+            n_traj,
+            ws, wp, wm, wf, wc,
+            up_pen, up_thr, op_pen, op_mar, stop_pen, cl_cap, rb_near, rb_wide,
+            zoom, ts,
+        ):
             ranker.n_trajectories = int(n_traj)
-            _apply_reward_config(ws, wp, wm, wf, wc)
+            _apply_reward_config(ws, wp, wm, wf, wc, up_pen, up_thr, op_pen, op_mar, stop_pen, cl_cap, rb_near, rb_wide)
             ranker.load_sample()
             sel_idx = 0
             renders = _render(sel_idx, zoom, ts)
@@ -1148,8 +1225,13 @@ def build_interface(
         )
 
         # --- Reward weight changes -> rescore only ---
-        def _rescore_and_render(sel_idx, ws, wp, wm, wf, wc, zoom, ts):
-            _apply_reward_config(ws, wp, wm, wf, wc)
+        def _rescore_and_render(
+            sel_idx,
+            ws, wp, wm, wf, wc,
+            up_pen, up_thr, op_pen, op_mar, stop_pen, cl_cap, rb_near, rb_wide,
+            zoom, ts,
+        ):
+            _apply_reward_config(ws, wp, wm, wf, wc, up_pen, up_thr, op_pen, op_mar, stop_pen, cl_cap, rb_near, rb_wide)
             ranker._score_trajectories()
             renders = _render(int(sel_idx), zoom, ts)
             choices = _dropdown_choices()
@@ -1342,18 +1424,24 @@ def main():
     )
     print(f"Prototypes: {prototypes_path}")
 
-    grpo_trainer = None
-    if not args.no_training:
+    # Load GRPO/reward config if provided — applies in both training and
+    # viz-only mode. In viz-only mode this seeds the reward sliders from the
+    # training config so the GUI reward breakdown matches training (not GUI
+    # defaults).
+    grpo_cfg = None
+    if args.config is not None:
         from rlvr.grpo_config import GRPOConfig
-
-        if args.config is None:
-            raise SystemExit(
-                "--config is required unless --no-training is set."
-            )
         if not args.config.exists():
             raise FileNotFoundError(f"GRPO config not found: {args.config}")
         grpo_cfg = GRPOConfig.from_json(args.config)
         print(f"Loaded GRPO config from {args.config}")
+
+    grpo_trainer = None
+    if not args.no_training:
+        if grpo_cfg is None:
+            raise SystemExit(
+                "--config is required unless --no-training is set."
+            )
 
         if args.use_lora:
             grpo_cfg.use_lora = True
@@ -1409,6 +1497,18 @@ def main():
         prototypes_path=prototypes_path,
         n_trajectories=args.n_trajectories,
     )
+
+    # Seed reward config from the loaded training config so slider defaults
+    # and the initial reward breakdown match training, not GUI defaults.
+    if grpo_cfg is not None:
+        shared_fields = {f.name for f in dc_fields(RewardConfig)} & {f.name for f in dc_fields(type(grpo_cfg))}
+        loaded_rc = RewardConfig(**{name: getattr(grpo_cfg, name) for name in shared_fields})
+        ranker.reward_config_base = loaded_rc
+        ranker.reward_config = loaded_rc
+        print(f"Seeded reward config from training config: w_progress={loaded_rc.w_progress}, "
+              f"w_centerline={loaded_rc.w_centerline}, "
+              f"underprogress_penalty={loaded_rc.underprogress_penalty}, "
+              f"overprogress_penalty={loaded_rc.overprogress_penalty}")
 
     demo = build_interface(ranker, trainer=grpo_trainer)
     demo.launch(server_port=args.port, share=args.share, inbrowser=True)

--- a/rlvr/trajectory_ranker_gui.py
+++ b/rlvr/trajectory_ranker_gui.py
@@ -865,7 +865,7 @@ def build_interface(
                     op_pen_sl = gr.Slider(0.0, 200.0, value=_rc0.overprogress_penalty, step=1.0, label="overprogress_penalty")
                     op_mar_sl = gr.Slider(1.0, 1.5, value=_rc0.overprogress_margin, step=0.01, label="overprogress_margin")
                     stop_pen_sl = gr.Slider(0.0, 200.0, value=_rc0.stopped_penalty, step=1.0, label="stopped_penalty")
-                    cl_cap_sl = gr.Slider(0.1, 5.0, value=_rc0.centerline_usage_cap, step=0.1, label="centerline_usage_cap (m)")
+                    cl_cap_sl = gr.Slider(0.1, 5.0, value=_rc0.centerline_usage_cap, step=0.1, label="centerline_usage_cap (dimensionless lane_usage ratio)")
                     rb_near_sl = gr.Slider(0.0, 20.0, value=_rc0.rb_near_scale, step=0.5, label="rb_near_scale")
                     rb_wide_sl = gr.Slider(0.0, 5.0, value=_rc0.rb_wide_scale, step=0.1, label="rb_wide_scale")
 
@@ -931,7 +931,8 @@ def build_interface(
                 det_cb = gr.Checkbox(value=True, label="Deterministic (noise=0)")
 
                 gr.Markdown("#### Guidance Functions")
-                # 9 guidance types: each gets a checkbox + scale slider
+                # Guidance toggles — order here must match ALL_GUIDANCE_NAMES
+                # and the inputs list in editor_guidance_components below.
                 cb_cl = gr.Checkbox(value=False, label="Centerline following (nearest lane)")
                 sl_cl = gr.Slider(0.1, 15.0, value=5.0, step=0.1, label="CL scale")
 


### PR DESCRIPTION
- New RouteCenterlineFollowingGuidance attracts toward route_lanes centerline (matches compute_centerline_score_batch, which also prefers route_lanes). Registered in diffusion_planner/model/guidance/ and exposed via the new GRPOConfig flag use_route_cl_guidance, which swaps centerline_following → route_centerline_following in generated CL+SPD slots.

- New generation_variant rl_cl_soft_sweep: K=8 slots with rl_cl scale ∈ {1.5, 2.0, 2.5, 3.0}, matched spd, no pure-noise slots.

- Move overprogress / stopped / underprogress penalties out of the w_progress-multiplied sum in compute_reward_batch. They are reward floors, not progress terms, so they must fire when w_progress=0 (CL-only configs). Regression: rlvr/test_progress_penalty_bugfix.py (5 cases).

- Default underprogress_reference switched from "det" to "baseline" so the threshold stays anchored to the LoRA-less model rather than shrinking with training. test_reward_gates.py default assertion updated.

- Drop hardcoded [:100] scene caps in save_epoch1_baselines and the offroad picker in run_experiment. Full scene list is scanned now.

- Trajectory ranker GUI: loads reward config from --config (default in viz mode was stock RewardConfig which hid real training weights); new penalty / usage-cap sliders; overlays route_lanes centerline in bold orange; Route CL toggle labelled "Route-Lanes Centerline (rl_cl)"; min N-trajectories lowered to 1 so det-only view works.

- New viz_rb_cross_scenes tool: per-val-scene rb-gate offender grid with ego OBB at worst-distance timestep.

- New eval_centerline_metrics tool: per-scene cl-score distribution with optional sanity-compare against naive reimpl.