### PR TITLE
fix(scenario_generation): add REPLAY_NO_PNG env to skip per-step PNG rendering

### DIFF
--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -2356,9 +2356,10 @@ def run_route_replay(
                     ))
 
             # Save PNG (concurrent with next step's compute).
-            # REPLAY_NO_PNG=1 skips per-step PNG rendering entirely — avoids the
-            # deepcopy(scene) backlog (a per-step memory leak under CPU contention
-            # that OOM-kills long runs) when only the NPZ dump is needed.
+            # REPLAY_NO_PNG=1 skips per-step PNG rendering entirely. Under CPU
+            # contention the save threadpool can't drain, so queued deep-copied
+            # scenes accumulate (unbounded memory growth, not a true leak) and
+            # OOM-kill long runs. Skipping is for when only the NPZ dump is needed.
             # out_path is still defined (used by the clearance log below).
             out_path = output_dir / f"step_{step:04d}.png"
             if os.environ.get("REPLAY_NO_PNG") != "1":

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -52,6 +52,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import os
 import random
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
@@ -2355,20 +2356,25 @@ def run_route_replay(
                     ))
 
             # Save PNG (concurrent with next step's compute).
+            # REPLAY_NO_PNG=1 skips per-step PNG rendering entirely — avoids the
+            # deepcopy(scene) backlog (a per-step memory leak under CPU contention
+            # that OOM-kills long runs) when only the NPZ dump is needed.
+            # out_path is still defined (used by the clearance log below).
             out_path = output_dir / f"step_{step:04d}.png"
-            overlay_metrics = (
-                metrics_log[-1]
-                if spawn_config.overlay_metrics_on_png and metrics_log
-                else None
-            )
-            pending_saves.append(save_pool.submit(
-                save_step_figure,
-                deepcopy(scene), agent_predictions, out_path,
-                step, spawn_config.max_steps, route_polylines,
-                _VIEW_HALF_M, _route_vis_ll_ids,
-                step * 0.1, road_border_polylines,
-                overlay_metrics,
-            ))
+            if os.environ.get("REPLAY_NO_PNG") != "1":
+                overlay_metrics = (
+                    metrics_log[-1]
+                    if spawn_config.overlay_metrics_on_png and metrics_log
+                    else None
+                )
+                pending_saves.append(save_pool.submit(
+                    save_step_figure,
+                    deepcopy(scene), agent_predictions, out_path,
+                    step, spawn_config.max_steps, route_polylines,
+                    _VIEW_HALF_M, _route_vis_ll_ids,
+                    step * 0.1, road_border_polylines,
+                    overlay_metrics,
+                ))
 
             # Record realized obstacle clearances (ego world pose + nearest
             # road-border / stopped-NPC / moving-NPC distances) for the


### PR DESCRIPTION
## Summary

`run_route_replay` submits a `deepcopy(scene)` per step to a 4-thread PNG save pool. Under CPU contention the render threads can't keep up, so the pending-saves queue — each entry holding a deepcopied scene (map + neighbor tensors) — grows unbounded. The result is per-step RAM growth that gets the process OOM-killed at a variable step on long runs, with no traceback.

This adds a `REPLAY_NO_PNG=1` env gate that skips per-step PNG rendering entirely when only the dumped NPZs are needed. `out_path` is still computed (the clearance log references its name), so non-PNG outputs are unchanged.

## Behavior

- `REPLAY_NO_PNG` unset (default): renders PNGs exactly as before — no behavioral change.
- `REPLAY_NO_PNG=1`: no `deepcopy`/submit, `pending_saves` stays empty (drain loops are no-ops), no leak, faster runs. NPZ dump, metrics log, clearance log, and trajectory log are all unaffected (they live outside the PNG path). The one downstream consumer of the recorded `png` field already guards with `if src.exists()`, so it degrades gracefully.

## Notes

- Render-on remains the safe default; skipping is opt-in.
- Follow-up (non-blocking): could be promoted to a `SpawnConfig`/CLI flag for config-reproducibility consistency with the rest of `replay.py`.