### PR TITLE
fix(scene_editor): enforce ego_shape, use reward.py for RB, save full NPZ context

### DIFF
--- a/preference_optimization/utils.py
+++ b/preference_optimization/utils.py
@@ -32,11 +32,9 @@ def load_npz_data(npz_path: str | Path, device: torch.device) -> dict[str, torch
         data["ego_agent_past"] = heading_to_cos_sin(data["ego_agent_past"])
 
     if "ego_shape" not in data:
-        wheel_base = 2.79
-        ego_length = 4.34
-        ego_width = 1.70
-        data["ego_shape"] = torch.tensor(
-            [[wheel_base, ego_length, ego_width]], dtype=torch.float32, device=device
+        raise ValueError(
+            f"load_npz_data: '{npz_path}' is missing 'ego_shape' "
+            "(wheel_base, length, width)."
         )
 
     # v4 decoder requires delay (always 0 at inference, training uses random delay)

--- a/preference_optimization/utils.py
+++ b/preference_optimization/utils.py
@@ -8,15 +8,21 @@ from diffusion_planner.model.guidance.config import GuidanceConfig, GuidanceSetC
 from diffusion_planner.train_epoch import heading_to_cos_sin
 
 
-def load_npz_data(npz_path: str | Path, device: torch.device) -> dict[str, torch.Tensor]:
+def load_npz_data(
+    npz_path: str | Path,
+    device: torch.device,
+    ego_shape_override: tuple[float, ...] | None = None,
+) -> dict[str, torch.Tensor]:
     """Load NPZ file into tensors on the specified device.
 
     Args:
-        npz_path: Path to the NPZ file
-        device: Device to load tensors onto
+        npz_path: Path to the NPZ file.
+        device: Device to load tensors onto.
+        ego_shape_override: If provided and the NPZ lacks ego_shape,
+            use this (wheelbase, length, width) instead of crashing.
 
     Returns:
-        Dictionary of tensors with observation data
+        Dictionary of tensors with observation data.
     """
     with np.load(str(npz_path)) as loaded:
         data: dict[str, torch.Tensor] = {}
@@ -32,10 +38,15 @@ def load_npz_data(npz_path: str | Path, device: torch.device) -> dict[str, torch
         data["ego_agent_past"] = heading_to_cos_sin(data["ego_agent_past"])
 
     if "ego_shape" not in data:
-        raise ValueError(
-            f"load_npz_data: '{npz_path}' is missing 'ego_shape' "
-            "(wheel_base, length, width)."
-        )
+        if ego_shape_override is not None:
+            data["ego_shape"] = torch.tensor(
+                [list(ego_shape_override)], dtype=torch.float32, device=device,
+            )
+        else:
+            raise ValueError(
+                f"load_npz_data: '{npz_path}' is missing 'ego_shape' "
+                "(wheel_base, length, width)."
+            )
 
     # v4 decoder requires delay (always 0 at inference, training uses random delay)
     if "delay" not in data:

--- a/rlvr/autoresearch/visualize_scenes.py
+++ b/rlvr/autoresearch/visualize_scenes.py
@@ -139,6 +139,23 @@ def draw_scene(ax, npz_path, traj, label, color, r, show_gt=True):
     # Ego box at t=0
     ax.add_patch(Rectangle((-ro, -width / 2), length, width, lw=2, ec="black", fc="#3366cc", alpha=0.9, zorder=20))
 
+    # Neighbors at t=0
+    nb_past = npz["neighbor_agents_past"]  # (N, 31, 11)
+    for i in range(nb_past.shape[0]):
+        nb = nb_past[i]
+        if np.abs(nb).sum() < 1e-6:
+            continue
+        nx, ny = nb[-1, 0], nb[-1, 1]
+        ncos, nsin = nb[-1, 2], nb[-1, 3]
+        nw, nl = nb[-1, 6], nb[-1, 7]
+        if nl < 0.1 or nw < 0.1:
+            continue
+        nro = nl * 0.175
+        nh = np.arctan2(nsin, ncos)
+        t_rot = mtransforms.Affine2D().rotate(nh).translate(nx, ny) + ax.transData
+        ax.add_patch(Rectangle((-nro, -nw / 2), nl, nw, lw=1.5, ec="#cc4400",
+                               fc="#ff8844", alpha=0.7, zorder=15, transform=t_rot))
+
     # Trajectory + footprints
     pl = np.linalg.norm(np.diff(traj[:, :2], axis=0), axis=1).sum()
     ax.plot(traj[:, 0], traj[:, 1], "-", color=color, lw=2, alpha=0.5, zorder=10)

--- a/rlvr/autoresearch/visualize_scenes.py
+++ b/rlvr/autoresearch/visualize_scenes.py
@@ -150,7 +150,7 @@ def draw_scene(ax, npz_path, traj, label, color, r, show_gt=True):
         nw, nl = nb[-1, 6], nb[-1, 7]
         if nl < 0.1 or nw < 0.1:
             continue
-        nro = nl * 0.175
+        nro = nl * 0.175  # ~(1 - 0.65) / 2; neighbors lack wheelbase, assume wb/l ~ 0.65
         nh = np.arctan2(nsin, ncos)
         t_rot = mtransforms.Affine2D().rotate(nh).translate(nx, ny) + ax.transData
         ax.add_patch(Rectangle((-nro, -nw / 2), nl, nw, lw=1.5, ec="#cc4400",

--- a/rlvr/autoresearch/visualize_scenes.py
+++ b/rlvr/autoresearch/visualize_scenes.py
@@ -243,11 +243,12 @@ def main():
             # Overlay LoRA trajectory with footprints
             npz = np.load(scenes[si], allow_pickle=True)
             es = npz.get("ego_shape", None)
-            # ego_shape = [wheel_base, length, width]
-            wb = float(es[0]) if es is not None and len(es) >= 1 else 2.75
-            length = float(es[1]) if es is not None and len(es) >= 2 else 4.34
-            width = float(es[2]) if es is not None and len(es) >= 3 else 1.70
-            ro = length - wb  # rear overhang
+            if es is None or len(es) < 3:
+                raise ValueError(
+                    f"NPZ at '{scenes[si]}' is missing 'ego_shape'."
+                )
+            wb, length, width = float(es[0]), float(es[1]), float(es[2])
+            ro = (length - wb) / 2
             pl_l = np.linalg.norm(np.diff(traj_l[:, :2], axis=0), axis=1).sum()
             ax.plot(traj_l[:, 0], traj_l[:, 1], "-", color="orange", lw=2, alpha=0.6, zorder=12)
             ax.plot(traj_l[::3, 0], traj_l[::3, 1], "o", color="orange", ms=3.5, alpha=0.9, mew=0,

--- a/rlvr/autoresearch/visualize_scenes.py
+++ b/rlvr/autoresearch/visualize_scenes.py
@@ -71,6 +71,20 @@ def infer(model, args, npz_path, reward_config=None):
     if reward_config is None:
         reward_config = RewardConfig(enable_overprogress=True)
     data = load_npz_data(npz_path, DEVICE)
+    norm_dict = args.observation_normalizer._normalization_dict
+    for k, v in norm_dict.items():
+        if k in data and isinstance(data[k], torch.Tensor):
+            expected_dim = v["mean"].shape[-1]
+            actual_dim = data[k].shape[-1]
+            if actual_dim != expected_dim:
+                raise ValueError(
+                    f"NPZ '{npz_path}': field '{k}' has {actual_dim} columns "
+                    f"but the model normalizer expects {expected_dim}. "
+                    f"Fix the NPZ upstream -- do not pad."
+                )
+    for k in data:
+        if isinstance(data[k], torch.Tensor) and data[k].dtype == torch.float64:
+            data[k] = data[k].float()
     norm = {k: v.clone() if isinstance(v, torch.Tensor) else v for k, v in data.items()}
     norm = args.observation_normalizer(norm)
     traj = generate_samples(model, args, norm, 0.0, 1, None, DEVICE)[0]
@@ -81,10 +95,13 @@ def infer(model, args, npz_path, reward_config=None):
 
 def draw_scene(ax, npz_path, traj, label, color, r, show_gt=True):
     npz = np.load(npz_path)
-    wb, length, width = 2.75, 4.34, 1.70
     es = npz.get("ego_shape", None)
-    if es is not None and len(es) >= 3:
-        wb, length, width = float(es[0]), float(es[1]), float(es[2])
+    if es is None or len(es) < 3:
+        raise ValueError(
+            f"NPZ at '{npz_path}' is missing 'ego_shape'. "
+            "Inject it upstream before visualizing."
+        )
+    wb, length, width = float(es[0]), float(es[1]), float(es[2])
     ro = (length - wb) / 2
 
     # Lanes

--- a/scenario_generation/README.md
+++ b/scenario_generation/README.md
@@ -314,7 +314,7 @@ python -m scenario_generation.tools.scene_branch_editor \
 3. Place a stopped vehicle with position, heading, dimensions, and history
    (how many past timesteps the model sees the obstacle)
 4. Preview the model's DET trajectory and guided trajectories
-5. Fork a branch and simulate N steps forward (closed-loop or open-loop)
+5. Click Simulate -- auto-forks from the current step and runs N steps forward (closed-loop or open-loop)
 6. Play back the simulation result, inspect with reward overlays
 7. Save for RSFT: save scene + guided trajectory for curated training
 8. Export NPZs: copy branch sequence with sequential naming
@@ -330,9 +330,10 @@ python -m scenario_generation.tools.scene_branch_editor \
 | Show DET | Deterministic model prediction (blue trajectory) |
 | Show Guided | Guided inference with configurable guidances + scales |
 | Dim/Zero Neighbors | Grey out neighbors visually + zero from model input |
-| Forward simulation | Closed-loop (re-inference per step) or open-loop (cached trajectory) |
+| Forward simulation | Auto-forks current branch, runs N steps closed-loop (re-inference per step) or open-loop (cached trajectory) |
 | Apply Guidance | Use guidance config during every simulation step |
-| Road border overlay | Distance line from ego to nearest border (from lanelet2 map) |
+| Anchor guidance | Click-to-select prototype gallery (16 motion modes); anchor index + prototypes path passed to anchor_following guidance |
+| Road border overlay | Distance from ego OBB perimeter to nearest border segment (uses `compute_road_border_penalty` from `reward.py`) |
 | Neighbor distance | OBB-OBB closest pair lines (uses `reward.py` primitives) |
 | Traj RB/NB Worst | Worst-case clearance along DET/guided trajectories with ego footprint |
 | Save for RSFT | Save scene NPZ with guided trajectory as `ego_agent_future`, validates against reward gates |
@@ -346,7 +347,7 @@ python -m scenario_generation.tools.scene_branch_editor \
 |---|---|
 | `--npz_dir` | Path to replay NPZ directory (required) |
 | `--model_path` | Model checkpoint for inference (optional, enables DET/guided/sim) |
-| `--ego_shape` | `wheelbase,length,width` — override when NPZ lacks `ego_shape` |
+| `--ego_shape` | `wheelbase,length,width` — required when NPZ lacks `ego_shape` field (e.g. psim NPZs) |
 | `--map_path` | Lanelet2 `.osm` map for road border overlays + RB gate scoring |
 | `--reward_config` | Reward config JSON for RSFT gate validation (uses canonical gates) |
 | `--port` | Gradio server port (default 7870) |

--- a/scenario_generation/simulate.py
+++ b/scenario_generation/simulate.py
@@ -736,6 +736,13 @@ def run_simulation(model, model_args, scene: SceneContext, n_steps: int,
                 progress_fn((step + 1) / n_steps, f"Simulating {step+1}/{n_steps}")
 
             # --- Dump NPZ ---
+            if dump_npz and step == 0 and not _can_refresh_ls:
+                raise RuntimeError(
+                    "dump_npz=True but builder/ego_world_pose not provided. "
+                    "Line_strings border flags would be all zeros, silently "
+                    "breaking road border reward scoring. Pass builder + "
+                    "ego_world_pose to enable NPZ dump."
+                )
             if dump_npz:
                 npz_data = dump_step_npz(scene, map_cache, future_len=model_args.future_len)
                 if ego_id in agent_predictions:

--- a/scenario_generation/simulate.py
+++ b/scenario_generation/simulate.py
@@ -737,12 +737,14 @@ def run_simulation(model, model_args, scene: SceneContext, n_steps: int,
 
             # --- Dump NPZ ---
             if dump_npz and step == 0 and not _can_refresh_ls:
-                raise RuntimeError(
-                    "dump_npz=True but builder/ego_world_pose not provided. "
-                    "Line_strings border flags would be all zeros, silently "
-                    "breaking road border reward scoring. Pass builder + "
-                    "ego_world_pose to enable NPZ dump."
-                )
+                ls = scene.map_data.line_strings
+                has_flags = ls.shape[-1] >= 4 and ls[:, :, 3].max() > 0.5
+                if not has_flags:
+                    raise RuntimeError(
+                        "dump_npz=True but line_strings lack border flags and "
+                        "builder/ego_world_pose not provided to rebuild them. "
+                        "Pass builder + ego_world_pose to enable NPZ dump."
+                    )
             if dump_npz:
                 npz_data = dump_step_npz(scene, map_cache, future_len=model_args.future_len)
                 if ego_id in agent_predictions:

--- a/scenario_generation/tools/scene_branch_editor.py
+++ b/scenario_generation/tools/scene_branch_editor.py
@@ -544,8 +544,12 @@ def render_scene_at_step(
                             ln_f = float(ego.length)
                             wd_f = float(ego.width)
                             ro_f = (ln_f - wb_f) / 2
-                            corners = [(-ro_f, -wd_f/2), (-ro_f, wd_f/2),
-                                       (ln_f - ro_f, -wd_f/2), (ln_f - ro_f, wd_f/2)]
+                            half_l = ln_f / 2
+                            corners = [
+                                (-ro_f, -wd_f/2), (-ro_f, 0.0), (-ro_f, wd_f/2),
+                                (ln_f - ro_f, -wd_f/2), (ln_f - ro_f, 0.0), (ln_f - ro_f, wd_f/2),
+                                (half_l - ro_f, -wd_f/2), (half_l - ro_f, wd_f/2),
+                            ]
                             cos_h = float(np.cos(ego_h))
                             sin_h = float(np.sin(ego_h))
                             perim_pts = []
@@ -708,8 +712,12 @@ def render_scene_at_step(
                                 ro_t = (ego_len - wb_t) / 2
                                 cos_wh = float(np.cos(wh))
                                 sin_wh = float(np.sin(wh))
-                                corners_t = [(-ro_t, -ego_wid/2), (-ro_t, ego_wid/2),
-                                             (ego_len - ro_t, -ego_wid/2), (ego_len - ro_t, ego_wid/2)]
+                                half_lt = ego_len / 2
+                                corners_t = [
+                                    (-ro_t, -ego_wid/2), (-ro_t, 0.0), (-ro_t, ego_wid/2),
+                                    (ego_len - ro_t, -ego_wid/2), (ego_len - ro_t, 0.0), (ego_len - ro_t, ego_wid/2),
+                                    (half_lt - ro_t, -ego_wid/2), (half_lt - ro_t, ego_wid/2),
+                                ]
                                 pp = []
                                 for lx, ly in corners_t:
                                     pp.append([wx + cos_wh*lx - sin_wh*ly,
@@ -1260,6 +1268,7 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
 
             # Refresh line_strings from map if source NPZ lacks border flags
             if (scene.map_data is not None
+                    and scene.map_data.line_strings is not None
                     and scene.map_data.line_strings.shape[-1] < 4
                     and map_builder is not None and ego_wp is not None):
                 from scenario_generation.simulate import _refresh_line_strings
@@ -1926,7 +1935,6 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
             rc = reward_config if reward_config is not None else _RC()
             if reward_config is None:
                 rc.rb_gate_enabled = True
-                rc.kinematic_gate_enabled = True
                 rc.enable_lane_departure = True
             rewards = _crb(traj_4col, scene_data, rc)
             r = rewards[0]
@@ -2315,6 +2323,7 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
                         gt_traj_r = _reconstruct_gt_from_sequence(seq, s, max_future=80)
                 ego_wp = _recover_ego_world_pose(seq, s) if (map_borders or map_builder) else None
                 if (scene.map_data is not None
+                        and scene.map_data.line_strings is not None
                         and scene.map_data.line_strings.shape[-1] < 4
                         and map_builder is not None and ego_wp is not None):
                     from scenario_generation.simulate import _refresh_line_strings as _rls2

--- a/scenario_generation/tools/scene_branch_editor.py
+++ b/scenario_generation/tools/scene_branch_editor.py
@@ -144,11 +144,14 @@ class _ModelCache:
                 params["v_low"] = max(0.0, speed * 0.5)
             fns.append(GuidanceConfig(name=name, enabled=True, scale=scale, params=params))
 
-        if not fns:
+        composer = None
+        if fns:
+            set_cfg = GuidanceSetConfig(functions=fns, global_scale=1.0)
+            composer = GuidanceComposer(set_cfg)
+
+        if not fns and noise_scale == 0.0:
             return det_raw
 
-        set_cfg = GuidanceSetConfig(functions=fns, global_scale=1.0)
-        composer = GuidanceComposer(set_cfg)
         return generate_samples(
             self._model, self._model_args, data,
             noise_scale=noise_scale, n_samples=n_samples,
@@ -515,14 +518,60 @@ def render_scene_at_step(
                         md.line_strings.astype(np.float32)
                     )
             if data_dict:
+                from rlvr.reward import _point_to_segments_dist
                 _, _, _, _, _, per_t_min = compute_road_border_penalty(
                     ego_traj_1, ego_shape_t, data_dict, RewardConfig(),
                 )
                 dist = float(per_t_min[0, 0].item())
                 if dist < 50.0:
                     color = "#dd2222" if dist < 0.5 else "#ff8800" if dist < 1.0 else "#22bb22"
+                    # Find closest ego perimeter point and border segment point
+                    ls_t = data_dict["line_strings"]
+                    if ls_t.dim() == 3:
+                        ls_t = ls_t.unsqueeze(0)
+                    border_flag = ls_t[0, :, :, 3] if ls_t.shape[-1] >= 4 else None
+                    if border_flag is not None:
+                        border_xy = ls_t[0, :, :, :2]
+                        is_border = border_flag > 0.5
+                        has_coords = border_xy.norm(dim=-1) > 1e-3
+                        valid = is_border & has_coords
+                        valid_pair = valid[:, :-1] & valid[:, 1:]
+                        idx = _t_rb.where(valid_pair.reshape(-1))[0]
+                        if idx.shape[0] > 0:
+                            seg_p1 = border_xy[:, :-1].reshape(-1, 2)[idx]
+                            seg_p2 = border_xy[:, 1:].reshape(-1, 2)[idx]
+                            wb_f = float(ego.wheelbase)
+                            ln_f = float(ego.length)
+                            wd_f = float(ego.width)
+                            ro_f = (ln_f - wb_f) / 2
+                            corners = [(-ro_f, -wd_f/2), (-ro_f, wd_f/2),
+                                       (ln_f - ro_f, -wd_f/2), (ln_f - ro_f, wd_f/2)]
+                            cos_h = float(np.cos(ego_h))
+                            sin_h = float(np.sin(ego_h))
+                            perim_pts = []
+                            for lx, ly in corners:
+                                wx = ego_pos[0] + cos_h * lx - sin_h * ly
+                                wy = ego_pos[1] + sin_h * lx + cos_h * ly
+                                perim_pts.append([wx, wy])
+                            perim_t = _t_rb.tensor(perim_pts, dtype=_t_rb.float32)
+                            d_mat = _point_to_segments_dist(perim_t, seg_p1, seg_p2)
+                            min_per_pt = d_mat.min(dim=1)
+                            best_pt_idx = min_per_pt.values.argmin().item()
+                            best_seg_idx = min_per_pt.indices[best_pt_idx].item()
+                            ep = perim_pts[best_pt_idx]
+                            s1 = seg_p1[best_seg_idx].numpy()
+                            s2 = seg_p2[best_seg_idx].numpy()
+                            p = np.array(ep, dtype=np.float64)
+                            d_seg = s2 - s1
+                            t_val = max(0.0, min(1.0, float(np.dot(p - s1, d_seg) / max(np.dot(d_seg, d_seg), 1e-12))))
+                            bp = s1 + t_val * d_seg
+                            ax.plot([ep[0], bp[0]], [ep[1], bp[1]],
+                                    "-", color=color, lw=2.5, alpha=0.9, zorder=35)
+                            ax.plot(bp[0], bp[1], "o", color=color, ms=6, zorder=36)
+                    mid_x = float(ego_pos[0])
+                    mid_y = float(ego_pos[1]) + 1.5
                     ax.annotate(
-                        f"RB {dist:.2f}m", (float(ego_pos[0]), float(ego_pos[1]) + 1.5),
+                        f"RB {dist:.2f}m", (mid_x, mid_y),
                         fontsize=8, fontweight="bold", color=color,
                         ha="center", va="bottom", zorder=37,
                         bbox=dict(boxstyle="round,pad=0.2", fc="white", ec=color, alpha=0.85),
@@ -642,6 +691,43 @@ def render_scene_at_step(
                         dc = "#dd2222" if worst_rb_dist < 0.5 else "#ff8800" if worst_rb_dist < 1.0 else "#22bb22"
                         draw_agent_box(ax, wx, wy, wh, ego_len, ego_wid, traj_color,
                                        alpha=0.4, lw=2.0, zorder=38)
+                        from rlvr.reward import _point_to_segments_dist as _ptsd_trb
+                        ls_trb = _trb_data["line_strings"]
+                        if ls_trb.dim() == 3:
+                            ls_trb = ls_trb.unsqueeze(0)
+                        bf = ls_trb[0, :, :, 3] if ls_trb.shape[-1] >= 4 else None
+                        if bf is not None:
+                            bxy = ls_trb[0, :, :, :2]
+                            vld = (bf > 0.5) & (bxy.norm(dim=-1) > 1e-3)
+                            vpair = vld[:, :-1] & vld[:, 1:]
+                            vidx = _t_trb.where(vpair.reshape(-1))[0]
+                            if vidx.shape[0] > 0:
+                                sp1 = bxy[:, :-1].reshape(-1, 2)[vidx]
+                                sp2 = bxy[:, 1:].reshape(-1, 2)[vidx]
+                                wb_t = float(ego.wheelbase)
+                                ro_t = (ego_len - wb_t) / 2
+                                cos_wh = float(np.cos(wh))
+                                sin_wh = float(np.sin(wh))
+                                corners_t = [(-ro_t, -ego_wid/2), (-ro_t, ego_wid/2),
+                                             (ego_len - ro_t, -ego_wid/2), (ego_len - ro_t, ego_wid/2)]
+                                pp = []
+                                for lx, ly in corners_t:
+                                    pp.append([wx + cos_wh*lx - sin_wh*ly,
+                                               wy + sin_wh*lx + cos_wh*ly])
+                                pp_t = _t_trb.tensor(pp, dtype=_t_trb.float32)
+                                dm = _ptsd_trb(pp_t, sp1, sp2)
+                                mpp = dm.min(dim=1)
+                                bpi = mpp.values.argmin().item()
+                                bsi = mpp.indices[bpi].item()
+                                ep_t = pp[bpi]
+                                s1_t = sp1[bsi].numpy()
+                                s2_t = sp2[bsi].numpy()
+                                d_s = s2_t - s1_t
+                                tv = max(0.0, min(1.0, float(np.dot(np.array(ep_t) - s1_t, d_s) / max(np.dot(d_s, d_s), 1e-12))))
+                                bp_t = s1_t + tv * d_s
+                                ax.plot([ep_t[0], bp_t[0]], [ep_t[1], bp_t[1]],
+                                        "-", color=dc, lw=2.5, alpha=0.9, zorder=39)
+                                ax.plot(bp_t[0], bp_t[1], "o", color=dc, ms=5, zorder=39)
                         ax.annotate(
                             f"{traj_label} RB {worst_rb_dist:.2f}m @t{worst_rb_idx}",
                             (wx, wy), fontsize=7, fontweight="bold", color=dc,
@@ -1169,8 +1255,19 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
                 if gt_traj_render is None and len(seq) > step + 1:
                     gt_traj_render = _reconstruct_gt_from_sequence(seq, step, max_future=80)
 
-            # Ego world pose for map border transform
-            ego_wp = _recover_ego_world_pose(seq, step) if map_borders else None
+            # Ego world pose for map border transform + line_strings refresh
+            ego_wp = _recover_ego_world_pose(seq, step) if (map_borders or map_builder) else None
+
+            # Refresh line_strings from map if source NPZ lacks border flags
+            if (scene.map_data is not None
+                    and scene.map_data.line_strings.shape[-1] < 4
+                    and map_builder is not None and ego_wp is not None):
+                from scenario_generation.simulate import _refresh_line_strings
+                _refresh_line_strings(
+                    scene, map_builder,
+                    np.array(ego_wp[:2], dtype=np.float64),
+                    np.array(ego_wp, dtype=np.float64),
+                )
 
             fig = render_scene_at_step(
                 scene, obstacles_at_step, selected_obs,
@@ -1268,7 +1365,9 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
                                 rb_dist=rb_on, nb_dist=nb_on, hide_nb=hide_nb,
                                 traj_rb=traj_rb_on, traj_nb=traj_nb_on)
             return img, info, s, det_traj, guided
-        def on_preview(tree, step, view_r, selected_obs, x, y, yaw, length, width, gt_on, det_cache, guided_cache):
+        def on_preview(tree, step, view_r, selected_obs, x, y, yaw, length, width,
+                       gt_on, det_cache, guided_cache,
+                       rb_on, nb_on, hide_nb, traj_rb_on, traj_nb_on):
             preview = ObstaclePlacement(
                 label="(preview)", timestep=_safe_step(step),
                 x=round(float(x), 1), y=round(float(y), 1),
@@ -1277,7 +1376,9 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
             )
             img, info = _render(tree, _safe_step(step), view_r, selected_obs, preview,
                                 show_gt_val=gt_on, det_traj=det_cache,
-                                guided_trajs=guided_cache)
+                                guided_trajs=guided_cache,
+                                rb_dist=rb_on, nb_dist=nb_on, hide_nb=hide_nb,
+                                traj_rb=traj_rb_on, traj_nb=traj_nb_on)
             return img, info
 
         def _obs_choices(tree):
@@ -1378,11 +1479,14 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
             return (tree, img, info, mods, label, det_traj, guided,
                     gr.update(choices=choices, value=label))
 
-        def on_select_obstacle(tree, label, step, view_r, gt_on, det_on, det_cache, guided_cache):
+        def on_select_obstacle(tree, label, step, view_r, gt_on, det_on, det_cache, guided_cache,
+                               rb_on, nb_on, hide_nb, traj_rb_on, traj_nb_on):
             obs = _find_obs(tree, label)
             s = _safe_step(step)
             img, info = _render(tree, s, view_r, label, show_gt_val=gt_on,
-                                det_traj=det_cache, guided_trajs=guided_cache)
+                                det_traj=det_cache, guided_trajs=guided_cache,
+                                rb_dist=rb_on, nb_dist=nb_on, hide_nb=hide_nb,
+                                traj_rb=traj_rb_on, traj_nb=traj_nb_on)
             if obs:
                 return (img, info, label,
                         obs.x, obs.y, obs.yaw_deg, obs.length, obs.width,
@@ -1437,6 +1541,7 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
 
         def on_generate_guided(tree, step, gt_on, view_r, selected_obs,
                                noise, k, det_on, det_cache, hide_nb,
+                               rb_on, nb_on, traj_rb_on, traj_nb_on,
                                *guidance_args):
             if model_cache is None or not model_cache.available:
                 return gr.update(), "No model loaded", det_cache, None
@@ -1472,7 +1577,10 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
 
             img, info = _render(tree, _safe_step(step), view_r, selected_obs,
                                 show_gt_val=gt_on, det_traj=det_traj,
-                                guided_trajs=guided_list, hide_nb=hide_nb)
+                                guided_trajs=guided_list,
+                                rb_dist=rb_on, nb_dist=nb_on,
+                                hide_nb=hide_nb,
+                                traj_rb=traj_rb_on, traj_nb=traj_nb_on)
             return img, info, det_cache, guided_list
 
         def on_branch_change(tree, branch_id, step, view_r, selected_obs, gt_on):
@@ -1631,7 +1739,8 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
             on_preview,
             [tree_state, step_slider, view_half, selected_obstacle_state,
              obs_x, obs_y, obs_yaw, obs_length, obs_width, show_gt,
-             det_traj_state, guided_trajs_state],
+             det_traj_state, guided_trajs_state,
+             show_rb_dist, show_nb_dist, hide_neighbors, show_traj_rb, show_traj_nb],
             [scene_image, step_info],
         )
 
@@ -1648,7 +1757,8 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
         obs_select.change(
             on_select_obstacle,
             [tree_state, obs_select, step_slider, view_half, show_gt,
-             show_det, det_traj_state, guided_trajs_state],
+             show_det, det_traj_state, guided_trajs_state,
+             show_rb_dist, show_nb_dist, hide_neighbors, show_traj_rb, show_traj_nb],
             [scene_image, step_info, selected_obstacle_state,
              edit_x, edit_y, edit_yaw, edit_length, edit_width, edit_history],
         )
@@ -1673,7 +1783,8 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
         # Guidance generation button
         guidance_btn_inputs = ([tree_state, step_slider, show_gt, view_half,
                                 selected_obstacle_state, guided_noise, guided_k,
-                                show_det, det_traj_state, hide_neighbors]
+                                show_det, det_traj_state, hide_neighbors,
+                                show_rb_dist, show_nb_dist, show_traj_rb, show_traj_nb]
                                + [v for gname in ALL_GUIDANCE_NAMES
                                   for v in (guidance_toggles[gname], guidance_scales[gname])])
         generate_guided_btn.click(
@@ -2202,7 +2313,14 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
                         gt_traj_r = ego.future_trajectory
                     if gt_traj_r is None and len(seq) > s + 1:
                         gt_traj_r = _reconstruct_gt_from_sequence(seq, s, max_future=80)
-                ego_wp = _recover_ego_world_pose(seq, s) if map_borders else None
+                ego_wp = _recover_ego_world_pose(seq, s) if (map_borders or map_builder) else None
+                if (scene.map_data is not None
+                        and scene.map_data.line_strings.shape[-1] < 4
+                        and map_builder is not None and ego_wp is not None):
+                    from scenario_generation.simulate import _refresh_line_strings as _rls2
+                    _rls2(scene, map_builder,
+                          np.array(ego_wp[:2], dtype=np.float64),
+                          np.array(ego_wp, dtype=np.float64))
                 fig = render_scene_at_step(
                     scene, obs_at_step, None,
                     view_half=view_r, step_idx=s, total_steps=len(seq),

--- a/scenario_generation/tools/scene_branch_editor.py
+++ b/scenario_generation/tools/scene_branch_editor.py
@@ -116,6 +116,8 @@ class _ModelCache:
         obstacles: list | None = None,
         zero_neighbors: bool = False,
         ego_shape_override: tuple[float, ...] | None = None,
+        anchor_index: int = 0,
+        anchor_path: str | None = None,
     ) -> np.ndarray | None:
         """Run guided inference. Returns (n_samples, 80, 4)."""
         self._ensure_loaded()
@@ -147,6 +149,9 @@ class _ModelCache:
             if name == "speed":
                 params["v_high"] = speed * 1.2
                 params["v_low"] = max(0.0, speed * 0.5)
+            if name == "anchor_following" and anchor_path:
+                params["prototypes_path"] = anchor_path
+                params["anchor_index"] = int(anchor_index)
             fns.append(GuidanceConfig(name=name, enabled=True, scale=scale, params=params))
 
         composer = None
@@ -306,7 +311,7 @@ def render_scene_at_step(
     fig.patch.set_facecolor("#f8f8f8")
 
     # Lane network
-    draw_lanes(ax, scene.map_data, alpha=0.5)
+    draw_lanes(ax, scene.map_data, alpha=0.7)
 
     # Road borders (red) — from NPZ if available
     draw_road_borders(ax, scene.map_data)
@@ -1116,6 +1121,27 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
                                     minimum=_min, maximum=10.0, value=2.0, step=0.5,
                                     show_label=False, interactive=_has_model,
                                 )
+                    _default_proto = str(Path(__file__).resolve().parent.parent.parent
+                                         / "guidance_gui" / "prototypes_k16.npy")
+                    with gr.Accordion("Anchor Prototypes", open=False):
+                        with gr.Row():
+                            anchor_index_sl = gr.Slider(
+                                minimum=0, maximum=15, value=0, step=1,
+                                label="Anchor Index", interactive=_has_model, scale=1,
+                            )
+                            anchor_path_tb = gr.Textbox(
+                                value=_default_proto,
+                                label="Prototypes Path", interactive=_has_model, scale=2,
+                            )
+                        from guidance_gui.visualization import render_prototype_gallery
+                        _init_gallery = render_prototype_gallery(_default_proto) or []
+                        anchor_gallery = gr.Gallery(
+                            value=_init_gallery,
+                            columns=8, rows=2, height=220,
+                            allow_preview=False,
+                            selected_index=0 if _init_gallery else None,
+                            label="Click to select anchor",
+                        )
                     with gr.Row():
                         guided_noise = gr.Slider(
                             minimum=0.0, maximum=5.0, value=0.0, step=0.1,
@@ -1465,12 +1491,15 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
                     if enabled:
                         cfgs.append((gname, float(scale)))
                 if cfgs:
-                    noise = float(guidance_args_tuple[-2])
-                    k = int(guidance_args_tuple[-1])
+                    noise = float(guidance_args_tuple[-4])
+                    k = int(guidance_args_tuple[-3])
+                    a_idx = int(guidance_args_tuple[-2])
+                    a_path = str(guidance_args_tuple[-1])
                     raw_g = model_cache.predict_guided(
                         npz_path, cfgs, noise_scale=noise, n_samples=max(1, k),
                         zero_neighbors=zero_neighbors,
                         ego_shape_override=tree.ego_shape,
+                        anchor_index=a_idx, anchor_path=a_path,
                     )
                     guided = [_traj_cos_sin_to_xyh(raw_g[j]) for j in range(raw_g.shape[0])]
             return det_traj, guided
@@ -1561,6 +1590,7 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
         def on_generate_guided(tree, step, gt_on, view_r, selected_obs,
                                noise, k, det_on, det_cache, hide_nb,
                                rb_on, nb_on, traj_rb_on, traj_nb_on,
+                               anchor_idx, anchor_proto_path,
                                *guidance_args):
             if model_cache is None or not model_cache.available:
                 return gr.update(), "No model loaded", det_cache, None
@@ -1593,6 +1623,7 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
                 npz_path, cfgs, noise_scale=float(noise), n_samples=int(k),
                 obstacles=obs or None, zero_neighbors=hide_nb,
                 ego_shape_override=tree.ego_shape,
+                anchor_index=int(anchor_idx), anchor_path=str(anchor_proto_path),
             )
             guided_list = [_traj_cos_sin_to_xyh(raw_guided[i]) for i in range(raw_guided.shape[0])]
 
@@ -1701,7 +1732,7 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
         # Guidance toggle+scale inputs for recomputation, plus noise and K at end
         _g_inputs = ([v for gname in ALL_GUIDANCE_NAMES
                        for v in (guidance_toggles[gname], guidance_scales[gname])]
-                     + [guided_noise, guided_k])
+                     + [guided_noise, guided_k, anchor_index_sl, anchor_path_tb])
         _overlay_inputs = [show_guided, hide_neighbors, show_rb_dist, show_nb_dist,
                            show_traj_rb, show_traj_nb]
 
@@ -1805,13 +1836,32 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
         guidance_btn_inputs = ([tree_state, step_slider, show_gt, view_half,
                                 selected_obstacle_state, guided_noise, guided_k,
                                 show_det, det_traj_state, hide_neighbors,
-                                show_rb_dist, show_nb_dist, show_traj_rb, show_traj_nb]
+                                show_rb_dist, show_nb_dist, show_traj_rb, show_traj_nb,
+                                anchor_index_sl, anchor_path_tb]
                                + [v for gname in ALL_GUIDANCE_NAMES
                                   for v in (guidance_toggles[gname], guidance_scales[gname])])
         generate_guided_btn.click(
             on_generate_guided,
             guidance_btn_inputs,
             [scene_image, step_info, det_traj_state, guided_trajs_state],
+        )
+
+        # Anchor gallery: click selects index, path change reloads gallery
+        def _on_anchor_select(evt: gr.SelectData):
+            return int(evt.index)
+
+        anchor_gallery.select(_on_anchor_select, None, anchor_index_sl)
+
+        def _on_anchor_path_change(path):
+            from guidance_gui.visualization import render_prototype_gallery as _rpg
+            imgs = _rpg(path) or []
+            k = len(imgs)
+            return (gr.update(value=imgs),
+                    gr.update(maximum=max(0, k - 1), value=0))
+
+        anchor_path_tb.change(
+            _on_anchor_path_change, [anchor_path_tb],
+            [anchor_gallery, anchor_index_sl],
         )
 
         _branch_switch_outputs = [tree_state, scene_image, step_info, branch_info, mods_display,
@@ -2153,6 +2203,8 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
                     GuidanceConfig,
                     GuidanceSetConfig,
                 )
+                _sim_anchor_idx = int(guidance_args[-2]) if len(guidance_args) > 2 else 0
+                _sim_anchor_path = str(guidance_args[-1]) if len(guidance_args) > 1 else ""
                 fns = []
                 for gi, gname in enumerate(ALL_GUIDANCE_NAMES):
                     enabled = guidance_args[gi * 2]
@@ -2165,6 +2217,9 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
                                 spd = float(np.linalg.norm(ego.current_velocity))
                                 params["v_high"] = spd * 1.2
                                 params["v_low"] = max(0.0, spd * 0.5)
+                        if gname == "anchor_following" and _sim_anchor_path:
+                            params["prototypes_path"] = _sim_anchor_path
+                            params["anchor_index"] = _sim_anchor_idx
                         fns.append(GuidanceConfig(name=gname, enabled=True,
                                                    scale=float(scale), params=params))
                 if fns:
@@ -2280,7 +2335,8 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
                         show_gt, view_half, hide_neighbors, sim_open_loop,
                         guided_trajs_state, det_traj_state]
                        + [v for gname in ALL_GUIDANCE_NAMES
-                          for v in (guidance_toggles[gname], guidance_scales[gname])])
+                          for v in (guidance_toggles[gname], guidance_scales[gname])]
+                       + [anchor_index_sl, anchor_path_tb])
         sim_btn.click(
             on_simulate,
             _sim_inputs,

--- a/scenario_generation/tools/scene_branch_editor.py
+++ b/scenario_generation/tools/scene_branch_editor.py
@@ -1327,7 +1327,8 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
             obs = _get_obstacles_at_step(tree, _safe_step(step))
             raw = model_cache.predict_det(npz_path, obstacles=obs or None,
                                           zero_neighbors=zero_neighbors,
-                                              ego_shape_override=tree.ego_shape)
+                                          ego_shape_override=tree.ego_shape)
+            return _traj_cos_sin_to_xyh(raw)
 
         def on_render(tree, step, view_r, selected_obs, gt_on, det_on, guided_on,
                       hide_nb, rb_on, nb_on, traj_rb_on, traj_nb_on,
@@ -1455,6 +1456,7 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
                 raw = model_cache.predict_det(npz_path, obstacles=obs or None,
                                               zero_neighbors=zero_neighbors,
                                               ego_shape_override=tree.ego_shape)
+                det_traj = _traj_cos_sin_to_xyh(raw)
             if guided_on and guidance_args_tuple:
                 cfgs = []
                 for gi, gname in enumerate(ALL_GUIDANCE_NAMES):
@@ -1583,7 +1585,8 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
                 else:
                     raw = model_cache.predict_det(npz_path, obstacles=obs or None,
                                                   zero_neighbors=hide_nb,
-                                              ego_shape_override=tree.ego_shape)
+                                                  ego_shape_override=tree.ego_shape)
+                    det_traj = _traj_cos_sin_to_xyh(raw)
                     det_cache = det_traj
 
             raw_guided = model_cache.predict_guided(

--- a/scenario_generation/tools/scene_branch_editor.py
+++ b/scenario_generation/tools/scene_branch_editor.py
@@ -2133,11 +2133,7 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
             tree.active_branch = new_id
             branch = tree.branches[new_id]
 
-            parent_branch = tree.branches[branch.parent_id]
-            saved_npz_dir = parent_branch.npz_dir
-            parent_branch.npz_dir = None
             seq = tree.get_npz_sequence(branch.parent_id)
-            parent_branch.npz_dir = saved_npz_dir
             if not seq:
                 return (tree, gr.update(), "No NPZ sequence", gr.update(),
                         gr.update(), gr.update(), gr.update(), gr.update(),
@@ -2208,7 +2204,7 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
                     GuidanceConfig,
                     GuidanceSetConfig,
                 )
-                _sim_anchor_idx = int(guidance_args[-2]) if len(guidance_args) > 2 else 0
+                _sim_anchor_idx = int(guidance_args[-2]) if len(guidance_args) >= 2 else 0
                 _sim_anchor_path = str(guidance_args[-1]) if len(guidance_args) > 1 else ""
                 fns = []
                 for gi, gname in enumerate(ALL_GUIDANCE_NAMES):

--- a/scenario_generation/tools/scene_branch_editor.py
+++ b/scenario_generation/tools/scene_branch_editor.py
@@ -498,25 +498,35 @@ def render_scene_at_step(
         ego_h = ego.current_heading
 
         if show_rb_dist:
-            from scenario_generation.replay import _nearest_border_point
-            border_polylines = _extract_border_polylines(scene)
-            # Fall back to map-derived borders (already in ego frame)
-            if not border_polylines and _ego_frame_borders:
-                border_polylines = _ego_frame_borders
-            bp = _nearest_border_point(ego_pos, border_polylines)
-            if bp is not None:
-                dist = float(np.linalg.norm(bp - ego_pos))
-                color = "#dd2222" if dist < 0.5 else "#ff8800" if dist < 1.0 else "#22bb22"
-                ax.plot([ego_pos[0], bp[0]], [ego_pos[1], bp[1]],
-                        "-", color=color, lw=2.5, alpha=0.9, zorder=35)
-                ax.plot(bp[0], bp[1], "o", color=color, ms=6, zorder=36)
-                mid_x, mid_y = (ego_pos[0] + bp[0]) / 2, (ego_pos[1] + bp[1]) / 2
-                ax.annotate(
-                    f"RB {dist:.2f}m", (mid_x, mid_y),
-                    fontsize=8, fontweight="bold", color=color,
-                    ha="center", va="bottom", zorder=37,
-                    bbox=dict(boxstyle="round,pad=0.2", fc="white", ec=color, alpha=0.85),
+            import torch as _t_rb
+            from rlvr.reward import compute_road_border_penalty, RewardConfig
+            ego_traj_1 = _t_rb.tensor([[[
+                float(ego_pos[0]), float(ego_pos[1]),
+                float(np.cos(ego_h)), float(np.sin(ego_h)),
+            ]]], dtype=_t_rb.float32)
+            ego_shape_t = _t_rb.tensor([
+                float(ego.wheelbase), float(ego.length), float(ego.width),
+            ], dtype=_t_rb.float32)
+            data_dict = {}
+            if hasattr(scene, "map_data") and scene.map_data is not None:
+                md = scene.map_data
+                if hasattr(md, "line_strings") and md.line_strings is not None:
+                    data_dict["line_strings"] = _t_rb.from_numpy(
+                        md.line_strings.astype(np.float32)
+                    )
+            if data_dict:
+                _, _, _, _, _, per_t_min = compute_road_border_penalty(
+                    ego_traj_1, ego_shape_t, data_dict, RewardConfig(),
                 )
+                dist = float(per_t_min[0, 0].item())
+                if dist < 50.0:
+                    color = "#dd2222" if dist < 0.5 else "#ff8800" if dist < 1.0 else "#22bb22"
+                    ax.annotate(
+                        f"RB {dist:.2f}m", (float(ego_pos[0]), float(ego_pos[1]) + 1.5),
+                        fontsize=8, fontweight="bold", color=color,
+                        ha="center", va="bottom", zorder=37,
+                        bbox=dict(boxstyle="round,pad=0.2", fc="white", ec=color, alpha=0.85),
+                    )
 
         if show_nb_dist:
             import torch as _torch
@@ -601,32 +611,43 @@ def render_scene_at_step(
             if (traj_pts.shape[0] - 1) not in idxs:
                 idxs.append(traj_pts.shape[0] - 1)
 
-            if show_traj_rb and border_polylines_for_traj:
-                from scenario_generation.replay import _nearest_border_point
-                worst_rb_dist, worst_rb_idx = float("inf"), 0
-                worst_rb_bp = None
-                for ti in idxs:
-                    px, py = float(traj_pts[ti, 0]), float(traj_pts[ti, 1])
-                    bp = _nearest_border_point(np.array([px, py]), border_polylines_for_traj)
-                    if bp is not None:
-                        d = float(np.linalg.norm(bp - np.array([px, py])))
-                        if d < worst_rb_dist:
-                            worst_rb_dist, worst_rb_idx, worst_rb_bp = d, ti, bp
-                if worst_rb_bp is not None and worst_rb_dist < 50.0:
-                    wx, wy = float(traj_pts[worst_rb_idx, 0]), float(traj_pts[worst_rb_idx, 1])
-                    wh = float(traj_pts[worst_rb_idx, 2])
-                    dc = "#dd2222" if worst_rb_dist < 0.5 else "#ff8800" if worst_rb_dist < 1.0 else "#22bb22"
-                    draw_agent_box(ax, wx, wy, wh, ego_len, ego_wid, traj_color,
-                                   alpha=0.4, lw=2.0, zorder=38)
-                    ax.plot([wx, worst_rb_bp[0]], [wy, worst_rb_bp[1]],
-                            "-", color=dc, lw=2.5, alpha=0.9, zorder=39)
-                    ax.plot(worst_rb_bp[0], worst_rb_bp[1], "o", color=dc, ms=5, zorder=39)
-                    ax.annotate(
-                        f"{traj_label} RB {worst_rb_dist:.2f}m @t{worst_rb_idx}",
-                        (wx, wy), fontsize=7, fontweight="bold", color=dc,
-                        ha="center", va="top", xytext=(0, -8),
-                        textcoords="offset points", zorder=40,
-                        bbox=dict(boxstyle="round,pad=0.2", fc="white", ec=traj_color, alpha=0.85),
+            if show_traj_rb:
+                import torch as _t_trb
+                from rlvr.reward import compute_road_border_penalty, RewardConfig
+                _trb_data = {}
+                if hasattr(scene, "map_data") and scene.map_data is not None:
+                    md = scene.map_data
+                    if hasattr(md, "line_strings") and md.line_strings is not None:
+                        _trb_data["line_strings"] = _t_trb.from_numpy(
+                            md.line_strings.astype(np.float32))
+                if _trb_data:
+                    T_tr = traj_pts.shape[0]
+                    ego_traj_t = _t_trb.zeros(1, T_tr, 4)
+                    ego_traj_t[0, :, 0] = _t_trb.from_numpy(traj_pts[:, 0].astype(np.float32))
+                    ego_traj_t[0, :, 1] = _t_trb.from_numpy(traj_pts[:, 1].astype(np.float32))
+                    ego_traj_t[0, :, 2] = _t_trb.from_numpy(np.cos(traj_pts[:, 2]).astype(np.float32))
+                    ego_traj_t[0, :, 3] = _t_trb.from_numpy(np.sin(traj_pts[:, 2]).astype(np.float32))
+                    ego_shape_t = _t_trb.tensor([
+                        float(ego.wheelbase), float(ego.length), float(ego.width),
+                    ], dtype=_t_trb.float32)
+                    _, _, _, _, _, per_t_min = compute_road_border_penalty(
+                        ego_traj_t, ego_shape_t, _trb_data, RewardConfig())
+                    per_t = per_t_min[0]  # (T,)
+                    worst_rb_idx = int(per_t.argmin().item())
+                    worst_rb_dist = float(per_t[worst_rb_idx].item())
+                    if worst_rb_dist < 50.0:
+                        wx = float(traj_pts[worst_rb_idx, 0])
+                        wy = float(traj_pts[worst_rb_idx, 1])
+                        wh = float(traj_pts[worst_rb_idx, 2])
+                        dc = "#dd2222" if worst_rb_dist < 0.5 else "#ff8800" if worst_rb_dist < 1.0 else "#22bb22"
+                        draw_agent_box(ax, wx, wy, wh, ego_len, ego_wid, traj_color,
+                                       alpha=0.4, lw=2.0, zorder=38)
+                        ax.annotate(
+                            f"{traj_label} RB {worst_rb_dist:.2f}m @t{worst_rb_idx}",
+                            (wx, wy), fontsize=7, fontweight="bold", color=dc,
+                            ha="center", va="top", xytext=(0, -8),
+                            textcoords="offset points", zorder=40,
+                            bbox=dict(boxstyle="round,pad=0.2", fc="white", ec=traj_color, alpha=0.85),
                     )
 
             _all_nb_corners = _placed_obs_corners[:]
@@ -923,12 +944,6 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
                     place_btn = gr.Button("Place Obstacle", variant="primary")
                     preview_btn = gr.Button("Preview", variant="secondary")
 
-                gr.Markdown("### View")
-                view_half = gr.Slider(
-                    minimum=10, maximum=200, value=50, step=5,
-                    label="View radius (m)",
-                )
-
                 gr.Markdown("### Crop")
                 with gr.Row():
                     crop_start = gr.Number(label="Start", value=0, precision=0)
@@ -946,12 +961,14 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
                     height=600,
                 )
 
-                # Timeline playback
+                # Timeline playback + view
                 with gr.Row():
                     btn_play = gr.Button("Play ▶", size="sm", min_width=60)
                     btn_stop = gr.Button("Stop ■", size="sm", min_width=60, variant="stop")
                     play_fps = gr.Slider(minimum=1, maximum=30, value=10, step=1,
                                          label="FPS", scale=1)
+                    view_half = gr.Slider(minimum=10, maximum=200, value=50, step=5,
+                                          label="View radius (m)", scale=1)
 
                 _has_model = model_cache is not None and model_cache.available
 
@@ -1766,6 +1783,9 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
             from rlvr.reward import RewardConfig as _RC
             from rlvr.reward import compute_reward_batch as _crb
             scene_data = _load_npz(npz_path, torch.device("cpu"))
+            if tree.ego_shape:
+                scene_data["ego_shape"] = torch.tensor(
+                    [list(tree.ego_shape)], dtype=torch.float32)
             obs_at_step = _get_obstacles_at_step(tree, s)
             if obs_at_step:
                 scene_data = _inject_obstacles_into_tensors(
@@ -1833,21 +1853,70 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
             else:
                 idx = 0
 
-            with np.load(npz_path) as src:
-                npz_data = dict(src)
+            # Start from the raw NPZ (pre-load_npz_data) to avoid
+            # double heading_to_cos_sin conversion on ego_agent_past
+            # and goal_pose. Then overlay fields that were rebuilt/modified.
+            with np.load(npz_path) as raw:
+                npz_data = {k: raw[k].astype(np.float32)
+                            if raw[k].dtype == np.float64 else raw[k]
+                            for k in raw.files}
+            # Overlay obstacle-injected neighbors from scene_data
             if obs_at_step:
-                device = torch.device("cpu")
-                tmp_data = {k: torch.from_numpy(v).unsqueeze(0) if v.ndim < 4
-                            else torch.from_numpy(v) for k, v in npz_data.items()
-                            if isinstance(v, np.ndarray)}
-                tmp_data = _inject_obstacles_into_tensors(tmp_data, obs_at_step, device)
                 for k in ("neighbor_agents_past", "neighbor_agents_future"):
-                    if k in tmp_data:
-                        v = tmp_data[k]
-                        npz_data[k] = v.squeeze(0).numpy() if v.dim() > 2 else v.numpy()
+                    if k in scene_data and isinstance(scene_data[k], torch.Tensor):
+                        npz_data[k] = scene_data[k].squeeze(0).cpu().numpy()
+            # Overlay rebuilt line_strings (4-col with border flags)
+            if "line_strings" in scene_data:
+                ls = scene_data["line_strings"]
+                if isinstance(ls, torch.Tensor):
+                    ls = ls.squeeze(0).cpu().numpy()
+                if ls.shape[-1] >= 4:
+                    npz_data["line_strings"] = ls.astype(np.float32)
+            # Rebuild polygons from map (3-col with type) if source is 2-col
+            if map_builder is not None and npz_data.get("polygons") is not None:
+                if npz_data["polygons"].shape[-1] < 3:
+                    ego_wp = _recover_ego_world_pose(
+                        tree.get_npz_sequence(tree.active_branch), s)
+                    if ego_wp is not None:
+                        from scenario_generation.transforms import (
+                            _rotation_matrix, transform_positions,
+                        )
+                        poly_world = map_builder.build_polygons_tensor(
+                            np.array(ego_wp[:2], dtype=np.float32))
+                        R_init = _rotation_matrix(float(ego_wp[2]) if len(ego_wp) > 2 else 0.0)
+                        init_xy = np.array(ego_wp[:2], dtype=np.float64)
+                        for pi in range(poly_world.shape[0]):
+                            pts = poly_world[pi, :, :2]
+                            valid = np.abs(pts).sum(axis=1) > 0.1
+                            if valid.any():
+                                poly_world[pi, valid, :2] = transform_positions(
+                                    pts[valid].astype(np.float64), R_init, init_xy,
+                                ).astype(np.float32)
+                        npz_data["polygons"] = poly_world.astype(np.float32)
             npz_data["ego_agent_future"] = traj_xyh
+            if tree.ego_shape:
+                npz_data["ego_shape"] = np.array(list(tree.ego_shape), dtype=np.float32)
+            # Sanity: crash if critical fields are missing
+            for req in ("ego_agent_past", "neighbor_agents_past",
+                        "lanes", "line_strings", "ego_shape",
+                        "ego_current_state"):
+                if req not in npz_data:
+                    return f"**ERROR** — saved NPZ would be missing `{req}`. Fix upstream."
             dst = out / f"scene_{idx:04d}.npz"
             np.savez(dst, **npz_data)
+
+            # Save sidecar JSON with ego world pose for future map rebuilds
+            ego_wp = _recover_ego_world_pose(
+                tree.get_npz_sequence(tree.active_branch), s)
+            if ego_wp is not None:
+                import math as _math
+                yaw = float(ego_wp[2]) if len(ego_wp) > 2 else 0.0
+                sidecar = dst.with_suffix(".json")
+                with open(sidecar, "w") as _sf:
+                    _json.dump({"x": float(ego_wp[0]), "y": float(ego_wp[1]),
+                                "qx": 0.0, "qy": 0.0,
+                                "qz": _math.sin(yaw / 2),
+                                "qw": _math.cos(yaw / 2)}, _sf)
 
             scene_list_path = out / "scene_list.json"
             if scene_list_path.exists():
@@ -2241,7 +2310,14 @@ def main():
     if args.tree_json:
         tree = SceneTree.load(args.tree_json)
     else:
-        tree = SceneTree.create_from_npz_dir(args.npz_dir)
+        try:
+            tree = SceneTree.create_from_npz_dir(args.npz_dir)
+        except ValueError as e:
+            if ego_shape_override and "ego_shape" in str(e):
+                tree = SceneTree._create_from_npz_dir_with_shape(
+                    args.npz_dir, ego_shape_override)
+            else:
+                raise
 
     if ego_shape_override:
         tree.ego_shape = ego_shape_override

--- a/scenario_generation/tools/scene_branch_editor.py
+++ b/scenario_generation/tools/scene_branch_editor.py
@@ -2079,6 +2079,12 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
                     n = min(n, plan.shape[0])
                     scene_ol = deepcopy(scene)
                     ego_id = scene_ol.ego_agent_id
+                    if map_builder is not None and ego_wp_arr is not None:
+                        from scenario_generation.simulate import _refresh_line_strings
+                        _refresh_line_strings(
+                            scene_ol, map_builder,
+                            ego_wp_arr[:2], ego_wp_arr,
+                        )
                     map_cache_ol = MapTensorCache(scene_ol.map_data)
 
                     for t in range(n):

--- a/scenario_generation/tools/scene_branch_editor.py
+++ b/scenario_generation/tools/scene_branch_editor.py
@@ -2124,24 +2124,29 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
                         *guidance_args, progress=gr.Progress()):
             if model_cache is None or not model_cache.available:
                 return (tree, gr.update(), "No model loaded — pass `--model_path`",
-                        gr.update(), gr.update(), gr.update(), gr.update(), None, None)
-
-            branch = tree.branches[tree.active_branch]
-            # Get source scene from parent (not from any previous resim output)
-            saved_npz_dir = branch.npz_dir
-            branch.npz_dir = None  # temporarily clear so get_npz_sequence uses parent
-            seq = tree.get_npz_sequence(tree.active_branch)
-            branch.npz_dir = saved_npz_dir  # restore
-            if not seq:
-                return (tree, gr.update(), "No NPZ sequence",
-                        gr.update(), gr.update(), gr.update(), gr.update(), None, None)
+                        gr.update(), gr.update(), gr.update(), gr.update(), gr.update(), None, None)
 
             s = _safe_step(step)
+
+            # Auto-fork from current step before simulating
+            new_id = tree.fork_branch(tree.active_branch, s)
+            tree.active_branch = new_id
+            branch = tree.branches[new_id]
+
+            parent_branch = tree.branches[branch.parent_id]
+            saved_npz_dir = parent_branch.npz_dir
+            parent_branch.npz_dir = None
+            seq = tree.get_npz_sequence(branch.parent_id)
+            parent_branch.npz_dir = saved_npz_dir
+            if not seq:
+                return (tree, gr.update(), "No NPZ sequence", gr.update(),
+                        gr.update(), gr.update(), gr.update(), gr.update(),
+                        None, None)
+
             n = max(1, int(n_steps))
             npz_path = seq[min(s, len(seq) - 1)]
 
-            # Create clean output dir for this branch's resim (remove stale files)
-            out_dir = Path(tree.base_npz_dir).parent / f"branch_{tree.active_branch}_resim"
+            out_dir = Path(tree.base_npz_dir).parent / f"branch_{new_id}_resim"
             if out_dir.exists():
                 for old_f in out_dir.glob("*.npz"):
                     old_f.unlink()
@@ -2247,7 +2252,7 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
                             np.cos(traj_xyh[:, 2]),
                             np.sin(traj_xyh[:, 2]),
                         ]).astype(np.float32)
-                    elif det_cache is not None:
+                    if plan is None and det_cache is not None:
                         traj_xyh = np.array(det_cache)
                         plan = np.column_stack([
                             traj_xyh[:, :2],
@@ -2257,7 +2262,7 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
                     if plan is None:
                         return (tree, gr.update(),
                                 "Open loop requires a DET or guided trajectory — toggle Show DET or generate guided first",
-                                gr.update(), gr.update(), gr.update(), gr.update(), None, None)
+                                gr.update(), gr.update(), gr.update(), gr.update(), gr.update(), None, None)
 
                     n = min(n, plan.shape[0])
                     scene_ol = deepcopy(scene)
@@ -2327,8 +2332,10 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
             img, info = _render(tree, 0, view_r, None, show_gt_val=gt_on)
             b_info = _branch_info_md(tree, tree.active_branch)
             mods = _modifications_md(tree, tree.active_branch)
-            status = f"Simulated **{n}** steps ({advance_mode}). Output: `{out_dir}`"
+            choices = list(tree.branches.keys())
+            status = f"Simulated **{n}** steps ({advance_mode}) on branch `{new_id}`. Output: `{out_dir}`"
             return (tree, img, status, b_info, mods,
+                    gr.update(choices=choices, value=new_id),
                     gr.update(maximum=max_step, value=0), info, None, None)
 
         _sim_inputs = ([tree_state, step_slider, sim_steps, sim_mode, sim_use_guidance,
@@ -2341,7 +2348,7 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
             on_simulate,
             _sim_inputs,
             [tree_state, scene_image, sim_status, branch_info, mods_display,
-             step_slider, step_info, det_traj_state, guided_trajs_state],
+             branch_dropdown, step_slider, step_info, det_traj_state, guided_trajs_state],
         )
 
         # Play button — pre-renders frames as PIL images for smooth playback

--- a/scenario_generation/tools/scene_branch_editor.py
+++ b/scenario_generation/tools/scene_branch_editor.py
@@ -93,12 +93,15 @@ class _ModelCache:
 
     @torch.no_grad()
     def predict_det(self, npz_path: str, obstacles: list | None = None,
-                    zero_neighbors: bool = False) -> np.ndarray | None:
+                    zero_neighbors: bool = False,
+                    ego_shape_override: tuple[float, ...] | None = None,
+                    ) -> np.ndarray | None:
         """Run deterministic inference. Returns (80, 4) [x,y,cos_h,sin_h] or None."""
         self._ensure_loaded()
         from guidance_gui.generate_samples import generate_samples
         data = self._load_npz(npz_path, obstacles=obstacles,
-                              zero_neighbors=zero_neighbors)
+                              zero_neighbors=zero_neighbors,
+                              ego_shape_override=ego_shape_override)
         trajs = generate_samples(
             self._model, self._model_args, data,
             noise_scale=0.0, n_samples=1, composer=None,
@@ -112,6 +115,7 @@ class _ModelCache:
         noise_scale: float = 1.0, n_samples: int = 1,
         obstacles: list | None = None,
         zero_neighbors: bool = False,
+        ego_shape_override: tuple[float, ...] | None = None,
     ) -> np.ndarray | None:
         """Run guided inference. Returns (n_samples, 80, 4)."""
         self._ensure_loaded()
@@ -121,7 +125,8 @@ class _ModelCache:
         from guidance_gui.generate_samples import generate_samples
 
         data = self._load_npz(npz_path, obstacles=obstacles,
-                              zero_neighbors=zero_neighbors)
+                              zero_neighbors=zero_neighbors,
+                              ego_shape_override=ego_shape_override)
 
         # Compute DET trajectory first — needed as reference_trajectory for
         # lateral/longitudinal guidance (same pattern as trajectory_ranker_gui)
@@ -159,9 +164,12 @@ class _ModelCache:
         )
 
     def _load_npz(self, npz_path: str, obstacles: list | None = None,
-                  zero_neighbors: bool = False) -> dict[str, torch.Tensor]:
+                  zero_neighbors: bool = False,
+                  ego_shape_override: tuple[float, ...] | None = None,
+                  ) -> dict[str, torch.Tensor]:
         from preference_optimization.utils import load_npz_data
-        data = load_npz_data(npz_path, self._device)
+        data = load_npz_data(npz_path, self._device,
+                             ego_shape_override=ego_shape_override)
         pnn = self._model_args.predicted_neighbor_num
         if zero_neighbors:
             for k in ("neighbor_agents_past", "neighbor_agents_future"):
@@ -1318,8 +1326,8 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
                 return None
             obs = _get_obstacles_at_step(tree, _safe_step(step))
             raw = model_cache.predict_det(npz_path, obstacles=obs or None,
-                                          zero_neighbors=zero_neighbors)
-            return _traj_cos_sin_to_xyh(raw)
+                                          zero_neighbors=zero_neighbors,
+                                              ego_shape_override=tree.ego_shape)
 
         def on_render(tree, step, view_r, selected_obs, gt_on, det_on, guided_on,
                       hide_nb, rb_on, nb_on, traj_rb_on, traj_nb_on,
@@ -1445,8 +1453,8 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
                 return det_traj, guided
             if det_on:
                 raw = model_cache.predict_det(npz_path, obstacles=obs or None,
-                                              zero_neighbors=zero_neighbors)
-                det_traj = _traj_cos_sin_to_xyh(raw)
+                                              zero_neighbors=zero_neighbors,
+                                              ego_shape_override=tree.ego_shape)
             if guided_on and guidance_args_tuple:
                 cfgs = []
                 for gi, gname in enumerate(ALL_GUIDANCE_NAMES):
@@ -1459,8 +1467,8 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
                     k = int(guidance_args_tuple[-1])
                     raw_g = model_cache.predict_guided(
                         npz_path, cfgs, noise_scale=noise, n_samples=max(1, k),
-                        obstacles=obs or None,
                         zero_neighbors=zero_neighbors,
+                        ego_shape_override=tree.ego_shape,
                     )
                     guided = [_traj_cos_sin_to_xyh(raw_g[j]) for j in range(raw_g.shape[0])]
             return det_traj, guided
@@ -1574,13 +1582,14 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
                     det_traj = det_cache
                 else:
                     raw = model_cache.predict_det(npz_path, obstacles=obs or None,
-                                                  zero_neighbors=hide_nb)
-                    det_traj = _traj_cos_sin_to_xyh(raw)
+                                                  zero_neighbors=hide_nb,
+                                              ego_shape_override=tree.ego_shape)
                     det_cache = det_traj
 
             raw_guided = model_cache.predict_guided(
                 npz_path, cfgs, noise_scale=float(noise), n_samples=int(k),
                 obstacles=obs or None, zero_neighbors=hide_nb,
+                ego_shape_override=tree.ego_shape,
             )
             guided_list = [_traj_cos_sin_to_xyh(raw_guided[i]) for i in range(raw_guided.shape[0])]
 
