### PR TITLE
feat(scenario_generation): parked vehicle injection + static collision heatmap

### DIFF
--- a/scenario_generation/README.md
+++ b/scenario_generation/README.md
@@ -240,6 +240,52 @@ across despawn, inference, and viz gates. Combine with
 `max_active_npcs=0, spawn_probability=0.0, enable_traffic_lights=false`
 to produce a static-only audit scene.
 
+**Parked vehicle injection from rosbag extraction.** Inject real parked
+vehicles (extracted from recorded rosbags) as static NPCs at their actual
+world-frame positions. Unlike synthetic `static_npc_*` placement, these
+vehicles have real dimensions and orientations from perception tracking.
+
+Config keys (on `SpawnConfig`, mutually exclusive with `static_npc_count`):
+
+- `parked_vehicles_yaml` (default `None` — feature off) — path to a YAML
+  file with a `parked_vehicles` list (each entry has `pose`, `orientation`,
+  `dimensions`)
+- `parked_vehicle_visibility_m` (default `125.0`) — perception-range
+  radius; parked vehicles are added/removed from `scene.agents` each step
+  based on distance to the ego, mimicking finite sensor range. Per-vehicle
+  `visibility_radius` from the YAML overrides this when present.
+
+Extract parked vehicles from rosbags:
+
+```bash
+python -m scenario_generation.tools.extract_parked_vehicles \
+    --bags /path/to/bag1.db3 /path/to/bag2.db3 ... \
+    --osm_path /path/to/lanelet2_map.osm \
+    --output /path/to/parked.yaml
+```
+
+The extraction tool processes ALL bag splits together so tracker UUIDs are
+merged — vehicles that eventually move (e.g. stopped at traffic lights) are
+correctly excluded. Overlapping detections are merged via OBB union-find.
+
+**Static collision clearance heatmap.** Scores ego clearance to parked
+vehicles along the route and renders an arc-binned heatmap.
+
+```bash
+# Ego-actual mode (default) — no model inference needed:
+python -m scenario_generation.tools.heatmap_static_collision \
+    --route /path/to/route.pkl \
+    --run_a /path/to/sim_dir_a \
+    --run_b /path/to/sim_dir_b \
+    --label_a baseline --label_b trained \
+    --output /path/to/heatmap.png \
+    --mode ego_actual --stride 2
+```
+
+Two modes: `ego_actual` (default) scores the real ego OBB at each step;
+`predicted` scores the model's 80-step predicted trajectory (requires
+`--model_a`, `--model_b`, `--config`).
+
 **Live ego ↔ stopped-NPC proximity line.** When the ego's OBB gets
 within `_STATIC_NPC_VIZ_THRESH_M` (= 2.0 m) of any static NPC's OBB,
 `_save_step_figure` draws a red line between the two closest-pair points
@@ -283,6 +329,8 @@ Relevant modules:
 | `scenario_generation/configs/replay_default.json` | Reference `SpawnConfig` template — not loaded automatically, `--config` is required |
 | `rlvr/autoresearch/tools/select_from_metrics_log.py` | Reads `metrics_log.json` + NPZ dir, emits pre-trigger scene list for training |
 | `rlvr/autoresearch/tools/rescore_replay_run.py` | Regenerate `metrics_log.json` from an existing run (no re-sim); `--mode instant` (no model) or `--mode full` (with model) — swap models to compare plans at the same observations |
+| `scenario_generation/tools/extract_parked_vehicles.py` | Multi-bag parked vehicle extraction with UUID merge |
+| `scenario_generation/tools/heatmap_static_collision.py` | Static collision clearance heatmap (ego_actual / predicted modes) |
 | `scenario_generation/tools/inspect_route.py` | CLI to dump a saved route pickle |
 | `scenario_generation/gui/app.py` | GUI panels + live route overlay wiring |
 | `scene_search/map_canvas_js.py` | JS canvas: start / goal / waypoint arrows + route polyline |

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -275,6 +275,12 @@ class SpawnConfig:
     static_npc_shoulder_margin_m: float = 0.3
     static_npc_seed: int | None = None
 
+    # Path to a YAML file with real parked-vehicle poses extracted from a
+    # rosbag (e.g. via extract_parked_vehicles_from_rosbag.py).  When set,
+    # the listed vehicles are injected as static NPCs at their world-frame
+    # positions — mutually exclusive with the synthetic static_npc_count.
+    parked_vehicles_yaml: str | None = None
+
     # Turn-indicator argmax: bias subtracted from the KEEP (class 4) logit
     # before argmax to imitate the C++ TurnIndicatorManager. Default 0.25
     # (the cpp planner's value); set to 0.0 to reproduce the raw argmax.
@@ -939,6 +945,71 @@ class SceneNPCManager:
         if added > 0:
             print(f"  [NPCManager] prepopulated {added} static NPC(s) "
                   f"(spacing≈{spacing:.0f} m, margin={self.cfg.static_npc_shoulder_margin_m:.2f} m)")
+        return added
+
+    def inject_parked_vehicles_from_yaml(
+        self, scene: "SceneContext", yaml_path: str,
+    ) -> int:
+        """Inject real parked vehicles from a YAML file as static NPCs.
+
+        The YAML must contain a ``parked_vehicles`` list where each entry has
+        ``pose.position.{x,y,z}``, ``pose.orientation.{x,y,z,w}``, and
+        ``dimensions.{x,y,z}`` in world (map) frame — the format produced by
+        ``extract_parked_vehicles_from_rosbag.py``.
+        """
+        import yaml as _yaml
+
+        with open(yaml_path, "r") as fh:
+            data = _yaml.safe_load(fh)
+
+        vehicles = data.get("parked_vehicles", [])
+        if not vehicles:
+            print(f"  [NPCManager] no parked_vehicles in {yaml_path}")
+            return 0
+
+        T_past = 31
+        added = 0
+        for i, v in enumerate(vehicles):
+            pos = v["pose"]["position"]
+            ori = v["pose"]["orientation"]
+            dims = v["dimensions"]
+
+            px, py = float(pos["x"]), float(pos["y"])
+            heading = 2.0 * math.atan2(float(ori["z"]), float(ori["w"]))
+            length = float(dims["x"])
+            width = float(dims["y"])
+            wheelbase = length * 0.65
+
+            history = np.zeros((T_past, 3), dtype=np.float32)
+            history[:, 0] = px
+            history[:, 1] = py
+            history[:, 2] = heading
+            velocities = np.zeros((T_past, 2), dtype=np.float32)
+
+            agent_id = f"{self.STATIC_NPC_PREFIX}parked_{i}"
+            agent = Agent(
+                id=agent_id,
+                agent_type=AgentType.VEHICLE,
+                length=length,
+                width=width,
+                wheelbase=wheelbase,
+                past_trajectory=history,
+                past_velocities=velocities,
+                acceleration=np.zeros(2, dtype=np.float32),
+                steering_angle=0.0,
+                yaw_rate=0.0,
+                goal_pose=None,
+                route_lanes=None,
+                route_speed_limit=None,
+                route_has_speed_limit=None,
+                turn_indicators=np.zeros(T_past, dtype=np.int32),
+                age_steps=T_past,
+                route_lanelet_ids=None,
+            )
+            scene.agents.append(agent)
+            added += 1
+
+        print(f"  [NPCManager] injected {added} parked vehicle(s) from {yaml_path}")
         return added
 
     def _trim_route_off_ego(self, route: list[int]) -> list[int]:
