### PR TITLE
feat: dataset clustering

### DIFF
--- a/diffusion_planner/requirements.txt
+++ b/diffusion_planner/requirements.txt
@@ -11,3 +11,5 @@ gradio>=4.0.0
 matplotlib>=3.7.0
 peft
 scipy>=1.7.0
+scikit-learn>=1.3.0
+tqdm>=4.64.0

--- a/diffusion_planner/sampling/README.md
+++ b/diffusion_planner/sampling/README.md
@@ -1,35 +1,36 @@
 # Sampling Package
 
-## 概要
+## Overview
 
-Sampling Package は Diffusion Planner の学習に利用するデータの偏りを避けるため、データが適切な分布となるようにサンプリングを行うためのパッケージです。
+The Sampling Package provides tools to cluster trajectory datasets used for Diffusion Planner training.
+By grouping ego future trajectories into clusters, it helps avoid sampling bias and ensures a balanced data distribution across training scenarios.
 
-Sampling Package は下記のファイルから構成されます。
-
-## ファイル構成
+## File Structure
 
 ```
 sampling/
-├── cluster.py            # クラスタリング本体（エルボー法 + KMeans）
-├── visualize_cluster.py  # クラスタリング結果の可視化
+├── cluster.py            # CLI entry point — argument parsing and file I/O
+├── visualize_cluster.py  # Visualize clustering results as trajectory plots
 ├── utils/
-│   └── elbow.py          # WCSS 計算・エルボー検出・KMeans のユーティリティ
+│   ├── elbow.py          # WCSS computation, elbow detection, KMeans fitting
+│   └── pipeline.py       # Feature extraction, ClusteringStrategy interface, and pipeline
 └── README.md
 ```
 
-### 各ファイルの役割
+### File Roles
 
-| ファイル | 役割 |
+| File | Role |
 |---|---|
-| `cluster.py` | NPZ ファイル一覧を受け取り、ego の将来軌跡を特徴量として KMeans でクラスタリングする。最適クラスタ数はエルボー法で自動決定する。 |
-| `visualize_cluster.py` | `cluster.py` が出力した JSON を読み込み、クラスタごとに ego 将来軌跡を重ね描きしたサブプロット図を出力する。 |
-| `utils/elbow.py` | WCSS（クラスタ内二乗和）の計算、エルボー点の検出、KMeans フィットをまとめたユーティリティ。 |
+| `cluster.py` | CLI entry point. Reads an NPZ file list, runs the clustering pipeline, and writes the result JSON. |
+| `visualize_cluster.py` | Reads the result JSON from `cluster.py` and produces a grid of subplots, one per cluster, showing overlaid ego future trajectories. |
+| `utils/elbow.py` | Utilities for computing WCSS (within-cluster sum of squares), finding the elbow point, and fitting KMeans. |
+| `utils/pipeline.py` | Feature extraction from NPZ files, the `ClusteringStrategy` abstract interface, the `ElbowKMeansStrategy` concrete implementation, and the `cluster_trajectories` pipeline function. |
 
 ---
 
-## 使い方
+## Usage
 
-### Step 1: クラスタリング（`cluster.py`）
+### Step 1: Clustering (`cluster.py`)
 
 ```bash
 python cluster.py \
@@ -40,15 +41,15 @@ python cluster.py \
     [--seed 42]
 ```
 
-| 引数 | 必須 | デフォルト | 説明 |
+| Argument | Required | Default | Description |
 |---|---|---|---|
-| `--data_list` | ✓ | — | NPZ ファイルのパスを列挙した JSON |
-| `--output` | ✓ | — | クラスタリング結果を書き出す JSON のパス |
-| `--k_max` | | `20` | 評価するクラスタ数の上限 |
-| `--pca_components` | | `50` | PCA で削減する次元数 |
-| `--seed` | | `42` | 乱数シード |
+| `--data_list` | ✓ | — | Path to a JSON file listing NPZ file paths |
+| `--output` | ✓ | — | Output path for the clustering result JSON |
+| `--k_max` | | `20` | Upper bound on the number of clusters to evaluate |
+| `--pca_components` | | `50` | Number of PCA components for dimensionality reduction |
+| `--seed` | | `42` | Random seed |
 
-**入力 JSON 形式（`--data_list`）**
+**Input JSON format (`--data_list`)**
 
 ```json
 [
@@ -58,7 +59,7 @@ python cluster.py \
 ]
 ```
 
-### Step 2: 可視化（`visualize_cluster.py`）
+### Step 2: Visualization (`visualize_cluster.py`)
 
 ```bash
 python visualize_cluster.py \
@@ -68,47 +69,81 @@ python visualize_cluster.py \
     [--seed 42]
 ```
 
-| 引数 | 必須 | デフォルト | 説明 |
+| Argument | Required | Default | Description |
 |---|---|---|---|
-| `--cluster_json` | ✓ | — | `cluster.py` が出力した JSON |
-| `--output` | | — | 保存先のパス（PNG / PDF / SVG）。省略するとインタラクティブ表示 |
-| `--max_samples` | | `200` | クラスタごとに描画する軌跡の最大本数 |
-| `--seed` | | `42` | サンプリング乱数シード |
+| `--cluster_json` | ✓ | — | Clustering result JSON produced by `cluster.py` |
+| `--output` | | — | Output path (PNG / PDF / SVG). If omitted, the figure is shown interactively. |
+| `--max_samples` | | `200` | Maximum number of trajectories to draw per cluster |
+| `--seed` | | `42` | Random seed for trajectory sampling |
 
 ---
 
-## 処理パイプライン
+## Processing Pipeline
 
 ```
-NPZ ファイル群
+NPZ files
      │
      ▼
-ego_agent_future (80, 3) をフラット化 → (240,)
+Extract ego_agent_future (80, 3) → flatten → (240,)
      │
      ▼
-Z スコア正規化
+Z-score normalization
      │
      ▼
-PCA（240 次元 → pca_components 次元）
+PCA  (240-dim → pca_components-dim)
      │
      ▼
-エルボー法で最適 k を決定（k = 1 .. k_max）
-     │
-     ▼
-KMeans（k = optimal_k）
-     │
-     ▼
-result.json（クラスタ ID ごとに NPZ パスを分類）
+ClusteringStrategy.fit_predict(features)
+     │                 │
+     │    ElbowKMeansStrategy (default)
+     │      Determine optimal k via elbow method (k = 1 .. k_max)
+     │      Fit KMeans with k = optimal_k
+     │                 │
+     ▼                 ▼
+result.json  (NPZ paths grouped by cluster ID)
 ```
+
+The clustering step is implemented as a **Strategy pattern**.
+The preprocessing steps (feature extraction, Z-score normalization, PCA) are fixed,
+while the clustering algorithm is delegated to a `ClusteringStrategy` instance.
+This makes it straightforward to swap in a different algorithm without touching the pipeline.
 
 ---
 
-## 出力ファイル
+## Extending with a Custom Clustering Strategy
 
-### `cluster.py` の出力 JSON
+To use a different clustering algorithm, subclass `ClusteringStrategy` and implement `fit_predict`.
+The method must set `self.n_clusters_` as a side-effect so the pipeline can report the number of clusters used.
 
