### PR TITLE
feat(rlvr): GT candidate ranking + hybrid CL-avoidance variant

### DIFF
--- a/rlvr/generation_variants.py
+++ b/rlvr/generation_variants.py
@@ -456,6 +456,34 @@ _VARIANTS: dict[str, GenerationVariant] = {
         ],
         noise_configs=_NOISE_SWEEP_FULL,
     ),
+    "rl_cl_stretch_col4": GenerationVariant(
+        description="K=16 hybrid: 7 rl_cl+stretch CL slots + 4 collision-guided "
+                    "slots + 4 noise-sweep. Combines centerline improvement with "
+                    "static-obstacle avoidance in a single generation pass.",
+        cl_spd_configs=[
+            _RL_CL_1_5_SPD1_5_DET,
+            _RL_CL_2_0_SPD2_0_DET,
+            _RL_CL_2_5_SPD2_5_DET,
+            _RL_CL_2_0_SPD2_0_STR12,
+            _RL_CL_2_5_SPD2_5_STR13,
+            _RL_CL_3_0_SPD3_0_STR12,
+            _RL_CL_3_0_SPD3_0_STR14,
+            {"cl": 2.0, "spd": 0.0, "noise": (0.0, 0.0), "col": 0.5,
+             "label": "RL_CL2.0_col05_det"},
+            {"cl": 2.0, "spd": 0.0, "noise": (0.3, 0.8), "col": 1.0,
+             "label": "RL_CL2.0_col10_n0308"},
+            {"cl": 2.0, "spd": 0.0, "noise": (0.3, 0.8), "col": 2.0,
+             "label": "RL_CL2.0_col20_n0308"},
+            {"cl": 2.0, "spd": 0.0, "noise": (0.5, 1.5), "col": 3.0,
+             "label": "RL_CL2.0_col30_n0515"},
+        ],
+        noise_configs=[
+            {"noise": (0.5, 1.0), "label": "noise_n0510"},
+            {"noise": (0.8, 1.8), "label": "noise_n0818"},
+            {"noise": (1.0, 2.0), "label": "noise_n1020"},
+            {"noise": (0.3, 0.8), "label": "noise_n0308"},
+        ],
+    ),
 }
 
 

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -289,6 +289,7 @@ class GRPOConfig:
     #                   accidentally filtered out by selective_threshold.
     gt_fallback_mode: str = "none"
     gt_fallback_margin: float = 0.0  # reward units. 0 = any GT advantage > 0 triggers fallback.
+    include_gt_candidate: bool = False  # append GT (ego_agent_future) as extra candidate in K+1 ranking pool
 
     # Ranked SFT batching: how many scenes per forward pass (default 1 = sequential).
     # With sft_batch_size=B, each forward pass processes B scenes. Grad accumulation