@@ -1752,6 +1823,11 @@ def run_route_replay(
     # move and never despawn — see SceneNPCManager.prepopulate_static_npcs.
     if spawn_config.static_npc_count > 0:
         npc_manager.prepopulate_static_npcs(scene)
+
+    if spawn_config.parked_vehicles_yaml:
+        npc_manager.inject_parked_vehicles_from_yaml(
+            scene, spawn_config.parked_vehicles_yaml,
+        )
 
     map_cache = MapTensorCache(scene.map_data)
     n_npc_spawned = 0

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -64,6 +64,24 @@ matplotlib.use("Agg")
 import numpy as np
 import torch
 
+# Live per-step lane / border / centerline scoring. Imports are module-
+# level (unconditional); the scoring path itself only runs when both
+# dump_npz_dir and reward_config_path are set in SpawnConfig. Matches
+# the exact same primitives ranked-SFT uses for its reward, so the
+# metrics log here and the training run speak the same thresholds.
+from rlvr.autoresearch.tools.reward_config_from_json import load_reward_config
+
+# Reuse the Savitzky-Golay smoother from the RL pipeline. Used there by
+# ranked-SFT to smooth diffusion-planner outputs before the SFT loss; same
+# defaults (window=11, order=3) and cos/sin-renormalisation logic apply at
+# replay time to suppress diffusion-sampler jitter. Importing rather than
+# duplicating so the two pipelines stay in sync.
+from rlvr.grpo_sft_trainer import _smooth_trajectory as _sg_smooth_trajectory
+from rlvr.reward import (
+    RewardConfig,
+    compute_centerline_score_batch,
+    compute_reward_batch,
+)
 from scenario_generation.gui.lanelet_scene_builder import (
     LaneletSceneBuilder,
     _obb_collides,
@@ -81,31 +99,11 @@ from scenario_generation.simulate import (
 )
 from scenario_generation.tensor_converter import MapTensorCache, dump_step_npz
 from scenario_generation.traffic_light import TrafficLightController
-
-# Reuse the Savitzky-Golay smoother from the RL pipeline. Used there by
-# ranked-SFT to smooth diffusion-planner outputs before the SFT loss; same
-# defaults (window=11, order=3) and cos/sin-renormalisation logic apply at
-# replay time to suppress diffusion-sampler jitter. Importing rather than
-# duplicating so the two pipelines stay in sync.
-from rlvr.grpo_sft_trainer import _smooth_trajectory as _sg_smooth_trajectory
-
-# Live per-step lane / border / centerline scoring. Imports are module-
-# level (unconditional); the scoring path itself only runs when both
-# dump_npz_dir and reward_config_path are set in SpawnConfig. Matches
-# the exact same primitives ranked-SFT uses for its reward, so the
-# metrics log here and the training run speak the same thresholds.
-from rlvr.autoresearch.tools.reward_config_from_json import load_reward_config
-from rlvr.reward import (
-    RewardConfig,
-    compute_centerline_score_batch,
-    compute_reward_batch,
-)
 from scenario_generation.visualize import (
     _agent_color,
     draw_agent_box,
     draw_trajectory,
 )
-
 
 # ── Config ───────────────────────────────────────────────────────────────────
 
@@ -412,6 +410,7 @@ class SceneNPCManager:
         # profile the full-map scan was 10 s of 114 s, and route progress
         # only ever advances through adjacent entries in the fixed route.
         self._last_ego_route_idx: int = 0
+        self._parked_vehicle_pool: list[tuple[np.ndarray, Agent, float | None]] = []
         # Flat (N, 2) world-frame stack of every valid centerline point
         # across the ego route. Used to reject NPC spawns whose goal
         # lands within ``cfg.npc_goal_min_dist_from_ego_route`` metres of
@@ -965,10 +964,10 @@ class SceneNPCManager:
         ``dimensions.{x,y,z}`` in world (map) frame — the format produced by
         ``extract_parked_vehicles_from_rosbag.py``.
         """
-        import yaml as _yaml
+        import yaml
 
         with open(yaml_path, "r") as fh:
-            data = _yaml.safe_load(fh)
+            data = yaml.safe_load(fh)
 
         vehicles = data.get("parked_vehicles", [])
         if not vehicles:
@@ -1033,18 +1032,22 @@ class SceneNPCManager:
         derived from the original bag's perception detection range + margin)
         if available, otherwise falls back to ``radius_m``.
         """
-        if not hasattr(self, "_parked_vehicle_pool"):
+        if not self._parked_vehicle_pool:
             return
 
         active_ids = {a.id for a in scene.agents}
+        to_add: list[Agent] = []
+        to_remove: set[str] = set()
         for world_pos, agent, per_vehicle_radius in self._parked_vehicle_pool:
             r = per_vehicle_radius if per_vehicle_radius is not None else radius_m
             dist = float(np.linalg.norm(ego_pos - world_pos))
-            is_active = agent.id in active_ids
-            if dist <= r and not is_active:
-                scene.agents.append(agent)
-            elif dist > r and is_active:
-                scene.agents = [a for a in scene.agents if a.id != agent.id]
+            if dist <= r and agent.id not in active_ids:
+                to_add.append(agent)
+            elif dist > r and agent.id in active_ids:
+                to_remove.add(agent.id)
+        if to_remove:
+            scene.agents = [a for a in scene.agents if a.id not in to_remove]
+        scene.agents.extend(to_add)
 
     def _trim_route_off_ego(self, route: list[int]) -> list[int]:
         """Trim route so its goal lanelet is not on an untransited ego lanelet.
@@ -1343,6 +1346,7 @@ def save_step_figure(
     #     tensor. The per-lane `tl_onehot.sum() < 0.5` filter below
     #     skips lanes with no TL data.
     from matplotlib.collections import LineCollection
+
     from scenario_generation.traffic_light import TL_HEX, TL_NONE
     tl_segments: dict[str, list[np.ndarray]] = {}  # hex → list of polylines
     lanes = scene.map_data.lanes
@@ -1859,6 +1863,11 @@ def run_route_replay(
     # One-shot stopped-NPC prepopulation (static-collision audit). No-op
     # when spawn_config.static_npc_count == 0 (default). These NPCs never
     # move and never despawn — see SceneNPCManager.prepopulate_static_npcs.
+    if spawn_config.static_npc_count > 0 and spawn_config.parked_vehicles_yaml:
+        raise ValueError(
+            "static_npc_count and parked_vehicles_yaml are mutually exclusive"
+        )
+
     if spawn_config.static_npc_count > 0:
         npc_manager.prepopulate_static_npcs(scene)
 

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -273,8 +273,8 @@ class SpawnConfig:
     static_npc_shoulder_margin_m: float = 0.3
     static_npc_seed: int | None = None
 
-    # Path to a YAML file with real parked-vehicle poses extracted from a
-    # rosbag (e.g. via extract_parked_vehicles_from_rosbag.py).  When set,
+    # Path to a YAML file with real parked-vehicle poses (e.g. via
+    # ``scenario_generation.tools.extract_parked_vehicles``).  When set,
     # the listed vehicles are injected as static NPCs at their world-frame
     # positions — mutually exclusive with the synthetic static_npc_count.
     parked_vehicles_yaml: str | None = None
@@ -346,6 +346,16 @@ class SpawnConfig:
                 "/ lane_gate values that only exist when the per-step "
                 "metrics log is being produced. Set both, or disable the "
                 "overlay."
+            )
+        if self.static_npc_count > 0 and self.parked_vehicles_yaml:
+            raise ValueError(
+                "static_npc_count and parked_vehicles_yaml are mutually "
+                "exclusive — use one or the other."
+            )
+        if self.parked_vehicle_visibility_m <= 0:
+            raise ValueError(
+                f"parked_vehicle_visibility_m must be > 0; "
+                f"got {self.parked_vehicle_visibility_m}"
             )
 
     @classmethod
@@ -962,7 +972,7 @@ class SceneNPCManager:
         The YAML must contain a ``parked_vehicles`` list where each entry has
         ``pose.position.{x,y,z}``, ``pose.orientation.{x,y,z,w}``, and
         ``dimensions.{x,y,z}`` in world (map) frame — the format produced by
-        ``extract_parked_vehicles_from_rosbag.py``.
+        ``scenario_generation.tools.extract_parked_vehicles``.
         """
         import yaml
 
@@ -1863,11 +1873,6 @@ def run_route_replay(
     # One-shot stopped-NPC prepopulation (static-collision audit). No-op
     # when spawn_config.static_npc_count == 0 (default). These NPCs never
     # move and never despawn — see SceneNPCManager.prepopulate_static_npcs.
-    if spawn_config.static_npc_count > 0 and spawn_config.parked_vehicles_yaml:
-        raise ValueError(
-            "static_npc_count and parked_vehicles_yaml are mutually exclusive"
-        )
-
     if spawn_config.static_npc_count > 0:
         npc_manager.prepopulate_static_npcs(scene)
 

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -280,6 +280,10 @@ class SpawnConfig:
     # the listed vehicles are injected as static NPCs at their world-frame
     # positions — mutually exclusive with the synthetic static_npc_count.
     parked_vehicles_yaml: str | None = None
+    # Perception-range radius for parked vehicle visibility. Only parked
+    # vehicles within this distance of the ego are added to scene.agents;
+    # the rest stay in a pool. Mimics finite sensor range.
+    parked_vehicle_visibility_m: float = 125.0
 
     # Turn-indicator argmax: bias subtracted from the KEEP (class 4) logit
     # before argmax to imitate the C++ TurnIndicatorManager. Default 0.25
@@ -950,7 +954,11 @@ class SceneNPCManager:
     def inject_parked_vehicles_from_yaml(
         self, scene: "SceneContext", yaml_path: str,
     ) -> int:
-        """Inject real parked vehicles from a YAML file as static NPCs.
+        """Load real parked vehicles from a YAML into a visibility pool.
+
+        Vehicles are NOT added to ``scene.agents`` immediately. Call
+        :meth:`update_parked_visibility` each sim step to add/remove them
+        based on proximity to the ego — mimicking perception range.
 
         The YAML must contain a ``parked_vehicles`` list where each entry has
         ``pose.position.{x,y,z}``, ``pose.orientation.{x,y,z,w}``, and
@@ -968,7 +976,7 @@ class SceneNPCManager:
             return 0
 
         T_past = 31
-        added = 0
+        self._parked_vehicle_pool: list[tuple[np.ndarray, Agent, float | None]] = []
         for i, v in enumerate(vehicles):
             pos = v["pose"]["position"]
             ori = v["pose"]["orientation"]
@@ -1006,11 +1014,37 @@ class SceneNPCManager:
                 age_steps=T_past,
                 route_lanelet_ids=None,
             )
-            scene.agents.append(agent)
-            added += 1
+            world_pos = np.array([px, py], dtype=np.float32)
+            per_veh_radius = v.get("visibility_radius")
+            if per_veh_radius is not None:
+                per_veh_radius = float(per_veh_radius)
+            self._parked_vehicle_pool.append((world_pos, agent, per_veh_radius))
 
-        print(f"  [NPCManager] injected {added} parked vehicle(s) from {yaml_path}")
-        return added
+        print(f"  [NPCManager] loaded {len(self._parked_vehicle_pool)} parked vehicle(s) "
+              f"into visibility pool from {yaml_path}")
+        return len(self._parked_vehicle_pool)
+
+    def update_parked_visibility(
+        self, scene: "SceneContext", ego_pos: np.ndarray, radius_m: float,
+    ) -> None:
+        """Add/remove pooled parked vehicles based on distance to ego.
+
+        Each vehicle uses its own ``visibility_radius`` (from the YAML,
+        derived from the original bag's perception detection range + margin)
+        if available, otherwise falls back to ``radius_m``.
+        """
+        if not hasattr(self, "_parked_vehicle_pool"):
+            return
+
+        active_ids = {a.id for a in scene.agents}
+        for world_pos, agent, per_vehicle_radius in self._parked_vehicle_pool:
+            r = per_vehicle_radius if per_vehicle_radius is not None else radius_m
+            dist = float(np.linalg.norm(ego_pos - world_pos))
+            is_active = agent.id in active_ids
+            if dist <= r and not is_active:
+                scene.agents.append(agent)
+            elif dist > r and is_active:
+                scene.agents = [a for a in scene.agents if a.id != agent.id]
 
     def _trim_route_off_ego(self, route: list[int]) -> list[int]:
         """Trim route so its goal lanelet is not on an untransited ego lanelet.
@@ -1421,6 +1455,10 @@ def save_step_figure(
     ax.set_xlim(ex - view_half_m, ex + view_half_m)
     ax.set_ylim(ey - view_half_m, ey + view_half_m)
     ax.set_aspect("equal")
+    # Fixed tick spacing so the grid doesn't jitter between frames.
+    from matplotlib.ticker import MultipleLocator
+    ax.xaxis.set_major_locator(MultipleLocator(20.0))
+    ax.yaxis.set_major_locator(MultipleLocator(20.0))
     ax.grid(True, alpha=0.15)
     ax.set_xlabel("X (m)")
     ax.set_ylabel("Y (m)")
@@ -1517,7 +1555,7 @@ def save_step_figure(
                     zorder=31)
 
     ax.set_title(title, fontsize=10)
-    fig.tight_layout()
+    fig.subplots_adjust(left=0.10, right=0.95, bottom=0.08, top=0.92)
     _save_and_close(fig, output_path)
 
 
@@ -1871,6 +1909,12 @@ def run_route_replay(
             # Track which ego route lanelets have been transited so NPC
             # goals avoid landing on the ego's future path.
             npc_manager.update_ego_progress(scene.ego_agent.current_position)
+
+            # Distance-gated parked vehicle visibility (perception range).
+            npc_manager.update_parked_visibility(
+                scene, scene.ego_agent.current_position,
+                spawn_config.parked_vehicle_visibility_m,
+            )
 
             # Run the NPC manager (after step 0 so the ego has a meaningful
             # ``current_position`` — always true by construction here).

--- a/scenario_generation/tools/_heatmap_common.py
+++ b/scenario_generation/tools/_heatmap_common.py
@@ -148,6 +148,32 @@ def bin_by_arc(
     return bin_s_mid, mean_abs, max_abs
 
 
+def bin_scalar_by_arc(
+    arc_s: np.ndarray, values: np.ndarray, s_max: float, bin_m: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Bin an arbitrary per-point scalar by arc-length.
+
+    Args:
+        arc_s:  (M,) arc-length position of each sample.
+        values: (M,) scalar value at each sample (e.g. min clearance).
+        s_max:  total route arc-length.
+        bin_m:  bin width in metres.
+
+    Returns (bin_s_mid, mean_val, min_val) — each (n_bins,), NaN for empty.
+    """
+    n_bins = max(1, int(math.ceil(s_max / bin_m)))
+    bin_s_mid = (np.arange(n_bins) + 0.5) * bin_m
+    mean_val = np.full(n_bins, np.nan, dtype=np.float64)
+    min_val = np.full(n_bins, np.nan, dtype=np.float64)
+    idx = np.clip((arc_s // bin_m).astype(int), 0, n_bins - 1)
+    for b in range(n_bins):
+        mask = idx == b
+        if mask.any():
+            mean_val[b] = np.mean(values[mask])
+            min_val[b] = np.min(values[mask])
+    return bin_s_mid, mean_val, min_val
+
+
 def segments_from_polyline(
     pts: np.ndarray, s: np.ndarray, bin_m: float, n_bins: int
 ) -> list:

--- a/scenario_generation/tools/extract_parked_vehicles.py
+++ b/scenario_generation/tools/extract_parked_vehicles.py
@@ -103,8 +103,15 @@ def collect_tracks_and_ego(
     from rclpy.serialization import deserialize_message
     from rosidl_runtime_py.utilities import get_message
 
-    ext = rosbag_path.suffix.lower()
-    storage_id = "mcap" if ext == ".mcap" else "sqlite3"
+    bag_path = Path(rosbag_path)
+    metadata = bag_path.parent / "metadata.yaml" if bag_path.is_file() else bag_path / "metadata.yaml"
+    if metadata.exists():
+        with open(metadata) as mf:
+            import re as _re
+            m = _re.search(r"storage_identifier:\s*(\S+)", mf.read())
+            storage_id = m.group(1) if m else "sqlite3"
+    else:
+        storage_id = "mcap" if bag_path.suffix.lower() == ".mcap" else "sqlite3"
 
     reader = rosbag2_py.SequentialReader()
     reader.open(
@@ -399,6 +406,11 @@ def main():
         print(f"Reading {bag} ...")
         tracks, ego_pos = collect_tracks_and_ego(bag, args.topic, args.kinematic_topic)
         print(f"  {len(tracks)} tracks, {len(ego_pos)} ego poses")
+        if ego_pos.ndim != 2 or ego_pos.shape[0] == 0:
+            raise RuntimeError(
+                f"No ego kinematic_state messages in {bag}. "
+                "Ensure the bag contains /localization/kinematic_state."
+            )
         all_ego.append(ego_pos)
         for key, entry in tracks.items():
             dst = merged_tracks[key]

--- a/scenario_generation/tools/extract_parked_vehicles.py
+++ b/scenario_generation/tools/extract_parked_vehicles.py
@@ -1,43 +1,378 @@
 #!/usr/bin/env python3
 """Extract truly-parked vehicles from multiple rosbag splits.
 
-Unlike the single-bag script, this processes ALL bags for a route together
-so that track UUIDs are merged across splits. A vehicle is only considered
-parked if its max speed across ALL observations is below the threshold.
-This filters out cars temporarily stopped at traffic lights — they will
-eventually move in a later split.
+Processes ALL bags for a route together so that track UUIDs are merged
+across splits. A vehicle is only considered parked if its max speed
+across ALL observations is below the threshold. This filters out cars
+temporarily stopped at traffic lights — they will eventually move in a
+later split.
 
-Requires: ROS2 Humble + pilot-auto sourced (for rclpy deserialization).
+Requires: ROS2 Humble + Autoware message types available (source the
+relevant workspace before running).
 
 Usage:
-    bash -c "source /opt/ros/humble/setup.bash && \\
-             source ~/pilot-auto.x2/install/setup.bash && \\
-             python3 -m scenario_generation.tools.extract_parked_vehicles \\
-                 --bags /path/to/bag1.db3 /path/to/bag2.db3 \\
-                 --osm_path /path/to/lanelet2_map.osm \\
-                 --output /path/to/parked.yaml"
+    python3 -m scenario_generation.tools.extract_parked_vehicles \\
+        --bags /path/to/bag1.db3 /path/to/bag2.db3 \\
+        --osm_path /path/to/lanelet2_map.osm \\
+        --output /path/to/parked.yaml
 """
 from __future__ import annotations
 
 import argparse
 import math
-import sys
 from collections import Counter, defaultdict
 from pathlib import Path
 
 import numpy as np
 import yaml
 
-sys.path.insert(0, str(Path.home() / "at-team-tools" / "sakoda"))
-from extract_parked_vehicles_from_rosbag import (
-    VEHICLE_LABELS,
-    collect_tracks_and_ego,
-    merge_overlapping_vehicles,
-    summarize_track,
-    visualize,
-)
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+LABEL_CAR = 1
+LABEL_TRUCK = 2
+LABEL_BUS = 3
+LABEL_TRAILER = 4
+
+VEHICLE_LABELS = {LABEL_CAR, LABEL_TRUCK, LABEL_BUS, LABEL_TRAILER}
+LABEL_TO_NAME = {
+    LABEL_CAR: "car",
+    LABEL_TRUCK: "truck",
+    LABEL_BUS: "bus",
+    LABEL_TRAILER: "trailer",
+}
+NAME_TO_COLOR = {
+    "car": "tab:blue",
+    "truck": "tab:orange",
+    "bus": "tab:red",
+    "trailer": "tab:purple",
+}
 
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _uuid_to_key(uuid_msg) -> str:
+    return bytes(uuid_msg.uuid).hex()
+
+
+def _primary_label(classification_list) -> int:
+    if len(classification_list) == 0:
+        return -1
+    best = max(classification_list, key=lambda c: c.probability)
+    return best.label
+
+
+def _quaternion_to_yaw(q) -> float:
+    siny_cosp = 2.0 * (q.w * q.z + q.x * q.y)
+    cosy_cosp = 1.0 - 2.0 * (q.y * q.y + q.z * q.z)
+    return math.atan2(siny_cosp, cosy_cosp)
+
+
+def _yaw_to_quaternion(yaw: float) -> tuple[float, float, float, float]:
+    return (0.0, 0.0, math.sin(yaw * 0.5), math.cos(yaw * 0.5))
+
+
+def _circular_mean(angles: list[float]) -> float:
+    sin_sum = sum(math.sin(a) for a in angles)
+    cos_sum = sum(math.cos(a) for a in angles)
+    return math.atan2(sin_sum, cos_sum)
+
+
+def _obb_corners(
+    cx: float, cy: float, yaw: float, dx: float, dy: float,
+) -> list[tuple[float, float]]:
+    cos_y = math.cos(yaw)
+    sin_y = math.sin(yaw)
+    hx, hy = dx * 0.5, dy * 0.5
+    corners_local = [(+hx, +hy), (+hx, -hy), (-hx, -hy), (-hx, +hy)]
+    return [
+        (cx + lx * cos_y - ly * sin_y, cy + lx * sin_y + ly * cos_y)
+        for lx, ly in corners_local
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Rosbag reading
+# ---------------------------------------------------------------------------
+def collect_tracks_and_ego(
+    rosbag_path: Path, track_topic: str, kinematic_topic: str,
+) -> tuple[dict, np.ndarray]:
+    """Read a rosbag and return (tracks_by_uuid, ego_positions)."""
+    import rosbag2_py
+    from rclpy.serialization import deserialize_message
+    from rosidl_runtime_py.utilities import get_message
+
+    ext = rosbag_path.suffix.lower()
+    storage_id = "mcap" if ext == ".mcap" else "sqlite3"
+
+    reader = rosbag2_py.SequentialReader()
+    reader.open(
+        rosbag2_py.StorageOptions(uri=str(rosbag_path), storage_id=storage_id),
+        rosbag2_py.ConverterOptions(
+            input_serialization_format="cdr",
+            output_serialization_format="cdr",
+        ),
+    )
+
+    type_map = {t.name: t.type for t in reader.get_all_topics_and_types()}
+    if track_topic not in type_map:
+        raise RuntimeError(f"Topic '{track_topic}' not found in rosbag.")
+    if kinematic_topic not in type_map:
+        raise RuntimeError(f"Topic '{kinematic_topic}' not found in rosbag.")
+
+    track_msg_type = get_message(type_map[track_topic])
+    kinematic_msg_type = get_message(type_map[kinematic_topic])
+
+    tracks: dict[str, dict] = defaultdict(
+        lambda: {
+            "positions": [], "yaws": [], "dims_x": [], "dims_y": [],
+            "dims_z": [], "speeds": [], "labels": [], "shape_types": [],
+        }
+    )
+    ego_positions: list[tuple[float, float]] = []
+
+    while reader.has_next():
+        topic_name, data, _ = reader.read_next()
+        if topic_name == track_topic:
+            msg = deserialize_message(data, track_msg_type)
+            for obj in msg.objects:
+                key = _uuid_to_key(obj.object_id)
+                pose = obj.kinematics.pose_with_covariance.pose
+                twist = obj.kinematics.twist_with_covariance.twist
+                speed = math.hypot(twist.linear.x, twist.linear.y)
+                label = _primary_label(obj.classification)
+                entry = tracks[key]
+                entry["positions"].append(
+                    (pose.position.x, pose.position.y, pose.position.z)
+                )
+                entry["yaws"].append(_quaternion_to_yaw(pose.orientation))
+                entry["dims_x"].append(obj.shape.dimensions.x)
+                entry["dims_y"].append(obj.shape.dimensions.y)
+                entry["dims_z"].append(obj.shape.dimensions.z)
+                entry["speeds"].append(speed)
+                entry["labels"].append(label)
+                entry["shape_types"].append(obj.shape.type)
+        elif topic_name == kinematic_topic:
+            msg = deserialize_message(data, kinematic_msg_type)
+            pos = msg.pose.pose.position
+            ego_positions.append((pos.x, pos.y))
+
+    return tracks, np.array(ego_positions)
+
+
+# ---------------------------------------------------------------------------
+# Track summarisation
+# ---------------------------------------------------------------------------
+def _summarize_track(entry: dict) -> dict:
+    positions = np.array(entry["positions"])
+    label_counter = Counter(entry["labels"])
+    dominant_label, _ = label_counter.most_common(1)[0]
+    shape_counter = Counter(entry["shape_types"])
+    dominant_shape, _ = shape_counter.most_common(1)[0]
+
+    pos_x = float(np.median(positions[:, 0]))
+    pos_y = float(np.median(positions[:, 1]))
+    pos_z = float(np.median(positions[:, 2]))
+
+    yaw = _circular_mean(entry["yaws"])
+    qx, qy, qz, qw = _yaw_to_quaternion(yaw)
+
+    dim_x = float(np.median(entry["dims_x"]))
+    dim_y = float(np.median(entry["dims_y"]))
+    dim_z = float(np.median(entry["dims_z"]))
+
+    return {
+        "classification": LABEL_TO_NAME[dominant_label],
+        "shape_type": int(dominant_shape),
+        "dimensions": {"x": dim_x, "y": dim_y, "z": dim_z},
+        "pose": {
+            "position": {"x": pos_x, "y": pos_y, "z": pos_z},
+            "orientation": {"x": qx, "y": qy, "z": qz, "w": qw},
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# OBB overlap merge (union-find)
+# ---------------------------------------------------------------------------
+def _merge_overlapping_vehicles(parked_vehicles: list) -> list:
+    from shapely.geometry import Polygon
+
+    n = len(parked_vehicles)
+    if n == 0:
+        return []
+
+    polygons, yaws = [], []
+    for v in parked_vehicles:
+        cx = v["pose"]["position"]["x"]
+        cy = v["pose"]["position"]["y"]
+        qz = v["pose"]["orientation"]["z"]
+        qw = v["pose"]["orientation"]["w"]
+        yaw = 2.0 * math.atan2(qz, qw)
+        polygons.append(
+            Polygon(_obb_corners(cx, cy, yaw, v["dimensions"]["x"], v["dimensions"]["y"]))
+        )
+        yaws.append(yaw)
+
+    parent = list(range(n))
+
+    def _root(i):
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
+
+    def _union(i, j):
+        ri, rj = _root(i), _root(j)
+        if ri != rj:
+            parent[ri] = rj
+
+    for i in range(n):
+        for j in range(i + 1, n):
+            if polygons[i].intersects(polygons[j]):
+                _union(i, j)
+
+    groups: dict[int, list[int]] = defaultdict(list)
+    for i in range(n):
+        groups[_root(i)].append(i)
+
+    merged = []
+    for indices in groups.values():
+        if len(indices) == 1:
+            merged.append(parked_vehicles[indices[0]])
+            continue
+
+        group = [parked_vehicles[i] for i in indices]
+        mean_yaw = _circular_mean([yaws[i] for i in indices])
+        cos_my, sin_my = math.cos(-mean_yaw), math.sin(-mean_yaw)
+
+        all_local_x, all_local_y, all_z = [], [], []
+        for v in group:
+            cx = v["pose"]["position"]["x"]
+            cy = v["pose"]["position"]["y"]
+            yaw = 2.0 * math.atan2(v["pose"]["orientation"]["z"],
+                                    v["pose"]["orientation"]["w"])
+            for wx, wy in _obb_corners(cx, cy, yaw,
+                                        v["dimensions"]["x"], v["dimensions"]["y"]):
+                all_local_x.append(wx * cos_my - wy * sin_my)
+                all_local_y.append(wx * sin_my + wy * cos_my)
+            all_z.append(v["pose"]["position"]["z"])
+
+        x_min, x_max = min(all_local_x), max(all_local_x)
+        y_min, y_max = min(all_local_y), max(all_local_y)
+        cx_l = (x_min + x_max) * 0.5
+        cy_l = (y_min + y_max) * 0.5
+        cos_yp, sin_yp = math.cos(mean_yaw), math.sin(mean_yaw)
+        new_cx = cx_l * cos_yp - cy_l * sin_yp
+        new_cy = cx_l * sin_yp + cy_l * cos_yp
+        qx, qy, qz, qw = _yaw_to_quaternion(mean_yaw)
+
+        label_votes: Counter = Counter()
+        for v in group:
+            label_votes[v["classification"]] += v["num_frames"]
+        dominant_class = label_votes.most_common(1)[0][0]
+
+        merged.append({
+            "classification": dominant_class,
+            "shape_type": group[0]["shape_type"],
+            "dimensions": {"x": x_max - x_min, "y": y_max - y_min,
+                           "z": max(v["dimensions"]["z"] for v in group)},
+            "pose": {
+                "position": {"x": new_cx, "y": new_cy,
+                             "z": float(np.mean(all_z))},
+                "orientation": {"x": qx, "y": qy, "z": qz, "w": qw},
+            },
+            "max_speed": max(v["max_speed"] for v in group),
+            "num_frames": sum(v["num_frames"] for v in group),
+            "min_ego_distance": min(v["min_ego_distance"] for v in group),
+            "merged_count": len(group),
+        })
+
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Visualisation
+# ---------------------------------------------------------------------------
+def _visualize(
+    osm_path: Path,
+    parked_vehicles: list,
+    ego_positions: np.ndarray,
+    viz_path: Path,
+) -> None:
+    import lanelet2
+    import matplotlib.patches as mpatches
+    import matplotlib.pyplot as plt
+    from autoware_lanelet2_extension_python.projection import MGRSProjector
+
+    if not parked_vehicles:
+        print("No parked vehicles to visualize.")
+        return
+
+    projection = MGRSProjector(lanelet2.io.Origin(0.0, 0.0))
+    lanelet_map = lanelet2.io.load(str(osm_path), projection)
+
+    xs = np.array([v["pose"]["position"]["x"] for v in parked_vehicles])
+    ys = np.array([v["pose"]["position"]["y"] for v in parked_vehicles])
+    pad = 30.0
+    x_min = min(xs.min(), ego_positions[:, 0].min()) - pad
+    x_max = max(xs.max(), ego_positions[:, 0].max()) + pad
+    y_min = min(ys.min(), ego_positions[:, 1].min()) - pad
+    y_max = max(ys.max(), ego_positions[:, 1].max()) + pad
+
+    fig, ax = plt.subplots(figsize=(20, 20))
+    for ll in lanelet_map.laneletLayer:
+        for bound in (ll.leftBound, ll.rightBound):
+            bxs = [p.x for p in bound]
+            bys = [p.y for p in bound]
+            if any(x_min <= x <= x_max and y_min <= y <= y_max
+                   for x, y in zip(bxs, bys)):
+                ax.plot(bxs, bys, color="gray", linewidth=0.5, alpha=0.7)
+
+    ax.plot(ego_positions[:, 0], ego_positions[:, 1],
+            color="tab:green", linewidth=1.0, alpha=0.6, label="ego trajectory")
+
+    seen_labels: set[str] = set()
+    for v in parked_vehicles:
+        name = v["classification"]
+        color = NAME_TO_COLOR[name]
+        cx = v["pose"]["position"]["x"]
+        cy = v["pose"]["position"]["y"]
+        yaw = 2.0 * math.atan2(v["pose"]["orientation"]["z"],
+                                v["pose"]["orientation"]["w"])
+        corners = _obb_corners(cx, cy, yaw, v["dimensions"]["x"],
+                               v["dimensions"]["y"])
+        label = name if name not in seen_labels else None
+        seen_labels.add(name)
+        edge_color = "red" if "merged_count" in v else "black"
+        lw = 1.2 if "merged_count" in v else 0.5
+        polygon = mpatches.Polygon(
+            corners, closed=True, facecolor=color, edgecolor=edge_color,
+            linewidth=lw, alpha=0.7, label=label,
+        )
+        ax.add_patch(polygon)
+        head_x = cx + v["dimensions"]["x"] * 0.5 * math.cos(yaw)
+        head_y = cy + v["dimensions"]["x"] * 0.5 * math.sin(yaw)
+        ax.plot([cx, head_x], [cy, head_y], color="black", linewidth=0.5)
+
+    ax.set_xlim(x_min, x_max)
+    ax.set_ylim(y_min, y_max)
+    ax.set_aspect("equal")
+    ax.set_xlabel("map x [m]")
+    ax.set_ylabel("map y [m]")
+    ax.set_title(f"Parked vehicles ({len(parked_vehicles)})")
+    ax.legend(loc="upper right")
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    fig.savefig(viz_path, dpi=150)
+    plt.close(fig)
+    print(f"Visualization saved to {viz_path}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
 def main():
     p = argparse.ArgumentParser()
     p.add_argument("--bags", type=Path, nargs="+", required=True,
@@ -91,7 +426,7 @@ def main():
         if dominant_label not in VEHICLE_LABELS:
             excluded_label += 1
             continue
-        summary = summarize_track(entry)
+        summary = _summarize_track(entry)
 
         vx = summary["pose"]["position"]["x"]
         vy = summary["pose"]["position"]["y"]
@@ -113,7 +448,7 @@ def main():
     print(f"  Excluded by ego overlap < {args.ego_overlap_threshold}m: {excluded_ego}")
     print(f"  Parked vehicles (before merge): {len(parked)}")
 
-    merged = merge_overlapping_vehicles(parked)
+    merged = _merge_overlapping_vehicles(parked)
     print(f"  Parked vehicles (after merge): {len(merged)}")
 
     out_data = {"parked_vehicles": merged}
@@ -123,8 +458,8 @@ def main():
     print(f"\nWritten to {args.output}")
 
     if not args.no_viz:
-        visualize(args.osm_path, merged, ego_positions,
-                  args.output.with_suffix(".png"), args.bags[0])
+        _visualize(args.osm_path, merged, ego_positions,
+                   args.output.with_suffix(".png"))
 
 
 if __name__ == "__main__":

--- a/scenario_generation/tools/extract_parked_vehicles.py
+++ b/scenario_generation/tools/extract_parked_vehicles.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Extract truly-parked vehicles from multiple rosbag splits.
+
+Unlike the single-bag script, this processes ALL bags for a route together
+so that track UUIDs are merged across splits. A vehicle is only considered
+parked if its max speed across ALL observations is below the threshold.
+This filters out cars temporarily stopped at traffic lights — they will
+eventually move in a later split.
+
+Requires: ROS2 Humble + pilot-auto sourced (for rclpy deserialization).
+
+Usage:
+    bash -c "source /opt/ros/humble/setup.bash && \\
+             source ~/pilot-auto.x2/install/setup.bash && \\
+             python3 -m scenario_generation.tools.extract_parked_vehicles \\
+                 --bags /path/to/bag1.db3 /path/to/bag2.db3 \\
+                 --osm_path /path/to/lanelet2_map.osm \\
+                 --output /path/to/parked.yaml"
+"""
+from __future__ import annotations
+
+import argparse
+import math
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import numpy as np
+import yaml
+
+sys.path.insert(0, str(Path.home() / "at-team-tools" / "sakoda"))
+from extract_parked_vehicles_from_rosbag import (
+    VEHICLE_LABELS,
+    collect_tracks_and_ego,
+    merge_overlapping_vehicles,
+    summarize_track,
+    visualize,
+)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--bags", type=Path, nargs="+", required=True,
+                   help="All .db3 bag files for this route (order doesn't matter)")
+    p.add_argument("--osm_path", type=Path, required=True)
+    p.add_argument("--output", type=Path, required=True)
+    p.add_argument("--velocity_threshold", type=float, default=0.5)
+    p.add_argument("--min_frames", type=int, default=10)
+    p.add_argument("--ego_overlap_threshold", type=float, default=2.0)
+    p.add_argument("--topic", default="/perception/object_recognition/tracking/objects")
+    p.add_argument("--kinematic_topic", default="/localization/kinematic_state")
+    p.add_argument("--no_viz", action="store_true")
+    args = p.parse_args()
+
+    merged_tracks: dict[str, dict] = defaultdict(
+        lambda: {
+            "positions": [], "yaws": [], "dims_x": [], "dims_y": [],
+            "dims_z": [], "speeds": [], "labels": [], "shape_types": [],
+        }
+    )
+    all_ego: list[np.ndarray] = []
+
+    for bag in args.bags:
+        print(f"Reading {bag} ...")
+        tracks, ego_pos = collect_tracks_and_ego(bag, args.topic, args.kinematic_topic)
+        print(f"  {len(tracks)} tracks, {len(ego_pos)} ego poses")
+        all_ego.append(ego_pos)
+        for key, entry in tracks.items():
+            dst = merged_tracks[key]
+            for field in entry:
+                dst[field].extend(entry[field])
+
+    ego_positions = np.concatenate(all_ego, axis=0)
+    print(f"\nMerged: {len(merged_tracks)} unique track UUIDs, "
+          f"{len(ego_positions)} total ego poses")
+
+    parked = []
+    excluded_speed = 0
+    excluded_ego = 0
+    excluded_label = 0
+    excluded_frames = 0
+    for key, entry in merged_tracks.items():
+        if len(entry["speeds"]) < args.min_frames:
+            excluded_frames += 1
+            continue
+        max_speed = max(entry["speeds"])
+        if max_speed >= args.velocity_threshold:
+            excluded_speed += 1
+            continue
+        dominant_label = Counter(entry["labels"]).most_common(1)[0][0]
+        if dominant_label not in VEHICLE_LABELS:
+            excluded_label += 1
+            continue
+        summary = summarize_track(entry)
+
+        vx = summary["pose"]["position"]["x"]
+        vy = summary["pose"]["position"]["y"]
+        diffs = ego_positions - np.array([vx, vy])
+        ego_dist = float(np.hypot(diffs[:, 0], diffs[:, 1]).min())
+
+        if ego_dist < args.ego_overlap_threshold:
+            excluded_ego += 1
+            continue
+        summary["max_speed"] = float(max_speed)
+        summary["num_frames"] = int(len(entry["speeds"]))
+        summary["min_ego_distance"] = ego_dist
+        parked.append(summary)
+
+    print(f"\nFiltering results:")
+    print(f"  Excluded by speed >= {args.velocity_threshold}: {excluded_speed}")
+    print(f"  Excluded by < {args.min_frames} frames: {excluded_frames}")
+    print(f"  Excluded by non-vehicle label: {excluded_label}")
+    print(f"  Excluded by ego overlap < {args.ego_overlap_threshold}m: {excluded_ego}")
+    print(f"  Parked vehicles (before merge): {len(parked)}")
+
+    merged = merge_overlapping_vehicles(parked)
+    print(f"  Parked vehicles (after merge): {len(merged)}")
+
+    out_data = {"parked_vehicles": merged}
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.output, "w") as f:
+        yaml.dump(out_data, f, default_flow_style=False, sort_keys=False)
+    print(f"\nWritten to {args.output}")
+
+    if not args.no_viz:
+        visualize(args.osm_path, merged, ego_positions,
+                  args.output.with_suffix(".png"), args.bags[0])
+
+
+if __name__ == "__main__":
+    main()

--- a/scenario_generation/tools/heatmap_static_collision.py
+++ b/scenario_generation/tools/heatmap_static_collision.py
@@ -30,7 +30,6 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import json
 import math
 import re
 from pathlib import Path
@@ -99,7 +98,7 @@ def _score_run_ego_actual(
         with np.load(path, allow_pickle=True) as raw:
             data_np = {k: raw[k] for k in raw.files if k != "version"}
 
-        ex, ey, eyaw = recover_ego_world_pose_from_goal(data_np["goal_pose"], route)
+        ex, ey, _ = recover_ego_world_pose_from_goal(data_np["goal_pose"], route)
         s_arc, _, _ = project_to_polyline(np.array([ex, ey]), pts, s)
 
         es = data_np["ego_shape"]

--- a/scenario_generation/tools/heatmap_static_collision.py
+++ b/scenario_generation/tools/heatmap_static_collision.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Static-collision clearance heatmap along a route.
+
+Scores each sim step's model prediction against stopped neighbours via
+``rlvr.reward.compute_static_collision_penalty`` and projects the
+per-step min OBB clearance onto the route arc-length to produce a heatmap.
+
+Supports single-run and two-run (A vs B) comparison modes.
+
+Input: dumped NPZs from ``scenario_generation.replay`` with
+``parked_vehicles_yaml`` or ``static_npc_count`` enabled, plus a model
+checkpoint and reward config.
+
+Usage:
+    python -m scenario_generation.tools.heatmap_static_collision \\
+        --route /path/to/route.pkl \\
+        --run_a /path/to/run_a_dir \\
+        --model_a /path/to/model_a.pth \\
+        --config /path/to/reward_config.json \\
+        --output /path/to/heatmap.png
+
+    # Two-run comparison:
+    python -m scenario_generation.tools.heatmap_static_collision \\
+        --route /path/to/route.pkl \\
+        --run_a /path/to/run_a_dir --model_a /path/to/model_a.pth \\
+        --run_b /path/to/run_b_dir --model_b /path/to/model_b.pth \\
+        --config /path/to/reward_config.json \\
+        --output /path/to/heatmap.png
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+
+from scenario_generation.tools._heatmap_common import (
+    bin_scalar_by_arc,
+    build_route_polyline,
+    load_route,
+    plot_route_heatmap,
+    recover_ego_world_pose_from_goal,
+    segments_from_polyline,
+)
+
+_NPZ_RE = re.compile(r"replay_step_(\d+)\.npz$")
+
+
+def _score_run(
+    run_dir: Path,
+    model_path: Path,
+    route,
+    reward_config_path: Path,
+    pts: np.ndarray,
+    s: np.ndarray,
+    device: str,
+    stride: int = 1,
+    max_steps: int | None = None,
+    inference_delay: int = 0,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Score a run. Returns (arc_positions (M,), min_clearance (M,))."""
+    from rlvr.autoresearch.tools.audit_static_collision import (
+        _score_prediction,
+        _synthesize_stopped_futures,
+    )
+    from rlvr.autoresearch.tools.reward_config_from_json import load_reward_config
+    from scenario_generation.npz_loader import from_npz
+    from scenario_generation.simulate import _predict_batch, load_model
+    from scenario_generation.tools._heatmap_common import project_to_polyline
+
+    reward_cfg = load_reward_config(str(reward_config_path))
+    if not reward_cfg.static_collision_enabled:
+        raise SystemExit(
+            f"reward config {reward_config_path} has static_collision_enabled=false. "
+            "Set it to true."
+        )
+
+    npz_dir = run_dir / "npz"
+    if not npz_dir.exists():
+        npz_dir = run_dir
+    npz_paths = sorted(
+        p for p in npz_dir.glob("*.npz")
+        if _NPZ_RE.search(p.name)
+    )
+    if stride > 1:
+        npz_paths = npz_paths[::stride]
+    if max_steps:
+        npz_paths = npz_paths[:max_steps]
+    if not npz_paths:
+        raise SystemExit(f"No replay_step_*.npz under {npz_dir}")
+    print(f"  {len(npz_paths)} steps to score")
+
+    model, model_args = load_model(str(model_path), device)
+
+    arc_positions = []
+    min_clearances = []
+
+    for i, path in enumerate(npz_paths):
+        with np.load(path, allow_pickle=True) as raw:
+            data_np = {k: raw[k] for k in raw.files if k != "version"}
+
+        ex, ey, eyaw = recover_ego_world_pose_from_goal(data_np["goal_pose"], route)
+
+        scene = from_npz(str(path))
+        preds = _predict_batch(
+            model, model_args, scene, [scene.ego_agent_id], device,
+            inference_delay=inference_delay,
+        )
+        ego_pred = preds.get(scene.ego_agent_id)
+        if ego_pred is None:
+            continue
+
+        result = _score_prediction(data_np, ego_pred, reward_cfg, device)
+
+        s_arc, _, _ = project_to_polyline(np.array([ex, ey]), pts, s)
+        arc_positions.append(s_arc)
+        min_clearances.append(result["sc_min_dist"])
+
+        if (i + 1) % 100 == 0:
+            print(f"    scored {i+1}/{len(npz_paths)}")
+
+    return np.array(arc_positions), np.array(min_clearances)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--route", type=Path, required=True)
+    p.add_argument("--run_a", type=Path, required=True)
+    p.add_argument("--model_a", type=Path, required=True)
+    p.add_argument("--run_b", type=Path, default=None)
+    p.add_argument("--model_b", type=Path, default=None)
+    p.add_argument("--config", type=Path, required=True,
+                   help="Reward config JSON (must have static_collision_enabled=true)")
+    p.add_argument("--label_a", default="A")
+    p.add_argument("--label_b", default="B")
+    p.add_argument("--output", type=Path, required=True)
+    p.add_argument("--bin_m", type=float, default=5.0)
+    p.add_argument("--stride", type=int, default=1)
+    p.add_argument("--max_steps", type=int, default=None)
+    p.add_argument("--clip_max_m", type=float, default=5.0,
+                   help="Clamp color scale at this clearance (m). Default 5.")
+    p.add_argument("--min_arc_m", type=float, default=None)
+    p.add_argument("--max_arc_m", type=float, default=None)
+    p.add_argument("--inference_delay", type=int, default=0)
+    args = p.parse_args()
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    print(f"Loading route {args.route}")
+    route = load_route(args.route)
+    pts, s = build_route_polyline(route)
+    s_max = float(s[-1])
+    print(f"Route polyline: {len(pts)} pts, arc length {s_max:.1f} m")
+
+    print(f"[{args.label_a}] scoring {args.run_a}")
+    arc_a, clr_a = _score_run(
+        args.run_a, args.model_a, route, args.config,
+        pts, s, device, args.stride, args.max_steps, args.inference_delay,
+    )
+    print(f"  {len(arc_a)} scored steps, clearance min={clr_a.min():.3f} "
+          f"mean={clr_a.mean():.3f} p5={np.percentile(clr_a, 5):.3f}")
+
+    has_b = args.run_b is not None and args.model_b is not None
+    if has_b:
+        print(f"[{args.label_b}] scoring {args.run_b}")
+        arc_b, clr_b = _score_run(
+            args.run_b, args.model_b, route, args.config,
+            pts, s, device, args.stride, args.max_steps, args.inference_delay,
+        )
+        print(f"  {len(arc_b)} scored steps, clearance min={clr_b.min():.3f} "
+              f"mean={clr_b.mean():.3f} p5={np.percentile(clr_b, 5):.3f}")
+
+    if args.min_arc_m is not None:
+        mask_a = arc_a >= args.min_arc_m
+        arc_a, clr_a = arc_a[mask_a], clr_a[mask_a]
+        if has_b:
+            mask_b = arc_b >= args.min_arc_m
+            arc_b, clr_b = arc_b[mask_b], clr_b[mask_b]
+
+    if args.max_arc_m is not None:
+        mask_a = arc_a <= args.max_arc_m
+        arc_a, clr_a = arc_a[mask_a], clr_a[mask_a]
+        s_max = min(s_max, args.max_arc_m)
+        if has_b:
+            mask_b = arc_b <= args.max_arc_m
+            arc_b, clr_b = arc_b[mask_b], clr_b[mask_b]
+
+    bin_m = args.bin_m
+    bs_mid_a, mean_a, min_a = bin_scalar_by_arc(arc_a, clr_a, s_max, bin_m)
+    n_bins = len(bs_mid_a)
+    bin_segments = segments_from_polyline(pts, s, bin_m, n_bins)
+
+    vmax = args.clip_max_m
+
+    if has_b:
+        bs_mid_b, mean_b, min_b = bin_scalar_by_arc(arc_b, clr_b, s_max, bin_m)
+
+        diff = mean_a - mean_b
+        diff_abs = float(np.nanmax(np.abs(diff))) if np.any(~np.isnan(diff)) else 1.0
+        diff_abs = max(diff_abs, 0.1)
+
+        fig = plt.figure(figsize=(22, 12))
+        gs = fig.add_gridspec(2, 3, height_ratios=[1.8, 1.0],
+                              width_ratios=[1, 1, 1], hspace=0.25, wspace=0.15)
+        ax_a = fig.add_subplot(gs[0, 0])
+        ax_b = fig.add_subplot(gs[0, 1], sharex=ax_a, sharey=ax_a)
+        ax_d = fig.add_subplot(gs[0, 2], sharex=ax_a, sharey=ax_a)
+        ax_line = fig.add_subplot(gs[1, :])
+
+        plot_route_heatmap(ax_a, pts, bin_segments, mean_a,
+                           f"{args.label_a}: mean clearance (m)", 0.0, vmax, "RdYlGn")
+        plot_route_heatmap(ax_b, pts, bin_segments, mean_b,
+                           f"{args.label_b}: mean clearance (m)", 0.0, vmax, "RdYlGn")
+        plot_route_heatmap(ax_d, pts, bin_segments, diff,
+                           f"A − B  (red = A closer, blue = B closer)",
+                           -diff_abs, diff_abs, "RdBu")
+
+        for ax, vmin_, vmax_, cm in [
+            (ax_a, 0.0, vmax, "RdYlGn"),
+            (ax_b, 0.0, vmax, "RdYlGn"),
+            (ax_d, -diff_abs, diff_abs, "RdBu"),
+        ]:
+            sm = plt.cm.ScalarMappable(cmap=cm, norm=plt.Normalize(vmin=vmin_, vmax=vmax_))
+            sm.set_array([])
+            cb = plt.colorbar(sm, ax=ax, pad=0.02, fraction=0.04, aspect=30)
+            cb.ax.tick_params(labelsize=8)
+            cb.set_label("m", fontsize=8)
+
+        ax_line.plot(bs_mid_a, mean_a, label=f"{args.label_a} mean clr", color="C0", lw=1.4)
+        ax_line.plot(bs_mid_b, mean_b, label=f"{args.label_b} mean clr", color="C1", lw=1.4)
+        ax_line.plot(bs_mid_a, min_a, label=f"{args.label_a} min clr", color="C0", lw=0.8, alpha=0.5)
+        ax_line.plot(bs_mid_b, min_b, label=f"{args.label_b} min clr", color="C1", lw=0.8, alpha=0.5)
+        ax_line.axhline(0.2, color="#cc0000", lw=0.5, ls="--", label="cross (0.2m)")
+        ax_line.axhline(0.4, color="#ff8800", lw=0.5, ls="--", label="near (0.4m)")
+        ax_line.set_xlabel("Route arc length (m)")
+        ax_line.set_ylabel("Min OBB clearance to stopped neighbor (m)")
+        ax_line.legend(fontsize=8, ncol=3)
+        ax_line.grid(alpha=0.3)
+
+        fig.suptitle(
+            f"Static collision clearance: {args.label_a} vs {args.label_b}  "
+            f"({len(arc_a)} / {len(arc_b)} steps, route {s_max:.0f} m)",
+            fontsize=11,
+        )
+    else:
+        fig = plt.figure(figsize=(18, 8))
+        gs = fig.add_gridspec(2, 1, height_ratios=[1.5, 1.0], hspace=0.25)
+        ax_map = fig.add_subplot(gs[0])
+        ax_line = fig.add_subplot(gs[1])
+
+        plot_route_heatmap(ax_map, pts, bin_segments, mean_a,
+                           f"{args.label_a}: mean clearance (m)", 0.0, vmax, "RdYlGn")
+        sm = plt.cm.ScalarMappable(cmap="RdYlGn", norm=plt.Normalize(vmin=0.0, vmax=vmax))
+        sm.set_array([])
+        cb = plt.colorbar(sm, ax=ax_map, pad=0.02, fraction=0.04, aspect=30)
+        cb.ax.tick_params(labelsize=8)
+        cb.set_label("m", fontsize=8)
+
+        ax_line.plot(bs_mid_a, mean_a, label="mean clr", color="C0", lw=1.4)
+        ax_line.plot(bs_mid_a, min_a, label="min clr", color="C0", lw=0.8, alpha=0.5)
+        ax_line.axhline(0.2, color="#cc0000", lw=0.5, ls="--", label="cross (0.2m)")
+        ax_line.axhline(0.4, color="#ff8800", lw=0.5, ls="--", label="near (0.4m)")
+        ax_line.set_xlabel("Route arc length (m)")
+        ax_line.set_ylabel("Min OBB clearance to stopped neighbor (m)")
+        ax_line.legend(fontsize=8)
+        ax_line.grid(alpha=0.3)
+
+        fig.suptitle(
+            f"Static collision clearance: {args.label_a}  "
+            f"({len(arc_a)} steps, route {s_max:.0f} m)",
+            fontsize=11,
+        )
+
+    fig.tight_layout(rect=(0, 0, 1, 0.97))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(args.output, dpi=140, bbox_inches="tight")
+    print(f"Saved {args.output}")
+
+    np.savez(
+        args.output.with_suffix(".npz"),
+        arc_a=arc_a, clr_a=clr_a,
+        **({"arc_b": arc_b, "clr_b": clr_b} if has_b else {}),
+        route_pts=pts, route_s=s,
+        bin_m=bin_m, bin_s_mid=bs_mid_a,
+        mean_a=mean_a, min_a=min_a,
+        **({"mean_b": mean_b, "min_b": min_b} if has_b else {}),
+    )
+    print(f"Saved {args.output.with_suffix('.npz')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scenario_generation/tools/heatmap_static_collision.py
+++ b/scenario_generation/tools/heatmap_static_collision.py
@@ -120,18 +120,25 @@ def _score_run_ego_actual(
         nb_xy = nb_last[valid, :2]
         nb_cos = nb_last[valid, 2]
         nb_sin = nb_last[valid, 3]
-        nb_w = nb_last[valid, 6] if nb_last.shape[-1] > 6 else np.full(valid.sum(), 2.0)
-        nb_l = nb_last[valid, 7] if nb_last.shape[-1] > 7 else np.full(valid.sum(), 4.5)
+        if nb_last.shape[-1] < 8:
+            raise ValueError(
+                f"neighbor_agents_past has {nb_last.shape[-1]} columns, "
+                "expected >= 8 (x, y, cos, sin, vx, vy, width, length)"
+            )
+        nb_w = nb_last[valid, 6]
+        nb_l = nb_last[valid, 7]
 
-        # Ego at origin in ego frame, heading = 0 (forward along x)
         ego_corners = _build_obb_corners(0.0, 0.0, 1.0, 0.0, ego_len, ego_w, wb)
 
         best_d = 99.0
         for j in range(len(nb_xy)):
             nx, ny = float(nb_xy[j, 0]), float(nb_xy[j, 1])
             nc, ns_ = float(nb_cos[j]), float(nb_sin[j])
-            nw = float(nb_w[j]) if nb_w[j] > 0.1 else 2.0
-            nl = float(nb_l[j]) if nb_l[j] > 0.1 else 4.5
+            nw, nl = float(nb_w[j]), float(nb_l[j])
+            if nw < 0.1 or nl < 0.1:
+                raise ValueError(
+                    f"Neighbor {j} has invalid dimensions (w={nw}, l={nl})"
+                )
             npc_corners = _build_obb_corners(nx, ny, nc, ns_, nl, nw, nl * 0.65)
 
             pt1, pt2 = _closest_points_between_rects(ego_corners, npc_corners)

--- a/scenario_generation/tools/heatmap_static_collision.py
+++ b/scenario_generation/tools/heatmap_static_collision.py
@@ -169,7 +169,6 @@ def _score_run(
     """Score a run. Returns (arc_positions (M,), min_clearance (M,))."""
     from rlvr.autoresearch.tools.audit_static_collision import (
         _score_prediction,
-        _synthesize_stopped_futures,
     )
     from rlvr.autoresearch.tools.reward_config_from_json import load_reward_config
     from scenario_generation.npz_loader import from_npz

--- a/scenario_generation/tools/heatmap_static_collision.py
+++ b/scenario_generation/tools/heatmap_static_collision.py
@@ -54,6 +54,106 @@ from scenario_generation.tools._heatmap_common import (
 _NPZ_RE = re.compile(r"replay_step_(\d+)\.npz$")
 
 
+def _score_run_ego_actual(
+    run_dir: Path,
+    route,
+    pts: np.ndarray,
+    s: np.ndarray,
+    stride: int = 1,
+    max_steps: int | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Score based on actual ego pose vs parked neighbors. No model needed."""
+    from diffusion_planner.model.guidance.collision import batch_signed_distance_rect
+
+    from rlvr.reward import _closest_points_between_rects
+    from scenario_generation.tools._heatmap_common import project_to_polyline
+
+    def _build_obb_corners(cx, cy, cos_h, sin_h, length, width, wheelbase):
+        """Build (1, 4, 2) OBB corners from center pose + dims."""
+        rear_overhang = (length - wheelbase) / 2.0
+        x0, x1 = -rear_overhang, length - rear_overhang
+        y0, y1 = -width / 2.0, width / 2.0
+        local = torch.tensor([[x0, y0], [x0, y1], [x1, y1], [x1, y0]], dtype=torch.float32)
+        R = torch.tensor([[cos_h, -sin_h], [sin_h, cos_h]], dtype=torch.float32)
+        world = (R @ local.T).T + torch.tensor([cx, cy], dtype=torch.float32)
+        return world.unsqueeze(0)
+
+    npz_dir = run_dir / "npz"
+    if not npz_dir.exists():
+        npz_dir = run_dir
+    npz_paths = sorted(
+        p for p in npz_dir.glob("*.npz") if _NPZ_RE.search(p.name)
+    )
+    if stride > 1:
+        npz_paths = npz_paths[::stride]
+    if max_steps:
+        npz_paths = npz_paths[:max_steps]
+    if not npz_paths:
+        raise SystemExit(f"No replay_step_*.npz under {npz_dir}")
+    print(f"  {len(npz_paths)} steps to score (ego actual)")
+
+    arc_positions = []
+    min_clearances = []
+
+    for i, path in enumerate(npz_paths):
+        with np.load(path, allow_pickle=True) as raw:
+            data_np = {k: raw[k] for k in raw.files if k != "version"}
+
+        ex, ey, eyaw = recover_ego_world_pose_from_goal(data_np["goal_pose"], route)
+        s_arc, _, _ = project_to_polyline(np.array([ex, ey]), pts, s)
+
+        es = data_np["ego_shape"]
+        if es.ndim == 2:
+            es = es[0]
+        wb, ego_len, ego_w = float(es[0]), float(es[1]), float(es[2])
+
+        nb_past = data_np["neighbor_agents_past"]
+        if nb_past.ndim == 3:
+            nb_last = nb_past[:, -1, :]
+        else:
+            nb_last = nb_past[0, :, -1, :]
+        valid = np.abs(nb_last[:, :2]).sum(axis=-1) > 1e-6
+        if not valid.any():
+            arc_positions.append(s_arc)
+            min_clearances.append(99.0)
+            continue
+
+        nb_xy = nb_last[valid, :2]
+        nb_cos = nb_last[valid, 2]
+        nb_sin = nb_last[valid, 3]
+        nb_w = nb_last[valid, 6] if nb_last.shape[-1] > 6 else np.full(valid.sum(), 2.0)
+        nb_l = nb_last[valid, 7] if nb_last.shape[-1] > 7 else np.full(valid.sum(), 4.5)
+
+        # Ego at origin in ego frame, heading = 0 (forward along x)
+        ego_corners = _build_obb_corners(0.0, 0.0, 1.0, 0.0, ego_len, ego_w, wb)
+
+        best_d = 99.0
+        for j in range(len(nb_xy)):
+            nx, ny = float(nb_xy[j, 0]), float(nb_xy[j, 1])
+            nc, ns_ = float(nb_cos[j]), float(nb_sin[j])
+            nw = float(nb_w[j]) if nb_w[j] > 0.1 else 2.0
+            nl = float(nb_l[j]) if nb_l[j] > 0.1 else 4.5
+            npc_corners = _build_obb_corners(nx, ny, nc, ns_, nl, nw, nl * 0.65)
+
+            pt1, pt2 = _closest_points_between_rects(ego_corners, npc_corners)
+            d_val = float(torch.norm(pt1[0] - pt2[0]))
+
+            sd = batch_signed_distance_rect(ego_corners, npc_corners)
+            if float(sd[0]) < 0:
+                d_val = float(sd[0])
+
+            if d_val < best_d:
+                best_d = d_val
+
+        arc_positions.append(s_arc)
+        min_clearances.append(best_d)
+
+        if (i + 1) % 200 == 0:
+            print(f"    scored {i+1}/{len(npz_paths)}")
+
+    return np.array(arc_positions), np.array(min_clearances)
+
+
 def _score_run(
     run_dir: Path,
     model_path: Path,
@@ -134,11 +234,14 @@ def main():
     p = argparse.ArgumentParser()
     p.add_argument("--route", type=Path, required=True)
     p.add_argument("--run_a", type=Path, required=True)
-    p.add_argument("--model_a", type=Path, required=True)
+    p.add_argument("--model_a", type=Path, default=None)
     p.add_argument("--run_b", type=Path, default=None)
     p.add_argument("--model_b", type=Path, default=None)
-    p.add_argument("--config", type=Path, required=True,
-                   help="Reward config JSON (must have static_collision_enabled=true)")
+    p.add_argument("--config", type=Path, default=None,
+                   help="Reward config JSON (required for --mode predicted)")
+    p.add_argument("--mode", choices=["predicted", "ego_actual"], default="ego_actual",
+                   help="'ego_actual' scores the real ego pose at each step (no model). "
+                        "'predicted' scores the model's 80-step prediction (needs --model_a/b + --config).")
     p.add_argument("--label_a", default="A")
     p.add_argument("--label_b", default="B")
     p.add_argument("--output", type=Path, required=True)
@@ -160,21 +263,37 @@ def main():
     s_max = float(s[-1])
     print(f"Route polyline: {len(pts)} pts, arc length {s_max:.1f} m")
 
-    print(f"[{args.label_a}] scoring {args.run_a}")
-    arc_a, clr_a = _score_run(
-        args.run_a, args.model_a, route, args.config,
-        pts, s, device, args.stride, args.max_steps, args.inference_delay,
-    )
+    if args.mode == "predicted":
+        if args.model_a is None or args.config is None:
+            raise SystemExit("--mode predicted requires --model_a and --config")
+
+    print(f"[{args.label_a}] scoring {args.run_a} (mode={args.mode})")
+    if args.mode == "ego_actual":
+        arc_a, clr_a = _score_run_ego_actual(
+            args.run_a, route, pts, s, args.stride, args.max_steps,
+        )
+    else:
+        arc_a, clr_a = _score_run(
+            args.run_a, args.model_a, route, args.config,
+            pts, s, device, args.stride, args.max_steps, args.inference_delay,
+        )
     print(f"  {len(arc_a)} scored steps, clearance min={clr_a.min():.3f} "
           f"mean={clr_a.mean():.3f} p5={np.percentile(clr_a, 5):.3f}")
 
-    has_b = args.run_b is not None and args.model_b is not None
+    has_b = args.run_b is not None
     if has_b:
-        print(f"[{args.label_b}] scoring {args.run_b}")
-        arc_b, clr_b = _score_run(
-            args.run_b, args.model_b, route, args.config,
-            pts, s, device, args.stride, args.max_steps, args.inference_delay,
-        )
+        print(f"[{args.label_b}] scoring {args.run_b} (mode={args.mode})")
+        if args.mode == "ego_actual":
+            arc_b, clr_b = _score_run_ego_actual(
+                args.run_b, route, pts, s, args.stride, args.max_steps,
+            )
+        else:
+            if args.model_b is None:
+                raise SystemExit("--mode predicted with --run_b requires --model_b")
+            arc_b, clr_b = _score_run(
+                args.run_b, args.model_b, route, args.config,
+                pts, s, device, args.stride, args.max_steps, args.inference_delay,
+            )
         print(f"  {len(arc_b)} scored steps, clearance min={clr_b.min():.3f} "
               f"mean={clr_b.mean():.3f} p5={np.percentile(clr_b, 5):.3f}")
 


### PR DESCRIPTION
## Summary
- Add `SpawnConfig.parked_vehicles_yaml` to inject real parked vehicles (extracted from rosbags) as static NPCs at their world-frame positions
- Distance-gated visibility: parked vehicles appear/disappear based on ego proximity (125m default, per-vehicle radius supported), mimicking perception range
- New multi-bag extraction tool that merges tracker UUIDs across bag splits — vehicles that eventually move (e.g. stopped at traffic lights) are correctly excluded
- New static collision clearance heatmap tool with `ego_actual` mode (scores real ego pose, no model inference) and `predicted` mode (scores 80-step model prediction)
- Fixed per-step PNG rendering: `MultipleLocator(20m)` ticks + fixed margins replace `tight_layout`, eliminating grid jitter in videos

## Test plan
- [x] Extracted 158 (M2T) and 102 (T2M) parked vehicles from 8 filtered bag splits per route
- [x] Verified UUID merge correctly excludes traffic-stopped vehicles (734 excluded on M2T, 729 on T2M)
- [x] Verified visibility gating: 16-21 visible neighbors per step (vs 160 without gating)
- [x] Ran perfect-tracker sim on both routes with baseline and champion models
- [x] Ego-actual heatmaps confirm no collisions for either model on either route
- [x] Fixed-grid rendering verified stable across frames