-クラスタ ID をキー、そのクラスタに属する NPZ ファイルのパス一覧を値とした辞書形式です。  
-キーは `cluster_id0`、`cluster_id1`、… の順にソートされています。
+```python
+import numpy as np
+from utils.pipeline import ClusteringStrategy, cluster_trajectories
+
+class MyStrategy(ClusteringStrategy):
+    def fit_predict(self, features: np.ndarray) -> np.ndarray:
+        # ... your algorithm ...
+        self.n_clusters_ = k  # must be set
+        return labels          # integer array of shape (n_samples,)
+
+strategy = MyStrategy()
+result = cluster_trajectories(npz_paths, strategy, pca_components=50)
+print(f"Clusters: {strategy.n_clusters_}")
+```
+
+### Built-in strategies
+
+| Class | Description |
+|---|---|
+| `ElbowKMeansStrategy(k_max, random_state)` | Selects the number of clusters automatically via the elbow method, then fits KMeans. |
+
+---
+
+## Output Files
+
+### Clustering result JSON (`cluster.py`)
+
+A dictionary mapping cluster IDs to lists of NPZ file paths.
+Keys are sorted as `cluster_id0`, `cluster_id1`, …
 
 ```json
 {
@@ -126,22 +161,22 @@ result.json（クラスタ ID ごとに NPZ パスを分類）
 }
 ```
 
-- 全入力ファイルがいずれか 1 つのクラスタに過不足なく割り当てられます。
-- 最適クラスタ数はエルボー法により `[1, k_max]` の範囲で自動決定されます。
+- Every input file appears in exactly one cluster.
+- The number of clusters is determined automatically within `[1, k_max]`.
 
-### `visualize_cluster.py` の出力図
+### Visualization figure (`visualize_cluster.py`)
 
-クラスタ数に応じてサブプロットを格子状に配置した PNG（または PDF / SVG）を出力します。  
-各サブプロットには、クラスタに属するサンプルの `(x, y)` 軌跡を重ね描きします。
+A PNG (or PDF / SVG) with one subplot per cluster arranged in a grid.
+Each subplot overlays the `(x, y)` trajectories of the samples assigned to that cluster.
 
 ---
 
-## トラブルシューティング
+## Troubleshooting
 
 ### `OpenBLAS: Program is Terminated. Because you tried to allocate too many memory regions.`
 
