### PR TITLE
feat(rlvr): anchor neighbor-reg/KL/ego-IL base pass to an external baseline (gated)

### DIFF
--- a/rlvr/autoresearch/run_experiment.py
+++ b/rlvr/autoresearch/run_experiment.py
@@ -577,10 +577,10 @@ def run(config_path: Path, name: str, skip_baseline: bool = False, baseline_cach
         )
         if grpo_config.neighbor_reg_anchor == "baseline":
             anchor_path = grpo_config.neighbor_reg_anchor_path
-            if not anchor_path or not Path(anchor_path).exists():
+            if not anchor_path or not Path(anchor_path).is_file():
                 raise ValueError(
                     "neighbor_reg_anchor='baseline' requires neighbor_reg_anchor_path "
-                    f"to point to an existing .pth; got {anchor_path!r}"
+                    f"to point to an existing .pth file; got {anchor_path!r}"
                 )
             print(f"Loading EXTERNAL frozen baseline anchor from {anchor_path} "
                   f"(neighbor_reg_anchor='baseline')...")

--- a/rlvr/autoresearch/run_experiment.py
+++ b/rlvr/autoresearch/run_experiment.py
@@ -576,6 +576,20 @@ def run(config_path: Path, name: str, skip_baseline: bool = False, baseline_cach
             or (grpo_config.ego_il_weight > 0.0 and grpo_config.ego_il_mode == "baseline")
         )
         if grpo_config.neighbor_reg_anchor == "baseline":
