### PR TITLE
feat(rlvr): ghost sim refactor + model comparison tools

### DIFF
--- a/rlvr/autoresearch/tools/collage_avoidance_compare.py
+++ b/rlvr/autoresearch/tools/collage_avoidance_compare.py
@@ -31,7 +31,6 @@ import torch
 from rlvr.autoresearch.tools.reward_config_from_json import load_reward_config
 from rlvr.autoresearch.tools.viz_collision_guidance import _score_traj
 from rlvr.autoresearch.tools.viz_prism_compare import _load_model, _det_predict
-from rlvr.grpo_trainer_batched import _stack_scene_data
 from preference_optimization.utils import load_npz_data
 
 
@@ -156,7 +155,8 @@ def main():
     print(f"\nCollage saved to {args.output}")
 
     summary_path = Path(args.output).with_suffix(".json")
-    json.dump(results, open(summary_path, "w"), indent=2)
+    with open(summary_path, "w") as f:
+        json.dump(results, f, indent=2)
     print(f"Full results saved to {summary_path}")
 
 

--- a/rlvr/autoresearch/tools/collage_avoidance_compare.py
+++ b/rlvr/autoresearch/tools/collage_avoidance_compare.py
@@ -77,9 +77,9 @@ def main():
 
         delta = sc_train["sc_min_dist"] - sc_base["sc_min_dist"]
 
-        png_candidates = list(Path(args.viz_dir).glob(f"*_{scene_name}.png"))
+        png_candidates = sorted(Path(args.viz_dir).glob(f"*_{scene_name}.png"))
         if not png_candidates:
