### PR TITLE
feat: closed-loop psim centerline-tracking tools

### DIFF
--- a/rlvr/autoresearch/tools/README.md
+++ b/rlvr/autoresearch/tools/README.md
@@ -20,6 +20,91 @@ python -m rlvr.autoresearch.tools.eval_lane_border_distance \
   --model_path <model.pth> --scenes <scenes.json> --tag <name>
 ```
 
+### eval_psim_centerline.py
+Closed-loop psim-rosbag centerline-tracking comparison between two runs (e.g. baseline
+vs a PRiSM-trained checkpoint). Reuses the official lateral metric:
+`compute_centerline_score_batch` from `rlvr.reward` via the helper
+`lat_offset_and_naive_score` (same code the GRPO training reward sees), so reported
+numbers are directly comparable to training metrics.
+
+Why it's separate from `eval_centerline_metrics.py`: that tool generates trajectories
+from a model and scores them on each npz's own `route_lanes` field. This tool consumes
+*already-rolled-out* psim ego poses across an entire run and projects them onto a
+reference centerline built from the rosbag's `LaneletRoute` + the lanelet2 map. The npz
+`route_lanes` field is unreliable in psim teleport bags (40–75% of frames have empty
+route segments — the route is published once before teleport and the converter cannot
+re-anchor it), so the reference must be reconstructed from `route.json` and the map.
+
+The signed lateral metric is exposed as `signed_lat_offset_m` in
+`lat_offset_and_naive_score`'s output dict — `+` = ego left of route direction, `−` =
+right (same sign convention `compute_centerline_score_batch` uses internally to pick
+between `left_hw` and `−right_hw`).
+
+```bash
+# 1. Convert rosbags to npz. psim bags lack /perception/traffic_light_recognition/
+#    traffic_signals; inject empty TL msgs first (see the helper script paired with
+#    your dataset), then run:
+python ros_scripts/parse_rosbag_by_cpp.py \
+    cpp_tools/build/autoware_diffusion_planner_tools/data_converter \
+    <bag_with_tl> <lanelet2_map.osm> <out>/npz/<run_name> \
+    --step 2 --min_frames 100 --interpolation 1
+
+# 2. Export the route message as JSON (one-time, from the route rosbag):
+#    python extract_route.py <route_bag> --output route.json
+
+# 3. Heatmap comparison:
+python -m rlvr.autoresearch.tools.eval_psim_centerline \
+    --baseline_dir <out>/npz/baseline \
+    --prism_dir <out>/npz/<prism_run> \
+    --osm <lanelet2_map.osm> \
+    --route_json <route.json> \
+    --out_dir <out>/analysis
+```
+Outputs: `summary.txt`, `{baseline,prism}_offsets.npz`, `route_polyline.npy`,
+`heatmap_combined.png` (3-panel: baseline | prism | Δ), `heatmap_centerline_xy.png`
+(2-panel scatter), `heatmap_centerline_diff.png` (Δ binned along route arc-length and
+re-projected onto the polyline so it remains visible at any zoom),
+`histogram_offsets.png`, `timeseries.png`, `progress_vs_offset.png`.
+
+### eval_psim_centerline_nway.py
+N-way generalisation of `eval_psim_centerline`. Compare any number of runs (≥2)
+side-by-side. Each run is a `--run name=<label>,kind=<npz|trajlog>,path=<...>` triple,
+mixing rosbag-derived npz directories and `scenario_generation.replay`
+`trajectory_log.json` outputs in the same comparison. Reuses the same lateral metric
+helper, so all per-run numbers stay comparable across rosbag-converted and
+closed-loop replay runs.
+```bash
+python -m rlvr.autoresearch.tools.eval_psim_centerline_nway \
+    --run name=baseline,kind=npz,path=<dir>/npz \
+    --run name=run_a,kind=trajlog,path=<dir>/trajectory_log.json \
+    --run name=run_b,kind=trajlog,path=<dir>/trajectory_log.json \
+    --osm <map>.osm --route_json <route>.json --out_dir <out>
+```
+Outputs: `summary.txt`, `route_polyline.npy`, per-run `<name>_offsets.npz`,
+`heatmap_nway_xy.png` (N-panel scatter), `heatmap_nway_diff.png` (Δ panels for each
+non-baseline run, projected onto the polyline), `histogram_offsets.png`,
+`progress_vs_offset.png`.
+
+### scenario_generation.render_npz_dir
+Render a directory of training-style npz files as `step_NNNN.png` PNGs that look like
+`scenario_generation.replay` output. Reuses the replay's per-step renderer
+(`_save_step_figure`), so the viewport, ego box, route overlay, road borders, agent
+predictions and HUD line all match closed-loop sim renders exactly. Useful for
+qualitative side-by-side video comparisons of a recorded rosbag and a closed-loop
+replay.
+```bash
+python -m scenario_generation.render_npz_dir \
+    --npz_dir <path>/npz --output_dir <path>/render \
+    [--route_pkl <route>.pkl] \
+    [--ego_length 7.24 --ego_width 2.29 --ego_wheelbase 4.76] \
+    [--workers 8] [--limit 100] [--stride 1]
+```
+The route pickle is optional; without it the route polyline isn't drawn but everything
+else (lane network, road borders, agents, predicted trajectory, HUD) still appears.
+Ego dimensions can be overridden when the npz was converted with the data_converter's
+default ego_length / ego_width but the rosbag was recorded on a vehicle with different
+dimensions.
+
 ### eval_reward_vs_gt.py
 Per-scene reward breakdown comparing model output vs ground truth. Useful for diagnosing which reward components are driving training.
 ```bash

