### PR TITLE
fix(data_converter): fix unreachable error

### DIFF
--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/types/skipping_info.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/types/skipping_info.hpp
@@ -46,6 +46,7 @@ inline const char * to_topic_name(MissingTopicType t)
     case MissingTopicType::TrafficSignals:
       return "/perception/traffic_light_recognition/traffic_signals";
   }
+  __builtin_unreachable();
 }
 
 // Detailed categorization of incomplete data at frame level


### PR DESCRIPTION
# Description

I'm getting a compiler warning stating that, even though the `switch` statement covers all enumerators, there is no default case and the end of the function is reached.
I fixed this by adding `__builtin_unreachable()` at the end.

```
/home/user/Diffusion-Planner/cpp_tools/src/autoware_diffusion_planner_tools/include/types/skipping_info.hpp:49:1: error: control reaches end of non-void function [-Werror=return-type]
   49 | }
      | ^
cc1plus: all warnings being treated as errors
```

# How to test

Run
```
./build.sh --test
```