+            # The external anchor is consumed ONLY by the ranked-SFT trainer (it is
+            # passed as base_model + prefer_external_base to train_epoch_ranked_sft).
+            # Fail loudly rather than load-and-ignore for the other trainers.
+            if (grpo_config.use_closed_loop or grpo_config.use_exploration_policy
+                    or grpo_config.ranked_sft_mode == "none"):
+                raise ValueError(
+                    "neighbor_reg_anchor='baseline' is only supported by the ranked-SFT "
+                    "trainer (ranked_sft_mode in gt_neighbor/baseline_neighbor/curated, with "
+                    "use_closed_loop=False and use_exploration_policy=False); got "
+                    f"ranked_sft_mode={grpo_config.ranked_sft_mode!r}, "
+                    f"use_closed_loop={grpo_config.use_closed_loop}, "
+                    f"use_exploration_policy={grpo_config.use_exploration_policy}. "
+                    "Loading the anchor for another trainer would silently have no effect."
+                )
             anchor_path = grpo_config.neighbor_reg_anchor_path
             if not anchor_path or not Path(anchor_path).is_file():
                 raise ValueError(

--- a/rlvr/autoresearch/run_experiment.py
+++ b/rlvr/autoresearch/run_experiment.py
@@ -575,7 +575,20 @@ def run(config_path: Path, name: str, skip_baseline: bool = False, baseline_cach
             grpo_config.kl_coef > 0.0
             or (grpo_config.ego_il_weight > 0.0 and grpo_config.ego_il_mode == "baseline")
         )
-        if _needs_base and not grpo_config.use_lora:
+        if grpo_config.neighbor_reg_anchor == "baseline":
+            anchor_path = grpo_config.neighbor_reg_anchor_path
+            if not anchor_path or not Path(anchor_path).exists():
+                raise ValueError(
+                    "neighbor_reg_anchor='baseline' requires neighbor_reg_anchor_path "
+                    f"to point to an existing .pth; got {anchor_path!r}"
+                )
+            print(f"Loading EXTERNAL frozen baseline anchor from {anchor_path} "
+                  f"(neighbor_reg_anchor='baseline')...")
+            _frozen_base_model, _ = load_model(Path(anchor_path), DEVICE)
+            _frozen_base_model.eval()
+            for p in _frozen_base_model.parameters():
+                p.requires_grad_(False)
+        elif _needs_base and not grpo_config.use_lora:
             print(f"Loading frozen base model (kl_coef={grpo_config.kl_coef}, "
                   f"ego_il={grpo_config.ego_il_weight}/{grpo_config.ego_il_mode})...")
             _frozen_base_model, _ = load_model(checkpoint_path, DEVICE)

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -224,7 +224,7 @@ class GRPOConfig:
     # high-progress lane-departing scenes at top, heavily crashed scenes at bottom).
     reward_trim_pct: float = 0.0  # 0.05 = trim 5% of scenes from each end
     lane_dep_trim_n: int = 0  # drop N scenes with highest lane departure fraction (0=disabled)
-    neighbor_loss_weight: float = 0.0  # weight for neighbor prediction regularization (0=disabled)
+    neighbor_loss_weight: float = 0.1  # weight for neighbor SFT loss term (default 0.1 matches original SFT alpha_neighbor_loss; 0=disabled)
 
     # Ranked SFT mode: generate N trajectories, pick best by reward, SFT on it.
     # "none": standard GRPO training (default).

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -224,8 +224,16 @@ class GRPOConfig:
     # high-progress lane-departing scenes at top, heavily crashed scenes at bottom).
     reward_trim_pct: float = 0.0  # 0.05 = trim 5% of scenes from each end
     lane_dep_trim_n: int = 0  # drop N scenes with highest lane departure fraction (0=disabled)
-    neighbor_loss_weight: float = 0.1  # weight for neighbor SFT loss term (default 0.1 matches original SFT alpha_neighbor_loss; 0=disabled)
-    # Anchor source for the base pass used by neighbor_reg / baseline ego-IL / KL.
+    # Weight for the neighbor loss term, consumed by BOTH the ranked-SFT path
+    # (grpo_sft_trainer: neighbor SFT loss) and the GRPO path (grpo_loss: neighbor
+    # MSE on trajectories). None = use each path's own default: ranked-SFT → 0.1
+    # (matches original SFT alpha_neighbor_loss), GRPO → 0.0 (neighbor term off,
+    # preserving prior behavior). An explicit float (including 0.0 to disable) is
+    # honored verbatim by both paths. (Sentinel None avoids silently enabling the
+    # GRPO neighbor term for configs that never set this field.)
+    neighbor_loss_weight: float | None = None
+    # Anchor source for the base pass used by neighbor_reg / baseline ego-IL / KL,
+    # in the RANKED-SFT path only (the fully-batched GRPO trainer does not read it).
     # "warmstart" (default): forward the LoRA model with adapters disabled
     #   (disable_adapter) — i.e. the merged warmstart's predictions (current behavior).
     # "baseline": forward an EXTERNAL frozen base model (the true original baseline)

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -225,6 +225,14 @@ class GRPOConfig:
     reward_trim_pct: float = 0.0  # 0.05 = trim 5% of scenes from each end
     lane_dep_trim_n: int = 0  # drop N scenes with highest lane departure fraction (0=disabled)
     neighbor_loss_weight: float = 0.1  # weight for neighbor SFT loss term (default 0.1 matches original SFT alpha_neighbor_loss; 0=disabled)
+    # Anchor source for the base pass used by neighbor_reg / baseline ego-IL / KL.
+    # "warmstart" (default): forward the LoRA model with adapters disabled
+    #   (disable_adapter) — i.e. the merged warmstart's predictions (current behavior).
+    # "baseline": forward an EXTERNAL frozen base model (the true original baseline)
+    #   loaded from neighbor_reg_anchor_path instead of disable_adapter.
+    neighbor_reg_anchor: str = "warmstart"
+    # Path to the external baseline .pth. REQUIRED when neighbor_reg_anchor=="baseline".
+    neighbor_reg_anchor_path: str | None = None
 
     # Ranked SFT mode: generate N trajectories, pick best by reward, SFT on it.
     # "none": standard GRPO training (default).

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -679,6 +679,10 @@ class GRPOConfig:
             raise ValueError(
                 f"gt_fallback_mode must be 'none', 'skip', or 'il', got {self.gt_fallback_mode!r}"
             )
+        if self.neighbor_reg_anchor not in ("warmstart", "baseline"):
+            raise ValueError(
+                f"neighbor_reg_anchor must be 'warmstart' or 'baseline', got {self.neighbor_reg_anchor!r}"
+            )
 
     @property
     def uses_importance_sampling(self) -> bool:

--- a/rlvr/grpo_loss.py
+++ b/rlvr/grpo_loss.py
@@ -680,7 +680,9 @@ def compute_batched_grpo_loss(
         policy_losses_k, ref_losses_k = _compute_batched_losses_and_ref(
             policy_model, trajectories_tensor, data, model_args, device, noise, t,
             compute_ref=True,
-            neighbor_loss_weight=getattr(config, 'neighbor_loss_weight', 0.0),
+            # None (the dataclass default) means "GRPO neighbor term off" → 0.0,
+            # preserving prior behavior for configs that never set this field.
+            neighbor_loss_weight=(getattr(config, 'neighbor_loss_weight', None) or 0.0),
         )
         policy_losses_sum = policy_losses_sum + policy_losses_k
         ref_losses_sum = ref_losses_sum + ref_losses_k

--- a/rlvr/grpo_sft_trainer.py
+++ b/rlvr/grpo_sft_trainer.py
@@ -135,6 +135,7 @@ def _compute_sft_diffusion_loss(
     velocity_weight: bool = False,
     kl_coef: float = 0.0,
     base_model: nn.Module | None = None,
+    prefer_external_base: bool = False,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     """Compute standard SFT diffusion loss with ego + neighbor targets.
 
@@ -176,8 +177,13 @@ def _compute_sft_diffusion_loss(
             Computes MSE(model_output, base_output) at the same (noise, timestep).
             Requires either LoRA (uses disable_adapter) or a separate base_model.
         base_model: Frozen reference model for KL/baseline-IL in full-model (non-LoRA)
-            training. Ignored when the policy model has LoRA (uses disable_adapter
-            instead). Must be in eval mode with requires_grad=False.
+            training. By default ignored when the policy model has LoRA (uses
+            disable_adapter instead). Must be in eval mode with requires_grad=False.
+        prefer_external_base: If True AND base_model is not None, route the base pass
+            (neighbor_reg / baseline ego-IL / KL) through the EXTERNAL frozen base_model
+            instead of disable_adapter — even when the policy has LoRA. Lets these terms
+            anchor to the true original baseline rather than the merged warmstart.
+            Default False preserves the disable_adapter (warmstart) behavior exactly.
 
     Returns:
         (loss, metrics_dict)
@@ -322,6 +328,10 @@ def _compute_sft_diffusion_loss(
         # Base model forward pass: needed for neighbor_reg, baseline ego IL, or KL
         need_base_pass = use_neighbor_reg or (use_ego_il and ego_il_mode == "baseline") or use_kl
         has_lora = hasattr(inner, "disable_adapter")
+        if need_base_pass and prefer_external_base and base_model is None:
+            raise ValueError(
+                "neighbor_reg_anchor='baseline' requires an external base_model; got None"
+            )
         if need_base_pass and not has_lora and base_model is None:
             active = []
             if use_kl:
@@ -336,12 +346,26 @@ def _compute_sft_diffusion_loss(
                 "Note: neighbor_reg only works with LoRA's disable_adapter."
             )
         if need_base_pass:
-            if has_lora:
+            use_external = prefer_external_base and (base_model is not None)
+            if has_lora and not use_external:
                 with inner.disable_adapter(), torch.no_grad():
                     _, base_outputs = model(merged_inputs)
             else:
-                with torch.no_grad():
-                    _, base_outputs = base_model(merged_inputs)
+                # The decoder dispatches on self.training: train mode ->
+                # _forward_training returns "model_output" (the denoiser output at
+                # this (noise, t)); eval mode -> _forward_inference returns a sampled
+                # "prediction" with NO "model_output" key. The disable_adapter path
+                # above runs the policy in train mode (model.train() in the epoch
+                # loop), so the external base_model must also forward in train mode to
+                # return "model_output" identically. Params stay frozen via
+                # requires_grad_(False) + no_grad; only the forward mode is toggled.
+                base_was_training = base_model.training
+                base_model.train()
+                try:
+                    with torch.no_grad():
+                        _, base_outputs = base_model(merged_inputs)
+                finally:
+                    base_model.train(base_was_training)
             base_output = base_outputs["model_output"][:, :, 1:, :]  # [B, P, T, 4]
 
             # Neighbor reg
@@ -405,6 +429,7 @@ def train_epoch_ranked_sft(
     exploration_optimizer=None,
     run_dir=None,
     base_model: nn.Module | None = None,
+    prefer_external_base: bool = False,
 ) -> dict[str, float]:
     """GRPO-ranked SFT epoch: generate, rank, filter, train with SFT loss.
 
@@ -1242,6 +1267,7 @@ def train_epoch_ranked_sft(
             velocity_weight=config.sft_velocity_weight,
             kl_coef=config.get_kl_coef(epoch, config.train_epochs),
             base_model=_base_model_ref,
+            prefer_external_base=(config.neighbor_reg_anchor == "baseline"),
         )
 
         # Scale loss to preserve per-scene gradient magnitude:

--- a/rlvr/grpo_sft_trainer.py
+++ b/rlvr/grpo_sft_trainer.py
@@ -126,6 +126,7 @@ def _compute_sft_diffusion_loss(
     neighbor_mask: torch.Tensor,
     device: torch.device,
     K: int = 8,
+    neighbor_loss_weight: float = 0.1,
     neighbor_reg_weight: float = 0.0,
     neighbor_reg_only: bool = False,
     ego_il_weight: float = 0.0,
@@ -370,8 +371,9 @@ def _compute_sft_diffusion_loss(
     ego_il_avg = total_ego_il_loss / K if isinstance(total_ego_il_loss, torch.Tensor) else torch.tensor(0.0, device=device)
     kl_loss_avg = total_kl_loss / K if isinstance(total_kl_loss, torch.Tensor) else torch.tensor(0.0, device=device)
 
-    # Combined loss: ego + neighbor (weight 0.1 to match original SFT alpha_neighbor_loss)
-    loss = ego_loss_avg + 0.1 * neighbor_loss_avg
+    # Combined loss: ego + neighbor (weight from config.neighbor_loss_weight,
+    # default 0.1 to match original SFT alpha_neighbor_loss; set to 0 to disable)
+    loss = ego_loss_avg + neighbor_loss_weight * neighbor_loss_avg
     if use_neighbor_reg:
         loss = loss + neighbor_reg_weight * neighbor_reg_avg
     if use_ego_il:
@@ -1231,6 +1233,7 @@ def train_epoch_ranked_sft(
             neighbor_mask=mini_neighbor_mask,
             device=device,
             K=config.diffusion_k_steps,
+            neighbor_loss_weight=config.neighbor_loss_weight,
             neighbor_reg_weight=config.neighbor_reg_weight,
             neighbor_reg_only=config.neighbor_reg_only,
             ego_il_weight=config.ego_il_weight,

--- a/rlvr/grpo_sft_trainer.py
+++ b/rlvr/grpo_sft_trainer.py
@@ -429,7 +429,6 @@ def train_epoch_ranked_sft(
     exploration_optimizer=None,
     run_dir=None,
     base_model: nn.Module | None = None,
-    prefer_external_base: bool = False,
 ) -> dict[str, float]:
     """GRPO-ranked SFT epoch: generate, rank, filter, train with SFT loss.
 
@@ -1258,7 +1257,9 @@ def train_epoch_ranked_sft(
             neighbor_mask=mini_neighbor_mask,
             device=device,
             K=config.diffusion_k_steps,
-            neighbor_loss_weight=config.neighbor_loss_weight,
+            # None (the dataclass default) means "ranked-SFT neighbor term = 0.1"
+            # (matches original SFT alpha_neighbor_loss); an explicit float (incl. 0.0) is honored.
+            neighbor_loss_weight=(0.1 if config.neighbor_loss_weight is None else config.neighbor_loss_weight),
             neighbor_reg_weight=config.neighbor_reg_weight,
             neighbor_reg_only=config.neighbor_reg_only,
             ego_il_weight=config.ego_il_weight,

--- a/rlvr/test_neighbor_reg.py
+++ b/rlvr/test_neighbor_reg.py
@@ -548,11 +548,18 @@ class TestConfigValidation:
         with pytest.raises(ValueError, match="selective_mode"):
             GRPOConfig(selective_mode="bad")
 
+    def test_invalid_neighbor_reg_anchor(self):
+        from rlvr.grpo_config import GRPOConfig
+        with pytest.raises(ValueError, match="neighbor_reg_anchor"):
+            GRPOConfig(neighbor_reg_anchor="basline")  # typo must fail loudly, not silently warmstart
+
     def test_valid_modes_pass(self):
         from rlvr.grpo_config import GRPOConfig
-        c = GRPOConfig(ego_il_mode="baseline", selective_mode="advantage")
+        c = GRPOConfig(ego_il_mode="baseline", selective_mode="advantage",
+                       neighbor_reg_anchor="baseline")
         assert c.ego_il_mode == "baseline"
         assert c.selective_mode == "advantage"
+        assert c.neighbor_reg_anchor == "baseline"
 
     def test_schedule_constant_no_end(self):
         from rlvr.grpo_config import GRPOConfig

--- a/rlvr/test_neighbor_reg.py
+++ b/rlvr/test_neighbor_reg.py
@@ -53,6 +53,28 @@ class _StubDiT(nn.Module):
         return None, {"model_output": output}
 
 
+class _StubExternalBase(nn.Module):
+    """External frozen baseline anchor: returns a constant distinct from _StubDiT's
+    outputs, and records the train/eval mode it was forwarded in (so tests can assert
+    the decoder-train-mode toggle + its restoration)."""
+
+    def __init__(self, P=5, T=80, const=0.5):
+        super().__init__()
+        self.P, self.T, self.const = P, T, const
+        self.forwarded_in_training = None
+        self.n_forward = 0
+
+    def forward(self, inputs):
+        B = inputs["ego_current_state"].shape[0]
+        self.forwarded_in_training = self.training  # capture mode at forward time
+        self.n_forward += 1
+        out = torch.full(
+            (B, self.P, self.T + 1, 4), self.const,
+            device=inputs["ego_current_state"].device,
+        )
+        return None, {"model_output": out}
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -195,6 +217,82 @@ class TestRankedSFTNeighborReg:
         # lora_delta should have a gradient (it's in the LoRA forward path)
         assert model.lora_delta.grad is not None, "LoRA param should have gradient"
         assert model.lora_delta.grad.abs().sum() > 0, "Gradient should be non-zero"
+
+    def test_prefer_external_base_routes_and_restores_mode(self):
+        """prefer_external_base=True routes the base pass through the EXTERNAL base
+        model (not disable_adapter), forwards it in train mode (so the decoder
+        returns 'model_output'), and restores its original eval mode afterward."""
+        from rlvr.grpo_sft_trainer import _compute_sft_diffusion_loss
+
+        model = _StubDiT(P=5, T=80)            # LoRA policy (has disable_adapter)
+        base = _StubExternalBase(P=5, T=80)
+        base.eval()                            # frozen baseline starts in eval mode
+        model_args = _make_model_args(P=5, T=80)
+        data = _make_scene_data(B=1, P=5, T=80)
+
+        ego_gt = torch.randn(1, 80, 4)
+        neighbor_gt = torch.randn(1, 4, 80, 4)
+        neighbor_mask = torch.zeros(1, 4, 80, dtype=torch.bool)
+
+        _, metrics = _compute_sft_diffusion_loss(
+            model=model, model_args=model_args, data=data,
+            ego_gt=ego_gt, neighbor_gt=neighbor_gt, neighbor_mask=neighbor_mask,
+            device=torch.device("cpu"), K=1,
+            neighbor_reg_weight=1.0, neighbor_reg_only=True,
+            base_model=base, prefer_external_base=True,
+        )
+        assert base.n_forward > 0, "External base must be used for the base pass"
+        assert base.forwarded_in_training is True, \
+            "Decoder dispatches on self.training; base must forward in train mode for 'model_output'"
+        assert base.training is False, \
+            "External base train/eval mode must be restored (it started in eval)"
+        assert metrics["sft_neighbor_reg_loss"] > 0, "Reg loss should be non-zero"
+
+    def test_default_does_not_use_external_base(self):
+        """Default (prefer_external_base=False) keeps the disable_adapter path even
+        when a base_model is supplied — byte-identical to prior behavior."""
+        from rlvr.grpo_sft_trainer import _compute_sft_diffusion_loss
+
+        model = _StubDiT(P=5, T=80)
+        base = _StubExternalBase(P=5, T=80)
+        base.eval()
+        model_args = _make_model_args(P=5, T=80)
+        data = _make_scene_data(B=1, P=5, T=80)
+
+        ego_gt = torch.randn(1, 80, 4)
+        neighbor_gt = torch.randn(1, 4, 80, 4)
+        neighbor_mask = torch.zeros(1, 4, 80, dtype=torch.bool)
+
+        _compute_sft_diffusion_loss(
+            model=model, model_args=model_args, data=data,
+            ego_gt=ego_gt, neighbor_gt=neighbor_gt, neighbor_mask=neighbor_mask,
+            device=torch.device("cpu"), K=1,
+            neighbor_reg_weight=1.0, neighbor_reg_only=True,
+            base_model=base, prefer_external_base=False,
+        )
+        assert base.n_forward == 0, \
+            "Default must use disable_adapter, not the external base_model"
+
+    def test_prefer_external_base_requires_base_model(self):
+        """prefer_external_base=True with base_model=None must fail loudly."""
+        from rlvr.grpo_sft_trainer import _compute_sft_diffusion_loss
+
+        model = _StubDiT(P=5, T=80)
+        model_args = _make_model_args(P=5, T=80)
+        data = _make_scene_data(B=1, P=5, T=80)
+
+        ego_gt = torch.randn(1, 80, 4)
+        neighbor_gt = torch.randn(1, 4, 80, 4)
+        neighbor_mask = torch.zeros(1, 4, 80, dtype=torch.bool)
+
+        with pytest.raises(ValueError, match="requires an external base_model"):
+            _compute_sft_diffusion_loss(
+                model=model, model_args=model_args, data=data,
+                ego_gt=ego_gt, neighbor_gt=neighbor_gt, neighbor_mask=neighbor_mask,
+                device=torch.device("cpu"), K=1,
+                neighbor_reg_weight=1.0, neighbor_reg_only=True,
+                base_model=None, prefer_external_base=True,
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

In LoRA fine-tuning, the regularization base pass (used by neighbor-reg, output-space KL, and baseline-anchored ego-IL) computed its "base" prediction by calling the model under `disable_adapter()`. That returns the **merged warmstart** weights — i.e. whatever the previous fine-tuning leg produced — not the original pre-fine-tuning baseline.

For a single LoRA leg this is fine: the warmstart *is* the baseline. But in a **multi-leg chain** (warmstart from leg N to train leg N+1, repeat), `disable_adapter()` only ever recovers leg N. So:

- The regularizer can only pull predictions back toward the **immediately previous** leg, never toward the true original baseline.
- Drift accumulates leg over leg — each leg anchors to an already-drifted reference.
- Increasing `neighbor_reg_weight` does not help, because the target it pins to is itself drifting (weight 1.0 and 3.0 behave the same).

This showed up as neighbor-output L2 creeping up across a chain of fine-tuning legs with no knob able to arrest it.

## Fix

Add a gated option to anchor the regularization base pass to an **external frozen model** instead of `disable_adapter()`:

- `neighbor_reg_anchor: str = "warmstart"` (new, default) — byte-identical to the previous behavior (`disable_adapter()` path). No change for existing configs.
- `neighbor_reg_anchor: "baseline"` + `neighbor_reg_anchor_path: <path>` — loads that checkpoint as a frozen, eval-mode anchor and runs the base pass against it, so the regularizer pins to a fixed reference for the whole chain.

`run_experiment.py` validates the path and loads/freezes the anchor model when the option is enabled; the existing non-LoRA frozen-base path is untouched.

Also makes the neighbor SFT loss weight configurable (small companion change in the same area).

## Notes

- Default behavior is unchanged (`"warmstart"`), so this is opt-in and backward compatible.
- The external-base forward is run with the model in train mode (decoder dispatches on `self.training` and only returns `model_output` in training mode) wrapped in `torch.no_grad()`, then restored — matching what the regularization loss expects.