@@ -1898,14 +1907,11 @@ def build_interface(tree: SceneTree, model_cache: _ModelCache | None = None,
                 np.sin(traj_xyh[:, 2]),
             ]).astype(np.float32)).unsqueeze(0)
 
-            # Score trajectory against reward gates
             from preference_optimization.utils import load_npz_data as _load_npz
             from rlvr.reward import RewardConfig as _RC
             from rlvr.reward import compute_reward_batch as _crb
-            scene_data = _load_npz(npz_path, torch.device("cpu"))
-            if tree.ego_shape:
-                scene_data["ego_shape"] = torch.tensor(
-                    [list(tree.ego_shape)], dtype=torch.float32)
+            scene_data = _load_npz(npz_path, torch.device("cpu"),
+                                   ego_shape_override=tree.ego_shape)
             obs_at_step = _get_obstacles_at_step(tree, s)
             if obs_at_step:
                 scene_data = _inject_obstacles_into_tensors(
@@ -2442,15 +2448,11 @@ def main():
 
     if args.tree_json:
         tree = SceneTree.load(args.tree_json)
+    elif ego_shape_override:
+        tree = SceneTree.create_from_npz_dir_with_shape(
+            args.npz_dir, ego_shape_override)
     else:
-        try:
-            tree = SceneTree.create_from_npz_dir(args.npz_dir)
-        except ValueError as e:
-            if ego_shape_override and "ego_shape" in str(e):
-                tree = SceneTree._create_from_npz_dir_with_shape(
-                    args.npz_dir, ego_shape_override)
-            else:
-                raise
+        tree = SceneTree.create_from_npz_dir(args.npz_dir)
 
     if ego_shape_override:
         tree.ego_shape = ego_shape_override

--- a/scenario_generation/tools/scene_tree.py
+++ b/scenario_generation/tools/scene_tree.py
@@ -87,7 +87,7 @@ class SceneTree:
         import numpy as np
         with np.load(npz_files[0]) as first:
             if "ego_shape" in first:
-                ego_shape = tuple(float(v) for v in first["ego_shape"])
+                ego_shape = tuple(float(v) for v in np.asarray(first["ego_shape"]).reshape(-1)[:3])
             else:
                 raise ValueError(
                     f"First NPZ '{npz_files[0]}' is missing 'ego_shape'. "
@@ -290,7 +290,7 @@ class SceneTree:
         if "ego_shape" not in data:
             raise ValueError(
                 f"Tree JSON '{path}' is missing 'ego_shape'. "
-                "Re-save with a newer editor or pass --ego_shape WB,L,W."
+                "Re-save the tree with a newer editor."
             )
         return cls(
             version=data.get("version", 1),

--- a/scenario_generation/tools/scene_tree.py
+++ b/scenario_generation/tools/scene_tree.py
@@ -105,7 +105,7 @@ class SceneTree:
         return tree
 
     @classmethod
-    def _create_from_npz_dir_with_shape(
+    def create_from_npz_dir_with_shape(
         cls, npz_dir: str | Path, ego_shape: tuple[float, float, float],
     ) -> SceneTree:
         npz_dir = str(Path(npz_dir).resolve())
@@ -287,6 +287,11 @@ class SceneTree:
         active = data.get("active_branch", "root")
         if active not in branches:
             active = "root" if "root" in branches else next(iter(branches), "root")
+        if "ego_shape" not in data:
+            raise ValueError(
+                f"Tree JSON '{path}' is missing 'ego_shape'. "
+                "Re-save with a newer editor or pass --ego_shape WB,L,W."
+            )
         return cls(
             version=data.get("version", 1),
             base_npz_dir=data["base_npz_dir"],

--- a/scenario_generation/tools/scene_tree.py
+++ b/scenario_generation/tools/scene_tree.py
@@ -86,7 +86,14 @@ class SceneTree:
 
         import numpy as np
         with np.load(npz_files[0]) as first:
-            ego_shape = tuple(float(v) for v in first["ego_shape"]) if "ego_shape" in first else (2.925, 4.5, 1.9)
+            if "ego_shape" in first:
+                ego_shape = tuple(float(v) for v in first["ego_shape"])
+            else:
+                raise ValueError(
+                    f"First NPZ '{npz_files[0]}' is missing 'ego_shape'. "
+                    "Pass --ego_shape WB,L,W on the command line or inject "
+                    "ego_shape into the NPZ."
+                )
 
         tree = cls(
             base_npz_dir=npz_dir,
@@ -96,6 +103,20 @@ class SceneTree:
             },
         )
         return tree
+
+    @classmethod
+    def _create_from_npz_dir_with_shape(
+        cls, npz_dir: str | Path, ego_shape: tuple[float, float, float],
+    ) -> SceneTree:
+        npz_dir = str(Path(npz_dir).resolve())
+        npz_files = _scan_npz_dir(npz_dir)
+        if not npz_files:
+            raise ValueError(f"No replay_step_*.npz or step_*.npz files found in {npz_dir}")
+        return cls(
+            base_npz_dir=npz_dir,
+            ego_shape=ego_shape,
+            branches={"root": BranchNode(id="root", npz_dir=npz_dir)},
+        )
 
     # ── Tree operations ───────────────────────────────────────────────
 
@@ -269,7 +290,7 @@ class SceneTree:
         return cls(
             version=data.get("version", 1),
             base_npz_dir=data["base_npz_dir"],
-            ego_shape=tuple(data.get("ego_shape", [2.925, 4.5, 1.9])),
+            ego_shape=tuple(data["ego_shape"]),
             active_branch=active,
             branches=branches,
         )

--- a/scenario_generation/visualize.py
+++ b/scenario_generation/visualize.py
@@ -34,7 +34,7 @@ _EGO_COLOR = "#3366cc"
 _NEIGHBOR_COLORS = ["#e67300", "#2ca02c", "#d62728", "#9467bd", "#8c564b", "#e377c2", "#7f7f7f", "#bcbd22"]
 _PED_COLOR = "#ff6699"
 _BIKE_COLOR = "#66ccff"
-_LANE_COLOR = "#bbbbbb"
+_LANE_COLOR = "#888888"
 _ROUTE_COLOR = "#4488ff"
 _GT_COLOR = "#22bb22"
 
@@ -59,13 +59,13 @@ def draw_lanes(ax, map_data, alpha=0.5):
         if valid.sum() < 2:
             continue
         # Centerline
-        ax.plot(pts[valid, 0], pts[valid, 1], "-", color=_LANE_COLOR, alpha=alpha * 0.5, lw=0.5)
+        ax.plot(pts[valid, 0], pts[valid, 1], "-", color=_LANE_COLOR, alpha=alpha * 0.8, lw=0.8)
         # Boundaries (offsets from centerline)
         if lane.shape[1] > 7:
             lb = lane[:, 4:6]
             rb = lane[:, 6:8]
-            ax.plot((pts + lb)[valid, 0], (pts + lb)[valid, 1], "-", color=_LANE_COLOR, alpha=alpha, lw=0.7)
-            ax.plot((pts + rb)[valid, 0], (pts + rb)[valid, 1], "-", color=_LANE_COLOR, alpha=alpha, lw=0.7)
+            ax.plot((pts + lb)[valid, 0], (pts + lb)[valid, 1], "-", color=_LANE_COLOR, alpha=alpha, lw=1.0)
+            ax.plot((pts + rb)[valid, 0], (pts + rb)[valid, 1], "-", color=_LANE_COLOR, alpha=alpha, lw=1.0)
 
 
 def draw_road_borders(ax, map_data):


### PR DESCRIPTION
## Summary
- Remove silent ego_shape fallback in `load_npz_data` -- now crashes when missing instead of silently using wrong sedan dimensions for RB/collision scoring
- Scene editor RSFT save rewritten to preserve all context: rebuilds line_strings (4-col with border flags) and polygons (3-col with type) from lanelet2 map, saves sidecar JSON with world pose quaternion, validates critical fields
- RB distance visualization uses `compute_road_border_penalty` from `reward.py` (ego OBB perimeter) instead of baselink-to-point distance
- `simulate.py` crashes if `dump_npz=True` without builder (would produce zero-flag line_strings)
- All hardcoded ego_shape fallbacks removed across `scene_tree.py`, `visualize_scenes.py`

## Test plan
- [ ] Launch scene branch editor with `--ego_shape` flag on NPZs without ego_shape field
- [ ] Place obstacle, generate guided trajectory, save RSFT scene
- [ ] Verify saved NPZ has 4-col line_strings with border flags, 3-col polygons, ego_shape, sidecar JSON
- [ ] Run `visualize_scenes.py` on saved scenes -- should render without fallbacks
- [ ] Run `replay.py` with `dump_npz_dir` -- verify NPZ has correct line_strings
- [ ] Confirm `load_npz_data` crashes on NPZ missing ego_shape