### PR TITLE
feat(rlvr): det-only avoidance eval + dual-model comparison tools

### DIFF
--- a/rlvr/autoresearch/tools/eval_det_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_det_avoidance.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Deterministic-only avoidance eval: score det trajectory on static-collision scenes.
+
+Single forward pass per scene (noise=0, no guidance). Reports per-scene
+metrics and aggregate distribution stats (mean, p5, p25, p50, p75, p95,
+min, max) for sc_min_dist, rb_min_dist, and safety flags.
+
+Usage:
+    python -m rlvr.autoresearch.tools.eval_det_avoidance \
+        --model_path <model.pth> \
+        --scenes <scenes.json> \
+        --config <reward_config.json> \
+        --ego_shape WB,L,W \
+        --output_dir <dir>
+
+Outputs:
+    <output_dir>/det_avoidance_summary.json   per-scene + aggregate stats
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from preference_optimization.utils import load_npz_data
+from rlvr.autoresearch.tools.reward_config_from_json import load_reward_config
+from rlvr.reward import compute_reward_batch
+
+
+def load_model(model_path: str, device: torch.device):
+    from diffusion_planner.model.diffusion_planner import Diffusion_Planner
+    from diffusion_planner.utils.config import Config
+
+    model_dir = Path(model_path).parent
+    args_path = model_dir / "args.json"
+    if not args_path.exists():
+        args_path = model_dir.parent / "args.json"
+    model_args = Config(str(args_path))
+    model = Diffusion_Planner(model_args)
+    ckpt = torch.load(model_path, map_location=device, weights_only=False)
+    state = ckpt.get("model", ckpt)
+    state = {k.replace("module.", ""): v for k, v in state.items()}
+    model.load_state_dict(state)
+    model.to(device).eval()
+    return model, model_args
+
+
+@torch.no_grad()
+def det_inference_batched(
+    model, model_args, datas: list[dict], device: torch.device,
+    norm_batch: dict | None = None,
+) -> torch.Tensor:
+    """Run deterministic inference (noise=0) on a batch of scenes.
+
+    Args:
+        model: Diffusion_Planner model.
+        model_args: Model config.
+        datas: List of per-scene dicts from load_npz_data.
+        device: Torch device.
+        norm_batch: Pre-computed normalized batch (skip stacking if provided).
+
+    Returns (B, T, 4) tensor of ego trajectories.
+    """
+    from rlvr.grpo_trainer_batched import _normalize_batch, _stack_scene_data
+
+    if norm_batch is None:
+        batch = _stack_scene_data(datas, device)
+        norm_batch = _normalize_batch(batch, model_args)
+
+    decoder = model.module.decoder if hasattr(model, "module") else model.decoder
+    saved_fn = decoder._guidance_fn
+    decoder._guidance_fn = None
+    try:
+        P = 1 + model_args.predicted_neighbor_num
+        future_len = model_args.future_len
+        norm_batch_d = {k: v for k, v in norm_batch.items()}
+        norm_batch_d["sampled_trajectories"] = torch.zeros(
+            len(datas), P, future_len + 1, 4, device=device,
+        )
+        _, det_out = model(norm_batch_d)
+        return det_out["prediction"][:, 0].detach()  # (B, T, 4)
+    finally:
+        decoder._guidance_fn = saved_fn
+
+
+def reward_breakdown_to_det_dict(r) -> dict:
+    """Extract deterministic scoring fields from a RewardBreakdown."""
+    return {
+        "det_cl": float(r.centerline),
+        "det_total": float(r.total),
+        "det_sc_min_dist": float(getattr(r, "sc_min_dist", 99.0)),
+        "det_rb_min_dist": float(getattr(r, "rb_min_dist", 99.0)),
+        "det_rb_cross": bool(getattr(r, "rb_crossing", False)),
+        "det_lane_cross": bool(getattr(r, "lane_crossing", False)),
+        "det_kin_violated": bool(getattr(r, "kinematic_violated", False)),
+        "det_static_crossing": bool(getattr(r, "static_crossing", False)),
+        "det_sc_n_stopped": int(getattr(r, "sc_n_stopped", 0)),
+    }
+
+
+def score_det_scenes(
+    model, model_args, scene_paths: list[str], rcfg, ego_shape: np.ndarray,
+    device: torch.device, batch_size: int = 32,
+) -> list[dict]:
+    """Run det inference + reward scoring on all scenes. Returns per-scene dicts."""
+    results = []
+
+    for start in range(0, len(scene_paths), batch_size):
+        batch_paths = scene_paths[start : start + batch_size]
+        datas = []
+        valid_paths = []
+
+        for p in batch_paths:
+            try:
+                raw_keys = set(np.load(p, allow_pickle=True).keys())
+                if "ego_shape" not in raw_keys:
+                    print(f"  [skip] {Path(p).name}: missing ego_shape")
+                    continue
+                d = load_npz_data(p, device)
+                es = d["ego_shape"].cpu().numpy().reshape(-1)[:3]
+                if not np.allclose(es, ego_shape, atol=1e-2):
+                    print(
+                        f"  [skip] {Path(p).name}: ego_shape={es.tolist()} "
+                        f"vs --ego_shape={ego_shape.tolist()}"
+                    )
+                    continue
+                datas.append(d)
+                valid_paths.append(p)
+            except Exception as e:  # noqa: BLE001
+                print(f"  [skip] {Path(p).name}: {e}")
+
+        if not datas:
+            continue
+
+        det_trajs = det_inference_batched(model, model_args, datas, device)
+
+        for bi, p in enumerate(valid_paths):
+            traj_1T4 = det_trajs[bi : bi + 1]
+            r = compute_reward_batch(traj_1T4, datas[bi], rcfg)[0]
+            results.append({
+                "scene": Path(p).name,
+                "scene_path": str(p),
+                "sc_min_dist": float(getattr(r, "sc_min_dist", 99.0)),
+                "rb_min_dist": float(getattr(r, "rb_min_dist", 99.0)),
+                "cl": float(r.centerline),
+                "total": float(r.total),
+                "static_crossing": bool(r.static_crossing),
+                "rb_cross": bool(r.rb_crossing),
+                "lane_cross": bool(r.lane_crossing),
+                "kin_violated": bool(r.kinematic_violated),
+                "sc_n_stopped": int(getattr(r, "sc_n_stopped", 0)),
+            })
+            flag = "COL" if r.static_crossing else "   "
+            print(
+                f"  [{start + bi:3d}] {flag}  "
+                f"sc={float(getattr(r, 'sc_min_dist', 99.0)):+.3f}m  "
+                f"rb={float(getattr(r, 'rb_min_dist', 99.0)):.3f}m  "
+                f"{Path(p).name}"
+            )
+
+    return results
+
+
+def aggregate_stats(results: list[dict]) -> dict:
+    """Compute distribution stats over per-scene metrics."""
+    n = len(results)
+    if n == 0:
+        return {}
+
+    def _dist(vals):
+        a = np.array(vals)
+        return {
+            "mean": float(a.mean()),
+            "p5": float(np.percentile(a, 5)),
+            "p25": float(np.percentile(a, 25)),
+            "p50": float(np.median(a)),
+            "p75": float(np.percentile(a, 75)),
+            "p95": float(np.percentile(a, 95)),
+            "min": float(a.min()),
+            "max": float(a.max()),
+        }
+
+    return {
+        "n_scenes": n,
+        "static_crossings": sum(r["static_crossing"] for r in results),
+        "rb_crossings": sum(r["rb_cross"] for r in results),
+        "lane_crossings": sum(r["lane_cross"] for r in results),
+        "kin_violated": sum(r["kin_violated"] for r in results),
+        "sc_min_dist": _dist([r["sc_min_dist"] for r in results]),
+        "rb_min_dist": _dist([r["rb_min_dist"] for r in results]),
+        "cl": _dist([r["cl"] for r in results]),
+        "total": _dist([r["total"] for r in results]),
+    }
+
+
+def print_avoidance_summary(agg: dict) -> None:
+    """Print avoidance-focused summary (sc_min_dist only)."""
+    n = agg["n_scenes"]
+    d = agg["sc_min_dist"]
+    print(f"\n{'=' * 65}")
+    print(f"  Avoidance Eval — {n} scenes")
+    print(f"{'=' * 65}")
+    print(f"  Static crossings:  {agg['static_crossings']}/{n}")
+    print()
+    print(
+        f"  sc_min_dist  "
+        f"mean={d['mean']:+.3f}  "
+        f"p5={d['p5']:+.3f}  "
+        f"p25={d['p25']:+.3f}  "
+        f"p50={d['p50']:+.3f}  "
+        f"p75={d['p75']:+.3f}  "
+        f"p95={d['p95']:+.3f}  "
+        f"min={d['min']:+.3f}  "
+        f"max={d['max']:+.3f}"
+    )
+    print(f"{'=' * 65}\n")
+
+
+def print_summary(agg: dict) -> None:
+    """Print a human-readable summary table."""
+    n = agg["n_scenes"]
+    print(f"\n{'=' * 65}")
+    print(f"  Deterministic Avoidance Eval — {n} scenes")
+    print(f"{'=' * 65}")
+    print(f"  Static crossings:  {agg['static_crossings']}/{n}")
+    print(f"  RB crossings:      {agg['rb_crossings']}/{n}")
+    print(f"  Lane crossings:    {agg['lane_crossings']}/{n}")
+    print(f"  Kin violated:      {agg['kin_violated']}/{n}")
+    print()
+    for key in ("sc_min_dist", "rb_min_dist", "cl"):
+        d = agg[key]
+        print(
+            f"  {key:14s}  "
+            f"mean={d['mean']:+.3f}  "
+            f"p5={d['p5']:+.3f}  "
+            f"p25={d['p25']:+.3f}  "
+            f"p50={d['p50']:+.3f}  "
+            f"p75={d['p75']:+.3f}  "
+            f"p95={d['p95']:+.3f}  "
+            f"min={d['min']:+.3f}  "
+            f"max={d['max']:+.3f}"
+        )
+    print(f"{'=' * 65}\n")
+
+
+@torch.no_grad()
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--model_path", required=True)
+    parser.add_argument("--scenes", required=True)
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--ego_shape", required=True,
+                        help="WB,L,W e.g. 4.76,7.24,2.29")
+    parser.add_argument("--output_dir", required=True)
+    parser.add_argument("--batch_size", type=int, default=32)
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    ego_shape = np.array([float(x) for x in args.ego_shape.split(",")])
+    rcfg = load_reward_config(args.config)
+
+    with open(args.scenes) as f:
+        scene_paths = json.load(f)
+    print(f"[eval_det_avoidance] {len(scene_paths)} scenes, model={args.model_path}")
+
+    model, model_args = load_model(args.model_path, device)
+
+    results = score_det_scenes(
+        model, model_args, scene_paths, rcfg, ego_shape,
+        device, batch_size=args.batch_size,
+    )
+
+    agg = aggregate_stats(results)
+    print_summary(agg)
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "det_avoidance_summary.json"
+    with open(out_path, "w") as f:
+        json.dump({"aggregate": agg, "scenes": results}, f, indent=2)
+    print(f"Wrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/eval_det_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_det_avoidance.py
@@ -122,7 +122,8 @@ def score_det_scenes(
 
         for p in batch_paths:
             try:
-                raw_keys = set(np.load(p, allow_pickle=True).keys())
+                with np.load(p, allow_pickle=True) as npz:
+                    raw_keys = set(npz.keys())
                 if "ego_shape" not in raw_keys:
                     print(f"  [skip] {Path(p).name}: missing ego_shape")
                     continue
@@ -282,6 +283,12 @@ def main():
         model, model_args, scene_paths, rcfg, ego_shape,
         device, batch_size=args.batch_size,
     )
+
+    if not results:
+        raise SystemExit(
+            f"All {len(scene_paths)} scenes were skipped (ego_shape mismatch "
+            f"or missing). Check --ego_shape={args.ego_shape} matches the NPZs."
+        )
 
     agg = aggregate_stats(results)
     print_summary(agg)

--- a/rlvr/autoresearch/tools/eval_det_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_det_avoidance.py
@@ -163,7 +163,7 @@ def score_det_scenes(
             })
             flag = "COL" if r.static_crossing else "   "
             print(
-                f"  [{start + bi:3d}] {flag}  "
+                f"  [{len(results) - 1:3d}] {flag}  "
                 f"sc={float(getattr(r, 'sc_min_dist', 99.0)):+.3f}m  "
                 f"rb={float(getattr(r, 'rb_min_dist', 99.0)):.3f}m  "
                 f"{Path(p).name}"

--- a/rlvr/autoresearch/tools/eval_det_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_det_avoidance.py
@@ -69,6 +69,13 @@ def det_inference_batched(
     if norm_batch is None:
         batch = _stack_scene_data(datas, device)
         norm_batch = _normalize_batch(batch, model_args)
+    else:
+        B_nb = norm_batch["ego_current_state"].shape[0]
+        if B_nb != len(datas):
+            raise ValueError(
+                f"norm_batch has batch size {B_nb} but len(datas)={len(datas)}. "
+                f"They must match when norm_batch is pre-provided."
+            )
 
     decoder = model.module.decoder if hasattr(model, "module") else model.decoder
     saved_fn = decoder._guidance_fn

--- a/rlvr/autoresearch/tools/viz_det_compare.py
+++ b/rlvr/autoresearch/tools/viz_det_compare.py
@@ -119,7 +119,6 @@ def main():
         det_b = det_inference_batched(model_b, args_b, datas, device)
 
         for bi, sp in enumerate(valid_paths):
-            si = start + bi
             name = Path(sp).stem
 
             r_a = compute_reward_batch(det_a[bi : bi + 1], datas[bi], rcfg)[0]
@@ -135,6 +134,7 @@ def main():
             sc_b = d_b["det_sc_min_dist"]
             flag_a = "COL" if d_a["det_static_crossing"] else "   "
             flag_b = "COL" if d_b["det_static_crossing"] else "   "
+            si = len(results_a) - 1
             print(
                 f"  [{si:3d}] {name:30s}  "
                 f"A: {flag_a} sc={sc_a:+.2f}m  "

--- a/rlvr/autoresearch/tools/viz_det_compare.py
+++ b/rlvr/autoresearch/tools/viz_det_compare.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Compare deterministic trajectories from two models side-by-side.
+
+Loads two models (each with optional LoRA), runs det inference on shared
+scenes, scores both with a reward config, and renders per-scene PNGs +
+a collage showing both trajectories on the same map.
+
+Usage:
+    python -m rlvr.autoresearch.tools.viz_det_compare \
+        --model_a <base.pth> --label_a "Baseline" \
+        --model_b <trained.pth> --label_b "a06" \
+        [--lora_a <lora_dir>] [--lora_b <lora_dir>] \
+        --scenes <scenes.json> \
+        --config <reward_config.json> \
+        --ego_shape WB,L,W \
+        --output_dir <dir> \
+        [--collage_cols 5]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+
+from preference_optimization.utils import load_npz_data
+from rlvr.autoresearch.tools.eval_det_avoidance import (
+    aggregate_stats,
+    det_inference_batched,
+    load_model,
+    print_summary,
+    reward_breakdown_to_det_dict,
+)
+from rlvr.autoresearch.tools.reward_config_from_json import load_reward_config
+from rlvr.autoresearch.tools.viz_cl_recovery import draw_scene_base, draw_traj
+from rlvr.reward import compute_reward_batch
+
+
+def _load_model_with_lora(model_path, lora_path, device):
+    model, model_args = load_model(model_path, device)
+    if lora_path:
+        from preference_optimization.lora_utils import load_lora_checkpoint
+
+        model = load_lora_checkpoint(model, lora_path)
+        model.eval()
+    return model, model_args
+
+
+@torch.no_grad()
+def main():
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--model_a", required=True)
+    p.add_argument("--model_b", required=True)
+    p.add_argument("--lora_a", default=None)
+    p.add_argument("--lora_b", default=None)
+    p.add_argument("--label_a", default="Model A")
+    p.add_argument("--label_b", default="Model B")
+    p.add_argument("--scenes", required=True)
+    p.add_argument("--config", required=True)
+    p.add_argument("--ego_shape", required=True, help="WB,L,W")
+    p.add_argument("--output_dir", required=True)
+    p.add_argument("--batch_size", type=int, default=32)
+    p.add_argument("--collage_cols", type=int, default=5)
+    p.add_argument("--no_viz", action="store_true",
+                   help="Skip per-scene PNGs and collage; only print stats.")
+    args = p.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    ego_shape = np.array([float(x) for x in args.ego_shape.split(",")])
+    rcfg = load_reward_config(args.config)
+
+    with open(args.scenes) as f:
+        scene_paths = json.load(f)
+
+    print(f"Loading model A: {args.model_a}")
+    model_a, args_a = _load_model_with_lora(args.model_a, args.lora_a, device)
+    print(f"Loading model B: {args.model_b}")
+    model_b, args_b = _load_model_with_lora(args.model_b, args.lora_b, device)
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    results_a, results_b = [], []
+
+    for start in range(0, len(scene_paths), args.batch_size):
+        batch_paths = scene_paths[start : start + args.batch_size]
+        datas, valid_paths = [], []
+
+        for sp in batch_paths:
+            try:
+                raw = set(np.load(sp, allow_pickle=True).keys())
+                if "ego_shape" not in raw:
+                    print(f"  [skip] {Path(sp).name}: missing ego_shape")
+                    continue
+                d = load_npz_data(sp, device)
+                es = d["ego_shape"].cpu().numpy().reshape(-1)[:3]
+                if not np.allclose(es, ego_shape, atol=1e-2):
+                    print(f"  [skip] {Path(sp).name}: shape mismatch")
+                    continue
+                datas.append(d)
+                valid_paths.append(sp)
+            except Exception as e:  # noqa: BLE001
+                print(f"  [skip] {Path(sp).name}: {e}")
+
+        if not datas:
+            continue
+
+        det_a = det_inference_batched(model_a, args_a, datas, device)
+        det_b = det_inference_batched(model_b, args_b, datas, device)
+
+        for bi, sp in enumerate(valid_paths):
+            si = start + bi
+            name = Path(sp).stem
+
+            r_a = compute_reward_batch(det_a[bi : bi + 1], datas[bi], rcfg)[0]
+            r_b = compute_reward_batch(det_b[bi : bi + 1], datas[bi], rcfg)[0]
+
+            d_a = reward_breakdown_to_det_dict(r_a)
+            d_b = reward_breakdown_to_det_dict(r_b)
+
+            results_a.append({"scene": name, **d_a})
+            results_b.append({"scene": name, **d_b})
+
+            sc_a = d_a["det_sc_min_dist"]
+            sc_b = d_b["det_sc_min_dist"]
+            flag_a = "COL" if d_a["det_static_crossing"] else "   "
+            flag_b = "COL" if d_b["det_static_crossing"] else "   "
+            print(
+                f"  [{si:3d}] {name:30s}  "
+                f"A: {flag_a} sc={sc_a:+.2f}m  "
+                f"B: {flag_b} sc={sc_b:+.2f}m"
+            )
+
+            if args.no_viz:
+                continue
+
+            traj_a_np = det_a[bi].cpu().numpy()
+            traj_b_np = det_b[bi].cpu().numpy()
+
+            fig, ax = plt.subplots(1, 1, figsize=(12, 12))
+            draw_scene_base(ax, sp)
+            draw_traj(ax, traj_a_np,
+                      f"{args.label_a} (sc={sc_a:.2f}m)", "#1f77b4", sp)
+            draw_traj(ax, traj_b_np,
+                      f"{args.label_b} (sc={sc_b:.2f}m)", "#d62728", sp)
+
+            all_pts = np.vstack([traj_a_np[:, :2], traj_b_np[:, :2], [[0, 0]]])
+            cx, cy = np.mean(all_pts[:, 0]), np.mean(all_pts[:, 1])
+            half = max(np.ptp(all_pts[:, 0]), np.ptp(all_pts[:, 1])) * 0.6 + 6
+            ax.set_xlim(cx - half, cx + half)
+            ax.set_ylim(cy - half, cy + half)
+            ax.set_aspect("equal")
+            ax.legend(fontsize=9, loc="upper left")
+            ax.set_title(f"{name}", fontsize=10)
+
+            fig.savefig(out_dir / f"{name}.png", dpi=120, bbox_inches="tight")
+            plt.close(fig)
+
+    # --- Aggregate stats ---
+    def _to_score_list(results):
+        return [
+            {
+                "sc_min_dist": r["det_sc_min_dist"],
+                "rb_min_dist": r["det_rb_min_dist"],
+                "cl": r["det_cl"],
+                "total": r["det_total"],
+                "static_crossing": r["det_static_crossing"],
+                "rb_cross": r["det_rb_cross"],
+                "lane_cross": r["det_lane_cross"],
+                "kin_violated": r["det_kin_violated"],
+                "sc_n_stopped": r.get("det_sc_n_stopped", 0),
+            }
+            for r in results
+        ]
+
+    agg_a = aggregate_stats(_to_score_list(results_a))
+    agg_b = aggregate_stats(_to_score_list(results_b))
+
+    print(f"\n--- {args.label_a} ---")
+    print_summary(agg_a)
+    print(f"--- {args.label_b} ---")
+    print_summary(agg_b)
+
+    # --- Collage ---
+    if not args.no_viz and results_a:
+        print("Creating collage...")
+        n = len(results_a)
+        cols = args.collage_cols
+        rows = (n + cols - 1) // cols
+        fig, axes = plt.subplots(rows, cols, figsize=(8 * cols, 8 * rows))
+        if rows == 1 and cols == 1:
+            axes = np.array([[axes]])
+        elif rows == 1:
+            axes = axes[None, :]
+        elif cols == 1:
+            axes = axes[:, None]
+        axes_flat = axes.flatten()
+
+        for si, sp in enumerate(scene_paths[: len(results_a)]):
+            if si >= len(axes_flat):
+                break
+            ax = axes_flat[si]
+            d = load_npz_data(sp, device)
+            t_a = det_inference_batched(model_a, args_a, [d], device)[0].cpu().numpy()
+            t_b = det_inference_batched(model_b, args_b, [d], device)[0].cpu().numpy()
+
+            draw_scene_base(ax, sp)
+            draw_traj(ax, t_a, args.label_a, "#1f77b4", sp)
+            draw_traj(ax, t_b, args.label_b, "#d62728", sp)
+
+            all_pts = np.vstack([t_a[:, :2], t_b[:, :2], [[0, 0]]])
+            cx, cy = np.mean(all_pts[:, 0]), np.mean(all_pts[:, 1])
+            half = max(np.ptp(all_pts[:, 0]), np.ptp(all_pts[:, 1])) * 0.6 + 6
+            ax.set_xlim(cx - half, cx + half)
+            ax.set_ylim(cy - half, cy + half)
+            ax.set_aspect("equal")
+            ax.legend(fontsize=7, loc="upper left")
+            ax.set_title(f"[{si}] {results_a[si]['scene']}", fontsize=8)
+
+        for j in range(n, len(axes_flat)):
+            axes_flat[j].axis("off")
+
+        fig.tight_layout()
+        fig.savefig(out_dir / "collage.png", dpi=80, bbox_inches="tight")
+        plt.close(fig)
+        print(f"Saved collage: {out_dir / 'collage.png'}")
+
+    # --- Save JSON ---
+    out_path = out_dir / "det_compare_summary.json"
+    with open(out_path, "w") as f:
+        json.dump({
+            "model_a": args.model_a, "lora_a": args.lora_a, "label_a": args.label_a,
+            "model_b": args.model_b, "lora_b": args.lora_b, "label_b": args.label_b,
+            "aggregate_a": agg_a, "aggregate_b": agg_b,
+            "scenes_a": results_a, "scenes_b": results_b,
+        }, f, indent=2)
+    print(f"Wrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/viz_det_compare.py
+++ b/rlvr/autoresearch/tools/viz_det_compare.py
@@ -97,7 +97,8 @@ def main():
 
         for sp in batch_paths:
             try:
-                raw = set(np.load(sp, allow_pickle=True).keys())
+                with np.load(sp, allow_pickle=True) as npz:
+                    raw = set(npz.keys())
                 if "ego_shape" not in raw:
                     print(f"  [skip] {Path(sp).name}: missing ego_shape")
                     continue
@@ -127,8 +128,8 @@ def main():
             d_a = reward_breakdown_to_det_dict(r_a)
             d_b = reward_breakdown_to_det_dict(r_b)
 
-            results_a.append({"scene": name, **d_a})
-            results_b.append({"scene": name, **d_b})
+            results_a.append({"scene": name, "scene_path": str(sp), **d_a})
+            results_b.append({"scene": name, "scene_path": str(sp), **d_b})
 
             sc_a = d_a["det_sc_min_dist"]
             sc_b = d_b["det_sc_min_dist"]
@@ -182,6 +183,12 @@ def main():
             for r in results
         ]
 
+    if not results_a:
+        raise SystemExit(
+            f"All {len(scene_paths)} scenes were skipped (ego_shape mismatch "
+            f"or missing). Check --ego_shape matches the NPZs."
+        )
+
     agg_a = aggregate_stats(_to_score_list(results_a))
     agg_b = aggregate_stats(_to_score_list(results_b))
 
@@ -193,7 +200,8 @@ def main():
     # --- Collage ---
     if not args.no_viz and results_a:
         print("Creating collage...")
-        n = len(results_a)
+        scored_paths = [r["scene_path"] for r in results_a]
+        n = len(scored_paths)
         cols = args.collage_cols
         rows = (n + cols - 1) // cols
         fig, axes = plt.subplots(rows, cols, figsize=(8 * cols, 8 * rows))
@@ -205,7 +213,7 @@ def main():
             axes = axes[:, None]
         axes_flat = axes.flatten()
 
-        for si, sp in enumerate(scene_paths[: len(results_a)]):
+        for si, sp in enumerate(scored_paths):
             if si >= len(axes_flat):
                 break
             ax = axes_flat[si]

--- a/rlvr/autoresearch/tools/viz_det_compare.py
+++ b/rlvr/autoresearch/tools/viz_det_compare.py
@@ -90,6 +90,7 @@ def main():
     out_dir.mkdir(parents=True, exist_ok=True)
 
     results_a, results_b = [], []
+    cached_trajs_a, cached_trajs_b = [], []
 
     for start in range(0, len(scene_paths), args.batch_size):
         batch_paths = scene_paths[start : start + args.batch_size]
@@ -141,11 +142,13 @@ def main():
                 f"B: {flag_b} sc={sc_b:+.2f}m"
             )
 
-            if args.no_viz:
-                continue
-
             traj_a_np = det_a[bi].cpu().numpy()
             traj_b_np = det_b[bi].cpu().numpy()
+            cached_trajs_a.append(traj_a_np)
+            cached_trajs_b.append(traj_b_np)
+
+            if args.no_viz:
+                continue
 
             fig, ax = plt.subplots(1, 1, figsize=(12, 12))
             draw_scene_base(ax, sp)
@@ -217,14 +220,12 @@ def main():
             if si >= len(axes_flat):
                 break
             ax = axes_flat[si]
-            d = load_npz_data(sp, device)
-            t_a = det_inference_batched(model_a, args_a, [d], device)[0].cpu().numpy()
-            t_b = det_inference_batched(model_b, args_b, [d], device)[0].cpu().numpy()
 
             draw_scene_base(ax, sp)
-            draw_traj(ax, t_a, args.label_a, "#1f77b4", sp)
-            draw_traj(ax, t_b, args.label_b, "#d62728", sp)
+            draw_traj(ax, cached_trajs_a[si], args.label_a, "#1f77b4", sp)
+            draw_traj(ax, cached_trajs_b[si], args.label_b, "#d62728", sp)
 
+            t_a, t_b = cached_trajs_a[si], cached_trajs_b[si]
             all_pts = np.vstack([t_a[:, :2], t_b[:, :2], [[0, 0]]])
             cx, cy = np.mean(all_pts[:, 0]), np.mean(all_pts[:, 1])
             half = max(np.ptp(all_pts[:, 0]), np.ptp(all_pts[:, 1])) * 0.6 + 6

--- a/rlvr/autoresearch/tools/viz_p4_recovery.py
+++ b/rlvr/autoresearch/tools/viz_p4_recovery.py
@@ -44,6 +44,10 @@ from matplotlib.patches import Rectangle
 
 from preference_optimization.lora_utils import load_lora_checkpoint
 from preference_optimization.utils import load_npz_data
+from rlvr.autoresearch.tools.eval_det_avoidance import (
+    det_inference_batched,
+    reward_breakdown_to_det_dict,
+)
 from rlvr.autoresearch.tools.percentile_filter_perturbed import is_scene_eligible
 from rlvr.autoresearch.tools.reward_config_from_json import load_reward_config
 from rlvr.autoresearch.tools.viz_cl_recovery import (
@@ -265,20 +269,9 @@ def main() -> None:
             use_route_cl_guidance=use_route_cl,
         )  # [B, K, T, 4]
 
-        decoder = model.module.decoder if hasattr(model, "module") else model.decoder
-        saved_fn = decoder._guidance_fn
-        decoder._guidance_fn = None
-        try:
-            P = 1 + model_args.predicted_neighbor_num
-            future_len = model_args.future_len
-            norm_batch_d = {k: v for k, v in norm_batch.items()}
-            norm_batch_d["sampled_trajectories"] = torch.zeros(
-                B, P, future_len + 1, 4, device=device
-            )
-            _, det_out = model(norm_batch_d)
-            det_trajs_BT4 = det_out["prediction"][:, 0].detach()  # [B, T, 4]
-        finally:
-            decoder._guidance_fn = saved_fn
+        det_trajs_BT4 = det_inference_batched(
+            model, model_args, datas_ok, device, norm_batch=norm_batch,
+        )
 
         for bi in range(B):
             si = orig_indices[bi]
@@ -318,7 +311,7 @@ def main() -> None:
                         and is_scene_eligible(top1, t0_cl=t0_cl))
 
             if args.no_viz:
-                summary.append({
+                entry = {
                     "scene": str(npz_path),
                     "scene_idx": si,
                     "t0_cl": t0_cl,
@@ -333,10 +326,10 @@ def main() -> None:
                     "top1_kin_violated": top1["kin_violated"],
                     "top1_coll_step": top1["coll_step"],
                     "top1_static_crossing": top1["static_crossing"],
-                    "det_cl": float(det_r.centerline),
-                    "det_total": float(det_r.total),
                     "png": None,
-                })
+                }
+                entry.update(reward_breakdown_to_det_dict(det_r))
+                summary.append(entry)
                 if improves:
                     improve_paths.append(str(npz_path))
                 flag = "IMPROVE" if improves else "       "
@@ -486,10 +479,9 @@ def main() -> None:
                 "top1_kin_violated": top1["kin_violated"],
                 "top1_coll_step": top1["coll_step"],
                 "top1_static_crossing": top1["static_crossing"],
-                "det_cl": float(det_r.centerline),
-                "det_total": float(det_r.total),
                 "png": str(out_path),
             })