--- a/rlvr/grpo_sft_trainer.py
+++ b/rlvr/grpo_sft_trainer.py
@@ -730,6 +730,9 @@ def train_epoch_ranked_sft(
             _ra_labels = [f"explorer_{i}" for i in range(K)]
         _ra = EpochRankAnalytics(epoch=epoch, n_scenes=N)
 
+        _include_gt_cand = getattr(config, "include_gt_candidate", False)
+        _gt_cand_count = 0
+
         for i in tqdm(range(N), desc="Scoring"):
             traj_K = all_trajs[i]  # [K, T, 4]
             data_i = all_data[i]
@@ -741,6 +744,33 @@ def train_epoch_ranked_sft(
                     data_i["baseline_path_len"] = torch.tensor(
                         baseline_path_lens[key], device=device, dtype=torch.float32,
                     )
+
+            # Optionally append GT trajectory as extra candidate in ranking pool
+            _gt_appended = False
+            if _include_gt_cand:
+                _real_gt = data_i.get("ego_agent_future")
+                if _real_gt is not None:
+                    _g = _real_gt
+                    if _g.dim() == 3:
+                        _g = _g[0]
+                    if _g.shape[-1] == 3:
+                        _valid = _g[..., :2].abs().sum(dim=-1) > 0.1
+                        _cos = torch.where(_valid, _g[..., 2].cos(), torch.zeros_like(_g[..., 2]))
+                        _sin = torch.where(_valid, _g[..., 2].sin(), torch.zeros_like(_g[..., 2]))
+                        _g = torch.stack([_g[..., 0], _g[..., 1], _cos, _sin], dim=-1)
+                    _g = _g[..., :4]
+                    T_gen = traj_K.shape[1]
+                    if _g.shape[0] > T_gen:
+                        _g = _g[:T_gen]
+                    elif _g.shape[0] < T_gen:
+                        _pad = torch.zeros(T_gen - _g.shape[0], 4, device=_g.device, dtype=_g.dtype)
+                        _g = torch.cat([_g, _pad], dim=0)
+                    traj_K = torch.cat([traj_K, _g.unsqueeze(0).to(traj_K.device, dtype=traj_K.dtype)], dim=0)
+                    _gt_appended = True
+                    _gt_cand_count += 1
+
+            # Extend labels if GT was appended
+            _scene_ra_labels = _ra_labels + (["gt_candidate"] if _gt_appended else [])
 
             rewards = compute_reward_batch(traj_K, data_i, reward_config)
             reward_vals = np.array([r.total for r in rewards])
@@ -842,7 +872,7 @@ def train_epoch_ranked_sft(
             _ra.records.append(SceneRankRecord(
                 scene_path=Path(valid_paths[i]).stem,
                 winner_idx=best_idx,
-                winner_label=_ra_labels[best_idx],
+                winner_label=_scene_ra_labels[best_idx],
                 winner_reward=float(reward_vals[best_idx]),
                 mean_reward=float(reward_vals.mean()),
                 det_reward=float(reward_vals[0]),
@@ -868,9 +898,14 @@ def train_epoch_ranked_sft(
             best_rewards_list.append(effective_reward)
 
         mean_best_reward = float(np.mean(best_rewards_list))
+        if _include_gt_cand:
+            _gt_wins = sum(1 for r in _ra.records if r.winner_label == "gt_candidate")
+            print(f"  [GT candidate] {_gt_cand_count}/{N} scenes had GT, "
+                  f"{_gt_wins}/{_gt_cand_count} GT won rank-1")
 
         # Rank analytics: aggregate and print/save
-        _ra.finalize(_ra_labels)
+        _ra_labels_final = _ra_labels + (["gt_candidate"] if _include_gt_cand else [])
+        _ra.finalize(_ra_labels_final)
         print_epoch_summary(_ra)
         if run_dir is not None:
             save_epoch_analytics(_ra, Path(run_dir), epoch)

--- a/rlvr/grpo_sft_trainer.py
+++ b/rlvr/grpo_sft_trainer.py
@@ -787,16 +787,16 @@ def train_epoch_ranked_sft(
             gt_reward = float("nan")
             gt_traj_4col = None
             if _gt_mode != "none":
-                _real_gt = data_i.get("ego_agent_future")
-                if _real_gt is not None:
+                # Reuse GT tensor + reward from include_gt_candidate if available
+                if _gt_appended:
+                    gt_traj_4col = traj_K[-1]
+                    gt_reward = float(reward_vals[-1])
+                    _gt_rewards = [rewards[-1]]
+                elif data_i.get("ego_agent_future") is not None:
+                    _real_gt = data_i["ego_agent_future"]
                     _g = _real_gt
                     if _g.dim() == 3:
                         _g = _g[0]
-                    # Map (T,3) -> (T,4) as (x, y, cos h, sin h). Align columns
-                    # with traj_K (which is also x, y, cos, sin). Mask zero-
-                    # padded trailing rows BEFORE cos/sin conversion so we don't
-                    # inject a phantom "pointing-east" pose (cos=1, sin=0) on
-                    # invalid timesteps — that would skew progress / RB on GT.
                     if _g.shape[-1] == 3:
                         _valid = _g[..., :2].abs().sum(dim=-1) > 0.1
                         _cos = torch.where(_valid, _g[..., 2].cos(), torch.zeros_like(_g[..., 2]))
@@ -815,11 +815,11 @@ def train_epoch_ranked_sft(
                         gt_traj_4col.unsqueeze(0), data_i, reward_config,
                     )
                     gt_reward = float(_gt_rewards[0].total)
+                if gt_traj_4col is not None:
                     _gt_scored_count += 1
                     if best_reward < gt_reward - _gt_margin:
                         _used_gt_fallback = True
                         _gt_fallback_count += 1
-                    # Always record per-scene comparison so we can analyze hard scenes
                     _gt_scene_log.append({
                         "scene": Path(valid_paths[i]).stem,
                         "gt_reward": gt_reward,
@@ -828,7 +828,6 @@ def train_epoch_ranked_sft(
                         "gap_best_minus_gt": float(best_reward - gt_reward),
                         "best_idx": int(best_idx),
                         "fallback": bool(_used_gt_fallback),
-                        # Gate / crossing flags from the GT-trajectory reward breakdown
                         "gt_rb_crossing": bool(_gt_rewards[0].rb_crossing),
                         "gt_lane_crossing": bool(_gt_rewards[0].lane_crossing),
                         "gt_collision_step": _gt_rewards[0].collision_step,
@@ -898,7 +897,7 @@ def train_epoch_ranked_sft(
             best_rewards_list.append(effective_reward)
 
         mean_best_reward = float(np.mean(best_rewards_list))
-        if _include_gt_cand:
+        if _include_gt_cand and _gt_cand_count > 0:
             _gt_wins = sum(1 for r in _ra.records if r.winner_label == "gt_candidate")
             print(f"  [GT candidate] {_gt_cand_count}/{N} scenes had GT, "
                   f"{_gt_wins}/{_gt_cand_count} GT won rank-1")

--- a/rlvr/rank_analytics.py
+++ b/rlvr/rank_analytics.py
@@ -261,7 +261,8 @@ class EpochRankAnalytics:
         cat_counter = Counter(get_category(r.winner_label) for r in self.records)
         # Include both standard and experimental categories
         all_cats = ["det_pure", "guided_det", "guided_noisy", "random",
-                    "lateral_exp", "stretched_exp", "decoupled_exp", "noise_only_exp", "collision_exp"]
+                    "lateral_exp", "stretched_exp", "decoupled_exp", "noise_only_exp",
+                    "collision_exp", "gt_candidate"]
         for cat in all_cats:
             self.category_rates[cat] = cat_counter.get(cat, 0) / n
 

--- a/rlvr/rank_analytics.py
+++ b/rlvr/rank_analytics.py
@@ -43,6 +43,8 @@ def _classify_label(label: str) -> str:
     """Classify any label (including experimental ones) into a category."""
     if label in _CATEGORY_MAP:
         return _CATEGORY_MAP[label]
+    if label == "gt_candidate":
+        return "gt_candidate"
     if label.startswith("random_") or label.startswith("explorer_"):
         return "random"
     if label == "det_pure":


### PR DESCRIPTION
## Summary
- Add `include_gt_candidate` config flag: appends `ego_agent_future` as an extra K+1 candidate in ranked SFT scoring pool, with heading format conversion (yaw→cos/sin) and time-step padding. Rank analytics tracks GT win rate per epoch.
- Add `rl_cl_stretch_col4` generation variant (K=16): 7 route-CL+stretch slots + 4 collision-guided slots + 4 noise-sweep slots for joint centerline-avoidance training.

## Test plan
- [ ] Run ranked SFT with `include_gt_candidate: true` and verify GT win count logged
- [ ] Run ranked SFT with `generation_variant: rl_cl_stretch_col4` and verify 16 slots generated
- [ ] Existing tests pass (`pytest rlvr/test_generation_variants.py`)