--- a/rlvr/autoresearch/tools/_psim_centerline_common.py
+++ b/rlvr/autoresearch/tools/_psim_centerline_common.py
@@ -1,0 +1,271 @@
+"""Shared helpers for ``eval_psim_centerline`` and
+``eval_psim_centerline_nway``.
+
+Lateral-offset metric is computed by ``lat_offset_and_naive_score`` in
+``eval_centerline_metrics.py`` (the same code path the GRPO training reward
+uses). These helpers handle aggregation, cropping, and arc-length binning
+on top of the metric.
+"""
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import numpy as np
+import torch
+
+
+# ---------------------------------------------------------------------------
+# Reference-centerline construction (route.json + lanelet2 map).
+# ---------------------------------------------------------------------------
+
+def parse_lanelet_centerlines(
+    osm_path: Path, wanted_ids: list[int], n_resample: int = 20
+) -> dict[int, np.ndarray]:
+    """Return a polyline (per-step midpoint of the left/right ways) for each
+    requested lanelet id. Each polyline is resampled to ``n_resample`` points
+    by arc-length so concatenation of consecutive lanelets is well-behaved."""
+    import xml.etree.ElementTree as ET
+
+    print(f"Parsing {osm_path} ...")
+    tree = ET.parse(osm_path)
+    root = tree.getroot()
+
+    nodes: dict[int, tuple[float, float]] = {}
+    ways: dict[int, list[int]] = {}
+    relations: dict[int, dict[str, int]] = {}
+
+    for el in root:
+        if el.tag == "node":
+            nid = int(el.get("id"))
+            x = y = None
+            for tag in el.findall("tag"):
+                k, v = tag.get("k"), tag.get("v")
+                if k == "local_x":
+                    x = float(v)
+                elif k == "local_y":
+                    y = float(v)
+            if x is not None and y is not None:
+                nodes[nid] = (x, y)
+        elif el.tag == "way":
+            wid = int(el.get("id"))
+            ways[wid] = [int(nd.get("ref")) for nd in el.findall("nd")]
+        elif el.tag == "relation":
+            rid = int(el.get("id"))
+            roles = {m.get("role"): int(m.get("ref")) for m in el.findall("member")}
+            relations[rid] = roles
+
+    def resample(poly: np.ndarray, N: int) -> np.ndarray:
+        d = np.linalg.norm(np.diff(poly, axis=0), axis=1)
+        cum = np.concatenate([[0.0], np.cumsum(d)])
+        if cum[-1] < 1e-6:
+            return poly[:1].repeat(N, axis=0)
+        tgt = np.linspace(0.0, cum[-1], N)
+        x = np.interp(tgt, cum, poly[:, 0])
+        y = np.interp(tgt, cum, poly[:, 1])
+        return np.stack([x, y], axis=1)
+
+    out = {}
+    for lid in wanted_ids:
+        rel = relations.get(lid)
+        if rel is None or "left" not in rel or "right" not in rel:
+            continue
+        L_ids = ways.get(rel["left"], [])
+        R_ids = ways.get(rel["right"], [])
+        L = np.array([nodes[n] for n in L_ids if n in nodes], dtype=np.float64)
+        R = np.array([nodes[n] for n in R_ids if n in nodes], dtype=np.float64)
+        if len(L) < 2 or len(R) < 2:
+            continue
+        out[lid] = 0.5 * (resample(L, n_resample) + resample(R, n_resample))
+    return out
+
+
+def build_route_polyline(osm_path: Path, route_json_path: Path) -> np.ndarray:
+    """Concatenate per-lanelet centerlines from ``route.json``'s preferred
+    primitives into a single ``(M, 2)`` world-frame polyline."""
+    import json
+
+    route = json.loads(route_json_path.read_text())
+    ids = [seg["preferred_primitive"]["id"] for seg in route["segments"]]
+    cls = parse_lanelet_centerlines(osm_path, ids)
+    poly: list[list[float]] = []
+    for lid in ids:
+        if lid not in cls:
+            continue
+        seg = cls[lid]
+        if poly and np.linalg.norm(seg[0] - poly[-1]) < 0.05:
+            poly.extend(seg[1:].tolist())
+        else:
+            poly.extend(seg.tolist())
+    arr = np.array(poly, dtype=np.float64)
+    print(f"Route polyline: {len(ids)} lanelets -> {len(arr)} centerline points")
+    return arr
+
+
+# ---------------------------------------------------------------------------
+# World→ego synthetic route_lanes tensor for the lateral-offset helper.
+# ---------------------------------------------------------------------------
+
+def world_polyline_to_ego_route_lanes(
+    polyline_world: np.ndarray,
+    ego_xy: tuple[float, float],
+    ego_yaw: float,
+    points_per_seg: int = 20,
+    lane_half_width: float = 1.75,
+) -> torch.Tensor:
+    """Transform the world-frame polyline into ego frame and pack into the
+    ``route_lanes`` segment-point feature layout consumed by
+    ``lat_offset_and_naive_score`` (centers at [0:2], dir at [2:4], left at
+    [4:6], right at [6:8] — all other channels zero).
+
+    Note on the synthetic left/right vectors: real ``lanes[..., 4:6]`` are
+    2-D offset vectors pointing left of the centerline. We emit
+    ``lat_dir * lane_half_width`` for the left channel and
+    ``-lat_dir * lane_half_width`` for the right; the helper then projects
+    via dot-product against ``lat_dir`` to recover ``+/-lane_half_width``
+    and clamps with ``min=0.5``. Result: ``side_hw == lane_half_width``
+    regardless of which side the ego is on. Don't "fix" the right-side
+    sign to match left without re-checking ``lat_offset_and_naive_score``.
+
+    Returns a tensor of shape ``(1, S, points_per_seg, 33)``.
+    """
+    cx, cy = ego_xy
+    cos_y = math.cos(-ego_yaw)
+    sin_y = math.sin(-ego_yaw)
+    R = np.array([[cos_y, -sin_y], [sin_y, cos_y]], dtype=np.float64)
+    pts = (polyline_world - np.array([cx, cy], dtype=np.float64)) @ R.T
+
+    # Chunk into segments of `points_per_seg` with a 1-point overlap between
+    # successive segments so direction vectors remain consistent at seams.
+    M = len(pts)
+    if M < 2:
+        return torch.zeros(1, 1, points_per_seg, 33, dtype=torch.float32)
+    step = points_per_seg - 1
+    starts = list(range(0, M - 1, step))
+    if starts[-1] + points_per_seg > M:
+        starts[-1] = max(0, M - points_per_seg)
+    starts = sorted(set(starts))
+    S = len(starts)
+    seg = np.zeros((S, points_per_seg, 33), dtype=np.float32)
+    for s_idx, st in enumerate(starts):
+        chunk = pts[st : st + points_per_seg]
+        if len(chunk) < points_per_seg:
+            pad = np.tile(chunk[-1:], (points_per_seg - len(chunk), 1))
+            chunk = np.concatenate([chunk, pad], axis=0)
+        seg[s_idx, :, 0] = chunk[:, 0]
+        seg[s_idx, :, 1] = chunk[:, 1]
+        d = np.diff(chunk, axis=0)
+        d_norm = np.linalg.norm(d, axis=1, keepdims=True)
+        d = d / np.where(d_norm < 1e-6, 1.0, d_norm)
+        d_full = np.concatenate([d, d[-1:]], axis=0)
+        seg[s_idx, :, 2] = d_full[:, 0]
+        seg[s_idx, :, 3] = d_full[:, 1]
+        lat_dir = np.stack([-d_full[:, 1], d_full[:, 0]], axis=1)
+        seg[s_idx, :, 4:6] = lat_dir * lane_half_width
+        seg[s_idx, :, 6:8] = -lat_dir * lane_half_width
+    return torch.from_numpy(seg)[None]
+
+
+# ---------------------------------------------------------------------------
+# Run aggregation + cropping + summary stats.
+# ---------------------------------------------------------------------------
+
+def polyline_cumulative_arclength(
+    polyline: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return ``(arc_cum, segment_lengths)`` for a polyline.
+
+    ``arc_cum`` has length ``N`` (one entry per polyline point, starts at 0);
+    ``segment_lengths`` has length ``N-1`` (one entry per segment)."""
+    seg = np.linalg.norm(np.diff(polyline, axis=0), axis=1)
+    cum = np.concatenate([[0.0], np.cumsum(seg)])
+    return cum, seg
+
+
+def project_point_to_polyline_arclength(
+    polyline: np.ndarray, x: float, y: float
+) -> float:
+    """Return the arc-length on ``polyline`` of the point closest to ``(x, y)``.
+
+    Standard point-to-segment projection across all segments; picks the segment
+    with the smallest perpendicular distance and adds the partial arc-length
+    along that segment."""
+    a = polyline[:-1]
+    b = polyline[1:]
+    ab = b - a
+    sl2 = np.maximum(np.sum(ab * ab, axis=1), 1e-9)
+    ap = np.array([x, y])[None, :] - a
+    t = np.clip(np.sum(ap * ab, axis=1) / sl2, 0.0, 1.0)
+    proj = a + t[:, None] * ab
+    d2 = np.sum((proj - np.array([x, y])[None, :]) ** 2, axis=1)
+    idx = int(np.argmin(d2))
+    cum, _ = polyline_cumulative_arclength(polyline)
+    return float(cum[idx] + t[idx] * np.sqrt(sl2[idx]))
+
+
+def crop_run_by_offset(d: dict, max_offset_m: float) -> dict:
+    """Drop frames whose ``|lateral offset|`` exceeds ``max_offset_m``.
+
+    Keeps the dict-of-arrays layout used by ``eval_psim_centerline.collect_run``
+    (``ts``, ``world_xy``, ``lat``, ``abs_lat``, ``lon``, ``speed``)."""
+    m = np.abs(d["lat"]) <= max_offset_m
+    return {k: v[m] for k, v in d.items()}
+
+
+def stats_line(name: str, d: dict, all_d: dict) -> str:
+    """One-line summary of a run's cropped vs raw lateral offsets.
+
+    Returns ``"… all values n/a"`` when the cropped run has zero kept frames
+    (e.g. when ``--max_offset_m`` excluded everything) so the caller can still
+    print a complete summary table without crashing."""
+    lat = d["lat"]
+    kept = len(lat)
+    total = len(all_d["lat"])
+    if kept == 0:
+        return (
+            f"{name:>14s}  kept={kept:4d}/{total:4d}  "
+            f"|lat| mean=n/a  median=n/a  p95=n/a  max=n/a  "
+            f"std(lat)=n/a  mean(lat)=n/a"
+        )
+    abs_lat = np.abs(lat)
+    return (
+        f"{name:>14s}  kept={kept:4d}/{total:4d}  "
+        f"|lat| mean={np.mean(abs_lat):.3f}m  "
+        f"median={np.median(abs_lat):.3f}m  "
+        f"p95={np.percentile(abs_lat,95):.3f}m  "
+        f"max={np.max(abs_lat):.3f}m  "
+        f"std(lat)={np.std(lat):.3f}m  "
+        f"mean(lat)={np.mean(lat):+.3f}m"
+    )
+
+
+def arc_bin_diff(
+    base_c: dict, prism_c: dict, bin_m: float = 5.0
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return ``(arc_bin_edges, arc_bin_centers, prism_bin_mean − base_bin_mean)``.
+
+    Bins both runs' ``|lat|`` along route arc-length with the given bin width
+    and returns the difference of the per-bin means. NaN where a bin has no
+    samples in either run. Returns three empty arrays when either input has
+    zero kept frames (so callers can detect "no comparison possible" without
+    a `.max()` reduction crash)."""
+    if len(base_c["lon"]) == 0 or len(prism_c["lon"]) == 0:
+        empty = np.array([], dtype=float)
+        return empty, empty, empty
+    arc_max = max(base_c["lon"].max(), prism_c["lon"].max())
+    arc_bins = np.arange(0, arc_max + bin_m, bin_m)
+    if len(arc_bins) < 2:
+        # Degenerate case: a single point at arc-length 0 (max==0). Build a
+        # 1-bin schema so np.digitize / arange invariants hold downstream.
+        arc_bins = np.array([0.0, bin_m], dtype=float)
+    arc_centers = 0.5 * (arc_bins[1:] + arc_bins[:-1])
+
+    def _bin(d: dict) -> np.ndarray:
+        idx = np.clip(np.digitize(d["lon"], arc_bins) - 1, 0, len(arc_centers) - 1)
+        sums = np.zeros(len(arc_centers))
+        cnts = np.zeros(len(arc_centers))
+        np.add.at(sums, idx, np.abs(d["lat"]))
+        np.add.at(cnts, idx, 1.0)
+        return np.divide(sums, cnts, out=np.full_like(sums, np.nan), where=cnts > 0)
+
+    return arc_bins, arc_centers, _bin(prism_c) - _bin(base_c)

--- a/rlvr/autoresearch/tools/_psim_centerline_common.py
+++ b/rlvr/autoresearch/tools/_psim_centerline_common.py
@@ -82,12 +82,20 @@ def parse_lanelet_centerlines(
 
 def build_route_polyline(osm_path: Path, route_json_path: Path) -> np.ndarray:
     """Concatenate per-lanelet centerlines from ``route.json``'s preferred
-    primitives into a single ``(M, 2)`` world-frame polyline."""
+    primitives into a single ``(M, 2)`` world-frame polyline.
+
+    Raises ``SystemExit`` if fewer than two centerline points were assembled
+    (e.g. all referenced lanelet ids missing from the map, or the map and
+    the route reference different worlds). Without this guard, downstream
+    point-to-polyline projection silently produces near-zero offsets — much
+    worse than failing loudly.
+    """
     import json
 
     route = json.loads(route_json_path.read_text())
     ids = [seg["preferred_primitive"]["id"] for seg in route["segments"]]
     cls = parse_lanelet_centerlines(osm_path, ids)
+    missing = [lid for lid in ids if lid not in cls]
     poly: list[list[float]] = []
     for lid in ids:
         if lid not in cls:
@@ -98,7 +106,18 @@ def build_route_polyline(osm_path: Path, route_json_path: Path) -> np.ndarray:
         else:
             poly.extend(seg.tolist())
     arr = np.array(poly, dtype=np.float64)
-    print(f"Route polyline: {len(ids)} lanelets -> {len(arr)} centerline points")
+    print(
+        f"Route polyline: {len(ids)} lanelets requested, "
+        f"{len(ids) - len(missing)} resolved -> {len(arr)} centerline points"
+        + (f" ({len(missing)} missing: e.g. {missing[:5]})" if missing else "")
+    )
+    if len(arr) < 2:
+        raise SystemExit(
+            f"build_route_polyline: only {len(arr)} centerline point(s) were "
+            f"resolved from {len(ids)} requested lanelets. The route.json and "
+            f"the lanelet2 map likely reference different worlds. "
+            f"First few missing lanelet ids: {missing[:10]}"
+        )
     return arr
 
 
@@ -183,13 +202,18 @@ def polyline_cumulative_arclength(
 
 
 def project_point_to_polyline_arclength(
-    polyline: np.ndarray, x: float, y: float
+    polyline: np.ndarray, x: float, y: float,
+    cum: np.ndarray | None = None,
 ) -> float:
     """Return the arc-length on ``polyline`` of the point closest to ``(x, y)``.
 
     Standard point-to-segment projection across all segments; picks the segment
     with the smallest perpendicular distance and adds the partial arc-length
-    along that segment."""
+    along that segment.
+
+    Pass a precomputed ``cum`` array (from ``polyline_cumulative_arclength``)
+    to skip per-call cumsum recomputation. This is O(N_polyline) extra work
+    per frame otherwise, which adds up in long runs."""
     a = polyline[:-1]
     b = polyline[1:]
     ab = b - a
@@ -199,7 +223,8 @@ def project_point_to_polyline_arclength(
     proj = a + t[:, None] * ab
     d2 = np.sum((proj - np.array([x, y])[None, :]) ** 2, axis=1)
     idx = int(np.argmin(d2))
-    cum, _ = polyline_cumulative_arclength(polyline)
+    if cum is None:
+        cum, _ = polyline_cumulative_arclength(polyline)
     return float(cum[idx] + t[idx] * np.sqrt(sl2[idx]))
 
 

--- a/rlvr/autoresearch/tools/eval_centerline_metrics.py
+++ b/rlvr/autoresearch/tools/eval_centerline_metrics.py
@@ -63,6 +63,16 @@ def lat_offset_and_naive_score(
     ``usage_mode`` must match the reward config's ``centerline_usage_mode``
     so the printed naive_score is comparable to compute_centerline_score_batch.
     Defaults to ``baselink`` (the new default since 2026-04-27).
+
+    Returns a dict with:
+      * ``lat_offset_m``: [T] absolute distance from base_link to the nearest
+        route-lane centerline point (m).
+      * ``signed_lat_offset_m``: [T] signed distance — ``+`` = ego is left of
+        the route direction, ``−`` = right. Same sign convention
+        ``compute_centerline_score_batch`` uses internally to pick between
+        ``left_hw`` and ``−right_hw``.
+      * ``lane_usage_uncapped``: [T] same metric divided by lane half-width.
+      * ``naive_score``, ``any_off_route``: see above.
     """
     device = traj.device
     lanes = data.get("route_lanes", data.get("lanes"))
@@ -107,6 +117,7 @@ def lat_offset_and_naive_score(
     any_off_route = bool(((min_dist > 5.0).cummax(dim=0).values & (min_dist > 5.0)).any().item())
     return {
         "lat_offset_m": ego_lat.abs().cpu().numpy(),  # [T]
+        "signed_lat_offset_m": ego_lat.cpu().numpy(),  # [T] (+ left of route, − right)
         "lane_usage_uncapped": lane_usage.cpu().numpy(),  # [T]
         "naive_score": naive_score,
         "any_off_route": any_off_route,

--- a/rlvr/autoresearch/tools/eval_psim_centerline.py
+++ b/rlvr/autoresearch/tools/eval_psim_centerline.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+"""Centerline-tracking heatmap comparison between two psim closed-loop runs
+(rosbag→npz). Reuses the official reward-function lateral metric so the
+numbers match what GRPO training sees.
+
+Why a separate tool from ``eval_centerline_metrics.py``:
+  * That tool *generates* trajectories from a model and scores them on each
+    npz's own ``route_lanes`` field.
+  * This tool consumes *already-rolled-out* psim trajectories (logged ego
+    poses across an entire run) and projects them onto a reference route
+    centerline built from the rosbag's published ``LaneletRoute`` + the
+    lanelet2 map. The npz ``route_lanes`` field is unreliable in psim teleport
+    bags (40-75% of frames have empty route lanes — the route message is
+    published once before teleport and the converter cannot re-anchor it).
+
+Lateral metric:
+  * Calls :func:`rlvr.autoresearch.tools.eval_centerline_metrics
+    .lat_offset_and_naive_score` per frame with the ego at the origin in
+    ego frame and the GT polyline projected into ego frame as a synthetic
+    ``route_lanes`` tensor.
+  * Default ``usage_mode='baselink'`` matches the current reward default
+    (since 2026-04-27); ``ego_lat`` is the signed metric distance from
+    base_link to the nearest centerline point.
+
+Outputs (in ``--out_dir``):
+  <baseline_label>_offsets.npz, <comparison_label>_offsets.npz,
+  route_polyline.npy, heatmap_combined.png, heatmap_centerline_xy.png,
+  heatmap_centerline_diff.png, heatmap_zoom*.png, histogram_offsets.png,
+  timeseries.png, progress_vs_offset.png, summary.txt
+
+Usage:
+    source .venv/bin/activate
+    python -m rlvr.autoresearch.tools.eval_psim_centerline \\
+        --baseline_dir <path>/npz/baseline \\
+        --prism_dir <path>/npz/<comparison_run> \\
+        --osm /path/to/lanelet2_map.osm \\
+        --route_json /path/to/route.json \\
+        --out_dir <path>/analysis
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+
+from rlvr.autoresearch.tools._psim_centerline_common import (
+    arc_bin_diff,
+    build_route_polyline,
+    crop_run_by_offset,
+    polyline_cumulative_arclength,
+    project_point_to_polyline_arclength,
+    stats_line,
+    world_polyline_to_ego_route_lanes,
+)
+from rlvr.autoresearch.tools.eval_centerline_metrics import (
+    lat_offset_and_naive_score,
+)
+from scenario_generation.transforms import yaw_from_quat
+
+
+# ---------------------------------------------------------------------------
+# Per-run aggregation.
+# ---------------------------------------------------------------------------
+
+def collect_run_trajectory_log(
+    traj_log_path: Path,
+    polyline: np.ndarray,
+    ego_half_w: float,
+    device: str = "cpu",
+) -> dict:
+    """Aggregate per-frame lateral metrics from a closed-loop replay's
+    ``trajectory_log.json`` (produced by ``scenario_generation.replay``).
+
+    The log is a list of dicts with ``step / x / y / heading / speed``. We
+    treat ``step`` as the timestamp (1 step ≈ 0.1 s in the replay) and use
+    the world-frame ``(x, y, heading)`` to compute lateral offset to the
+    reference polyline via the official reward helper.
+    """
+    log = json.loads(Path(traj_log_path).read_text())
+    print(f"  {traj_log_path.parent.name}: {len(log)} replay steps")
+    n = len(log)
+    ts = np.zeros(n, dtype=np.int64)
+    world_xy = np.zeros((n, 2), dtype=np.float64)
+    lat = np.full(n, np.nan, dtype=np.float64)
+    lat_signed = np.full(n, np.nan, dtype=np.float64)
+    lon = np.full(n, np.nan, dtype=np.float64)
+    speed = np.full(n, np.nan, dtype=np.float64)
+
+    traj = torch.tensor([[0.0, 0.0, 1.0, 0.0]], device=device)
+
+    for i, entry in enumerate(log):
+        x = float(entry["x"])
+        y = float(entry["y"])
+        yaw = float(entry["heading"])
+        # Convert replay step index to nanoseconds (replay is at 10 Hz / 0.1 s
+        # per step) so the same time-axis code that handles rosbag-derived
+        # nanosecond timestamps works for trajectory_log inputs.
+        ts[i] = int(entry["step"]) * 100_000_000
+        world_xy[i] = (x, y)
+        speed[i] = float(entry.get("speed", 0.0))
+
+        route_lanes = world_polyline_to_ego_route_lanes(
+            polyline, (x, y), yaw
+        ).to(device)
+        out = lat_offset_and_naive_score(
+            traj=traj, data={"route_lanes": route_lanes},
+            ego_half_w=ego_half_w, usage_mode="baselink",
+        )
+        if out is None:
+            continue
+        lat[i] = float(out["lat_offset_m"][0])
+        lat_signed[i] = float(out["signed_lat_offset_m"][0])
+        lon[i] = project_point_to_polyline_arclength(polyline, x, y)
+
+    order = np.argsort(ts)
+    return {
+        "ts": ts[order], "world_xy": world_xy[order],
+        "lat": lat_signed[order], "abs_lat": lat[order],
+        "lon": lon[order], "speed": speed[order],
+    }
+
+
+def collect_run(
+    npz_dir: Path,
+    polyline: np.ndarray,
+    ego_half_w: float,
+    device: str = "cpu",
+) -> dict:
+    files = sorted(glob.glob(str(npz_dir / "*.npz")))
+    print(f"  {npz_dir.name}: {len(files)} npz files")
+    n = len(files)
+    ts = np.zeros(n, dtype=np.int64)
+    world_xy = np.zeros((n, 2), dtype=np.float64)
+    lat = np.full(n, np.nan, dtype=np.float64)
+    lat_signed = np.full(n, np.nan, dtype=np.float64)
+    lon = np.full(n, np.nan, dtype=np.float64)
+    speed = np.full(n, np.nan, dtype=np.float64)
+
+    traj = torch.tensor([[0.0, 0.0, 1.0, 0.0]], device=device)  # (T=1, 4)
+
+    for i, fp in enumerate(files):
+        js_path = fp.replace(".npz", ".json")
+        if not os.path.exists(js_path):
+            continue
+        with open(js_path) as f:
+            j = json.load(f)
+        x = float(j["x"])
+        y = float(j["y"])
+        yaw = yaw_from_quat(j["qx"], j["qy"], j["qz"], j["qw"])
+        ts[i] = j.get("timestamp", 0)
+        world_xy[i] = (x, y)
+        with np.load(fp) as d:
+            ego = d["ego_current_state"]
+        speed[i] = float(np.linalg.norm(ego[4:6]))
+
+        route_lanes = world_polyline_to_ego_route_lanes(
+            polyline, (x, y), yaw
+        ).to(device)
+        out = lat_offset_and_naive_score(
+            traj=traj,
+            data={"route_lanes": route_lanes},
+            ego_half_w=ego_half_w,
+            usage_mode="baselink",
+        )
+        if out is None:
+            continue
+        lat[i] = float(out["lat_offset_m"][0])
+        lat_signed[i] = float(out["signed_lat_offset_m"][0])
+        lon[i] = project_point_to_polyline_arclength(polyline, x, y)
+
+    order = np.argsort(ts)
+    return {
+        "ts": ts[order],
+        "world_xy": world_xy[order],
+        "lat": lat_signed[order],
+        "abs_lat": lat[order],
+        "lon": lon[order],
+        "speed": speed[order],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Plotting.
+# ---------------------------------------------------------------------------
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--baseline_dir", type=Path, default=None,
+                    help="Directory of npz files (rosbag→npz pipeline). "
+                         "Mutually exclusive with --baseline_traj_log.")
+    ap.add_argument("--prism_dir", type=Path, default=None,
+                    help="Directory of npz files. Mutually exclusive with "
+                         "--prism_traj_log.")
+    ap.add_argument("--baseline_traj_log", type=Path, default=None,
+                    help="trajectory_log.json from a closed-loop replay run. "
+                         "Use this for scenario_generation.replay output.")
+    ap.add_argument("--prism_traj_log", type=Path, default=None,
+                    help="trajectory_log.json from a closed-loop replay run.")
+    ap.add_argument("--baseline_label", default="baseline",
+                    help="Label for the baseline run, used in plot titles, "
+                         "histogram legends, summary lines, and the output "
+                         "<label>_offsets.npz filename.")
+    ap.add_argument("--prism_label", default="comparison",
+                    help="Label for the comparison run. The CLI flag name "
+                         "is `--prism_label` for backward-compat with earlier "
+                         "PRiSM-vs-baseline workflows; the run does not have "
+                         "to be a PRiSM-trained checkpoint.")
+    ap.add_argument("--osm", type=Path, required=True,
+                    help="lanelet2_map.osm matching the rosbag map.")
+    ap.add_argument("--route_json", type=Path, required=True,
+                    help="LaneletRoute exported as JSON (see "
+                         "extract_route.py in the route-rosbag.)")
+    ap.add_argument("--out_dir", type=Path, required=True)
+    ap.add_argument("--max_offset_m", type=float, default=10.0,
+                    help="Drop frames whose |lateral offset| exceeds this "
+                         "(off-route detours, teleport boundaries).")
+    ap.add_argument("--ego_half_w", type=float, default=0.85,
+                    help="Half ego width (m). Only consumed when usage_mode is "
+                         "'body'; the tool currently hardcodes 'baselink' so "
+                         "this is ignored. Kept for forward-compat in case a "
+                         "--usage_mode flag is added later.")
+    ap.add_argument("--device", default="cpu")
+    args = ap.parse_args()
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    polyline = build_route_polyline(args.osm, args.route_json)
+    np.save(args.out_dir / "route_polyline.npy", polyline)
+
+    if (args.baseline_dir is None) == (args.baseline_traj_log is None):
+        raise SystemExit("Provide exactly one of --baseline_dir / --baseline_traj_log")
+    if (args.prism_dir is None) == (args.prism_traj_log is None):
+        raise SystemExit("Provide exactly one of --prism_dir / --prism_traj_log")
+
+    print(f"Loading {args.baseline_label}...")
+    if args.baseline_traj_log is not None:
+        base = collect_run_trajectory_log(
+            args.baseline_traj_log, polyline, args.ego_half_w, args.device,
+        )
+    else:
+        base = collect_run(args.baseline_dir, polyline, args.ego_half_w, args.device)
+    print(f"Loading {args.prism_label}...")
+    if args.prism_traj_log is not None:
+        prism = collect_run_trajectory_log(
+            args.prism_traj_log, polyline, args.ego_half_w, args.device,
+        )
+    else:
+        prism = collect_run(args.prism_dir, polyline, args.ego_half_w, args.device)
+
+    np.savez(args.out_dir / f"{args.baseline_label}_offsets.npz", **base)
+    np.savez(args.out_dir / f"{args.prism_label}_offsets.npz", **prism)
+
+    base_c = crop_run_by_offset(base, args.max_offset_m)
+    prism_c = crop_run_by_offset(prism, args.max_offset_m)
+    if len(base_c["lat"]) == 0 or len(prism_c["lat"]) == 0:
+        empty = []
+        if len(base_c["lat"]) == 0:
+            empty.append(args.baseline_label)
+        if len(prism_c["lat"]) == 0:
+            empty.append(args.prism_label)
+        raise SystemExit(
+            f"No frames remain after cropping by --max_offset_m="
+            f"{args.max_offset_m} for run(s): {', '.join(empty)}. "
+            "This can happen if the threshold is too small or if the metric "
+            "failed on every frame. Increase --max_offset_m or inspect the "
+            "input data."
+        )
+
+    summary_lines = [
+        "psim centerline-tracking comparison (lateral via "
+        "rlvr.reward.compute_centerline_score_batch / lat_offset_and_naive_score)",
+        f"Reference: {args.route_json.name} ({len(polyline)} centerline points)",
+        f"Map: {args.osm}",
+        f"Frames cropped where |lateral offset| > {args.max_offset_m} m.",
+        "Sign: + = left of route direction, − = right.",
+        "",
+        stats_line(args.baseline_label, base_c, base),
+        stats_line(args.prism_label, prism_c, prism),
+        "",
+    ]
+
+    b_abs = np.abs(base_c["lat"])
+    p_abs = np.abs(prism_c["lat"])
+    delta_label = f"{args.prism_label} − {args.baseline_label}"
+
+    def _delta_line(metric: str, p_val: float, b_val: float) -> str:
+        delta = p_val - b_val
+        if abs(b_val) <= 1e-12:
+            pct = "pct n/a; baseline ≈ 0"
+        else:
+            pct = f"{100 * delta / b_val:+.2f}%"
+        return f"Δ |lat| {metric:<6s} ({delta_label}): {delta:+.4f} m  ({pct})"
+
+    summary_lines.append(_delta_line("mean", float(np.mean(p_abs)), float(np.mean(b_abs))))
+    summary_lines.append(_delta_line("median", float(np.median(p_abs)), float(np.median(b_abs))))
+    summary_lines.append(
+        _delta_line("p95", float(np.percentile(p_abs, 95)), float(np.percentile(b_abs, 95)))
+    )
+    for thr in (0.3, 0.5, 1.0):
+        summary_lines.append(
+            f"Frames with |lat| > {thr}m:  "
+            f"{args.baseline_label}={(b_abs>thr).sum()}/{len(b_abs)} ({100*(b_abs>thr).mean():.2f}%) | "
+            f"{args.prism_label}={(p_abs>thr).sum()}/{len(p_abs)} ({100*(p_abs>thr).mean():.2f}%)"
+        )
+    summary = "\n".join(summary_lines)
+    print("\n" + summary)
+    (args.out_dir / "summary.txt").write_text(summary + "\n")
+
+    # ---- Scatter heatmaps and combined panel ----
+    all_xy = np.concatenate([base_c["world_xy"], prism_c["world_xy"]], axis=0)
+    x_min, x_max = all_xy[:, 0].min() - 20, all_xy[:, 0].max() + 20
+    y_min, y_max = all_xy[:, 1].min() - 20, all_xy[:, 1].max() + 20
+    vmax = float(np.percentile(np.concatenate([np.abs(base_c["lat"]), np.abs(prism_c["lat"])]), 95))
+    vmax = max(vmax, 0.5)
+
+    def scatter_panel(ax, run, ttl):
+        ax.plot(polyline[:, 0], polyline[:, 1], "-", color="0.7", lw=2.5,
+                alpha=0.5, zorder=1, label="route centerline")
+        sc = ax.scatter(
+            run["world_xy"][:, 0], run["world_xy"][:, 1],
+            c=np.abs(run["lat"]), cmap="inferno", vmin=0.0, vmax=vmax,
+            s=18, alpha=0.9, edgecolors="none", zorder=2,
+        )
+        ax.set_title(
+            f"{ttl}\nmean|lat|={np.mean(np.abs(run['lat'])):.3f}m  "
+            f"p95={np.percentile(np.abs(run['lat']),95):.3f}m  "
+            f"max={np.max(np.abs(run['lat'])):.3f}m"
+        )
+        ax.set_xlabel("MGRS x [m]")
+        ax.set_ylabel("MGRS y [m]")
+        ax.set_xlim(x_min, x_max)
+        ax.set_ylim(y_min, y_max)
+        ax.set_aspect("equal")
+        ax.legend(loc="upper right")
+        return sc
+
+    arc_bins, arc_centers, diff_arc = arc_bin_diff(base_c, prism_c, bin_m=5.0)
+    poly_arc, _ = polyline_cumulative_arclength(polyline)
+    poly_bin = np.clip(np.digitize(poly_arc, arc_bins) - 1, 0, len(arc_centers) - 1)
+    poly_diff = diff_arc[poly_bin]
+    valid_diff = np.isfinite(poly_diff)
+    finite = diff_arc[np.isfinite(diff_arc)]
+    vlim = max(float(np.percentile(np.abs(finite), 98)) if finite.size else 1.0, 0.3)
+
+    # Two-panel side-by-side
+    fig, axes = plt.subplots(1, 2, figsize=(16, 9), sharex=True, sharey=True)
+    sc_b = scatter_panel(axes[0], base_c, args.baseline_label)
+    sc_p = scatter_panel(axes[1], prism_c, args.prism_label)
+    plt.colorbar(sc_b, ax=axes[0], fraction=0.04, pad=0.02, label="|lat| [m]")
+    plt.colorbar(sc_p, ax=axes[1], fraction=0.04, pad=0.02, label="|lat| [m]")
+    plt.suptitle("Centerline-tracking heatmap (lat from compute_centerline_score_batch)", y=0.98)
+    plt.tight_layout()
+    plt.savefig(args.out_dir / "heatmap_centerline_xy.png", dpi=140)
+    plt.close()
+
+    # Diff-only
+    fig, ax = plt.subplots(figsize=(11, 11))
+    ax.plot(polyline[:, 0], polyline[:, 1], "-", color="0.85", lw=2.0, zorder=1)
+    sc = ax.scatter(
+        polyline[valid_diff, 0], polyline[valid_diff, 1],
+        c=poly_diff[valid_diff], cmap="RdBu_r", vmin=-vlim, vmax=vlim,
+        s=80, edgecolors="none", zorder=2,
+    )
+    ax.set_title(
+        f"Δ mean |lateral offset|  ({args.prism_label} − {args.baseline_label}), "
+        f"5 m arc-length bins\n"
+        f"blue = {args.prism_label} better   red = {args.prism_label} worse"
+    )
+    ax.set_xlabel("MGRS x [m]")
+    ax.set_ylabel("MGRS y [m]")
+    ax.set_aspect("equal")
+    ax.set_xlim(x_min, x_max)
+    ax.set_ylim(y_min, y_max)
+    plt.colorbar(sc, ax=ax, fraction=0.04, pad=0.02, label="Δ |lat| [m]")
+    plt.tight_layout()
+    plt.savefig(args.out_dir / "heatmap_centerline_diff.png", dpi=140)
+    plt.close()
+
+    # Combined 3-panel
+    fig, axes = plt.subplots(1, 3, figsize=(22, 11), sharex=True, sharey=True)
+    sc_b = scatter_panel(axes[0], base_c, args.baseline_label)
+    sc_p = scatter_panel(axes[1], prism_c, args.prism_label)
+    plt.colorbar(sc_b, ax=axes[0], fraction=0.04, pad=0.02, label="|lat| [m]")
+    plt.colorbar(sc_p, ax=axes[1], fraction=0.04, pad=0.02, label="|lat| [m]")
+    ax = axes[2]
+    ax.plot(polyline[:, 0], polyline[:, 1], "-", color="0.85", lw=2.0, zorder=1)
+    sc = ax.scatter(
+        polyline[valid_diff, 0], polyline[valid_diff, 1],
+        c=poly_diff[valid_diff], cmap="RdBu_r", vmin=-vlim, vmax=vlim,
+        s=80, edgecolors="none", zorder=2,
+    )
+    ax.set_title(
+        f"Δ |lat|  ({args.prism_label} − {args.baseline_label})\n"
+        f"blue = {args.prism_label} better   red = {args.prism_label} worse\n"
+        f"mean Δ|lat| = {np.nanmean(diff_arc):+.3f} m"
+    )
+    ax.set_xlabel("MGRS x [m]")
+    ax.set_ylabel("MGRS y [m]")
+    ax.set_xlim(x_min, x_max)
+    ax.set_ylim(y_min, y_max)
+    ax.set_aspect("equal")
+    plt.colorbar(sc, ax=ax, fraction=0.04, pad=0.02, label="Δ |lat| [m]")
+    plt.suptitle(
+        f"Centerline-tracking comparison — {args.baseline_label} vs {args.prism_label} (psim)",
+        y=0.99, fontsize=14,
+    )
+    plt.tight_layout()
+    plt.savefig(args.out_dir / "heatmap_combined.png", dpi=140)
+    plt.close()
+
+    # Histogram
+    fig, ax = plt.subplots(figsize=(9, 5))
+    bins = np.linspace(-2.0, 2.0, 161)
+    ax.hist(base_c["lat"], bins=bins, alpha=0.55, color="C0", density=True,
+            label=f"{args.baseline_label} (n={len(base_c['lat'])}, "
+                  f"mean|lat|={np.mean(np.abs(base_c['lat'])):.3f}m)")
+    ax.hist(prism_c["lat"], bins=bins, alpha=0.55, color="C3", density=True,
+            label=f"{args.prism_label} (n={len(prism_c['lat'])}, "
+                  f"mean|lat|={np.mean(np.abs(prism_c['lat'])):.3f}m)")
+    ax.axvline(0, color="k", lw=0.7)
+    ax.set_xlabel("signed lateral offset [m]   (+ left, − right)")
+    ax.set_ylabel("density")
+    ax.set_title("Lateral offset distribution to route centerline")
+    ax.legend(loc="upper right")
+    plt.tight_layout()
+    plt.savefig(args.out_dir / "histogram_offsets.png", dpi=140)
+    plt.close()
+
+    # Time series
+    fig, axes = plt.subplots(2, 1, figsize=(12, 6), sharex=True)
+    for run, color, label in [(base_c, "C0", args.baseline_label), (prism_c, "C3", args.prism_label)]:
+        if len(run["ts"]) == 0:
+            continue
+        t = (run["ts"] - run["ts"][0]) / 1e9
+        axes[0].plot(t, run["lat"], color=color, lw=0.7, label=label)
+        axes[1].plot(t, np.abs(run["lat"]), color=color, lw=0.7, label=label)
+    axes[0].set_ylabel("signed lat [m]")
+    axes[0].axhline(0, color="k", lw=0.5)
+    axes[0].legend(loc="upper right")
+    axes[0].set_title("Lateral offset to route centerline vs simulation time")
+    axes[1].set_ylabel("|lat| [m]")
+    axes[1].set_xlabel("time [s] from run start")
+    plt.tight_layout()
+    plt.savefig(args.out_dir / "timeseries.png", dpi=140)
+    plt.close()
+
+    # |lat| vs longitudinal route progress
+    fig, ax = plt.subplots(figsize=(11, 5))
+    for run, color, label in [(base_c, "C0", args.baseline_label), (prism_c, "C3", args.prism_label)]:
+        order = np.argsort(run["lon"])
+        ax.plot(run["lon"][order], np.abs(run["lat"])[order], color=color, lw=0.7,
+                alpha=0.5, label=label)
+    arc_max = max(base_c["lon"].max(), prism_c["lon"].max())
+    bins = np.linspace(0, arc_max, 50)
+    for run, color, label in [(base_c, "C0", args.baseline_label), (prism_c, "C3", args.prism_label)]:
+        idx = np.digitize(run["lon"], bins)
+        mu = np.array([
+            np.mean(np.abs(run["lat"])[idx == i]) if (idx == i).any() else np.nan
+            for i in range(1, len(bins))
+        ])
+        ax.plot(0.5 * (bins[1:] + bins[:-1]), mu, color=color, lw=2.0,
+                label=f"{label} (binned mean)")
+    ax.set_xlabel("longitudinal arc-length along route centerline [m]")
+    ax.set_ylabel("|lateral offset| [m]")
+    ax.set_title("Lateral tracking error vs route progress")
+    ax.legend(loc="upper right")
+    ax.grid(True, alpha=0.3)
+    plt.tight_layout()
+    plt.savefig(args.out_dir / "progress_vs_offset.png", dpi=140)
+    plt.close()
+
+    print(f"\nWrote outputs to {args.out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/eval_psim_centerline.py
+++ b/rlvr/autoresearch/tools/eval_psim_centerline.py
@@ -95,6 +95,10 @@ def collect_run_trajectory_log(
     lon = np.full(n, np.nan, dtype=np.float64)
     speed = np.full(n, np.nan, dtype=np.float64)
 
+    # Precompute the polyline cumulative-arclength once and reuse it across
+    # frames; otherwise project_point_to_polyline_arclength would recompute
+    # an O(N_polyline) cumsum per frame.
+    poly_cum, _ = polyline_cumulative_arclength(polyline)
     traj = torch.tensor([[0.0, 0.0, 1.0, 0.0]], device=device)
 
     for i, entry in enumerate(log):
@@ -119,7 +123,7 @@ def collect_run_trajectory_log(
             continue
         lat[i] = float(out["lat_offset_m"][0])
         lat_signed[i] = float(out["signed_lat_offset_m"][0])
-        lon[i] = project_point_to_polyline_arclength(polyline, x, y)
+        lon[i] = project_point_to_polyline_arclength(polyline, x, y, cum=poly_cum)
 
     order = np.argsort(ts)
     return {
@@ -145,6 +149,9 @@ def collect_run(
     lon = np.full(n, np.nan, dtype=np.float64)
     speed = np.full(n, np.nan, dtype=np.float64)
 
+    # Precompute the polyline cumulative-arclength once and reuse it across
+    # frames (see collect_run_trajectory_log for rationale).
+    poly_cum, _ = polyline_cumulative_arclength(polyline)
     traj = torch.tensor([[0.0, 0.0, 1.0, 0.0]], device=device)  # (T=1, 4)
 
     for i, fp in enumerate(files):
@@ -175,7 +182,7 @@ def collect_run(
             continue
         lat[i] = float(out["lat_offset_m"][0])
         lat_signed[i] = float(out["signed_lat_offset_m"][0])
-        lon[i] = project_point_to_polyline_arclength(polyline, x, y)
+        lon[i] = project_point_to_polyline_arclength(polyline, x, y, cum=poly_cum)
 
     order = np.argsort(ts)
     return {

--- a/rlvr/autoresearch/tools/eval_psim_centerline_nway.py
+++ b/rlvr/autoresearch/tools/eval_psim_centerline_nway.py
@@ -49,12 +49,21 @@ from rlvr.autoresearch.tools.eval_psim_centerline import (
 
 
 def _parse_run(spec: str) -> dict:
+    """Parse a single ``--run name=<>,kind=<>,path=<>`` spec.
+
+    Validates: all three keys present, all three values non-empty, kind in
+    {npz, trajlog}. Caller (``main``) further enforces that ``name`` is
+    unique across runs — duplicate names would silently overwrite the
+    same ``<name>_offsets.npz`` output and confuse downstream plots."""
     out = {}
     for part in spec.split(","):
         k, _, v = part.partition("=")
         out[k.strip()] = v.strip()
-    if "name" not in out or "kind" not in out or "path" not in out:
-        raise SystemExit(f"--run must include name=, kind=, path= (got {spec!r})")
+    for key in ("name", "kind", "path"):
+        if key not in out or not out[key]:
+            raise SystemExit(
+                f"--run must include non-empty name=, kind=, path= (got {spec!r})"
+            )
     if out["kind"] not in ("npz", "trajlog"):
         raise SystemExit(f"--run kind must be 'npz' or 'trajlog' (got {out['kind']})")
     return out
@@ -88,6 +97,16 @@ def main():
     runs = [_parse_run(s) for s in args.run]
     if len(runs) < 2:
         raise SystemExit("Need at least 2 runs.")
+    seen: set[str] = set()
+    for r in runs:
+        if r["name"] in seen:
+            raise SystemExit(
+                f"Duplicate run name {r['name']!r}. Run names must be unique — "
+                "they appear in plot legends and the output "
+                "<name>_offsets.npz filename, so duplicates would silently "
+                "overwrite each other."
+            )
+        seen.add(r["name"])
 
     polyline = build_route_polyline(args.osm, args.route_json)
     np.save(args.out_dir / "route_polyline.npy", polyline)

--- a/rlvr/autoresearch/tools/eval_psim_centerline_nway.py
+++ b/rlvr/autoresearch/tools/eval_psim_centerline_nway.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""N-way centerline-tracking heatmap comparison across closed-loop psim runs.
+
+Reuses :func:`rlvr.autoresearch.tools.eval_psim_centerline.collect_run`
+(npz directory) and ``collect_run_trajectory_log`` (replay JSON) so the
+lateral metric is identical to ``compute_centerline_score_batch`` /
+``lat_offset_and_naive_score`` (the GRPO training reward function).
+
+Each run is described by a ``--run`` argument:
+
+  --run name=<label>,kind=<npz|trajlog>,path=<dir or .json>
+
+At least two runs must be given. Outputs (in ``--out_dir``):
+  summary.txt
+  heatmap_nway_xy.png        N-panel scatter colored by |lat|
+  heatmap_nway_diff.png      (run_i − run_0) projected onto the route polyline
+  histogram_offsets.png      stacked density histograms
+  progress_vs_offset.png     binned mean |lat| vs route arc-length
+  per-run npz dumps + route_polyline.npy
+
+Usage:
+    python -m rlvr.autoresearch.tools.eval_psim_centerline_nway \\
+        --run name=psim_new,kind=npz,path=<npz_dir> \\
+        --run name=perfect,kind=trajlog,path=<replay>/trajectory_log.json \\
+        --run name=mpc,kind=trajlog,path=<replay>/trajectory_log.json \\
+        --osm <map>.osm --route_json <route>.json --out_dir <out>
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+from rlvr.autoresearch.tools._psim_centerline_common import (
+    build_route_polyline,
+    crop_run_by_offset,
+    polyline_cumulative_arclength,
+    stats_line,
+)
+from rlvr.autoresearch.tools.eval_psim_centerline import (
+    collect_run,
+    collect_run_trajectory_log,
+)
+
+
+def _parse_run(spec: str) -> dict:
+    out = {}
+    for part in spec.split(","):
+        k, _, v = part.partition("=")
+        out[k.strip()] = v.strip()
+    if "name" not in out or "kind" not in out or "path" not in out:
+        raise SystemExit(f"--run must include name=, kind=, path= (got {spec!r})")
+    if out["kind"] not in ("npz", "trajlog"):
+        raise SystemExit(f"--run kind must be 'npz' or 'trajlog' (got {out['kind']})")
+    return out
+
+
+def _load(run: dict, polyline: np.ndarray, ego_half_w: float, device: str) -> dict:
+    p = Path(run["path"])
+    if run["kind"] == "npz":
+        return collect_run(p, polyline, ego_half_w, device)
+    return collect_run_trajectory_log(p, polyline, ego_half_w, device)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--run", action="append", required=True,
+                    help="Repeat. Format: name=<label>,kind=<npz|trajlog>,path=<...>")
+    ap.add_argument("--osm", type=Path, required=True)
+    ap.add_argument("--route_json", type=Path, required=True)
+    ap.add_argument("--out_dir", type=Path, required=True)
+    ap.add_argument("--max_offset_m", type=float, default=10.0)
+    ap.add_argument("--ego_half_w", type=float, default=0.85,
+                    help="Half ego width (m). Forwarded to "
+                         "lat_offset_and_naive_score; currently consumed only "
+                         "in 'body' usage_mode and the underlying tool "
+                         "hardcodes 'baselink', so this is effectively "
+                         "ignored. Kept for forward-compat.")
+    ap.add_argument("--device", default="cpu")
+    args = ap.parse_args()
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    runs = [_parse_run(s) for s in args.run]
+    if len(runs) < 2:
+        raise SystemExit("Need at least 2 runs.")
+
+    polyline = build_route_polyline(args.osm, args.route_json)
+    np.save(args.out_dir / "route_polyline.npy", polyline)
+
+    print(f"Loaded route polyline ({len(polyline)} points). Loading {len(runs)} runs...")
+    raw = {}
+    cropped = {}
+    for r in runs:
+        print(f"-> {r['name']} ({r['kind']}: {r['path']})")
+        d = _load(r, polyline, args.ego_half_w, args.device)
+        raw[r["name"]] = d
+        cropped[r["name"]] = crop_run_by_offset(d, args.max_offset_m)
+        np.savez(args.out_dir / f"{r['name']}_offsets.npz", **d)
+
+    summary_lines = [
+        f"N-way centerline-tracking comparison (lateral via "
+        f"compute_centerline_score_batch / lat_offset_and_naive_score)",
+        f"Reference: {args.route_json.name} ({len(polyline)} centerline points)",
+        f"Map: {args.osm}",
+        f"Frames cropped where |lateral offset| > {args.max_offset_m} m",
+        "Sign: + = left of route direction, − = right",
+        "",
+    ]
+    # Abort early if any run has no kept frames — the rest of the pipeline
+    # (stats, scatter, arc-length binning) all reduce over potentially-empty
+    # arrays and would crash.
+    empty_runs = [name for name, d in cropped.items() if len(d["lat"]) == 0]
+    if empty_runs:
+        raise SystemExit(
+            f"No frames remain after cropping by --max_offset_m="
+            f"{args.max_offset_m} for run(s): {', '.join(empty_runs)}. "
+            "Increase --max_offset_m or inspect the input data."
+        )
+
+    for r in runs:
+        summary_lines.append(stats_line(r["name"], cropped[r["name"]], raw[r["name"]]))
+    summary_lines.append("")
+    base_name = runs[0]["name"]
+    base_abs = np.abs(cropped[base_name]["lat"])
+    base_mean = float(np.mean(base_abs))
+    summary_lines.append(f"Δ baseline = {base_name}")
+    for r in runs[1:]:
+        a = np.abs(cropped[r["name"]]["lat"])
+        d_mean = float(np.mean(a)) - base_mean
+        d_p95 = float(np.percentile(a, 95)) - float(np.percentile(base_abs, 95))
+        d_med = float(np.median(a)) - float(np.median(base_abs))
+        # Guard against a perfectly-on-centerline baseline (mean ≈ 0).
+        if abs(base_mean) <= 1e-12:
+            pct = "pct n/a"
+        else:
+            pct = f"{100 * d_mean / base_mean:+.1f}%"
+        summary_lines.append(
+            f"  {r['name']} vs {base_name}: "
+            f"Δmean={d_mean:+.3f}m ({pct})  "
+            f"Δmed={d_med:+.3f}m  Δp95={d_p95:+.3f}m"
+        )
+    summary_lines.append("")
+    for thr in (0.3, 0.5, 1.0):
+        line = f"Frames |lat| > {thr}m:"
+        for r in runs:
+            a = np.abs(cropped[r["name"]]["lat"])
+            line += f"  {r['name']}={(a>thr).sum()}/{len(a)} ({100*(a>thr).mean():.1f}%)"
+        summary_lines.append(line)
+    summary = "\n".join(summary_lines)
+    print("\n" + summary)
+    (args.out_dir / "summary.txt").write_text(summary + "\n")
+
+    # ---- N-panel scatter ----
+    all_xy = np.concatenate([cropped[r["name"]]["world_xy"] for r in runs], axis=0)
+    x_min, x_max = all_xy[:, 0].min() - 20, all_xy[:, 0].max() + 20
+    y_min, y_max = all_xy[:, 1].min() - 20, all_xy[:, 1].max() + 20
+    vmax = float(np.percentile(
+        np.concatenate([np.abs(cropped[r["name"]]["lat"]) for r in runs]), 95
+    ))
+    vmax = max(vmax, 0.5)
+
+    N = len(runs)
+    fig, axes = plt.subplots(1, N, figsize=(7 * N, 9), sharex=True, sharey=True)
+    if N == 1:
+        axes = [axes]
+    for ax, r in zip(axes, runs):
+        d = cropped[r["name"]]
+        ax.plot(polyline[:, 0], polyline[:, 1], "-", color="0.7", lw=2.5,
+                alpha=0.5, zorder=1, label="route centerline")
+        sc = ax.scatter(
+            d["world_xy"][:, 0], d["world_xy"][:, 1],
+            c=np.abs(d["lat"]), cmap="inferno", vmin=0.0, vmax=vmax,
+            s=18, alpha=0.9, edgecolors="none", zorder=2,
+        )
+        ax.set_title(
+            f"{r['name']}\nmean|lat|={np.mean(np.abs(d['lat'])):.3f}m  "
+            f"p95={np.percentile(np.abs(d['lat']),95):.3f}m  "
+            f"max={np.max(np.abs(d['lat'])):.3f}m  n={len(d['lat'])}"
+        )
+        ax.set_xlabel("MGRS x [m]")
+        ax.set_ylabel("MGRS y [m]")
+        ax.set_xlim(x_min, x_max)
+        ax.set_ylim(y_min, y_max)
+        ax.set_aspect("equal")
+        ax.legend(loc="upper right")
+        plt.colorbar(sc, ax=ax, fraction=0.04, pad=0.02, label="|lat| [m]")
+    plt.suptitle("Centerline-tracking heatmap (each dot = one frame)", y=0.99)
+    plt.tight_layout()
+    plt.savefig(args.out_dir / "heatmap_nway_xy.png", dpi=140)
+    plt.close()
+
+    # ---- Δ map: each non-base run binned along arc-length and re-projected ----
+    arc_max = max(cropped[r["name"]]["lon"].max() for r in runs)
+    arc_bins = np.arange(0, arc_max + 5.0, 5.0)
+    arc_centers = 0.5 * (arc_bins[1:] + arc_bins[:-1])
+
+    def bin_arc(d: dict) -> np.ndarray:
+        idx = np.clip(np.digitize(d["lon"], arc_bins) - 1, 0, len(arc_centers) - 1)
+        sums = np.zeros(len(arc_centers))
+        cnts = np.zeros(len(arc_centers))
+        np.add.at(sums, idx, np.abs(d["lat"]))
+        np.add.at(cnts, idx, 1.0)
+        return np.divide(sums, cnts, out=np.full_like(sums, np.nan), where=cnts > 0)
+
+    arcs = {r["name"]: bin_arc(cropped[r["name"]]) for r in runs}
+    poly_arc, _ = polyline_cumulative_arclength(polyline)
+    poly_bin = np.clip(np.digitize(poly_arc, arc_bins) - 1, 0, len(arc_centers) - 1)
+
+    diff_panels = [(r["name"], arcs[r["name"]] - arcs[base_name]) for r in runs[1:]]
+    if diff_panels:
+        fig, axes = plt.subplots(1, len(diff_panels), figsize=(8 * len(diff_panels), 9),
+                                 sharex=True, sharey=True)
+        if len(diff_panels) == 1:
+            axes = [axes]
+        all_finite = np.concatenate([d[np.isfinite(d)] for _, d in diff_panels])
+        vlim = max(float(np.percentile(np.abs(all_finite), 98)) if all_finite.size else 1.0, 0.3)
+        for ax, (name, diff_arc) in zip(axes, diff_panels):
+            poly_diff = diff_arc[poly_bin]
+            valid = np.isfinite(poly_diff)
+            ax.plot(polyline[:, 0], polyline[:, 1], "-", color="0.85", lw=2.0, zorder=1)
+            sc = ax.scatter(
+                polyline[valid, 0], polyline[valid, 1],
+                c=poly_diff[valid], cmap="RdBu_r", vmin=-vlim, vmax=vlim,
+                s=80, edgecolors="none", zorder=2,
+            )
+            ax.set_title(
+                f"Δ |lat| ({name} − {base_name})\n"
+                f"blue = {name} better   red = {name} worse\n"
+                f"mean Δ = {np.nanmean(diff_arc):+.3f} m"
+            )
+            ax.set_xlabel("MGRS x [m]")
+            ax.set_ylabel("MGRS y [m]")
+            ax.set_xlim(x_min, x_max)
+            ax.set_ylim(y_min, y_max)
+            ax.set_aspect("equal")
+            plt.colorbar(sc, ax=ax, fraction=0.04, pad=0.02, label="Δ |lat| [m]")
+        plt.tight_layout()
+        plt.savefig(args.out_dir / "heatmap_nway_diff.png", dpi=140)
+        plt.close()
+
+    # ---- Stacked histograms ----
+    colors = ["C0", "C3", "C2", "C4", "C1", "C5"]
+    fig, ax = plt.subplots(figsize=(10, 5))
+    bins = np.linspace(-2.0, 2.0, 161)
+    for i, r in enumerate(runs):
+        d = cropped[r["name"]]
+        ax.hist(d["lat"], bins=bins, alpha=0.5, density=True,
+                color=colors[i % len(colors)],
+                label=f"{r['name']} (n={len(d['lat'])}, mean|lat|={np.mean(np.abs(d['lat'])):.3f}m)")
+    ax.axvline(0, color="k", lw=0.7)
+    ax.set_xlabel("signed lateral offset [m]   (+ left, − right)")
+    ax.set_ylabel("density")
+    ax.set_title("Lateral offset distribution to route centerline")
+    ax.legend(loc="upper right")
+    plt.tight_layout()
+    plt.savefig(args.out_dir / "histogram_offsets.png", dpi=140)
+    plt.close()
+
+    # ---- Progress vs |lat| ----
+    fig, ax = plt.subplots(figsize=(12, 5))
+    for i, r in enumerate(runs):
+        d = cropped[r["name"]]
+        c = colors[i % len(colors)]
+        ax.plot(arc_centers, arcs[r["name"]], color=c, lw=2.0,
+                label=f"{r['name']} (binned mean)")
+    ax.set_xlabel("longitudinal arc-length along route centerline [m]")
+    ax.set_ylabel("|lateral offset| [m]")
+    ax.set_title("Lateral tracking error vs route progress")
+    ax.legend(loc="upper right")
+    ax.grid(True, alpha=0.3)
+    plt.tight_layout()
+    plt.savefig(args.out_dir / "progress_vs_offset.png", dpi=140)
+    plt.close()
+
+    print(f"\nWrote outputs to {args.out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/recovery_sim.py
+++ b/rlvr/autoresearch/tools/recovery_sim.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Recovery sim: render sim-style PNGs of a closed-loop lateral-recovery rollout.
 
-Mirrors the rendering of ``scenario_generation.replay`` (`_save_step_figure`):
+Mirrors the rendering of ``scenario_generation.replay`` (`save_step_figure`):
 lane network, road borders, ego oriented box, predicted trajectory ahead,
 and a body-to-border distance overlay. Operates in the **initial ego frame**
 (the frame stored in the NPZ) so we don't need an OSM / lanelet2 lookup —
@@ -294,7 +294,7 @@ def closed_loop_rollout_with_plans(
 
 
 # ---------------------------------------------------------------------------
-# Per-step rendering (mirrors scenario_generation.replay._save_step_figure)
+# Per-step rendering (mirrors scenario_generation.replay.save_step_figure)
 # ---------------------------------------------------------------------------
 
 

--- a/scenario_generation/render_npz_dir.py
+++ b/scenario_generation/render_npz_dir.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Render a directory of training-style NPZ files as per-step PNGs that look
+exactly like ``scenario_generation.replay`` output.
+
+Reuses ``scenario_generation.replay._save_step_figure`` (the same function
+the replay calls every step) so the viewport, agent boxes, route overlay,
+lane network, road borders, etc. all match closed-loop sim renders.
+
+Usage:
+    python -m scenario_generation.render_npz_dir \\
+        --npz_dir <path>/npz \\
+        --output_dir <path>/render \\
+        [--route_pkl <route>.pkl] \\
+        [--workers 8] [--limit 100] [--stride 1]
+"""
+from __future__ import annotations
+
+import argparse
+import multiprocessing as mp
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import numpy as np
+
+from scenario_generation.npz_loader import from_npz
+from scenario_generation.replay import _save_step_figure
+from scenario_generation.transforms import yaw_from_quat
+
+
+def _world_to_ego_polylines(
+    polylines_world: list[np.ndarray] | None,
+    ego_xy_yaw_world: tuple[float, float, float],
+    crop_radius_m: float = 120.0,
+) -> list[np.ndarray] | None:
+    """Transform a list of world-frame ``(K, 2)`` polylines into the ego
+    frame at this frame and crop to those passing within ``crop_radius_m``
+    of the ego origin (a soft viewport prefilter). Returns ``None`` when
+    the input is ``None``."""
+    if polylines_world is None:
+        return None
+    cx, cy, yaw = ego_xy_yaw_world
+    cos_y, sin_y = np.cos(-yaw), np.sin(-yaw)
+    R = np.array([[cos_y, -sin_y], [sin_y, cos_y]], dtype=np.float64)
+    out: list[np.ndarray] = []
+    for pl in polylines_world:
+        if pl.shape[0] < 2:
+            continue
+        local = (pl - np.array([cx, cy], dtype=np.float64)) @ R.T
+        # Drop polylines whose AABB lies entirely outside the viewport in
+        # at least one axis — covers e.g. polylines well left/right of ego
+        # whose y-extent still straddles 0. The earlier `min(abs)` check
+        # incorrectly only rejected polylines outside on BOTH axes.
+        if (
+            local[:, 0].min() > crop_radius_m
+            or local[:, 0].max() < -crop_radius_m
+            or local[:, 1].min() > crop_radius_m
+            or local[:, 1].max() < -crop_radius_m
+        ):
+            continue
+        out.append(local.astype(np.float32))
+    return out if out else None
+
+
+def _build_map_overlays(
+    route_pkl_path: Path | None,
+) -> tuple[list[np.ndarray] | None, list[np.ndarray] | None]:
+    """Return ``(route_polylines, road_border_polylines)`` from a Route
+    pickle. Both are world-frame ``(K, 2)`` arrays. Returns ``(None, None)``
+    when no route is given."""
+    if route_pkl_path is None:
+        return None, None
+    from scenario_generation.gui.lanelet_scene_builder import LaneletSceneBuilder
+    from scenario_generation.route import Route
+
+    route = Route.load(route_pkl_path)
+    builder = LaneletSceneBuilder(route.map_path)
+    rp: list[np.ndarray] = []
+    if route.route_lanelet_ids:
+        for lid in route.route_lanelet_ids:
+            if not builder.has_lanelet_id(lid):
+                continue
+            cl = np.asarray(builder.raw_centerline(lid), dtype=np.float64)
+            # raw_centerline can be (N, 3) on z-bearing maps; we only need
+            # the (x, y) projection for the 2-D viewport overlay.
+            if cl.ndim == 2 and cl.shape[1] >= 2 and len(cl) >= 2:
+                rp.append(cl[:, :2])
+    rb = builder.road_border_polylines()
+    return (rp if rp else None), (rb if rb else None)
+
+
+def _ego_future_to_predictions(scene):
+    """Convert the rosbag's ``ego_agent_future`` (T, 3) [x, y, yaw_rad] in
+    ego frame to the (T, 4) [x, y, cos_h, sin_h] format the replay's
+    ``agent_predictions`` dict expects. Returns an empty dict when the
+    scene has no future trajectory (or it has an unexpected shape)."""
+    ego = scene.ego_agent
+    fut = getattr(ego, "future_trajectory", None)
+    if fut is None or len(fut) == 0:
+        return {}
+    if fut.shape[-1] == 3:
+        fut4 = np.concatenate(
+            [fut[:, :2], np.cos(fut[:, 2:3]), np.sin(fut[:, 2:3])], axis=-1
+        )
+    elif fut.shape[-1] >= 4:
+        fut4 = fut[:, :4]
+    else:
+        return {}
+    return {ego.id: fut4.astype(np.float32)}
+
+
+def _override_ego_dims(scene, ego_dims: tuple[float, float, float] | None) -> None:
+    """Override ego length / width on the loaded SceneContext when the npz
+    was converted with mismatched dims (e.g. data_converter defaults vs.
+    the actual vehicle the rosbag was recorded on)."""
+    if ego_dims is None:
+        return
+    length, width, wheelbase = ego_dims
+    ego = scene.ego_agent
+    if ego is not None:
+        ego.length = float(length)
+        ego.width = float(width)
+        # ``wheelbase`` is consumed by some downstream metrics; assign it
+        # if the dataclass has the slot, otherwise ignore.
+        if hasattr(ego, "wheelbase"):
+            ego.wheelbase = float(wheelbase)
+
+
+# Worker-side globals populated by ``_pool_init`` so that the route /
+# road-border polyline lists (often thousands of (K, 2) numpy arrays) are
+# transmitted ONCE per worker instead of duplicated into every task tuple.
+# This matters most under the ``spawn`` start method where every task is
+# pickled — under ``fork`` (Linux default) the parent's memory is shared
+# copy-on-write, but the dispatch overhead is still lower this way.
+_WORKER_ROUTE_POLYLINES: list[np.ndarray] | None = None
+_WORKER_ROAD_BORDER_POLYLINES: list[np.ndarray] | None = None
+_WORKER_EGO_DIMS: tuple[float, float, float] | None = None
+_WORKER_N_STEPS: int = 0
+
+
+def _pool_init(
+    route_polylines_world: list[np.ndarray] | None,
+    road_border_polylines_world: list[np.ndarray] | None,
+    ego_dims: tuple[float, float, float] | None,
+    n_steps: int,
+) -> None:
+    global _WORKER_ROUTE_POLYLINES, _WORKER_ROAD_BORDER_POLYLINES
+    global _WORKER_EGO_DIMS, _WORKER_N_STEPS
+    _WORKER_ROUTE_POLYLINES = route_polylines_world
+    _WORKER_ROAD_BORDER_POLYLINES = road_border_polylines_world
+    _WORKER_EGO_DIMS = ego_dims
+    _WORKER_N_STEPS = n_steps
+
+
+def _render_one(args):
+    idx, npz_path, out_path = args
+    try:
+        scene = from_npz(npz_path)
+        _override_ego_dims(scene, _WORKER_EGO_DIMS)
+        # The npz stores all geometry in ego frame at t=0; the json
+        # sidecar gives the world MGRS pose so we can transform any
+        # world-frame overlays (route, road borders) into the same ego
+        # frame.
+        sidecar = npz_path.with_suffix(".json")
+        ego_xy_yaw = (0.0, 0.0, 0.0)
+        if sidecar.exists():
+            import json as _json
+            j = _json.loads(sidecar.read_text())
+            ego_xy_yaw = (
+                float(j["x"]), float(j["y"]),
+                yaw_from_quat(j["qx"], j["qy"], j["qz"], j["qw"]),
+            )
+        route_polylines = _world_to_ego_polylines(
+            _WORKER_ROUTE_POLYLINES, ego_xy_yaw,
+        )
+        road_border_polylines = _world_to_ego_polylines(
+            _WORKER_ROAD_BORDER_POLYLINES, ego_xy_yaw, crop_radius_m=80.0,
+        )
+        agent_predictions = _ego_future_to_predictions(scene)
+        _save_step_figure(
+            scene=scene,
+            agent_predictions=agent_predictions,
+            output_path=out_path,
+            step=idx,
+            n_steps=_WORKER_N_STEPS,
+            route_polylines=route_polylines,
+            tl_controller=None,
+            road_border_polylines=road_border_polylines,
+            metrics=None,
+        )
+    except Exception as e:
+        return f"FAIL {npz_path.name}: {type(e).__name__}: {e}"
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--npz_dir", type=Path, required=True)
+    ap.add_argument("--output_dir", type=Path, required=True)
+    ap.add_argument("--route_pkl", type=Path, default=None,
+                    help="Optional Route pickle. Provides both the route "
+                         "polyline overlay and the road-border line strings "
+                         "(loaded once from the lanelet2 map referenced by the "
+                         "Route). Without it neither overlay is drawn — "
+                         "everything else (lane network, agents, predicted "
+                         "trajectory, HUD) still appears.")
+    ap.add_argument("--workers", type=int, default=8)
+    ap.add_argument("--limit", type=int, default=-1)
+    ap.add_argument("--stride", type=int, default=1)
+    ap.add_argument("--ego_length", type=float, default=None,
+                    help="Override ego length (m). Defaults to whatever's in "
+                         "the npz (the data_converter writes its --ego_length "
+                         "default unless overridden at convert time).")
+    ap.add_argument("--ego_width", type=float, default=None)
+    ap.add_argument("--ego_wheelbase", type=float, default=None)
+    args = ap.parse_args()
+    ego_dims = None
+    given = [args.ego_length, args.ego_width, args.ego_wheelbase]
+    if any(v is not None for v in given):
+        if not all(v is not None for v in given):
+            ap.error("--ego_length / --ego_width / --ego_wheelbase must all be "
+                     "set together, or all be omitted (defaults from npz).")
+        ego_dims = (args.ego_length, args.ego_width, args.ego_wheelbase)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    files = sorted(args.npz_dir.glob("*.npz"))
+    if args.stride > 1:
+        files = files[:: args.stride]
+    if args.limit > 0:
+        files = files[: args.limit]
+    n_steps = len(files)
+    print(f"Rendering {n_steps} files from {args.npz_dir} -> {args.output_dir} "
+          f"with {args.workers} workers")
+
+    # Building the route polylines + road borders pulls in lanelet2 (heavy);
+    # do it once in the parent and ship to workers via a Pool initializer
+    # rather than duplicating into every task tuple.
+    route_polylines, road_border_polylines = _build_map_overlays(args.route_pkl)
+    if route_polylines:
+        print(f"  loaded {len(route_polylines)} route lanelet centerlines")
+    if road_border_polylines:
+        print(f"  loaded {len(road_border_polylines)} road-border polylines")
+    if ego_dims:
+        print(f"  overriding ego dims: length={ego_dims[0]} width={ego_dims[1]} "
+              f"wheelbase={ego_dims[2]}")
+
+    tasks = [
+        (i, f, args.output_dir / f"step_{i:04d}.png")
+        for i, f in enumerate(files)
+    ]
+
+    with mp.Pool(
+        args.workers,
+        initializer=_pool_init,
+        initargs=(route_polylines, road_border_polylines, ego_dims, n_steps),
+    ) as pool:
+        for j, err in enumerate(pool.imap_unordered(_render_one, tasks, chunksize=4)):
+            if err:
+                print(err)
+            if (j + 1) % 100 == 0:
+                print(f"  {j+1}/{n_steps}")
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scenario_generation/render_npz_dir.py
+++ b/scenario_generation/render_npz_dir.py
@@ -2,7 +2,7 @@
 """Render a directory of training-style NPZ files as per-step PNGs that look
 exactly like ``scenario_generation.replay`` output.
 
-Reuses ``scenario_generation.replay._save_step_figure`` (the same function
+Reuses ``scenario_generation.replay.save_step_figure`` (the same function
 the replay calls every step) so the viewport, agent boxes, route overlay,
 lane network, road borders, etc. all match closed-loop sim renders.
 
@@ -25,7 +25,7 @@ matplotlib.use("Agg")
 import numpy as np
 
 from scenario_generation.npz_loader import from_npz
-from scenario_generation.replay import _save_step_figure
+from scenario_generation.replay import save_step_figure
 from scenario_generation.transforms import yaw_from_quat
 
 
@@ -178,7 +178,7 @@ def _render_one(args):
             _WORKER_ROAD_BORDER_POLYLINES, ego_xy_yaw, crop_radius_m=80.0,
         )
         agent_predictions = _ego_future_to_predictions(scene)
-        _save_step_figure(
+        save_step_figure(
             scene=scene,
             agent_predictions=agent_predictions,
             output_path=out_path,

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -1184,7 +1184,7 @@ def _ego_nearest_static_npc(
     )
 
 
-def _save_step_figure(
+def save_step_figure(
     scene: SceneContext,
     agent_predictions: dict,
     output_path: Path,
@@ -1949,7 +1949,7 @@ def run_route_replay(
                 else None
             )
             pending_saves.append(save_pool.submit(
-                _save_step_figure,
+                save_step_figure,
                 deepcopy(scene), agent_predictions, out_path,
                 step, spawn_config.max_steps, route_polylines,
                 _VIEW_HALF_M, tl_controller, _route_vis_ll_ids,

--- a/scenario_generation/transforms.py
+++ b/scenario_generation/transforms.py
@@ -7,7 +7,22 @@ This rotates by -heading, making the heading direction become [1, 0].
 
 from __future__ import annotations
 
+import math
+
 import numpy as np
+
+
+def yaw_from_quat(qx: float, qy: float, qz: float, qw: float) -> float:
+    """Extract yaw (heading about +Z) from a quaternion using the standard
+    ZYX-Euler reduction.
+
+    For a unit quaternion this matches ``tf2::getYaw`` (ROS) and
+    ``Rotation.from_quat([qx, qy, qz, qw]).as_euler('xyz')[2]``. Returned
+    angle is in radians, range ``(-pi, pi]``.
+    """
+    siny_cosp = 2.0 * (qw * qz + qx * qy)
+    cosy_cosp = 1.0 - 2.0 * (qy * qy + qz * qz)
+    return math.atan2(siny_cosp, cosy_cosp)
 
 
 def _rotation_matrix(heading: float) -> np.ndarray:


### PR DESCRIPTION
## Summary

Adds three closed-loop / psim centerline-tracking analysis tools plus shared helpers, all reusing the existing `lat_offset_and_naive_score` reward helper so numbers stay comparable to GRPO training metrics.

- **`rlvr/autoresearch/tools/eval_psim_centerline.py`** — rosbag→npz centerline-heatmap tool. Per-frame baselink lateral offset to a reference centerline built from `route.json` + lanelet2.
- **`rlvr/autoresearch/tools/eval_psim_centerline_nway.py`** — N-way generalisation. Mixes rosbag-derived npz directories and `scenario_generation.replay` `trajectory_log.json` outputs in the same comparison; produces N-panel heatmaps, Δ heatmaps vs a chosen baseline, histograms, arc-length progress plots.
- **`scenario_generation/render_npz_dir.py`** — renders a directory of training-style npz files as `step_NNNN.png` PNGs using the replay's `_save_step_figure` (matches closed-loop sim renders: viewport, ego box, route overlay, road borders, predicted trajectory, HUD). Supports `--ego_{length,width,wheelbase}` overrides for rosbags converted with mismatched vehicle dims.

Supporting changes:

- **`rlvr/autoresearch/tools/_psim_centerline_common.py`** (new) — extracted helpers shared by both eval tools (route polyline construction, world→ego synthetic `route_lanes` packing, cropping, summary stats, arc-length binning, point-to-polyline projection).
- **`scenario_generation/transforms.py`** — new `yaw_from_quat` helper centralising the ZYX-Euler yaw extraction that was previously duplicated across the new tools.
- **`rlvr/autoresearch/tools/eval_centerline_metrics.py`** — `lat_offset_and_naive_score` now additionally returns `signed_lat_offset_m` (signed metric distance, was only `|lat|` before). Default behaviour unchanged.
- **`rlvr/autoresearch/tools/README.md`** — sections for the three new tools.

## Test plan

- [x] `python -c "import …"` smoke-test passes for `_psim_centerline_common`, `eval_psim_centerline`, `eval_psim_centerline_nway`, `scenario_generation.render_npz_dir`, and `scenario_generation.transforms.yaw_from_quat`.
- [x] `eval_psim_centerline_nway` re-run on existing psim runs reproduces prior numbers exactly (Δ mean +0.943 m, Δ p95 +3.477 m).
- [x] `render_npz_dir` smoke-render of 3 frames with `--route_pkl` produces correctly-zoomed PNGs (±50 m around ego, route + road-border overlays, ego box drawn at supplied dims, predicted-future trajectory).
- [x] Sensitive-content sweep over the diff (vehicle / place names / hardcoded paths): clean.
- [x] Local code review (general-purpose agent): bug list addressed (signed-label propagation, trajlog timeseries timestamp, `--ego_*` partial-override gating, dead code in `_ego_future_to_predictions`, `--ego_half_w` doc clarification, `--route_pkl` doc clarification).