-エルボー法のループ中に OpenBLAS がメモリマップ領域の上限を超えることで発生します。  
-実行前に下記の環境変数を設定してください。
+This occurs when OpenBLAS exhausts the OS memory-map region limit during the elbow-method loop.
+Set the following environment variables before running:
 
 ```bash
 OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 python cluster.py ...

--- a/diffusion_planner/sampling/README.md
+++ b/diffusion_planner/sampling/README.md
@@ -1,0 +1,148 @@
+# Sampling Package
+
+## 概要
+
+Sampling Package は Diffusion Planner の学習に利用するデータの偏りを避けるため、データが適切な分布となるようにサンプリングを行うためのパッケージです。
+
+Sampling Package は下記のファイルから構成されます。
+
+## ファイル構成
+
+```
+sampling/
+├── cluster.py            # クラスタリング本体（エルボー法 + KMeans）
+├── visualize_cluster.py  # クラスタリング結果の可視化
+├── utils/
+│   └── elbow.py          # WCSS 計算・エルボー検出・KMeans のユーティリティ
+└── README.md
+```
+
+### 各ファイルの役割
+
+| ファイル | 役割 |
+|---|---|
+| `cluster.py` | NPZ ファイル一覧を受け取り、ego の将来軌跡を特徴量として KMeans でクラスタリングする。最適クラスタ数はエルボー法で自動決定する。 |
+| `visualize_cluster.py` | `cluster.py` が出力した JSON を読み込み、クラスタごとに ego 将来軌跡を重ね描きしたサブプロット図を出力する。 |
+| `utils/elbow.py` | WCSS（クラスタ内二乗和）の計算、エルボー点の検出、KMeans フィットをまとめたユーティリティ。 |
+
+---
+
+## 使い方
+
+### Step 1: クラスタリング（`cluster.py`）
+
+```bash
+python cluster.py \
+    --data_list /path/to/data_list.json \
+    --output    /path/to/result.json \
+    [--k_max 20] \
+    [--pca_components 50] \
+    [--seed 42]
+```
+
+| 引数 | 必須 | デフォルト | 説明 |
+|---|---|---|---|
+| `--data_list` | ✓ | — | NPZ ファイルのパスを列挙した JSON |
+| `--output` | ✓ | — | クラスタリング結果を書き出す JSON のパス |
+| `--k_max` | | `20` | 評価するクラスタ数の上限 |
+| `--pca_components` | | `50` | PCA で削減する次元数 |
+| `--seed` | | `42` | 乱数シード |
+
+**入力 JSON 形式（`--data_list`）**
+
+```json
+[
+    "/path/to/sample_0000.npz",
+    "/path/to/sample_0001.npz",
+    ...
+]
+```
+
+### Step 2: 可視化（`visualize_cluster.py`）
+
+```bash
+python visualize_cluster.py \
+    --cluster_json /path/to/result.json \
+    --output       /path/to/figure.png \
+    [--max_samples 200] \
+    [--seed 42]
+```
+
+| 引数 | 必須 | デフォルト | 説明 |
+|---|---|---|---|
+| `--cluster_json` | ✓ | — | `cluster.py` が出力した JSON |
+| `--output` | | — | 保存先のパス（PNG / PDF / SVG）。省略するとインタラクティブ表示 |
+| `--max_samples` | | `200` | クラスタごとに描画する軌跡の最大本数 |
+| `--seed` | | `42` | サンプリング乱数シード |
+
+---
+
+## 処理パイプライン
+
+```
+NPZ ファイル群
+     │
+     ▼
+ego_agent_future (80, 3) をフラット化 → (240,)
+     │
+     ▼
+Z スコア正規化
+     │
+     ▼
+PCA（240 次元 → pca_components 次元）
+     │
+     ▼
+エルボー法で最適 k を決定（k = 1 .. k_max）
+     │
+     ▼
+KMeans（k = optimal_k）
+     │
+     ▼
+result.json（クラスタ ID ごとに NPZ パスを分類）
+```
+
+---
+
+## 出力ファイル
+
+### `cluster.py` の出力 JSON
+
+クラスタ ID をキー、そのクラスタに属する NPZ ファイルのパス一覧を値とした辞書形式です。  
+キーは `cluster_id0`、`cluster_id1`、… の順にソートされています。
+
+```json
+{
+    "cluster_id0": [
+        "/path/to/sample_0000.npz",
+        "/path/to/sample_0003.npz"
+    ],
+    "cluster_id1": [
+        "/path/to/sample_0001.npz"
+    ],
+    "cluster_id2": [
+        "/path/to/sample_0002.npz",
+        "/path/to/sample_0004.npz"
+    ]
+}
+```
+
+- 全入力ファイルがいずれか 1 つのクラスタに過不足なく割り当てられます。
+- 最適クラスタ数はエルボー法により `[1, k_max]` の範囲で自動決定されます。
+
+### `visualize_cluster.py` の出力図
+
+クラスタ数に応じてサブプロットを格子状に配置した PNG（または PDF / SVG）を出力します。  
+各サブプロットには、クラスタに属するサンプルの `(x, y)` 軌跡を重ね描きします。
+
+---
+
+## トラブルシューティング
+
+### `OpenBLAS: Program is Terminated. Because you tried to allocate too many memory regions.`
+
+エルボー法のループ中に OpenBLAS がメモリマップ領域の上限を超えることで発生します。  
+実行前に下記の環境変数を設定してください。
+
+```bash
+OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 python cluster.py ...
+```

--- a/diffusion_planner/sampling/cluster.py
+++ b/diffusion_planner/sampling/cluster.py
@@ -29,40 +29,20 @@ Output JSON format:
         "cluster_id1": ["path/to/sample_1.npz", ...],
         ...
     }
-
-Feature pipeline:
-    ego_agent_future (80, 3) → flatten (240,) → Z-score → PCA → KMeans (elbow)
 """
 
 import argparse
 import json
 import sys
-from collections import defaultdict
 from pathlib import Path
 
-import numpy as np
-from sklearn.decomposition import PCA
-from tqdm import tqdm
-
 sys.path.insert(0, str(Path(__file__).parent))
-from utils.elbow import elbow_kmeans
+from utils.pipeline import ElbowKMeansStrategy, cluster_trajectories
 
 
 def load_npz_paths(data_list_json: str) -> list:
     with open(data_list_json, "r", encoding="utf-8") as f:
         return json.load(f)
-
-
-def extract_features(npz_path: str) -> np.ndarray:
-    """Return the flattened ego_agent_future trajectory as a feature vector.
-
-    ego_agent_future has shape (T, 3) with columns [x, y, heading_rad].
-    The returned vector has shape (T*3,).
-    """
-    data = np.load(npz_path, allow_pickle=True)
-    # ego_agent_future: (80, 3) — [x, y, heading_rad]
-    ego_future = data["ego_agent_future"].astype(float)
-    return ego_future.flatten()
 
 
 def get_args():
@@ -101,47 +81,9 @@ def main():
     npz_paths = load_npz_paths(args.data_list)
     print(f"Loaded {len(npz_paths)} NPZ paths from {args.data_list}")
 
-    features = []
-    valid_paths = []
-    for path in tqdm(npz_paths, desc="Extracting features", unit="file"):
-        try:
-            features.append(extract_features(path))
-            valid_paths.append(path)
-        except Exception as e:
-            tqdm.write(f"  [warn] skipping {path}: {e}")
-
-    if not features:
-        raise RuntimeError("No valid NPZ files found.")
-
-    features = np.array(features)  # (N, T*3) = (N, 240)
-
-    # Z-score normalise so each dimension contributes equally
-    mean = features.mean(axis=0)
-    std = features.std(axis=0) + 1e-8
-    features_norm = (features - mean) / std
-
-    # PCA: reduce from 240-dim trajectory space to a manageable subspace
-    n_components = min(args.pca_components, features_norm.shape[0], features_norm.shape[1])
-    pca = PCA(n_components=n_components, random_state=args.seed)
-    features_pca = pca.fit_transform(features_norm)
-    explained = pca.explained_variance_ratio_.sum()
-    print(
-        f"PCA: {features_norm.shape[1]}-dim → {n_components}-dim "
-        f"({explained * 100:.1f}% variance explained)"
-    )
-
-    print(f"Running elbow KMeans (k_max={args.k_max}, seed={args.seed})...")
-    labels, optimal_k, wcss = elbow_kmeans(
-        features_pca, k_max=args.k_max, random_state=args.seed
-    )
-    print(f"Optimal k = {optimal_k}")
-
-    clusters: dict = defaultdict(list)
-    for path, label in zip(valid_paths, labels):
-        clusters[f"cluster_id{label}"].append(path)
-
-    # Sort keys so the output is deterministic
-    result = {k: clusters[k] for k in sorted(clusters, key=lambda x: int(x.replace("cluster_id", "")))}
+    strategy = ElbowKMeansStrategy(k_max=args.k_max, random_state=args.seed)
+    result = cluster_trajectories(npz_paths, strategy, pca_components=args.pca_components)
+    print(f"Optimal k = {strategy.n_clusters_}")
 
     output_path = Path(args.output)
     output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/diffusion_planner/sampling/cluster.py
+++ b/diffusion_planner/sampling/cluster.py
@@ -1,0 +1,157 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cluster a dataset of NPZ files using K-Means with the elbow method.
+
+Usage:
+    python cluster.py \\
+        --data_list /path/to/data_list.json \\
+        --output    /path/to/result.json \\
+        [--k_max 20] [--pca_components 50] [--seed 42]
+
+Input JSON format (same as train_predictor.py):
+    ["path/to/sample_0.npz", "path/to/sample_1.npz", ...]
+
+Output JSON format:
+    {
+        "cluster_id0": ["path/to/sample_0.npz", ...],
+        "cluster_id1": ["path/to/sample_1.npz", ...],
+        ...
+    }
+
+Feature pipeline:
+    ego_agent_future (80, 3) → flatten (240,) → Z-score → PCA → KMeans (elbow)
+"""
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+from sklearn.decomposition import PCA
+from tqdm import tqdm
+
+sys.path.insert(0, str(Path(__file__).parent))
+from utils.elbow import elbow_kmeans
+
+
+def load_npz_paths(data_list_json: str) -> list:
+    with open(data_list_json, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def extract_features(npz_path: str) -> np.ndarray:
+    """Return the flattened ego_agent_future trajectory as a feature vector.
+
+    ego_agent_future has shape (T, 3) with columns [x, y, heading_rad].
+    The returned vector has shape (T*3,).
+    """
+    data = np.load(npz_path, allow_pickle=True)
+    # ego_agent_future: (80, 3) — [x, y, heading_rad]
+    ego_future = data["ego_agent_future"].astype(float)
+    return ego_future.flatten()
+
+
+def get_args():
+    parser = argparse.ArgumentParser(description="Cluster NPZ dataset with elbow-method KMeans")
+    parser.add_argument(
+        "--data_list",
+        type=str,
+        required=True,
+        help="Path to JSON file listing NPZ file paths (same format as train_predictor.py)",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        required=True,
+        help="Output path for the clustering result JSON",
+    )
+    parser.add_argument(
+        "--k_max",
+        type=int,
+        default=20,
+        help="Maximum number of clusters to evaluate (default: 20)",
+    )
+    parser.add_argument(
+        "--pca_components",
+        type=int,
+        default=50,
+        help="Number of PCA components used to reduce the trajectory feature dimension (default: 50)",
+    )
+    parser.add_argument("--seed", type=int, default=42)
+    return parser.parse_args()
+
+
+def main():
+    args = get_args()
+
+    npz_paths = load_npz_paths(args.data_list)
+    print(f"Loaded {len(npz_paths)} NPZ paths from {args.data_list}")
+
+    features = []
+    valid_paths = []
+    for path in tqdm(npz_paths, desc="Extracting features", unit="file"):
+        try:
+            features.append(extract_features(path))
+            valid_paths.append(path)
+        except Exception as e:
+            tqdm.write(f"  [warn] skipping {path}: {e}")
+
+    if not features:
+        raise RuntimeError("No valid NPZ files found.")
+
+    features = np.array(features)  # (N, T*3) = (N, 240)
+
+    # Z-score normalise so each dimension contributes equally
+    mean = features.mean(axis=0)
+    std = features.std(axis=0) + 1e-8
+    features_norm = (features - mean) / std
+
+    # PCA: reduce from 240-dim trajectory space to a manageable subspace
+    n_components = min(args.pca_components, features_norm.shape[0], features_norm.shape[1])
+    pca = PCA(n_components=n_components, random_state=args.seed)
+    features_pca = pca.fit_transform(features_norm)
+    explained = pca.explained_variance_ratio_.sum()
+    print(
+        f"PCA: {features_norm.shape[1]}-dim → {n_components}-dim "
+        f"({explained * 100:.1f}% variance explained)"
+    )
+
+    print(f"Running elbow KMeans (k_max={args.k_max}, seed={args.seed})...")
+    labels, optimal_k, wcss = elbow_kmeans(
+        features_pca, k_max=args.k_max, random_state=args.seed
+    )
+    print(f"Optimal k = {optimal_k}")
+
+    clusters: dict = defaultdict(list)
+    for path, label in zip(valid_paths, labels):
+        clusters[f"cluster_id{label}"].append(path)
+
+    # Sort keys so the output is deterministic
+    result = {k: clusters[k] for k in sorted(clusters, key=lambda x: int(x.replace("cluster_id", "")))}
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(result, f, indent=4)
+
+    print(f"Saved clustering result to {args.output}")
+    for cluster_key, paths in result.items():
+        print(f"  {cluster_key}: {len(paths)} samples")
+
+
+if __name__ == "__main__":
+    main()

--- a/diffusion_planner/sampling/utils/elbow.py
+++ b/diffusion_planner/sampling/utils/elbow.py
@@ -1,0 +1,62 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+from sklearn.cluster import KMeans
+
+
+def compute_wcss(features: np.ndarray, k_max: int, random_state: int = 42) -> list:
+    """Compute within-cluster sum of squares (inertia) for k = 1 .. k_max."""
+    wcss = []
+    for k in range(1, k_max + 1):
+        km = KMeans(n_clusters=k, random_state=random_state, n_init="auto")
+        km.fit(features)
+        wcss.append(km.inertia_)
+    return wcss
+
+
+def find_elbow(wcss: list) -> int:
+    """Return the optimal k (1-indexed) using the maximum second-derivative criterion."""
+    if len(wcss) < 3:
+        return len(wcss)
+    second_diff = np.diff(np.array(wcss), n=2)
+    # argmax gives 0-indexed position among the second-diff array;
+    # add 2 to convert back to the original k index.
+    return int(np.argmax(second_diff) + 2)
+
+
+def elbow_kmeans(
+    features: np.ndarray,
+    k_max: int = 20,
+    random_state: int = 42,
+) -> tuple:
+    """Determine k via the elbow method, then fit KMeans.
+
+    Args:
+        features: 2-D array of shape (n_samples, n_features).
+        k_max: upper bound on the number of clusters to evaluate.
+        random_state: random seed for reproducibility.
+
+    Returns:
+        labels: integer cluster assignment for each sample, shape (n_samples,).
+        optimal_k: chosen number of clusters.
+        wcss: list of inertia values for k = 1 .. k_max (useful for plotting).
+    """
+    k_max = min(k_max, len(features))
+    wcss = compute_wcss(features, k_max, random_state)
+    optimal_k = find_elbow(wcss)
+
+    km = KMeans(n_clusters=optimal_k, random_state=random_state, n_init="auto")
+    labels = km.fit_predict(features)
+    return labels, optimal_k, wcss

--- a/diffusion_planner/sampling/utils/pipeline.py
+++ b/diffusion_planner/sampling/utils/pipeline.py
@@ -1,0 +1,158 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Trajectory feature extraction and clustering pipeline.
+
+Feature pipeline:
+    ego_agent_future (80, 3) → flatten (240,) → Z-score → PCA → ClusteringStrategy
+
+Usage example:
+    strategy = ElbowKMeansStrategy(k_max=20, random_state=42)
+    result = cluster_trajectories(npz_paths, strategy, pca_components=50)
+    print(strategy.n_clusters_)
+"""
+
+import sys
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+from sklearn.decomposition import PCA
+from tqdm import tqdm
+
+sys.path.insert(0, str(Path(__file__).parent))
+from elbow import elbow_kmeans
+
+
+# ──────────────────────────── Strategy interface ─────────────────────────────
+
+
+class ClusteringStrategy(ABC):
+    """Interface for clustering algorithms used in the trajectory pipeline.
+
+    Implementations must set ``self.n_clusters_`` (int) inside ``fit_predict``
+    so that callers can inspect the chosen number of clusters after the call.
+    """
+
+    n_clusters_: int
+
+    @abstractmethod
+    def fit_predict(self, features: np.ndarray) -> np.ndarray:
+        """Assign a cluster label to each sample.
+
+        Args:
+            features: 2-D array of shape (n_samples, n_features).
+
+        Returns:
+            Integer label array of shape (n_samples,).
+            Must also set ``self.n_clusters_`` as a side-effect.
+        """
+
+
+# ──────────────────────────── Concrete strategies ────────────────────────────
+
+
+class ElbowKMeansStrategy(ClusteringStrategy):
+    """KMeans whose number of clusters is chosen automatically via the elbow method."""
+
+    def __init__(self, k_max: int = 20, random_state: int = 42) -> None:
+        self.k_max = k_max
+        self.random_state = random_state
+
+    def fit_predict(self, features: np.ndarray) -> np.ndarray:
+        print(f"Running elbow KMeans (k_max={self.k_max}, seed={self.random_state})...")
+        labels, optimal_k, _ = elbow_kmeans(
+            features, k_max=self.k_max, random_state=self.random_state
+        )
+        self.n_clusters_ = optimal_k
+        return labels
+
+
+# ──────────────────────────── Feature extraction ─────────────────────────────
+
+
+def extract_features(npz_path: str) -> np.ndarray:
+    """Return the flattened ego_agent_future trajectory as a feature vector.
+
+    ego_agent_future has shape (T, 3) with columns [x, y, heading_rad].
+    The returned vector has shape (T*3,).
+    """
+    data = np.load(npz_path, allow_pickle=True)
+    ego_future = data["ego_agent_future"].astype(float)
+    return ego_future.flatten()
+
+
+# ──────────────────────────── Pipeline ───────────────────────────────────────
+
+
+def cluster_trajectories(
+    npz_paths: list,
+    strategy: ClusteringStrategy,
+    pca_components: int = 50,
+) -> dict:
+    """Run the full trajectory clustering pipeline.
+
+    Preprocessing (feature extraction, Z-score, PCA) is fixed; the clustering
+    algorithm is delegated to ``strategy``.  After the call, ``strategy.n_clusters_``
+    holds the number of clusters that were used.
+
+    Args:
+        npz_paths: list of paths to NPZ files.
+        strategy: clustering algorithm to apply after preprocessing.
+        pca_components: number of PCA components for dimensionality reduction.
+
+    Returns:
+        dict mapping ``"cluster_idN"`` to list of NPZ paths, sorted by id.
+
+    Raises:
+        RuntimeError: if no valid NPZ files are found.
+    """
+    features = []
+    valid_paths = []
+    for path in tqdm(npz_paths, desc="Extracting features", unit="file"):
+        try:
+            features.append(extract_features(path))
+            valid_paths.append(path)
+        except Exception as e:
+            tqdm.write(f"  [warn] skipping {path}: {e}")
+
+    if not features:
+        raise RuntimeError("No valid NPZ files found.")
+
+    features = np.array(features)
+
+    mean = features.mean(axis=0)
+    std = features.std(axis=0) + 1e-8
+    features_norm = (features - mean) / std
+
+    n_components = min(pca_components, features_norm.shape[0], features_norm.shape[1])
+    pca = PCA(n_components=n_components, random_state=0)
+    features_pca = pca.fit_transform(features_norm)
+    explained = pca.explained_variance_ratio_.sum()
+    print(
+        f"PCA: {features_norm.shape[1]}-dim → {n_components}-dim "
+        f"({explained * 100:.1f}% variance explained)"
+    )
+
+    labels = strategy.fit_predict(features_pca)
+
+    clusters: dict = defaultdict(list)
+    for path, label in zip(valid_paths, labels):
+        clusters[f"cluster_id{label}"].append(path)
+
+    return {
+        k: clusters[k]
+        for k in sorted(clusters, key=lambda x: int(x.replace("cluster_id", "")))
+    }

--- a/diffusion_planner/sampling/visualize_cluster.py
+++ b/diffusion_planner/sampling/visualize_cluster.py
@@ -1,0 +1,162 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Visualize ego_agent_future trajectories grouped by cluster.
+
+Usage:
+    python visualize_cluster.py \\
+        --cluster_json /path/to/result.json \\
+        --output       /path/to/figure.png \\
+        [--max_samples 200] [--seed 42]
+
+The cluster JSON is the output of cluster.py:
+    {
+        "cluster_id0": ["path/to/a.npz", ...],
+        "cluster_id1": ["path/to/b.npz", ...],
+        ...
+    }
+
+Each sub-plot shows the (x, y) paths from ego_agent_future for one cluster.
+If --output is omitted the figure is shown interactively.
+"""
+
+import argparse
+import json
+import math
+import random
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+# ── I/O ──────────────────────────────────────────────────────────────────────
+
+def load_cluster_json(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def load_trajectory(npz_path: str) -> np.ndarray:
+    """Return ego_agent_future as (T, 2) array of (x, y) positions."""
+    data = np.load(npz_path, allow_pickle=True)
+    future = data["ego_agent_future"].astype(float)  # (T, 3): x, y, heading
+    return future[:, :2]
+
+
+# ── plotting ─────────────────────────────────────────────────────────────────
+
+def _draw_cluster(ax: plt.Axes, paths: list, max_samples: int, color: str, rng: random.Random) -> None:
+    sampled = rng.sample(paths, min(max_samples, len(paths)))
+
+    for npz_path in sampled:
+        try:
+            xy = load_trajectory(npz_path)
+            ax.plot(xy[:, 0], xy[:, 1], color=color, alpha=0.3, linewidth=0.8)
+        except Exception as e:
+            print(f"  [warn] skipping {npz_path}: {e}")
+
+    # Mark the ego origin
+    ax.scatter([0], [0], color="black", s=20, zorder=5)
+
+
+def visualize(cluster_json: str, output: str | None, max_samples: int, seed: int) -> None:
+    clusters = load_cluster_json(cluster_json)
+    cluster_ids = sorted(clusters.keys(), key=lambda x: int(x.replace("cluster_id", "")))
+    n_clusters = len(cluster_ids)
+
+    # Grid layout: prefer roughly square arrangement
+    n_cols = math.ceil(math.sqrt(n_clusters))
+    n_rows = math.ceil(n_clusters / n_cols)
+
+    cmap = plt.get_cmap("tab20")
+    rng = random.Random(seed)
+
+    fig, axes = plt.subplots(
+        n_rows, n_cols,
+        figsize=(4 * n_cols, 4 * n_rows),
+        squeeze=False,
+    )
+    fig.suptitle(
+        f"ego_agent_future trajectories by cluster  (max {max_samples} samples each)",
+        fontsize=12,
+    )
+
+    for idx, cluster_id in enumerate(cluster_ids):
+        row, col = divmod(idx, n_cols)
+        ax = axes[row][col]
+        paths = clusters[cluster_id]
+        color = cmap(idx % 20)
+
+        _draw_cluster(ax, paths, max_samples, color, rng)
+
+        ax.set_title(f"{cluster_id}  (n={len(paths)})", fontsize=9)
+        ax.set_xlabel("x [m]", fontsize=7)
+        ax.set_ylabel("y [m]", fontsize=7)
+        ax.set_aspect("equal")
+        ax.grid(True, linewidth=0.4, alpha=0.5)
+        ax.tick_params(labelsize=7)
+
+    # Hide unused axes
+    for idx in range(n_clusters, n_rows * n_cols):
+        row, col = divmod(idx, n_cols)
+        axes[row][col].set_visible(False)
+
+    fig.tight_layout()
+
+    if output:
+        out_path = Path(output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(out_path, dpi=150, bbox_inches="tight")
+        print(f"Saved figure to {out_path}")
+    else:
+        plt.show()
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+def get_args():
+    parser = argparse.ArgumentParser(
+        description="Visualize ego_agent_future trajectories grouped by cluster"
+    )
+    parser.add_argument(
+        "--cluster_json",
+        type=str,
+        required=True,
+        help="Path to the clustering result JSON produced by cluster.py",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Save figure to this path (PNG/PDF/SVG). If omitted, display interactively.",
+    )
+    parser.add_argument(
+        "--max_samples",
+        type=int,
+        default=200,
+        help="Maximum number of trajectories to draw per cluster (default: 200)",
+    )
+    parser.add_argument("--seed", type=int, default=42)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = get_args()
+    visualize(
+        cluster_json=args.cluster_json,
+        output=args.output,
+        max_samples=args.max_samples,
+        seed=args.seed,
+    )

--- a/diffusion_planner/tests/test_cluster.py
+++ b/diffusion_planner/tests/test_cluster.py
@@ -1,0 +1,421 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit and integration tests for diffusion_planner/sampling/cluster.py
+and diffusion_planner/sampling/utils/elbow.py.
+
+Covers:
+- load_npz_paths: valid JSON, missing file
+- extract_features: output shape, values, missing key
+- compute_wcss: list length, monotonically non-increasing inertia
+- find_elbow: short list edge cases, synthetic WCSS with clear elbow
+- elbow_kmeans: label shape/range, optimal_k bounds, k_max clamping
+- main (integration): end-to-end run with synthetic NPZ files
+
+Usage:
+    python tests/test_cluster.py          # standalone
+    pytest tests/test_cluster.py -v       # with pytest
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+
+SAMPLING_DIR = Path(__file__).resolve().parent.parent / "sampling"
+sys.path.insert(0, str(SAMPLING_DIR))
+
+from cluster import extract_features, load_npz_paths, main
+from utils.elbow import compute_wcss, elbow_kmeans, find_elbow
+
+
+# ─────────────────────────────── helpers ────────────────────────────────────
+
+
+def _make_npz(path: str, ego_future: np.ndarray | None = None) -> None:
+    """Write a minimal NPZ file with ego_agent_future."""
+    if ego_future is None:
+        ego_future = np.random.randn(80, 3).astype(np.float32)
+    np.savez(path, ego_agent_future=ego_future)
+
+
+def _synthetic_clusters(n_per_cluster: int = 10, n_clusters: int = 3, seed: int = 42) -> np.ndarray:
+    """Return a 2-D feature array with clear cluster structure."""
+    rng = np.random.default_rng(seed)
+    centers = np.array([[0.0, 0.0], [10.0, 0.0], [0.0, 10.0]])[:n_clusters]
+    parts = [rng.normal(c, 0.3, (n_per_cluster, 2)) for c in centers]
+    return np.vstack(parts)
+
+
+# ─────────────────────────── load_npz_paths ─────────────────────────────────
+
+
+def test_load_npz_paths_valid():
+    with tempfile.TemporaryDirectory() as tmp:
+        paths = ["/a/b.npz", "/c/d.npz"]
+        json_path = Path(tmp) / "list.json"
+        json_path.write_text(json.dumps(paths))
+        result = load_npz_paths(str(json_path))
+    assert result == paths, f"Expected {paths}, got {result}"
+    print("  [PASS] load_npz_paths valid JSON")
+
+
+def test_load_npz_paths_missing_file():
+    try:
+        load_npz_paths("/nonexistent/path.json")
+        assert False, "Should have raised FileNotFoundError"
+    except (FileNotFoundError, OSError):
+        pass
+    print("  [PASS] load_npz_paths missing file raises")
+
+
+# ─────────────────────────── extract_features ───────────────────────────────
+
+
+def test_extract_features_shape():
+    with tempfile.TemporaryDirectory() as tmp:
+        npz_path = str(Path(tmp) / "sample.npz")
+        _make_npz(npz_path)
+        feat = extract_features(npz_path)
+    assert feat.shape == (240,), f"Expected (240,), got {feat.shape}"
+    print("  [PASS] extract_features shape (240,)")
+
+
+def test_extract_features_values():
+    """Returned vector equals ego_agent_future.flatten()."""
+    with tempfile.TemporaryDirectory() as tmp:
+        npz_path = str(Path(tmp) / "sample.npz")
+        ego_future = np.arange(240, dtype=np.float32).reshape(80, 3)
+        _make_npz(npz_path, ego_future)
+        feat = extract_features(npz_path)
+    np.testing.assert_array_almost_equal(feat, ego_future.flatten())
+    print("  [PASS] extract_features values match flatten")
+
+
+def test_extract_features_missing_key():
+    with tempfile.TemporaryDirectory() as tmp:
+        npz_path = str(Path(tmp) / "sample.npz")
+        np.savez(npz_path, wrong_key=np.zeros((80, 3)))
+        try:
+            extract_features(npz_path)
+            assert False, "Should have raised KeyError"
+        except KeyError:
+            pass
+    print("  [PASS] extract_features missing key raises KeyError")
+
+
+def test_extract_features_dtype_is_float():
+    with tempfile.TemporaryDirectory() as tmp:
+        npz_path = str(Path(tmp) / "sample.npz")
+        _make_npz(npz_path, np.ones((80, 3), dtype=np.int16))
+        feat = extract_features(npz_path)
+    assert np.issubdtype(feat.dtype, np.floating), f"Expected float dtype, got {feat.dtype}"
+    print("  [PASS] extract_features dtype is float")
+
+
+# ──────────────────────────── compute_wcss ──────────────────────────────────
+
+
+def test_compute_wcss_length():
+    X = _synthetic_clusters()
+    k_max = 5
+    wcss = compute_wcss(X, k_max=k_max)
+    assert len(wcss) == k_max, f"Expected {k_max} values, got {len(wcss)}"
+    print("  [PASS] compute_wcss length equals k_max")
+
+
+def test_compute_wcss_monotone():
+    """Inertia must be non-increasing as k grows."""
+    X = _synthetic_clusters()
+    wcss = compute_wcss(X, k_max=6)
+    for i in range(len(wcss) - 1):
+        assert wcss[i] >= wcss[i + 1] - 1e-6, (
+            f"WCSS not non-increasing at k={i+1}: {wcss[i]:.4f} > {wcss[i+1]:.4f}"
+        )
+    print("  [PASS] compute_wcss monotonically non-increasing")
+
+
+def test_compute_wcss_k1_max_inertia():
+    """k=1 must have the largest inertia (whole dataset in one cluster)."""
+    X = _synthetic_clusters()
+    wcss = compute_wcss(X, k_max=4)
+    assert wcss[0] == max(wcss), "k=1 should have the highest inertia"
+    print("  [PASS] compute_wcss k=1 has maximum inertia")
+
+
+# ──────────────────────────── find_elbow ────────────────────────────────────
+
+
+def test_find_elbow_single_value():
+    assert find_elbow([42.0]) == 1
+    print("  [PASS] find_elbow single value returns 1")
+
+
+def test_find_elbow_two_values():
+    assert find_elbow([10.0, 5.0]) == 2
+    print("  [PASS] find_elbow two values returns 2")
+
+
+def test_find_elbow_clear_elbow():
+    """WCSS drops sharply before k=3 then flattens — elbow expected at k=3."""
+    # second_diff = [10, 38, 1, 0] → argmax index 1 → k = 1+2 = 3
+    wcss = [100.0, 50.0, 10.0, 8.0, 7.0, 6.0]
+    k = find_elbow(wcss)
+    assert k == 3, f"Expected elbow at k=3, got k={k}"
+    print("  [PASS] find_elbow clear elbow at k=3")
+
+
+def test_find_elbow_returns_int():
+    wcss = [100.0, 50.0, 10.0, 8.0]
+    k = find_elbow(wcss)
+    assert isinstance(k, int), f"Expected int, got {type(k)}"
+    print("  [PASS] find_elbow return type is int")
+
+
+# ──────────────────────────── elbow_kmeans ──────────────────────────────────
+
+
+def test_elbow_kmeans_labels_shape():
+    X = _synthetic_clusters(n_per_cluster=10, n_clusters=3)
+    labels, _, _ = elbow_kmeans(X, k_max=6)
+    assert labels.shape == (X.shape[0],), (
+        f"Expected ({X.shape[0]},), got {labels.shape}"
+    )
+    print("  [PASS] elbow_kmeans labels shape")
+
+
+def test_elbow_kmeans_labels_range():
+    X = _synthetic_clusters(n_per_cluster=10, n_clusters=3)
+    labels, optimal_k, _ = elbow_kmeans(X, k_max=6)
+    assert labels.min() >= 0, f"Negative label: {labels.min()}"
+    assert labels.max() < optimal_k, (
+        f"Label {labels.max()} >= optimal_k {optimal_k}"
+    )
+    print("  [PASS] elbow_kmeans label values in [0, optimal_k)")
+
+
+def test_elbow_kmeans_optimal_k_bounds():
+    X = _synthetic_clusters(n_per_cluster=10, n_clusters=3)
+    k_max = 8
+    _, optimal_k, _ = elbow_kmeans(X, k_max=k_max)
+    assert 1 <= optimal_k <= k_max, f"optimal_k={optimal_k} outside [1, {k_max}]"
+    print("  [PASS] elbow_kmeans optimal_k within [1, k_max]")
+
+
+def test_elbow_kmeans_wcss_length():
+    X = _synthetic_clusters(n_per_cluster=10, n_clusters=3)
+    k_max = 6
+    _, _, wcss = elbow_kmeans(X, k_max=k_max)
+    assert len(wcss) == k_max, f"Expected wcss length {k_max}, got {len(wcss)}"
+    print("  [PASS] elbow_kmeans wcss length equals k_max")
+
+
+def test_elbow_kmeans_k_max_clamped_to_n_samples():
+    """When k_max > n_samples, k_max is clamped to n_samples."""
+    n = 5
+    X = np.random.default_rng(0).random((n, 4))
+    labels, optimal_k, wcss = elbow_kmeans(X, k_max=100)
+    assert len(wcss) == n, f"Expected wcss length {n}, got {len(wcss)}"
+    assert 1 <= optimal_k <= n, f"optimal_k={optimal_k} outside [1, {n}]"
+    assert labels.shape == (n,)
+    print("  [PASS] elbow_kmeans k_max clamped to n_samples")
+
+
+def test_elbow_kmeans_reproducible():
+    X = _synthetic_clusters()
+    labels1, k1, _ = elbow_kmeans(X, k_max=6, random_state=0)
+    labels2, k2, _ = elbow_kmeans(X, k_max=6, random_state=0)
+    assert k1 == k2
+    np.testing.assert_array_equal(labels1, labels2)
+    print("  [PASS] elbow_kmeans same seed gives same result")
+
+
+# ──────────────────────────── integration: main ─────────────────────────────
+
+
+def _make_synthetic_dataset(tmp_dir: str, n: int = 30, seed: int = 0) -> list[str]:
+    """Create n NPZ files with three distinct trajectory patterns."""
+    rng = np.random.default_rng(seed)
+    paths = []
+    patterns = [
+        np.column_stack([np.linspace(0, 20, 80), np.zeros(80), np.zeros(80)]),   # straight
+        np.column_stack([np.linspace(0, 10, 80), np.linspace(0, 10, 80), np.linspace(0, np.pi / 2, 80)]),  # left turn
+        np.column_stack([np.linspace(0, 10, 80), np.linspace(0, -10, 80), np.linspace(0, -np.pi / 2, 80)]),  # right turn
+    ]
+    for i in range(n):
+        pattern = patterns[i % len(patterns)].copy().astype(np.float32)
+        pattern += rng.normal(0, 0.05, pattern.shape).astype(np.float32)
+        npz_path = str(Path(tmp_dir) / f"sample_{i:04d}.npz")
+        np.savez(npz_path, ego_agent_future=pattern)
+        paths.append(npz_path)
+    return paths
+
+
+def test_main_end_to_end():
+    with tempfile.TemporaryDirectory() as tmp:
+        npz_paths = _make_synthetic_dataset(tmp, n=30)
+
+        data_list_path = str(Path(tmp) / "data_list.json")
+        with open(data_list_path, "w") as f:
+            json.dump(npz_paths, f)
+
+        output_path = str(Path(tmp) / "result.json")
+
+        argv = [
+            "cluster.py",
+            "--data_list", data_list_path,
+            "--output", output_path,
+            "--k_max", "6",
+            "--pca_components", "10",
+            "--seed", "42",
+        ]
+        with patch("sys.argv", argv):
+            main()
+
+        assert Path(output_path).exists(), "Output JSON was not created"
+
+        with open(output_path) as f:
+            result = json.load(f)
+
+        # Keys must follow "cluster_idN" pattern
+        for key in result:
+            assert key.startswith("cluster_id"), f"Unexpected key: {key}"
+
+        # All input paths must appear exactly once in the output
+        all_output_paths = [p for paths in result.values() for p in paths]
+        assert sorted(all_output_paths) == sorted(npz_paths), (
+            "Output paths do not match input paths"
+        )
+
+    print("  [PASS] main end-to-end: output JSON has correct structure")
+
+
+def test_main_output_no_duplicates():
+    with tempfile.TemporaryDirectory() as tmp:
+        npz_paths = _make_synthetic_dataset(tmp, n=15)
+
+        data_list_path = str(Path(tmp) / "data_list.json")
+        with open(data_list_path, "w") as f:
+            json.dump(npz_paths, f)
+
+        output_path = str(Path(tmp) / "result.json")
+
+        argv = [
+            "cluster.py",
+            "--data_list", data_list_path,
+            "--output", output_path,
+            "--k_max", "5",
+            "--pca_components", "10",
+            "--seed", "0",
+        ]
+        with patch("sys.argv", argv):
+            main()
+
+        with open(output_path) as f:
+            result = json.load(f)
+
+        all_paths = [p for paths in result.values() for p in paths]
+        assert len(all_paths) == len(set(all_paths)), "Duplicate paths in output"
+
+    print("  [PASS] main end-to-end: no duplicate paths in output")
+
+
+def test_main_output_keys_sorted():
+    """Cluster keys in output JSON are sorted by numeric id."""
+    with tempfile.TemporaryDirectory() as tmp:
+        npz_paths = _make_synthetic_dataset(tmp, n=20)
+
+        data_list_path = str(Path(tmp) / "data_list.json")
+        with open(data_list_path, "w") as f:
+            json.dump(npz_paths, f)
+
+        output_path = str(Path(tmp) / "result.json")
+
+        argv = [
+            "cluster.py",
+            "--data_list", data_list_path,
+            "--output", output_path,
+            "--k_max", "5",
+            "--pca_components", "10",
+            "--seed", "7",
+        ]
+        with patch("sys.argv", argv):
+            main()
+
+        with open(output_path) as f:
+            result = json.load(f)
+
+        keys = list(result.keys())
+        ids = [int(k.replace("cluster_id", "")) for k in keys]
+        assert ids == sorted(ids), f"Keys are not sorted: {keys}"
+
+    print("  [PASS] main end-to-end: output keys are sorted")
+
+
+# ──────────────────────────────── runner ────────────────────────────────────
+
+
+ALL_TESTS = [
+    test_load_npz_paths_valid,
+    test_load_npz_paths_missing_file,
+    test_extract_features_shape,
+    test_extract_features_values,
+    test_extract_features_missing_key,
+    test_extract_features_dtype_is_float,
+    test_compute_wcss_length,
+    test_compute_wcss_monotone,
+    test_compute_wcss_k1_max_inertia,
+    test_find_elbow_single_value,
+    test_find_elbow_two_values,
+    test_find_elbow_clear_elbow,
+    test_find_elbow_returns_int,
+    test_elbow_kmeans_labels_shape,
+    test_elbow_kmeans_labels_range,
+    test_elbow_kmeans_optimal_k_bounds,
+    test_elbow_kmeans_wcss_length,
+    test_elbow_kmeans_k_max_clamped_to_n_samples,
+    test_elbow_kmeans_reproducible,
+    test_main_end_to_end,
+    test_main_output_no_duplicates,
+    test_main_output_keys_sorted,
+]
+
+
+if __name__ == "__main__":
+    print(f"Running {len(ALL_TESTS)} tests for cluster.py / elbow.py\n")
+    passed, failed, errors = 0, 0, []
+
+    for fn in ALL_TESTS:
+        try:
+            fn()
+            passed += 1
+        except Exception as e:
+            failed += 1
+            errors.append((fn.__name__, e))
+            print(f"  [FAIL] {fn.__name__}: {e}")
+
+    print(f"\n{'=' * 60}")
+    print(f"Results: {passed}/{len(ALL_TESTS)} passed, {failed} failed")
+    if errors:
+        print("\nFailed tests:")
+        for name, err in errors:
+            print(f"  {name}: {err}")
+        sys.exit(1)
+    else:
+        print("All tests passed!")

--- a/diffusion_planner/tests/test_cluster.py
+++ b/diffusion_planner/tests/test_cluster.py
@@ -41,8 +41,14 @@ import numpy as np
 SAMPLING_DIR = Path(__file__).resolve().parent.parent / "sampling"
 sys.path.insert(0, str(SAMPLING_DIR))
 
-from cluster import extract_features, load_npz_paths, main
+from cluster import load_npz_paths, main
 from utils.elbow import compute_wcss, elbow_kmeans, find_elbow
+from utils.pipeline import (
+    ClusteringStrategy,
+    ElbowKMeansStrategy,
+    cluster_trajectories,
+    extract_features,
+)
 
 
 # ─────────────────────────────── helpers ────────────────────────────────────
@@ -246,6 +252,114 @@ def test_elbow_kmeans_reproducible():
     print("  [PASS] elbow_kmeans same seed gives same result")
 
 
+# ──────────────────────────── ElbowKMeansStrategy ───────────────────────────
+
+
+def test_elbow_kmeans_strategy_labels_shape():
+    X = _synthetic_clusters(n_per_cluster=10, n_clusters=3)
+    strategy = ElbowKMeansStrategy(k_max=6, random_state=42)
+    labels = strategy.fit_predict(X)
+    assert labels.shape == (X.shape[0],), f"Expected ({X.shape[0]},), got {labels.shape}"
+    print("  [PASS] ElbowKMeansStrategy labels shape")
+
+
+def test_elbow_kmeans_strategy_n_clusters_set():
+    X = _synthetic_clusters(n_per_cluster=10, n_clusters=3)
+    strategy = ElbowKMeansStrategy(k_max=6, random_state=42)
+    strategy.fit_predict(X)
+    assert isinstance(strategy.n_clusters_, int), (
+        f"n_clusters_ should be int, got {type(strategy.n_clusters_)}"
+    )
+    assert 1 <= strategy.n_clusters_ <= 6
+    print("  [PASS] ElbowKMeansStrategy n_clusters_ set after fit_predict")
+
+
+def test_elbow_kmeans_strategy_is_subclass():
+    assert issubclass(ElbowKMeansStrategy, ClusteringStrategy)
+    print("  [PASS] ElbowKMeansStrategy is subclass of ClusteringStrategy")
+
+
+def test_elbow_kmeans_strategy_reproducible():
+    X = _synthetic_clusters()
+    s1 = ElbowKMeansStrategy(k_max=6, random_state=0)
+    s2 = ElbowKMeansStrategy(k_max=6, random_state=0)
+    np.testing.assert_array_equal(s1.fit_predict(X), s2.fit_predict(X))
+    assert s1.n_clusters_ == s2.n_clusters_
+    print("  [PASS] ElbowKMeansStrategy same seed gives same result")
+
+
+# ─────────────────────────── cluster_trajectories ───────────────────────────
+
+
+def test_cluster_trajectories_returns_dict():
+    with tempfile.TemporaryDirectory() as tmp:
+        npz_paths = _make_synthetic_dataset(tmp, n=15)
+        strategy = ElbowKMeansStrategy(k_max=5, random_state=42)
+        result = cluster_trajectories(npz_paths, strategy, pca_components=10)
+    assert isinstance(result, dict), f"Expected dict, got {type(result)}"
+    assert isinstance(strategy.n_clusters_, int), (
+        f"strategy.n_clusters_ should be int after call, got {type(strategy.n_clusters_)}"
+    )
+    print("  [PASS] cluster_trajectories returns dict, strategy.n_clusters_ is int")
+
+
+def test_cluster_trajectories_all_paths_present():
+    with tempfile.TemporaryDirectory() as tmp:
+        npz_paths = _make_synthetic_dataset(tmp, n=20)
+        result = cluster_trajectories(
+            npz_paths, ElbowKMeansStrategy(k_max=5, random_state=42), pca_components=10
+        )
+    all_out = [p for paths in result.values() for p in paths]
+    assert sorted(all_out) == sorted(npz_paths), "Output paths do not match input paths"
+    print("  [PASS] cluster_trajectories all paths present")
+
+
+def test_cluster_trajectories_key_format():
+    with tempfile.TemporaryDirectory() as tmp:
+        npz_paths = _make_synthetic_dataset(tmp, n=15)
+        strategy = ElbowKMeansStrategy(k_max=5, random_state=42)
+        result = cluster_trajectories(npz_paths, strategy, pca_components=10)
+    for key in result:
+        assert key.startswith("cluster_id"), f"Unexpected key format: {key}"
+    assert len(result) == strategy.n_clusters_, (
+        f"Number of keys ({len(result)}) does not match strategy.n_clusters_ ({strategy.n_clusters_})"
+    )
+    print("  [PASS] cluster_trajectories key format and count")
+
+
+def test_cluster_trajectories_no_valid_files_raises():
+    strategy = ElbowKMeansStrategy(k_max=3)
+    try:
+        cluster_trajectories(["/nonexistent/a.npz", "/nonexistent/b.npz"], strategy)
+        assert False, "Should have raised RuntimeError"
+    except RuntimeError:
+        pass
+    print("  [PASS] cluster_trajectories raises on no valid files")
+
+
+def test_cluster_trajectories_uses_strategy():
+    """cluster_trajectories delegates clustering to the injected strategy."""
+
+    class _FixedKStrategy(ClusteringStrategy):
+        def __init__(self, k: int) -> None:
+            self._k = k
+
+        def fit_predict(self, features: np.ndarray) -> np.ndarray:
+            self.n_clusters_ = self._k
+            return np.arange(len(features)) % self._k
+
+    with tempfile.TemporaryDirectory() as tmp:
+        npz_paths = _make_synthetic_dataset(tmp, n=9)
+        strategy = _FixedKStrategy(k=3)
+        result = cluster_trajectories(npz_paths, strategy, pca_components=5)
+
+    assert strategy.n_clusters_ == 3, "Strategy's fit_predict was not called"
+    assert len(result) == 3, f"Expected 3 clusters, got {len(result)}"
+    all_out = [p for paths in result.values() for p in paths]
+    assert sorted(all_out) == sorted(npz_paths)
+    print("  [PASS] cluster_trajectories delegates to injected strategy")
+
+
 # ──────────────────────────── integration: main ─────────────────────────────
 
 
@@ -391,6 +505,15 @@ ALL_TESTS = [
     test_elbow_kmeans_wcss_length,
     test_elbow_kmeans_k_max_clamped_to_n_samples,
     test_elbow_kmeans_reproducible,
+    test_elbow_kmeans_strategy_labels_shape,
+    test_elbow_kmeans_strategy_n_clusters_set,
+    test_elbow_kmeans_strategy_is_subclass,
+    test_elbow_kmeans_strategy_reproducible,
+    test_cluster_trajectories_returns_dict,
+    test_cluster_trajectories_all_paths_present,
+    test_cluster_trajectories_key_format,
+    test_cluster_trajectories_no_valid_files_raises,
+    test_cluster_trajectories_uses_strategy,
     test_main_end_to_end,
     test_main_output_no_duplicates,
     test_main_output_keys_sorted,


### PR DESCRIPTION
# Description

For training Diffusion Planner, I add a package for dataset sampling to prevent bias in the dataset.
The Sampling Package classifies data using clustering and prevents bias by sampling datasets belonging to each cluster. 

For example, when clustering is performed using time-series data from routes as features, the data is classified into four clusters: straight (low speed), straight (high speed), left curve, and right curve.
By sampling from these clusters to ensure an even distribution, we can prevent bias in the dataset.

In this PR, we are making changes only to the portion of the code related to dataset clustering.
Please refer to the README for specific details.

# How to test

By running `cluster.py` on the existing training dataset and then running `visualize_cluster.py` on the resulting JSON file, I was able to visualize the path shapes for each cluster, as shown below.

<img width="1185" height="1058" alt="cluster_image" src="https://github.com/user-attachments/assets/b36bc8d8-27a7-4f48-9841-50300f0eb7ee" />

Furthermore, the unit tests are passed.