-            png_candidates = list(Path(args.viz_dir).glob(f"scene_{i:03d}_*.png"))
+            png_candidates = sorted(Path(args.viz_dir).glob(f"scene_{i:03d}_*.png"))
         png_path = str(png_candidates[0]) if png_candidates else None
 
         results.append({

--- a/rlvr/autoresearch/tools/collage_avoidance_compare.py
+++ b/rlvr/autoresearch/tools/collage_avoidance_compare.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Collage comparing baseline vs trained model on static-collision avoidance.
+
+Scores both models (DET) on each scene via compute_static_collision_penalty,
+picks the best-improved scenes, and assembles a grid from pre-rendered
+viz_prism_compare PNGs annotated with sc_min_dist for each model.
+
+Usage:
+    python -m rlvr.autoresearch.tools.collage_avoidance_compare \
+        --baseline_model <base.pth> \
+        --trained_model <merged.pth> \
+        --scenes <scenes.json> \
+        --config <reward_config.json> \
+        --viz_dir <viz_compare_dir with per-scene PNGs> \
+        --output <collage.png> \
+        [--n 12] [--cols 4]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import matplotlib.image as mpimg
+import numpy as np
+import torch
+
+from rlvr.autoresearch.tools.reward_config_from_json import load_reward_config
+from rlvr.autoresearch.tools.viz_collision_guidance import _score_traj
+from rlvr.autoresearch.tools.viz_prism_compare import _load_model, _det_predict
+from rlvr.grpo_trainer_batched import _stack_scene_data
+from preference_optimization.utils import load_npz_data
+
+
+@torch.no_grad()
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--baseline_model", required=True)
+    parser.add_argument("--trained_model", required=True)
+    parser.add_argument("--scenes", required=True)
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--viz_dir", required=True,
+                        help="Dir with per-scene PNGs from viz_prism_compare")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--n", type=int, default=12, help="Number of scenes in collage")
+    parser.add_argument("--cols", type=int, default=4)
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    rcfg = load_reward_config(args.config)
+
+    with open(args.scenes) as f:
+        scene_paths = json.load(f)
+
+    print(f"Loading baseline model...")
+    m_base, args_base = _load_model(args.baseline_model, None, device)
+    print(f"Loading trained model...")
+    m_train, args_train = _load_model(args.trained_model, None, device)
+
+    results = []
+    for i, sp in enumerate(scene_paths):
+        scene_name = Path(sp).stem
+        data = load_npz_data(sp, device)
+        data_np = dict(np.load(sp, allow_pickle=True))
+
+        traj_base = _det_predict(m_base, args_base, data)
+        traj_train = _det_predict(m_train, args_train, data)
+
+        traj_base_t = torch.from_numpy(traj_base).to(device)
+        traj_train_t = torch.from_numpy(traj_train).to(device)
+
+        sc_base = _score_traj(traj_base_t, data_np, rcfg, device)
+        sc_train = _score_traj(traj_train_t, data_np, rcfg, device)
+
+        delta = sc_train["sc_min_dist"] - sc_base["sc_min_dist"]
+
+        png_candidates = list(Path(args.viz_dir).glob(f"*_{scene_name}.png"))
+        if not png_candidates:
+            png_candidates = list(Path(args.viz_dir).glob(f"scene_{i:03d}_*.png"))
+        png_path = str(png_candidates[0]) if png_candidates else None
+
+        results.append({
+            "idx": i,
+            "scene": scene_name,
+            "base_sc_min": sc_base["sc_min_dist"],
+            "train_sc_min": sc_train["sc_min_dist"],
+            "base_zone": sc_base["zone"],
+            "train_zone": sc_train["zone"],
+            "base_crossing": sc_base["static_crossing"],
+            "train_crossing": sc_train["static_crossing"],
+            "delta": delta,
+            "png": png_path,
+        })
+        zone_b = sc_base["zone"]
+        zone_t = sc_train["zone"]
+        tag = "FIXED" if sc_base["static_crossing"] and not sc_train["static_crossing"] else ""
+        print(f"  [{i:2d}] {scene_name}: base={sc_base['sc_min_dist']:+.2f}m ({zone_b}) "
+              f"train={sc_train['sc_min_dist']:+.2f}m ({zone_t}) "
+              f"Δ={delta:+.2f}m {tag}")
+
+    improved = [r for r in results if r["delta"] > 0.01 and r["png"]]
+    improved.sort(key=lambda r: (-int(r["base_crossing"] and not r["train_crossing"]),
+                                  -r["delta"]))
+
+    selected = improved[:args.n]
+    if not selected:
+        print("No improved scenes found!")
+        return
+
+    n_fixed = sum(1 for r in selected if r["base_crossing"] and not r["train_crossing"])
+    n_margin = len(selected) - n_fixed
+    print(f"\nSelected {len(selected)} scenes: {n_fixed} collision-fixed, {n_margin} margin-improved")
+
+    rows = (len(selected) + args.cols - 1) // args.cols
+    fig, axes = plt.subplots(rows, args.cols, figsize=(7 * args.cols, 7 * rows))
+    if rows == 1:
+        axes = [axes] if args.cols == 1 else [axes]
+    axes_flat = np.array(axes).flatten()
+
+    for ax in axes_flat:
+        ax.axis("off")
+
+    for k, r in enumerate(selected):
+        ax = axes_flat[k]
+        img = mpimg.imread(r["png"])
+        ax.imshow(img)
+        ax.axis("off")
+
+        base_d = r["base_sc_min"]
+        train_d = r["train_sc_min"]
+        delta = r["delta"]
+        tag = ""
+        if r["base_crossing"] and not r["train_crossing"]:
+            tag = "  [COLLISION FIXED]"
+        elif r["base_crossing"] and r["train_crossing"]:
+            tag = "  [BOTH COLLIDE]"
+
+        base_color = "#cc0000" if r["base_crossing"] else "#333333"
+        train_color = "#006600" if not r["train_crossing"] else "#cc0000"
+
+        title = (f"{r['scene']}\n"
+                 f"baseline: {base_d:+.2f}m ({r['base_zone']})  →  "
+                 f"trained: {train_d:+.2f}m ({r['train_zone']})  "
+                 f"Δ={delta:+.2f}m{tag}")
+        ax.set_title(title, fontsize=10, fontweight="bold" if tag else "normal")
+
+    fig.suptitle(f"Static Obstacle Avoidance: Baseline vs Trained Model\n"
+                 f"{n_fixed} collisions fixed, {n_margin} margins improved",
+                 fontsize=14, fontweight="bold", y=1.01)
+    fig.tight_layout()
+    fig.savefig(args.output, dpi=150, bbox_inches="tight", pad_inches=0.3)
+    print(f"\nCollage saved to {args.output}")
+
+    summary_path = Path(args.output).with_suffix(".json")
+    json.dump(results, open(summary_path, "w"), indent=2)
+    print(f"Full results saved to {summary_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/collage_avoidance_compare.py
+++ b/rlvr/autoresearch/tools/collage_avoidance_compare.py
@@ -116,9 +116,7 @@ def main():
 
     rows = (len(selected) + args.cols - 1) // args.cols
     fig, axes = plt.subplots(rows, args.cols, figsize=(7 * args.cols, 7 * rows))
-    if rows == 1:
-        axes = [axes] if args.cols == 1 else [axes]
-    axes_flat = np.array(axes).flatten()
+    axes_flat = np.atleast_1d(axes).ravel()
 
     for ax in axes_flat:
         ax.axis("off")

--- a/rlvr/autoresearch/tools/compare_models_ghost.py
+++ b/rlvr/autoresearch/tools/compare_models_ghost.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Ghost-overlay closed-loop sim comparing two models on the same scene.
+
+Runs both models from identical initial conditions, renders per-step PNGs
+with both ego footprints (different colors), planned trajectories, stopped
+neighbor OBBs, and assembles a WebM clip.
+
+Usage:
+    python -m rlvr.autoresearch.tools.compare_models_ghost \
+        --model_a <baseline.pth> --label_a baseline \
+        --model_b <trained.pth>  --label_b "trained (ep27)" \
+        --scenes scene_0038.npz scene_0037.npz ... \
+        --output_dir /path/out --steps 80 --make_webm
+
+    # Single scene:
+    python -m rlvr.autoresearch.tools.compare_models_ghost \
+        --model_a <baseline.pth> --model_b <trained.pth> \
+        --scenes scene_0038.npz --output_dir /path/out --make_webm
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+from preference_optimization.utils import load_npz_data
+
+from rlvr.autoresearch.tools.ghost_sim_common import (
+    GhostSimConfig,
+    extract_stopped_neighbors,
+    load_model,
+    run_ghost_sim,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--model_a", required=True, help="First model (e.g. baseline)")
+    parser.add_argument("--lora_a", default=None)
+    parser.add_argument("--label_a", default="baseline")
+    parser.add_argument("--model_b", required=True, help="Second model (e.g. trained)")
+    parser.add_argument("--lora_b", default=None)
+    parser.add_argument("--label_b", default="trained")
+    parser.add_argument("--scenes", nargs="+", required=True, help="NPZ scene paths")
+    parser.add_argument("--output_dir", required=True)
+    parser.add_argument("--steps", type=int, default=80)
+    parser.add_argument("--advance_k", type=int, default=0)
+    parser.add_argument("--view_half_m", type=float, default=30.0)
+    parser.add_argument("--make_webm", action="store_true")
+    parser.add_argument("--webm_fps", type=int, default=10)
+    parser.add_argument("--show_lateral", action="store_true",
+                        help="Show lateral offset to route centerline")
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"[compare] loading model A: {args.label_a}")
+    model_a, args_a = load_model(args.model_a, args.lora_a, device)
+    print(f"[compare] loading model B: {args.label_b}")
+    model_b, args_b = load_model(args.model_b, args.lora_b, device)
+
+    cfg = GhostSimConfig(
+        model_a_label=args.label_a,
+        model_b_label=args.label_b,
+        view_half_m=args.view_half_m,
+        steps=args.steps,
+        advance_k=args.advance_k,
+        webm_fps=args.webm_fps,
+        show_lateral=args.show_lateral,
+    )
+
+    out_root = Path(args.output_dir)
+
+    for scene_path in args.scenes:
+        scene_name = Path(scene_path).stem
+        print(f"\n=== {scene_name} ===")
+
+        data = load_npz_data(scene_path, device)
+        nb_boxes = extract_stopped_neighbors(scene_path)
+        if nb_boxes:
+            print(f"  {len(nb_boxes)} stopped neighbor(s)")
+
+        scene_out = out_root / scene_name if len(args.scenes) > 1 else out_root
+        cfg.subtitle = scene_name
+
+        run_ghost_sim(
+            scene_path=scene_path,
+            model_a=model_a, model_a_args=args_a,
+            model_b=model_b, model_b_args=args_b,
+            scene_data=data,
+            output_dir=scene_out,
+            cfg=cfg,
+            neighbor_boxes=nb_boxes,
+            make_webm=args.make_webm,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/ghost_sim_common.py
+++ b/rlvr/autoresearch/tools/ghost_sim_common.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import math
 import subprocess
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 import matplotlib
@@ -38,8 +38,7 @@ from rlvr.autoresearch.tools.recovery_sim import (
 
 MODEL_A_COLOR = "#1f77b4"  # blue
 MODEL_B_COLOR = "#d62728"  # red
-_NB_EDGE_COLOR = "#cc6600"
-_NB_FACE_COLOR = "#ffb366"
+_NB_COLOR = "#cc6600"
 
 
 @dataclass
@@ -172,7 +171,7 @@ def render_ghost_step(
     if neighbor_boxes:
         for nx, ny, nh, nl, nw in neighbor_boxes:
             _draw_agent_box(ax, nx, ny, nh, nl, nw,
-                            _NB_EDGE_COLOR, alpha=0.75, lw=1.5, zorder=14)
+                            _NB_COLOR, alpha=0.75, lw=1.5, zorder=14)
 
     if a_plan is not None and a_plan.shape[0] > 1:
         ax.plot(a_plan[:, 0], a_plan[:, 1], "-",
@@ -298,8 +297,11 @@ def run_ghost_sim(
             "-c:v", "libvpx-vp9", "-b:v", "0", "-crf", "32",
             "-row-mt", "1", str(webm_path),
         ]
-        subprocess.run(cmd, capture_output=True)
-        print(f"[ghost-sim] WebM: {webm_path}")
+        result = subprocess.run(cmd, capture_output=True)
+        if result.returncode != 0:
+            print(f"[ghost-sim] ffmpeg failed (rc={result.returncode}): {result.stderr.decode()[-200:]}")
+        else:
+            print(f"[ghost-sim] WebM: {webm_path}")
 
     print(f"\nDone — {output_dir} ({n + 1} frames)")
     return rollout_a, rollout_b, webm_path

--- a/rlvr/autoresearch/tools/ghost_sim_common.py
+++ b/rlvr/autoresearch/tools/ghost_sim_common.py
@@ -20,7 +20,6 @@ from diffusion_planner.utils.config import Config
 from matplotlib.collections import LineCollection
 from matplotlib.figure import Figure
 from preference_optimization.lora_utils import load_lora_checkpoint
-from preference_optimization.utils import load_npz_data
 
 from rlvr.autoresearch.tools.recovery_sim import (
     _build_segments,

--- a/rlvr/autoresearch/tools/ghost_sim_common.py
+++ b/rlvr/autoresearch/tools/ghost_sim_common.py
@@ -1,0 +1,306 @@
+"""Shared library for dual-model ghost overlay closed-loop simulation.
+
+Provides model loading, neighbor extraction, scene polyline extraction,
+per-step rendering, and webm assembly. Used by recovery_sim_ghost.py
+(PRiSM lane-keeping) and compare_models_ghost.py (generic A/B comparison).
+"""
+from __future__ import annotations
+
+import math
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import numpy as np
+import torch
+from diffusion_planner.model.diffusion_planner import Diffusion_Planner
+from diffusion_planner.utils.config import Config
+from matplotlib.collections import LineCollection
+from matplotlib.figure import Figure
+from preference_optimization.lora_utils import load_lora_checkpoint
+from preference_optimization.utils import load_npz_data
+
+from rlvr.autoresearch.tools.recovery_sim import (
+    _build_segments,
+    _draw_agent_box,
+    _lane_polylines,
+    _point_to_segments_dist,
+    _road_border_polylines,
+    _route_polylines,
+    _LANE_BORDER_COLOR,
+    _LANE_COLOR,
+    _ROAD_BORDER_COLOR,
+    _ROUTE_COLOR,
+    _VIEW_HALF_M,
+    closed_loop_rollout_with_plans,
+)
+
+MODEL_A_COLOR = "#1f77b4"  # blue
+MODEL_B_COLOR = "#d62728"  # red
+_NB_EDGE_COLOR = "#cc6600"
+_NB_FACE_COLOR = "#ffb366"
+
+
+@dataclass
+class GhostSimConfig:
+    model_a_label: str = "model A"
+    model_b_label: str = "model B"
+    model_a_color: str = MODEL_A_COLOR
+    model_b_color: str = MODEL_B_COLOR
+    view_half_m: float = _VIEW_HALF_M
+    ego_length: float = 7.2369
+    ego_width: float = 2.29156
+    steps: int = 80
+    advance_k: int = 0
+    webm_fps: int = 10
+    subtitle: str = ""
+    show_lateral: bool = True
+
+
+def load_model(model_path: str, lora_path: str | None, device):
+    model_dir = Path(model_path).parent
+    args_path = model_dir / "args.json"
+    if not args_path.exists():
+        args_path = model_dir.parent / "args.json"
+    margs = Config(str(args_path))
+    model = Diffusion_Planner(margs)
+    ckpt = torch.load(model_path, map_location=device, weights_only=False)
+    state = ckpt.get("model", ckpt)
+    state = {k.replace("module.", ""): v for k, v in state.items()}
+    model.load_state_dict(state)
+    model.to(device).eval()
+    if lora_path:
+        model = load_lora_checkpoint(model, lora_path)
+        model.eval()
+    return model, margs
+
+
+def extract_stopped_neighbors(npz_path: str) -> list[tuple[float, float, float, float, float]]:
+    """Return list of (x, y, heading, length, width) for stopped neighbors."""
+    data_np = dict(np.load(npz_path, allow_pickle=True))
+    boxes = []
+    if "neighbor_agents_past" not in data_np or "neighbor_agents_future" not in data_np:
+        return boxes
+    nb_past = data_np["neighbor_agents_past"]
+    if nb_past.ndim == 4:
+        nb_past = nb_past[0]
+    nb_fut = data_np["neighbor_agents_future"]
+    if nb_fut.ndim == 4:
+        nb_fut = nb_fut[0]
+    for i in range(nb_past.shape[0]):
+        xy0 = nb_past[i, -1, :2]
+        if abs(xy0[0]) + abs(xy0[1]) < 1e-6:
+            continue
+        fut_xy = nb_fut[i, :, :2]
+        fut_valid = np.abs(fut_xy).sum(axis=-1) > 1e-6
+        disp = 0.0 if fut_valid.sum() < 2 else float(
+            np.linalg.norm(fut_xy[fut_valid].max(0) - fut_xy[fut_valid].min(0)))
+        if disp >= 0.5:
+            continue
+        w = float(nb_past[i, -1, 6])
+        length = float(nb_past[i, -1, 7])
+        if w < 0.1 or length < 0.1:
+            continue
+        h = float(math.atan2(nb_past[i, -1, 3], nb_past[i, -1, 2]))
+        boxes.append((float(xy0[0]), float(xy0[1]), h, length, w))
+    return boxes
+
+
+def extract_scene_polylines(data: dict[str, torch.Tensor]):
+    """Extract lane, border, route polylines and centerline segments from scene data."""
+    rl = data["route_lanes"]
+    if rl.dim() == 4:
+        rl = rl[0]
+    lanes = data.get("lanes")
+    if lanes is not None and lanes.dim() == 4:
+        lanes = lanes[0]
+    line_strings = data.get("line_strings")
+    if line_strings is not None and line_strings.dim() == 4:
+        line_strings = line_strings[0]
+    centerlines, lefts, rights = _lane_polylines(
+        lanes.cpu().numpy() if lanes is not None else None)
+    border_polylines = _road_border_polylines(
+        line_strings.cpu().numpy() if line_strings is not None else None)
+    route_polylines = _route_polylines(rl.cpu().numpy())
+    centerline_segments = _build_segments(data["route_lanes"])
+    return centerlines, lefts, rights, border_polylines, route_polylines, centerline_segments
+
+
+def render_ghost_step(
+    output_path: Path, step: int, n_steps: int,
+    a_pose: np.ndarray, a_speed: float, a_plan: np.ndarray | None,
+    b_pose: np.ndarray, b_speed: float, b_plan: np.ndarray | None,
+    centerlines, lefts, rights, border_polylines, route_polylines,
+    centerline_segments,
+    cfg: GhostSimConfig,
+    neighbor_boxes: list[tuple[float, float, float, float, float]] | None = None,
+    extra_title: str = "",
+) -> None:
+    ax_val, ay_val, ah_val = float(a_pose[0]), float(a_pose[1]), float(a_pose[2])
+    bx_val, by_val, bh_val = float(b_pose[0]), float(b_pose[1]), float(b_pose[2])
+    cx, cy = (ax_val + bx_val) / 2, (ay_val + by_val) / 2
+
+    fig = Figure(figsize=(11, 11))
+    ax = fig.add_subplot(1, 1, 1)
+    fig.patch.set_facecolor("#f8f8f8")
+
+    if centerlines:
+        ax.add_collection(LineCollection(
+            centerlines, colors=_LANE_COLOR, linewidths=0.6, alpha=0.28, zorder=1))
+    if lefts:
+        ax.add_collection(LineCollection(
+            lefts, colors=_LANE_BORDER_COLOR, linewidths=1.1, alpha=0.7, zorder=2))
+    if rights:
+        ax.add_collection(LineCollection(
+            rights, colors=_LANE_BORDER_COLOR, linewidths=1.1, alpha=0.7, zorder=2))
+
+    half = cfg.view_half_m * 1.5
+    flt_borders = [pl for pl in border_polylines
+                   if pl.shape[0] >= 2 and (
+                       (pl[:, 0] >= cx - half) & (pl[:, 0] <= cx + half)
+                       & (pl[:, 1] >= cy - half) & (pl[:, 1] <= cy + half)).any()]
+    if flt_borders:
+        ax.add_collection(LineCollection(
+            flt_borders, colors=_ROAD_BORDER_COLOR, linewidths=2.0, alpha=0.9, zorder=5))
+
+    for pl in route_polylines:
+        if pl.shape[0] >= 2:
+            ax.plot(pl[:, 0], pl[:, 1], "-", color=_ROUTE_COLOR,
+                    lw=2.5, alpha=0.55, zorder=3)
+
+    if neighbor_boxes:
+        for nx, ny, nh, nl, nw in neighbor_boxes:
+            _draw_agent_box(ax, nx, ny, nh, nl, nw,
+                            _NB_EDGE_COLOR, alpha=0.75, lw=1.5, zorder=14)
+
+    if a_plan is not None and a_plan.shape[0] > 1:
+        ax.plot(a_plan[:, 0], a_plan[:, 1], "-",
+                color=cfg.model_a_color, lw=1.4, alpha=0.45, zorder=24)
+    if b_plan is not None and b_plan.shape[0] > 1:
+        ax.plot(b_plan[:, 0], b_plan[:, 1], "-",
+                color=cfg.model_b_color, lw=1.4, alpha=0.45, zorder=24)
+
+    _draw_agent_box(ax, ax_val, ay_val, ah_val, cfg.ego_length, cfg.ego_width,
+                    cfg.model_a_color, alpha=0.78, lw=2, zorder=20)
+    _draw_agent_box(ax, bx_val, by_val, bh_val, cfg.ego_length, cfg.ego_width,
+                    cfg.model_b_color, alpha=0.78, lw=2, zorder=21)
+    arrow_len = max(cfg.ego_length, 2.5)
+    ax.annotate("", xy=(ax_val + arrow_len * math.cos(ah_val),
+                        ay_val + arrow_len * math.sin(ah_val)),
+                xytext=(ax_val, ay_val),
+                arrowprops=dict(arrowstyle="-|>", color=cfg.model_a_color,
+                                lw=1.2, mutation_scale=10), zorder=22)
+    ax.annotate("", xy=(bx_val + arrow_len * math.cos(bh_val),
+                        by_val + arrow_len * math.sin(bh_val)),
+                xytext=(bx_val, by_val),
+                arrowprops=dict(arrowstyle="-|>", color=cfg.model_b_color,
+                                lw=1.2, mutation_scale=10), zorder=23)
+
+    label_a = f"{cfg.model_a_label}  v={a_speed:.1f} m/s"
+    label_b = f"{cfg.model_b_label}  v={b_speed:.1f} m/s"
+    if cfg.show_lateral and centerline_segments.shape[0]:
+        lat_a = float(_point_to_segments_dist(
+            np.array([[ax_val, ay_val]]), centerline_segments)[0])
+        lat_b = float(_point_to_segments_dist(
+            np.array([[bx_val, by_val]]), centerline_segments)[0])
+        label_a += f"  lat={lat_a:.2f}m"
+        label_b += f"  lat={lat_b:.2f}m"
+
+    ax.plot([], [], "-", color=cfg.model_a_color, lw=2, label=label_a)
+    ax.plot([], [], "-", color=cfg.model_b_color, lw=2, label=label_b)
+    ax.legend(fontsize=9, loc="upper left")
+
+    ax.set_xlim(cx - cfg.view_half_m, cx + cfg.view_half_m)
+    ax.set_ylim(cy - cfg.view_half_m, cy + cfg.view_half_m)
+    ax.set_aspect("equal")
+    ax.grid(True, alpha=0.15)
+    ax.set_xlabel("X (m, initial ego frame)")
+    ax.set_ylabel("Y (m, initial ego frame)")
+
+    title = f"Step {step:04d}/{n_steps}  t={step * 0.1:.1f}s"
+    if cfg.subtitle:
+        title += f"  {cfg.subtitle}"
+    if extra_title:
+        title += f"\n{extra_title}"
+    ax.set_title(title, fontsize=10)
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=100)
+    fig.clf()
+
+
+def run_ghost_sim(
+    scene_path: str,
+    model_a, model_a_args,
+    model_b, model_b_args,
+    scene_data: dict[str, torch.Tensor],
+    output_dir: Path,
+    cfg: GhostSimConfig,
+    neighbor_boxes: list[tuple[float, float, float, float, float]] | None = None,
+    make_webm: bool = True,
+    extra_title_fn=None,
+):
+    """Run dual-model ghost sim and render per-step PNGs + optional webm.
+
+    extra_title_fn: optional callable(step, a_pose, b_pose) -> str for per-step subtitle.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"[ghost-sim] rollout ({cfg.model_a_label})...")
+    rollout_a = closed_loop_rollout_with_plans(
+        model_a, model_a_args, scene_data,
+        n_steps=cfg.steps, advance_k=cfg.advance_k,
+    )
+    print(f"[ghost-sim] rollout ({cfg.model_b_label})...")
+    rollout_b = closed_loop_rollout_with_plans(
+        model_b, model_b_args, scene_data,
+        n_steps=cfg.steps, advance_k=cfg.advance_k,
+    )
+
+    centerlines, lefts, rights, border_polylines, route_polylines, cl_segments = \
+        extract_scene_polylines(scene_data)
+
+    if neighbor_boxes is None:
+        neighbor_boxes = extract_stopped_neighbors(scene_path)
+
+    n = cfg.steps
+    print(f"[ghost-sim] rendering {n + 1} frames...")
+    for step_i in range(n + 1):
+        a_plan = rollout_a["plans_world"][step_i] if step_i < len(rollout_a["plans_world"]) else None
+        b_plan = rollout_b["plans_world"][step_i] if step_i < len(rollout_b["plans_world"]) else None
+        et = ""
+        if extra_title_fn:
+            et = extra_title_fn(step_i, rollout_a["positions"][step_i],
+                                rollout_b["positions"][step_i])
+        render_ghost_step(
+            output_dir / f"ghost_step_{step_i:04d}.png",
+            step=step_i, n_steps=n,
+            a_pose=rollout_a["positions"][step_i],
+            a_speed=float(rollout_a["velocities"][step_i]),
+            a_plan=a_plan,
+            b_pose=rollout_b["positions"][step_i],
+            b_speed=float(rollout_b["velocities"][step_i]),
+            b_plan=b_plan,
+            centerlines=centerlines, lefts=lefts, rights=rights,
+            border_polylines=border_polylines, route_polylines=route_polylines,
+            centerline_segments=cl_segments,
+            cfg=cfg,
+            neighbor_boxes=neighbor_boxes,
+            extra_title=et,
+        )
+
+    webm_path = None
+    if make_webm:
+        webm_path = output_dir / "ghost_sim.webm"
+        cmd = [
+            "ffmpeg", "-y", "-framerate", str(cfg.webm_fps),
+            "-i", str(output_dir / "ghost_step_%04d.png"),
+            "-c:v", "libvpx-vp9", "-b:v", "0", "-crf", "32",
+            "-row-mt", "1", str(webm_path),
+        ]
+        subprocess.run(cmd, capture_output=True)
+        print(f"[ghost-sim] WebM: {webm_path}")
+
+    print(f"\nDone — {output_dir} ({n + 1} frames)")
+    return rollout_a, rollout_b, webm_path

--- a/rlvr/autoresearch/tools/ghost_sim_common.py
+++ b/rlvr/autoresearch/tools/ghost_sim_common.py
@@ -117,10 +117,14 @@ def extract_scene_polylines(data: dict[str, torch.Tensor]):
     line_strings = data.get("line_strings")
     if line_strings is not None and line_strings.dim() == 4:
         line_strings = line_strings[0]
-    centerlines, lefts, rights = _lane_polylines(
-        lanes.cpu().numpy() if lanes is not None else None)
-    border_polylines = _road_border_polylines(
-        line_strings.cpu().numpy() if line_strings is not None else None)
+    if lanes is not None:
+        centerlines, lefts, rights = _lane_polylines(lanes.cpu().numpy())
+    else:
+        centerlines, lefts, rights = [], [], []
+    if line_strings is not None:
+        border_polylines = _road_border_polylines(line_strings.cpu().numpy())
+    else:
+        border_polylines = []
     route_polylines = _route_polylines(rl.cpu().numpy())
     centerline_segments = _build_segments(data["route_lanes"])
     return centerlines, lefts, rights, border_polylines, route_polylines, centerline_segments

--- a/rlvr/autoresearch/tools/ghost_sim_common.py
+++ b/rlvr/autoresearch/tools/ghost_sim_common.py
@@ -117,14 +117,12 @@ def extract_scene_polylines(data: dict[str, torch.Tensor]):
     line_strings = data.get("line_strings")
     if line_strings is not None and line_strings.dim() == 4:
         line_strings = line_strings[0]
-    if lanes is not None:
-        centerlines, lefts, rights = _lane_polylines(lanes.cpu().numpy())
-    else:
-        centerlines, lefts, rights = [], [], []
-    if line_strings is not None:
-        border_polylines = _road_border_polylines(line_strings.cpu().numpy())
-    else:
-        border_polylines = []
+    if lanes is None:
+        raise ValueError("Scene data missing 'lanes' — NPZ is incomplete")
+    if line_strings is None:
+        raise ValueError("Scene data missing 'line_strings' — NPZ is incomplete")
+    centerlines, lefts, rights = _lane_polylines(lanes.cpu().numpy())
+    border_polylines = _road_border_polylines(line_strings.cpu().numpy())
     route_polylines = _route_polylines(rl.cpu().numpy())
     centerline_segments = _build_segments(data["route_lanes"])
     return centerlines, lefts, rights, border_polylines, route_polylines, centerline_segments

--- a/rlvr/autoresearch/tools/recovery_sim_ghost.py
+++ b/rlvr/autoresearch/tools/recovery_sim_ghost.py
@@ -93,6 +93,9 @@ def _render_ghost_step(
     ego_length: float, ego_width: float,
     perturbation_label: str, init_lateral: float,
     view_half_m: float = _VIEW_HALF_M,
+    neighbor_boxes: list[tuple[float, float, float, float, float]] | None = None,
+    baseline_label: str = "baseline (LoRA-less)",
+    trained_label: str = "PRiSM",
 ) -> None:
     bx, by, bh = float(bl_pose[0]), float(bl_pose[1]), float(bl_pose[2])
     px, py, ph = float(pr_pose[0]), float(pr_pose[1]), float(pr_pose[2])
@@ -129,6 +132,12 @@ def _render_ghost_step(
             ax.plot(pl[:, 0], pl[:, 1], "-", color=_ROUTE_COLOR,
                     lw=2.5, alpha=0.55, zorder=3)
 
+    # Stopped neighbor OBBs
+    if neighbor_boxes:
+        for nx, ny, nh, nl, nw in neighbor_boxes:
+            _draw_agent_box(ax, nx, ny, nh, nl, nw,
+                            "#cc6600", alpha=0.75, lw=1.5, zorder=14)
+
     # Plans (faded thin)
     if bl_plan is not None and bl_plan.shape[0] > 1:
         ax.plot(bl_plan[:, 0], bl_plan[:, 1], "-",
@@ -160,9 +169,9 @@ def _render_ghost_step(
 
     # Legend
     ax.plot([], [], "-", color=_BASELINE_COLOR, lw=2,
-            label=f"baseline (LoRA-less)  v={bl_speed:.1f} m/s  lat={cur_lat_b:.2f}m")
+            label=f"{baseline_label}  v={bl_speed:.1f} m/s  lat={cur_lat_b:.2f}m")
     ax.plot([], [], "-", color=_PRISM_COLOR, lw=2,
-            label=f"PRiSM  v={pr_speed:.1f} m/s  lat={cur_lat_p:.2f}m")
+            label=f"{trained_label}  v={pr_speed:.1f} m/s  lat={cur_lat_p:.2f}m")
     ax.legend(fontsize=9, loc="upper left")
 
     ax.set_xlim(cx - view_half_m, cx + view_half_m)
@@ -173,8 +182,8 @@ def _render_ghost_step(
     ax.set_ylabel("Y (m, initial ego frame)")
     ax.set_title(
         f"Step {step:04d}/{n_steps}  t={step * 0.1:.1f}s  perturb={perturbation_label}  init lat={init_lateral:.2f}m\n"
-        f"baseline lat={cur_lat_b:.2f}m   PRiSM lat={cur_lat_p:.2f}m   "
-        f"Δ={cur_lat_b - cur_lat_p:+.2f}m (positive = PRiSM closer to centerline)",
+        f"{baseline_label} lat={cur_lat_b:.2f}m   {trained_label} lat={cur_lat_p:.2f}m   "
+        f"Δ={cur_lat_b - cur_lat_p:+.2f}m (positive = {trained_label} closer to centerline)",
         fontsize=10,
     )
     fig.tight_layout()
@@ -249,6 +258,33 @@ def main() -> None:
     route_polylines = _route_polylines(rl.cpu().numpy())
     centerline_segments = _build_segments(perturbed["route_lanes"])
 
+    # Extract stopped neighbor OBBs from NPZ (static obstacles)
+    data_np = dict(np.load(args.scene, allow_pickle=True))
+    nb_boxes = []
+    if "neighbor_agents_past" in data_np and "neighbor_agents_future" in data_np:
+        nb_past = data_np["neighbor_agents_past"]
+        if nb_past.ndim == 4:
+            nb_past = nb_past[0]
+        nb_fut = data_np["neighbor_agents_future"]
+        if nb_fut.ndim == 4:
+            nb_fut = nb_fut[0]
+        for i in range(nb_past.shape[0]):
+            xy0 = nb_past[i, -1, :2]
+            if abs(xy0[0]) + abs(xy0[1]) < 1e-6:
+                continue
+            fut_xy = nb_fut[i, :, :2]
+            fut_valid = np.abs(fut_xy).sum(axis=-1) > 1e-6
+            disp = 0.0 if fut_valid.sum() < 2 else float(
+                np.linalg.norm(fut_xy[fut_valid].max(0) - fut_xy[fut_valid].min(0)))
+            if disp >= 0.5:
+                continue
+            w = float(nb_past[i, -1, 6])
+            l = float(nb_past[i, -1, 7])
+            if w < 0.1 or l < 0.1:
+                continue
+            h = float(math.atan2(nb_past[i, -1, 3], nb_past[i, -1, 2]))
+            nb_boxes.append((float(xy0[0]), float(xy0[1]), h, l, w))
+
     # Render per-step PNGs
     n = args.steps
     print(f"[ghost-sim] rendering {n + 1} frames...")
@@ -268,6 +304,7 @@ def main() -> None:
             ego_length=args.ego_length, ego_width=args.ego_width,
             perturbation_label=perturb_label, init_lateral=init_lat,
             view_half_m=args.view_half_m,
+            neighbor_boxes=nb_boxes,
         )
 
     if args.make_webm:

--- a/rlvr/autoresearch/tools/recovery_sim_ghost.py
+++ b/rlvr/autoresearch/tools/recovery_sim_ghost.py
@@ -34,11 +34,8 @@ import matplotlib
 matplotlib.use("Agg")
 import numpy as np
 import torch
-from diffusion_planner.model.diffusion_planner import Diffusion_Planner
-from diffusion_planner.utils.config import Config
 from matplotlib.collections import LineCollection
 from matplotlib.figure import Figure
-from preference_optimization.lora_utils import load_lora_checkpoint
 from preference_optimization.utils import load_npz_data
 
 # Reuse all the heavy lifting from recovery_sim
@@ -59,30 +56,15 @@ from rlvr.autoresearch.tools.recovery_sim import (
     _VIEW_HALF_M,
     closed_loop_rollout_with_plans,
 )
-from rlvr.autoresearch.tools.ghost_sim_common import extract_stopped_neighbors
+from rlvr.autoresearch.tools.ghost_sim_common import (
+    extract_stopped_neighbors,
+    load_model as _load_model,
+)
 from rlvr.autoresearch.tools.recovery_test import get_tangent_at_origin
 
 
 _BASELINE_COLOR = "#1f77b4"   # blue
 _PRISM_COLOR    = "#d62728"   # red
-
-
-def _load_model(model_path: str, lora_path: str | None, device):
-    model_dir = Path(model_path).parent
-    args_path = model_dir / "args.json"
-    if not args_path.exists():
-        args_path = model_dir.parent / "args.json"
-    margs = Config(str(args_path))
-    model = Diffusion_Planner(margs)
-    ckpt = torch.load(model_path, map_location=device, weights_only=False)
-    state = ckpt.get("model", ckpt)
-    state = {k.replace("module.", ""): v for k, v in state.items()}
-    model.load_state_dict(state)
-    model.to(device).eval()
-    if lora_path:
-        model = load_lora_checkpoint(model, lora_path)
-        model.eval()
-    return model, margs
 
 
 def _render_ghost_step(

--- a/rlvr/autoresearch/tools/recovery_sim_ghost.py
+++ b/rlvr/autoresearch/tools/recovery_sim_ghost.py
@@ -59,6 +59,7 @@ from rlvr.autoresearch.tools.recovery_sim import (
     _VIEW_HALF_M,
     closed_loop_rollout_with_plans,
 )
+from rlvr.autoresearch.tools.ghost_sim_common import extract_stopped_neighbors
 from rlvr.autoresearch.tools.recovery_test import get_tangent_at_origin
 
 
@@ -258,32 +259,7 @@ def main() -> None:
     route_polylines = _route_polylines(rl.cpu().numpy())
     centerline_segments = _build_segments(perturbed["route_lanes"])
 
-    # Extract stopped neighbor OBBs from NPZ (static obstacles)
-    data_np = dict(np.load(args.scene, allow_pickle=True))
-    nb_boxes = []
-    if "neighbor_agents_past" in data_np and "neighbor_agents_future" in data_np:
-        nb_past = data_np["neighbor_agents_past"]
-        if nb_past.ndim == 4:
-            nb_past = nb_past[0]
-        nb_fut = data_np["neighbor_agents_future"]
-        if nb_fut.ndim == 4:
-            nb_fut = nb_fut[0]
-        for i in range(nb_past.shape[0]):
-            xy0 = nb_past[i, -1, :2]
-            if abs(xy0[0]) + abs(xy0[1]) < 1e-6:
-                continue
-            fut_xy = nb_fut[i, :, :2]
-            fut_valid = np.abs(fut_xy).sum(axis=-1) > 1e-6
-            disp = 0.0 if fut_valid.sum() < 2 else float(
-                np.linalg.norm(fut_xy[fut_valid].max(0) - fut_xy[fut_valid].min(0)))
-            if disp >= 0.5:
-                continue
-            w = float(nb_past[i, -1, 6])
-            l = float(nb_past[i, -1, 7])
-            if w < 0.1 or l < 0.1:
-                continue
-            h = float(math.atan2(nb_past[i, -1, 3], nb_past[i, -1, 2]))
-            nb_boxes.append((float(xy0[0]), float(xy0[1]), h, l, w))
+    nb_boxes = extract_stopped_neighbors(args.scene)
 
     # Render per-step PNGs
     n = args.steps

--- a/rlvr/autoresearch/tools/recovery_sim_ghost.py
+++ b/rlvr/autoresearch/tools/recovery_sim_ghost.py
@@ -212,6 +212,8 @@ def main() -> None:
     parser.add_argument("--view_half_m", type=float, default=_VIEW_HALF_M)
     parser.add_argument("--make_webm", action="store_true")
     parser.add_argument("--webm_fps", type=int, default=10)
+    parser.add_argument("--baseline_label", type=str, default="baseline (LoRA-less)")
+    parser.add_argument("--trained_label", type=str, default="PRiSM")
     args = parser.parse_args()
 
     out = Path(args.output_dir)
@@ -281,6 +283,8 @@ def main() -> None:
             perturbation_label=perturb_label, init_lateral=init_lat,
             view_half_m=args.view_half_m,
             neighbor_boxes=nb_boxes,
+            baseline_label=args.baseline_label,
+            trained_label=args.trained_label,
         )
 
     if args.make_webm:

--- a/scenario_generation/simulate.py
+++ b/scenario_generation/simulate.py
@@ -412,18 +412,17 @@ def _draw_agent_view(
         gt = agent.future_trajectory
         ax.plot(gt[:, 0], gt[:, 1], "--", color="#22bb22", lw=1.5, alpha=0.5, zorder=15, label="GT")
 
-    # Zoom: center on agent, show ~30m radius
+    # Zoom: center on agent + plan tip, tight view
     zoom_pts = [pos.reshape(1, 2)]
     if agent_id in agent_predictions:
-        zoom_pts.append(plan_xy[:20])
-    if agent.goal_pose is not None:
-        zoom_pts.append(agent.goal_pose[:2].reshape(1, 2))
+        zoom_pts.append(plan_xy[:40])
     if len(world_history) > 1:
-        zoom_pts.append(np.array(world_history[-min(20, len(world_history)):]))
+        zoom_pts.append(np.array(world_history[-min(10, len(world_history)):]))
     all_pts = np.vstack(zoom_pts)
     cx, cy = np.mean(all_pts[:, 0]), np.mean(all_pts[:, 1])
-    half = max(np.ptp(all_pts[:, 0]), np.ptp(all_pts[:, 1])) * 0.6 + 8
-    half = max(half, 15)  # minimum 15m radius
+    half = max(np.ptp(all_pts[:, 0]), np.ptp(all_pts[:, 1])) * 0.55 + 5
+    half = max(half, 20)
+    half = min(half, 40)
     ax.set_xlim(cx - half, cx + half)
     ax.set_ylim(cy - half, cy + half)
 


### PR DESCRIPTION
## Summary
- Extract `ghost_sim_common.py`: reusable dual-model ghost overlay closed-loop simulation library with configurable labels, colors, neighbor OBBs, and webm assembly
- Add `compare_models_ghost.py`: generic A/B model comparison CLI (not tied to PRiSM)
- Add `collage_avoidance_compare.py`: static collision distance collage builder
- Add stopped-neighbor OBB rendering to `viz_cl_recovery.py` (shared by viz_prism_compare)
- Add neighbor OBB + configurable labels to `recovery_sim_ghost.py`
- Fix `simulate.py` per-agent zoom: cap view radius to prevent distant-goal blowup on scene-editor NPZs

## Test plan
- [x] `compare_models_ghost` tested on 6 avoidance scenes (baseline vs trained), produces correct per-step PNGs + webm
- [x] `collage_avoidance_compare` tested on 42 scenes, produces correct collage with sc_min_dist annotations  
- [x] `recovery_sim_ghost` still works for PRiSM scenes (neighbor boxes rendered, labels configurable)
- [x] `simulate.py --per_agent` zoom fix verified on scene-editor NPZs

