### PR TITLE
fix(scenario_generation): compute lanelet centerlines from bounds

### DIFF
--- a/scenario_generation/gui/lanelet_scene_builder.py
+++ b/scenario_generation/gui/lanelet_scene_builder.py
@@ -326,7 +326,7 @@ class LaneletSceneBuilder:
             # (it shortcuts instead of following the loop). The C++
             # centerline3d() handles this correctly; resampling + midpoint
             # replicates that behaviour.
-            n_cl = max(len(raw_lb), len(raw_rb))
+            n_cl = min(max(len(raw_lb), len(raw_rb)), 50)
             raw_cl = ((_interpolate_lane(raw_lb, n_cl)
                        + _interpolate_lane(raw_rb, n_cl)) * 0.5).astype(np.float32)
 

--- a/scenario_generation/gui/lanelet_scene_builder.py
+++ b/scenario_generation/gui/lanelet_scene_builder.py
@@ -314,12 +314,21 @@ class LaneletSceneBuilder:
 
         for ll in self._lanelet_map.laneletLayer:
             subtype = ll.attributes["subtype"] if "subtype" in ll.attributes else ""
-            raw_cl = np.array([(p.x, p.y) for p in ll.centerline], dtype=np.float32)
             raw_lb = np.array([(p.x, p.y) for p in ll.leftBound], dtype=np.float32)
             raw_rb = np.array([(p.x, p.y) for p in ll.rightBound], dtype=np.float32)
 
-            if len(raw_cl) < 2:
+            if len(raw_lb) < 2 or len(raw_rb) < 2:
                 continue
+
+            # Compute centerline as midpoint of arc-length-resampled bounds.
+            # The lanelet2 Python binding's ll.centerline produces broken
+            # geometry for U-turn lanelets with asymmetric left/right bounds
+            # (it shortcuts instead of following the loop). The C++
+            # centerline3d() handles this correctly; resampling + midpoint
+            # replicates that behaviour.
+            n_cl = max(len(raw_lb), len(raw_rb))
+            raw_cl = ((_interpolate_lane(raw_lb, n_cl)
+                       + _interpolate_lane(raw_rb, n_cl)) * 0.5).astype(np.float32)
 
             self._ll_by_id[ll.id] = ll
 


### PR DESCRIPTION
## Summary

- The lanelet2 Python binding's `ll.centerline` produces broken geometry for lanelets with asymmetric left/right bounds (U-turn / turnaround areas). It shortcuts across the loop instead of following it, dropping the entire bottom half of the centerline.
- The C++ `centerline3d()` handles this correctly by interpolating between left and right bounds.
- Compute centerlines as midpoint of arc-length-resampled left/right bounds, matching the C++ behaviour. This fixes `route_lanes` context in replay sims where the model was seeing truncated route centerlines near turnaround areas.

Resolves T4DEV-53332.

## Test plan

- [x] All existing scenario_generation tests pass (26/26, 1 pre-existing failure unrelated)
- [x] Verified lanelet 179280 centerline now reaches y=42421 (4.4m from goal) vs y=42432 before (15.3m from goal), matching C++ debug/route_marker output from psim
- [x] Full perfect-tracker replay on teleport-to-miraikan route completes with correct route centerline through turnaround area


Before-After comparison: 
<img width="2868" height="1431" alt="before_after_comparison" src="https://github.com/user-attachments/assets/0d6321c8-58b8-438b-b279-bcd4aab8d056" />