+            summary[-1].update(reward_breakdown_to_det_dict(det_r))
             flag = "IMPROVE" if improves else "       "
             print(
                 f"  [{si:3d}] {flag}  t0={t0_cl:+.3f}  top1={top1['cl']:+.3f}  "

--- a/rlvr/grpo_trainer.py
+++ b/rlvr/grpo_trainer.py
@@ -788,15 +788,30 @@ class GRPOTrainer:
                 return f"{v:.2e}"
             return f"{v:.6f}"
 
-        loss = _fmt(metrics.get("loss", 0))
-        ploss = _fmt(metrics.get("policy_loss", 0))
-        kl = _fmt(metrics.get("kl_loss", 0))
-        logp = _fmt(metrics.get("mean_policy_logprob", 0))
-        print(
-            f"  Epoch {epoch} [{mode_str}]: "
-            f"Loss={loss}, PolicyLoss={ploss}, KL={kl}, "
-            f"MeanLogProb={logp}{clip_str}"
-        )
+        # Ranked SFT uses sft_-prefixed keys; GRPO uses unprefixed.
+        is_sft = "sft_total_loss" in metrics
+        loss = _fmt(metrics.get("sft_total_loss" if is_sft else "loss", None))
+        if loss is None:
+            raise KeyError(
+                f"Neither 'loss' nor 'sft_total_loss' found in metrics. "
+                f"Available keys: {sorted(metrics.keys())}"
+            )
+        kl = _fmt(metrics.get("sft_kl_loss" if is_sft else "kl_loss", 0))
+        if is_sft:
+            ego_l = _fmt(metrics.get("sft_ego_loss", 0))
+            nreg = _fmt(metrics.get("sft_neighbor_reg_loss", 0))
+            print(
+                f"  Epoch {epoch} [{mode_str}]: "
+                f"Loss={loss}, EgoLoss={ego_l}, NeighReg={nreg}, KL={kl}{clip_str}"
+            )
+        else:
+            ploss = _fmt(metrics.get("policy_loss", 0))
+            logp = _fmt(metrics.get("mean_policy_logprob", 0))
+            print(
+                f"  Epoch {epoch} [{mode_str}]: "
+                f"Loss={loss}, PolicyLoss={ploss}, KL={kl}, "
+                f"MeanLogProb={logp}{clip_str}"
+            )
 
     def save_epoch1_baselines(self, npz_paths: list[str]) -> None:
         """Save deterministic trajectories as epoch-1 reference for drift tracking.

--- a/rlvr/grpo_trainer.py
+++ b/rlvr/grpo_trainer.py
@@ -790,12 +790,13 @@ class GRPOTrainer:
 
         # Ranked SFT uses sft_-prefixed keys; GRPO uses unprefixed.
         is_sft = "sft_total_loss" in metrics
-        loss = _fmt(metrics.get("sft_total_loss" if is_sft else "loss", None))
-        if loss is None:
+        loss_val = metrics.get("sft_total_loss" if is_sft else "loss", None)
+        if loss_val is None:
             raise KeyError(
                 f"Neither 'loss' nor 'sft_total_loss' found in metrics. "
                 f"Available keys: {sorted(metrics.keys())}"
             )
+        loss = _fmt(loss_val)
         kl = _fmt(metrics.get("sft_kl_loss" if is_sft else "kl_loss", 0))
         if is_sft:
             ego_l = _fmt(metrics.get("sft_ego_loss", 0))


### PR DESCRIPTION
## Summary
- Add `eval_det_avoidance.py`: single-forward-pass deterministic scoring with built-in aggregate statistics (mean/p5/p25/p50/p75/p95/min/max). Exports `det_inference_batched` and `reward_breakdown_to_det_dict` for reuse by other tools.
- Add `viz_det_compare.py`: side-by-side deterministic trajectory comparison between two models with per-scene PNGs, collage output, and full distribution stats.
- Refactor `viz_p4_recovery.py` to import det inference and reward field extraction from `eval_det_avoidance` instead of reimplementing inline.
- Fix `grpo_trainer.py` `log_epoch_summary` to detect ranked-SFT metrics (`sft_total_loss`) vs GRPO metrics (`loss`) — was showing `Loss=0` for ranked SFT due to key mismatch.

## Test plan
- [ ] `python -m rlvr.autoresearch.tools.eval_det_avoidance --model_path <model.pth> --scenes <scenes.json> --config <reward.json> --ego_shape WB,L,W --output_dir /tmp/test` runs without error and prints aggregate stats
- [ ] `python -m rlvr.autoresearch.tools.viz_det_compare --model_a <a.pth> --model_b <b.pth> --scenes <scenes.json> --config <reward.json> --ego_shape WB,L,W --output_dir /tmp/test --no_viz` prints side-by-side stats
- [ ] `viz_p4_recovery --no_viz` produces identical `det_*` fields in summary.json as before refactor
- [ ] Ranked SFT training log shows correct `Loss=` values (not 0)

