### PR TITLE
Guidance explorer: learned per-scene guidance for the frozen planner

### DIFF
--- a/docs/guidance_explorer_framework.md
+++ b/docs/guidance_explorer_framework.md
@@ -1,0 +1,135 @@
+# Training a Guidance-Explorer Policy: A General Framework
+
+This document describes a case-agnostic methodology for training a small
+learned policy that steers a FROZEN diffusion planner via classifier
+guidance — "guidance explorer" — for a target behavior (e.g. obstacle
+avoidance) while staying inert everywhere else. It distills the logic and
+the order of operations; it deliberately contains no experiment-specific
+numbers.
+
+## 1. Architecture and contract
+
+- The planner is frozen. A policy (~small MLP over the frozen encoder's
+  scene encoding + the planner's own deterministic trajectory as a
+  reference input) outputs per-head guidance commands ("etas") in [-1, 1]
+  through Beta distributions; deterministic inference uses the means.
+- Each head maps to a guidance energy applied during diffusion sampling
+  through a composer. The contract per head: eta = 0 must be EXACTLY inert
+  (zero energy and zero gradient), magnitude must mean roughly the same
+  thing in every scene, and commands must be O(1).
+
+## 2. Calibrate the guidances FIRST (most failures start here)
+
+Before any policy training, measure each guidance's response curve:
+sweep eta over [-1, 1] on a handful of diverse scenes, generate, and plot
+realized displacement / task metric vs eta, plus rendered fans.
+Acceptance: monotonic, side-symmetric, and scene-consistent gain.
+Findings to expect and fix:
+- Linear "push" energies without a bounded target have scene-dependent
+  endpoint gain (the same eta can move the plan 50x more in one scene
+  than another) — prefer bounded-target quadratic energies.
+- Per-step-normalized energies concentrate curvature and can destabilize
+  the sampler; full-horizon (mean-over-all-steps) energies with held or
+  ramped targets are the stable family.
+- Demanding a target offset at the first future step distorts the plan
+  head (closed-loop poison); ramp the target over the first ~2 s.
+- Larger guidance magnitude is NOT more capability: past the corridor
+  width it trades the target metric for boundary violations. Calibrate the
+  envelope (lambda/scales) so eta = +-1 spans what the road allows.
+
+## 3. Labels by sweep, selected for ROBUSTNESS
+
+- For each training scene run a dense grid sweep over the joint eta space,
+  score every combo with the canonical task reward, and keep the metadata
+  for ALL combos.
+- Proactive margins: label a scene as needing action when the unguided
+  plan's clearance is below a chosen margin (not only when it violates);
+  the target is the best CLEAN combo achieving the margin, with a
+  best-improvement fallback when nothing reaches it.
+- CRITICAL — robust selection: a regression policy cannot hit exact eta
+  values, and a Beta mean can never reach +-1. The diffusion prior is
+  multi-modal, so the response surface has cliffs where a small eta error
+  flips the outcome. Therefore: pick combos at the center of a clean
+  PLATEAU (maximize the worst outcome over the eta-neighbourhood), and
+  EXCLUDE scenes whose only solutions are cliff-edge — they are
+  unlearnable by regression and belong to other mechanisms. Expect
+  behavioral metrics to improve even when label-fit metrics get worse.
+
+## 4. Data coverage is the real lever
+
+- Perturbation diversity of a few base scenes generalizes far better than
+  adding more unique scenes.
+- Mid-maneuver states: re-anchor scenes along the policy's own OPEN-LOOP
+  guided trajectories (executed prefix spliced into history) so the policy
+  learns to continue and to decay an action in progress. (Labels derived
+  from CLOSED-LOOP visited states do not transfer — feedback compounding
+  makes open-loop-solved labels wrong there.)
+- When evaluation reveals a failing geometry class, MINT it: select seed
+  scenes containing that geometry, perturbation-generate variants, sweep,
+  and label. Teaching the true geometry tends to improve precision
+  everywhere (imitation-deviation cost can drop at the same time).
+- Hygiene screens that must run on every pool: (a) scenes already
+  violating at t=0 are dropped; (b) zero-target "normal" scenes must be
+  verified conflict-free with the canonical clearance (a mislabeled normal
+  teaches driving into obstacles); (c) any neighbour that is stopped but
+  has an empty future track must be repaired (future = pose repeated) or
+  the future-based reward machinery is blind to it; (d) never let
+  training pools touch the metric rulers (check by path AND basename).
+
+## 5. Splits and rulers
+
+- Hold out by BASE-SCENE GROUP across all label files (perturbation and
+  rolled siblings leave together), or overfit detection is meaningless.
+- Judge candidates behaviorally, in this order: (1) closed-loop
+  per-step-replanning rollouts on held-out sets, scored by the canonical
+  collision machinery — batch all scenes in lockstep for speed; apply the
+  same plan smoothing the production stack uses; (2) open-loop counts and
+  clearance distributions; (3) imitation deviation on a dedicated
+  validation list the policy never touched; (4) inertness on no-action
+  scenes (mean and max trajectory deviation, raw eta magnitudes).
+  Label-fit metrics (MSE, sign accuracy) are diagnostics only — they can
+  anti-correlate with behavior.
+- Evaluate beyond the nominal horizon occasionally: a pass that is clean
+  at the protocol cutoff can still graze later. Report minimum clearances,
+  not just counts — "no contact" at a few cm is an operational near-miss.
+
+## 6. Iteration discipline
+
+- Change ONE variable per retrain; with cached encoder features a retrain
+  is minutes, so prefer many small single-variable runs.
+- Diagnose per scene before choosing the next lever: is the policy BLIND
+  (eta ~ 0 in a real conflict -> coverage problem), MISCALIBRATED (right
+  sign, wrong magnitude -> robustness/labels), or is the scene INFEASIBLE
+  under the envelope (sweep ceiling says no clean combo -> different
+  action type, or out of scope)?
+- Loss-balance knobs (avoid-vs-zero weighting) have a narrow useful range
+  and a noise floor; if two settings straddle the target without meeting
+  it, the fix is data or labels, not finer knob steps.
+- RL on top of a converged supervised policy: treat as polish only.
+  Value-head warmup must not touch shared trunks (freeze everything but
+  the value head, or the critic's gradients drift the actor); evaluate
+  EVERY epoch checkpoint and select, because policy-gradient epochs drift.
+  Expect it to defend, not advance, the supervised result.
+
+## 7. Inference engineering
+
+- Cache anything constant across denoise steps (observation
+  inverse-normalization), short-circuit the whole guidance path when all
+  etas are ~0 (most frames), and avoid recomputing model forwards the
+  solver already made. Gate every optimization behind an equivalence
+  battery: response curves unchanged, closed-loop tables within noise,
+  bit-identical trajectories where exactness is claimed.
+- The end state for a latency-critical deployment is distillation: use the
+  frozen-planner+policy combo as a data engine (guided trajectories as
+  curated targets) and bake the behavior into the planner via standard
+  fine-tuning, removing inference-time guidance entirely.
+
+## 8. Failure modes checklist
+
+blind scenes (coverage) | cliff labels (robust selection) | scene-gain
+variance (guidance design) | plan-head distortion (target ramps / closed
+loop) | inertness leak on unfamiliar normals (zero-target coverage +
+balance) | poisoned normals / blind rewards (hygiene screens) | holdout
+leakage via siblings (grouped split) | proxy-metric chasing (behavioral
+rulers) | RL drift (warmup + per-epoch selection) | "clean at cutoff"
+passes (extended-horizon spot checks).

--- a/docs/guidance_explorer_framework.md
+++ b/docs/guidance_explorer_framework.md
@@ -123,6 +123,13 @@ Findings to expect and fix:
   frozen-planner+policy combo as a data engine (guided trajectories as
   curated targets) and bake the behavior into the planner via standard
   fine-tuning, removing inference-time guidance entirely.
+- A trained explorer doubles as a scene CLASSIFIER: run it deterministically
+  over any scene list and threshold the per-head |eta| — a strong lateral or
+  collision request means the policy sees something to avoid, near-zero means
+  a normal scene (`rlvr/autoresearch/tools/classify_avoidance_scenes.py`,
+  `--lat_thresh`/`--col_thresh`, rule any/both). Useful for mining avoidance
+  scenes from large unlabeled pools and for auditing dataset composition; the
+  inertness contract makes the signal bimodal, so the threshold is forgiving.
 
 ## 8. Failure modes checklist
 

--- a/docs/guidance_framework_design.md
+++ b/docs/guidance_framework_design.md
@@ -627,3 +627,31 @@ from . import my_guidance   # triggers @register
 ```
 
 That's it. The playground UI, DPO pipeline, and GRPO reward loop can immediately use `"my_guidance"` as a string key in their `GuidanceSetConfig`. No other files need to change.
+
+## Batched guidance v2 set (rlvr/guidance_batched.py)
+
+Opt-in registry names (the v1 functions are unchanged; select via
+`--envelope v2` in `sweep_guidance_params` / `eval_policy_avoidance` /
+`valid_predictor_guided`, or `envelope="v2"` in
+`guidance_batched.build_head_composer`):
+
+- `lateral_ramp_batched` — Eq.2 lateral energy with a linear feasibility
+  ramp on the target (0 -> lambda*eta over `ramp_steps`, default 20). The
+  un-ramped target demands the full offset at the first future step, which
+  concentrates gradient on the plan head and distorts it.
+- `collision_swerve_v2_batched` — bounded-target swerve. Proximity gate is
+  computed from the (detached) reference trajectory (the current noisy x is
+  garbage early in denoising); the target profile is the cummax of the gate
+  (ramps up on approach, HOLDS after passing); energy is a plain mean-over-T
+  quadratic. Design notes from probe iterations: the v1 linear energy has a
+  scene-dependent endpoint gain (it pushes forever, scaled by in-range step
+  count); support-normalized quadratics concentrate curvature on few steps
+  and diverge under DPM guidance steps; bump-shaped targets (return-to-zero
+  mid-pass) fight themselves and sign-invert at useful scales. Full-horizon
+  / held targets with mean-over-T energies are the stable family.
+
+Calibration guidance: response-curve probes (eta sweep -> realized lateral
+displacement and clearance) are the acceptance test for any new guidance —
+require monotonic, side-symmetric, scene-consistent curves before use.
+Larger lambda is not "stronger avoidance": past the corridor width it
+trades obstacle clearance for road-border violations.

--- a/exploration_policy/loss.py
+++ b/exploration_policy/loss.py
@@ -1,16 +1,20 @@
 """Loss functions for the Exploration Policy (joint GRPO training).
 
-The policy outputs a Beta distribution, K η values are sampled from it,
-each generates a trajectory scored by the reward function. GRPO-style
-group-relative advantages are used to train the policy via advantage-weighted
-log probability (advantage_logprob mode).
+The policy outputs one Beta distribution per guidance head, K η values are
+sampled from them, each generates a trajectory scored by the reward function.
+GRPO-style group-relative advantages are used to train the policy via
+advantage-weighted log probability (advantage_logprob mode).
 
-Loss = policy_gradient + c_e * entropy_loss + c_kl * kl_loss
+Loss = policy_gradient + c_e * entropy_loss + c_kl * kl_loss + c_a * action_cost
 
 Where:
 - policy_gradient: -mean(A_k * log_prob_k) — advantage-weighted log_prob
-- entropy_loss: -mean(H(lat_dist) + H(lon_dist)) — encourage exploration
-- kl_loss: KL(current || init) — anchor to initial uniform-ish policy
+- entropy_loss: -mean(Σ_h H(dist_h)) — encourage exploration
+- kl_loss: Σ_h KL(current_h || init) — anchor to initial zero-mean policy
+- action_cost: Σ_h (2*mean_h - 1)^2 — differentiable pull of the deterministic
+  action (the Beta mean) toward η=0. A tie-breaker for inertness: negligible
+  next to real advantages, but breaks reward-indifference plateaus on scenes
+  where doing nothing is already optimal.
 """
 
 from __future__ import annotations
@@ -22,42 +26,54 @@ from torch.distributions import Beta, kl_divergence
 
 # Initial Beta params from zero-initialized GuidanceHead: softplus(0) + 1
 _INIT_PARAM = math.log(2) + 1.0
-_INIT_DIST_LAT = None
-_INIT_DIST_LON = None
+_INIT_DIST = {}
+
+
+def _get_init_distribution(device: torch.device) -> Beta:
+    """The initial (zero-init) Beta distribution for KL computation."""
+    key = str(device)
+    if key not in _INIT_DIST:
+        param = torch.tensor(_INIT_PARAM, device=device)
+        _INIT_DIST[key] = Beta(param, param)
+    return _INIT_DIST[key]
 
 
 def _get_init_distributions(device: torch.device) -> tuple[Beta, Beta]:
-    """Get the initial (zero-init) Beta distributions for KL computation."""
-    global _INIT_DIST_LAT, _INIT_DIST_LON
-    if _INIT_DIST_LAT is None or _INIT_DIST_LAT.concentration1.device != device:
-        param = torch.tensor(_INIT_PARAM, device=device)
-        _INIT_DIST_LAT = Beta(param, param)
-        _INIT_DIST_LON = Beta(param, param)
-    return _INIT_DIST_LAT, _INIT_DIST_LON
+    """Backward-compat: the (lat, lon) pair of init distributions."""
+    d = _get_init_distribution(device)
+    return d, d
 
 
 def compute_exploration_loss(
     advantages: torch.Tensor,
     log_probs: torch.Tensor,
-    lat_dist: Beta,
-    lon_dist: Beta,
+    lat_dist: Beta | None = None,
+    lon_dist: Beta | None = None,
     entropy_coef: float = 0.05,
     kl_coef: float = 0.01,
+    dists: dict[str, Beta] | None = None,
+    action_cost_coef: float = 0.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     """Compute the exploration policy loss for one scene.
 
     Args:
         advantages: [K] GRPO group-relative advantages for each η sample.
-        log_probs: [K] log π(η_k) = log_prob_lat_k + log_prob_lon_k.
-        lat_dist: Beta distribution for η_lat (batch_shape=[] or (B,)).
-        lon_dist: Beta distribution for η_lon (batch_shape=[] or (B,)).
+        log_probs: [K] log π(η_k) summed over heads.
+        lat_dist / lon_dist: legacy 2-head API — Beta distributions for
+            η_lat / η_lon. Ignored when ``dists`` is given.
         entropy_coef: Weight for entropy bonus (higher = more exploration).
         kl_coef: Weight for KL penalty against initial policy.
+        dists: head name -> Beta distribution (any number of heads).
+        action_cost_coef: Weight for the η=0 action-cost tie-breaker.
 
     Returns:
         (loss, metrics_dict)
     """
     device = advantages.device
+    if dists is None:
+        if lat_dist is None or lon_dist is None:
+            raise ValueError("pass either dists or both lat_dist and lon_dist")
+        dists = {"lateral": lat_dist, "longitudinal": lon_dist}
 
     # --- Advantage-weighted policy gradient ---
     # Negative because we maximize reward (minimize negative advantage-weighted log_prob)
@@ -66,27 +82,42 @@ def compute_exploration_loss(
     # --- Entropy bonus ---
     # Maximize entropy to prevent η collapse. Beta entropy is well-defined.
     # Reduce to scalar with .mean() since distributions may have batch dims.
-    entropy_value = (lat_dist.entropy() + lon_dist.entropy()).mean()
+    entropy_value = sum(d.entropy().mean() for d in dists.values())
     entropy_loss = -entropy_value
 
     # --- KL divergence against initial policy ---
     # Prevents the policy from straying too far from the zero-mean init
-    init_lat, init_lon = _get_init_distributions(device)
-    kl_value = (kl_divergence(lat_dist, init_lat) + kl_divergence(lon_dist, init_lon)).mean()
+    init_dist = _get_init_distribution(device)
+    kl_value = sum(kl_divergence(d, init_dist).mean() for d in dists.values())
     kl_loss = kl_value
 
+    # --- Action cost: pull the deterministic action (Beta mean) toward 0 ---
+    action_cost = sum(((2.0 * d.mean - 1.0) ** 2).mean() for d in dists.values())
+
     # --- Total loss (guaranteed scalar) ---
-    total_loss = policy_loss + entropy_coef * entropy_loss + kl_coef * kl_loss
+    total_loss = (
+        policy_loss
+        + entropy_coef * entropy_loss
+        + kl_coef * kl_loss
+        + action_cost_coef * action_cost
+    )
 
     metrics = {
         "exploration_policy_loss": policy_loss.item(),
         "exploration_entropy": entropy_value.item(),
         "exploration_kl": kl_value.item(),
+        "exploration_action_cost": float(action_cost),
         "exploration_total_loss": total_loss.item(),
-        "exploration_eta_lat_mean": lat_dist.mean.mean().item() * 2 - 1,
-        "exploration_eta_lon_mean": lon_dist.mean.mean().item() * 2 - 1,
-        "exploration_eta_lat_std": (lat_dist.variance.mean().item() * 4) ** 0.5,
-        "exploration_eta_lon_std": (lon_dist.variance.mean().item() * 4) ** 0.5,
     }
+    for name, d in dists.items():
+        metrics[f"exploration_eta_{name}_mean"] = d.mean.mean().item() * 2 - 1
+        metrics[f"exploration_eta_{name}_std"] = (d.variance.mean().item() * 4) ** 0.5
+    # Legacy metric aliases for the original 2-head layout
+    if "lateral" in dists:
+        metrics["exploration_eta_lat_mean"] = metrics["exploration_eta_lateral_mean"]
+        metrics["exploration_eta_lat_std"] = metrics["exploration_eta_lateral_std"]
+    if "longitudinal" in dists:
+        metrics["exploration_eta_lon_mean"] = metrics["exploration_eta_longitudinal_mean"]
+        metrics["exploration_eta_lon_std"] = metrics["exploration_eta_longitudinal_std"]
 
     return total_loss, metrics

--- a/exploration_policy/loss.py
+++ b/exploration_policy/loss.py
@@ -106,7 +106,9 @@ def compute_exploration_loss(
         "exploration_policy_loss": policy_loss.item(),
         "exploration_entropy": entropy_value.item(),
         "exploration_kl": kl_value.item(),
-        "exploration_action_cost": float(action_cost),
+        "exploration_action_cost": float(
+            action_cost.detach() if isinstance(action_cost, torch.Tensor) else action_cost
+        ),
         "exploration_total_loss": total_loss.item(),
     }
     for name, d in dists.items():

--- a/exploration_policy/model.py
+++ b/exploration_policy/model.py
@@ -23,8 +23,8 @@ Architecture (Figure 2):
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
 import json
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 import torch

--- a/exploration_policy/model.py
+++ b/exploration_policy/model.py
@@ -23,7 +23,7 @@ Architecture (Figure 2):
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 import json
 from pathlib import Path
 
@@ -56,6 +56,12 @@ class ExplorationPolicyConfig:
     # flow through the softplus compression. Default 1.0 (no scaling).
     # Set to 10.0 to make the policy learn ~12x faster.
     head_raw_scale: float = 1.0
+    # Guidance heads, one Beta distribution (-> eta in [-1, 1]) each. The
+    # policy itself is head-name agnostic — names define count, ordering, and
+    # the dict keys of ExplorationPolicyOutput; mapping eta -> guidance params
+    # is the caller's job. Default matches the original 2-head layout, so old
+    # checkpoints (fc2 [4, H]) load unchanged.
+    heads: list[str] = field(default_factory=lambda: ["lateral", "longitudinal"])
 
     def to_json(self, path: str | Path) -> None:
         with open(path, "w") as f:
@@ -70,15 +76,42 @@ class ExplorationPolicyConfig:
 
 @dataclass
 class ExplorationPolicyOutput:
-    """Output container for a single forward pass."""
+    """Output container for a single forward pass.
 
-    eta_lat: torch.Tensor       # [B] sampled lateral eta in [-1, 1]
-    eta_lon: torch.Tensor       # [B] sampled longitudinal eta in [-1, 1]
-    log_prob_lat: torch.Tensor  # [B] log probability of sampled eta_lat
-    log_prob_lon: torch.Tensor  # [B] log probability of sampled eta_lon
-    value: torch.Tensor         # [B] state value estimate (Phase 2)
-    lat_dist: Beta              # Beta distribution object for eta_lat
-    lon_dist: Beta              # Beta distribution object for eta_lon
+    Per-head tensors are keyed by the head names from
+    ExplorationPolicyConfig.heads. The eta_lat / eta_lon / lat_dist / lon_dist
+    accessors preserve the original 2-head API (KeyError if the corresponding
+    head is not configured).
+    """
+
+    etas: dict[str, torch.Tensor]       # head -> [B] sampled eta in [-1, 1]
+    log_probs: dict[str, torch.Tensor]  # head -> [B] log prob of sampled eta
+    value: torch.Tensor                 # [B] state value estimate (Phase 2)
+    dists: dict[str, Beta]              # head -> Beta distribution object
+
+    @property
+    def eta_lat(self) -> torch.Tensor:
+        return self.etas["lateral"]
+
+    @property
+    def eta_lon(self) -> torch.Tensor:
+        return self.etas["longitudinal"]
+
+    @property
+    def log_prob_lat(self) -> torch.Tensor:
+        return self.log_probs["lateral"]
+
+    @property
+    def log_prob_lon(self) -> torch.Tensor:
+        return self.log_probs["longitudinal"]
+
+    @property
+    def lat_dist(self) -> Beta:
+        return self.dists["lateral"]
+
+    @property
+    def lon_dist(self) -> Beta:
+        return self.dists["longitudinal"]
 
 
 class ExplorationPolicy(nn.Module):
@@ -113,6 +146,7 @@ class ExplorationPolicy(nn.Module):
 
         self.guidance_head = GuidanceHead(
             config.hidden_dim,
+            n_heads=len(config.heads),
             init_mode=config.head_init,
             init_std=config.head_init_std,
             raw_scale=config.head_raw_scale,
@@ -132,7 +166,8 @@ class ExplorationPolicy(nn.Module):
             deterministic: If True, use distribution mean instead of sampling.
 
         Returns:
-            ExplorationPolicyOutput with sampled eta values and log probs.
+            ExplorationPolicyOutput with sampled eta values and log probs
+            keyed by head name.
         """
         # Compress reference trajectory to a single token
         ref_token = self.ref_mixer(x_ref)  # [B, H]
@@ -140,34 +175,24 @@ class ExplorationPolicy(nn.Module):
         # Fuse with scene context via cross-attention
         fused = self.ref_fusion(ref_token, scene_encoding)  # [B, H]
 
-        # Get Beta distributions for guidance parameters
-        lat_dist, lon_dist = self.guidance_head(fused)
+        # One Beta distribution per configured head
+        head_dists = self.guidance_head(fused)
 
         # Get value estimate
         value = self.value_head(fused)  # [B]
 
-        if deterministic:
-            eta_lat_01 = lat_dist.mean
-            eta_lon_01 = lon_dist.mean
-        else:
-            # rsample() for reparameterized gradients
-            eta_lat_01 = lat_dist.rsample()  # [B] in (0, 1)
-            eta_lon_01 = lon_dist.rsample()  # [B] in (0, 1)
-
-        # Map from (0, 1) to (-1, 1)
-        eta_lat = 2.0 * eta_lat_01 - 1.0
-        eta_lon = 2.0 * eta_lon_01 - 1.0
-
-        # Log probabilities in the original (0, 1) space
-        log_prob_lat = lat_dist.log_prob(eta_lat_01)
-        log_prob_lon = lon_dist.log_prob(eta_lon_01)
+        etas: dict[str, torch.Tensor] = {}
+        log_probs: dict[str, torch.Tensor] = {}
+        dists: dict[str, Beta] = {}
+        for name, dist in zip(self.config.heads, head_dists):
+            eta_01 = dist.mean if deterministic else dist.rsample()  # [B] in (0, 1)
+            etas[name] = 2.0 * eta_01 - 1.0  # map to (-1, 1)
+            log_probs[name] = dist.log_prob(eta_01)
+            dists[name] = dist
 
         return ExplorationPolicyOutput(
-            eta_lat=eta_lat,
-            eta_lon=eta_lon,
-            log_prob_lat=log_prob_lat,
-            log_prob_lon=log_prob_lon,
+            etas=etas,
+            log_probs=log_probs,
             value=value,
-            lat_dist=lat_dist,
-            lon_dist=lon_dist,
+            dists=dists,
         )

--- a/exploration_policy/module/heads.py
+++ b/exploration_policy/module/heads.py
@@ -11,15 +11,19 @@ from torch.distributions import Beta
 
 
 class GuidanceHead(nn.Module):
-    """Outputs Beta distribution parameters for lateral and longitudinal eta.
+    """Outputs Beta distribution parameters for n_heads guidance etas.
 
-    Produces 4 values: (alpha_lat, beta_lat, alpha_lon, beta_lon).
+    Produces 2*n_heads values: (alpha_0, beta_0, alpha_1, beta_1, ...), one
+    (alpha, beta) pair per head. The default n_heads=2 reproduces the original
+    (lateral, longitudinal) layout exactly — fc2 stays [4, H] and old
+    checkpoints load unchanged.
+
     Beta params constrained >= 1.0 via softplus + 1.0, ensuring unimodal
     distributions.
 
     Zero-initialization: The last linear layer is zero-initialized so that
-    raw output = [0,0,0,0] at init. Through softplus(0)+1 = ln(2)+1 ≈ 1.693,
-    this gives alpha=beta for both distributions, meaning:
+    raw output = 0 at init. Through softplus(0)+1 = ln(2)+1 ≈ 1.693,
+    this gives alpha=beta for every distribution, meaning:
       - Beta mean = 0.5 in (0,1) → eta mean = 0.0 in (-1,1)
       - Beta std ≈ 0.24 in (0,1) → eta std ≈ 0.48 in (-1,1)
     This ensures unbiased exploration around the reference trajectory and
@@ -29,11 +33,13 @@ class GuidanceHead(nn.Module):
     def __init__(
         self,
         hidden_dim: int,
+        n_heads: int = 2,
         init_mode: str = "zeros",
         init_std: float = 0.01,
         raw_scale: float = 1.0,
     ):
         super().__init__()
+        self.n_heads = n_heads
         self.fc1 = nn.Linear(hidden_dim, hidden_dim)
         self.act = nn.GELU()
         # bias=False removes a direct global offset at the output layer:
@@ -43,7 +49,7 @@ class GuidanceHead(nn.Module):
         # scene-dependence — but empirically it significantly improves per-scene
         # variation vs having bias=True on fc2.
         # Zero-init still works: zero weights → output=0 → softplus(0)+1 ≈ 1.693.
-        self.fc2 = nn.Linear(hidden_dim, 4, bias=False)
+        self.fc2 = nn.Linear(hidden_dim, 2 * n_heads, bias=False)
         self.raw_scale = raw_scale
 
         # Output layer initialization controls the initial exploration behavior:
@@ -56,15 +62,15 @@ class GuidanceHead(nn.Module):
         else:
             raise ValueError(f"Unknown init_mode: {init_mode!r} (expected 'zeros' or 'normal')")
 
-    def forward(self, fused: torch.Tensor) -> tuple[Beta, Beta]:
+    def forward(self, fused: torch.Tensor) -> list[Beta]:
         """
         Args:
             fused: [B, H] fused scene + reference representation.
 
         Returns:
-            (lat_dist, lon_dist): Beta distributions with batch_shape=[B].
+            list of n_heads Beta distributions with batch_shape=[B].
         """
-        raw = self.fc2(self.act(self.fc1(fused)))  # [B, 4]
+        raw = self.fc2(self.act(self.fc1(fused)))  # [B, 2*n_heads]
 
         # raw_scale amplifies gradients through softplus to overcome compression.
         # Without scaling (raw_scale=1): raw=0.03 → softplus(0.03)+1=1.72, eta≈0.004
@@ -74,12 +80,11 @@ class GuidanceHead(nn.Module):
         # softplus + 1.0 ensures params >= 1.0 (unimodal Beta)
         # Clamp to max_conc to prevent distribution collapse (alpha=10 → high concentration)
         max_conc = 10.0
-        alpha_lat = torch.clamp(F.softplus(scaled[:, 0]) + 1.0, max=max_conc)
-        beta_lat = torch.clamp(F.softplus(scaled[:, 1]) + 1.0, max=max_conc)
-        alpha_lon = torch.clamp(F.softplus(scaled[:, 2]) + 1.0, max=max_conc)
-        beta_lon = torch.clamp(F.softplus(scaled[:, 3]) + 1.0, max=max_conc)
-
-        return Beta(alpha_lat, beta_lat), Beta(alpha_lon, beta_lon)
+        params = torch.clamp(F.softplus(scaled) + 1.0, max=max_conc)
+        return [
+            Beta(params[:, 2 * i], params[:, 2 * i + 1])
+            for i in range(self.n_heads)
+        ]
 
 
 class ValueHead(nn.Module):

--- a/exploration_policy/test_exploration_policy.py
+++ b/exploration_policy/test_exploration_policy.py
@@ -359,8 +359,9 @@ def test_multi_head_zero_init_inert():
 
 def test_loss_multi_head_dists():
     """compute_exploration_loss accepts a dists dict + action cost."""
-    from exploration_policy.loss import compute_exploration_loss
     from torch.distributions import Beta
+
+    from exploration_policy.loss import compute_exploration_loss
 
     dists = {
         "lateral": Beta(torch.tensor([2.0]), torch.tensor([1.5])),

--- a/exploration_policy/test_exploration_policy.py
+++ b/exploration_policy/test_exploration_policy.py
@@ -299,3 +299,79 @@ if __name__ == "__main__":
     test_grpo_config_exploration_fields()
 
     print("\nAll tests passed!")
+
+
+# ---------------------------------------------------------------------------
+# Multi-head (config-driven heads) tests
+# ---------------------------------------------------------------------------
+
+def test_multi_head_config():
+    """Three heads -> three Beta dists, etas dict keyed by head name."""
+    config = ExplorationPolicyConfig(
+        hidden_dim=64, n_attn_heads=2, encoder_hidden_dim=128,
+        heads=["lateral", "collision", "stretch"],
+    )
+    policy = ExplorationPolicy(config, ref_seq_len=20)
+    policy.eval()
+    out = policy(torch.randn(2, 10, 128), torch.randn(2, 20, 4))
+    assert set(out.etas.keys()) == {"lateral", "collision", "stretch"}
+    assert policy.guidance_head.fc2.weight.shape[0] == 6
+    for eta in out.etas.values():
+        assert eta.shape == (2,)
+        assert (eta >= -1).all() and (eta <= 1).all()
+    # lateral accessor works; longitudinal must fail loudly (not configured)
+    _ = out.eta_lat
+    try:
+        _ = out.eta_lon
+        raise AssertionError("eta_lon should raise for a policy without that head")
+    except KeyError:
+        pass
+
+
+def test_default_heads_checkpoint_backward_compat(tmp_path):
+    """A default-config (2-head) state dict round-trips into the new layout."""
+    config = ExplorationPolicyConfig(hidden_dim=64, n_attn_heads=2, encoder_hidden_dim=128)
+    policy = ExplorationPolicy(config, ref_seq_len=20)
+    path = tmp_path / "p.pth"
+    torch.save(policy.state_dict(), path)
+    fresh = ExplorationPolicy(
+        ExplorationPolicyConfig(hidden_dim=64, n_attn_heads=2, encoder_hidden_dim=128),
+        ref_seq_len=20,
+    )
+    fresh.load_state_dict(torch.load(path), strict=True)
+    out = fresh(torch.randn(1, 5, 128), torch.randn(1, 20, 4), deterministic=True)
+    assert abs(out.eta_lat.item()) < 1e-5  # zero-init -> inert mean
+    assert abs(out.eta_lon.item()) < 1e-5
+
+
+def test_multi_head_zero_init_inert():
+    """Every head's deterministic action is exactly 0 at zero-init."""
+    config = ExplorationPolicyConfig(
+        hidden_dim=64, n_attn_heads=2, encoder_hidden_dim=128,
+        heads=["lateral", "collision"],
+    )
+    policy = ExplorationPolicy(config, ref_seq_len=20)
+    policy.eval()
+    out = policy(torch.randn(4, 8, 128), torch.randn(4, 20, 4), deterministic=True)
+    for name, eta in out.etas.items():
+        assert torch.all(eta.abs() < 1e-5), f"head {name} not inert at init"
+
+
+def test_loss_multi_head_dists():
+    """compute_exploration_loss accepts a dists dict + action cost."""
+    from exploration_policy.loss import compute_exploration_loss
+    from torch.distributions import Beta
+
+    dists = {
+        "lateral": Beta(torch.tensor([2.0]), torch.tensor([1.5])),
+        "collision": Beta(torch.tensor([1.7]), torch.tensor([1.7])),
+    }
+    adv = torch.tensor([1.0, -1.0, 0.5])
+    lp = torch.tensor([-1.0, -2.0, -1.5], requires_grad=True)
+    loss, metrics = compute_exploration_loss(
+        advantages=adv, log_probs=lp, dists=dists, action_cost_coef=0.01,
+    )
+    assert loss.dim() == 0
+    assert "exploration_eta_collision_mean" in metrics
+    assert "exploration_eta_lat_mean" in metrics  # legacy alias
+    assert metrics["exploration_action_cost"] > 0

--- a/exploration_policy/test_exploration_policy.py
+++ b/exploration_policy/test_exploration_policy.py
@@ -184,7 +184,7 @@ def test_zero_initialization():
 
     # Check that the guidance head output layer is zero-initialized
     assert (policy.guidance_head.fc2.weight == 0).all(), "GuidanceHead output weight not zero"
-    assert (policy.guidance_head.fc2.bias == 0).all(), "GuidanceHead output bias not zero"
+    assert policy.guidance_head.fc2.bias is None, "GuidanceHead fc2 is bias=False by design"
 
     # Check that value head output layer is zero-initialized
     assert (policy.value_head.fc2.weight == 0).all(), "ValueHead output weight not zero"

--- a/rlvr/autoresearch/run_experiment.py
+++ b/rlvr/autoresearch/run_experiment.py
@@ -553,11 +553,11 @@ def run(config_path: Path, name: str, skip_baseline: bool = False, baseline_cach
             else:
                 from preference_optimization.lora_utils import (
                     LORA_TARGET_BLOCKS_01_REGEX,
+                    LORA_TARGET_BLOCKS_02_REGEX,
                     LORA_TARGET_FIRST_BLOCK_REGEX,
                     LORA_TARGET_LAST_BLOCK_REGEX,
                     apply_lora,
                 )
-                from preference_optimization.lora_utils import LORA_TARGET_BLOCKS_02_REGEX
                 target = {"last": LORA_TARGET_LAST_BLOCK_REGEX, "first": LORA_TARGET_FIRST_BLOCK_REGEX, "blocks01": LORA_TARGET_BLOCKS_01_REGEX, "blocks02": LORA_TARGET_BLOCKS_02_REGEX}.get(grpo_config.lora_target)
                 kwargs = dict(r=grpo_config.lora_rank, lora_alpha=grpo_config.lora_alpha,
                              lora_dropout=grpo_config.lora_dropout)
@@ -737,7 +737,10 @@ def run(config_path: Path, name: str, skip_baseline: bool = False, baseline_cach
                     if grpo_config.ranked_sft_use_explorer and grpo_config.exploration_checkpoint_path:
                         from pathlib import Path as _P
 
-                        from exploration_policy.model import ExplorationPolicy, ExplorationPolicyConfig
+                        from exploration_policy.model import (
+                            ExplorationPolicy,
+                            ExplorationPolicyConfig,
+                        )
                         _ckpt = _P(grpo_config.exploration_checkpoint_path)
                         if not _ckpt.exists():
                             print(f"  WARNING: exploration_checkpoint_path not found: {_ckpt}")

--- a/rlvr/autoresearch/run_experiment.py
+++ b/rlvr/autoresearch/run_experiment.py
@@ -565,8 +565,18 @@ def run(config_path: Path, name: str, skip_baseline: bool = False, baseline_cach
                     kwargs["target_modules"] = target
                 policy_model = apply_lora(policy_model, **kwargs)
 
-        trainable_params = [p for p in policy_model.parameters() if p.requires_grad]
-        optimizer = torch.optim.AdamW(trainable_params, lr=grpo_config.learning_rate)
+        if not grpo_config.train_dit:
+            # Frozen-DiT policy-only training (exploration trainer): freeze the
+            # whole planner; only the exploration policy gets an optimizer
+            # (created inside GRPOExplorationTrainer).
+            for p in policy_model.parameters():
+                p.requires_grad_(False)
+            policy_model.eval()
+            optimizer = None
+            print("train_dit=False: DiT frozen, training exploration policy only")
+        else:
+            trainable_params = [p for p in policy_model.parameters() if p.requires_grad]
+            optimizer = torch.optim.AdamW(trainable_params, lr=grpo_config.learning_rate)
 
         # Load frozen base model for full-model (non-LoRA) training when features
         # need a base reference: KL reg or baseline ego IL.
@@ -783,8 +793,25 @@ def run(config_path: Path, name: str, skip_baseline: bool = False, baseline_cach
             trainer.log_metrics(epoch, metrics)
             trainer.save_checkpoint(epoch, args_dict)
 
-            prob_result = evaluate_checkpoint(policy_model, model_args, prob_eval, eval_reward_config, f"epoch{epoch}-prob", baseline_cache=baseline_cache)
-            val_eval = evaluate_checkpoint(policy_model, model_args, val_50, eval_reward_config, f"epoch{epoch}-val", baseline_cache=baseline_cache)
+            if grpo_config.use_exploration_policy and not grpo_config.train_dit:
+                # Frozen DiT: evaluate_checkpoint ignores the policy and would
+                # return identical numbers every epoch. Score what the explorer
+                # actually does: deterministic policy-guided trajectories.
+                prob_result = trainer.evaluate_policy_guided(
+                    prob_eval, eval_reward_config, f"epoch{epoch}-prob")
+                _dump_rows = getattr(trainer, "last_eval_rows", None)
+                if _dump_rows is not None:
+                    with open(run_dir / f"policy_eval_prob_epoch_{epoch:03d}.json", "w") as _pf:
+                        json.dump(_dump_rows, _pf, indent=1)
+                val_eval = trainer.evaluate_policy_guided(
+                    val_50, eval_reward_config, f"epoch{epoch}-val")
+                _dump_rows = getattr(trainer, "last_eval_rows", None)
+                if _dump_rows is not None:
+                    with open(run_dir / f"policy_eval_val_epoch_{epoch:03d}.json", "w") as _pf:
+                        json.dump(_dump_rows, _pf, indent=1)
+            else:
+                prob_result = evaluate_checkpoint(policy_model, model_args, prob_eval, eval_reward_config, f"epoch{epoch}-prob", baseline_cache=baseline_cache)
+                val_eval = evaluate_checkpoint(policy_model, model_args, val_50, eval_reward_config, f"epoch{epoch}-val", baseline_cache=baseline_cache)
 
             # Log to wandb
             wandb_log.log_training(epoch, metrics)
@@ -804,7 +831,9 @@ def run(config_path: Path, name: str, skip_baseline: bool = False, baseline_cach
                 best_val_reward = val_eval["reward_mean"]
                 best_val_collision = val_eval["collision_rate"]
                 best_epoch = epoch
-                if grpo_config.use_lora:
+                if not grpo_config.train_dit:
+                    best_checkpoint = str(run_dir / f"exploration_policy_epoch_{epoch:03d}.pth")
+                elif grpo_config.use_lora:
                     best_checkpoint = str(run_dir / f"lora_epoch_{epoch:03d}")
                 else:
                     best_checkpoint = str(run_dir / "latest.pth")

--- a/rlvr/autoresearch/tools/README.md
+++ b/rlvr/autoresearch/tools/README.md
@@ -372,7 +372,7 @@ python -m rlvr.autoresearch.tools.classify_avoidance_scenes \
   --scenes <scenes.json> --out <report.json> \
   [--lat_thresh 0.15] [--col_thresh 0.15] [--rule any|both] \
   [--out_avoidance_list <a.json>] [--out_normal_list <n.json>] \
-  [--render_dir <dir>]
+  [--render_dir <dir> --ego_shape WB,L,W]
 ```
 
 - `--model_path` must be the planner the policy was trained against (the
@@ -381,7 +381,8 @@ python -m rlvr.autoresearch.tools.classify_avoidance_scenes \
   counts and |eta| distribution percentiles per head.
 - `--out_avoidance_list` / `--out_normal_list`: plain NPZ path lists,
   directly usable as dataset lists.
-- `--render_dir`: per-scene verdict PNGs for human audit — det trajectory
+- `--render_dir`: per-scene verdict PNGs for human audit — ego footprint at
+  t0 (blue, requires `--ego_shape WB,L,W`, no default) + det trajectory
   (black) + stopped-neighbor OBBs (crimson) + the policy-guided trajectory
   (green, dashed) on flagged scenes — and `collage_avoid.png` /
   `collage_normal.png`. The guidance envelope flags (`--lambda_lat`,

--- a/rlvr/autoresearch/tools/README.md
+++ b/rlvr/autoresearch/tools/README.md
@@ -340,6 +340,54 @@ Per-epoch L2-to-target distribution (+ per-arc) tracker for a HEAL/curated run, 
 ### build_baseline_det_target.py
 Build curated GRAFT-CL targets = a competent model's deterministic trajectory. Runs `--model`'s det inference (`eval_det_avoidance.det_inference_batched`) on a scene list, unit-normalizes the (cos,sin) heading columns, and writes the result into each NPZ's `ego_agent_future` (the curated SFT target) — for HEAL Mechanism B (train the wounded model toward a known-good line instead of ranking its own samples). `--model` is the TARGET source (e.g. the baseline that keeps the line where the grafted model drifted), NOT the model being trained; train curated (lr 5e-5) warm-started from the wounded model. Usage: `--model <competent.pth> --scenes <json> --ego_shape WB,L,W --out_dir <dir> --out_list <json>`.
 
+## Guidance-explorer tools
+
+Tools around the exploration policy (small Beta-head network that outputs
+per-scene guidance etas steering the FROZEN planner — see
+`docs/guidance_explorer_framework.md` for the training method). The training
+chain is `sweep_guidance_params` → `rederive_margin_labels` →
+`split_labels_holdout` → `rlvr.train_explorer_regression`; eval via
+`eval_policy_avoidance` (open-loop + inertness) and
+`batched_closedloop_videos` (lockstep closed-loop + renders).
+
+### classify_avoidance_scenes.py
+Use a trained explorer as an **avoidance-scene detector** over any NPZ scene
+list. Per scene it runs the frozen planner's deterministic inference (the
+policy's `x_ref` input), the frozen encoder, and the policy head
+(deterministic = Beta means), then flags the scene as avoidance when the
+requested guidance exceeds per-head thresholds — a weak signal below
+threshold is treated as not-really-avoidance.
+
+**Semantics caveat:** the etas judge *the baseline's plan*, not the scene in
+isolation. A scene whose obstacle the frozen planner already avoids unaided
+reads as "normal" (the policy's inertness contract) — usually what you want
+when mining training data, but not a "does this scene contain a parked car"
+detector. The signal is strongly bimodal (flagged scenes cluster at high
+|eta|, normals at ~0), so the threshold has wide margin; lower it to ~0.05
+to also catch borderline scenes, raise it for high-precision curation.
+
+```bash
+python -m rlvr.autoresearch.tools.classify_avoidance_scenes \
+  --model_path <base.pth> --policy_dir <dir with exploration_policy.pth + config> \
+  --scenes <scenes.json> --out <report.json> \
+  [--lat_thresh 0.15] [--col_thresh 0.15] [--rule any|both] \
+  [--out_avoidance_list <a.json>] [--out_normal_list <n.json>] \
+  [--render_dir <dir>]
+```
+
+- `--model_path` must be the planner the policy was trained against (the
+  etas are conditional on that model's det trajectory).
+- Report JSON: per-scene etas + verdict + triggered head(s), plus summary
+  counts and |eta| distribution percentiles per head.
+- `--out_avoidance_list` / `--out_normal_list`: plain NPZ path lists,
+  directly usable as dataset lists.
+- `--render_dir`: per-scene verdict PNGs for human audit — det trajectory
+  (black) + stopped-neighbor OBBs (crimson) + the policy-guided trajectory
+  (green, dashed) on flagged scenes — and `collage_avoid.png` /
+  `collage_normal.png`. The guidance envelope flags (`--lambda_lat`,
+  `--lat_scale`, `--col_scale`, `--envelope`, ...) only affect these
+  renders and must match the policy's training envelope.
+
 ## Data preparation (NPZ format / mining)
 
 ### convert_3col_to_4col.py / convert_4col_to_3col.py

--- a/rlvr/autoresearch/tools/README.md
+++ b/rlvr/autoresearch/tools/README.md
@@ -372,6 +372,7 @@ python -m rlvr.autoresearch.tools.classify_avoidance_scenes \
   --scenes <scenes.json> --out <report.json> \
   [--lat_thresh 0.15] [--col_thresh 0.15] [--rule any|both] \
   [--out_avoidance_list <a.json>] [--out_normal_list <n.json>] \
+  [--verify_clearance 1.5 --ego_shape WB,L,W] \
   [--render_dir <dir> --ego_shape WB,L,W]
 ```
 
@@ -381,6 +382,13 @@ python -m rlvr.autoresearch.tools.classify_avoidance_scenes \
   counts and |eta| distribution percentiles per head.
 - `--out_avoidance_list` / `--out_normal_list`: plain NPZ path lists,
   directly usable as dataset lists.
+- `--verify_clearance <m>` (recommended: 1.5): cross-check every flagged
+  scene with the canonical det-plan OBB clearance vs stopped neighbors and
+  DEMOTE it to normal when the baseline plan was already safe by that
+  margin — kills policy false positives (inertness leaks on unfamiliar
+  normals) without touching true positives, mirroring the deployment
+  activation gate. Demotions are recorded per scene (`demoted: true`,
+  `det_clearance`).
 - `--render_dir`: per-scene verdict PNGs for human audit — ego footprint at
   t0 (blue, requires `--ego_shape WB,L,W`, no default) + det trajectory
   (black) + stopped-neighbor OBBs (crimson) + the policy-guided trajectory

--- a/rlvr/autoresearch/tools/README.md
+++ b/rlvr/autoresearch/tools/README.md
@@ -356,7 +356,10 @@ list. Per scene it runs the frozen planner's deterministic inference (the
 policy's `x_ref` input), the frozen encoder, and the policy head
 (deterministic = Beta means), then flags the scene as avoidance when the
 requested guidance exceeds per-head thresholds — a weak signal below
-threshold is treated as not-really-avoidance.
+threshold is treated as not-really-avoidance. All three passes are BATCHED
+across scenes (`--batch_size`, default 32 — bit-identical to per-scene,
+~15x faster); NPZs must be shape-homogeneous (e.g. 320 neighbor slots).
+GT-future fields are ignored, so 3-col and 4-col pools mix freely.
 
 **Semantics caveat:** the etas judge *the baseline's plan*, not the scene in
 isolation. A scene whose obstacle the frozen planner already avoids unaided
@@ -372,8 +375,9 @@ python -m rlvr.autoresearch.tools.classify_avoidance_scenes \
   --scenes <scenes.json> --out <report.json> \
   [--lat_thresh 0.15] [--col_thresh 0.15] [--rule any|both] \
   [--out_avoidance_list <a.json>] [--out_normal_list <n.json>] \
+  [--batch_size 32] \
   [--verify_clearance 1.5 --ego_shape WB,L,W] \
-  [--render_dir <dir> --ego_shape WB,L,W]
+  [--render_dir <dir> --ego_shape WB,L,W [--render_only_avoidance]]
 ```
 
 - `--model_path` must be the planner the policy was trained against (the
@@ -392,8 +396,11 @@ python -m rlvr.autoresearch.tools.classify_avoidance_scenes \
 - `--render_dir`: per-scene verdict PNGs for human audit — ego footprint at
   t0 (blue, requires `--ego_shape WB,L,W`, no default) + det trajectory
   (black) + stopped-neighbor OBBs (crimson) + the policy-guided trajectory
-  (green, dashed) on flagged scenes — and `collage_avoid.png` /
-  `collage_normal.png`. The guidance envelope flags (`--lambda_lat`,
+  (green, dashed) on flagged scenes — and per-class collages
+  (`collage_avoid` / `collage_demoted` / `collage_normal`).
+  `--render_only_avoidance` skips normal scenes (for large sweeps);
+  clearance-demoted scenes always render with a DEMOTED title carrying the
+  measured clearance. The guidance envelope flags (`--lambda_lat`,
   `--lat_scale`, `--col_scale`, `--envelope`, ...) only affect these
   renders and must match the policy's training envelope.
 

--- a/rlvr/autoresearch/tools/batched_closedloop_videos.py
+++ b/rlvr/autoresearch/tools/batched_closedloop_videos.py
@@ -169,7 +169,9 @@ def _render_one(job):
     import matplotlib
     matplotlib.use("Agg")
     from rlvr.autoresearch.tools.ghost_sim_common import (
-        GhostSimConfig, extract_stopped_neighbors, run_ghost_sim,
+        GhostSimConfig,
+        extract_stopped_neighbors,
+        run_ghost_sim,
     )
     # Disambiguate same-basename scenes from different perturbation pools
     # (e.g. train_parallel/ and train_yaw/ both holding scene_0008_var02.npz).

--- a/rlvr/autoresearch/tools/batched_closedloop_videos.py
+++ b/rlvr/autoresearch/tools/batched_closedloop_videos.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Batched closed-loop A/B videos: step ALL scenes together, render in a pool.
+
+Phase 1 (GPU): two legs stepping every scene in lockstep —
+  baseline leg: ONE batched deterministic generation per step (all scenes);
+  explorer leg: det x_ref + policy etas + guided generation, batched the
+  same way (the batched guidances accept [B] etas, one composer call).
+Per-scene state update / SG filtering / pose integration mirror
+recovery_sim.closed_loop_rollout_with_plans exactly (advance_k=0, dt=0.1).
+
+Phase 2 (CPU pool): ghost_sim_common.run_ghost_sim in render-only mode
+(precomputed rollouts; no model, no GPU) — per-step PNGs + WebM per scene.
+
+Usage:
+    python -m rlvr.autoresearch.tools.batched_closedloop_videos \
+        --model_path <base.pth> --policy_dir <dir> --scenes <json> \
+        --output_dir <dir> [--steps 80] [--chunk 25] [--workers 10] \
+        [--lambda_lat 5.0] [--lat_scale 2.0] [--col_scale 9.0]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import multiprocessing as mp
+import pickle
+from pathlib import Path
+
+import numpy as np
+import torch
+
+import rlvr.guidance_batched  # noqa: F401
+from exploration_policy.utils import run_frozen_encoder
+from preference_optimization.utils import load_npz_data
+from rlvr.autoresearch.tools.recovery_test import transform_to_new_ego_frame
+from rlvr.closed_loop.batched_rollout import _batched_generate_varied_noise
+from rlvr.grpo_sft_trainer import _smooth_trajectory
+from rlvr.grpo_trainer_batched import _normalize_batch, _stack_scene_data
+
+
+@torch.no_grad()
+def batched_closed_loop(
+    model, margs, scene_datas, device,
+    policy=None, heads=None, gargs=None,
+    n_steps: int = 80, dt: float = 0.1, chunk: int = 25,
+):
+    """Roll all scenes forward in lockstep. Returns (rollouts, eta_logs);
+    rollouts match closed_loop_rollout_with_plans output per scene."""
+    from rlvr.autoresearch.tools.eval_policy_avoidance import make_composer
+
+    N = len(scene_datas)
+    datas = [{k: v.clone() if isinstance(v, torch.Tensor) else v
+              for k, v in d.items()} for d in scene_datas]
+    cum = [[0.0, 0.0, 1.0, 0.0] for _ in range(N)]  # x, y, cos, sin
+    positions = [[np.array([0.0, 0.0, 0.0])] for _ in range(N)]
+    plans_world = [[] for _ in range(N)]
+    eta_logs = [[] for _ in range(N)]
+    velocities = []
+    for d in datas:
+        ecs0 = d["ego_current_state"]
+        ecs0 = ecs0[0] if ecs0.dim() == 2 else ecs0
+        velocities.append([float(torch.linalg.vector_norm(ecs0[4:6]).item())])
+
+    for step_i in range(n_steps):
+        preds = [None] * N
+        for c0 in range(0, N, chunk):
+            idx = list(range(c0, min(c0 + chunk, N)))
+            batch = _stack_scene_data([datas[i] for i in idx], device)
+            norm = _normalize_batch(batch, margs)
+            det = _batched_generate_varied_noise(
+                model, margs, norm, noise_min=0.0, noise_max=0.0,
+                first_deterministic=False, composer=None, device=device,
+            )  # [B, T, 4]
+            if policy is None:
+                out = det.cpu().numpy()
+            else:
+                norm["reference_trajectory"] = det
+                enc = run_frozen_encoder(model, norm)
+                pout = policy(enc, det, deterministic=True)
+                etas = {h: (2.0 * pout.dists[h].mean - 1.0).reshape(-1)
+                        for h in heads}
+                out = _batched_generate_varied_noise(
+                    model, margs, norm, noise_min=0.0, noise_max=0.0,
+                    first_deterministic=False,
+                    composer=make_composer(etas, gargs), device=device,
+                ).cpu().numpy()
+                for j, i in enumerate(idx):
+                    eta_logs[i].append(
+                        {h: float(etas[h][j].item()) for h in heads})
+            for j, i in enumerate(idx):
+                preds[i] = out[j]
+
+        for i in range(N):
+            pred = _smooth_trajectory(preds[i], 11, 3)
+            cum_x, cum_y, cum_cos, cum_sin = cum[i]
+
+            cur_xy = pred[:, :2].astype(np.float64)
+            wx = cum_x + cum_cos * cur_xy[:, 0] - cum_sin * cur_xy[:, 1]
+            wy = cum_y + cum_sin * cur_xy[:, 0] + cum_cos * cur_xy[:, 1]
+            cur_h = np.arctan2(pred[:, 3], pred[:, 2])
+            wh = (cur_h + math.atan2(cum_sin, cum_cos)).astype(np.float64)
+            plans_world[i].append(np.stack([wx, wy, wh], axis=-1))
+
+            nx_loc = float(pred[0, 0])
+            ny_loc = float(pred[0, 1])
+            ncos_loc = float(pred[0, 2])
+            nsin_loc = float(pred[0, 3])
+            nrm = float(np.hypot(ncos_loc, nsin_loc)) or 1.0
+            ncos_loc /= nrm
+            nsin_loc /= nrm
+
+            dvx_loc = float(pred[1, 0] - pred[0, 0]) / dt
+            dvy_loc = float(pred[1, 1] - pred[0, 1]) / dt
+            new_vx = ncos_loc * dvx_loc + nsin_loc * dvy_loc
+            new_vy = -nsin_loc * dvx_loc + ncos_loc * dvy_loc
+
+            new_world_x = cum_x + cum_cos * nx_loc - cum_sin * ny_loc
+            new_world_y = cum_y + cum_sin * nx_loc + cum_cos * ny_loc
+            new_cum_cos = cum_cos * ncos_loc - cum_sin * nsin_loc
+            new_cum_sin = cum_sin * ncos_loc + cum_cos * nsin_loc
+
+            positions[i].append(np.array(
+                [new_world_x, new_world_y,
+                 math.atan2(new_cum_sin, new_cum_cos)]))
+            velocities[i].append(float(np.hypot(new_vx, new_vy)))
+            cum[i] = [new_world_x, new_world_y, new_cum_cos, new_cum_sin]
+
+            data = datas[i]
+            if "ego_agent_past" in data:
+                eap = data["ego_agent_past"].clone()
+                old_origin = torch.tensor([0.0, 0.0, 1.0, 0.0],
+                                          dtype=eap.dtype, device=eap.device)
+                T = eap.shape[1]
+                eap = torch.cat(
+                    [eap[:, 1:T],
+                     old_origin.view(1, 1, 4).expand(eap.shape[0], 1, 4)],
+                    dim=1)
+                data["ego_agent_past"] = eap
+            data = transform_to_new_ego_frame(
+                data, nx_loc, ny_loc, ncos_loc, nsin_loc)
+            if "ego_current_state" in data:
+                ecs = data["ego_current_state"]
+                ecs[..., 0] = 0.0
+                ecs[..., 1] = 0.0
+                ecs[..., 2] = 1.0
+                ecs[..., 3] = 0.0
+                ecs[..., 4] = float(new_vx)
+                ecs[..., 5] = float(new_vy)
+                data["ego_current_state"] = ecs
+            datas[i] = data
+        if (step_i + 1) % 10 == 0:
+            print(f"  [batched-cl] step {step_i + 1}/{n_steps}")
+
+    rollouts = []
+    for i in range(N):
+        rollouts.append({
+            "positions": np.stack(positions[i], axis=0),
+            "plans_world": plans_world[i],
+            "extra_plans_world": [[] for _ in range(n_steps)],
+            "velocities": np.array(velocities[i]),
+        })
+    return rollouts, eta_logs
+
+
+def _render_one(job):
+    """Worker: render one scene's ghost PNGs + webm from precomputed rollouts."""
+    (scene_path, rollout_a, rollout_b, eta_log, out_dir,
+     label_a, label_b, steps, hist_steps, webm_fps) = job
+    import matplotlib
+    matplotlib.use("Agg")
+    from rlvr.autoresearch.tools.ghost_sim_common import (
+        GhostSimConfig, extract_stopped_neighbors, run_ghost_sim,
+    )
+    # Disambiguate same-basename scenes from different perturbation pools
+    # (e.g. train_parallel/ and train_yaw/ both holding scene_0008_var02.npz).
+    scene_name = f"{Path(scene_path).parent.name}__{Path(scene_path).stem}"
+    cfg = GhostSimConfig(
+        model_a_label=label_a, model_b_label=label_b,
+        steps=steps, hist_steps=hist_steps, webm_fps=webm_fps,
+    )
+    cfg.subtitle = scene_name
+    data = load_npz_data(scene_path, "cpu")
+
+    def eta_title(step, a_pose, b_pose):
+        if not eta_log or step >= len(eta_log):
+            return ""
+        return "  explorer η: " + " ".join(
+            f"{h[:3]}={v:+.2f}" for h, v in eta_log[step].items())
+
+    run_ghost_sim(
+        scene_path=scene_path,
+        model_a=None, model_a_args=None, model_b=None, model_b_args=None,
+        scene_data=data,
+        output_dir=Path(out_dir) / scene_name,
+        cfg=cfg,
+        neighbor_boxes=extract_stopped_neighbors(scene_path),
+        make_webm=True,
+        extra_title_fn=eta_title,
+        rollout_a=rollout_a, rollout_b=rollout_b,
+    )
+    return scene_name
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--model_path", required=True)
+    parser.add_argument("--policy_dir", required=True)
+    parser.add_argument("--scenes", required=True)
+    parser.add_argument("--output_dir", required=True)
+    parser.add_argument("--steps", type=int, default=80)
+    parser.add_argument("--chunk", type=int, default=25)
+    parser.add_argument("--workers", type=int, default=10)
+    parser.add_argument("--hist_steps", type=int, default=30)
+    parser.add_argument("--webm_fps", type=int, default=10)
+    parser.add_argument("--label_a", default="baseline")
+    parser.add_argument("--label_b", default="explorer")
+    parser.add_argument("--render_only", action="store_true",
+                        help="skip phase 1, render from saved rollouts.pkl")
+    parser.add_argument("--lambda_lat", type=float, default=5.0)
+    parser.add_argument("--lat_scale", type=float, default=2.0)
+    parser.add_argument("--col_scale", type=float, default=9.0)
+    parser.add_argument("--col_range", type=float, default=8.0)
+    parser.add_argument("--lambda_spd", type=float, default=0.2)
+    parser.add_argument("--stretch_scale", type=float, default=1.0)
+    parser.add_argument("--guidance_scale", type=float, default=0.5)
+    args = parser.parse_args()
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    pkl = out_dir / "rollouts.pkl"
+
+    with open(args.scenes) as f:
+        paths = json.load(f)
+
+    if not args.render_only:
+        from rlvr.autoresearch.tools.eval_det_avoidance import load_model
+        from rlvr.autoresearch.tools.eval_policy_avoidance import load_policy
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        model, margs = load_model(args.model_path, device)
+        policy, heads = load_policy(args.policy_dir, margs, device)
+        datas = [load_npz_data(p, device) for p in paths]
+        print(f"[phase1] baseline leg: {len(paths)} scenes x {args.steps} steps")
+        ro_base, _ = batched_closed_loop(
+            model, margs, datas, device,
+            n_steps=args.steps, chunk=args.chunk)
+        print(f"[phase1] explorer leg")
+        ro_gui, eta_logs = batched_closed_loop(
+            model, margs, datas, device,
+            policy=policy, heads=heads, gargs=args,
+            n_steps=args.steps, chunk=args.chunk)
+        with open(pkl, "wb") as f:
+            pickle.dump({"paths": paths, "base": ro_base, "gui": ro_gui,
+                         "etas": eta_logs}, f)
+        print(f"[phase1] saved {pkl}")
+        del model, policy, datas
+        torch.cuda.empty_cache()
+    else:
+        with open(pkl, "rb") as f:
+            saved = pickle.load(f)
+        paths, ro_base, ro_gui, eta_logs = (
+            saved["paths"], saved["base"], saved["gui"], saved["etas"])
+
+    jobs = [(paths[i], ro_base[i], ro_gui[i], eta_logs[i], str(out_dir),
+             args.label_a, args.label_b, args.steps, args.hist_steps,
+             args.webm_fps) for i in range(len(paths))]
+    print(f"[phase2] rendering {len(jobs)} scenes with {args.workers} workers")
+    ctx = mp.get_context("spawn")
+    with ctx.Pool(args.workers) as pool:
+        for name in pool.imap_unordered(_render_one, jobs):
+            print(f"  [done] {name}")
+    print("[phase2] all renders complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/batched_closedloop_videos.py
+++ b/rlvr/autoresearch/tools/batched_closedloop_videos.py
@@ -165,7 +165,7 @@ def batched_closed_loop(
 def _render_one(job):
     """Worker: render one scene's ghost PNGs + webm from precomputed rollouts."""
     (scene_path, rollout_a, rollout_b, eta_log, out_dir,
-     label_a, label_b, steps, hist_steps, webm_fps) = job
+     label_a, label_b, steps, hist_steps, webm_fps, lambda_spd) = job
     import matplotlib
     matplotlib.use("Agg")
     from rlvr.autoresearch.tools.ghost_sim_common import (
@@ -188,7 +188,7 @@ def _render_one(job):
         for h, v in eta_log[step].items():
             if h == "stretch":
                 # show the actual factor (1 + lambda_spd * eta), not raw eta
-                parts.append(f"str×{1.0 + 0.2 * v:.2f}")
+                parts.append(f"str×{1.0 + lambda_spd * v:.2f}")
             else:
                 parts.append(f"{h[:3]}={v:+.2f}")
         return "  explorer η: " + " ".join(parts)
@@ -271,7 +271,7 @@ def main():
 
     jobs = [(paths[i], ro_base[i], ro_gui[i], eta_logs[i], str(out_dir),
              args.label_a, args.label_b, args.steps, args.hist_steps,
-             args.webm_fps) for i in range(len(paths))]
+             args.webm_fps, args.lambda_spd) for i in range(len(paths))]
     print(f"[phase2] rendering {len(jobs)} scenes with {args.workers} workers")
     ctx = mp.get_context("spawn")
     with ctx.Pool(args.workers) as pool:

--- a/rlvr/autoresearch/tools/batched_closedloop_videos.py
+++ b/rlvr/autoresearch/tools/batched_closedloop_videos.py
@@ -184,8 +184,14 @@ def _render_one(job):
     def eta_title(step, a_pose, b_pose):
         if not eta_log or step >= len(eta_log):
             return ""
-        return "  explorer η: " + " ".join(
-            f"{h[:3]}={v:+.2f}" for h, v in eta_log[step].items())
+        parts = []
+        for h, v in eta_log[step].items():
+            if h == "stretch":
+                # show the actual factor (1 + lambda_spd * eta), not raw eta
+                parts.append(f"str×{1.0 + 0.2 * v:.2f}")
+            else:
+                parts.append(f"{h[:3]}={v:+.2f}")
+        return "  explorer η: " + " ".join(parts)
 
     run_ghost_sim(
         scene_path=scene_path,

--- a/rlvr/autoresearch/tools/batched_closedloop_videos.py
+++ b/rlvr/autoresearch/tools/batched_closedloop_videos.py
@@ -232,6 +232,10 @@ def main():
     parser.add_argument("--lambda_spd", type=float, default=0.2)
     parser.add_argument("--stretch_scale", type=float, default=1.0)
     parser.add_argument("--guidance_scale", type=float, default=0.5)
+    parser.add_argument("--envelope", choices=["v1", "v2"], default="v1",
+                        help="guidance envelope — must match the policy's "
+                             "training labels")
+    parser.add_argument("--lambda_col", type=float, default=3.0)
     args = parser.parse_args()
 
     out_dir = Path(args.output_dir)

--- a/rlvr/autoresearch/tools/bench_explorer_latency.py
+++ b/rlvr/autoresearch/tools/bench_explorer_latency.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Latency benchmark: baseline det vs explorer K=1 vs explorer K=8.
+
+Single-scene (B=1) online setting, CUDA-synced, warmed up. Per mode:
+  baseline : one plain det generation (what the planner does today)
+  k1       : det generation (policy reference) + encoder + policy forward
+             + ONE guided generation  (single-pass explorer)
+  k8       : same, but 1+8 guided generations in one batched call
+             (mean + 8 sampled candidates — the fan / refine mode)
+
+Reports per-stage and total mean/p95 ms over scenes x repeats.
+
+Usage:
+    python -m rlvr.autoresearch.tools.bench_explorer_latency \
+        --model_path <base.pth> --policy_dir <dir> --scenes <json> \
+        [--n_scenes 10] [--repeats 5] \
+        [--lambda_lat 5.0] [--lat_scale 2.0] [--col_scale 9.0]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import time
+
+import numpy as np
+import torch
+
+import rlvr.guidance_batched  # noqa: F401
+from exploration_policy.utils import run_frozen_encoder
+from preference_optimization.utils import load_npz_data
+from rlvr.autoresearch.tools.eval_det_avoidance import load_model
+from rlvr.autoresearch.tools.eval_policy_avoidance import load_policy, make_composer
+from rlvr.autoresearch.tools.recovery_sim import deterministic_predict
+from rlvr.closed_loop.batched_rollout import _batched_generate_varied_noise
+from rlvr.grpo_trainer_batched import _normalize_batch, _stack_scene_data
+
+
+def _sync():
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+@torch.no_grad()
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--model_path", required=True)
+    parser.add_argument("--policy_dir", required=True)
+    parser.add_argument("--scenes", required=True)
+    parser.add_argument("--n_scenes", type=int, default=10)
+    parser.add_argument("--repeats", type=int, default=5)
+    parser.add_argument("--lambda_lat", type=float, default=5.0)
+    parser.add_argument("--lat_scale", type=float, default=2.0)
+    parser.add_argument("--col_scale", type=float, default=9.0)
+    parser.add_argument("--col_range", type=float, default=8.0)
+    parser.add_argument("--lambda_spd", type=float, default=0.2)
+    parser.add_argument("--stretch_scale", type=float, default=1.0)
+    parser.add_argument("--guidance_scale", type=float, default=0.5)
+    parser.add_argument("--output", default=None)
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model, model_args = load_model(args.model_path, device)
+    policy, heads = load_policy(args.policy_dir, model_args, device)
+    with open(args.scenes) as f:
+        paths = json.load(f)[: args.n_scenes]
+    datas = [load_npz_data(p, device) for p in paths]
+
+    t = {"baseline": [], "k1_det": [], "k1_policy": [], "k1_guided": [],
+         "k8_guided": []}
+
+    # warmup
+    for d in datas[:2]:
+        deterministic_predict(model, model_args, d)
+    _sync()
+
+    for rep in range(args.repeats):
+        for d in datas:
+            # --- baseline: plain det generation ---
+            _sync(); t0 = time.perf_counter()
+            det = deterministic_predict(model, model_args, d)
+            _sync(); t["baseline"].append(time.perf_counter() - t0)
+
+            # --- k1: det (reference) + encoder+policy + 1 guided gen ---
+            _sync(); t0 = time.perf_counter()
+            det = deterministic_predict(model, model_args, d)
+            _sync(); t1 = time.perf_counter()
+            batch = _stack_scene_data([d], device)
+            norm = _normalize_batch(batch, model_args)
+            x_ref = torch.from_numpy(np.ascontiguousarray(det)).float()
+            x_ref = x_ref.unsqueeze(0).to(device)
+            norm["reference_trajectory"] = x_ref
+            enc = run_frozen_encoder(model, norm)
+            out = policy(enc, x_ref, deterministic=True)
+            etas1 = {h: (2.0 * out.dists[h].mean - 1.0).reshape(1) for h in heads}
+            _sync(); t2 = time.perf_counter()
+            _ = _batched_generate_varied_noise(
+                model, model_args, norm, noise_min=0.0, noise_max=0.0,
+                first_deterministic=False,
+                composer=make_composer(etas1, args), device=device,
+            )
+            _sync(); t3 = time.perf_counter()
+            t["k1_det"].append(t1 - t0)
+            t["k1_policy"].append(t2 - t1)
+            t["k1_guided"].append(t3 - t2)
+
+            # --- k8: 1 mean + 8 sampled candidates, one batched gen ---
+            etas9 = {
+                h: torch.cat([
+                    (2.0 * out.dists[h].mean - 1.0).reshape(1),
+                    (2.0 * out.dists[h].rsample((8,)).reshape(-1) - 1.0),
+                ]) for h in heads
+            }
+            gen = {k: (v.expand(9, *v.shape[1:]).contiguous()
+                       if isinstance(v, torch.Tensor) and v.shape[0] == 1 else v)
+                   for k, v in norm.items()}
+            _sync(); t0 = time.perf_counter()
+            _ = _batched_generate_varied_noise(
+                model, model_args, gen, noise_min=0.0, noise_max=0.0,
+                first_deterministic=False,
+                composer=make_composer(etas9, args), device=device,
+            )
+            _sync(); t["k8_guided"].append(time.perf_counter() - t0)
+
+    def ms(v):
+        a = np.array(v) * 1000
+        return {"mean_ms": round(float(a.mean()), 2),
+                "p95_ms": round(float(np.percentile(a, 95)), 2)}
+
+    stages = {k: ms(v) for k, v in t.items()}
+    report = {
+        "n_scenes": len(datas), "repeats": args.repeats,
+        "stages": stages,
+        "totals": {
+            "baseline": stages["baseline"]["mean_ms"],
+            "k1_total": round(stages["k1_det"]["mean_ms"]
+                              + stages["k1_policy"]["mean_ms"]
+                              + stages["k1_guided"]["mean_ms"], 2),
+            "k8_total": round(stages["k1_det"]["mean_ms"]
+                              + stages["k1_policy"]["mean_ms"]
+                              + stages["k8_guided"]["mean_ms"], 2),
+        },
+    }
+    report["totals"]["k1_overhead_x"] = round(
+        report["totals"]["k1_total"] / report["totals"]["baseline"], 2)
+    report["totals"]["k8_overhead_x"] = round(
+        report["totals"]["k8_total"] / report["totals"]["baseline"], 2)
+    print(json.dumps(report, indent=1))
+    if args.output:
+        with open(args.output, "w") as f:
+            json.dump(report, f, indent=1)
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/classify_avoidance_scenes.py
+++ b/rlvr/autoresearch/tools/classify_avoidance_scenes.py
@@ -234,7 +234,25 @@ def main():
     done = 0
     for start in range(0, len(paths), args.batch_size):
         batch_paths = paths[start:start + args.batch_size]
-        datas = [load_npz_data(p, device) for p in batch_paths]
+        ego_override = getattr(args, "ego_shape_t", None)
+        datas = [load_npz_data(p, device, ego_shape_override=ego_override)
+                 for p in batch_paths]
+        # Raw NPZs may carry fewer neighbor slots than the model's
+        # agent_num (e.g. 32 vs 320) — zero-pad up (zero rows ARE empty
+        # slots, identical to pad_neighbors_320.py). More slots than the
+        # model expects would drop real agents — fail loudly.
+        agent_num = int(model_args.agent_num)
+        for d in datas:
+            nb = d["neighbor_agents_past"]
+            if nb.shape[1] > agent_num:
+                raise ValueError(
+                    f"scene has {nb.shape[1]} neighbor slots but the model "
+                    f"expects {agent_num} — truncating would drop agents")
+            if nb.shape[1] < agent_num:
+                pad = torch.zeros(nb.shape[0], agent_num - nb.shape[1],
+                                  *nb.shape[2:], dtype=nb.dtype,
+                                  device=nb.device)
+                d["neighbor_agents_past"] = torch.cat([nb, pad], dim=1)
         # GT futures are not model inputs and may differ in width across
         # pools (3-col raw vs 4-col) — drop them so mixed lists stack.
         stack_in = [{k: v for k, v in d.items()

--- a/rlvr/autoresearch/tools/classify_avoidance_scenes.py
+++ b/rlvr/autoresearch/tools/classify_avoidance_scenes.py
@@ -11,7 +11,9 @@ treated as not-really-avoidance.
 
 No guided generation and no reward scoring happen here: per scene this is
 one deterministic planner pass (for the reference trajectory), one frozen
-encoder pass, and the policy head.
+encoder pass, and the policy head — all BATCHED across scenes
+(--batch_size, default 32; requires shape-homogeneous NPZs, e.g. 320
+neighbor slots).
 
 Outputs a JSON report (per-scene etas + flag + which head(s) triggered,
 plus summary counts and |eta| distributions) and, optionally, plain NPZ
@@ -35,7 +37,10 @@ import torch
 
 from exploration_policy.utils import generate_reference_trajectory, run_frozen_encoder
 from preference_optimization.utils import load_npz_data
-from rlvr.autoresearch.tools.eval_det_avoidance import load_model
+from rlvr.autoresearch.tools.eval_det_avoidance import (
+    det_inference_batched,
+    load_model,
+)
 from rlvr.autoresearch.tools.eval_policy_avoidance import load_policy, make_composer
 
 
@@ -63,7 +68,8 @@ def scene_etas(model, model_args, policy, heads, npz_path, device):
 
 @torch.no_grad()
 def render_verdict(model, model_args, scene_path, etas, det, norm_data,
-                   is_avoid, triggers, args, device, out_png):
+                   is_avoid, triggers, args, device, out_png,
+                   verdict_label: str | None = None):
     """Scene render for human judgment: det trajectory + stopped-neighbor
     OBBs + verdict; flagged scenes also show the policy-guided trajectory
     (what the policy wants to do instead)."""
@@ -96,7 +102,8 @@ def render_verdict(model, model_args, scene_path, etas, det, norm_data,
     if guided is not None:
         ax.plot(guided[:, 0], guided[:, 1], "--", color="lime", lw=2.2,
                 label="policy-guided")
-    verdict = ("AVOIDANCE [" + "+".join(triggers) + "]") if is_avoid else "normal"
+    verdict = verdict_label or (
+        ("AVOIDANCE [" + "+".join(triggers) + "]") if is_avoid else "normal")
     eta_str = " ".join(f"{h[:3]}={v:+.2f}" for h, v in etas.items())
     ax.set_title(f"{Path(scene_path).stem}\n{verdict}  η: {eta_str}",
                  color=("darkred" if is_avoid else "darkgreen"))
@@ -158,6 +165,11 @@ def main():
     parser.add_argument("--rule", choices=["any", "both"], default="any",
                         help="'any': either head over threshold flags the "
                              "scene; 'both': require both heads")
+    parser.add_argument("--batch_size", type=int, default=32,
+                        help="scenes per batched det+encoder+policy pass")
+    parser.add_argument("--render_only_avoidance", action="store_true",
+                        help="with --render_dir: render only flagged (and "
+                             "clearance-demoted) scenes, skip normals")
     parser.add_argument("--out_avoidance_list", default=None,
                         help="optional JSON list of flagged NPZ paths")
     parser.add_argument("--out_normal_list", default=None,
@@ -216,44 +228,80 @@ def main():
     if render_dir:
         render_dir.mkdir(parents=True, exist_ok=True)
 
+    from rlvr.grpo_trainer_batched import _normalize_batch, _stack_scene_data
+
     rows, per_head_abs = [], {h: [] for h in heads}
-    for i, sp in enumerate(paths):
-        etas, det, norm_data = scene_etas(
-            model, model_args, policy, heads, sp, device)
-        is_avoid, triggers = classify(
-            etas, args.lat_thresh, args.col_thresh, args.rule)
-        row = {
-            "scene": sp,
-            "etas": {h: round(v, 4) for h, v in etas.items()},
-            "avoidance": is_avoid,
-            "triggered": triggers,
-        }
-        if is_avoid and args.verify_clearance > 0:
-            from rlvr.autoresearch.tools.ghost_sim_common import (
-                extract_stopped_neighbors,
-            )
-            from scenario_generation.explorer_runner import plan_static_clearance
-            boxes = extract_stopped_neighbors(sp)
-            det_clr = (plan_static_clearance(det, boxes, args.ego_shape_t,
-                                             device) if boxes else float("inf"))
-            row["det_clearance"] = round(float(det_clr), 3)
-            if det_clr >= args.verify_clearance:
-                # baseline plan already safe — policy false positive
-                is_avoid = False
-                row["avoidance"] = False
-                row["demoted"] = True
-        rows.append(row)
-        for h, v in etas.items():
-            per_head_abs[h].append(v)
-        if render_dir:
-            # pool-prefix the PNG name (same-basename scenes across pools)
-            png = render_dir / (
-                f"{'avoid' if is_avoid else 'normal'}__"
-                f"{Path(sp).parent.name}__{Path(sp).stem}.png")
-            render_verdict(model, model_args, sp, etas, det, norm_data,
-                           is_avoid, triggers, args, device, png)
-        if (i + 1) % 50 == 0:
-            print(f"  [classify] {i + 1}/{len(paths)}")
+    done = 0
+    for start in range(0, len(paths), args.batch_size):
+        batch_paths = paths[start:start + args.batch_size]
+        datas = [load_npz_data(p, device) for p in batch_paths]
+        # GT futures are not model inputs and may differ in width across
+        # pools (3-col raw vs 4-col) — drop them so mixed lists stack.
+        stack_in = [{k: v for k, v in d.items()
+                     if k not in ("ego_agent_future", "neighbor_agents_future")}
+                    for d in datas]
+        batch = _stack_scene_data(stack_in, device)
+        norm_batch = _normalize_batch(batch, model_args)
+        det_b = det_inference_batched(model, model_args, datas, device,
+                                      norm_batch=norm_batch)  # [B, T, 4]
+        norm_batch["reference_trajectory"] = det_b
+        enc = run_frozen_encoder(model, norm_batch)
+        out = policy(enc, det_b, deterministic=True)
+        etas_b = {h: (2.0 * out.dists[h].mean - 1.0).cpu() for h in heads}
+        det_np = det_b.cpu().numpy()
+
+        for i, sp in enumerate(batch_paths):
+            etas = {h: float(etas_b[h][i]) for h in heads}
+            det = det_np[i]
+            is_avoid, triggers = classify(
+                etas, args.lat_thresh, args.col_thresh, args.rule)
+            row = {
+                "scene": sp,
+                "etas": {h: round(v, 4) for h, v in etas.items()},
+                "avoidance": is_avoid,
+                "triggered": triggers,
+            }
+            if is_avoid and args.verify_clearance > 0:
+                from rlvr.autoresearch.tools.ghost_sim_common import (
+                    extract_stopped_neighbors,
+                )
+                from scenario_generation.explorer_runner import (
+                    plan_static_clearance,
+                )
+                boxes = extract_stopped_neighbors(sp)
+                det_clr = (plan_static_clearance(det, boxes, args.ego_shape_t,
+                                                 device)
+                           if boxes else float("inf"))
+                row["det_clearance"] = round(float(det_clr), 3)
+                if det_clr >= args.verify_clearance:
+                    # baseline plan already safe — policy false positive
+                    is_avoid = False
+                    row["avoidance"] = False
+                    row["demoted"] = True
+            rows.append(row)
+            for h, v in etas.items():
+                per_head_abs[h].append(v)
+            if render_dir and (is_avoid or row.get("demoted")
+                               or not args.render_only_avoidance):
+                # pool-prefix the PNG name (same-basename scenes across pools)
+                cls = ("avoid" if is_avoid
+                       else "demoted" if row.get("demoted") else "normal")
+                png = render_dir / (
+                    f"{cls}__{Path(sp).parent.name}__{Path(sp).stem}.png")
+                label = (f"DEMOTED (det clearance "
+                         f"{row['det_clearance']}m)" if cls == "demoted"
+                         else None)
+                # per-scene norm_data for the guided-trajectory render
+                nd = {k: v.clone() if isinstance(v, torch.Tensor) else v
+                      for k, v in datas[i].items()}
+                nd = model_args.observation_normalizer(nd)
+                nd["reference_trajectory"] = det_b[i:i + 1]
+                render_verdict(model, model_args, sp, etas, det, nd,
+                               is_avoid or bool(row.get("demoted")), triggers,
+                               args, device, png, verdict_label=label)
+        done += len(batch_paths)
+        if done % (args.batch_size * 4) < args.batch_size or done == len(paths):
+            print(f"  [classify] {done}/{len(paths)}")
 
     n_avoid = sum(r["avoidance"] for r in rows)
     n_demoted = sum(r.get("demoted", False) for r in rows)
@@ -282,7 +330,7 @@ def main():
 
     if render_dir:
         from rlvr.autoresearch.tools.eval_policy_avoidance import make_collage
-        for cls in ("avoid", "normal"):
+        for cls in ("avoid", "demoted", "normal"):
             pngs = sorted(render_dir.glob(f"{cls}__*.png"))
             make_collage(pngs, render_dir / f"collage_{cls}.png")
         print(f"[render] {len(list(render_dir.glob('*__*.png')))} PNGs + "

--- a/rlvr/autoresearch/tools/classify_avoidance_scenes.py
+++ b/rlvr/autoresearch/tools/classify_avoidance_scenes.py
@@ -184,6 +184,10 @@ def main():
         raise ValueError(
             f"policy heads {heads} contain neither 'lateral' nor 'collision' "
             "— this classifier keys on the avoidance heads")
+    if args.rule == "both" and not ("lateral" in heads and "collision" in heads):
+        raise ValueError(
+            f"--rule both requires BOTH avoidance heads; policy has {heads} "
+            "— no scene could ever be flagged")
 
     with open(args.scenes) as f:
         paths = json.load(f)

--- a/rlvr/autoresearch/tools/classify_avoidance_scenes.py
+++ b/rlvr/autoresearch/tools/classify_avoidance_scenes.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Classify scenes as avoidance / non-avoidance using the guidance explorer.
+
+The exploration policy was trained to request lateral / collision-swerve
+guidance exactly when the frozen planner's deterministic trajectory needs
+an avoidance correction, and to stay inert (eta ~ 0) otherwise. This tool
+runs the policy (deterministic = Beta means) over an NPZ scene list and
+flags a scene as "avoidance" when the requested guidance exceeds
+configurable per-head thresholds — a weak signal below threshold is
+treated as not-really-avoidance.
+
+No guided generation and no reward scoring happen here: per scene this is
+one deterministic planner pass (for the reference trajectory), one frozen
+encoder pass, and the policy head.
+
+Outputs a JSON report (per-scene etas + flag + which head(s) triggered,
+plus summary counts and |eta| distributions) and, optionally, plain NPZ
+path lists for the two classes, directly usable as dataset lists.
+
+Usage:
+    python -m rlvr.autoresearch.tools.classify_avoidance_scenes \
+        --model_path <base.pth> --policy_dir <dir with exploration_policy.pth> \
+        --scenes <scenes.json> --out <report.json> \
+        [--lat_thresh 0.15] [--col_thresh 0.15] [--rule any] \
+        [--out_avoidance_list <a.json>] [--out_normal_list <n.json>]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from exploration_policy.utils import generate_reference_trajectory, run_frozen_encoder
+from preference_optimization.utils import load_npz_data
+from rlvr.autoresearch.tools.eval_det_avoidance import load_model
+from rlvr.autoresearch.tools.eval_policy_avoidance import load_policy
+
+
+@torch.no_grad()
+def scene_etas(model, model_args, policy, heads, npz_path, device) -> dict[str, float]:
+    """Deterministic per-head etas in [-1, 1] for one scene."""
+    data = load_npz_data(npz_path, device)
+    norm_data = {
+        k: v.clone() if isinstance(v, torch.Tensor) else v for k, v in data.items()
+    }
+    norm_data = model_args.observation_normalizer(norm_data)
+    x_ref_np = generate_reference_trajectory(model, model_args, norm_data, device)
+    x_ref = torch.from_numpy(x_ref_np).unsqueeze(0).to(device)
+    norm_data["reference_trajectory"] = x_ref
+    enc = run_frozen_encoder(model, norm_data)
+    out = policy(enc, x_ref, deterministic=True)
+    return {h: float(2.0 * out.dists[h].mean - 1.0) for h in heads}
+
+
+def classify(etas: dict[str, float], lat_thresh: float, col_thresh: float,
+             rule: str) -> tuple[bool, list[str]]:
+    """Return (is_avoidance, triggered_heads) from the per-head etas."""
+    triggers = []
+    if "lateral" in etas and abs(etas["lateral"]) >= lat_thresh:
+        triggers.append("lateral")
+    if "collision" in etas and abs(etas["collision"]) >= col_thresh:
+        triggers.append("collision")
+    if rule == "any":
+        return bool(triggers), triggers
+    # rule == "both": only count scenes where BOTH heads fire
+    return ("lateral" in triggers and "collision" in triggers), triggers
+
+
+def _pct(vals: list[float]) -> dict[str, float]:
+    if not vals:
+        return {}
+    a = np.abs(np.asarray(vals))
+    qs = np.percentile(a, [5, 25, 50, 75, 95])
+    return {
+        "mean": round(float(a.mean()), 4),
+        "p5": round(float(qs[0]), 4), "p25": round(float(qs[1]), 4),
+        "p50": round(float(qs[2]), 4), "p75": round(float(qs[3]), 4),
+        "p95": round(float(qs[4]), 4), "max": round(float(a.max()), 4),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--model_path", required=True,
+                        help="frozen base planner checkpoint (must be the "
+                             "model the policy was trained against)")
+    parser.add_argument("--policy_dir", required=True,
+                        help="dir with exploration_policy.pth + "
+                             "exploration_policy_config.json")
+    parser.add_argument("--scenes", required=True, help="JSON list of NPZ paths")
+    parser.add_argument("--out", required=True, help="JSON report path")
+    parser.add_argument("--lat_thresh", type=float, default=0.15,
+                        help="min |eta_lateral| to count as an avoidance "
+                             "request (policy inertness bar on normal scenes "
+                             "is ~0.1; below this = weak signal)")
+    parser.add_argument("--col_thresh", type=float, default=0.15,
+                        help="min |eta_collision| to count as an avoidance "
+                             "request")
+    parser.add_argument("--rule", choices=["any", "both"], default="any",
+                        help="'any': either head over threshold flags the "
+                             "scene; 'both': require both heads")
+    parser.add_argument("--out_avoidance_list", default=None,
+                        help="optional JSON list of flagged NPZ paths")
+    parser.add_argument("--out_normal_list", default=None,
+                        help="optional JSON list of non-flagged NPZ paths")
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model, model_args = load_model(args.model_path, device)
+    policy, heads = load_policy(args.policy_dir, model_args, device)
+    if "lateral" not in heads and "collision" not in heads:
+        raise ValueError(
+            f"policy heads {heads} contain neither 'lateral' nor 'collision' "
+            "— this classifier keys on the avoidance heads")
+
+    with open(args.scenes) as f:
+        paths = json.load(f)
+
+    rows, per_head_abs = [], {h: [] for h in heads}
+    for i, sp in enumerate(paths):
+        etas = scene_etas(model, model_args, policy, heads, sp, device)
+        is_avoid, triggers = classify(
+            etas, args.lat_thresh, args.col_thresh, args.rule)
+        rows.append({
+            "scene": sp,
+            "etas": {h: round(v, 4) for h, v in etas.items()},
+            "avoidance": is_avoid,
+            "triggered": triggers,
+        })
+        for h, v in etas.items():
+            per_head_abs[h].append(v)
+        if (i + 1) % 50 == 0:
+            print(f"  [classify] {i + 1}/{len(paths)}")
+
+    n_avoid = sum(r["avoidance"] for r in rows)
+    summary = {
+        "n_scenes": len(rows),
+        "n_avoidance": n_avoid,
+        "n_normal": len(rows) - n_avoid,
+        "thresholds": {"lat": args.lat_thresh, "col": args.col_thresh,
+                       "rule": args.rule},
+        "policy_dir": args.policy_dir,
+        "model_path": args.model_path,
+        "abs_eta_distribution": {h: _pct(v) for h, v in per_head_abs.items()},
+    }
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    with open(args.out, "w") as f:
+        json.dump({"summary": summary, "scenes": rows}, f, indent=1)
+
+    if args.out_avoidance_list:
+        with open(args.out_avoidance_list, "w") as f:
+            json.dump([r["scene"] for r in rows if r["avoidance"]], f, indent=1)
+    if args.out_normal_list:
+        with open(args.out_normal_list, "w") as f:
+            json.dump([r["scene"] for r in rows if not r["avoidance"]], f, indent=1)
+
+    print(f"\n[classify] {len(rows)} scenes: {n_avoid} avoidance, "
+          f"{len(rows) - n_avoid} normal "
+          f"(|eta_lat|>={args.lat_thresh} {args.rule} "
+          f"|eta_col|>={args.col_thresh})")
+    for h, st in summary["abs_eta_distribution"].items():
+        if st:
+            print(f"  |eta_{h}|: mean {st['mean']} p50 {st['p50']} "
+                  f"p95 {st['p95']} max {st['max']}")
+    print(f"Wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/classify_avoidance_scenes.py
+++ b/rlvr/autoresearch/tools/classify_avoidance_scenes.py
@@ -35,35 +35,13 @@ from pathlib import Path
 import numpy as np
 import torch
 
-from exploration_policy.utils import generate_reference_trajectory, run_frozen_encoder
+from exploration_policy.utils import run_frozen_encoder
 from preference_optimization.utils import load_npz_data
 from rlvr.autoresearch.tools.eval_det_avoidance import (
     det_inference_batched,
     load_model,
 )
 from rlvr.autoresearch.tools.eval_policy_avoidance import load_policy, make_composer
-
-
-@torch.no_grad()
-def scene_etas(model, model_args, policy, heads, npz_path, device):
-    """Deterministic per-head etas in [-1, 1] for one scene.
-
-    Returns (etas, det_traj, norm_data): the unguided deterministic
-    trajectory IS the policy's x_ref input — the etas are a judgment of
-    that specific baseline plan, not of the scene in isolation.
-    """
-    data = load_npz_data(npz_path, device)
-    norm_data = {
-        k: v.clone() if isinstance(v, torch.Tensor) else v for k, v in data.items()
-    }
-    norm_data = model_args.observation_normalizer(norm_data)
-    x_ref_np = generate_reference_trajectory(model, model_args, norm_data, device)
-    x_ref = torch.from_numpy(x_ref_np).unsqueeze(0).to(device)
-    norm_data["reference_trajectory"] = x_ref
-    enc = run_frozen_encoder(model, norm_data)
-    out = policy(enc, x_ref, deterministic=True)
-    etas = {h: float(2.0 * out.dists[h].mean - 1.0) for h in heads}
-    return etas, x_ref_np, norm_data
 
 
 @torch.no_grad()
@@ -181,7 +159,10 @@ def main():
                              "+ collages")
     parser.add_argument("--ego_shape", default=None,
                         help="WB,L,W — required with --render_dir or "
-                             "--verify_clearance, no default")
+                             "--verify_clearance, no default. Used for the "
+                             "render footprint + clearance OBB, and as a "
+                             "FALLBACK for NPZs missing ego_shape (NPZs "
+                             "carrying their own keep it for model input)")
     parser.add_argument("--verify_clearance", type=float, default=0.0,
                         help="if > 0: cross-check flagged scenes with the "
                              "canonical det-plan OBB clearance vs stopped "

--- a/rlvr/autoresearch/tools/classify_avoidance_scenes.py
+++ b/rlvr/autoresearch/tools/classify_avoidance_scenes.py
@@ -168,8 +168,15 @@ def main():
                              "scenes also show the policy-guided trajectory) "
                              "+ collages")
     parser.add_argument("--ego_shape", default=None,
-                        help="WB,L,W — required with --render_dir (ego "
-                             "footprint), no default")
+                        help="WB,L,W — required with --render_dir or "
+                             "--verify_clearance, no default")
+    parser.add_argument("--verify_clearance", type=float, default=0.0,
+                        help="if > 0: cross-check flagged scenes with the "
+                             "canonical det-plan OBB clearance vs stopped "
+                             "neighbors and DEMOTE to normal when clearance "
+                             ">= this value (the baseline plan was already "
+                             "safe — policy false positive). Suggested: 1.5. "
+                             "Mirrors the deployment activation gate.")
     # Guidance envelope — only used for the guided trajectory in renders;
     # must match what the policy was trained against.
     parser.add_argument("--lambda_lat", type=float, default=5.0)
@@ -201,11 +208,12 @@ def main():
         paths = json.load(f)
 
     render_dir = Path(args.render_dir) if args.render_dir else None
-    if render_dir:
+    if render_dir or args.verify_clearance > 0:
         if not args.ego_shape:
-            raise ValueError("--render_dir requires --ego_shape WB,L,W "
-                             "(ego footprint) — no default")
+            raise ValueError("--render_dir / --verify_clearance require "
+                             "--ego_shape WB,L,W — no default")
         args.ego_shape_t = tuple(float(x) for x in args.ego_shape.split(","))
+    if render_dir:
         render_dir.mkdir(parents=True, exist_ok=True)
 
     rows, per_head_abs = [], {h: [] for h in heads}
@@ -214,12 +222,27 @@ def main():
             model, model_args, policy, heads, sp, device)
         is_avoid, triggers = classify(
             etas, args.lat_thresh, args.col_thresh, args.rule)
-        rows.append({
+        row = {
             "scene": sp,
             "etas": {h: round(v, 4) for h, v in etas.items()},
             "avoidance": is_avoid,
             "triggered": triggers,
-        })
+        }
+        if is_avoid and args.verify_clearance > 0:
+            from rlvr.autoresearch.tools.ghost_sim_common import (
+                extract_stopped_neighbors,
+            )
+            from scenario_generation.explorer_runner import plan_static_clearance
+            boxes = extract_stopped_neighbors(sp)
+            det_clr = (plan_static_clearance(det, boxes, args.ego_shape_t,
+                                             device) if boxes else float("inf"))
+            row["det_clearance"] = round(float(det_clr), 3)
+            if det_clr >= args.verify_clearance:
+                # baseline plan already safe — policy false positive
+                is_avoid = False
+                row["avoidance"] = False
+                row["demoted"] = True
+        rows.append(row)
         for h, v in etas.items():
             per_head_abs[h].append(v)
         if render_dir:
@@ -233,12 +256,15 @@ def main():
             print(f"  [classify] {i + 1}/{len(paths)}")
 
     n_avoid = sum(r["avoidance"] for r in rows)
+    n_demoted = sum(r.get("demoted", False) for r in rows)
     summary = {
         "n_scenes": len(rows),
         "n_avoidance": n_avoid,
         "n_normal": len(rows) - n_avoid,
+        "n_demoted_by_clearance": n_demoted,
         "thresholds": {"lat": args.lat_thresh, "col": args.col_thresh,
-                       "rule": args.rule},
+                       "rule": args.rule,
+                       "verify_clearance": args.verify_clearance},
         "policy_dir": args.policy_dir,
         "model_path": args.model_path,
         "abs_eta_distribution": {h: _pct(v) for h, v in per_head_abs.items()},
@@ -265,7 +291,10 @@ def main():
     print(f"\n[classify] {len(rows)} scenes: {n_avoid} avoidance, "
           f"{len(rows) - n_avoid} normal "
           f"(|eta_lat|>={args.lat_thresh} {args.rule} "
-          f"|eta_col|>={args.col_thresh})")
+          f"|eta_col|>={args.col_thresh})"
+          + (f", {n_demoted} demoted by det clearance "
+             f">={args.verify_clearance}m" if args.verify_clearance > 0
+             else ""))
     for h, st in summary["abs_eta_distribution"].items():
         if st:
             print(f"  |eta_{h}|: mean {st['mean']} p50 {st['p50']} "

--- a/rlvr/autoresearch/tools/classify_avoidance_scenes.py
+++ b/rlvr/autoresearch/tools/classify_avoidance_scenes.py
@@ -36,12 +36,17 @@ import torch
 from exploration_policy.utils import generate_reference_trajectory, run_frozen_encoder
 from preference_optimization.utils import load_npz_data
 from rlvr.autoresearch.tools.eval_det_avoidance import load_model
-from rlvr.autoresearch.tools.eval_policy_avoidance import load_policy
+from rlvr.autoresearch.tools.eval_policy_avoidance import load_policy, make_composer
 
 
 @torch.no_grad()
-def scene_etas(model, model_args, policy, heads, npz_path, device) -> dict[str, float]:
-    """Deterministic per-head etas in [-1, 1] for one scene."""
+def scene_etas(model, model_args, policy, heads, npz_path, device):
+    """Deterministic per-head etas in [-1, 1] for one scene.
+
+    Returns (etas, det_traj, norm_data): the unguided deterministic
+    trajectory IS the policy's x_ref input — the etas are a judgment of
+    that specific baseline plan, not of the scene in isolation.
+    """
     data = load_npz_data(npz_path, device)
     norm_data = {
         k: v.clone() if isinstance(v, torch.Tensor) else v for k, v in data.items()
@@ -52,7 +57,52 @@ def scene_etas(model, model_args, policy, heads, npz_path, device) -> dict[str, 
     norm_data["reference_trajectory"] = x_ref
     enc = run_frozen_encoder(model, norm_data)
     out = policy(enc, x_ref, deterministic=True)
-    return {h: float(2.0 * out.dists[h].mean - 1.0) for h in heads}
+    etas = {h: float(2.0 * out.dists[h].mean - 1.0) for h in heads}
+    return etas, x_ref_np, norm_data
+
+
+@torch.no_grad()
+def render_verdict(model, model_args, scene_path, etas, det, norm_data,
+                   is_avoid, triggers, args, device, out_png):
+    """Scene render for human judgment: det trajectory + stopped-neighbor
+    OBBs + verdict; flagged scenes also show the policy-guided trajectory
+    (what the policy wants to do instead)."""
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    from guidance_gui.generate_samples import generate_samples
+    from rlvr.autoresearch.tools.ghost_sim_common import extract_stopped_neighbors
+    from rlvr.autoresearch.tools.viz_cl_recovery import draw_scene_base
+    from scenario_generation.visualize import draw_agent_box
+
+    guided = None
+    if is_avoid:
+        eta_t = {h: torch.tensor([v], device=device) for h, v in etas.items()}
+        composer = make_composer(eta_t, args)
+        guided = generate_samples(model=model, model_args=model_args,
+                                  data=norm_data, noise_scale=0.0, n_samples=1,
+                                  composer=composer, device=device)[0]
+
+    fig, ax = plt.subplots(figsize=(10, 10))
+    draw_scene_base(ax, scene_path)
+    for (x, y, h, length, w) in extract_stopped_neighbors(scene_path):
+        draw_agent_box(ax, x, y, h, length, w, color="crimson", alpha=0.5)
+    ax.plot(det[:, 0], det[:, 1], "-", color="black", lw=2.2, label="baseline det")
+    if guided is not None:
+        ax.plot(guided[:, 0], guided[:, 1], "--", color="lime", lw=2.2,
+                label="policy-guided")
+    verdict = ("AVOIDANCE [" + "+".join(triggers) + "]") if is_avoid else "normal"
+    eta_str = " ".join(f"{h[:3]}={v:+.2f}" for h, v in etas.items())
+    ax.set_title(f"{Path(scene_path).stem}\n{verdict}  η: {eta_str}",
+                 color=("darkred" if is_avoid else "darkgreen"))
+    ax.legend(loc="upper right", fontsize=9)
+    ax.set_aspect("equal")
+    span = float(np.abs(det[..., :2]).max()) + 12
+    ax.set_xlim(-12, max(span, 40))
+    ax.set_ylim(-span / 2, span / 2)
+    fig.savefig(out_png, dpi=110, bbox_inches="tight")
+    plt.close(fig)
 
 
 def classify(etas: dict[str, float], lat_thresh: float, col_thresh: float,
@@ -108,6 +158,23 @@ def main():
                         help="optional JSON list of flagged NPZ paths")
     parser.add_argument("--out_normal_list", default=None,
                         help="optional JSON list of non-flagged NPZ paths")
+    parser.add_argument("--render_dir", default=None,
+                        help="render per-scene verdict PNGs (det trajectory + "
+                             "stopped neighbors; flagged scenes also show the "
+                             "policy-guided trajectory) + collages")
+    # Guidance envelope — only used for the guided trajectory in renders;
+    # must match what the policy was trained against.
+    parser.add_argument("--lambda_lat", type=float, default=5.0)
+    parser.add_argument("--lat_scale", type=float, default=2.0)
+    parser.add_argument("--col_scale", type=float, default=9.0)
+    parser.add_argument("--col_range", type=float, default=8.0)
+    parser.add_argument("--lambda_spd", type=float, default=0.2)
+    parser.add_argument("--stretch_scale", type=float, default=1.0)
+    parser.add_argument("--guidance_scale", type=float, default=0.5)
+    parser.add_argument("--head_protect", type=int, default=0)
+    parser.add_argument("--envelope", choices=["v1", "v2"], default="v1")
+    parser.add_argument("--lambda_col", type=float, default=3.0)
+    parser.add_argument("--slow_composer", action="store_true")
     args = parser.parse_args()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -121,9 +188,14 @@ def main():
     with open(args.scenes) as f:
         paths = json.load(f)
 
+    render_dir = Path(args.render_dir) if args.render_dir else None
+    if render_dir:
+        render_dir.mkdir(parents=True, exist_ok=True)
+
     rows, per_head_abs = [], {h: [] for h in heads}
     for i, sp in enumerate(paths):
-        etas = scene_etas(model, model_args, policy, heads, sp, device)
+        etas, det, norm_data = scene_etas(
+            model, model_args, policy, heads, sp, device)
         is_avoid, triggers = classify(
             etas, args.lat_thresh, args.col_thresh, args.rule)
         rows.append({
@@ -134,6 +206,13 @@ def main():
         })
         for h, v in etas.items():
             per_head_abs[h].append(v)
+        if render_dir:
+            # pool-prefix the PNG name (same-basename scenes across pools)
+            png = render_dir / (
+                f"{'avoid' if is_avoid else 'normal'}__"
+                f"{Path(sp).parent.name}__{Path(sp).stem}.png")
+            render_verdict(model, model_args, sp, etas, det, norm_data,
+                           is_avoid, triggers, args, device, png)
         if (i + 1) % 50 == 0:
             print(f"  [classify] {i + 1}/{len(paths)}")
 
@@ -158,6 +237,14 @@ def main():
     if args.out_normal_list:
         with open(args.out_normal_list, "w") as f:
             json.dump([r["scene"] for r in rows if not r["avoidance"]], f, indent=1)
+
+    if render_dir:
+        from rlvr.autoresearch.tools.eval_policy_avoidance import make_collage
+        for cls in ("avoid", "normal"):
+            pngs = sorted(render_dir.glob(f"{cls}__*.png"))
+            make_collage(pngs, render_dir / f"collage_{cls}.png")
+        print(f"[render] {len(list(render_dir.glob('*__*.png')))} PNGs + "
+              f"collages -> {render_dir}")
 
     print(f"\n[classify] {len(rows)} scenes: {n_avoid} avoidance, "
           f"{len(rows) - n_avoid} normal "

--- a/rlvr/autoresearch/tools/classify_avoidance_scenes.py
+++ b/rlvr/autoresearch/tools/classify_avoidance_scenes.py
@@ -88,6 +88,10 @@ def render_verdict(model, model_args, scene_path, etas, det, norm_data,
     draw_scene_base(ax, scene_path)
     for (x, y, h, length, w) in extract_stopped_neighbors(scene_path):
         draw_agent_box(ax, x, y, h, length, w, color="crimson", alpha=0.5)
+    # ego footprint at t0 (ego frame: rear axle at origin, heading 0)
+    wb, length, width = args.ego_shape_t
+    draw_agent_box(ax, 0.0, 0.0, 0.0, length, width, color="royalblue",
+                   alpha=0.35, wheelbase=wb)
     ax.plot(det[:, 0], det[:, 1], "-", color="black", lw=2.2, label="baseline det")
     if guided is not None:
         ax.plot(guided[:, 0], guided[:, 1], "--", color="lime", lw=2.2,
@@ -159,9 +163,13 @@ def main():
     parser.add_argument("--out_normal_list", default=None,
                         help="optional JSON list of non-flagged NPZ paths")
     parser.add_argument("--render_dir", default=None,
-                        help="render per-scene verdict PNGs (det trajectory + "
-                             "stopped neighbors; flagged scenes also show the "
-                             "policy-guided trajectory) + collages")
+                        help="render per-scene verdict PNGs (ego footprint + "
+                             "det trajectory + stopped neighbors; flagged "
+                             "scenes also show the policy-guided trajectory) "
+                             "+ collages")
+    parser.add_argument("--ego_shape", default=None,
+                        help="WB,L,W — required with --render_dir (ego "
+                             "footprint), no default")
     # Guidance envelope — only used for the guided trajectory in renders;
     # must match what the policy was trained against.
     parser.add_argument("--lambda_lat", type=float, default=5.0)
@@ -194,6 +202,10 @@ def main():
 
     render_dir = Path(args.render_dir) if args.render_dir else None
     if render_dir:
+        if not args.ego_shape:
+            raise ValueError("--render_dir requires --ego_shape WB,L,W "
+                             "(ego footprint) — no default")
+        args.ego_shape_t = tuple(float(x) for x in args.ego_shape.split(","))
         render_dir.mkdir(parents=True, exist_ok=True)
 
     rows, per_head_abs = [], {h: [] for h in heads}

--- a/rlvr/autoresearch/tools/compare_models_ghost.py
+++ b/rlvr/autoresearch/tools/compare_models_ghost.py
@@ -75,6 +75,13 @@ def main() -> None:
     parser.add_argument("--head_protect", type=int, default=0,
                         help="zero guidance on the first N plan steps "
                              "(closed-loop stall fix; 0 = off)")
+    parser.add_argument("--speed_floor", type=float, default=0.0,
+                        help="add stock band speed guidance with v_low = this "
+                             "fraction of current ego speed (e.g. 0.85) to the "
+                             "guided leg — prevents the closed-loop speed-decay "
+                             "spiral (the Branch Editor pairs swerve with speed "
+                             "guidance the same way). 0 = off")
+    parser.add_argument("--speed_scale", type=float, default=2.0)
     args = parser.parse_args()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -136,6 +143,17 @@ def main() -> None:
                     if isinstance(v, torch.Tensor) and v.shape[0] == 1:
                         gen[k] = v.expand(B, *v.shape[1:]).contiguous()
             composer = make_composer(etas, args)
+            if args.speed_floor > 0:
+                from diffusion_planner.model.guidance.config import GuidanceConfig
+                ecs = data["ego_current_state"]
+                ecs = ecs[0] if ecs.dim() == 2 else ecs
+                v_now = float(torch.linalg.vector_norm(ecs[4:6]).item())
+                composer._functions.append(__import__(
+                    "diffusion_planner.model.guidance.registry",
+                    fromlist=["build"]).build(GuidanceConfig(
+                        name="speed", enabled=True, scale=args.speed_scale,
+                        params={"v_low": args.speed_floor * v_now,
+                                "v_high": max(1.2 * v_now, 8.0)})))
             trajs = _batched_generate_varied_noise(
                 model, model_args, gen, noise_min=0.0, noise_max=0.0,
                 first_deterministic=False, composer=composer, device=device,

--- a/rlvr/autoresearch/tools/compare_models_ghost.py
+++ b/rlvr/autoresearch/tools/compare_models_ghost.py
@@ -72,6 +72,9 @@ def main() -> None:
     parser.add_argument("--lambda_spd", type=float, default=0.2)
     parser.add_argument("--stretch_scale", type=float, default=1.0)
     parser.add_argument("--guidance_scale", type=float, default=0.5)
+    parser.add_argument("--head_protect", type=int, default=0,
+                        help="zero guidance on the first N plan steps "
+                             "(closed-loop stall fix; 0 = off)")
     args = parser.parse_args()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/rlvr/autoresearch/tools/compare_models_ghost.py
+++ b/rlvr/autoresearch/tools/compare_models_ghost.py
@@ -53,6 +53,9 @@ def main() -> None:
     parser.add_argument("--make_webm", action="store_true")
     parser.add_argument("--hist_steps", type=int, default=0,
                         help="render N recorded-history frames (gray ego) before the sim")
+    parser.add_argument("--n_candidates", type=int, default=0,
+                        help="per step, also sample N etas from the policy "
+                             "distribution and render their plans as a faint fan")
     parser.add_argument("--webm_fps", type=int, default=10)
     parser.add_argument("--show_lateral", action="store_true",
                         help="Show lateral offset to route centerline")
@@ -114,14 +117,30 @@ def main() -> None:
             norm["reference_trajectory"] = x_ref
             enc = run_frozen_encoder(model, norm)
             out = policy(enc, x_ref, deterministic=True)
-            etas = {h: (2.0 * out.dists[h].mean - 1.0).reshape(1) for h in policy_heads}
-            eta_log.append({h: float(v.item()) for h, v in etas.items()})
+            N = max(0, args.n_candidates)
+            etas = {
+                h: torch.cat([
+                    (2.0 * out.dists[h].mean - 1.0).reshape(1),
+                    (2.0 * out.dists[h].rsample((N,)).reshape(-1) - 1.0),
+                ]) if N else (2.0 * out.dists[h].mean - 1.0).reshape(1)
+                for h in policy_heads
+            }
+            eta_log.append({h: float(v[0].item()) for h, v in etas.items()})
+            B = 1 + N
+            gen = dict(norm)
+            if N:
+                for k, v in norm.items():
+                    if isinstance(v, torch.Tensor) and v.shape[0] == 1:
+                        gen[k] = v.expand(B, *v.shape[1:]).contiguous()
             composer = make_composer(etas, args)
-            guided = _batched_generate_varied_noise(
-                model, model_args, norm, noise_min=0.0, noise_max=0.0,
+            trajs = _batched_generate_varied_noise(
+                model, model_args, gen, noise_min=0.0, noise_max=0.0,
                 first_deterministic=False, composer=composer, device=device,
-            )[0].cpu().numpy()
-            return _sg(guided)
+            ).cpu().numpy()
+            guided = _sg(trajs[0])
+            if N:
+                return guided, [trajs[i] for i in range(1, B)]
+            return guided
 
         return predict_a, predict_b
 

--- a/rlvr/autoresearch/tools/compare_models_ghost.py
+++ b/rlvr/autoresearch/tools/compare_models_ghost.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+import numpy as np
 import torch
 from preference_optimization.utils import load_npz_data
 
@@ -53,13 +54,72 @@ def main() -> None:
     parser.add_argument("--webm_fps", type=int, default=10)
     parser.add_argument("--show_lateral", action="store_true",
                         help="Show lateral offset to route centerline")
+    parser.add_argument("--policy_dir", default=None,
+                        help="exploration-policy dir: model B = model A + guidance "
+                             "(per-step policy etas via composer); --model_b ignored")
+    parser.add_argument("--sg_smooth", action="store_true",
+                        help="Savitzky-Golay smooth both legs' per-step plans "
+                             "(11/3) — matches scenario_generation.replay behavior")
+    parser.add_argument("--lambda_lat", type=float, default=5.0)
+    parser.add_argument("--lat_scale", type=float, default=2.0)
+    parser.add_argument("--col_scale", type=float, default=9.0)
+    parser.add_argument("--col_range", type=float, default=8.0)
+    parser.add_argument("--lambda_spd", type=float, default=0.2)
+    parser.add_argument("--stretch_scale", type=float, default=1.0)
+    parser.add_argument("--guidance_scale", type=float, default=0.5)
     args = parser.parse_args()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print(f"[compare] loading model A: {args.label_a}")
     model_a, args_a = load_model(args.model_a, args.lora_a, device)
-    print(f"[compare] loading model B: {args.label_b}")
-    model_b, args_b = load_model(args.model_b, args.lora_b, device)
+    policy = None
+    if args.policy_dir:
+        from rlvr.autoresearch.tools.eval_policy_avoidance import load_policy
+        policy, policy_heads = load_policy(args.policy_dir, args_a, device)
+        model_b, args_b = model_a, args_a
+        print(f"[compare] model B = model A + explorer ({args.policy_dir})")
+    else:
+        print(f"[compare] loading model B: {args.label_b}")
+        model_b, args_b = load_model(args.model_b, args.lora_b, device)
+
+    def _sg(traj):
+        if not args.sg_smooth:
+            return traj
+        from rlvr.grpo_sft_trainer import _smooth_trajectory
+        return _smooth_trajectory(traj, 11, 3)
+
+    def make_predict_fns(eta_log):
+        """(predict_a, predict_b): plain[+SG] vs explorer-guided[+SG]."""
+        from exploration_policy.utils import run_frozen_encoder
+        from rlvr.autoresearch.tools.eval_policy_avoidance import make_composer
+        from rlvr.autoresearch.tools.recovery_sim import deterministic_predict
+        from rlvr.closed_loop.batched_rollout import _batched_generate_varied_noise
+        from rlvr.grpo_trainer_batched import _normalize_batch, _stack_scene_data
+
+        def predict_a(model, model_args, data):
+            return _sg(deterministic_predict(model, model_args, data))
+
+        def predict_b(model, model_args, data):
+            det = deterministic_predict(model, model_args, data)
+            if policy is None:
+                return _sg(det)
+            batch = _stack_scene_data([data], device)
+            norm = _normalize_batch(batch, model_args)
+            x_ref = torch.from_numpy(np.ascontiguousarray(det)).float()
+            x_ref = x_ref.unsqueeze(0).to(device)
+            norm["reference_trajectory"] = x_ref
+            enc = run_frozen_encoder(model, norm)
+            out = policy(enc, x_ref, deterministic=True)
+            etas = {h: (2.0 * out.dists[h].mean - 1.0).reshape(1) for h in policy_heads}
+            eta_log.append({h: float(v.item()) for h, v in etas.items()})
+            composer = make_composer(etas, args)
+            guided = _batched_generate_varied_noise(
+                model, model_args, norm, noise_min=0.0, noise_max=0.0,
+                first_deterministic=False, composer=composer, device=device,
+            )[0].cpu().numpy()
+            return _sg(guided)
+
+        return predict_a, predict_b
 
     cfg = GhostSimConfig(
         model_a_label=args.label_a,
@@ -86,6 +146,15 @@ def main() -> None:
         scene_out = out_root / scene_name if len(args.scenes) > 1 else out_root
         cfg.subtitle = scene_name
 
+        eta_log: list[dict] = []
+        predict_a, predict_b = make_predict_fns(eta_log)
+
+        def eta_title(step, a_pose, b_pose):
+            if not eta_log or step >= len(eta_log):
+                return ""
+            e = eta_log[step]
+            return "  explorer η: " + " ".join(f"{h[:3]}={v:+.2f}" for h, v in e.items())
+
         run_ghost_sim(
             scene_path=scene_path,
             model_a=model_a, model_a_args=args_a,
@@ -95,6 +164,9 @@ def main() -> None:
             cfg=cfg,
             neighbor_boxes=nb_boxes,
             make_webm=args.make_webm,
+            extra_title_fn=eta_title if policy is not None else None,
+            predict_fn_a=predict_a if args.sg_smooth else None,
+            predict_fn_b=predict_b if (policy is not None or args.sg_smooth) else None,
         )
 
 

--- a/rlvr/autoresearch/tools/compare_models_ghost.py
+++ b/rlvr/autoresearch/tools/compare_models_ghost.py
@@ -62,9 +62,10 @@ def main() -> None:
     parser.add_argument("--policy_dir", default=None,
                         help="exploration-policy dir: model B = model A + guidance "
                              "(per-step policy etas via composer); --model_b ignored")
-    parser.add_argument("--sg_smooth", action="store_true",
-                        help="Savitzky-Golay smooth both legs' per-step plans "
-                             "(11/3) — matches scenario_generation.replay behavior")
+    parser.add_argument("--no_sg_smooth", action="store_true",
+                        help="disable the default SG plan filtering (11/3, "
+                             "grpo_sft_trainer._smooth_trajectory) applied by "
+                             "the rollout — matches scenario_generation.replay")
     parser.add_argument("--lambda_lat", type=float, default=5.0)
     parser.add_argument("--lat_scale", type=float, default=2.0)
     parser.add_argument("--col_scale", type=float, default=9.0)
@@ -99,14 +100,9 @@ def main() -> None:
     else:
         raise SystemExit("pass either --model_b or --policy_dir")
 
-    def _sg(traj):
-        if not args.sg_smooth:
-            return traj
-        from rlvr.grpo_sft_trainer import _smooth_trajectory
-        return _smooth_trajectory(traj, 11, 3)
-
     def make_predict_fns(eta_log):
-        """(predict_a, predict_b): plain[+SG] vs explorer-guided[+SG]."""
+        """(predict_a, predict_b): plain vs explorer-guided (SG happens in
+        the rollout itself, on whatever the predict fn returns)."""
         from exploration_policy.utils import run_frozen_encoder
         from rlvr.autoresearch.tools.eval_policy_avoidance import make_composer
         from rlvr.autoresearch.tools.recovery_sim import deterministic_predict
@@ -114,12 +110,12 @@ def main() -> None:
         from rlvr.grpo_trainer_batched import _normalize_batch, _stack_scene_data
 
         def predict_a(model, model_args, data):
-            return _sg(deterministic_predict(model, model_args, data))
+            return deterministic_predict(model, model_args, data)
 
         def predict_b(model, model_args, data):
             det = deterministic_predict(model, model_args, data)
             if policy is None:
-                return _sg(det)
+                return det
             batch = _stack_scene_data([data], device)
             norm = _normalize_batch(batch, model_args)
             x_ref = torch.from_numpy(np.ascontiguousarray(det)).float()
@@ -162,7 +158,7 @@ def main() -> None:
                 model, model_args, gen, noise_min=0.0, noise_max=0.0,
                 first_deterministic=False, composer=composer, device=device,
             ).cpu().numpy()
-            guided = _sg(trajs[0])
+            guided = trajs[0]
             if N:
                 return guided, [trajs[i] for i in range(1, B)]
             return guided
@@ -214,8 +210,9 @@ def main() -> None:
             neighbor_boxes=nb_boxes,
             make_webm=args.make_webm,
             extra_title_fn=eta_title if policy is not None else None,
-            predict_fn_a=predict_a if args.sg_smooth else None,
-            predict_fn_b=predict_b if (policy is not None or args.sg_smooth) else None,
+            predict_fn_a=None,
+            predict_fn_b=predict_b if policy is not None else None,
+            sg_smooth=not args.no_sg_smooth,
         )
 
 

--- a/rlvr/autoresearch/tools/compare_models_ghost.py
+++ b/rlvr/autoresearch/tools/compare_models_ghost.py
@@ -104,17 +104,15 @@ def main() -> None:
     else:
         raise SystemExit("pass either --model_b or --policy_dir")
 
-    def make_predict_fns(eta_log):
-        """(predict_a, predict_b): plain vs explorer-guided (SG happens in
-        the rollout itself, on whatever the predict fn returns)."""
+    def make_predict_fn(eta_log):
+        """predict_b: explorer-guided prediction for leg B (SG happens in
+        the rollout itself, on whatever the predict fn returns). Leg A uses
+        run_ghost_sim's built-in det path (predict_fn_a=None)."""
         from exploration_policy.utils import run_frozen_encoder
         from rlvr.autoresearch.tools.eval_policy_avoidance import make_composer
         from rlvr.autoresearch.tools.recovery_sim import deterministic_predict
         from rlvr.closed_loop.batched_rollout import _batched_generate_varied_noise
         from rlvr.grpo_trainer_batched import _normalize_batch, _stack_scene_data
-
-        def predict_a(model, model_args, data):
-            return deterministic_predict(model, model_args, data)
 
         def predict_b(model, model_args, data):
             det = deterministic_predict(model, model_args, data)
@@ -167,7 +165,7 @@ def main() -> None:
                 return guided, [trajs[i] for i in range(1, B)]
             return guided
 
-        return predict_a, predict_b
+        return predict_b
 
     cfg = GhostSimConfig(
         model_a_label=args.label_a,
@@ -196,7 +194,7 @@ def main() -> None:
         cfg.subtitle = scene_name
 
         eta_log: list[dict] = []
-        predict_a, predict_b = make_predict_fns(eta_log)
+        predict_b = make_predict_fn(eta_log)
 
         def eta_title(step, a_pose, b_pose):
             if not eta_log or step >= len(eta_log):

--- a/rlvr/autoresearch/tools/compare_models_ghost.py
+++ b/rlvr/autoresearch/tools/compare_models_ghost.py
@@ -73,6 +73,10 @@ def main() -> None:
     parser.add_argument("--lambda_spd", type=float, default=0.2)
     parser.add_argument("--stretch_scale", type=float, default=1.0)
     parser.add_argument("--guidance_scale", type=float, default=0.5)
+    parser.add_argument("--envelope", choices=["v1", "v2"], default="v1",
+                        help="guidance envelope — must match the policy's "
+                             "training labels")
+    parser.add_argument("--lambda_col", type=float, default=3.0)
     parser.add_argument("--head_protect", type=int, default=0,
                         help="zero guidance on the first N plan steps "
                              "(closed-loop stall fix; 0 = off)")

--- a/rlvr/autoresearch/tools/compare_models_ghost.py
+++ b/rlvr/autoresearch/tools/compare_models_ghost.py
@@ -40,7 +40,7 @@ def main() -> None:
     parser.add_argument("--model_a", required=True, help="First model (e.g. baseline)")
     parser.add_argument("--lora_a", default=None)
     parser.add_argument("--label_a", default="baseline")
-    parser.add_argument("--model_b", required=True, help="Second model (e.g. trained)")
+    parser.add_argument("--model_b", default=None, help="Second model; omit with --policy_dir")
     parser.add_argument("--lora_b", default=None)
     parser.add_argument("--label_b", default="trained")
     parser.add_argument("--scenes", nargs="+", required=True, help="NPZ scene paths")
@@ -80,9 +80,11 @@ def main() -> None:
         policy, policy_heads = load_policy(args.policy_dir, args_a, device)
         model_b, args_b = model_a, args_a
         print(f"[compare] model B = model A + explorer ({args.policy_dir})")
-    else:
+    elif args.model_b:
         print(f"[compare] loading model B: {args.label_b}")
         model_b, args_b = load_model(args.model_b, args.lora_b, device)
+    else:
+        raise SystemExit("pass either --model_b or --policy_dir")
 
     def _sg(traj):
         if not args.sg_smooth:

--- a/rlvr/autoresearch/tools/compare_models_ghost.py
+++ b/rlvr/autoresearch/tools/compare_models_ghost.py
@@ -145,15 +145,19 @@ def main() -> None:
             composer = make_composer(etas, args)
             if args.speed_floor > 0:
                 from diffusion_planner.model.guidance.config import GuidanceConfig
-                ecs = data["ego_current_state"]
-                ecs = ecs[0] if ecs.dim() == 2 else ecs
-                v_now = float(torch.linalg.vector_norm(ecs[4:6]).item())
-                composer._functions.append(__import__(
-                    "diffusion_planner.model.guidance.registry",
-                    fromlist=["build"]).build(GuidanceConfig(
-                        name="speed", enabled=True, scale=args.speed_scale,
-                        params={"v_low": args.speed_floor * v_now,
-                                "v_high": max(1.2 * v_now, 8.0)})))
+                from diffusion_planner.model.guidance.registry import build as _build_g
+                # Anchor the floor to the scene's INITIAL speed — anchoring to
+                # the current speed lets the floor decay with the stall spiral.
+                if not hasattr(predict_b, "_v_init"):
+                    ecs = data["ego_current_state"]
+                    ecs = ecs[0] if ecs.dim() == 2 else ecs
+                    predict_b._v_init = max(
+                        float(torch.linalg.vector_norm(ecs[4:6]).item()), 2.0)
+                v0 = predict_b._v_init
+                composer._functions.append(_build_g(GuidanceConfig(
+                    name="speed", enabled=True, scale=args.speed_scale,
+                    params={"v_low": args.speed_floor * v0,
+                            "v_high": max(1.3 * v0, 8.0)})))
             trajs = _batched_generate_varied_noise(
                 model, model_args, gen, noise_min=0.0, noise_max=0.0,
                 first_deterministic=False, composer=composer, device=device,

--- a/rlvr/autoresearch/tools/compare_models_ghost.py
+++ b/rlvr/autoresearch/tools/compare_models_ghost.py
@@ -51,6 +51,8 @@ def main() -> None:
     parser.add_argument("--ego_wheelbase", type=float, default=4.76,
                         help="Ego wheelbase (m); ego footprint is rear-axle offset by (length-wheelbase)/2")
     parser.add_argument("--make_webm", action="store_true")
+    parser.add_argument("--hist_steps", type=int, default=0,
+                        help="render N recorded-history frames (gray ego) before the sim")
     parser.add_argument("--webm_fps", type=int, default=10)
     parser.add_argument("--show_lateral", action="store_true",
                         help="Show lateral offset to route centerline")
@@ -128,6 +130,7 @@ def main() -> None:
         steps=args.steps,
         advance_k=args.advance_k,
         webm_fps=args.webm_fps,
+        hist_steps=args.hist_steps,
         show_lateral=args.show_lateral,
         ego_wheelbase=args.ego_wheelbase,
     )

--- a/rlvr/autoresearch/tools/compare_models_ghost.py
+++ b/rlvr/autoresearch/tools/compare_models_ghost.py
@@ -24,8 +24,8 @@ from pathlib import Path
 
 import numpy as np
 import torch
-from preference_optimization.utils import load_npz_data
 
+from preference_optimization.utils import load_npz_data
 from rlvr.autoresearch.tools.ghost_sim_common import (
     GhostSimConfig,
     extract_stopped_neighbors,

--- a/rlvr/autoresearch/tools/distill_guided_targets.py
+++ b/rlvr/autoresearch/tools/distill_guided_targets.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Distill explorer-guided trajectories into curated-RSFT training NPZs.
+
+For every scene: run the frozen planner + guidance policy (deterministic
+etas, batched), Savitzky-Golay-filter the guided trajectory (the standard
+pre-SFT smoothing), and write a copy of the NPZ whose ``ego_agent_future``
+IS that guided trajectory — the exact format the curated ranked-SFT mode
+(``ranked_sft_mode="curated"``) trains on. The explorer thereby becomes a
+data-generation engine replacing hand-tuned Branch-Editor sessions.
+
+Safety screens (fail-quiet per scene, loud in the summary):
+  - only scenes where the GUIDED plan is collision-free vs stopped
+    neighbours (canonical clearance > --min_clearance) are written;
+  - scenes where the policy is inert (all |eta| < 0.05) are SKIPPED by
+    default (nothing to distill; pass --keep_inert to keep them).
+
+Usage:
+    python -m rlvr.autoresearch.tools.distill_guided_targets \
+        --model_path <base.pth> --policy_dir <dir> --scenes <list.json> \
+        --out_dir <dir> --out_list <json> [--envelope v1] [--min_clearance 0.2]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+
+import rlvr.guidance_batched  # noqa: F401
+from exploration_policy.utils import run_frozen_encoder
+from preference_optimization.utils import load_npz_data
+from rlvr.autoresearch.tools.eval_det_avoidance import load_model
+from rlvr.autoresearch.tools.eval_policy_avoidance import load_policy, make_composer
+from rlvr.autoresearch.tools.ghost_sim_common import extract_stopped_neighbors
+from rlvr.autoresearch.tools.recovery_sim import deterministic_predict
+from rlvr.closed_loop.batched_rollout import _batched_generate_varied_noise
+from rlvr.grpo_sft_trainer import _smooth_trajectory
+from rlvr.grpo_trainer_batched import _normalize_batch, _stack_scene_data
+from scenario_generation.explorer_runner import plan_static_clearance
+
+
+@torch.no_grad()
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--model_path", required=True)
+    parser.add_argument("--policy_dir", required=True)
+    parser.add_argument("--scenes", required=True)
+    parser.add_argument("--out_dir", required=True)
+    parser.add_argument("--out_list", required=True)
+    parser.add_argument("--ego_shape", default="4.76,7.24,2.29")
+    parser.add_argument("--min_clearance", type=float, default=0.2)
+    parser.add_argument("--keep_inert", action="store_true")
+    parser.add_argument("--lambda_lat", type=float, default=5.0)
+    parser.add_argument("--lat_scale", type=float, default=2.0)
+    parser.add_argument("--col_scale", type=float, default=9.0)
+    parser.add_argument("--col_range", type=float, default=8.0)
+    parser.add_argument("--lambda_spd", type=float, default=0.2)
+    parser.add_argument("--stretch_scale", type=float, default=1.0)
+    parser.add_argument("--guidance_scale", type=float, default=0.5)
+    parser.add_argument("--envelope", choices=["v1", "v2"], default="v1")
+    parser.add_argument("--lambda_col", type=float, default=3.0)
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model, margs = load_model(args.model_path, device)
+    policy, heads = load_policy(args.policy_dir, margs, device)
+    ego_shape = tuple(float(x) for x in args.ego_shape.split(","))
+
+    with open(args.scenes) as f:
+        paths = json.load(f)
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    written, manifest = [], []
+    n_inert = n_unsafe = n_err = 0
+    for sp in paths:
+        try:
+            data = load_npz_data(sp, device)
+            boxes = extract_stopped_neighbors(sp)
+            det = deterministic_predict(model, margs, data)
+            batch = _stack_scene_data([data], device)
+            norm = _normalize_batch(batch, margs)
+            x_ref = torch.from_numpy(np.ascontiguousarray(det)).float()
+            x_ref = x_ref.unsqueeze(0).to(device)
+            norm["reference_trajectory"] = x_ref
+            enc = run_frozen_encoder(model, norm)
+            out = policy(enc, x_ref, deterministic=True)
+            etas = {h: (2.0 * out.dists[h].mean - 1.0).reshape(1) for h in heads}
+            eta_f = {h: float(v.item()) for h, v in etas.items()}
+            if not args.keep_inert and all(abs(v) < 0.05 for v in eta_f.values()):
+                n_inert += 1
+                continue
+            guided = _batched_generate_varied_noise(
+                model, margs, norm, noise_min=0.0, noise_max=0.0,
+                first_deterministic=False, composer=make_composer(etas, args),
+                device=device,
+            )[0].cpu().numpy()
+            guided = _smooth_trajectory(guided, 11, 3)
+            if boxes:
+                clr = float(plan_static_clearance(
+                    guided.astype(np.float32), boxes, ego_shape, device))
+                if clr < args.min_clearance:
+                    n_unsafe += 1
+                    continue
+            else:
+                clr = 99.0
+        except Exception as e:  # noqa: BLE001
+            print(f"  [err ] {Path(sp).name}: {e}")
+            n_err += 1
+            continue
+
+        raw = dict(np.load(sp, allow_pickle=True))
+        fut = raw["ego_agent_future"]
+        T = min(fut.shape[0], guided.shape[0])
+        if fut.shape[-1] == 3:
+            # (x, y, yaw) format
+            new = np.stack([guided[:T, 0], guided[:T, 1],
+                            np.arctan2(guided[:T, 3], guided[:T, 2])], axis=-1)
+        else:
+            new = guided[:T, : fut.shape[-1]]
+        raw["ego_agent_future"] = new.astype(fut.dtype)
+
+        pool = Path(sp).parent.name
+        out_path = out_dir / f"{pool}__{Path(sp).stem}_distilled.npz"
+        np.savez(out_path, **raw)
+        written.append(str(out_path))
+        manifest.append({"source": sp, "etas": eta_f,
+                         "guided_clearance": round(clr, 3),
+                         "out": str(out_path)})
+
+    with open(args.out_list, "w") as f:
+        json.dump(written, f, indent=1)
+    with open(out_dir / "manifest.json", "w") as f:
+        json.dump(manifest, f, indent=1)
+    print(f"\nDistilled {len(written)} targets (skipped: {n_inert} inert, "
+          f"{n_unsafe} unsafe-guided, {n_err} errors) -> {args.out_list}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/distill_guided_targets.py
+++ b/rlvr/autoresearch/tools/distill_guided_targets.py
@@ -51,7 +51,8 @@ def main():
     parser.add_argument("--scenes", required=True)
     parser.add_argument("--out_dir", required=True)
     parser.add_argument("--out_list", required=True)
-    parser.add_argument("--ego_shape", default="4.76,7.24,2.29")
+    parser.add_argument("--ego_shape", required=True,
+                        help="WB,L,W — no default, must match the platform")
     parser.add_argument("--min_clearance", type=float, default=0.2)
     parser.add_argument("--keep_inert", action="store_true")
     parser.add_argument("--lambda_lat", type=float, default=5.0)

--- a/rlvr/autoresearch/tools/distill_guided_targets.py
+++ b/rlvr/autoresearch/tools/distill_guided_targets.py
@@ -121,8 +121,12 @@ def main():
             # (x, y, yaw) format
             new = np.stack([guided[:T, 0], guided[:T, 1],
                             np.arctan2(guided[:T, 3], guided[:T, 2])], axis=-1)
+        elif fut.shape[-1] == 4:
+            new = guided[:T, :4]
         else:
-            new = guided[:T, : fut.shape[-1]]
+            raise ValueError(
+                f"{sp}: unsupported ego_agent_future width {fut.shape[-1]} "
+                "(expected 3 or 4) — refusing to silently truncate")
         raw["ego_agent_future"] = new.astype(fut.dtype)
 
         pool = Path(sp).parent.name

--- a/rlvr/autoresearch/tools/eval_closedloop_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_closedloop_avoidance.py
@@ -99,6 +99,9 @@ def main():
     parser.add_argument("--scenes", required=True)
     parser.add_argument("--output", required=True)
     parser.add_argument("--steps", type=int, default=80)
+    parser.add_argument("--trim_backward", action="store_true",
+                        help="trim leading behind-ego plan points before "
+                             "tracking (see recovery_sim rollout docstring)")
     parser.add_argument("--ego_shape", default="4.76,7.24,2.29")
     parser.add_argument("--lambda_lat", type=float, default=5.0)
     parser.add_argument("--lat_scale", type=float, default=2.0)
@@ -124,10 +127,12 @@ def main():
             data = load_npz_data(sp, device)
             boxes = extract_stopped_neighbors(sp)
             r_base = closed_loop_rollout_with_plans(
-                model, margs, data, n_steps=args.steps)
+                model, margs, data, n_steps=args.steps,
+                trim_backward=args.trim_backward)
             r_gui = closed_loop_rollout_with_plans(
                 model, margs, data, n_steps=args.steps,
-                predict_fn=guided_predict)
+                predict_fn=guided_predict,
+                trim_backward=args.trim_backward)
         except Exception as e:  # noqa: BLE001
             print(f"  [err ] {Path(sp).name}: {e}")
             continue

--- a/rlvr/autoresearch/tools/eval_closedloop_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_closedloop_avoidance.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Batch closed-loop avoidance eval: does the ego CLEAR the obstacle?
+
+For every scene, runs the 80-step (8 s) closed-loop rollout (per-step
+replanning, ego advances to each fresh plan's first point) for the plain
+baseline and for baseline+explorer (pure, no gates/rules), then scores the
+REALIZED motion:
+
+  cleared   : traveled arc > t0 distance-to-obstacle + obstacle length + 2 m
+              AND min realized OBB clearance > 0 (no contact)
+  contact   : min realized OBB clearance <= 0 at any step
+  stalled   : mean speed over the last 2 s < 0.5 m/s and not cleared
+  min_clear : min OBB clearance of realized poses to static neighbors
+              (canonical compute_static_collision_penalty)
+
+Usage:
+    python -m rlvr.autoresearch.tools.eval_closedloop_avoidance \
+        --model_path <base.pth> --policy_dir <dir> --scenes <json> \
+        --output <json> [--steps 80] \
+        [--lambda_lat 5.0] [--lat_scale 2.0] [--col_scale 9.0]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+import numpy as np
+import torch
+
+import rlvr.guidance_batched  # noqa: F401
+from exploration_policy.utils import run_frozen_encoder
+from preference_optimization.utils import load_npz_data
+from rlvr.autoresearch.tools.eval_det_avoidance import load_model
+from rlvr.autoresearch.tools.eval_policy_avoidance import load_policy, make_composer
+from rlvr.autoresearch.tools.ghost_sim_common import extract_stopped_neighbors
+from rlvr.autoresearch.tools.recovery_sim import (
+    closed_loop_rollout_with_plans,
+    deterministic_predict,
+)
+from rlvr.closed_loop.batched_rollout import _batched_generate_varied_noise
+from rlvr.grpo_trainer_batched import _normalize_batch, _stack_scene_data
+from scenario_generation.explorer_runner import plan_static_clearance
+
+
+def make_guided_predict(policy, heads, args, device):
+    def predict(model, model_args, data):
+        det = deterministic_predict(model, model_args, data)
+        batch = _stack_scene_data([data], device)
+        norm = _normalize_batch(batch, model_args)
+        x_ref = torch.from_numpy(np.ascontiguousarray(det)).float()
+        x_ref = x_ref.unsqueeze(0).to(device)
+        norm["reference_trajectory"] = x_ref
+        enc = run_frozen_encoder(model, norm)
+        out = policy(enc, x_ref, deterministic=True)
+        etas = {h: (2.0 * out.dists[h].mean - 1.0).reshape(1) for h in heads}
+        return _batched_generate_varied_noise(
+            model, model_args, norm, noise_min=0.0, noise_max=0.0,
+            first_deterministic=False, composer=make_composer(etas, args),
+            device=device,
+        )[0].cpu().numpy()
+    return predict
+
+
+def score_rollout(rollout, boxes, ego_shape, device, dt=0.1):
+    pos = np.asarray(rollout["positions"])          # [N+1, 3] initial frame
+    vel = np.asarray(rollout["velocities"])
+    arc = float(np.linalg.norm(np.diff(pos[:, :2], axis=0), axis=1).sum())
+
+    # realized trajectory as (T,4) for the canonical clearance fn
+    traj = np.stack([pos[1:, 0], pos[1:, 1],
+                     np.cos(pos[1:, 2]), np.sin(pos[1:, 2])], axis=-1)
+    min_clear = plan_static_clearance(traj.astype(np.float32), boxes,
+                                      ego_shape, device)
+
+    if boxes:
+        d0 = min(math.hypot(b[0], b[1]) for b in boxes)
+        nearest = min(boxes, key=lambda b: math.hypot(b[0], b[1]))
+        need = d0 + nearest[3] + 2.0
+    else:
+        d0, need = 0.0, 0.0
+    cleared = bool(arc > need and min_clear > 0.0)
+    tail_speed = float(vel[-20:].mean())
+    contact = bool(min_clear <= 0.0)
+    stalled = bool(tail_speed < 0.5 and not cleared)
+    return {"arc": round(arc, 2), "min_clear": round(min_clear, 3),
+            "cleared": cleared, "contact": contact, "stalled": stalled,
+            "tail_speed": round(tail_speed, 2)}
+
+
+@torch.no_grad()
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--model_path", required=True)
+    parser.add_argument("--policy_dir", required=True)
+    parser.add_argument("--scenes", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--steps", type=int, default=80)
+    parser.add_argument("--ego_shape", default="4.76,7.24,2.29")
+    parser.add_argument("--lambda_lat", type=float, default=5.0)
+    parser.add_argument("--lat_scale", type=float, default=2.0)
+    parser.add_argument("--col_scale", type=float, default=9.0)
+    parser.add_argument("--col_range", type=float, default=8.0)
+    parser.add_argument("--lambda_spd", type=float, default=0.2)
+    parser.add_argument("--stretch_scale", type=float, default=1.0)
+    parser.add_argument("--guidance_scale", type=float, default=0.5)
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model, margs = load_model(args.model_path, device)
+    policy, heads = load_policy(args.policy_dir, margs, device)
+    guided_predict = make_guided_predict(policy, heads, args, device)
+    ego_shape = tuple(float(x) for x in args.ego_shape.split(","))
+
+    with open(args.scenes) as f:
+        paths = json.load(f)
+
+    rows = []
+    for sp in paths:
+        try:
+            data = load_npz_data(sp, device)
+            boxes = extract_stopped_neighbors(sp)
+            r_base = closed_loop_rollout_with_plans(
+                model, margs, data, n_steps=args.steps)
+            r_gui = closed_loop_rollout_with_plans(
+                model, margs, data, n_steps=args.steps,
+                predict_fn=guided_predict)
+        except Exception as e:  # noqa: BLE001
+            print(f"  [err ] {Path(sp).name}: {e}")
+            continue
+        row = {
+            "scene": Path(sp).name,
+            "baseline": score_rollout(r_base, boxes, ego_shape, device),
+            "explorer": score_rollout(r_gui, boxes, ego_shape, device),
+        }
+        rows.append(row)
+        b, g = row["baseline"], row["explorer"]
+        print(f"  {row['scene']:26s} base[clr={b['min_clear']:+.2f} "
+              f"{'CLEAR' if b['cleared'] else 'CONTACT' if b['contact'] else 'stall' if b['stalled'] else 'short'}] "
+              f"expl[clr={g['min_clear']:+.2f} "
+              f"{'CLEAR' if g['cleared'] else 'CONTACT' if g['contact'] else 'stall' if g['stalled'] else 'short'}]")
+
+    def agg(key):
+        sub = [r[key] for r in rows]
+        return {
+            "cleared": sum(s["cleared"] for s in sub),
+            "contact": sum(s["contact"] for s in sub),
+            "stalled": sum(s["stalled"] for s in sub),
+            "min_clear_p5": round(float(np.percentile(
+                [s["min_clear"] for s in sub], 5)), 3),
+        }
+    report = {"n": len(rows), "baseline": agg("baseline"),
+              "explorer": agg("explorer"), "scenes": rows}
+    with open(args.output, "w") as f:
+        json.dump(report, f, indent=1)
+    print(json.dumps({k: report[k] for k in ("n", "baseline", "explorer")},
+                     indent=1))
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/eval_closedloop_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_closedloop_avoidance.py
@@ -102,7 +102,8 @@ def main():
     parser.add_argument("--trim_backward", action="store_true",
                         help="trim leading behind-ego plan points before "
                              "tracking (see recovery_sim rollout docstring)")
-    parser.add_argument("--ego_shape", default="4.76,7.24,2.29")
+    parser.add_argument("--ego_shape", required=True,
+                        help="WB,L,W — no default, must match the platform")
     parser.add_argument("--lambda_lat", type=float, default=5.0)
     parser.add_argument("--lat_scale", type=float, default=2.0)
     parser.add_argument("--col_scale", type=float, default=9.0)

--- a/rlvr/autoresearch/tools/eval_labels_holdout.py
+++ b/rlvr/autoresearch/tools/eval_labels_holdout.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Evaluate a trained explorer policy on HELD-OUT sweep-label rows.
+
+Generalization check on base-scene groups the policy never saw (made by
+split_labels_holdout): reports weighted eta-MSE, dominant-head sign accuracy
+on solved rows, and mean |eta| on already-clean rows (inertness), mirroring
+the trainer's own metrics so train-vs-holdout gaps read directly as overfit.
+
+Usage:
+    python -m rlvr.autoresearch.tools.eval_labels_holdout \
+        --model_path <base.pth> --policy_dir <dir> --holdout <holdout.json>
+"""
+from __future__ import annotations
+
+import argparse
+import json
+
+import numpy as np
+import torch
+
+from exploration_policy.utils import generate_reference_trajectory, run_frozen_encoder
+from preference_optimization.utils import load_npz_data
+from rlvr.autoresearch.tools.eval_det_avoidance import load_model
+from rlvr.autoresearch.tools.eval_policy_avoidance import load_policy
+from rlvr.train_explorer_regression import label_target
+
+
+@torch.no_grad()
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--model_path", required=True)
+    parser.add_argument("--policy_dir", required=True)
+    parser.add_argument("--holdout", required=True)
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model, margs = load_model(args.model_path, device)
+    policy, heads = load_policy(args.policy_dir, margs, device)
+
+    with open(args.holdout) as f:
+        rows = json.load(f)["scenes"]
+
+    preds, targs, kinds = [], [], []
+    for r in rows:
+        if r["status"] == "solved":
+            t = [label_target(h, r["best"]) for h in heads]
+        elif r["status"] == "already_clean":
+            t = [0.0] * len(heads)
+        else:
+            continue
+        data = load_npz_data(r["scene_path"], device)
+        norm = {k: v.clone() if isinstance(v, torch.Tensor) else v
+                for k, v in data.items()}
+        norm = margs.observation_normalizer(norm)
+        x_ref = torch.from_numpy(
+            generate_reference_trajectory(model, margs, norm, device)
+        ).unsqueeze(0).to(device)
+        norm["reference_trajectory"] = x_ref
+        enc = run_frozen_encoder(model, norm)
+        out = policy(enc, x_ref, deterministic=True)
+        preds.append([float(2.0 * out.dists[h].mean - 1.0) for h in heads])
+        targs.append(t)
+        kinds.append(r["status"])
+
+    p = np.array(preds)
+    t = np.array(targs)
+    solved = np.array([k == "solved" for k in kinds])
+    mse = float(((p - t) ** 2).mean())
+    res = {"n": len(kinds), "n_solved": int(solved.sum()), "mse": round(mse, 4)}
+    if solved.any():
+        ps, ts = p[solved], t[solved]
+        dom = np.abs(ts).argmax(axis=1)
+        idx = np.arange(len(ts))
+        res["solved_mse"] = round(float(((ps - ts) ** 2).mean()), 4)
+        res["sign_acc"] = round(float(
+            (np.sign(ps[idx, dom]) == np.sign(ts[idx, dom])).mean()), 3)
+    if (~solved).any():
+        res["clean_pred_absmean"] = round(float(np.abs(p[~solved]).mean()), 4)
+    print(json.dumps(res))
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/eval_policy_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_policy_avoidance.py
@@ -63,6 +63,8 @@ def make_composer(etas: dict[str, torch.Tensor], args) -> GuidanceComposer:
         stretch_scale=args.stretch_scale,
         guidance_scale=args.guidance_scale,
         head_protect=int(getattr(args, "head_protect", 0)),
+        envelope=getattr(args, "envelope", "v1"),
+        lambda_col=getattr(args, "lambda_col", 3.0),
     )
 
 
@@ -254,6 +256,8 @@ def main():
     parser.add_argument("--lambda_spd", type=float, default=0.2)
     parser.add_argument("--stretch_scale", type=float, default=1.0)
     parser.add_argument("--guidance_scale", type=float, default=0.5)
+    parser.add_argument("--envelope", choices=["v1", "v2"], default="v1")
+    parser.add_argument("--lambda_col", type=float, default=3.0)
     args = parser.parse_args()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/rlvr/autoresearch/tools/eval_policy_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_policy_avoidance.py
@@ -50,16 +50,27 @@ def load_policy(policy_dir: str, model_args, device) -> tuple[ExplorationPolicy,
 
 
 def make_composer(etas: dict[str, torch.Tensor], args) -> GuidanceComposer:
+    # head_protect > 0 zeroes guidance on the first N plan steps (closed-loop
+    # stall fix); 0 keeps the exact original functions/behavior.
+    hp = int(getattr(args, "head_protect", 0))
     fns = []
     if "lateral" in etas:
-        fns.append(GuidanceConfig(
-            name="lateral", enabled=True, scale=args.lat_scale,
-            params={"lambda_lat": args.lambda_lat, "eta_lat": etas["lateral"]},
-        ))
+        if hp > 0:
+            fns.append(GuidanceConfig(
+                name="lateral_batched", enabled=True, scale=args.lat_scale,
+                params={"lambda_lat": args.lambda_lat, "eta_lat": etas["lateral"],
+                        "head_protect": hp},
+            ))
+        else:
+            fns.append(GuidanceConfig(
+                name="lateral", enabled=True, scale=args.lat_scale,
+                params={"lambda_lat": args.lambda_lat, "eta_lat": etas["lateral"]},
+            ))
     if "collision" in etas:
         fns.append(GuidanceConfig(
             name="collision_swerve_batched", enabled=True, scale=args.col_scale,
-            params={"eta_col": etas["collision"], "range": args.col_range},
+            params={"eta_col": etas["collision"], "range": args.col_range,
+                    "head_protect": hp},
         ))
     if "stretch" in etas:
         fns.append(GuidanceConfig(

--- a/rlvr/autoresearch/tools/eval_policy_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_policy_avoidance.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Policy-guided avoidance eval: frozen model + exploration policy vs baseline.
+
+Per scene: the exploration policy (deterministic=True) picks per-head etas,
+ONE guided deterministic trajectory is generated through the guidance
+composer, plus the unguided det trajectory; both are scored with the
+canonical reward. Reports the full side-by-side table (guided vs baseline)
+on avoidance scenes, and inertness metrics (|eta|, trajectory deviation) on
+normal scenes.
+
+Optionally renders per-scene baseline-vs-guided comparison PNGs + a collage.
+
+Usage:
+    python -m rlvr.autoresearch.tools.eval_policy_avoidance \
+        --model_path <base.pth> --policy_dir <run_dir with exploration_policy.pth> \
+        --scenes <avoidance_val.json> [--normal_scenes <normal_val.json>] \
+        --config <reward_config.json> --ego_shape WB,L,W --output_dir <dir> \
+        [--render] [--lambda_lat 4.0] [--col_scale 6.0] [--lat_scale 1.5]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+
+import rlvr.guidance_batched  # noqa: F401 -- registers batched guidance
+from diffusion_planner.model.guidance.composer import GuidanceComposer
+from diffusion_planner.model.guidance.config import GuidanceConfig, GuidanceSetConfig
+from exploration_policy.model import ExplorationPolicy, ExplorationPolicyConfig
+from exploration_policy.utils import generate_reference_trajectory, run_frozen_encoder
+from guidance_gui.generate_samples import generate_samples
+from preference_optimization.utils import load_npz_data
+from rlvr.autoresearch.tools.eval_det_avoidance import aggregate_stats, load_model
+from rlvr.autoresearch.tools.reward_config_from_json import load_reward_config
+from rlvr.reward import compute_reward_batch
+
+
+def load_policy(policy_dir: str, model_args, device) -> tuple[ExplorationPolicy, list[str]]:
+    pdir = Path(policy_dir)
+    cfg = ExplorationPolicyConfig.from_json(pdir / "exploration_policy_config.json")
+    policy = ExplorationPolicy(cfg, ref_seq_len=model_args.future_len).to(device)
+    state = torch.load(pdir / "exploration_policy.pth", map_location=device,
+                       weights_only=False)
+    policy.load_state_dict(state, strict=True)
+    policy.eval()
+    return policy, cfg.heads
+
+
+def make_composer(etas: dict[str, torch.Tensor], args) -> GuidanceComposer:
+    fns = []
+    if "lateral" in etas:
+        fns.append(GuidanceConfig(
+            name="lateral", enabled=True, scale=args.lat_scale,
+            params={"lambda_lat": args.lambda_lat, "eta_lat": etas["lateral"]},
+        ))
+    if "collision" in etas:
+        fns.append(GuidanceConfig(
+            name="collision_swerve_batched", enabled=True, scale=args.col_scale,
+            params={"eta_col": etas["collision"], "range": args.col_range},
+        ))
+    if "stretch" in etas:
+        fns.append(GuidanceConfig(
+            name="speed_stretch_batched", enabled=True, scale=args.stretch_scale,
+            params={"stretch": 1.0 + args.lambda_spd * etas["stretch"]},
+        ))
+    set_cfg = GuidanceSetConfig(functions=fns, global_scale=args.guidance_scale)
+    return GuidanceComposer(set_cfg)
+
+
+@torch.no_grad()
+def eval_scene(model, model_args, policy, heads, npz_path, rcfg, args, device):
+    data = load_npz_data(npz_path, device)
+    norm_data = {
+        k: v.clone() if isinstance(v, torch.Tensor) else v for k, v in data.items()
+    }
+    norm_data = model_args.observation_normalizer(norm_data)
+
+    x_ref_np = generate_reference_trajectory(model, model_args, norm_data, device)
+    x_ref = torch.from_numpy(x_ref_np).unsqueeze(0).to(device)
+    norm_data["reference_trajectory"] = x_ref
+    enc = run_frozen_encoder(model, norm_data)
+
+    out = policy(enc, x_ref, deterministic=True)
+    etas = {h: (2.0 * out.dists[h].mean - 1.0).reshape(1) for h in heads}
+
+    composer = make_composer(etas, args)
+    guided = generate_samples(model=model, model_args=model_args, data=norm_data,
+                              noise_scale=0.0, n_samples=1, composer=composer,
+                              device=device)[0]
+    det = x_ref_np  # x_ref IS the unguided det trajectory
+
+    traj_batch = torch.tensor(np.stack([guided, det]), device=device,
+                              dtype=torch.float32)
+    g_bd, d_bd = compute_reward_batch(traj_batch, data, rcfg)
+    deviation = float(np.linalg.norm(guided[:, :2] - det[:, :2], axis=-1).mean())
+
+    def _row(r):
+        return {
+            "sc_min_dist": float(r.sc_min_dist), "rb_min_dist": float(getattr(r, "rb_min_dist", 99.0)),
+            "cl": float(r.centerline), "total": float(r.total),
+            "static_crossing": bool(r.static_crossing), "rb_cross": bool(r.rb_crossing),
+            "lane_cross": bool(r.lane_crossing), "kin_violated": bool(r.kinematic_violated),
+            "sc_n_stopped": int(r.sc_n_stopped),
+        }
+
+    return {
+        "scene": Path(npz_path).name, "scene_path": str(npz_path),
+        "etas": {h: float(v.item()) for h, v in etas.items()},
+        "deviation": deviation,
+        "guided": _row(g_bd), "baseline": _row(d_bd),
+        "_trajs": (guided, det),
+    }
+
+
+def render_scene(row, out_png):
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    from rlvr.autoresearch.tools.ghost_sim_common import extract_stopped_neighbors
+    from rlvr.autoresearch.tools.viz_cl_recovery import draw_scene_base
+    from scenario_generation.visualize import draw_agent_box
+
+    guided, det = row["_trajs"]
+    fig, ax = plt.subplots(figsize=(10, 10))
+    draw_scene_base(ax, row["scene_path"])
+    for (x, y, h, length, w) in extract_stopped_neighbors(row["scene_path"]):
+        draw_agent_box(ax, x, y, h, length, w, color="crimson", alpha=0.5)
+    ax.plot(det[:, 0], det[:, 1], "-", color="black", lw=2.2,
+            label=f"baseline det sc={row['baseline']['sc_min_dist']:+.2f}m")
+    ax.plot(guided[:, 0], guided[:, 1], "-", color="lime", lw=2.2,
+            label=f"policy-guided sc={row['guided']['sc_min_dist']:+.2f}m")
+    eta_str = " ".join(f"{h}={v:+.2f}" for h, v in row["etas"].items())
+    ax.set_title(f"{row['scene']}  η: {eta_str}  dev={row['deviation']:.2f}m")
+    ax.legend(loc="upper right", fontsize=9)
+    ax.set_aspect("equal")
+    span = max(np.abs(det[..., :2]).max(), np.abs(guided[..., :2]).max()) + 12
+    ax.set_xlim(-12, max(span, 40))
+    ax.set_ylim(-span / 2, span / 2)
+    fig.savefig(out_png, dpi=110, bbox_inches="tight")
+    plt.close(fig)
+
+
+def make_collage(png_paths: list[Path], out_path: Path, cols: int = 4):
+    from PIL import Image
+    if not png_paths:
+        return
+    ims = [Image.open(p) for p in png_paths]
+    w = min(im.width for im in ims)
+    ims = [im.resize((w, int(im.height * w / im.width))) for im in ims]
+    h = max(im.height for im in ims)
+    rows = (len(ims) + cols - 1) // cols
+    canvas = Image.new("RGB", (cols * w, rows * h), "white")
+    for i, im in enumerate(ims):
+        canvas.paste(im, ((i % cols) * w, (i // cols) * h))
+    canvas.save(out_path)
+
+
+def summarize(rows: list[dict], which: str) -> dict:
+    sub = [dict(r[which], scene=r["scene"]) for r in rows]
+    agg = aggregate_stats([
+        {**s, "static_crossing": s["static_crossing"], "rb_cross": s["rb_cross"],
+         "lane_cross": s["lane_cross"], "kin_violated": s["kin_violated"]}
+        for s in sub
+    ])
+    return agg
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--model_path", required=True)
+    parser.add_argument("--policy_dir", required=True)
+    parser.add_argument("--scenes", required=True, help="avoidance eval scene list")
+    parser.add_argument("--normal_scenes", default=None)
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--ego_shape", required=True)
+    parser.add_argument("--output_dir", required=True)
+    parser.add_argument("--render", action="store_true")
+    # Guidance envelope (must match the sweep that produced the training labels)
+    parser.add_argument("--lambda_lat", type=float, default=4.0)
+    parser.add_argument("--lat_scale", type=float, default=1.5)
+    parser.add_argument("--col_scale", type=float, default=6.0)
+    parser.add_argument("--col_range", type=float, default=8.0)
+    parser.add_argument("--lambda_spd", type=float, default=0.2)
+    parser.add_argument("--stretch_scale", type=float, default=1.0)
+    parser.add_argument("--guidance_scale", type=float, default=0.5)
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    ego_shape = np.array([float(x) for x in args.ego_shape.split(",")])
+    rcfg = load_reward_config(args.config)
+    model, model_args = load_model(args.model_path, device)
+    policy, heads = load_policy(args.policy_dir, model_args, device)
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    def run_set(scene_list_path, tag):
+        with open(scene_list_path) as f:
+            paths = json.load(f)
+        rows = []
+        render_dir = out_dir / f"render_{tag}"
+        if args.render:
+            render_dir.mkdir(exist_ok=True)
+        for p in paths:
+            try:
+                with np.load(p, allow_pickle=True) as npz:
+                    if "ego_shape" not in set(npz.keys()):
+                        print(f"  [skip] {Path(p).name}: missing ego_shape")
+                        continue
+                    es = np.asarray(npz["ego_shape"]).reshape(-1)[:3]
+                if not np.allclose(es, ego_shape, atol=1e-2):
+                    print(f"  [skip] {Path(p).name}: ego_shape={es.tolist()}")
+                    continue
+                row = eval_scene(model, model_args, policy, heads, p, rcfg, args, device)
+            except Exception as e:  # noqa: BLE001
+                print(f"  [err ] {Path(p).name}: {e}")
+                continue
+            if args.render:
+                render_scene(row, render_dir / f"{Path(p).stem}.png")
+            row.pop("_trajs")
+            rows.append(row)
+            g, b = row["guided"], row["baseline"]
+            flag = ("FIX " if b["static_crossing"] and not g["static_crossing"] else
+                    "BRK " if g["static_crossing"] and not b["static_crossing"] else
+                    "COL " if g["static_crossing"] else "    ")
+            eta_str = " ".join(f"{h[0]}={v:+.2f}" for h, v in row["etas"].items())
+            print(f"  [{tag}] {flag} sc {b['sc_min_dist']:+.2f}->{g['sc_min_dist']:+.2f} "
+                  f"dev={row['deviation']:.2f} η[{eta_str}]  {row['scene']}")
+        if args.render and rows:
+            pngs = sorted(render_dir.glob("*.png"))
+            make_collage(pngs, out_dir / f"collage_{tag}.png")
+        return rows
+
+    avoid_rows = run_set(args.scenes, "avoid")
+    normal_rows = run_set(args.normal_scenes, "normal") if args.normal_scenes else []
+
+    report = {
+        "guidance_args": {k: getattr(args, k) for k in (
+            "lambda_lat", "lat_scale", "col_scale", "col_range",
+            "lambda_spd", "stretch_scale", "guidance_scale")},
+        "avoid": {
+            "n": len(avoid_rows),
+            "guided": summarize(avoid_rows, "guided") if avoid_rows else {},
+            "baseline": summarize(avoid_rows, "baseline") if avoid_rows else {},
+            "deviation_mean": float(np.mean([r["deviation"] for r in avoid_rows])) if avoid_rows else 0.0,
+            "eta_abs_mean": {
+                h: float(np.mean([abs(r["etas"][h]) for r in avoid_rows]))
+                for h in heads
+            } if avoid_rows else {},
+        },
+        "normal": {
+            "n": len(normal_rows),
+            "guided": summarize(normal_rows, "guided") if normal_rows else {},
+            "baseline": summarize(normal_rows, "baseline") if normal_rows else {},
+            "deviation_mean": float(np.mean([r["deviation"] for r in normal_rows])) if normal_rows else 0.0,
+            "deviation_max": float(np.max([r["deviation"] for r in normal_rows])) if normal_rows else 0.0,
+            "eta_abs_mean": {
+                h: float(np.mean([abs(r["etas"][h]) for r in normal_rows]))
+                for h in heads
+            } if normal_rows else {},
+        },
+        "scenes_avoid": avoid_rows,
+        "scenes_normal": normal_rows,
+    }
+    with open(out_dir / "policy_eval.json", "w") as f:
+        json.dump(report, f, indent=1)
+
+    for tag, rows in (("avoid", avoid_rows), ("normal", normal_rows)):
+        if not rows:
+            continue
+        g = report[tag]["guided"]
+        b = report[tag]["baseline"]
+        print(f"\n== {tag} ({len(rows)} scenes) ==")
+        print(f"  static crossings: baseline {b['static_crossings']} -> guided {g['static_crossings']}")
+        print(f"  rb crossings:     baseline {b['rb_crossings']} -> guided {g['rb_crossings']}")
+        print(f"  lane crossings:   baseline {b['lane_crossings']} -> guided {g['lane_crossings']}")
+        print(f"  sc_min_dist p5:   baseline {b['sc_min_dist']['p5']:+.3f} -> guided {g['sc_min_dist']['p5']:+.3f}")
+        print(f"  deviation mean:   {report[tag]['deviation_mean']:.3f} m")
+        print(f"  |eta| mean:       {report[tag]['eta_abs_mean']}")
+    print(f"\nWrote {out_dir / 'policy_eval.json'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/eval_policy_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_policy_avoidance.py
@@ -50,35 +50,20 @@ def load_policy(policy_dir: str, model_args, device) -> tuple[ExplorationPolicy,
 
 
 def make_composer(etas: dict[str, torch.Tensor], args) -> GuidanceComposer:
-    # head_protect > 0 zeroes guidance on the first N plan steps (closed-loop
-    # stall fix); 0 keeps the exact original functions/behavior.
-    hp = int(getattr(args, "head_protect", 0))
-    fns = []
-    if "lateral" in etas:
-        if hp > 0:
-            fns.append(GuidanceConfig(
-                name="lateral_batched", enabled=True, scale=args.lat_scale,
-                params={"lambda_lat": args.lambda_lat, "eta_lat": etas["lateral"],
-                        "head_protect": hp},
-            ))
-        else:
-            fns.append(GuidanceConfig(
-                name="lateral", enabled=True, scale=args.lat_scale,
-                params={"lambda_lat": args.lambda_lat, "eta_lat": etas["lateral"]},
-            ))
-    if "collision" in etas:
-        fns.append(GuidanceConfig(
-            name="collision_swerve_batched", enabled=True, scale=args.col_scale,
-            params={"eta_col": etas["collision"], "range": args.col_range,
-                    "head_protect": hp},
-        ))
-    if "stretch" in etas:
-        fns.append(GuidanceConfig(
-            name="speed_stretch_batched", enabled=True, scale=args.stretch_scale,
-            params={"stretch": 1.0 + args.lambda_spd * etas["stretch"]},
-        ))
-    set_cfg = GuidanceSetConfig(functions=fns, global_scale=args.guidance_scale)
-    return GuidanceComposer(set_cfg)
+    # Thin wrapper over the shared head mapping; head_protect > 0 zeroes
+    # guidance on the first N plan steps.
+    from rlvr.guidance_batched import build_head_composer
+    return build_head_composer(
+        etas,
+        lambda_lat=args.lambda_lat,
+        lat_scale=args.lat_scale,
+        col_scale=args.col_scale,
+        col_range=args.col_range,
+        lambda_spd=args.lambda_spd,
+        stretch_scale=args.stretch_scale,
+        guidance_scale=args.guidance_scale,
+        head_protect=int(getattr(args, "head_protect", 0)),
+    )
 
 
 def _new_violation(g, d) -> bool:

--- a/rlvr/autoresearch/tools/eval_policy_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_policy_avoidance.py
@@ -65,7 +65,7 @@ def make_composer(etas: dict[str, torch.Tensor], args) -> GuidanceComposer:
         head_protect=int(getattr(args, "head_protect", 0)),
         envelope=getattr(args, "envelope", "v1"),
         lambda_col=getattr(args, "lambda_col", 3.0),
-        fast=bool(getattr(args, "fast_composer", False)),
+        fast=not bool(getattr(args, "slow_composer", False)),
     )
 
 
@@ -259,9 +259,10 @@ def main():
     parser.add_argument("--guidance_scale", type=float, default=0.5)
     parser.add_argument("--envelope", choices=["v1", "v2"], default="v1")
     parser.add_argument("--lambda_col", type=float, default=3.0)
-    parser.add_argument("--fast_composer", action="store_true",
-                        help="use FastGuidanceComposer (equivalence-certified: "
-                             "bit-identical active frames, inert short-circuit)")
+    parser.add_argument("--slow_composer", action="store_true",
+                        help="use the original GuidanceComposer (FastGuidance"
+                             "Composer is the default: 288/288 active "
+                             "generations bit-identical, inert short-circuit)")
     args = parser.parse_args()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/rlvr/autoresearch/tools/eval_policy_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_policy_avoidance.py
@@ -134,18 +134,20 @@ def eval_scene(model, model_args, policy, heads, npz_path, rcfg, args, device):
     cand_bds, d_bd = bds[:-1], bds[-1]
 
     # Pick the best candidate: no NEW violations, then max total reward.
-    # Falls back to the unguided det when every candidate regresses
-    # (certify mode) or none beats it.
+    # Certify semantics: guidance exists ONLY for avoidance — when the
+    # unguided det has no static crossing, keep it untouched (strict
+    # inertness on scenes with no avoidance need). When det fails, pick the
+    # best clean candidate; fall back to det if every candidate regresses.
     pick, g_bd = 0, cand_bds[0]
-    if args.certify or K > 1:
+    if args.certify and not d_bd.static_crossing:
+        pick, g_bd = -1, d_bd
+    elif args.certify or K > 1:
         clean = [i for i, b in enumerate(cand_bds) if not _new_violation(b, d_bd)]
         if not clean:
             pick, g_bd = -1, d_bd  # fall back to baseline
         else:
             pick = max(clean, key=lambda i: cand_bds[i].total)
             g_bd = cand_bds[pick]
-            if args.certify and g_bd.total < d_bd.total and not d_bd.static_crossing:
-                pick, g_bd = -1, d_bd
 
     guided = det if pick == -1 else cands[pick]
     etas = (

--- a/rlvr/autoresearch/tools/eval_policy_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_policy_avoidance.py
@@ -25,10 +25,10 @@ from pathlib import Path
 
 import numpy as np
 import torch
-
-import rlvr.guidance_batched  # noqa: F401 -- registers batched guidance
 from diffusion_planner.model.guidance.composer import GuidanceComposer
 from diffusion_planner.model.guidance.config import GuidanceConfig, GuidanceSetConfig
+
+import rlvr.guidance_batched  # noqa: F401 -- registers batched guidance
 from exploration_policy.model import ExplorationPolicy, ExplorationPolicyConfig
 from exploration_policy.utils import generate_reference_trajectory, run_frozen_encoder
 from guidance_gui.generate_samples import generate_samples

--- a/rlvr/autoresearch/tools/eval_policy_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_policy_avoidance.py
@@ -65,6 +65,7 @@ def make_composer(etas: dict[str, torch.Tensor], args) -> GuidanceComposer:
         head_protect=int(getattr(args, "head_protect", 0)),
         envelope=getattr(args, "envelope", "v1"),
         lambda_col=getattr(args, "lambda_col", 3.0),
+        fast=bool(getattr(args, "fast_composer", False)),
     )
 
 
@@ -258,6 +259,9 @@ def main():
     parser.add_argument("--guidance_scale", type=float, default=0.5)
     parser.add_argument("--envelope", choices=["v1", "v2"], default="v1")
     parser.add_argument("--lambda_col", type=float, default=3.0)
+    parser.add_argument("--fast_composer", action="store_true",
+                        help="use FastGuidanceComposer (equivalence-certified: "
+                             "bit-identical active frames, inert short-circuit)")
     args = parser.parse_args()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/rlvr/autoresearch/tools/eval_policy_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_policy_avoidance.py
@@ -316,7 +316,8 @@ def main():
     report = {
         "guidance_args": {k: getattr(args, k) for k in (
             "lambda_lat", "lat_scale", "col_scale", "col_range",
-            "lambda_spd", "stretch_scale", "guidance_scale")},
+            "lambda_spd", "stretch_scale", "guidance_scale",
+            "envelope", "lambda_col")},
         "avoid": {
             "n": len(avoid_rows),
             "guided": summarize(avoid_rows, "guided") if avoid_rows else {},

--- a/rlvr/autoresearch/tools/eval_policy_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_policy_avoidance.py
@@ -70,6 +70,16 @@ def make_composer(etas: dict[str, torch.Tensor], args) -> GuidanceComposer:
     return GuidanceComposer(set_cfg)
 
 
+def _new_violation(g, d) -> bool:
+    """Guided introduces a violation the baseline det didn't have."""
+    return (
+        (g.static_crossing and not d.static_crossing)
+        or (g.rb_crossing and not d.rb_crossing)
+        or (g.lane_crossing and not d.lane_crossing)
+        or (g.collision_step is not None and d.collision_step is None)
+    )
+
+
 @torch.no_grad()
 def eval_scene(model, model_args, policy, heads, npz_path, rcfg, args, device):
     data = load_npz_data(npz_path, device)
@@ -84,17 +94,65 @@ def eval_scene(model, model_args, policy, heads, npz_path, rcfg, args, device):
     enc = run_frozen_encoder(model, norm_data)
 
     out = policy(enc, x_ref, deterministic=True)
-    etas = {h: (2.0 * out.dists[h].mean - 1.0).reshape(1) for h in heads}
+    mean_etas = {h: (2.0 * out.dists[h].mean - 1.0).reshape(1) for h in heads}
 
-    composer = make_composer(etas, args)
-    guided = generate_samples(model=model, model_args=model_args, data=norm_data,
-                              noise_scale=0.0, n_samples=1, composer=composer,
-                              device=device)[0]
+    K = max(1, args.refine_k)
+    if K > 1:
+        # Candidate 0 = the deterministic mean; the rest sampled from the
+        # policy's Beta distributions (its own uncertainty = search width).
+        cand = {
+            h: torch.cat([
+                mean_etas[h],
+                (2.0 * out.dists[h].rsample((K - 1,)).reshape(-1) - 1.0),
+            ])
+            for h in heads
+        }
+        K_data = {}
+        for k, v in norm_data.items():
+            if isinstance(v, torch.Tensor) and v.shape[0] == 1:
+                K_data[k] = v.expand(K, *v.shape[1:]).contiguous()
+            else:
+                K_data[k] = v
+        composer = make_composer(cand, args)
+        from rlvr.closed_loop.batched_rollout import _batched_generate_varied_noise
+        cands = _batched_generate_varied_noise(
+            model, model_args, K_data, noise_min=0.0, noise_max=0.0,
+            first_deterministic=False, composer=composer, device=device,
+        ).cpu().numpy()
+    else:
+        cand = mean_etas
+        composer = make_composer(cand, args)
+        cands = generate_samples(model=model, model_args=model_args, data=norm_data,
+                                 noise_scale=0.0, n_samples=1, composer=composer,
+                                 device=device)[None, 0]
+
     det = x_ref_np  # x_ref IS the unguided det trajectory
+    traj_batch = torch.tensor(
+        np.concatenate([cands, det[None]]), device=device, dtype=torch.float32,
+    )
+    bds = compute_reward_batch(traj_batch, data, rcfg)
+    cand_bds, d_bd = bds[:-1], bds[-1]
 
-    traj_batch = torch.tensor(np.stack([guided, det]), device=device,
-                              dtype=torch.float32)
-    g_bd, d_bd = compute_reward_batch(traj_batch, data, rcfg)
+    # Pick the best candidate: no NEW violations, then max total reward.
+    # Falls back to the unguided det when every candidate regresses
+    # (certify mode) or none beats it.
+    pick, g_bd = 0, cand_bds[0]
+    if args.certify or K > 1:
+        clean = [i for i, b in enumerate(cand_bds) if not _new_violation(b, d_bd)]
+        if not clean:
+            pick, g_bd = -1, d_bd  # fall back to baseline
+        else:
+            pick = max(clean, key=lambda i: cand_bds[i].total)
+            g_bd = cand_bds[pick]
+            if args.certify and g_bd.total < d_bd.total and not d_bd.static_crossing:
+                pick, g_bd = -1, d_bd
+
+    guided = det if pick == -1 else cands[pick]
+    etas = (
+        {h: 0.0 for h in heads} if pick == -1
+        else {h: float(cand[h][pick].item()) for h in heads}
+    )
+    etas = {h: torch.tensor([v], device=device) for h, v in etas.items()}
     deviation = float(np.linalg.norm(guided[:, :2] - det[:, :2], axis=-1).mean())
 
     def _row(r):
@@ -181,6 +239,15 @@ def main():
     parser.add_argument("--ego_shape", required=True)
     parser.add_argument("--output_dir", required=True)
     parser.add_argument("--render", action="store_true")
+    parser.add_argument("--certify", action="store_true",
+                        help="Fall back to the unguided det trajectory whenever "
+                             "the guided one introduces a NEW violation (or "
+                             "lowers total reward on an already-clean scene). "
+                             "Guarantees no regressions by construction.")
+    parser.add_argument("--refine_k", type=int, default=1,
+                        help="Sample K-1 extra eta candidates from the policy "
+                             "distribution, score all, pick the best clean one "
+                             "(policy = prior, reward = judge). 1 = mean only.")
     # Guidance envelope (must match the sweep that produced the training labels)
     parser.add_argument("--lambda_lat", type=float, default=4.0)
     parser.add_argument("--lat_scale", type=float, default=1.5)

--- a/rlvr/autoresearch/tools/eval_policy_l2.py
+++ b/rlvr/autoresearch/tools/eval_policy_l2.py
@@ -39,6 +39,12 @@ from preference_optimization.utils import load_npz_data
 
 
 def make_composer(etas, args):
+    unmapped = set(etas) - {"lateral", "collision"}
+    if unmapped:
+        raise ValueError(
+            f"policy heads {sorted(unmapped)} have no guidance mapping in "
+            "this tool — evaluating without them would misrepresent the "
+            "deployed config")
     fns = []
     if "lateral" in etas:
         fns.append(GuidanceConfig(
@@ -69,7 +75,6 @@ def main():
     parser.add_argument("--model_path", required=True)
     parser.add_argument("--policy_dir", required=True)
     parser.add_argument("--scenes", required=True)
-    parser.add_argument("--ego_shape", required=True)
     parser.add_argument("--output_dir", required=True)
     parser.add_argument("--lambda_lat", type=float, default=5.0)
     parser.add_argument("--lat_scale", type=float, default=2.0)

--- a/rlvr/autoresearch/tools/eval_policy_l2.py
+++ b/rlvr/autoresearch/tools/eval_policy_l2.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Open-loop L2 (ADE) of explorer-GUIDED trajectories vs GT on a large val set.
+
+Answers "what would running the explorer online cost in L2?": for every
+scene, generate BOTH the plain det trajectory and the policy-guided one
+(policy etas + guidance composer, noise=0), and compare their displacement
+error against the recorded GT future on identical scenes. Also reports
+wall-clock per scene for the policy+guided path (the online-latency axis).
+
+Fully batched: one encoder pass + one det generation + one policy forward +
+one guided generation per batch of scenes.
+
+Usage:
+    python -m rlvr.autoresearch.tools.eval_policy_l2 \
+        --model_path <base.pth> --policy_dir <dir> --scenes <val.json> \
+        --ego_shape WB,L,W --output_dir <dir> \
+        [--lambda_lat 5.0] [--lat_scale 2.0] [--col_scale 9.0] \
+        [--batch_size 32] [--limit 0]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+
+import rlvr.guidance_batched  # noqa: F401
+from diffusion_planner.model.guidance.composer import GuidanceComposer
+from diffusion_planner.model.guidance.config import GuidanceConfig, GuidanceSetConfig
+from exploration_policy.utils import run_frozen_encoder
+from rlvr.autoresearch.tools.eval_det_avoidance import det_inference_batched, load_model
+from rlvr.autoresearch.tools.eval_policy_avoidance import load_policy
+from rlvr.closed_loop.batched_rollout import _batched_generate_varied_noise
+from rlvr.grpo_trainer_batched import _normalize_batch, _stack_scene_data
+from preference_optimization.utils import load_npz_data
+
+
+def make_composer(etas, args):
+    fns = []
+    if "lateral" in etas:
+        fns.append(GuidanceConfig(
+            name="lateral", enabled=True, scale=args.lat_scale,
+            params={"lambda_lat": args.lambda_lat, "eta_lat": etas["lateral"]},
+        ))
+    if "collision" in etas:
+        fns.append(GuidanceConfig(
+            name="collision_swerve_batched", enabled=True, scale=args.col_scale,
+            params={"eta_col": etas["collision"], "range": args.col_range},
+        ))
+    return GuidanceComposer(GuidanceSetConfig(functions=fns,
+                                              global_scale=args.guidance_scale))
+
+
+def ade(pred_xy: torch.Tensor, gt_xy: torch.Tensor, gt_valid: torch.Tensor) -> torch.Tensor:
+    """Mean displacement over valid GT steps, per scene. [B, T, 2] -> [B]."""
+    d = (pred_xy - gt_xy).norm(dim=-1)            # [B, T]
+    d = d * gt_valid
+    return d.sum(dim=1) / gt_valid.sum(dim=1).clamp_min(1)
+
+
+@torch.no_grad()
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--model_path", required=True)
+    parser.add_argument("--policy_dir", required=True)
+    parser.add_argument("--scenes", required=True)
+    parser.add_argument("--ego_shape", required=True)
+    parser.add_argument("--output_dir", required=True)
+    parser.add_argument("--lambda_lat", type=float, default=5.0)
+    parser.add_argument("--lat_scale", type=float, default=2.0)
+    parser.add_argument("--col_scale", type=float, default=9.0)
+    parser.add_argument("--col_range", type=float, default=8.0)
+    parser.add_argument("--guidance_scale", type=float, default=0.5)
+    parser.add_argument("--batch_size", type=int, default=32)
+    parser.add_argument("--limit", type=int, default=0, help="0 = all scenes")
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model, model_args = load_model(args.model_path, device)
+    policy, heads = load_policy(args.policy_dir, model_args, device)
+
+    with open(args.scenes) as f:
+        scene_paths = json.load(f)
+    if args.limit:
+        scene_paths = scene_paths[: args.limit]
+    print(f"[policy_l2] {len(scene_paths)} scenes, heads={heads}")
+
+    det_ades, guided_ades, eta_abs, t_policy = [], [], [], []
+    n_skipped = 0
+    for start in range(0, len(scene_paths), args.batch_size):
+        batch_paths = scene_paths[start : start + args.batch_size]
+        datas = []
+        for p in batch_paths:
+            try:
+                datas.append(load_npz_data(p, device))
+            except Exception as e:  # noqa: BLE001
+                n_skipped += 1
+                if n_skipped <= 5:
+                    print(f"  [skip] {Path(p).name}: {e}")
+        if not datas:
+            continue
+        B = len(datas)
+        batch = _stack_scene_data(datas, device)
+        norm_batch = _normalize_batch(batch, model_args)
+
+        # 1. det generation (plain planner)
+        det = det_inference_batched(model, model_args, datas, device,
+                                    norm_batch=norm_batch)  # [B, T, 4]
+
+        # 2. policy forward + guided generation (the online path)
+        t0 = time.perf_counter()
+        norm_batch_g = dict(norm_batch)
+        norm_batch_g["reference_trajectory"] = det
+        enc = run_frozen_encoder(model, norm_batch_g)
+        out = policy(enc, det, deterministic=True)
+        etas = {h: (2.0 * out.dists[h].mean - 1.0) for h in heads}  # [B]
+        composer = make_composer(etas, args)
+        guided = _batched_generate_varied_noise(
+            model, model_args, norm_batch_g,
+            noise_min=0.0, noise_max=0.0, first_deterministic=False,
+            composer=composer, device=device,
+        )  # [B, T, 4]
+        if device.type == "cuda":
+            torch.cuda.synchronize()
+        t_policy.append((time.perf_counter() - t0) / B)
+
+        # 3. ADE vs GT
+        gt = batch["ego_agent_future"]
+        if gt.dim() == 2:
+            gt = gt.unsqueeze(0)
+        gt_xy = gt[..., :2]
+        gt_valid = (gt_xy.abs().sum(dim=-1) > 1e-6).float()
+        det_ades.append(ade(det[..., :2], gt_xy, gt_valid).cpu())
+        guided_ades.append(ade(guided[..., :2], gt_xy, gt_valid).cpu())
+        eta_abs.append(torch.stack(
+            [etas[h].abs().cpu() for h in heads], dim=-1).max(dim=-1).values)
+
+        done = start + B
+        if done % (args.batch_size * 20) < args.batch_size:
+            d = torch.cat(det_ades); g = torch.cat(guided_ades)
+            print(f"  [{done}/{len(scene_paths)}] det ADE={d.mean():.4f} "
+                  f"guided ADE={g.mean():.4f} Δ={(g.mean()-d.mean())/d.mean()*100:+.2f}%")
+
+    det_a = torch.cat(det_ades).numpy()
+    g_a = torch.cat(guided_ades).numpy()
+    e_a = torch.cat(eta_abs).numpy()
+
+    def dist(a):
+        return {"mean": float(a.mean()), "p50": float(np.median(a)),
+                "p95": float(np.percentile(a, 95)), "max": float(a.max())}
+
+    acting = e_a > 0.1
+    report = {
+        "n_scenes": int(len(det_a)), "n_skipped": n_skipped,
+        "det_ade": dist(det_a), "guided_ade": dist(g_a),
+        "delta_pct_mean": float((g_a.mean() - det_a.mean()) / det_a.mean() * 100),
+        "per_scene_delta": dist(g_a - det_a),
+        "n_acting_scenes": int(acting.sum()),
+        "acting_delta_mean": float((g_a - det_a)[acting].mean()) if acting.any() else 0.0,
+        "policy_path_sec_per_scene": float(np.mean(t_policy)),
+        "guidance_args": {k: getattr(args, k) for k in (
+            "lambda_lat", "lat_scale", "col_scale", "col_range", "guidance_scale")},
+    }
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with open(out_dir / "policy_l2.json", "w") as f:
+        json.dump(report, f, indent=1)
+    print(json.dumps(report, indent=1))
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/eval_policy_l2.py
+++ b/rlvr/autoresearch/tools/eval_policy_l2.py
@@ -13,7 +13,7 @@ one guided generation per batch of scenes.
 Usage:
     python -m rlvr.autoresearch.tools.eval_policy_l2 \
         --model_path <base.pth> --policy_dir <dir> --scenes <val.json> \
-        --ego_shape WB,L,W --output_dir <dir> \
+        --output_dir <dir> \
         [--lambda_lat 5.0] [--lat_scale 2.0] [--col_scale 9.0] \
         [--batch_size 32] [--limit 0]
 """
@@ -26,16 +26,16 @@ from pathlib import Path
 
 import numpy as np
 import torch
-
-import rlvr.guidance_batched  # noqa: F401
 from diffusion_planner.model.guidance.composer import GuidanceComposer
 from diffusion_planner.model.guidance.config import GuidanceConfig, GuidanceSetConfig
+
+import rlvr.guidance_batched  # noqa: F401
 from exploration_policy.utils import run_frozen_encoder
+from preference_optimization.utils import load_npz_data
 from rlvr.autoresearch.tools.eval_det_avoidance import det_inference_batched, load_model
 from rlvr.autoresearch.tools.eval_policy_avoidance import load_policy
 from rlvr.closed_loop.batched_rollout import _batched_generate_varied_noise
 from rlvr.grpo_trainer_batched import _normalize_batch, _stack_scene_data
-from preference_optimization.utils import load_npz_data
 
 
 def make_composer(etas, args):

--- a/rlvr/autoresearch/tools/filter_sc_t0_clean.py
+++ b/rlvr/autoresearch/tools/filter_sc_t0_clean.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Filter avoidance scenes to those that are sc-clean at t=0.
+
+The static-collision gate ignores t=0, so a scene whose ego ALREADY overlaps
+(or nearly touches) a stopped neighbor at t=0 silently passes every gate and
+poisons recovery/avoidance training (can't train avoidance from an
+already-failed start). This tool drops such scenes, plus scenes with no
+stopped neighbor at all (nothing to avoid).
+
+Mechanism (canonical reward path, no hand-rolled geometry): score a static
+trajectory pinned at the t=0 ego pose (origin of the ego frame) through
+``compute_reward_batch``; its ``sc_min_dist`` IS the t=0 OBB clearance to the
+nearest stopped neighbor. Keep scenes with sc_min_dist >= sc_cross_thresh.
+
+Usage:
+    python -m rlvr.autoresearch.tools.filter_sc_t0_clean \
+        --scenes <scenes.json> --config <reward_config.json> \
+        --out <filtered.json>
+
+Outputs <out> (kept scene list) and <out>.report.json (kept / dropped lists).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+
+from preference_optimization.utils import load_npz_data
+from rlvr.autoresearch.tools.reward_config_from_json import load_reward_config
+from rlvr.reward import compute_reward_batch
+
+
+def t0_sc_clearance(data: dict, rcfg, device: torch.device) -> tuple[float, int]:
+    """t=0 OBB clearance to the nearest stopped neighbor + stopped count.
+
+    Scores a static trajectory held at the ego-frame origin (the t=0 pose):
+    every future step sits at the t=0 footprint, so the breakdown's
+    sc_min_dist (min over t>=1) equals the t=0 clearance.
+    """
+    T = data["ego_agent_future"].shape[-2] if "ego_agent_future" in data else 80
+    static_traj = torch.zeros(1, T, 4, device=device)
+    static_traj[..., 2] = 1.0  # heading 0 -> (cos, sin) = (1, 0)
+    r = compute_reward_batch(static_traj, data, rcfg)[0]
+    return float(r.sc_min_dist), int(r.sc_n_stopped)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--scenes", required=True)
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--require_stopped", action="store_true", default=True,
+                        help="Drop scenes with no stopped neighbor (default on)")
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    rcfg = load_reward_config(args.config)
+    if not rcfg.static_collision_enabled:
+        raise SystemExit(
+            "--config must have static_collision_enabled=true: without it the "
+            "sc fields this filter reads are never computed."
+        )
+
+    with open(args.scenes) as f:
+        scene_paths = json.load(f)
+
+    kept, dropped_t0, dropped_no_stopped, errors = [], [], [], []
+    for p in scene_paths:
+        try:
+            data = load_npz_data(p, device)
+            clearance, n_stopped = t0_sc_clearance(data, rcfg, device)
+        except Exception as e:  # noqa: BLE001
+            errors.append({"scene": p, "error": str(e)})
+            print(f"  [err ] {Path(p).name}: {e}")
+            continue
+        if n_stopped == 0 and args.require_stopped:
+            dropped_no_stopped.append({"scene": p})
+            print(f"  [drop] {Path(p).name}: no stopped neighbor")
+        elif clearance < rcfg.sc_cross_thresh:
+            dropped_t0.append({"scene": p, "t0_clearance": clearance})
+            print(f"  [drop] {Path(p).name}: t0 clearance {clearance:+.3f}m "
+                  f"< {rcfg.sc_cross_thresh}m")
+        else:
+            kept.append(p)
+            print(f"  [keep] {Path(p).name}: t0 clearance {clearance:+.3f}m, "
+                  f"{n_stopped} stopped")
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with open(out, "w") as f:
+        json.dump(kept, f, indent=1)
+    with open(str(out) + ".report.json", "w") as f:
+        json.dump({
+            "n_input": len(scene_paths), "n_kept": len(kept),
+            "n_dropped_t0": len(dropped_t0),
+            "n_dropped_no_stopped": len(dropped_no_stopped),
+            "n_errors": len(errors),
+            "dropped_t0": dropped_t0,
+            "dropped_no_stopped": dropped_no_stopped,
+            "errors": errors,
+        }, f, indent=1)
+    print(f"\nKept {len(kept)}/{len(scene_paths)} "
+          f"(dropped {len(dropped_t0)} t0-violating, "
+          f"{len(dropped_no_stopped)} no-stopped, {len(errors)} errors)")
+    print(f"Wrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/filter_sc_t0_clean.py
+++ b/rlvr/autoresearch/tools/filter_sc_t0_clean.py
@@ -53,8 +53,10 @@ def main():
     parser.add_argument("--scenes", required=True)
     parser.add_argument("--config", required=True)
     parser.add_argument("--out", required=True)
-    parser.add_argument("--require_stopped", action="store_true", default=True,
-                        help="Drop scenes with no stopped neighbor (default on)")
+    parser.add_argument("--require_stopped",
+                        action=argparse.BooleanOptionalAction, default=True,
+                        help="Drop scenes with no stopped neighbor "
+                             "(--no-require_stopped to keep them)")
     args = parser.parse_args()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/rlvr/autoresearch/tools/ghost_replay_openloop.py
+++ b/rlvr/autoresearch/tools/ghost_replay_openloop.py
@@ -22,6 +22,7 @@ import subprocess
 from pathlib import Path
 
 import matplotlib
+
 matplotlib.use("Agg")
 import numpy as np
 import torch
@@ -31,16 +32,16 @@ from matplotlib.figure import Figure
 from preference_optimization.utils import load_npz_data
 from rlvr.autoresearch.tools.eval_det_avoidance import det_inference_batched, load_model
 from rlvr.autoresearch.tools.ghost_sim_common import (
+    _NB_COLOR,
     extract_scene_polylines,
     extract_stopped_neighbors,
-    _NB_COLOR,
 )
 from rlvr.autoresearch.tools.recovery_sim import (
-    _draw_agent_box,
     _LANE_BORDER_COLOR,
     _LANE_COLOR,
     _ROAD_BORDER_COLOR,
     _ROUTE_COLOR,
+    _draw_agent_box,
 )
 
 BASELINE_COLOR = "#1f77b4"  # blue

--- a/rlvr/autoresearch/tools/ghost_replay_openloop.py
+++ b/rlvr/autoresearch/tools/ghost_replay_openloop.py
@@ -115,7 +115,11 @@ def _render_frame(out_png, egos, polylines, neighbor_boxes, show_nb, title,
 def main():
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--model_baseline", required=True)
-    p.add_argument("--model_best", required=True)
+    p.add_argument("--model_best", default=None,
+                   help="second model .pth; omit when using --policy_dir")
+    p.add_argument("--policy_dir", default=None,
+                   help="exploration-policy dir: 'best' = baseline + guidance "
+                        "(same frozen model, policy-chosen etas via composer)")
     p.add_argument("--label_baseline", default="baseline")
     p.add_argument("--label_best", default="best")
     p.add_argument("--scenes", required=True)
@@ -128,12 +132,30 @@ def main():
                    help="stopped neighbors with t0 longitudinal x >= this are AHEAD "
                         "(ego approaching) -> appear at t=0; x < this are beside/behind "
                         "(post-avoidance/branch, were visible) -> shown during history too")
+    # Guidance envelope (must match the policy's training labels)
+    p.add_argument("--lambda_lat", type=float, default=5.0)
+    p.add_argument("--lat_scale", type=float, default=2.0)
+    p.add_argument("--col_scale", type=float, default=9.0)
+    p.add_argument("--col_range", type=float, default=8.0)
+    p.add_argument("--lambda_spd", type=float, default=0.2)
+    p.add_argument("--stretch_scale", type=float, default=1.0)
+    p.add_argument("--guidance_scale", type=float, default=0.5)
     args = p.parse_args()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     ego_shape = [float(x) for x in args.ego_shape.split(",")]
     m_base, a_base = load_model(args.model_baseline, device)
-    m_best, a_best = load_model(args.model_best, device)
+    policy = None
+    if args.policy_dir:
+        from exploration_policy.utils import run_frozen_encoder
+        from guidance_gui.generate_samples import generate_samples
+        from rlvr.autoresearch.tools.eval_policy_avoidance import load_policy, make_composer
+        policy, heads = load_policy(args.policy_dir, a_base, device)
+        m_best, a_best = m_base, a_base
+    elif args.model_best:
+        m_best, a_best = load_model(args.model_best, device)
+    else:
+        raise SystemExit("pass either --model_best or --policy_dir")
     scenes = json.load(open(args.scenes))
     out_root = Path(args.output_dir)
     out_root.mkdir(parents=True, exist_ok=True)
@@ -142,7 +164,26 @@ def main():
         name = Path(sp).stem
         data = load_npz_data(sp, device)
         traj_base = det_inference_batched(m_base, a_base, [data], device)[0].cpu().numpy()
-        traj_best = det_inference_batched(m_best, a_best, [data], device)[0].cpu().numpy()
+        label_best = args.label_best
+        if policy is not None:
+            norm_data = {k: v.clone() if isinstance(v, torch.Tensor) else v
+                         for k, v in data.items()}
+            norm_data = a_base.observation_normalizer(norm_data)
+            x_ref = torch.from_numpy(np.ascontiguousarray(traj_base)).float()
+            x_ref = x_ref.unsqueeze(0).to(device)
+            norm_data["reference_trajectory"] = x_ref
+            enc = run_frozen_encoder(m_base, norm_data)
+            pout = policy(enc, x_ref, deterministic=True)
+            etas = {h: (2.0 * pout.dists[h].mean - 1.0).reshape(1) for h in heads}
+            composer = make_composer(etas, args)
+            traj_best = generate_samples(
+                model=m_base, model_args=a_base, data=norm_data,
+                noise_scale=0.0, n_samples=1, composer=composer, device=device,
+            )[0]
+            eta_str = " ".join(f"{h[:3]}={float(v.item()):+.2f}" for h, v in etas.items())
+            label_best = f"{args.label_best} ({eta_str})"
+        else:
+            traj_best = det_inference_batched(m_best, a_best, [data], device)[0].cpu().numpy()
         past = np.load(sp, allow_pickle=True)["ego_agent_past"].astype(np.float32)
         nb_boxes = extract_stopped_neighbors(sp)
         polylines = extract_scene_polylines(data)
@@ -179,7 +220,7 @@ def main():
             tb.append(pb[:2]); tk.append(pk[:2])
             egos = [
                 dict(pose=pb, trail=np.array(tb), color=BASELINE_COLOR, label=args.label_baseline, lw=2),
-                dict(pose=pk, trail=np.array(tk), color=BEST_COLOR, label=args.label_best, lw=2),
+                dict(pose=pk, trail=np.array(tk), color=BEST_COLOR, label=label_best, lw=2),
             ]
             _render_frame(sc_dir / f"f{fi:04d}.png", egos, polylines, nb_boxes,
                           True, f"{name}   t={i*0.1:+.1f}s   PERFECT-TRACK (baseline vs best)",

--- a/rlvr/autoresearch/tools/ghost_replay_openloop.py
+++ b/rlvr/autoresearch/tools/ghost_replay_openloop.py
@@ -76,8 +76,9 @@ def _scene_base(ax, polylines, cx, cy, view_half):
 
 
 def _render_frame(out_png, egos, polylines, neighbor_boxes, show_nb, title,
-                  view_half, ego_shape):
+                  view_half, ego_shape, extra_lines=None):
     # egos: list of dicts {pose:[x,y,h], trail:(N,2), color, label, lw}
+    # extra_lines: optional list of (xy:(N,2), color, alpha, label|None) static lines
     cx = float(np.mean([e["pose"][0] for e in egos]))
     cy = float(np.mean([e["pose"][1] for e in egos]))
     fig = Figure(figsize=(11, 11))
@@ -87,6 +88,12 @@ def _render_frame(out_png, egos, polylines, neighbor_boxes, show_nb, title,
     if show_nb and neighbor_boxes:
         for nx, ny, nh, nl, nw in neighbor_boxes:
             _draw_agent_box(ax, nx, ny, nh, nl, nw, _NB_COLOR, alpha=0.8, lw=1.5, zorder=14)
+    if extra_lines:
+        labeled = False
+        for xy, color, alpha, lab in extra_lines:
+            ax.plot(xy[:, 0], xy[:, 1], "-", color=color, lw=1.0, alpha=alpha,
+                    zorder=16, label=(lab if not labeled and lab else None))
+            labeled = labeled or bool(lab)
     for e in egos:
         tr = e["trail"]
         if tr.shape[0] > 1:
@@ -140,6 +147,9 @@ def main():
     p.add_argument("--lambda_spd", type=float, default=0.2)
     p.add_argument("--stretch_scale", type=float, default=1.0)
     p.add_argument("--guidance_scale", type=float, default=0.5)
+    p.add_argument("--n_candidates", type=int, default=0,
+                   help="additionally sample N etas from the policy distribution "
+                        "and draw their guided trajectories as a faint candidate fan")
     args = p.parse_args()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -165,6 +175,7 @@ def main():
         data = load_npz_data(sp, device)
         traj_base = det_inference_batched(m_base, a_base, [data], device)[0].cpu().numpy()
         label_best = args.label_best
+        cand_lines = []
         if policy is not None:
             norm_data = {k: v.clone() if isinstance(v, torch.Tensor) else v
                          for k, v in data.items()}
@@ -182,6 +193,28 @@ def main():
             )[0]
             eta_str = " ".join(f"{h[:3]}={float(v.item()):+.2f}" for h, v in etas.items())
             label_best = f"{args.label_best} ({eta_str})"
+            cand_lines = []
+            if args.n_candidates > 0:
+                from rlvr.closed_loop.batched_rollout import _batched_generate_varied_noise
+                N = args.n_candidates
+                cand = {h: (2.0 * pout.dists[h].rsample((N,)).reshape(-1) - 1.0)
+                        for h in heads}
+                N_data = {}
+                for k, v in norm_data.items():
+                    if isinstance(v, torch.Tensor) and v.shape[0] == 1:
+                        N_data[k] = v.expand(N, *v.shape[1:]).contiguous()
+                    else:
+                        N_data[k] = v
+                cand_trajs = _batched_generate_varied_noise(
+                    m_base, a_base, N_data, noise_min=0.0, noise_max=0.0,
+                    first_deterministic=False, composer=make_composer(cand, args),
+                    device=device,
+                ).cpu().numpy()
+                cand_lines = [
+                    (cand_trajs[i, :, :2], BEST_COLOR, 0.22,
+                     f"{N} candidates from policy distribution" if i == 0 else None)
+                    for i in range(N)
+                ]
         else:
             traj_best = det_inference_batched(m_best, a_best, [data], device)[0].cpu().numpy()
         past = np.load(sp, allow_pickle=True)["ego_agent_past"].astype(np.float32)
@@ -224,7 +257,7 @@ def main():
             ]
             _render_frame(sc_dir / f"f{fi:04d}.png", egos, polylines, nb_boxes,
                           True, f"{name}   t={i*0.1:+.1f}s   PERFECT-TRACK (baseline vs best)",
-                          args.view_half, ego_shape)
+                          args.view_half, ego_shape, extra_lines=cand_lines)
             fi += 1
 
         webm = out_root / f"{name}.webm"

--- a/rlvr/autoresearch/tools/ghost_sim_common.py
+++ b/rlvr/autoresearch/tools/ghost_sim_common.py
@@ -277,28 +277,36 @@ def run_ghost_sim(
     extra_title_fn=None,
     predict_fn_a=None,
     predict_fn_b=None,
+    sg_smooth: bool = True,
+    rollout_a: dict | None = None,
+    rollout_b: dict | None = None,
 ):
     """Run dual-model ghost sim and render per-step PNGs + optional webm.
 
     extra_title_fn: optional callable(step, a_pose, b_pose) -> str for per-step subtitle.
     predict_fn_a / predict_fn_b: optional per-step planner-call overrides for
-        the rollouts (e.g. SG smoothing, exploration-policy guided generation);
+        the rollouts (e.g. exploration-policy guided generation);
         same signature as recovery_sim.deterministic_predict.
+    sg_smooth: SG-filter every per-step plan before tracking (sim convention).
+    rollout_a / rollout_b: precomputed rollout dicts (closed_loop_rollout_with_plans
+        format) — render-only mode, models may be None (no GPU needed).
     """
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    print(f"[ghost-sim] rollout ({cfg.model_a_label})...")
-    rollout_a = closed_loop_rollout_with_plans(
-        model_a, model_a_args, scene_data,
-        n_steps=cfg.steps, advance_k=cfg.advance_k,
-        predict_fn=predict_fn_a,
-    )
-    print(f"[ghost-sim] rollout ({cfg.model_b_label})...")
-    rollout_b = closed_loop_rollout_with_plans(
-        model_b, model_b_args, scene_data,
-        n_steps=cfg.steps, advance_k=cfg.advance_k,
-        predict_fn=predict_fn_b,
-    )
+    if rollout_a is None:
+        print(f"[ghost-sim] rollout ({cfg.model_a_label})...")
+        rollout_a = closed_loop_rollout_with_plans(
+            model_a, model_a_args, scene_data,
+            n_steps=cfg.steps, advance_k=cfg.advance_k,
+            predict_fn=predict_fn_a, sg_smooth=sg_smooth,
+        )
+    if rollout_b is None:
+        print(f"[ghost-sim] rollout ({cfg.model_b_label})...")
+        rollout_b = closed_loop_rollout_with_plans(
+            model_b, model_b_args, scene_data,
+            n_steps=cfg.steps, advance_k=cfg.advance_k,
+            predict_fn=predict_fn_b, sg_smooth=sg_smooth,
+        )
 
     centerlines, lefts, rights, border_polylines, route_polylines, cl_segments = \
         extract_scene_polylines(scene_data)

--- a/rlvr/autoresearch/tools/ghost_sim_common.py
+++ b/rlvr/autoresearch/tools/ghost_sim_common.py
@@ -143,6 +143,7 @@ def render_ghost_step(
     extra_title: str = "",
     history_mode: bool = False,
     history_trail: np.ndarray | None = None,
+    fan_plans: list[np.ndarray] | None = None,
 ) -> None:
     ax_val, ay_val, ah_val = float(a_pose[0]), float(a_pose[1]), float(a_pose[2])
     bx_val, by_val, bh_val = float(b_pose[0]), float(b_pose[1]), float(b_pose[2])
@@ -201,6 +202,12 @@ def render_ghost_step(
         fig.clf()
         return
 
+    if fan_plans:
+        for fi, fp in enumerate(fan_plans):
+            ax.plot(fp[:, 0], fp[:, 1], "-", color=cfg.model_b_color,
+                    lw=0.8, alpha=0.16, zorder=22,
+                    label=(f"{len(fan_plans)} candidates from policy dist"
+                           if fi == 0 else None))
     if a_plan is not None and a_plan.shape[0] > 1:
         ax.plot(a_plan[:, 0], a_plan[:, 1], "-",
                 color=cfg.model_a_color, lw=1.4, alpha=0.45, zorder=24)
@@ -349,6 +356,8 @@ def run_ghost_sim(
             cfg=cfg,
             neighbor_boxes=neighbor_boxes,
             extra_title=et,
+            fan_plans=(rollout_b.get("extra_plans_world", [[]])[step_i]
+                       if step_i < len(rollout_b.get("extra_plans_world", [])) else None),
         )
 
     webm_path = None

--- a/rlvr/autoresearch/tools/ghost_sim_common.py
+++ b/rlvr/autoresearch/tools/ghost_sim_common.py
@@ -54,6 +54,9 @@ class GhostSimConfig:
     steps: int = 80
     advance_k: int = 0
     webm_fps: int = 10
+    # Render this many recorded-history frames (gray ego from ego_agent_past)
+    # BEFORE the closed-loop frames — the model-context preamble.
+    hist_steps: int = 0
     subtitle: str = ""
     show_lateral: bool = True
 
@@ -138,6 +141,8 @@ def render_ghost_step(
     cfg: GhostSimConfig,
     neighbor_boxes: list[tuple[float, float, float, float, float]] | None = None,
     extra_title: str = "",
+    history_mode: bool = False,
+    history_trail: np.ndarray | None = None,
 ) -> None:
     ax_val, ay_val, ah_val = float(a_pose[0]), float(a_pose[1]), float(a_pose[2])
     bx_val, by_val, bh_val = float(b_pose[0]), float(b_pose[1]), float(b_pose[2])
@@ -175,6 +180,26 @@ def render_ghost_step(
         for nx, ny, nh, nl, nw in neighbor_boxes:
             _draw_agent_box(ax, nx, ny, nh, nl, nw,
                             _NB_COLOR, alpha=0.75, lw=1.5, zorder=14)
+
+    if history_mode:
+        # Single gray recorded-history ego (model context preamble)
+        if history_trail is not None and history_trail.shape[0] > 1:
+            ax.plot(history_trail[:, 0], history_trail[:, 1], "-",
+                    color="#555555", lw=1.6, alpha=0.7, zorder=18)
+        _draw_agent_box(ax, ax_val, ay_val, ah_val, cfg.ego_length, cfg.ego_width,
+                        "#555555", alpha=0.8, lw=2, zorder=20,
+                        wheelbase=cfg.ego_wheelbase)
+        ax.plot([], [], "-", color="#555555", lw=2, label="ego history (recorded)")
+        ax.legend(fontsize=10, loc="upper left")
+        ax.set_xlim(cx - cfg.view_half_m, cx + cfg.view_half_m)
+        ax.set_ylim(cy - cfg.view_half_m, cy + cfg.view_half_m)
+        ax.set_aspect("equal")
+        ax.grid(True, alpha=0.15)
+        ax.set_title(f"{cfg.subtitle}{extra_title}", fontsize=11)
+        fig.tight_layout()
+        fig.savefig(output_path, dpi=100)
+        fig.clf()
+        return
 
     if a_plan is not None and a_plan.shape[0] > 1:
         ax.plot(a_plan[:, 0], a_plan[:, 1], "-",
@@ -275,6 +300,32 @@ def run_ghost_sim(
         neighbor_boxes = extract_stopped_neighbors(scene_path)
 
     n = cfg.steps
+    H = 0
+    if cfg.hist_steps > 0 and "ego_agent_past" in scene_data:
+        past = scene_data["ego_agent_past"]
+        past = past[0] if past.dim() == 3 else past
+        past = past.cpu().numpy()
+        H = min(cfg.hist_steps, past.shape[0])
+        hist = past[past.shape[0] - H:]
+        print(f"[ghost-sim] rendering {H} history frames...")
+        trail = []
+        for hi in range(H):
+            row = hist[hi]
+            hh = float(np.arctan2(row[3], row[2])) if row.shape[-1] >= 4 else float(row[2])
+            pose = np.array([float(row[0]), float(row[1]), hh])
+            trail.append(pose[:2])
+            render_ghost_step(
+                output_dir / f"ghost_step_{hi:04d}.png",
+                step=hi - H, n_steps=n,
+                a_pose=pose, a_speed=0.0, a_plan=None,
+                b_pose=pose, b_speed=0.0, b_plan=None,
+                centerlines=centerlines, lefts=lefts, rights=rights,
+                border_polylines=border_polylines, route_polylines=route_polylines,
+                centerline_segments=cl_segments,
+                cfg=cfg, neighbor_boxes=neighbor_boxes,
+                extra_title=f"  HISTORY t={(hi - H) * 0.1:+.1f}s (model context)",
+                history_mode=True, history_trail=np.array(trail),
+            )
     print(f"[ghost-sim] rendering {n + 1} frames...")
     for step_i in range(n + 1):
         a_plan = rollout_a["plans_world"][step_i] if step_i < len(rollout_a["plans_world"]) else None
@@ -284,7 +335,7 @@ def run_ghost_sim(
             et = extra_title_fn(step_i, rollout_a["positions"][step_i],
                                 rollout_b["positions"][step_i])
         render_ghost_step(
-            output_dir / f"ghost_step_{step_i:04d}.png",
+            output_dir / f"ghost_step_{step_i + H:04d}.png",
             step=step_i, n_steps=n,
             a_pose=rollout_a["positions"][step_i],
             a_speed=float(rollout_a["velocities"][step_i]),

--- a/rlvr/autoresearch/tools/ghost_sim_common.py
+++ b/rlvr/autoresearch/tools/ghost_sim_common.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import matplotlib
+
 matplotlib.use("Agg")
 import numpy as np
 import torch
@@ -19,20 +20,20 @@ from diffusion_planner.model.diffusion_planner import Diffusion_Planner
 from diffusion_planner.utils.config import Config
 from matplotlib.collections import LineCollection
 from matplotlib.figure import Figure
-from preference_optimization.lora_utils import load_lora_checkpoint
 
+from preference_optimization.lora_utils import load_lora_checkpoint
 from rlvr.autoresearch.tools.recovery_sim import (
+    _LANE_BORDER_COLOR,
+    _LANE_COLOR,
+    _ROAD_BORDER_COLOR,
+    _ROUTE_COLOR,
+    _VIEW_HALF_M,
     _build_segments,
     _draw_agent_box,
     _lane_polylines,
     _point_to_segments_dist,
     _road_border_polylines,
     _route_polylines,
-    _LANE_BORDER_COLOR,
-    _LANE_COLOR,
-    _ROAD_BORDER_COLOR,
-    _ROUTE_COLOR,
-    _VIEW_HALF_M,
     closed_loop_rollout_with_plans,
 )
 

--- a/rlvr/autoresearch/tools/ghost_sim_common.py
+++ b/rlvr/autoresearch/tools/ghost_sim_common.py
@@ -243,10 +243,15 @@ def run_ghost_sim(
     neighbor_boxes: list[tuple[float, float, float, float, float]] | None = None,
     make_webm: bool = True,
     extra_title_fn=None,
+    predict_fn_a=None,
+    predict_fn_b=None,
 ):
     """Run dual-model ghost sim and render per-step PNGs + optional webm.
 
     extra_title_fn: optional callable(step, a_pose, b_pose) -> str for per-step subtitle.
+    predict_fn_a / predict_fn_b: optional per-step planner-call overrides for
+        the rollouts (e.g. SG smoothing, exploration-policy guided generation);
+        same signature as recovery_sim.deterministic_predict.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -254,11 +259,13 @@ def run_ghost_sim(
     rollout_a = closed_loop_rollout_with_plans(
         model_a, model_a_args, scene_data,
         n_steps=cfg.steps, advance_k=cfg.advance_k,
+        predict_fn=predict_fn_a,
     )
     print(f"[ghost-sim] rollout ({cfg.model_b_label})...")
     rollout_b = closed_loop_rollout_with_plans(
         model_b, model_b_args, scene_data,
         n_steps=cfg.steps, advance_k=cfg.advance_k,
+        predict_fn=predict_fn_b,
     )
 
     centerlines, lefts, rights, border_polylines, route_polylines, cl_segments = \

--- a/rlvr/autoresearch/tools/pad_static_neighbor_futures.py
+++ b/rlvr/autoresearch/tools/pad_static_neighbor_futures.py
@@ -59,11 +59,23 @@ def main():
                 np.linalg.norm(nb[i, -1, :2] - nb[i, -11, :2])) < args.stop_disp
             fut_valid = (np.abs(nf[i, :, :2]).sum(axis=1) > 0.1).sum()
             if stopped and fut_valid == 0:
-                # Future of a parked car = current pose, repeated. Copy the
-                # state columns the future format shares with the past frame
-                # (x, y, heading components ...), zero-velocity by identity.
+                # Future of a parked car = current pose, repeated,
+                # zero-velocity by identity. Past frames are
+                # (x, y, cos, sin, ...); the future is either 4-col
+                # (x, y, cos, sin) — copy directly — or 3-col
+                # (x, y, heading_rad) — recover the angle, NEVER copy
+                # the past's cos into the radians slot.
                 T, F = nf.shape[1], nf.shape[2]
-                nf[i, :, :] = np.tile(last[i, :F], (T, 1))
+                if F == 4:
+                    row = last[i, :4]
+                elif F == 3:
+                    row = np.array([last[i, 0], last[i, 1],
+                                    np.arctan2(last[i, 3], last[i, 2])])
+                else:
+                    raise ValueError(
+                        f"{sp}: unsupported neighbor_agents_future width {F} "
+                        "(expected 3 or 4)")
+                nf[i, :, :] = np.tile(row, (T, 1))
                 n_padded += 1
         if n_padded:
             raw["neighbor_agents_future"] = nf.astype(

--- a/rlvr/autoresearch/tools/pad_static_neighbor_futures.py
+++ b/rlvr/autoresearch/tools/pad_static_neighbor_futures.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Repair NPZs whose STOPPED neighbours have empty future tracks.
+
+The reward/label pipeline classifies static obstacles through
+``neighbor_agents_future`` validity; extraction sometimes leaves a parked
+vehicle with an all-zero future track, making it INVISIBLE to sweeps,
+margin labels and reward-based metrics (sc_n_stopped=0 -> "already_clean"
+-> zero-target) while past-based eval extraction still sees it — i.e. the
+policy is actively taught that the scene is empty road, then scored for
+crashing into the car it was never told about.
+
+Fix: for every neighbour that is (a) valid in the past, (b) stopped by past
+displacement (< --stop_disp over the last second), and (c) has zero valid
+future steps, fill the future track with its current pose repeated — the
+physically exact future of a parked vehicle. All other fields copied
+verbatim; output mirrors the input list with pool-prefixed filenames.
+
+Usage:
+    python -m rlvr.autoresearch.tools.pad_static_neighbor_futures \
+        --scenes <list.json> --out_dir <dir> --out_list <json>
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--scenes", required=True)
+    parser.add_argument("--out_dir", required=True)
+    parser.add_argument("--out_list", required=True)
+    parser.add_argument("--stop_disp", type=float, default=0.5,
+                        help="max displacement (m) over the last 1 s of past "
+                             "to classify a neighbour as stopped")
+    args = parser.parse_args()
+
+    with open(args.scenes) as f:
+        paths = json.load(f)
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    written, n_padded_total = [], 0
+    for sp in paths:
+        raw = dict(np.load(sp, allow_pickle=True))
+        nb = raw["neighbor_agents_past"]
+        nf = np.array(raw["neighbor_agents_future"], copy=True)
+        n_padded = 0
+        last = nb[:, -1, :]
+        valid = np.abs(last[:, :2]).sum(axis=1) > 0.1
+        for i in np.nonzero(valid)[0]:
+            past_ok = np.abs(nb[i, -11, :2]).sum() > 0
+            stopped = past_ok and float(
+                np.linalg.norm(nb[i, -1, :2] - nb[i, -11, :2])) < args.stop_disp
+            fut_valid = (np.abs(nf[i, :, :2]).sum(axis=1) > 0.1).sum()
+            if stopped and fut_valid == 0:
+                # Future of a parked car = current pose, repeated. Copy the
+                # state columns the future format shares with the past frame
+                # (x, y, heading components ...), zero-velocity by identity.
+                T, F = nf.shape[1], nf.shape[2]
+                nf[i, :, :] = np.tile(last[i, :F], (T, 1))
+                n_padded += 1
+        if n_padded:
+            raw["neighbor_agents_future"] = nf.astype(
+                np.array(raw["neighbor_agents_future"]).dtype)
+        pool = Path(sp).parent.name
+        out_path = out_dir / f"{pool}__{Path(sp).stem}.npz"
+        np.savez(out_path, **raw)
+        written.append(str(out_path))
+        n_padded_total += n_padded
+        if n_padded:
+            print(f"  [pad ] {pool}/{Path(sp).name}: {n_padded} neighbour(s)")
+
+    with open(args.out_list, "w") as f:
+        json.dump(written, f, indent=1)
+    print(f"\nWrote {len(written)} scenes ({n_padded_total} futures padded) "
+          f"-> {args.out_list}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/recovery_sim.py
+++ b/rlvr/autoresearch/tools/recovery_sim.py
@@ -205,6 +205,7 @@ def closed_loop_rollout_with_plans(
     positions = [np.array([0.0, 0.0, 0.0])]
     velocities = [0.0]
     plans_world: list[np.ndarray] = []
+    extra_plans_world: list[list[np.ndarray]] = []
 
     # Initial speed from ego_current_state (channels 4=vx, 5=vy in current frame)
     ecs0 = data["ego_current_state"]
@@ -216,7 +217,13 @@ def closed_loop_rollout_with_plans(
     for step_i in range(n_steps):
         # predict_fn lets callers swap the per-step planner call (e.g.
         # explorer-guided generation); default = plain deterministic forward.
-        pred = (predict_fn or deterministic_predict)(model, model_args, data)  # [T, 4] CURRENT frame
+        # It may return (pred, [candidate_plans...]) — candidates are
+        # transformed alongside and stored in extra_plans_world.
+        _out = (predict_fn or deterministic_predict)(model, model_args, data)
+        if isinstance(_out, tuple):
+            pred, _cands = _out
+        else:
+            pred, _cands = _out, []
 
         # Re-express the ENTIRE plan in the INITIAL frame for visualization.
         # current frame -> initial frame: p_init = (cum_x, cum_y) + R(cum) @ p_cur
@@ -228,6 +235,15 @@ def closed_loop_rollout_with_plans(
         cum_yaw = math.atan2(cum_sin, cum_cos)
         wh = (cur_h + cum_yaw).astype(np.float64)
         plans_world.append(np.stack([wx, wy, wh], axis=-1))
+
+        step_extra = []
+        for c in _cands:
+            cxy = c[:, :2].astype(np.float64)
+            step_extra.append(np.stack([
+                cum_x + cum_cos * cxy[:, 0] - cum_sin * cxy[:, 1],
+                cum_y + cum_sin * cxy[:, 0] + cum_cos * cxy[:, 1],
+            ], axis=-1))
+        extra_plans_world.append(step_extra)
 
         if pred.shape[0] <= advance_k:
             advance_k = pred.shape[0] - 1
@@ -288,7 +304,8 @@ def closed_loop_rollout_with_plans(
 
     return {
         "positions": np.stack(positions, axis=0),  # [N+1, 3]
-        "plans_world": plans_world,                # len N
+        "plans_world": plans_world,
+        "extra_plans_world": extra_plans_world,                # len N
         "velocities": np.array(velocities),
     }
 

--- a/rlvr/autoresearch/tools/recovery_sim.py
+++ b/rlvr/autoresearch/tools/recovery_sim.py
@@ -184,10 +184,28 @@ def closed_loop_rollout_with_plans(
     advance_k: int = 0,
     dt: float = 0.1,
     predict_fn=None,
+    sg_smooth: bool = True,
+    sg_window: int = 11,
+    sg_order: int = 3,
+    trim_backward: bool = False,
 ) -> dict:
     """Run the closed-loop rollout and capture per-step predictions in the
     initial ego frame. Direct extension of recovery_test.closed_loop_rollout —
     forked because we need extra outputs (yaw + per-step world-frame plans).
+
+    sg_smooth: Savitzky-Golay smooth every per-step plan before the tracker
+    consumes it — same filter (and 11/3 defaults) scenario_generation.replay
+    applies via SpawnConfig.sg_smooth_enabled. Raw diffusion/guided output can
+    place the first plan point slightly behind the ego, which an unfiltered
+    advance_k=0 tracker turns into a backwards step.
+
+    trim_backward: drop a leading run of plan points that sit BEHIND the ego
+    (longitudinal x < 0) before tracking, advancing to the first forward
+    point. Guidance gradients are strongest on the points nearest an
+    obstacle and can bend the plan's near-field a few cm backwards at
+    standstill; SG smoothing preserves that systematic offset, and the
+    literal advance_k=0 tracker would reverse — a lookahead tracker (real
+    vehicle) would not.
 
     Returns dict:
         positions: [n_steps + 1, 3] (x, y, yaw) in initial ego frame
@@ -224,6 +242,13 @@ def closed_loop_rollout_with_plans(
             pred, _cands = _out
         else:
             pred, _cands = _out, []
+        if sg_smooth:
+            from rlvr.grpo_sft_trainer import _smooth_trajectory
+            pred = _smooth_trajectory(pred, sg_window, sg_order)
+        if trim_backward and pred[0, 0] < -1e-3:
+            fwd = np.nonzero(pred[:, 0] > 0.05)[0]
+            if len(fwd):
+                pred = pred[int(fwd[0]):]
 
         # Re-express the ENTIRE plan in the INITIAL frame for visualization.
         # current frame -> initial frame: p_init = (cum_x, cum_y) + R(cum) @ p_cur

--- a/rlvr/autoresearch/tools/recovery_sim.py
+++ b/rlvr/autoresearch/tools/recovery_sim.py
@@ -183,6 +183,7 @@ def closed_loop_rollout_with_plans(
     n_steps: int = 80,
     advance_k: int = 0,
     dt: float = 0.1,
+    predict_fn=None,
 ) -> dict:
     """Run the closed-loop rollout and capture per-step predictions in the
     initial ego frame. Direct extension of recovery_test.closed_loop_rollout —
@@ -213,7 +214,9 @@ def closed_loop_rollout_with_plans(
     velocities[0] = init_speed
 
     for step_i in range(n_steps):
-        pred = deterministic_predict(model, model_args, data)  # [T, 4] in CURRENT frame
+        # predict_fn lets callers swap the per-step planner call (e.g.
+        # explorer-guided generation); default = plain deterministic forward.
+        pred = (predict_fn or deterministic_predict)(model, model_args, data)  # [T, 4] CURRENT frame
 
         # Re-express the ENTIRE plan in the INITIAL frame for visualization.
         # current frame -> initial frame: p_init = (cum_x, cum_y) + R(cum) @ p_cur

--- a/rlvr/autoresearch/tools/recovery_sim_ghost.py
+++ b/rlvr/autoresearch/tools/recovery_sim_ghost.py
@@ -200,6 +200,12 @@ def main() -> None:
     parser.add_argument("--webm_fps", type=int, default=10)
     parser.add_argument("--baseline_label", type=str, default="baseline (LoRA-less)")
     parser.add_argument("--trained_label", type=str, default="PRiSM")
+    # closed_loop_rollout_with_plans now SG-smooths every per-step plan by
+    # default (matches the perfect-tracker sim convention). Older renders
+    # from this tool consumed raw plans — pass --no_sg_smooth to reproduce.
+    parser.add_argument("--no_sg_smooth", action="store_true",
+                        help="track raw per-step plans (pre-SG-default "
+                             "behaviour of this tool)")
     args = parser.parse_args()
 
     out = Path(args.output_dir)
@@ -228,11 +234,13 @@ def main() -> None:
     bl = closed_loop_rollout_with_plans(
         bl_model, bl_args, perturbed,
         n_steps=args.steps, advance_k=args.advance_k,
+        sg_smooth=not args.no_sg_smooth,
     )
     print(f"[ghost-sim] rollout (PRiSM)...")
     pr = closed_loop_rollout_with_plans(
         pr_model, pr_args, perturbed,
         n_steps=args.steps, advance_k=args.advance_k,
+        sg_smooth=not args.no_sg_smooth,
     )
 
     # Pre-compute scene polylines from perturbed (matches recovery_sim)

--- a/rlvr/autoresearch/tools/recovery_sim_ghost.py
+++ b/rlvr/autoresearch/tools/recovery_sim_ghost.py
@@ -36,10 +36,23 @@ import numpy as np
 import torch
 from matplotlib.collections import LineCollection
 from matplotlib.figure import Figure
+
 from preference_optimization.utils import load_npz_data
+from rlvr.autoresearch.tools.ghost_sim_common import (
+    extract_stopped_neighbors,
+)
+from rlvr.autoresearch.tools.ghost_sim_common import (
+    load_model as _load_model,
+)
 
 # Reuse all the heavy lifting from recovery_sim
 from rlvr.autoresearch.tools.recovery_sim import (
+    _LANE_BORDER_COLOR,
+    _LANE_COLOR,
+    _ROAD_BORDER_COLOR,
+    _ROUTE_COLOR,
+    _VIEW_HALF_M,
+    _apply_perturbation,
     _build_segments,
     _draw_agent_box,
     _ego_obb_corners,
@@ -48,20 +61,9 @@ from rlvr.autoresearch.tools.recovery_sim import (
     _point_to_segments_dist,
     _road_border_polylines,
     _route_polylines,
-    _apply_perturbation,
-    _LANE_BORDER_COLOR,
-    _LANE_COLOR,
-    _ROAD_BORDER_COLOR,
-    _ROUTE_COLOR,
-    _VIEW_HALF_M,
     closed_loop_rollout_with_plans,
 )
-from rlvr.autoresearch.tools.ghost_sim_common import (
-    extract_stopped_neighbors,
-    load_model as _load_model,
-)
 from rlvr.autoresearch.tools.recovery_test import get_tangent_at_origin
-
 
 _BASELINE_COLOR = "#1f77b4"   # blue
 _PRISM_COLOR    = "#d62728"   # red

--- a/rlvr/autoresearch/tools/rederive_margin_labels.py
+++ b/rlvr/autoresearch/tools/rederive_margin_labels.py
@@ -51,7 +51,8 @@ def _neighborhood_min_clearance(c: dict, combos: list[dict],
 
 
 def relabel_scene(r: dict, margin: float, min_gain: float,
-                  robust_radius: float = 0.0) -> dict:
+                  robust_radius: float = 0.0,
+                  robust_min_required: float = 0.0) -> dict:
     out = dict(r)
     det = r["det"]
     combos = r["combos"]
@@ -76,6 +77,14 @@ def relabel_scene(r: dict, margin: float, min_gain: float,
     if at_margin:
         out["status"] = "solved"
         out["best"] = pick(at_margin)
+        # Cliffy-scene exclusion: a "solution" whose eta-neighbourhood
+        # contains a crossing is unlearnable by regression (the policy's
+        # eta error lands on the cliff) — exclude from training like
+        # unsolved scenes instead of teaching a target it cannot hit.
+        if (robust_radius > 0 and robust_min_required > 0
+                and out.get("robust_min_clr", 0.0) < robust_min_required):
+            out["status"] = "unsolved"
+            out["best"] = None
     else:
         improved = [c for c in clean
                     if c["sc_min_dist"] >= det["sc_min_dist"] + min_gain]
@@ -104,6 +113,11 @@ def main():
                              "(cliff-avoiding) label selection; 0 = argmax "
                              "reward (original behaviour). Grid step is "
                              "0.25, so 0.25 = adjacent combos, 0.5 = 2 steps.")
+    parser.add_argument("--robust_min_required", type=float, default=0.0,
+                        help="exclude (mark unsolved) solved scenes whose "
+                             "best label's neighbourhood-min clearance is "
+                             "below this — cliff-edge scenes are unlearnable "
+                             "by regression")
     parser.add_argument("--out", required=True)
     args = parser.parse_args()
 
@@ -116,7 +130,8 @@ def main():
                 continue
             seen.add(r["scene_path"])
             scenes.append(relabel_scene(r, args.margin, args.min_gain,
-                                        args.robust_radius))
+                                        args.robust_radius,
+                                        args.robust_min_required))
 
     n = {"solved": 0, "already_clean": 0, "unsolved": 0}
     for r in scenes:

--- a/rlvr/autoresearch/tools/rederive_margin_labels.py
+++ b/rlvr/autoresearch/tools/rederive_margin_labels.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Re-derive sweep labels with a PROACTIVE clearance margin.
+
+The original labels teach "act only when the det plan collides"
+(sc crossing at <0.2 m). This transform re-labels the SAME per-scene combo
+tables so that any scene whose det clearance is below --margin counts as
+needing action, and the target is the best-reward combo that achieves at
+least the margin (clean: no sc/rb crossing, not stopped):
+
+  det sc_min_dist <  margin -> "solved" with best clean combo
+                               having sc_min_dist >= margin
+                               (fallback: best clean combo that improves
+                                det clearance by >= --min_gain; else
+                                "unsolved" = excluded)
+  det sc_min_dist >= margin -> "already_clean" (eta = 0 target)
+
+Output is sweep_labels-format JSON, directly consumable by
+rlvr.train_explorer_regression.
+
+Usage:
+    python -m rlvr.autoresearch.tools.rederive_margin_labels \
+        --labels <sweep_labels.json ...> --margin 0.7 --min_gain 0.3 \
+        --out <margin_labels.json>
+"""
+from __future__ import annotations
+
+import argparse
+import json
+
+
+def relabel_scene(r: dict, margin: float, min_gain: float) -> dict:
+    out = dict(r)
+    det = r["det"]
+    combos = r["combos"]
+    if det["sc_min_dist"] >= margin or r["sc_n_stopped"] == 0:
+        out["status"] = "already_clean"
+        out["best"] = None
+        return out
+
+    clean = [c for c in combos
+             if not c["static_crossing"] and not c["rb_cross"] and not c["stopped"]]
+    at_margin = [c for c in clean if c["sc_min_dist"] >= margin]
+    if at_margin:
+        out["status"] = "solved"
+        out["best"] = max(at_margin, key=lambda c: c["total"])
+    else:
+        improved = [c for c in clean
+                    if c["sc_min_dist"] >= det["sc_min_dist"] + min_gain]
+        if improved:
+            out["status"] = "solved"
+            # No combo reaches the margin: take the one with max clearance
+            # (reward as tiebreak) — partial-but-real improvement.
+            best_clr = max(c["sc_min_dist"] for c in improved)
+            out["best"] = max(
+                [c for c in improved if c["sc_min_dist"] >= best_clr - 0.05],
+                key=lambda c: c["total"],
+            )
+        else:
+            out["status"] = "unsolved"
+            out["best"] = None
+    return out
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--labels", required=True, nargs="+")
+    parser.add_argument("--margin", type=float, required=True)
+    parser.add_argument("--min_gain", type=float, default=0.3)
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    scenes, seen = [], set()
+    for lp in args.labels:
+        with open(lp) as f:
+            data = json.load(f)
+        for r in data["scenes"]:
+            if r["scene_path"] in seen:
+                continue
+            seen.add(r["scene_path"])
+            scenes.append(relabel_scene(r, args.margin, args.min_gain))
+
+    n = {"solved": 0, "already_clean": 0, "unsolved": 0}
+    for r in scenes:
+        n[r["status"]] += 1
+    summary = {
+        "margin": args.margin, "min_gain": args.min_gain,
+        "n_scenes": len(scenes), **{f"n_{k}": v for k, v in n.items()},
+    }
+    with open(args.out, "w") as f:
+        json.dump({"summary": summary, "scenes": scenes}, f, indent=1)
+    print(json.dumps(summary, indent=1))
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/rederive_margin_labels.py
+++ b/rlvr/autoresearch/tools/rederive_margin_labels.py
@@ -28,7 +28,30 @@ import argparse
 import json
 
 
-def relabel_scene(r: dict, margin: float, min_gain: float) -> dict:
+def _neighborhood_min_clearance(c: dict, combos: list[dict],
+                                radius: float) -> float:
+    """Worst sc clearance over the combo's eta-neighbourhood (incl. itself).
+
+    A combo whose neighbours collide sits on a response CLIFF (prior mode
+    boundary): regression eta error — and the Beta mean's compression of
+    +-1 targets — lands the policy on the bad side at inference (measured:
+    label eta +1.0 -> clearance +1.6, policy eta +0.82 -> -0.97 on the
+    same scene). Robust labels live mid-plateau. Crossing/stopped
+    neighbours count as clearance 0.
+    """
+    worst = c["sc_min_dist"]
+    for o in combos:
+        if (abs(o["eta_lat"] - c["eta_lat"]) <= radius + 1e-6
+                and abs(o["eta_col"] - c["eta_col"]) <= radius + 1e-6
+                and o.get("stretch", 1.0) == c.get("stretch", 1.0)):
+            v = 0.0 if (o["static_crossing"] or o["rb_cross"] or o["stopped"]) \
+                else o["sc_min_dist"]
+            worst = min(worst, v)
+    return worst
+
+
+def relabel_scene(r: dict, margin: float, min_gain: float,
+                  robust_radius: float = 0.0) -> dict:
     out = dict(r)
     det = r["det"]
     combos = r["combos"]
@@ -37,12 +60,22 @@ def relabel_scene(r: dict, margin: float, min_gain: float) -> dict:
         out["best"] = None
         return out
 
+    def pick(cands):
+        if robust_radius > 0:
+            best = max(cands, key=lambda c: (
+                _neighborhood_min_clearance(c, combos, robust_radius),
+                c["total"]))
+            out["robust_min_clr"] = round(
+                _neighborhood_min_clearance(best, combos, robust_radius), 3)
+            return best
+        return max(cands, key=lambda c: c["total"])
+
     clean = [c for c in combos
              if not c["static_crossing"] and not c["rb_cross"] and not c["stopped"]]
     at_margin = [c for c in clean if c["sc_min_dist"] >= margin]
     if at_margin:
         out["status"] = "solved"
-        out["best"] = max(at_margin, key=lambda c: c["total"])
+        out["best"] = pick(at_margin)
     else:
         improved = [c for c in clean
                     if c["sc_min_dist"] >= det["sc_min_dist"] + min_gain]
@@ -51,10 +84,8 @@ def relabel_scene(r: dict, margin: float, min_gain: float) -> dict:
             # No combo reaches the margin: take the one with max clearance
             # (reward as tiebreak) — partial-but-real improvement.
             best_clr = max(c["sc_min_dist"] for c in improved)
-            out["best"] = max(
-                [c for c in improved if c["sc_min_dist"] >= best_clr - 0.05],
-                key=lambda c: c["total"],
-            )
+            out["best"] = pick(
+                [c for c in improved if c["sc_min_dist"] >= best_clr - 0.05])
         else:
             out["status"] = "unsolved"
             out["best"] = None
@@ -68,6 +99,11 @@ def main():
     parser.add_argument("--labels", required=True, nargs="+")
     parser.add_argument("--margin", type=float, required=True)
     parser.add_argument("--min_gain", type=float, default=0.3)
+    parser.add_argument("--robust_radius", type=float, default=0.0,
+                        help="eta-neighbourhood radius for plateau-centred "
+                             "(cliff-avoiding) label selection; 0 = argmax "
+                             "reward (original behaviour). Grid step is "
+                             "0.25, so 0.25 = adjacent combos, 0.5 = 2 steps.")
     parser.add_argument("--out", required=True)
     args = parser.parse_args()
 
@@ -79,13 +115,15 @@ def main():
             if r["scene_path"] in seen:
                 continue
             seen.add(r["scene_path"])
-            scenes.append(relabel_scene(r, args.margin, args.min_gain))
+            scenes.append(relabel_scene(r, args.margin, args.min_gain,
+                                        args.robust_radius))
 
     n = {"solved": 0, "already_clean": 0, "unsolved": 0}
     for r in scenes:
         n[r["status"]] += 1
     summary = {
         "margin": args.margin, "min_gain": args.min_gain,
+        "robust_radius": args.robust_radius,
         "n_scenes": len(scenes), **{f"n_{k}": v for k, v in n.items()},
     }
     with open(args.out, "w") as f:

--- a/rlvr/autoresearch/tools/rederive_margin_labels.py
+++ b/rlvr/autoresearch/tools/rederive_margin_labels.py
@@ -77,14 +77,6 @@ def relabel_scene(r: dict, margin: float, min_gain: float,
     if at_margin:
         out["status"] = "solved"
         out["best"] = pick(at_margin)
-        # Cliffy-scene exclusion: a "solution" whose eta-neighbourhood
-        # contains a crossing is unlearnable by regression (the policy's
-        # eta error lands on the cliff) — exclude from training like
-        # unsolved scenes instead of teaching a target it cannot hit.
-        if (robust_radius > 0 and robust_min_required > 0
-                and out.get("robust_min_clr", 0.0) < robust_min_required):
-            out["status"] = "unsolved"
-            out["best"] = None
     else:
         improved = [c for c in clean
                     if c["sc_min_dist"] >= det["sc_min_dist"] + min_gain]
@@ -98,6 +90,15 @@ def relabel_scene(r: dict, margin: float, min_gain: float,
         else:
             out["status"] = "unsolved"
             out["best"] = None
+    # Cliffy-scene exclusion (BOTH solved branches): a "solution" whose
+    # eta-neighbourhood contains a crossing is unlearnable by regression
+    # (the policy's eta error lands on the cliff) — exclude from training
+    # like unsolved scenes instead of teaching a target it cannot hit.
+    if (out["status"] == "solved"
+            and robust_radius > 0 and robust_min_required > 0
+            and out.get("robust_min_clr", 0.0) < robust_min_required):
+        out["status"] = "unsolved"
+        out["best"] = None
     return out
 
 

--- a/rlvr/autoresearch/tools/rederive_margin_labels.py
+++ b/rlvr/autoresearch/tools/rederive_margin_labels.py
@@ -52,7 +52,8 @@ def _neighborhood_min_clearance(c: dict, combos: list[dict],
 
 def relabel_scene(r: dict, margin: float, min_gain: float,
                   robust_radius: float = 0.0,
-                  robust_min_required: float = 0.0) -> dict:
+                  robust_min_required: float = 0.0,
+                  eta_cap: float = 0.0) -> dict:
     out = dict(r)
     det = r["det"]
     combos = r["combos"]
@@ -73,6 +74,14 @@ def relabel_scene(r: dict, margin: float, min_gain: float,
 
     clean = [c for c in combos
              if not c["static_crossing"] and not c["rb_cross"] and not c["stopped"]]
+    if eta_cap > 0:
+        # Grid-edge labels (|eta| = 1) are UNREACHABLE by Beta-mean heads
+        # (the original cliff lesson) and their one-sided neighborhoods
+        # look spuriously robust — exclude edge combos from CANDIDATES.
+        # Neighborhood scoring still sees all combos (plateau check intact).
+        clean = [c for c in clean
+                 if abs(c["eta_lat"]) <= eta_cap + 1e-6
+                 and abs(c["eta_col"]) <= eta_cap + 1e-6]
     at_margin = [c for c in clean if c["sc_min_dist"] >= margin]
     if at_margin:
         out["status"] = "solved"
@@ -119,6 +128,11 @@ def main():
                              "best label's neighbourhood-min clearance is "
                              "below this — cliff-edge scenes are unlearnable "
                              "by regression")
+    parser.add_argument("--eta_cap", type=float, default=0.0,
+                        help="exclude grid-edge combos (|eta| > cap) from "
+                             "label CANDIDATES — edge labels are unreachable "
+                             "by Beta-mean heads and spuriously robust. "
+                             "0 = off (original behaviour). Suggested 0.75.")
     parser.add_argument("--out", required=True)
     args = parser.parse_args()
 
@@ -132,7 +146,8 @@ def main():
             seen.add(r["scene_path"])
             scenes.append(relabel_scene(r, args.margin, args.min_gain,
                                         args.robust_radius,
-                                        args.robust_min_required))
+                                        args.robust_min_required,
+                                        eta_cap=args.eta_cap))
 
     n = {"solved": 0, "already_clean": 0, "unsolved": 0}
     for r in scenes:

--- a/rlvr/autoresearch/tools/rollforward_avoidance_scenes.py
+++ b/rlvr/autoresearch/tools/rollforward_avoidance_scenes.py
@@ -143,7 +143,10 @@ def main():
         except Exception as e:  # noqa: BLE001
             print(f"  [err ] {Path(sp).name}: {e}")
             continue
-        stem = Path(sp).stem
+        # Pool-prefixed stem: perturbation pools share basenames (e.g.
+        # train_parallel/ and train_yaw/ both hold scene_0008_var02.npz),
+        # which previously silently overwrote rolls across pools.
+        stem = f"{Path(sp).parent.name}__{Path(sp).stem}"
         for k in steps:
             try:
                 rolled = rollforward_scene(raw, guided, k)

--- a/rlvr/autoresearch/tools/rollforward_avoidance_scenes.py
+++ b/rlvr/autoresearch/tools/rollforward_avoidance_scenes.py
@@ -121,6 +121,10 @@ def main():
     parser.add_argument("--lambda_spd", type=float, default=0.2)
     parser.add_argument("--stretch_scale", type=float, default=1.0)
     parser.add_argument("--guidance_scale", type=float, default=0.5)
+    parser.add_argument("--envelope", choices=["v1", "v2"], default="v1",
+                        help="guidance envelope — must match the policy's "
+                             "training labels")
+    parser.add_argument("--lambda_col", type=float, default=3.0)
     args = parser.parse_args()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/rlvr/autoresearch/tools/rollforward_avoidance_scenes.py
+++ b/rlvr/autoresearch/tools/rollforward_avoidance_scenes.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Generate MID-MANEUVER training scenes by rolling the model+explorer forward.
+
+For every (solved) avoidance scene: generate the explorer-guided trajectory
+open-loop, then for each rollforward step k create a NEW scene whose ego sits
+AT guided[k] with the executed guided prefix as its recorded history — the
+states a closed-loop run actually visits. Sweeping labels on these states
+teaches the policy to CONTINUE an avoidance in progress and to decay back to
+zero after passing (recover/rejoin) — closing the t0-only distribution gap
+that causes the closed-loop speed-decay stall.
+
+Re-anchoring reuses the canonical perturbation transform
+(disturb_and_replay._apply_inverse_rigid_to_spatial); ego_current_state is
+reset to origin with body-frame speed taken from the guided trajectory's
+local displacement at k.
+
+Usage:
+    python -m rlvr.autoresearch.tools.rollforward_avoidance_scenes \
+        --scenes <solved_t0_scenes.json> --model_path <base.pth> \
+        --policy_dir <dir> --steps 5,10,15,20,25,30 \
+        --out_dir <dir> --out_list <json> \
+        [--lambda_lat 5.0] [--lat_scale 2.0] [--col_scale 9.0]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+import numpy as np
+import torch
+
+import rlvr.guidance_batched  # noqa: F401
+from exploration_policy.utils import run_frozen_encoder
+from preference_optimization.utils import load_npz_data
+from rlvr.autoresearch.tools.disturb_and_replay import _apply_inverse_rigid_to_spatial
+from rlvr.autoresearch.tools.eval_det_avoidance import load_model
+from rlvr.autoresearch.tools.eval_policy_avoidance import load_policy, make_composer
+from rlvr.autoresearch.tools.recovery_sim import deterministic_predict
+from rlvr.closed_loop.batched_rollout import _batched_generate_varied_noise
+from rlvr.grpo_trainer_batched import _normalize_batch, _stack_scene_data
+
+
+@torch.no_grad()
+def guided_trajectory(model, margs, policy, heads, data, args, device) -> np.ndarray:
+    det = deterministic_predict(model, margs, data)
+    batch = _stack_scene_data([data], device)
+    norm = _normalize_batch(batch, margs)
+    x_ref = torch.from_numpy(np.ascontiguousarray(det)).float().unsqueeze(0).to(device)
+    norm["reference_trajectory"] = x_ref
+    enc = run_frozen_encoder(model, norm)
+    out = policy(enc, x_ref, deterministic=True)
+    etas = {h: (2.0 * out.dists[h].mean - 1.0).reshape(1) for h in heads}
+    g = _batched_generate_varied_noise(
+        model, margs, norm, noise_min=0.0, noise_max=0.0,
+        first_deterministic=False, composer=make_composer(etas, args),
+        device=device,
+    )[0].cpu().numpy()
+    return g, {h: float(v.item()) for h, v in etas.items()}
+
+
+def rollforward_scene(raw: dict, guided: np.ndarray, k: int, dt: float = 0.1) -> dict:
+    """Build the scene at guided[k]: re-anchor everything, splice ego history."""
+    out = {key: np.array(v, copy=True) for key, v in raw.items()}
+
+    gx, gy = float(guided[k, 0]), float(guided[k, 1])
+    gth = float(math.atan2(guided[k, 3], guided[k, 2]))
+
+    # Ego history = original recorded past followed by the EXECUTED guided
+    # prefix (still in the ORIGINAL ego frame; the rigid transform below
+    # re-anchors it). ego_agent_past is (T, 3) [x, y, yaw].
+    past = out["ego_agent_past"]
+    g_yaw = np.arctan2(guided[: k + 1, 3], guided[: k + 1, 2])
+    g_rows = np.stack([guided[: k + 1, 0], guided[: k + 1, 1], g_yaw], axis=-1)
+    combined = np.concatenate([past, g_rows.astype(past.dtype)], axis=0)
+    out["ego_agent_past"] = np.ascontiguousarray(combined[-past.shape[0]:])
+
+    # Drop the GT future — these scenes are for label sweeps, which never use
+    # it; keep shape with zeros so loaders stay happy.
+    if "ego_agent_future" in out:
+        out["ego_agent_future"] = np.zeros_like(out["ego_agent_future"])
+
+    _apply_inverse_rigid_to_spatial(out, gx, gy, gth)
+
+    # ego_current_state -> origin pose; body-frame speed from the guided
+    # trajectory's local displacement at k.
+    ecs = out["ego_current_state"].copy()
+    ecs[0] = 0.0
+    ecs[1] = 0.0
+    ecs[2] = 1.0
+    ecs[3] = 0.0
+    if k + 1 < guided.shape[0]:
+        spd = float(np.linalg.norm(guided[k + 1, :2] - guided[k, :2])) / dt
+    else:
+        spd = float(np.linalg.norm(guided[k, :2] - guided[k - 1, :2])) / dt
+    if ecs.size >= 6:
+        ecs[4] = spd
+        ecs[5] = 0.0
+    if ecs.size >= 8:
+        ecs[6] = 0.0
+        ecs[7] = 0.0
+    out["ego_current_state"] = ecs
+    return out
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--scenes", required=True)
+    parser.add_argument("--model_path", required=True)
+    parser.add_argument("--policy_dir", required=True)
+    parser.add_argument("--steps", default="5,10,15,20,25,30")
+    parser.add_argument("--out_dir", required=True)
+    parser.add_argument("--out_list", required=True)
+    parser.add_argument("--lambda_lat", type=float, default=5.0)
+    parser.add_argument("--lat_scale", type=float, default=2.0)
+    parser.add_argument("--col_scale", type=float, default=9.0)
+    parser.add_argument("--col_range", type=float, default=8.0)
+    parser.add_argument("--lambda_spd", type=float, default=0.2)
+    parser.add_argument("--stretch_scale", type=float, default=1.0)
+    parser.add_argument("--guidance_scale", type=float, default=0.5)
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model, margs = load_model(args.model_path, device)
+    policy, heads = load_policy(args.policy_dir, margs, device)
+    steps = [int(s) for s in args.steps.split(",")]
+
+    with open(args.scenes) as f:
+        scene_paths = json.load(f)
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    written, manifest = [], []
+    for sp in scene_paths:
+        try:
+            data = load_npz_data(sp, device)
+            guided, etas = guided_trajectory(model, margs, policy, heads, data,
+                                             args, device)
+            raw = dict(np.load(sp, allow_pickle=True))
+        except Exception as e:  # noqa: BLE001
+            print(f"  [err ] {Path(sp).name}: {e}")
+            continue
+        stem = Path(sp).stem
+        for k in steps:
+            try:
+                rolled = rollforward_scene(raw, guided, k)
+            except Exception as e:  # noqa: BLE001
+                print(f"  [err ] {stem} k={k}: {e}")
+                continue
+            out_path = out_dir / f"{stem}_roll{k:02d}.npz"
+            np.savez(out_path, **rolled)
+            written.append(str(out_path))
+            manifest.append({"source": sp, "k": k, "t0_etas": etas,
+                             "out": str(out_path)})
+        print(f"  [ok  ] {stem}: {len(steps)} rolled states "
+              f"(t0 etas {etas})")
+
+    with open(args.out_list, "w") as f:
+        json.dump(written, f, indent=1)
+    with open(out_dir / "manifest.json", "w") as f:
+        json.dump(manifest, f, indent=1)
+    print(f"\nWrote {len(written)} rolled scenes -> {args.out_list}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/rollforward_avoidance_scenes.py
+++ b/rlvr/autoresearch/tools/rollforward_avoidance_scenes.py
@@ -43,7 +43,9 @@ from rlvr.grpo_trainer_batched import _normalize_batch, _stack_scene_data
 
 
 @torch.no_grad()
-def guided_trajectory(model, margs, policy, heads, data, args, device) -> np.ndarray:
+def guided_trajectory(
+    model, margs, policy, heads, data, args, device,
+) -> tuple[np.ndarray, dict[str, float]]:
     det = deterministic_predict(model, margs, data)
     batch = _stack_scene_data([data], device)
     norm = _normalize_batch(batch, margs)

--- a/rlvr/autoresearch/tools/rollforward_closedloop_scenes.py
+++ b/rlvr/autoresearch/tools/rollforward_closedloop_scenes.py
@@ -59,6 +59,10 @@ def main():
     parser.add_argument("--lambda_spd", type=float, default=0.2)
     parser.add_argument("--stretch_scale", type=float, default=1.0)
     parser.add_argument("--guidance_scale", type=float, default=0.5)
+    parser.add_argument("--envelope", choices=["v1", "v2"], default="v1",
+                        help="guidance envelope — must match the policy's "
+                             "training labels")
+    parser.add_argument("--lambda_col", type=float, default=3.0)
     args = parser.parse_args()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/rlvr/autoresearch/tools/rollforward_closedloop_scenes.py
+++ b/rlvr/autoresearch/tools/rollforward_closedloop_scenes.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Generate mid-maneuver training scenes from CLOSED-LOOP realized states.
+
+Same idea as rollforward_avoidance_scenes (re-anchor the scene at a later
+ego state with the executed prefix as history), but the states come from the
+closed-loop rollout of model+explorer (batched_closed_loop) instead of the
+open-loop plan — i.e. the states a closed-loop run ACTUALLY visits,
+including the slow conflicted ones the open-loop roll never reaches.
+
+Per scene: roll k in --steps, PLUS every step where realized speed drops
+below --slow_thresh (the OOD stall states; deduped, capped by --max_slow).
+
+Output filenames are prefixed with the source pool dir to avoid the
+same-basename collision across perturbation pools.
+
+Usage:
+    python -m rlvr.autoresearch.tools.rollforward_closedloop_scenes \
+        --scenes <list.json> --model_path <base.pth> --policy_dir <dir> \
+        --steps 10,20,30,40,50,60 --slow_thresh 1.5 --max_slow 4 \
+        --out_dir <dir> --out_list <json>
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+
+import rlvr.guidance_batched  # noqa: F401
+from preference_optimization.utils import load_npz_data
+from rlvr.autoresearch.tools.batched_closedloop_videos import batched_closed_loop
+from rlvr.autoresearch.tools.eval_det_avoidance import load_model
+from rlvr.autoresearch.tools.eval_policy_avoidance import load_policy
+from rlvr.autoresearch.tools.rollforward_avoidance_scenes import rollforward_scene
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--scenes", required=True)
+    parser.add_argument("--model_path", required=True)
+    parser.add_argument("--policy_dir", required=True)
+    parser.add_argument("--steps", default="10,20,30,40,50,60")
+    parser.add_argument("--slow_thresh", type=float, default=1.5,
+                        help="also roll at steps where realized speed < this")
+    parser.add_argument("--max_slow", type=int, default=4,
+                        help="max extra slow-state rolls per scene")
+    parser.add_argument("--n_steps", type=int, default=80)
+    parser.add_argument("--chunk", type=int, default=25)
+    parser.add_argument("--out_dir", required=True)
+    parser.add_argument("--out_list", required=True)
+    parser.add_argument("--lambda_lat", type=float, default=5.0)
+    parser.add_argument("--lat_scale", type=float, default=2.0)
+    parser.add_argument("--col_scale", type=float, default=9.0)
+    parser.add_argument("--col_range", type=float, default=8.0)
+    parser.add_argument("--lambda_spd", type=float, default=0.2)
+    parser.add_argument("--stretch_scale", type=float, default=1.0)
+    parser.add_argument("--guidance_scale", type=float, default=0.5)
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model, margs = load_model(args.model_path, device)
+    policy, heads = load_policy(args.policy_dir, margs, device)
+    base_steps = [int(s) for s in args.steps.split(",")]
+
+    with open(args.scenes) as f:
+        paths = json.load(f)
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"[cl-roll] closed-loop rollouts: {len(paths)} scenes")
+    datas = [load_npz_data(p, device) for p in paths]
+    rollouts, eta_logs = batched_closed_loop(
+        model, margs, datas, device,
+        policy=policy, heads=heads, gargs=args,
+        n_steps=args.n_steps, chunk=args.chunk)
+    del datas
+    torch.cuda.empty_cache()
+
+    written, manifest = [], []
+    for i, sp in enumerate(paths):
+        pos = np.asarray(rollouts[i]["positions"])      # [N+1, 3] initial frame
+        vel = np.asarray(rollouts[i]["velocities"])
+        # realized trajectory as (T, 4) — same shape rollforward_scene expects
+        realized = np.stack([pos[1:, 0], pos[1:, 1],
+                             np.cos(pos[1:, 2]), np.sin(pos[1:, 2])], axis=-1)
+
+        ks = [k for k in base_steps if k < realized.shape[0]]
+        slow = [int(k) for k in np.nonzero(vel[1:] < args.slow_thresh)[0]
+                if k >= 5 and k not in ks][: args.max_slow]
+        ks = sorted(set(ks + slow))
+
+        try:
+            raw = dict(np.load(sp, allow_pickle=True))
+        except Exception as e:  # noqa: BLE001
+            print(f"  [err ] {Path(sp).name}: {e}")
+            continue
+        pool = Path(sp).parent.name
+        stem = Path(sp).stem
+        for k in ks:
+            try:
+                rolled = rollforward_scene(raw, realized, k)
+            except Exception as e:  # noqa: BLE001
+                print(f"  [err ] {pool}/{stem} k={k}: {e}")
+                continue
+            out_path = out_dir / f"{pool}__{stem}_clroll{k:02d}.npz"
+            np.savez(out_path, **rolled)
+            written.append(str(out_path))
+            manifest.append({"source": sp, "k": k, "slow": k in slow,
+                             "v_at_k": round(float(vel[k + 1]), 2),
+                             "etas_at_k": eta_logs[i][k] if eta_logs[i] else None,
+                             "out": str(out_path)})
+        print(f"  [ok  ] {pool}/{stem}: {len(ks)} rolled "
+              f"({len(slow)} slow-state)")
+
+    with open(args.out_list, "w") as f:
+        json.dump(written, f, indent=1)
+    with open(out_dir / "manifest.json", "w") as f:
+        json.dump(manifest, f, indent=1)
+    print(f"\nWrote {len(written)} closed-loop rolled scenes -> {args.out_list}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/split_labels_holdout.py
+++ b/rlvr/autoresearch/tools/split_labels_holdout.py
@@ -66,7 +66,9 @@ def main():
     print(f"[split] {len(groups)} base-scene groups -> {len(hold)} held out "
           f"({sorted(hold)})")
 
-    held_rows = []
+    # Compute the full split FIRST; only write files after validation so a
+    # failed run doesn't leave truncated *_train.json next to the originals.
+    held_rows, pending = [], []
     for lp, d in loaded:
         tr = [r for r in d["scenes"] if base_id(r["scene_path"]) not in hold]
         hd = [r for r in d["scenes"] if base_id(r["scene_path"]) in hold]
@@ -78,6 +80,15 @@ def main():
                                   n_scenes=len(tr),
                                   holdout_removed=len(hd))
         out_path = str(Path(lp).with_name(Path(lp).stem + "_train.json"))
+        pending.append((lp, out_path, out, tr, hd))
+
+    n_solved = sum(1 for r in held_rows if r["status"] == "solved")
+    if n_solved == 0:
+        raise SystemExit("holdout contains NO solved avoidance rows — "
+                         "useless for overfit detection; re-seed or raise "
+                         "frac (no files written)")
+
+    for lp, out_path, out, tr, hd in pending:
         with open(out_path, "w") as f:
             json.dump(out, f, indent=1)
 
@@ -91,10 +102,6 @@ def main():
         json.dump({"summary": {"n_scenes": len(held_rows),
                                "holdout_groups": sorted(hold)},
                    "scenes": held_rows}, f, indent=1)
-    n_solved = sum(1 for r in held_rows if r["status"] == "solved")
-    if n_solved == 0:
-        raise SystemExit("holdout contains NO solved avoidance rows — "
-                         "useless for overfit detection; re-seed or raise frac")
     print(f"[split] holdout: {len(held_rows)} rows, {n_solved} solved -> "
           f"{args.out_holdout}")
 

--- a/rlvr/autoresearch/tools/split_labels_holdout.py
+++ b/rlvr/autoresearch/tools/split_labels_holdout.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Group-aware train/holdout split for sweep-label files.
+
+Splits by BASE SCENE identity (the ``scene_NNNN`` stem shared by every
+perturbation variant and rolled state), so no base scene contributes labels
+to both sides — the strict anti-leakage split for overfit detection. The
+trainer's internal random split can place perturbation siblings of a train
+scene into its early-stop val, which is fine for stopping but too soft to
+measure generalization.
+
+Writes, per input label file, ``<stem>_train.json`` next to it, plus ONE
+combined holdout file with every held-out scene row (sweep_labels format,
+directly consumable by the same eval code paths). Prints the composition
+(groups, solved/clean counts per side) so the split can be sanity-checked.
+
+Usage:
+    python -m rlvr.autoresearch.tools.split_labels_holdout \
+        --labels <labels1.json> <labels2.json> ... \
+        --holdout_frac 0.15 --out_holdout <holdout.json> [--seed 0]
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+
+_BASE_RE = re.compile(r"(scene_\d+)")
+
+
+def base_id(scene_path: str) -> str:
+    m = _BASE_RE.search(Path(scene_path).stem)
+    if not m:
+        raise ValueError(f"no scene_NNNN stem in {scene_path}")
+    return m.group(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--labels", required=True, nargs="+")
+    parser.add_argument("--holdout_frac", type=float, default=0.15)
+    parser.add_argument("--out_holdout", required=True)
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+
+    # Collect every base id across ALL files, then deterministically assign
+    # groups to the holdout by salted-hash order (stable across runs/files).
+    groups: set[str] = set()
+    loaded = []
+    for lp in args.labels:
+        with open(lp) as f:
+            d = json.load(f)
+        loaded.append((lp, d))
+        for r in d["scenes"]:
+            groups.add(base_id(r["scene_path"]))
+
+    def rank(g: str) -> int:
+        return int(hashlib.sha256(f"{args.seed}:{g}".encode()).hexdigest()[:8], 16)
+
+    ordered = sorted(groups, key=rank)
+    n_hold = max(1, int(len(ordered) * args.holdout_frac))
+    hold = set(ordered[:n_hold])
+    print(f"[split] {len(groups)} base-scene groups -> {len(hold)} held out "
+          f"({sorted(hold)})")
+
+    held_rows = []
+    for lp, d in loaded:
+        tr = [r for r in d["scenes"] if base_id(r["scene_path"]) not in hold]
+        hd = [r for r in d["scenes"] if base_id(r["scene_path"]) in hold]
+        held_rows.extend(hd)
+        out = dict(d)
+        out["scenes"] = tr
+        if "summary" in out:
+            out["summary"] = dict(out["summary"],
+                                  n_scenes=len(tr),
+                                  holdout_removed=len(hd))
+        out_path = str(Path(lp).with_name(Path(lp).stem + "_train.json"))
+        with open(out_path, "w") as f:
+            json.dump(out, f, indent=1)
+
+        def comp(rows):
+            s = sum(1 for r in rows if r["status"] == "solved")
+            c = sum(1 for r in rows if r["status"] == "already_clean")
+            return f"{len(rows)} rows ({s} solved / {c} clean)"
+        print(f"  {Path(lp).name}: train {comp(tr)} | holdout {comp(hd)}")
+
+    with open(args.out_holdout, "w") as f:
+        json.dump({"summary": {"n_scenes": len(held_rows),
+                               "holdout_groups": sorted(hold)},
+                   "scenes": held_rows}, f, indent=1)
+    n_solved = sum(1 for r in held_rows if r["status"] == "solved")
+    if n_solved == 0:
+        raise SystemExit("holdout contains NO solved avoidance rows — "
+                         "useless for overfit detection; re-seed or raise frac")
+    print(f"[split] holdout: {len(held_rows)} rows, {n_solved} solved -> "
+          f"{args.out_holdout}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/strip_neighbors_npz.py
+++ b/rlvr/autoresearch/tools/strip_neighbors_npz.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Counterfactual zero-target variants: copy scenes with ALL neighbors removed.
+
+For guidance-explorer training: an avoidance scene with its neighbors
+stripped has nothing to avoid, so the policy's correct output there is
+exactly eta = 0. Pairing each solved avoidance scene with its neighbor-less
+twin teaches the policy to key on the actual obstacles rather than the road
+geometry (the observed failure mode: inertness leaks on unfamiliar normals,
+e.g. firing on intersection turns with nothing nearby).
+
+Zeroed fields: neighbor_agents_past, neighbor_agents_future (zero rows are
+empty slots — the same convention as padding). Everything else is copied
+verbatim.
+
+Usage:
+    python -m rlvr.autoresearch.tools.strip_neighbors_npz \
+        --scenes <scenes.json> --out_dir <dir> --out_list <list.json>
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--scenes", required=True, help="JSON list of NPZ paths")
+    parser.add_argument("--out_dir", required=True)
+    parser.add_argument("--out_list", required=True)
+    args = parser.parse_args()
+
+    with open(args.scenes) as f:
+        paths = json.load(f)
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    written = []
+    for sp in paths:
+        raw = dict(np.load(sp, allow_pickle=True))
+        if "neighbor_agents_past" not in raw:
+            raise ValueError(f"{sp}: missing neighbor_agents_past")
+        raw["neighbor_agents_past"] = np.zeros_like(raw["neighbor_agents_past"])
+        if "neighbor_agents_future" in raw:
+            raw["neighbor_agents_future"] = np.zeros_like(
+                raw["neighbor_agents_future"])
+        pool = Path(sp).parent.name
+        out_path = out_dir / f"{pool}__{Path(sp).stem}_nonbr.npz"
+        np.savez(out_path, **raw)
+        written.append(str(out_path))
+
+    with open(args.out_list, "w") as f:
+        json.dump(written, f, indent=1)
+    print(f"[strip] {len(written)} neighbor-less variants -> {args.out_list}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/sweep_guidance_params.py
+++ b/rlvr/autoresearch/tools/sweep_guidance_params.py
@@ -67,16 +67,33 @@ def build_grid(eta_lat_grid, eta_col_grid, stretch_grid):
 
 def make_composer(eta_lat, eta_col, stretch, args) -> GuidanceComposer:
     """Composer with per-sample [K] tensors for all three knobs."""
-    fns = [
-        GuidanceConfig(
-            name="lateral", enabled=True, scale=args.lat_scale,
-            params={"lambda_lat": args.lambda_lat, "eta_lat": eta_lat},
-        ),
-        GuidanceConfig(
-            name="collision_swerve_batched", enabled=True, scale=args.col_scale,
-            params={"eta_col": eta_col, "range": args.col_range},
-        ),
-    ]
+    if getattr(args, "envelope", "v1") == "v2":
+        # v2 guidances: ramped lateral target + ramp-and-hold bounded swerve
+        # (new opt-in registry names; v1 labels/policies are untouched).
+        fns = [
+            GuidanceConfig(
+                name="lateral_ramp_batched", enabled=True, scale=args.lat_scale,
+                params={"lambda_lat": args.lambda_lat, "eta_lat": eta_lat,
+                        "ramp_steps": 20},
+            ),
+            GuidanceConfig(
+                name="collision_swerve_v2_batched", enabled=True,
+                scale=args.col_scale,
+                params={"eta_col": eta_col, "lambda_col": args.lambda_col,
+                        "range": args.col_range},
+            ),
+        ]
+    else:
+        fns = [
+            GuidanceConfig(
+                name="lateral", enabled=True, scale=args.lat_scale,
+                params={"lambda_lat": args.lambda_lat, "eta_lat": eta_lat},
+            ),
+            GuidanceConfig(
+                name="collision_swerve_batched", enabled=True, scale=args.col_scale,
+                params={"eta_col": eta_col, "range": args.col_range},
+            ),
+        ]
     if bool((stretch != 1.0).any()):
         fns.append(GuidanceConfig(
             name="speed_stretch_batched", enabled=True, scale=args.stretch_scale,
@@ -221,6 +238,12 @@ def main():
     parser.add_argument("--lat_scale", type=float, default=1.0)
     parser.add_argument("--col_scale", type=float, default=2.0)
     parser.add_argument("--col_range", type=float, default=8.0)
+    parser.add_argument("--envelope", choices=["v1", "v2"], default="v1",
+                        help="guidance set: v1 = stock lateral + linear "
+                             "collision_swerve; v2 = lateral_ramp + bounded "
+                             "ramp-and-hold collision_swerve_v2")
+    parser.add_argument("--lambda_col", type=float, default=3.0,
+                        help="v2 swerve max target offset in metres")
     parser.add_argument("--stretch_scale", type=float, default=1.0)
     parser.add_argument("--guidance_scale", type=float, default=0.5)
     parser.add_argument("--audit_scenes", type=int, default=0,

--- a/rlvr/autoresearch/tools/sweep_guidance_params.py
+++ b/rlvr/autoresearch/tools/sweep_guidance_params.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Per-scene guidance-parameter grid sweep on a FROZEN model.
+
+For each scene, generates one deterministic trajectory per grid combo of
+(eta_lat, eta_col[, stretch]) — all combos in a single batched forward pass —
+scores them with the canonical reward, and records the best combo. The zero
+combo (eta_lat=0, eta_col=0, stretch=1) IS the unguided det baseline, so the
+sweep answers two questions at once:
+
+  1. Feasibility: can ANY guidance params make this model avoid each scene?
+  2. Labels: per-scene best params for supervised explorer regression.
+
+Guidance functions used (all support per-sample [K] tensors):
+  lateral                  -- PlannerRFT Eq.2, target offset = lambda_lat * eta_lat
+  collision_swerve_batched -- signed proximity-gated swerve (+ = left)
+  speed_stretch_batched    -- displacement stretch (< 1 = slow down), optional
+
+Usage:
+    python -m rlvr.autoresearch.tools.sweep_guidance_params \
+        --model_path <model.pth> --scenes <scenes.json> \
+        --config <reward_config.json> --ego_shape WB,L,W \
+        --output_dir <dir> \
+        [--eta_lat_grid="-1,-0.5,0,0.5,1"] [--eta_col_grid="-1,-0.5,0,0.5,1"] \
+        [--stretch_grid 1.0] [--lambda_lat 2.5] [--col_scale 2.0] \
+        [--col_range 8.0] [--guidance_scale 0.5] [--audit_scenes 0]
+
+Outputs:
+    <output_dir>/sweep_labels.json   per-scene combo table + best params + summary
+    <output_dir>/audit/<scene>.png   trajectory-fan renders (first --audit_scenes)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+
+import rlvr.guidance_batched  # noqa: F401 -- registers batched guidance
+from diffusion_planner.model.guidance.composer import GuidanceComposer
+from diffusion_planner.model.guidance.config import GuidanceConfig, GuidanceSetConfig
+from exploration_policy.utils import generate_reference_trajectory
+from preference_optimization.utils import load_npz_data
+from rlvr.autoresearch.tools.eval_det_avoidance import load_model
+from rlvr.autoresearch.tools.reward_config_from_json import load_reward_config
+from rlvr.closed_loop.batched_rollout import _batched_generate_varied_noise
+from rlvr.reward import compute_reward_batch
+
+
+def build_grid(eta_lat_grid, eta_col_grid, stretch_grid):
+    """Cartesian grid -> three [K] float lists. Asserts the zero combo exists."""
+    combos = [
+        (el, ec, st)
+        for el in eta_lat_grid
+        for ec in eta_col_grid
+        for st in stretch_grid
+    ]
+    zero = (0.0, 0.0, 1.0)
+    if zero not in combos:
+        raise SystemExit(
+            "Grid must contain the zero combo (eta_lat=0, eta_col=0, stretch=1) "
+            "— it is the unguided det baseline."
+        )
+    return combos, combos.index(zero)
+
+
+def make_composer(eta_lat, eta_col, stretch, args) -> GuidanceComposer:
+    """Composer with per-sample [K] tensors for all three knobs."""
+    fns = [
+        GuidanceConfig(
+            name="lateral", enabled=True, scale=args.lat_scale,
+            params={"lambda_lat": args.lambda_lat, "eta_lat": eta_lat},
+        ),
+        GuidanceConfig(
+            name="collision_swerve_batched", enabled=True, scale=args.col_scale,
+            params={"eta_col": eta_col, "range": args.col_range},
+        ),
+    ]
+    if bool((stretch != 1.0).any()):
+        fns.append(GuidanceConfig(
+            name="speed_stretch_batched", enabled=True, scale=args.stretch_scale,
+            params={"stretch": stretch},
+        ))
+    set_cfg = GuidanceSetConfig(functions=fns, global_scale=args.guidance_scale)
+    return GuidanceComposer(set_cfg)
+
+
+@torch.no_grad()
+def sweep_scene(model, model_args, npz_path, combos, zero_idx, rcfg, args, device):
+    """Run the full grid on one scene. Returns per-scene result dict."""
+    data = load_npz_data(npz_path, device)
+    norm_data = {
+        k: v.clone() if isinstance(v, torch.Tensor) else v for k, v in data.items()
+    }
+    norm_data = model_args.observation_normalizer(norm_data)
+
+    x_ref_np = generate_reference_trajectory(model, model_args, norm_data, device)
+    x_ref = torch.from_numpy(x_ref_np).unsqueeze(0).to(device)
+    norm_data["reference_trajectory"] = x_ref
+
+    K = len(combos)
+    eta_lat = torch.tensor([c[0] for c in combos], device=device, dtype=torch.float32)
+    eta_col = torch.tensor([c[1] for c in combos], device=device, dtype=torch.float32)
+    stretch = torch.tensor([c[2] for c in combos], device=device, dtype=torch.float32)
+
+    K_data = {}
+    for k, v in norm_data.items():
+        if isinstance(v, torch.Tensor) and v.shape[0] == 1:
+            K_data[k] = v.expand(K, *v.shape[1:]).contiguous()
+        else:
+            K_data[k] = v
+
+    composer = make_composer(eta_lat, eta_col, stretch, args)
+    trajs = _batched_generate_varied_noise(
+        model, model_args, K_data,
+        noise_min=0.0, noise_max=0.0, first_deterministic=False,
+        composer=composer, device=device,
+    )  # [K, T, 4]
+
+    breakdowns = compute_reward_batch(trajs.float(), data, rcfg)
+
+    combo_rows = []
+    for i, (el, ec, st) in enumerate(combos):
+        r = breakdowns[i]
+        combo_rows.append({
+            "eta_lat": el, "eta_col": ec, "stretch": st,
+            "total": float(r.total),
+            "static_crossing": bool(r.static_crossing),
+            "sc_min_dist": float(r.sc_min_dist),
+            "rb_cross": bool(r.rb_crossing),
+            "lane_cross": bool(r.lane_crossing),
+            "cl": float(r.centerline),
+            "stopped": bool(getattr(r, "stopped", False)),
+        })
+
+    det = combo_rows[zero_idx]
+    # Best = clean (no sc crossing, no rb crossing, not stopped) with max total.
+    clean = [c for c in combo_rows
+             if not c["static_crossing"] and not c["rb_cross"] and not c["stopped"]]
+    best = max(clean, key=lambda c: c["total"]) if clean else None
+
+    sc_n_stopped = int(breakdowns[zero_idx].sc_n_stopped)
+    if not det["static_crossing"]:
+        status = "already_clean"
+    elif best is not None:
+        status = "solved"
+    else:
+        status = "unsolved"
+
+    return {
+        "scene": Path(npz_path).name,
+        "scene_path": str(npz_path),
+        "sc_n_stopped": sc_n_stopped,
+        "status": status,
+        "det": det,
+        "best": best,
+        "combos": combo_rows,
+        "_trajs": trajs.cpu().numpy(),  # stripped before JSON; used by audit render
+    }
+
+
+def render_audit(result, combos, zero_idx, out_png):
+    """Trajectory-fan render: all combos colored by eta_col, det in black."""
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    from rlvr.autoresearch.tools.ghost_sim_common import extract_stopped_neighbors
+    from rlvr.autoresearch.tools.viz_cl_recovery import draw_scene_base
+    from scenario_generation.visualize import draw_agent_box
+
+    trajs = result["_trajs"]
+    fig, ax = plt.subplots(figsize=(11, 11))
+    draw_scene_base(ax, result["scene_path"])
+    for (x, y, h, length, w) in extract_stopped_neighbors(result["scene_path"]):
+        draw_agent_box(ax, x, y, h, length, w, color="crimson", alpha=0.5)
+
+    cmap = plt.get_cmap("coolwarm")
+    for i, (el, ec, st) in enumerate(combos):
+        if i == zero_idx:
+            continue
+        color = cmap(0.5 * (ec + 1.0))
+        crossed = result["combos"][i]["static_crossing"]
+        ax.plot(trajs[i, :, 0], trajs[i, :, 1], "-", color=color,
+                lw=0.9, alpha=0.35 if crossed else 0.8)
+    ax.plot(trajs[zero_idx, :, 0], trajs[zero_idx, :, 1], "-", color="black",
+            lw=2.2, label="det (no guidance)")
+    if result["best"] is not None:
+        b = result["best"]
+        bi = result["combos"].index(b)
+        ax.plot(trajs[bi, :, 0], trajs[bi, :, 1], "-", color="lime", lw=2.2,
+                label=(f"best lat={b['eta_lat']:+.2f} col={b['eta_col']:+.2f} "
+                       f"st={b['stretch']:.2f} sc={b['sc_min_dist']:+.2f}m"))
+    ax.set_title(
+        f"{result['scene']}  [{result['status']}]  "
+        f"det sc={result['det']['sc_min_dist']:+.2f}m  stopped={result['sc_n_stopped']}"
+    )
+    ax.legend(loc="upper right", fontsize=8)
+    ax.set_aspect("equal")
+    span = np.abs(trajs[..., :2]).max() + 10
+    ax.set_xlim(-10, max(span, 40))
+    ax.set_ylim(-span / 2, span / 2)
+    fig.savefig(out_png, dpi=110, bbox_inches="tight")
+    plt.close(fig)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--model_path", required=True)
+    parser.add_argument("--scenes", required=True)
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--ego_shape", required=True, help="WB,L,W (consistency check)")
+    parser.add_argument("--output_dir", required=True)
+    parser.add_argument("--eta_lat_grid", default="-1,-0.5,0,0.5,1")
+    parser.add_argument("--eta_col_grid", default="-1,-0.5,0,0.5,1")
+    parser.add_argument("--stretch_grid", default="1.0")
+    parser.add_argument("--lambda_lat", type=float, default=2.5)
+    parser.add_argument("--lat_scale", type=float, default=1.0)
+    parser.add_argument("--col_scale", type=float, default=2.0)
+    parser.add_argument("--col_range", type=float, default=8.0)
+    parser.add_argument("--stretch_scale", type=float, default=1.0)
+    parser.add_argument("--guidance_scale", type=float, default=0.5)
+    parser.add_argument("--audit_scenes", type=int, default=0,
+                        help="Render trajectory fans for the first N scenes")
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    ego_shape = np.array([float(x) for x in args.ego_shape.split(",")])
+    rcfg = load_reward_config(args.config)
+    if not rcfg.static_collision_enabled:
+        raise SystemExit("--config must have static_collision_enabled=true")
+
+    eta_lat_grid = [float(x) for x in args.eta_lat_grid.split(",")]
+    eta_col_grid = [float(x) for x in args.eta_col_grid.split(",")]
+    stretch_grid = [float(x) for x in args.stretch_grid.split(",")]
+    combos, zero_idx = build_grid(eta_lat_grid, eta_col_grid, stretch_grid)
+    print(f"[sweep] {len(combos)} combos/scene "
+          f"(lat {eta_lat_grid} x col {eta_col_grid} x stretch {stretch_grid})")
+
+    with open(args.scenes) as f:
+        scene_paths = json.load(f)
+
+    model, model_args = load_model(args.model_path, device)
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    audit_dir = out_dir / "audit"
+    if args.audit_scenes > 0:
+        audit_dir.mkdir(exist_ok=True)
+
+    results = []
+    for si, p in enumerate(scene_paths):
+        try:
+            with np.load(p, allow_pickle=True) as npz:
+                if "ego_shape" not in set(npz.keys()):
+                    print(f"  [skip] {Path(p).name}: missing ego_shape")
+                    continue
+                es = np.asarray(npz["ego_shape"]).reshape(-1)[:3]
+            if not np.allclose(es, ego_shape, atol=1e-2):
+                print(f"  [skip] {Path(p).name}: ego_shape={es.tolist()}")
+                continue
+            res = sweep_scene(model, model_args, p, combos, zero_idx, rcfg, args, device)
+        except Exception as e:  # noqa: BLE001
+            print(f"  [err ] {Path(p).name}: {e}")
+            continue
+
+        if si < args.audit_scenes:
+            render_audit(res, combos, zero_idx, audit_dir / f"{Path(p).stem}.png")
+        res.pop("_trajs")
+        results.append(res)
+
+        b = res["best"]
+        best_str = (f"best(lat={b['eta_lat']:+.2f} col={b['eta_col']:+.2f} "
+                    f"st={b['stretch']:.2f} sc={b['sc_min_dist']:+.2f})") if b else "NO CLEAN COMBO"
+        print(f"  [{si:3d}] {res['status']:13s} det_sc={res['det']['sc_min_dist']:+.3f} "
+              f"{best_str}  {Path(p).name}")
+
+    n = len(results)
+    n_avoid = sum(r["status"] != "already_clean" for r in results)
+    n_solved = sum(r["status"] == "solved" for r in results)
+    n_unsolved = sum(r["status"] == "unsolved" for r in results)
+    summary = {
+        "n_scenes": n,
+        "n_already_clean": n - n_avoid,
+        "n_needs_avoidance": n_avoid,
+        "n_solved": n_solved,
+        "n_unsolved": n_unsolved,
+        "solve_rate": (n_solved / n_avoid) if n_avoid else None,
+        "grid": {"eta_lat": eta_lat_grid, "eta_col": eta_col_grid,
+                 "stretch": stretch_grid},
+        "guidance_args": {
+            "lambda_lat": args.lambda_lat, "lat_scale": args.lat_scale,
+            "col_scale": args.col_scale, "col_range": args.col_range,
+            "stretch_scale": args.stretch_scale,
+            "guidance_scale": args.guidance_scale,
+        },
+    }
+    with open(out_dir / "sweep_labels.json", "w") as f:
+        json.dump({"summary": summary, "scenes": results}, f, indent=1)
+
+    print(f"\n[sweep] {n} scenes: {summary['n_already_clean']} already clean, "
+          f"{n_solved}/{n_avoid} solved by guidance, {n_unsolved} unsolved")
+    print(f"Wrote {out_dir / 'sweep_labels.json'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/sweep_guidance_params.py
+++ b/rlvr/autoresearch/tools/sweep_guidance_params.py
@@ -36,10 +36,10 @@ from pathlib import Path
 
 import numpy as np
 import torch
-
-import rlvr.guidance_batched  # noqa: F401 -- registers batched guidance
 from diffusion_planner.model.guidance.composer import GuidanceComposer
 from diffusion_planner.model.guidance.config import GuidanceConfig, GuidanceSetConfig
+
+import rlvr.guidance_batched  # noqa: F401 -- registers batched guidance
 from exploration_policy.utils import generate_reference_trajectory
 from preference_optimization.utils import load_npz_data
 from rlvr.autoresearch.tools.eval_det_avoidance import load_model

--- a/rlvr/autoresearch/tools/sweep_guidance_params.py
+++ b/rlvr/autoresearch/tools/sweep_guidance_params.py
@@ -319,6 +319,7 @@ def main():
             "col_scale": args.col_scale, "col_range": args.col_range,
             "stretch_scale": args.stretch_scale,
             "guidance_scale": args.guidance_scale,
+            "envelope": args.envelope, "lambda_col": args.lambda_col,
         },
     }
     with open(out_dir / "sweep_labels.json", "w") as f:

--- a/rlvr/autoresearch/tools/valid_predictor_guided.py
+++ b/rlvr/autoresearch/tools/valid_predictor_guided.py
@@ -127,11 +127,16 @@ def main():
           f"heads={heads}")
 
     validate_model = _load_validate_model()
-    ego_loss, nbr_loss = validate_model(shim, loader, cfg)
+    result = validate_model(shim, loader, cfg)
+    ego_loss = result["avg_loss_ego"]
+    nbr_loss = result["avg_loss_neighbor"]
+    extra = {k: float(v) for k, v in result.items()
+             if isinstance(v, float)}
 
     report = {
         "ego_avg_loss": float(ego_loss),
         "neighbor_avg_loss": float(nbr_loss),
+        "extra": extra,
         "n_scenes": len(valid_set),
         "guidance_args": {k: getattr(args, k) for k in (
             "lambda_lat", "lat_scale", "col_scale", "col_range",

--- a/rlvr/autoresearch/tools/valid_predictor_guided.py
+++ b/rlvr/autoresearch/tools/valid_predictor_guided.py
@@ -22,14 +22,14 @@ import json
 from pathlib import Path
 
 import torch
-from torch.utils.data import DataLoader, Subset
-from tqdm import tqdm
-
-import rlvr.guidance_batched  # noqa: F401
 from diffusion_planner.dimensions import MAX_NUM_AGENTS, OUTPUT_T, POSE_DIM
 from diffusion_planner.train_epoch import heading_to_cos_sin
 from diffusion_planner.utils.config import Config
 from diffusion_planner.utils.dataset import DiffusionPlannerData
+from torch.utils.data import DataLoader, Subset
+from tqdm import tqdm
+
+import rlvr.guidance_batched  # noqa: F401
 from exploration_policy.utils import run_frozen_encoder
 from rlvr.autoresearch.tools.eval_det_avoidance import load_model
 from rlvr.autoresearch.tools.eval_policy_avoidance import load_policy, make_composer

--- a/rlvr/autoresearch/tools/valid_predictor_guided.py
+++ b/rlvr/autoresearch/tools/valid_predictor_guided.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python3
-"""Canonical valid_predictor ego/neighbor L2 with the explorer in the loop.
+"""Canonical valid_predictor ego/neighbor L2: det vs explorer-guided, one pass.
 
-Wraps the frozen planner in a shim whose forward runs: plain det generation ->
-exploration policy (deterministic etas) -> guidance composer -> guided
-generation, and feeds that shim to the UNMODIFIED
-diffusion_planner.valid_predictor.validate_model loop — so the reported
-ego/neighbor avg_loss is the exact canonical metric (squared error of the
-generated trajectory vs GT, neighbor-validity masked), directly comparable to
-the memorized baselines (J6 12k: ego=1.920, neighbor=3.435).
+Replicates the EXACT loss computation of diffusion_planner/valid_predictor.py
+(squared error of the generated trajectory vs GT, cos/sin headings, neighbor
+validity masking) for BOTH the plain det trajectory and the explorer-guided
+one, computed in the same batch — the det numbers double as the baseline
+column AND as a validation that this loop reproduces the canonical script
+(full 12k det ego must come out ~=1.920 / neighbor ~=3.435).
 
 Usage:
     python -m rlvr.autoresearch.tools.valid_predictor_guided \
         --model_path <base.pth> --policy_dir <dir> \
         --args_json_path <args.json> --valid_set_list <val.json> \
-        [--batch_size 32] [--lambda_lat 5.0] [--lat_scale 2.0] [--col_scale 9.0]
+        --output_dir <dir> [--limit 500] [--batch_size 64] \
+        [--lambda_lat 5.0] [--lat_scale 2.0] [--col_scale 9.0]
 """
 from __future__ import annotations
 
@@ -22,10 +22,12 @@ import json
 from pathlib import Path
 
 import torch
-from torch import nn
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, Subset
+from tqdm import tqdm
 
 import rlvr.guidance_batched  # noqa: F401
+from diffusion_planner.dimensions import MAX_NUM_AGENTS, OUTPUT_T, POSE_DIM
+from diffusion_planner.train_epoch import heading_to_cos_sin
 from diffusion_planner.utils.config import Config
 from diffusion_planner.utils.dataset import DiffusionPlannerData
 from exploration_policy.utils import run_frozen_encoder
@@ -33,64 +35,29 @@ from rlvr.autoresearch.tools.eval_det_avoidance import load_model
 from rlvr.autoresearch.tools.eval_policy_avoidance import load_policy, make_composer
 
 
-def _load_validate_model():
-    """valid_predictor.py is a SCRIPT under <repo>/diffusion_planner/, not a
-    package module — load it by file path (same code the canonical torchrun
-    invocation executes)."""
-    import importlib.util
+class _LossAccum:
+    """Canonical avg_loss accumulation (valid_predictor lines 120-127)."""
 
-    repo_root = Path(__file__).resolve().parents[3]
-    script = repo_root / "diffusion_planner" / "valid_predictor.py"
-    spec = importlib.util.spec_from_file_location("dp_valid_predictor", script)
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod.validate_model
+    def __init__(self):
+        self.ego = self.ego_n = self.nbr = self.nbr_n = 0.0
 
+    def add(self, prediction, all_gt, neighbors_future_valid, B):
+        loss_tensor = (prediction - all_gt) ** 2
+        self.ego += loss_tensor[:, 0, :].mean().item() * B
+        self.ego_n += B
+        loss_nei = loss_tensor[:, 1:, :][neighbors_future_valid]
+        if loss_nei.shape[0] > 0:
+            self.nbr += loss_nei.mean().item() * loss_nei.shape[0]
+            self.nbr_n += loss_nei.shape[0]
 
-class GuidedPlannerShim(nn.Module):
-    """model(inputs) -> guided (enc, outputs); inputs arrive pre-normalized."""
-
-    def __init__(self, model, policy, heads, env_args):
-        super().__init__()
-        self.model = model
-        self.policy = policy
-        self.heads = heads
-        self.env_args = env_args
-
-    @torch.no_grad()
-    def forward(self, inputs: dict):
-        # validate_model builds sampled_trajectories on CPU; pin everything to
-        # the model device before the forward passes.
-        dev = next(self.model.parameters()).device
-        inputs = {k: (v.to(dev) if isinstance(v, torch.Tensor) else v)
-                  for k, v in inputs.items()}
-        decoder = self.model.module.decoder if hasattr(self.model, "module") else self.model.decoder
-        saved_fn, saved_scale = decoder._guidance_fn, decoder._guidance_scale
-
-        # 1. plain det generation (guidance off) = the policy's reference
-        decoder._guidance_fn = None
-        _, det_out = self.model(inputs)
-        det = det_out["prediction"][:, 0].detach()  # [B, T, 4] physical
-
-        # 2. policy -> per-scene etas -> composer
-        data = dict(inputs)
-        data["reference_trajectory"] = det
-        enc = run_frozen_encoder(self.model, data)
-        pout = self.policy(enc, det, deterministic=True)
-        etas = {h: (2.0 * pout.dists[h].mean - 1.0) for h in self.heads}
-        composer = make_composer(etas, self.env_args)
-
-        # 3. guided generation, restoring decoder state afterwards
-        decoder._guidance_fn = composer
-        decoder._guidance_scale = composer._set_config.global_scale
-        try:
-            result = self.model(data)
-        finally:
-            decoder._guidance_fn = saved_fn
-            decoder._guidance_scale = saved_scale
-        return result
+    def result(self):
+        return {
+            "ego_avg_loss": self.ego / max(self.ego_n, 1),
+            "neighbor_avg_loss": self.nbr / max(self.nbr_n, 1),
+        }
 
 
+@torch.no_grad()
 def main():
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -100,8 +67,9 @@ def main():
     parser.add_argument("--args_json_path", required=True)
     parser.add_argument("--valid_set_list", required=True)
     parser.add_argument("--output_dir", required=True)
-    parser.add_argument("--batch_size", type=int, default=32)
-    parser.add_argument("--num_workers", type=int, default=4)
+    parser.add_argument("--batch_size", type=int, default=64)
+    parser.add_argument("--num_workers", type=int, default=8)
+    parser.add_argument("--limit", type=int, default=0, help="0 = all scenes")
     parser.add_argument("--lambda_lat", type=float, default=5.0)
     parser.add_argument("--lat_scale", type=float, default=2.0)
     parser.add_argument("--col_scale", type=float, default=9.0)
@@ -114,30 +82,87 @@ def main():
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model, model_args = load_model(args.model_path, device)
     policy, heads = load_policy(args.policy_dir, model_args, device)
-
     cfg = Config(args.args_json_path)
-    cfg.device = device
-
-    shim = GuidedPlannerShim(model, policy, heads, args).to(device)
 
     valid_set = DiffusionPlannerData(args.valid_set_list)
+    if args.limit:
+        valid_set = Subset(valid_set, range(min(args.limit, len(valid_set))))
     loader = DataLoader(valid_set, batch_size=args.batch_size, shuffle=False,
                         num_workers=args.num_workers, pin_memory=True)
-    print(f"[valid_guided] {len(valid_set)} scenes, batch {args.batch_size}, "
-          f"heads={heads}")
+    print(f"[valid_guided] {len(valid_set)} scenes, batch {args.batch_size}, heads={heads}")
 
-    validate_model = _load_validate_model()
-    result = validate_model(shim, loader, cfg)
-    ego_loss = result["avg_loss_ego"]
-    nbr_loss = result["avg_loss_neighbor"]
-    extra = {k: float(v) for k, v in result.items()
-             if isinstance(v, float)}
+    decoder = model.module.decoder if hasattr(model, "module") else model.decoder
+    det_acc, gui_acc = _LossAccum(), _LossAccum()
 
+    for inputs in tqdm(loader, desc="valid_guided"):
+        # ---- canonical preprocessing (valid_predictor lines 53-80) ----
+        inputs = {k: v.to(device) for k, v in inputs.items()}
+        B = inputs["ego_current_state"].shape[0]
+        inputs["sampled_trajectories"] = torch.zeros(
+            B, MAX_NUM_AGENTS, OUTPUT_T + 1, POSE_DIM,
+            dtype=torch.float32, device=device,
+        )
+        inputs["delay"] = torch.full((B,), 0, dtype=torch.float32, device=device)
+        inputs["ego_agent_past"] = heading_to_cos_sin(inputs["ego_agent_past"])
+        inputs["goal_pose"] = heading_to_cos_sin(inputs["goal_pose"])
+
+        ego_future = heading_to_cos_sin(inputs["ego_agent_future"])
+        neighbors_future = inputs["neighbor_agents_future"]
+        neighbor_future_mask = (
+            torch.sum(torch.ne(neighbors_future[..., :3], 0), dim=-1) == 0
+        )
+        neighbors_future = heading_to_cos_sin(neighbors_future)
+        neighbors_future[neighbor_future_mask] = 0.0
+        B, Pn, T, _ = neighbors_future.shape
+        ego_current = inputs["ego_current_state"][:, :4]
+        neighbors_current = inputs["neighbor_agents_past"][:, :Pn, -1, :4]
+        inputs = cfg.observation_normalizer(inputs)
+
+        neighbor_current_mask = (
+            torch.sum(torch.ne(neighbors_current[..., :4], 0), dim=-1) == 0
+        )
+        neighbor_mask = torch.cat(
+            (neighbor_current_mask.unsqueeze(-1), neighbor_future_mask), dim=-1
+        )
+        gt_future = torch.cat([ego_future[:, None], neighbors_future], dim=1)
+        current_states = torch.cat([ego_current[:, None], neighbors_current], dim=1)
+        all_gt = torch.cat([current_states[:, :, None, :], gt_future], dim=2)
+        all_gt[:, 1:][neighbor_mask] = 0.0
+        all_gt = all_gt[:, :, 1:, :]
+        neighbors_future_valid = ~neighbor_future_mask
+
+        # ---- pass 1: plain det (baseline column + policy reference) ----
+        saved_fn, saved_scale = decoder._guidance_fn, decoder._guidance_scale
+        decoder._guidance_fn = None
+        _, det_out = model(inputs)
+        det_pred = det_out["prediction"]
+        det_acc.add(det_pred, all_gt, neighbors_future_valid, B)
+
+        # ---- pass 2: policy -> composer -> guided ----
+        det_ego = det_pred[:, 0].detach()
+        data = dict(inputs)
+        data["reference_trajectory"] = det_ego
+        enc = run_frozen_encoder(model, data)
+        pout = policy(enc, det_ego, deterministic=True)
+        etas = {h: (2.0 * pout.dists[h].mean - 1.0) for h in heads}
+        composer = make_composer(etas, args)
+        decoder._guidance_fn = composer
+        decoder._guidance_scale = composer._set_config.global_scale
+        try:
+            _, gui_out = model(data)
+        finally:
+            decoder._guidance_fn = saved_fn
+            decoder._guidance_scale = saved_scale
+        gui_acc.add(gui_out["prediction"], all_gt, neighbors_future_valid, B)
+
+    det_r, gui_r = det_acc.result(), gui_acc.result()
     report = {
-        "ego_avg_loss": float(ego_loss),
-        "neighbor_avg_loss": float(nbr_loss),
-        "extra": extra,
         "n_scenes": len(valid_set),
+        "det": det_r,
+        "guided": gui_r,
+        "delta_pct": {
+            k: (gui_r[k] - det_r[k]) / det_r[k] * 100 for k in det_r
+        },
         "guidance_args": {k: getattr(args, k) for k in (
             "lambda_lat", "lat_scale", "col_scale", "col_range",
             "lambda_spd", "stretch_scale", "guidance_scale")},

--- a/rlvr/autoresearch/tools/valid_predictor_guided.py
+++ b/rlvr/autoresearch/tools/valid_predictor_guided.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Canonical valid_predictor ego/neighbor L2 with the explorer in the loop.
+
+Wraps the frozen planner in a shim whose forward runs: plain det generation ->
+exploration policy (deterministic etas) -> guidance composer -> guided
+generation, and feeds that shim to the UNMODIFIED
+diffusion_planner.valid_predictor.validate_model loop — so the reported
+ego/neighbor avg_loss is the exact canonical metric (squared error of the
+generated trajectory vs GT, neighbor-validity masked), directly comparable to
+the memorized baselines (J6 12k: ego=1.920, neighbor=3.435).
+
+Usage:
+    python -m rlvr.autoresearch.tools.valid_predictor_guided \
+        --model_path <base.pth> --policy_dir <dir> \
+        --args_json_path <args.json> --valid_set_list <val.json> \
+        [--batch_size 32] [--lambda_lat 5.0] [--lat_scale 2.0] [--col_scale 9.0]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+
+import rlvr.guidance_batched  # noqa: F401
+from diffusion_planner.utils.config import Config
+from diffusion_planner.utils.dataset import DiffusionPlannerData
+from diffusion_planner.valid_predictor import validate_model
+from exploration_policy.utils import run_frozen_encoder
+from rlvr.autoresearch.tools.eval_det_avoidance import load_model
+from rlvr.autoresearch.tools.eval_policy_avoidance import load_policy, make_composer
+
+
+class GuidedPlannerShim(nn.Module):
+    """model(inputs) -> guided (enc, outputs); inputs arrive pre-normalized."""
+
+    def __init__(self, model, policy, heads, env_args):
+        super().__init__()
+        self.model = model
+        self.policy = policy
+        self.heads = heads
+        self.env_args = env_args
+
+    @torch.no_grad()
+    def forward(self, inputs: dict):
+        decoder = self.model.module.decoder if hasattr(self.model, "module") else self.model.decoder
+        saved_fn, saved_scale = decoder._guidance_fn, decoder._guidance_scale
+
+        # 1. plain det generation (guidance off) = the policy's reference
+        decoder._guidance_fn = None
+        _, det_out = self.model(inputs)
+        det = det_out["prediction"][:, 0].detach()  # [B, T, 4] physical
+
+        # 2. policy -> per-scene etas -> composer
+        data = dict(inputs)
+        data["reference_trajectory"] = det
+        enc = run_frozen_encoder(self.model, data)
+        pout = self.policy(enc, det, deterministic=True)
+        etas = {h: (2.0 * pout.dists[h].mean - 1.0) for h in self.heads}
+        composer = make_composer(etas, self.env_args)
+
+        # 3. guided generation, restoring decoder state afterwards
+        decoder._guidance_fn = composer
+        decoder._guidance_scale = composer._set_config.global_scale
+        try:
+            result = self.model(data)
+        finally:
+            decoder._guidance_fn = saved_fn
+            decoder._guidance_scale = saved_scale
+        return result
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--model_path", required=True)
+    parser.add_argument("--policy_dir", required=True)
+    parser.add_argument("--args_json_path", required=True)
+    parser.add_argument("--valid_set_list", required=True)
+    parser.add_argument("--output_dir", required=True)
+    parser.add_argument("--batch_size", type=int, default=32)
+    parser.add_argument("--num_workers", type=int, default=4)
+    parser.add_argument("--lambda_lat", type=float, default=5.0)
+    parser.add_argument("--lat_scale", type=float, default=2.0)
+    parser.add_argument("--col_scale", type=float, default=9.0)
+    parser.add_argument("--col_range", type=float, default=8.0)
+    parser.add_argument("--lambda_spd", type=float, default=0.2)
+    parser.add_argument("--stretch_scale", type=float, default=1.0)
+    parser.add_argument("--guidance_scale", type=float, default=0.5)
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model, model_args = load_model(args.model_path, device)
+    policy, heads = load_policy(args.policy_dir, model_args, device)
+
+    cfg = Config(args.args_json_path)
+    cfg.device = device
+
+    shim = GuidedPlannerShim(model, policy, heads, args).to(device)
+
+    valid_set = DiffusionPlannerData(args.valid_set_list)
+    loader = DataLoader(valid_set, batch_size=args.batch_size, shuffle=False,
+                        num_workers=args.num_workers, pin_memory=True)
+    print(f"[valid_guided] {len(valid_set)} scenes, batch {args.batch_size}, "
+          f"heads={heads}")
+
+    ego_loss, nbr_loss = validate_model(shim, loader, cfg)
+
+    report = {
+        "ego_avg_loss": float(ego_loss),
+        "neighbor_avg_loss": float(nbr_loss),
+        "n_scenes": len(valid_set),
+        "guidance_args": {k: getattr(args, k) for k in (
+            "lambda_lat", "lat_scale", "col_scale", "col_range",
+            "lambda_spd", "stretch_scale", "guidance_scale")},
+        "policy_dir": args.policy_dir,
+    }
+    out = Path(args.output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    with open(out / "valid_guided_l2.json", "w") as f:
+        json.dump(report, f, indent=1)
+    print(json.dumps(report, indent=1))
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/valid_predictor_guided.py
+++ b/rlvr/autoresearch/tools/valid_predictor_guided.py
@@ -6,7 +6,7 @@ Replicates the EXACT loss computation of diffusion_planner/valid_predictor.py
 validity masking) for BOTH the plain det trajectory and the explorer-guided
 one, computed in the same batch — the det numbers double as the baseline
 column AND as a validation that this loop reproduces the canonical script
-(full 12k det ego must come out ~=1.920 / neighbor ~=3.435).
+(the det column must match a plain valid_predictor run on the same list).
 
 Usage:
     python -m rlvr.autoresearch.tools.valid_predictor_guided \

--- a/rlvr/autoresearch/tools/valid_predictor_guided.py
+++ b/rlvr/autoresearch/tools/valid_predictor_guided.py
@@ -59,6 +59,11 @@ class GuidedPlannerShim(nn.Module):
 
     @torch.no_grad()
     def forward(self, inputs: dict):
+        # validate_model builds sampled_trajectories on CPU; pin everything to
+        # the model device before the forward passes.
+        dev = next(self.model.parameters()).device
+        inputs = {k: (v.to(dev) if isinstance(v, torch.Tensor) else v)
+                  for k, v in inputs.items()}
         decoder = self.model.module.decoder if hasattr(self.model, "module") else self.model.decoder
         saved_fn, saved_scale = decoder._guidance_fn, decoder._guidance_scale
 

--- a/rlvr/autoresearch/tools/valid_predictor_guided.py
+++ b/rlvr/autoresearch/tools/valid_predictor_guided.py
@@ -28,10 +28,23 @@ from torch.utils.data import DataLoader
 import rlvr.guidance_batched  # noqa: F401
 from diffusion_planner.utils.config import Config
 from diffusion_planner.utils.dataset import DiffusionPlannerData
-from diffusion_planner.valid_predictor import validate_model
 from exploration_policy.utils import run_frozen_encoder
 from rlvr.autoresearch.tools.eval_det_avoidance import load_model
 from rlvr.autoresearch.tools.eval_policy_avoidance import load_policy, make_composer
+
+
+def _load_validate_model():
+    """valid_predictor.py is a SCRIPT under <repo>/diffusion_planner/, not a
+    package module — load it by file path (same code the canonical torchrun
+    invocation executes)."""
+    import importlib.util
+
+    repo_root = Path(__file__).resolve().parents[3]
+    script = repo_root / "diffusion_planner" / "valid_predictor.py"
+    spec = importlib.util.spec_from_file_location("dp_valid_predictor", script)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.validate_model
 
 
 class GuidedPlannerShim(nn.Module):
@@ -108,6 +121,7 @@ def main():
     print(f"[valid_guided] {len(valid_set)} scenes, batch {args.batch_size}, "
           f"heads={heads}")
 
+    validate_model = _load_validate_model()
     ego_loss, nbr_loss = validate_model(shim, loader, cfg)
 
     report = {

--- a/rlvr/autoresearch/tools/valid_predictor_guided.py
+++ b/rlvr/autoresearch/tools/valid_predictor_guided.py
@@ -77,6 +77,8 @@ def main():
     parser.add_argument("--lambda_spd", type=float, default=0.2)
     parser.add_argument("--stretch_scale", type=float, default=1.0)
     parser.add_argument("--guidance_scale", type=float, default=0.5)
+    parser.add_argument("--envelope", choices=["v1", "v2"], default="v1")
+    parser.add_argument("--lambda_col", type=float, default=3.0)
     args = parser.parse_args()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/rlvr/closed_loop/batched_rollout.py
+++ b/rlvr/closed_loop/batched_rollout.py
@@ -212,6 +212,8 @@ class BatchedRolloutManager:
         reward_config: RewardConfig | None = None,
         batch_size: int = 16,
         drop_last: bool = True,
+        heads: list[str] | None = None,
+        head_params: dict | None = None,
     ):
         self.policy_model = policy_model
         self.model_args = model_args
@@ -220,6 +222,13 @@ class BatchedRolloutManager:
         self.lambda_lat = lambda_lat
         self.lambda_lon = lambda_lon
         self.guidance_scale = guidance_scale
+        # Head spec: None keeps the original lateral+longitudinal behavior.
+        # Anything else routes through guidance_batched.build_head_composer
+        # (e.g. ["lateral", "collision"] with envelope-v2 head_params:
+        # lambda_lat / lat_scale / col_scale / col_range / lambda_spd /
+        # stretch_scale / guidance_scale).
+        self.heads = heads
+        self.head_params = head_params or {}
         self.rollout_steps = rollout_steps
         self.noise_range = noise_range
         self.gamma = gamma
@@ -260,21 +269,35 @@ class BatchedRolloutManager:
         return GuidanceComposer(set_cfg)
 
     def _build_batched_composer(
-        self, eta_lat_batch: torch.Tensor, eta_lon_batch: torch.Tensor,
+        self, etas: dict[str, torch.Tensor],
     ) -> GuidanceComposer:
         """Build composer with batched etas [B] for GPU-parallel guidance.
 
-        The lateral/longitudinal guidance functions support tensor etas,
-        so this creates a single composer that applies per-element guidance.
+        With self.heads set, routes through the shared head mapping
+        (guidance_batched.build_head_composer). Otherwise keeps the original
+        lateral+longitudinal wiring byte-for-byte.
         """
+        if self.heads is not None:
+            from rlvr.guidance_batched import build_head_composer
+            return build_head_composer(
+                etas,
+                lambda_lat=self.head_params.get("lambda_lat", self.lambda_lat),
+                guidance_scale=self.head_params.get(
+                    "guidance_scale", self.guidance_scale),
+                **{k: v for k, v in self.head_params.items()
+                   if k in ("lat_scale", "col_scale", "col_range",
+                            "lambda_spd", "stretch_scale", "lambda_lon")},
+            )
         guidance_fns = [
             GuidanceConfig(
                 name="lateral", enabled=True, scale=1.0,
-                params={"lambda_lat": self.lambda_lat, "eta_lat": eta_lat_batch},
+                params={"lambda_lat": self.lambda_lat,
+                        "eta_lat": etas["lateral"]},
             ),
             GuidanceConfig(
                 name="longitudinal", enabled=True, scale=1.0,
-                params={"lambda_lon": self.lambda_lon, "eta_lon": eta_lon_batch},
+                params={"lambda_lon": self.lambda_lon,
+                        "eta_lon": etas["longitudinal"]},
             ),
         ]
         set_cfg = GuidanceSetConfig(functions=guidance_fns, global_scale=self.guidance_scale)
@@ -375,20 +398,21 @@ class BatchedRolloutManager:
 
                 # Explorer policy (batched) — or zero-init if no explorer
                 noise = random.uniform(*self.noise_range)
+                active_heads = self.heads or ["lateral", "longitudinal"]
                 if self.exploration_policy is not None:
                     policy_out = self.exploration_policy(
                         scene_encoding, ref_trajs, deterministic=False,
                     )
-                    eta_lat_batch = policy_out.eta_lat[:B_chunk]
-                    eta_lon_batch = policy_out.eta_lon[:B_chunk]
+                    etas_batch = {h: policy_out.etas[h][:B_chunk]
+                                  for h in active_heads}
                 else:
                     # No explorer — use zero guidance (equivalent to zero-init)
                     policy_out = None
-                    eta_lat_batch = torch.zeros(B_chunk, device=self.device)
-                    eta_lon_batch = torch.zeros(B_chunk, device=self.device)
+                    etas_batch = {h: torch.zeros(B_chunk, device=self.device)
+                                  for h in active_heads}
 
                 # Build batched composer — guidance functions support tensor etas [B]
-                composer = self._build_batched_composer(eta_lat_batch, eta_lon_batch)
+                composer = self._build_batched_composer(etas_batch)
 
                 # Batched guided trajectory generation
                 guided_trajs = _batched_generate(
@@ -404,16 +428,20 @@ class BatchedRolloutManager:
 
                     # Eta values for this scene
                     if policy_out is not None:
-                        eta_lat_01_raw = (policy_out.eta_lat[local_idx].item() + 1.0) / 2.0
-                        eta_lon_01_raw = (policy_out.eta_lon[local_idx].item() + 1.0) / 2.0
-                        log_prob = (policy_out.log_prob_lat[local_idx].item()
-                                   + policy_out.log_prob_lon[local_idx].item())
+                        etas_01 = {
+                            h: (policy_out.etas[h][local_idx].item() + 1.0) / 2.0
+                            for h in active_heads
+                        }
+                        log_prob = sum(
+                            policy_out.log_probs[h][local_idx].item()
+                            for h in active_heads)
                         value = policy_out.value[local_idx].item()
                     else:
-                        eta_lat_01_raw = 0.5  # zero-init maps to 0.5 in (0,1) space
-                        eta_lon_01_raw = 0.5
+                        etas_01 = {h: 0.5 for h in active_heads}  # zero-eta
                         log_prob = 0.0
                         value = 0.0
+                    eta_lat_01_raw = etas_01.get("lateral", 0.5)
+                    eta_lon_01_raw = etas_01.get("longitudinal", 0.5)
 
                     # Get neighbor positions for reward
                     data_i = scene_data[global_idx]
@@ -474,6 +502,7 @@ class BatchedRolloutManager:
                         value=value,
                         reward=step_reward.total,
                         terminal=step_reward.terminal,
+                        etas_01=etas_01,
                     ))
                     buffers[global_idx].total_return += step_reward.total
                     buffers[global_idx].episode_length = step_t + 1
@@ -589,20 +618,19 @@ class BatchedRolloutManager:
 
                 policy_out = self.exploration_policy(scene_enc, x_ref, deterministic=False)
 
-                eta_lat_01 = torch.tensor(
-                    step.eta_lat_01, dtype=torch.float32, device=self.device,
-                ).clamp(1e-6, 1 - 1e-6)
-                eta_lon_01 = torch.tensor(
-                    step.eta_lon_01, dtype=torch.float32, device=self.device,
-                ).clamp(1e-6, 1 - 1e-6)
-
-                log_prob = (policy_out.lat_dist.log_prob(eta_lat_01)
-                           + policy_out.lon_dist.log_prob(eta_lon_01))
+                step_etas = step.etas_01 or {"lateral": step.eta_lat_01,
+                                             "longitudinal": step.eta_lon_01}
+                log_prob = sum(
+                    policy_out.dists[h].log_prob(torch.tensor(
+                        v, dtype=torch.float32, device=self.device,
+                    ).clamp(1e-6, 1 - 1e-6))
+                    for h, v in step_etas.items())
 
                 adv = advantages[t].to(self.device)
                 reinforce_loss = -(log_prob * adv.detach())
                 value_loss = (policy_out.value.squeeze() - value_targets[t].to(self.device).detach()) ** 2
-                entropy = policy_out.lat_dist.entropy() + policy_out.lon_dist.entropy()
+                entropy = sum(policy_out.dists[h].entropy()
+                              for h in step_etas)
 
                 step_loss = (reinforce_loss
                             + self.online_value_coef * value_loss

--- a/rlvr/closed_loop/batched_rollout.py
+++ b/rlvr/closed_loop/batched_rollout.py
@@ -279,14 +279,23 @@ class BatchedRolloutManager:
         """
         if self.heads is not None:
             from rlvr.guidance_batched import build_head_composer
+            _passthrough = ("lat_scale", "col_scale", "col_range",
+                            "lambda_spd", "stretch_scale", "lambda_lon",
+                            "envelope", "lambda_col", "ramp_steps",
+                            "head_protect", "fast")
+            unknown = (set(self.head_params) - set(_passthrough)
+                       - {"lambda_lat", "guidance_scale"})
+            if unknown:
+                raise ValueError(
+                    f"unrecognized head_params keys {sorted(unknown)} — "
+                    "refusing to silently drop guidance config")
             return build_head_composer(
                 etas,
                 lambda_lat=self.head_params.get("lambda_lat", self.lambda_lat),
                 guidance_scale=self.head_params.get(
                     "guidance_scale", self.guidance_scale),
                 **{k: v for k, v in self.head_params.items()
-                   if k in ("lat_scale", "col_scale", "col_range",
-                            "lambda_spd", "stretch_scale", "lambda_lon")},
+                   if k in _passthrough},
             )
         guidance_fns = [
             GuidanceConfig(

--- a/rlvr/closed_loop/closed_loop_trainer.py
+++ b/rlvr/closed_loop/closed_loop_trainer.py
@@ -523,6 +523,11 @@ class ClosedLoopExplorationTrainer:
                     # warmup ep3 checkpoint diverged from the warm-start).
                     # The epoch loop freezes non-value params during warmup.
                     step_loss = self.config.closed_loop_value_coef * value_loss
+                    # Keep logged metrics honest: REINFORCE/entropy are NOT
+                    # optimized during warmup — report them as zero rather
+                    # than as if they contributed to the step.
+                    reinforce_loss = torch.zeros_like(reinforce_loss)
+                    entropy = torch.zeros_like(entropy)
                 else:
                     step_loss = (
                         reinforce_loss

--- a/rlvr/closed_loop/closed_loop_trainer.py
+++ b/rlvr/closed_loop/closed_loop_trainer.py
@@ -418,6 +418,12 @@ class ClosedLoopExplorationTrainer:
 
         # Use batched rollout for GPU parallelism
         use_batched = self.config.closed_loop_batch_size > 1
+        if not use_batched and self.heads != ["lateral", "longitudinal"]:
+            raise ValueError(
+                "sequential rollout (closed_loop_batch_size<=1) only drives "
+                "the legacy lateral+longitudinal guidance — it would train "
+                f"different heads than configured ({self.heads}). Use "
+                "closed_loop_batch_size>1 for custom head specs.")
         if use_batched:
             print(f"  Batched rollout: {len(scene_paths)} scenes, batch_size={self.config.closed_loop_batch_size}")
             rollout_buffers = self.batched_rollout_manager.run_rollouts(scene_paths)
@@ -580,7 +586,9 @@ class ClosedLoopExplorationTrainer:
             **head_stats,
         }
 
-        self.train_log.append(metrics)
+        # NOTE: do not append to train_log here — log_metrics() (the TSV
+        # writer, called by the experiment driver) appends the prefixed
+        # entry; appending the raw dict too duplicated every epoch row.
 
         # --- Free rollout data from GPU before GRPO to avoid OOM ---
         # (eta stats already collected above from rollout_buffers)

--- a/rlvr/closed_loop/closed_loop_trainer.py
+++ b/rlvr/closed_loop/closed_loop_trainer.py
@@ -61,45 +61,10 @@ class ClosedLoopExplorationTrainer:
         self.config = config
         self.use_lora = use_lora
 
-        # Reward config
-        self.reward_config = RewardConfig(
-            w_safety=config.w_safety,
-            w_progress=config.w_progress,
-            w_smooth=config.w_smooth,
-            w_feasibility=config.w_feasibility,
-            w_centerline=config.w_centerline,
-            rb_near_scale=config.rb_near_scale,
-            rb_wide_scale=config.rb_wide_scale,
-            rb_cont_scale=config.rb_cont_scale,
-            rb_gate_enabled=config.rb_gate_enabled,
-            rb_penalty_mode=config.rb_penalty_mode,
-            rb_cross_thresh=config.rb_cross_thresh,
-            rb_near_thresh=config.rb_near_thresh,
-            rb_wide_thresh=config.rb_wide_thresh,
-            rb_cont_thresh=config.rb_cont_thresh,
-            stopped_penalty=config.stopped_penalty,
-            enable_lane_departure=config.enable_lane_departure,
-            lane_gate_enabled=config.lane_gate_enabled,
-            lane_near_scale=config.lane_near_scale,
-            lane_wide_scale=config.lane_wide_scale,
-            lane_cont_scale=config.lane_cont_scale,
-            lane_cross_thresh=config.lane_cross_thresh,
-            lane_near_thresh=config.lane_near_thresh,
-            lane_wide_thresh=config.lane_wide_thresh,
-            lane_cont_thresh=config.lane_cont_thresh,
-            max_lat_accel=config.max_lat_accel,
-            lat_accel_scale=config.lat_accel_scale,
-            max_yaw_rate=config.max_yaw_rate,
-            max_steer=config.max_steer,
-            kinematic_margin=config.kinematic_margin,
-            enable_overprogress=config.enable_overprogress,
-            overprogress_margin=config.overprogress_margin,
-            overprogress_penalty=config.overprogress_penalty,
-            underprogress_penalty=config.underprogress_penalty,
-            underprogress_threshold=config.underprogress_threshold,
-            underprogress_reference=config.underprogress_reference,
-            reward_mode=config.reward_mode,
-        )
+        # Reward config — field-intersection builder so sc_* / future fields
+        # are never silently dropped (same fix as GRPOExplorationTrainer).
+        from rlvr.grpo_exploration_trainer import reward_config_from_grpo
+        self.reward_config = reward_config_from_grpo(config)
 
         # --- Exploration policy ---
         ep_config = ExplorationPolicyConfig(
@@ -112,7 +77,19 @@ class ClosedLoopExplorationTrainer:
             head_init=config.exploration_head_init,
             head_init_std=config.exploration_head_init_std,
             head_raw_scale=config.exploration_head_raw_scale,
+            heads=config.exploration_heads,
         )
+        self.heads = list(config.exploration_heads)
+        self.head_params = {
+            "lambda_lat": config.exploration_lambda_lat,
+            "lat_scale": config.exploration_lat_scale,
+            "col_scale": config.exploration_col_scale,
+            "col_range": config.exploration_col_range,
+            "lambda_spd": config.exploration_lambda_spd,
+            "stretch_scale": config.exploration_stretch_scale,
+            "guidance_scale": config.exploration_guidance_scale,
+            "lambda_lon": config.exploration_lambda_lon,
+        }
         self.exploration_policy = ExplorationPolicy(
             ep_config, ref_seq_len=model_args.future_len,
         ).to(device)
@@ -161,6 +138,8 @@ class ClosedLoopExplorationTrainer:
             reward_config=self.reward_config,
             batch_size=config.closed_loop_batch_size,
             drop_last=config.closed_loop_drop_last,
+            heads=self.heads,
+            head_params=self.head_params,
         )
         # Enable online explorer updates during rollout (PlannerRFT-style)
         if config.closed_loop_online_interval > 0:
@@ -284,16 +263,17 @@ class ClosedLoopExplorationTrainer:
                 batch_norm["x_ref"] = ref_trajs
                 batch_norm["reference_trajectory"] = ref_trajs  # Required by lateral/longitudinal guidance
 
-                # Explorer etas
+                # Explorer etas — K samples per head, flattened to [N*K]
                 if self.exploration_policy is not None:
                     policy_out = self.exploration_policy(scene_encoding, ref_trajs, deterministic=False)
-                    lat_samples = policy_out.lat_dist.rsample((K,)).squeeze(-1)
-                    lon_samples = policy_out.lon_dist.rsample((K,)).squeeze(-1)
-                    eta_lat_NK = (2.0 * lat_samples - 1.0).T.reshape(-1)
-                    eta_lon_NK = (2.0 * lon_samples - 1.0).T.reshape(-1)
+                    etas_NK = {
+                        h: (2.0 * policy_out.dists[h].rsample((K,)).squeeze(-1)
+                            - 1.0).T.reshape(-1)
+                        for h in self.heads
+                    }
                 else:
-                    eta_lat_NK = torch.zeros(N_chunk * K, device=self.device)
-                    eta_lon_NK = torch.zeros(N_chunk * K, device=self.device)
+                    etas_NK = {h: torch.zeros(N_chunk * K, device=self.device)
+                               for h in self.heads}
 
                 # Expand to N×K
                 NK_data = {}
@@ -305,14 +285,8 @@ class ClosedLoopExplorationTrainer:
                     else:
                         NK_data[k_key] = v
 
-                guidance_fns = [
-                    GuidanceConfig(name="lateral", enabled=True, scale=1.0,
-                        params={"lambda_lat": self.lambda_lat, "eta_lat": eta_lat_NK}),
-                    GuidanceConfig(name="longitudinal", enabled=True, scale=1.0,
-                        params={"lambda_lon": self.lambda_lon, "eta_lon": eta_lon_NK}),
-                ]
-                set_cfg = GuidanceSetConfig(functions=guidance_fns, global_scale=self.guidance_scale)
-                composer = GuidanceComposer(set_cfg)
+                composer = self.batched_rollout_manager._build_batched_composer(
+                    etas_NK)
 
                 all_trajs = _batched_generate_varied_noise(
                     self.policy_model, self.model_args, NK_data,
@@ -506,16 +480,13 @@ class ClosedLoopExplorationTrainer:
                 policy_out = self.exploration_policy(scene_enc, x_ref, deterministic=False)
 
                 # Recompute log_prob for the SAME sampled eta values
-                eta_lat_01_t = torch.tensor(
-                    step.eta_lat_01, dtype=torch.float32, device=self.device
-                ).clamp(1e-6, 1 - 1e-6)
-                eta_lon_01_t = torch.tensor(
-                    step.eta_lon_01, dtype=torch.float32, device=self.device
-                ).clamp(1e-6, 1 - 1e-6)
-
-                log_prob = (
-                    policy_out.lat_dist.log_prob(eta_lat_01_t)
-                    + policy_out.lon_dist.log_prob(eta_lon_01_t)
+                step_etas = step.etas_01 or {"lateral": step.eta_lat_01,
+                                             "longitudinal": step.eta_lon_01}
+                log_prob = sum(
+                    policy_out.dists[h].log_prob(torch.tensor(
+                        v, dtype=torch.float32, device=self.device,
+                    ).clamp(1e-6, 1 - 1e-6))
+                    for h, v in step_etas.items()
                 )
 
                 # REINFORCE loss
@@ -527,10 +498,7 @@ class ClosedLoopExplorationTrainer:
                 value_loss = (policy_out.value.squeeze() - value_target.detach()) ** 2
 
                 # Entropy bonus
-                entropy = (
-                    policy_out.lat_dist.entropy()
-                    + policy_out.lon_dist.entropy()
-                )
+                entropy = sum(policy_out.dists[h].entropy() for h in step_etas)
 
                 step_loss = (
                     reinforce_loss
@@ -549,31 +517,32 @@ class ClosedLoopExplorationTrainer:
             torch.nn.utils.clip_grad_norm_(self.exploration_policy.parameters(), max_norm=1.0)
             self.policy_optimizer.step()
 
-        # --- Collect eta statistics ---
-        # Per-step etas (across all scenes and steps)
-        eta_lats = [s.eta_lat_01 * 2 - 1 for buf in rollout_buffers for s in buf.steps]
-        eta_lons = [s.eta_lon_01 * 2 - 1 for buf in rollout_buffers for s in buf.steps]
-        eta_lat_mean = sum(eta_lats) / len(eta_lats) if eta_lats else 0.0
-        eta_lon_mean = sum(eta_lons) / len(eta_lons) if eta_lons else 0.0
-        eta_lat_std = (sum((e - eta_lat_mean) ** 2 for e in eta_lats) / len(eta_lats)) ** 0.5 if eta_lats else 0.0
-        eta_lon_std = (sum((e - eta_lon_mean) ** 2 for e in eta_lons) / len(eta_lons)) ** 0.5 if eta_lons else 0.0
+        # --- Collect eta statistics (per configured head) ---
+        def _step_etas(s):
+            return s.etas_01 or {"lateral": s.eta_lat_01,
+                                 "longitudinal": s.eta_lon_01}
 
-        # Per-scene mean eta (measures scene-dependence: high variance = good)
-        per_scene_lat = []
-        per_scene_lon = []
-        for buf in rollout_buffers:
-            if buf.steps:
-                scene_lat = sum(s.eta_lat_01 * 2 - 1 for s in buf.steps) / len(buf.steps)
-                scene_lon = sum(s.eta_lon_01 * 2 - 1 for s in buf.steps) / len(buf.steps)
-                per_scene_lat.append(scene_lat)
-                per_scene_lon.append(scene_lon)
-        scene_var_lat = 0.0
-        scene_var_lon = 0.0
-        if len(per_scene_lat) > 1:
-            m_lat = sum(per_scene_lat) / len(per_scene_lat)
-            m_lon = sum(per_scene_lon) / len(per_scene_lon)
-            scene_var_lat = (sum((x - m_lat) ** 2 for x in per_scene_lat) / len(per_scene_lat)) ** 0.5
-            scene_var_lon = (sum((x - m_lon) ** 2 for x in per_scene_lon) / len(per_scene_lon)) ** 0.5
+        head_stats: dict[str, float] = {}
+        for h in self.heads:
+            vals = [_step_etas(s)[h] * 2 - 1
+                    for buf in rollout_buffers for s in buf.steps
+                    if h in _step_etas(s)]
+            mean = sum(vals) / len(vals) if vals else 0.0
+            std = (sum((v - mean) ** 2 for v in vals) / len(vals)) ** 0.5 if vals else 0.0
+            per_scene = [
+                sum(_step_etas(s)[h] * 2 - 1 for s in buf.steps) / len(buf.steps)
+                for buf in rollout_buffers if buf.steps
+            ]
+            svar = 0.0
+            if len(per_scene) > 1:
+                m = sum(per_scene) / len(per_scene)
+                svar = (sum((x - m) ** 2 for x in per_scene) / len(per_scene)) ** 0.5
+            head_stats[f"eta_{h}_mean"] = mean
+            head_stats[f"eta_{h}_std"] = std
+            head_stats[f"scene_var_{h}"] = svar
+        # Legacy aliases used by run_experiment dashboards
+        eta_lat_mean = head_stats.get("eta_lateral_mean", 0.0)
+        eta_lon_mean = head_stats.get("eta_longitudinal_mean", 0.0)
 
         metrics = {
             "epoch": epoch,
@@ -588,10 +557,11 @@ class ClosedLoopExplorationTrainer:
             "entropy": total_entropy / max(n_train_steps, 1),
             "eta_lat_mean": eta_lat_mean,
             "eta_lon_mean": eta_lon_mean,
-            "eta_lat_std": eta_lat_std,
-            "eta_lon_std": eta_lon_std,
-            "scene_var_lat": scene_var_lat,
-            "scene_var_lon": scene_var_lon,
+            "eta_lat_std": head_stats.get("eta_lateral_std", 0.0),
+            "eta_lon_std": head_stats.get("eta_longitudinal_std", 0.0),
+            "scene_var_lat": head_stats.get("scene_var_lateral", 0.0),
+            "scene_var_lon": head_stats.get("scene_var_longitudinal", 0.0),
+            **head_stats,
         }
 
         self.train_log.append(metrics)

--- a/rlvr/closed_loop/closed_loop_trainer.py
+++ b/rlvr/closed_loop/closed_loop_trainer.py
@@ -500,11 +500,16 @@ class ClosedLoopExplorationTrainer:
                 # Entropy bonus
                 entropy = sum(policy_out.dists[h].entropy() for h in step_etas)
 
-                step_loss = (
-                    reinforce_loss
-                    + self.config.closed_loop_value_coef * value_loss
-                    - self.config.exploration_entropy_coef * entropy
-                )
+                if epoch <= self.config.closed_loop_value_warmup_epochs:
+                    # Value-head warmup: no policy/entropy gradient until the
+                    # critic has seen real returns.
+                    step_loss = self.config.closed_loop_value_coef * value_loss
+                else:
+                    step_loss = (
+                        reinforce_loss
+                        + self.config.closed_loop_value_coef * value_loss
+                        - self.config.exploration_entropy_coef * entropy
+                    )
                 step_loss = step_loss / n_steps_in_buf  # normalize by steps in THIS scene
                 step_loss.backward()
 

--- a/rlvr/closed_loop/closed_loop_trainer.py
+++ b/rlvr/closed_loop/closed_loop_trainer.py
@@ -402,6 +402,13 @@ class ClosedLoopExplorationTrainer:
         self.exploration_policy.eval()
         self.policy_model.eval()
 
+        # Value-warmup epochs: freeze everything except the value head so
+        # critic gradients cannot drift the shared trunk (and thereby the
+        # actor outputs) before policy training starts.
+        in_warmup = epoch <= self.config.closed_loop_value_warmup_epochs
+        for name, p in self.exploration_policy.named_parameters():
+            p.requires_grad = (not in_warmup) or name.startswith("value_head")
+
         rollout_buffers: list[RolloutBuffer] = []
         total_steps = 0
         total_return = 0.0
@@ -502,7 +509,11 @@ class ClosedLoopExplorationTrainer:
 
                 if epoch <= self.config.closed_loop_value_warmup_epochs:
                     # Value-head warmup: no policy/entropy gradient until the
-                    # critic has seen real returns.
+                    # critic has seen real returns. NOTE: the value head
+                    # shares the trunk with the actor heads — value gradients
+                    # through the trunk DRIFT the actor indirectly (measured:
+                    # warmup ep3 checkpoint diverged from the warm-start).
+                    # The epoch loop freezes non-value params during warmup.
                     step_loss = self.config.closed_loop_value_coef * value_loss
                 else:
                     step_loss = (

--- a/rlvr/closed_loop/closed_loop_trainer.py
+++ b/rlvr/closed_loop/closed_loop_trainer.py
@@ -585,8 +585,6 @@ class ClosedLoopExplorationTrainer:
             dit_metrics = self._run_dit_grpo(scene_paths, epoch)
             metrics.update(dit_metrics)
 
-        lat_shift_cm = eta_lat_mean * self.lambda_lat * 100
-        lon_shift_pct = eta_lon_mean * self.lambda_lon * 100
 
         print(
             f"  Epoch {epoch}: "
@@ -597,9 +595,11 @@ class ClosedLoopExplorationTrainer:
             f"policy_loss={metrics['policy_loss']:.4f}, "
             f"value_loss={metrics['value_loss']:.4f}, "
             f"entropy={metrics['entropy']:.4f}, "
-            f"η_lat={eta_lat_mean:.4f}±{eta_lat_std:.4f} ({lat_shift_cm:+.1f}cm), "
-            f"η_lon={eta_lon_mean:.4f}±{eta_lon_std:.4f} ({lon_shift_pct:+.1f}%), "
-            f"scene_var_lat={scene_var_lat:.4f}, scene_var_lon={scene_var_lon:.4f}"
+            + ", ".join(
+                f"η_{h}={head_stats[f'eta_{h}_mean']:+.4f}"
+                f"±{head_stats[f'eta_{h}_std']:.4f}"
+                f" (scene_var {head_stats[f'scene_var_{h}']:.4f})"
+                for h in self.heads)
         )
         if "dit_loss" in metrics:
             print(f"  DiT GRPO loss: {metrics['dit_loss']:.4f}")
@@ -646,6 +646,17 @@ class ClosedLoopExplorationTrainer:
             elif latest_link.is_dir():
                 shutil.rmtree(latest_link)
             latest_link.symlink_to(f"lora_epoch_{epoch:03d}")
+        elif self.config.closed_loop_freeze_dit:
+            # Frozen DiT: per-epoch policy-only checkpoints (the DiT is the
+            # unchanged base model — re-serializing it every epoch wastes
+            # gigabytes and loses the per-epoch history needed for sweeps).
+            ep_dir = self.run_dir / f"policy_epoch_{epoch:03d}"
+            ep_dir.mkdir(parents=True, exist_ok=True)
+            torch.save(self.exploration_policy.state_dict(),
+                       ep_dir / "exploration_policy.pth")
+            torch.save(self.policy_optimizer.state_dict(),
+                       ep_dir / "policy_optimizer.pth")
+            self.config.to_json(ep_dir / "grpo_config.json")
         else:
             checkpoint_data = {
                 "epoch": epoch,

--- a/rlvr/closed_loop/closed_loop_trainer.py
+++ b/rlvr/closed_loop/closed_loop_trainer.py
@@ -89,6 +89,8 @@ class ClosedLoopExplorationTrainer:
             "stretch_scale": config.exploration_stretch_scale,
             "guidance_scale": config.exploration_guidance_scale,
             "lambda_lon": config.exploration_lambda_lon,
+            "envelope": config.exploration_envelope,
+            "lambda_col": config.exploration_lambda_col,
         }
         self.exploration_policy = ExplorationPolicy(
             ep_config, ref_seq_len=model_args.future_len,

--- a/rlvr/closed_loop/rollout.py
+++ b/rlvr/closed_loop/rollout.py
@@ -49,12 +49,15 @@ class RolloutStep:
     """Data collected at one simulation step (all detached, no grad graph)."""
     scene_encoding: torch.Tensor   # [1, N, D]
     x_ref: torch.Tensor            # [1, T, 4]
-    eta_lat_01: float              # sampled value in (0, 1)
-    eta_lon_01: float              # sampled value in (0, 1)
+    eta_lat_01: float              # sampled value in (0, 1) — legacy 2-head API
+    eta_lon_01: float              # sampled value in (0, 1) — legacy 2-head API
     log_prob: float
     value: float
     reward: float
     terminal: bool
+    # head -> sampled eta in (0, 1); generalizes the two legacy fields for
+    # arbitrary head specs (e.g. lateral+collision). None on old buffers.
+    etas_01: dict[str, float] | None = None
 
 
 @dataclass

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -345,6 +345,11 @@ class GRPOConfig:
     exploration_lambda_lat: float = 2.5   # max lateral offset in metres
     exploration_lambda_lon: float = 0.25  # max speed deviation fraction
     exploration_guidance_scale: float = 0.5  # global guidance scale for policy-guided trajectories
+    # Guidance envelope (must match the sweep that produced the policy's
+    # training labels): "v1" = stock lateral + bounded swerve, "v2" = ramped
+    # variants (lambda_col = v2 swerve target magnitude).
+    exploration_envelope: str = "v1"
+    exploration_lambda_col: float = 3.0
     # Guidance heads for the exploration policy. Default reproduces the
     # original 2-head layout. Supported: "lateral" (lateral offset, existing
     # guidance), "longitudinal" (legacy, weak), "collision"

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -419,9 +419,11 @@ class GRPOConfig:
     # model. Only honored by GRPOExplorationTrainer; validated in __post_init__.
     train_dit: bool = True
     # Pin generation slot 0 to η=0 for all guidance heads. With
-    # noise_scale_range=[0,0] this makes slot 0 the exact unguided
-    # deterministic trajectory, giving the group a true no-guidance reference
-    # so advantages compare "guided" vs "do nothing" (slot 0 is excluded from
+    # noise_scale_range=[0,0] slot 0 approximates the unguided deterministic
+    # trajectory (exact for collision/stretch heads, which are inert at η=0;
+    # the legacy v1 lateral head still applies a small centering pull toward
+    # the reference at η=0), giving the group a no-guidance reference so
+    # advantages compare "guided" vs "do nothing" (slot 0 is excluded from
     # the policy log-prob gradient since it is a forced, not sampled, action).
     # Set False to reproduce older runs where slot 0's η was sampled.
     exploration_pin_zero_eta: bool = True

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -395,6 +395,19 @@ class GRPOConfig:
     # "none": η=0 always (no guidance, pure noise diversity).
     random_guidance_mode: str = "explorer"
 
+    # Train the DiT planner alongside the exploration policy. When False, the
+    # DiT is fully frozen (no GRPO loss, no DiT optimizer step) and ONLY the
+    # exploration policy trains — i.e. learn guidance params for a fixed base
+    # model. Only honored by GRPOExplorationTrainer; validated in __post_init__.
+    train_dit: bool = True
+    # Pin generation slot 0 to η=0 for all guidance heads. With
+    # noise_scale_range=[0,0] this makes slot 0 the exact unguided
+    # deterministic trajectory, giving the group a true no-guidance reference
+    # so advantages compare "guided" vs "do nothing" (slot 0 is excluded from
+    # the policy log-prob gradient since it is a forced, not sampled, action).
+    # Set False to reproduce older runs where slot 0's η was sampled.
+    exploration_pin_zero_eta: bool = True
+
     # --- Closed-loop training ---
     # When True, uses ClosedLoopExplorationTrainer instead of GRPOExplorationTrainer.
     # The explorer operates per-step (0.1s) with GAE temporal credit assignment.
@@ -683,6 +696,26 @@ class GRPOConfig:
             raise ValueError(
                 f"neighbor_reg_anchor must be 'warmstart' or 'baseline', got {self.neighbor_reg_anchor!r}"
             )
+        if not self.train_dit:
+            if not self.use_exploration_policy or self.use_closed_loop:
+                raise ValueError(
+                    "train_dit=False (frozen-DiT, policy-only training) is only "
+                    "supported by GRPOExplorationTrainer; requires "
+                    "use_exploration_policy=True and use_closed_loop=False, got "
+                    f"use_exploration_policy={self.use_exploration_policy}, "
+                    f"use_closed_loop={self.use_closed_loop}."
+                )
+            if self.use_lora:
+                raise ValueError(
+                    "train_dit=False is incompatible with use_lora=True: a frozen "
+                    "DiT must not carry trainable LoRA adapters."
+                )
+            if self.random_guidance_mode != "explorer":
+                raise ValueError(
+                    "train_dit=False trains ONLY the exploration policy, so "
+                    f"random_guidance_mode must be 'explorer', got "
+                    f"{self.random_guidance_mode!r} (nothing would train)."
+                )
 
     @property
     def uses_importance_sampling(self) -> bool:

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -345,6 +345,24 @@ class GRPOConfig:
     exploration_lambda_lat: float = 2.5   # max lateral offset in metres
     exploration_lambda_lon: float = 0.25  # max speed deviation fraction
     exploration_guidance_scale: float = 0.5  # global guidance scale for policy-guided trajectories
+    # Guidance heads for the exploration policy. Default reproduces the
+    # original 2-head layout. Supported: "lateral" (lateral offset, existing
+    # guidance), "longitudinal" (legacy, weak), "collision"
+    # (collision_swerve_batched: sign = side, |eta| = strength), "stretch"
+    # (speed_stretch_batched: stretch = 1 + lambda_spd * eta).
+    exploration_heads: list[str] = field(default_factory=lambda: ["lateral", "longitudinal"])
+    # Per-function energy scales (multiply each guidance fn's energy; the
+    # campaign avoidance envelope uses lat_scale=1.5, col_scale=6.0,
+    # lambda_lat=4.0, col_range=8.0 — must match the sweep that produced any
+    # warm-start labels).
+    exploration_lat_scale: float = 1.0
+    exploration_col_scale: float = 2.0
+    exploration_col_range: float = 8.0
+    exploration_lambda_spd: float = 0.2
+    exploration_stretch_scale: float = 1.0
+    # Action-cost coefficient: pulls each head's deterministic action (Beta
+    # mean) toward 0 — inertness tie-breaker on reward-indifferent scenes.
+    exploration_action_cost: float = 0.0
     # GuidanceHead init mode: "zeros" (recommended) or "normal"
     exploration_head_init: str = "zeros"
     exploration_head_init_std: float = 0.01

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -434,6 +434,10 @@ class GRPOConfig:
     closed_loop_gamma: float = 0.99         # GAE discount factor
     closed_loop_gae_lambda: float = 0.95    # GAE lambda
     closed_loop_value_coef: float = 0.5     # value loss coefficient
+    # Train ONLY the value head for the first N epochs (policy/entropy terms
+    # skipped) so REINFORCE advantages aren't driven by a cold critic —
+    # counters the early-epoch policy drift seen with warm-started policies.
+    closed_loop_value_warmup_epochs: int = 0
     closed_loop_alive_bonus: float = 0.5    # per-step alive reward
     closed_loop_freeze_dit: bool = True     # freeze DiT during explorer training
     closed_loop_batch_size: int = 8        # scenes per batch in rollout (8 fits ~24GB VRAM)

--- a/rlvr/grpo_exploration_trainer.py
+++ b/rlvr/grpo_exploration_trainer.py
@@ -29,14 +29,13 @@ from pathlib import Path
 
 import numpy as np
 import torch
-
-import rlvr.guidance_batched  # noqa: F401 -- registers collision_swerve_batched etc.
 from diffusion_planner.model.guidance.composer import GuidanceComposer
 from diffusion_planner.model.guidance.config import GuidanceConfig, GuidanceSetConfig
 from torch import nn, optim
 from torch.distributions import kl_divergence as kl_div
 from tqdm import tqdm
 
+import rlvr.guidance_batched  # noqa: F401 -- registers collision_swerve_batched etc.
 from exploration_policy.loss import _get_init_distributions, compute_exploration_loss
 from exploration_policy.model import ExplorationPolicy, ExplorationPolicyConfig
 from exploration_policy.utils import generate_reference_trajectory, run_frozen_encoder

--- a/rlvr/grpo_exploration_trainer.py
+++ b/rlvr/grpo_exploration_trainer.py
@@ -23,6 +23,8 @@ from pathlib import Path
 
 import numpy as np
 import torch
+
+import rlvr.guidance_batched  # noqa: F401 -- registers collision_swerve_batched etc.
 from diffusion_planner.model.guidance.composer import GuidanceComposer
 from diffusion_planner.model.guidance.config import GuidanceConfig, GuidanceSetConfig
 from torch import nn, optim
@@ -138,6 +140,13 @@ class GRPOExplorationTrainer:
         self.random_guidance_mode = config.random_guidance_mode
         self.use_explorer = self.random_guidance_mode == "explorer"
 
+        self.heads = list(config.exploration_heads)
+        if not self.use_explorer and self.heads != ["lateral", "longitudinal"]:
+            raise ValueError(
+                f"random_guidance_mode={self.random_guidance_mode!r} supports only "
+                f"the default ['lateral', 'longitudinal'] heads, got {self.heads}."
+            )
+
         if self.use_explorer:
             ep_config = ExplorationPolicyConfig(
                 hidden_dim=config.exploration_hidden_dim,
@@ -149,6 +158,7 @@ class GRPOExplorationTrainer:
                 head_init=config.exploration_head_init,
                 head_init_std=config.exploration_head_init_std,
                 head_raw_scale=config.exploration_head_raw_scale,
+                heads=self.heads,
             )
             self.exploration_policy = ExplorationPolicy(
                 ep_config, ref_seq_len=model_args.future_len,
@@ -185,6 +195,43 @@ class GRPOExplorationTrainer:
         self.eval_log: list[dict] = []
         self.best_det_reward: float = float("-inf")
         self.best_epoch: int = 0
+
+    def _build_guidance_fns(self, eta_vals: dict[str, torch.Tensor]) -> list[GuidanceConfig]:
+        """Map head-name -> GuidanceConfig with per-sample eta tensors.
+
+        Default ["lateral", "longitudinal"] reproduces the original hard-coded
+        pair exactly; "collision"/"stretch" use the batched variants from
+        rlvr.guidance_batched.
+        """
+        cfg = self.config
+        fns = []
+        for head in self.heads:
+            eta = eta_vals[head]
+            if head == "lateral":
+                fns.append(GuidanceConfig(
+                    name="lateral", enabled=True, scale=cfg.exploration_lat_scale,
+                    params={"lambda_lat": self.lambda_lat, "eta_lat": eta},
+                ))
+            elif head == "longitudinal":
+                fns.append(GuidanceConfig(
+                    name="longitudinal", enabled=True, scale=1.0,
+                    params={"lambda_lon": self.lambda_lon, "eta_lon": eta},
+                ))
+            elif head == "collision":
+                fns.append(GuidanceConfig(
+                    name="collision_swerve_batched", enabled=True,
+                    scale=cfg.exploration_col_scale,
+                    params={"eta_col": eta, "range": cfg.exploration_col_range},
+                ))
+            elif head == "stretch":
+                fns.append(GuidanceConfig(
+                    name="speed_stretch_batched", enabled=True,
+                    scale=cfg.exploration_stretch_scale,
+                    params={"stretch": 1.0 + cfg.exploration_lambda_spd * eta},
+                ))
+            else:
+                raise ValueError(f"unknown exploration head {head!r}")
+        return fns
 
     def _sample_random_eta(self, K: int) -> tuple[torch.Tensor, torch.Tensor]:
         """Sample random η values based on random_guidance_mode."""
@@ -262,21 +309,21 @@ class GRPOExplorationTrainer:
                 scene_encoding = run_frozen_encoder(self.policy_model, norm_data)
 
                 policy_output = self.exploration_policy(scene_encoding, x_ref, deterministic=True)
-                lat_dist = policy_output.lat_dist
-                lon_dist = policy_output.lon_dist
+                dists = policy_output.dists
 
-                eta_lat_01 = lat_dist.rsample((K,)).squeeze(-1)
-                eta_lon_01 = lon_dist.rsample((K,)).squeeze(-1)
+                eta_01 = {
+                    h: dists[h].rsample((K,)).squeeze(-1) for h in self.heads
+                }
                 if self.config.exploration_pin_zero_eta:
                     # Slot 0 = forced η=0 (0.5 in Beta space): the unguided
                     # reference the group advantages compare against. Excluded
                     # from the policy log-prob gradient in train_on_groups.
-                    eta_lat_01[0] = 0.5
-                    eta_lon_01[0] = 0.5
-                eta_lat_vals = 2.0 * eta_lat_01 - 1.0
-                eta_lon_vals = 2.0 * eta_lon_01 - 1.0
+                    for h in self.heads:
+                        eta_01[h][0] = 0.5
+                eta_vals = {h: 2.0 * v - 1.0 for h, v in eta_01.items()}
             else:
-                # Random guidance path: sample η directly
+                # Random guidance path: sample η directly (default heads only,
+                # validated in __init__)
                 eta_lat_vals, eta_lon_vals = self._sample_random_eta(K)
 
                 # Generate reference trajectory (needed by lateral/longitudinal guidance)
@@ -287,10 +334,9 @@ class GRPOExplorationTrainer:
                 norm_data["reference_trajectory"] = x_ref
 
                 scene_encoding = None
-                lat_dist = None
-                lon_dist = None
-                eta_lat_01 = (eta_lat_vals + 1.0) / 2.0  # map to (0,1) for compatibility
-                eta_lon_01 = (eta_lon_vals + 1.0) / 2.0
+                dists = None
+                eta_vals = {"lateral": eta_lat_vals, "longitudinal": eta_lon_vals}
+                eta_01 = {h: (v + 1.0) / 2.0 for h, v in eta_vals.items()}
 
             # 6. Generate K trajectories — batched with per-trajectory varied noise
             from rlvr.closed_loop.batched_rollout import _batched_generate_varied_noise
@@ -304,17 +350,8 @@ class GRPOExplorationTrainer:
                 else:
                     K_data[k_key] = v
 
-            # Build batched composer with K etas
-            guidance_fns = [
-                GuidanceConfig(
-                    name="lateral", enabled=True, scale=1.0,
-                    params={"lambda_lat": self.lambda_lat, "eta_lat": eta_lat_vals},
-                ),
-                GuidanceConfig(
-                    name="longitudinal", enabled=True, scale=1.0,
-                    params={"lambda_lon": self.lambda_lon, "eta_lon": eta_lon_vals},
-                ),
-            ]
+            # Build batched composer with K etas per configured head
+            guidance_fns = self._build_guidance_fns(eta_vals)
             set_cfg = GuidanceSetConfig(functions=guidance_fns, global_scale=self.guidance_scale)
             composer = GuidanceComposer(set_cfg)
 
@@ -337,14 +374,18 @@ class GRPOExplorationTrainer:
             fixed_scale=self.config.advantage_fixed_scale,
         )
 
-        # Store sampled eta values for recomputation during training
-        if self.use_explorer:
+        # Store sampled eta values for recomputation during training.
+        # PolicyGroupMetadata is lat/lon-specific bookkeeping kept for the
+        # default head layout only (train_on_groups recomputes log-probs).
+        if self.use_explorer and self.heads == ["lateral", "longitudinal"]:
             policy_meta = PolicyGroupMetadata(
                 log_probs=torch.zeros(K, device=self.device),
-                lat_dist_params=(lat_dist.concentration1.detach(), lat_dist.concentration0.detach()),
-                lon_dist_params=(lon_dist.concentration1.detach(), lon_dist.concentration0.detach()),
-                eta_lat_samples=eta_lat_vals.detach(),
-                eta_lon_samples=eta_lon_vals.detach(),
+                lat_dist_params=(dists["lateral"].concentration1.detach(),
+                                 dists["lateral"].concentration0.detach()),
+                lon_dist_params=(dists["longitudinal"].concentration1.detach(),
+                                 dists["longitudinal"].concentration0.detach()),
+                eta_lat_samples=eta_vals["lateral"].detach(),
+                eta_lon_samples=eta_vals["longitudinal"].detach(),
             )
         else:
             policy_meta = None
@@ -360,8 +401,7 @@ class GRPOExplorationTrainer:
             "det_trajectory": det_traj,
             "scene_encoding": scene_encoding.detach() if scene_encoding is not None else None,
             "x_ref": x_ref.detach() if x_ref is not None else None,
-            "eta_lat_01": eta_lat_01.detach(),
-            "eta_lon_01": eta_lon_01.detach(),
+            "eta_01": {h: v.detach() for h, v in eta_01.items()},
         }
 
     def train_on_groups(
@@ -446,8 +486,7 @@ class GRPOExplorationTrainer:
             if self.use_explorer:
                 scene_encoding = group["scene_encoding"]
                 x_ref = group["x_ref"]
-                eta_lat_01 = group["eta_lat_01"]
-                eta_lon_01 = group["eta_lon_01"]
+                eta_01 = group["eta_01"]
 
                 grad_enabled = not policy_frozen
                 advantages_t = torch.tensor(advantages_np, device=self.device, dtype=torch.float32)
@@ -455,23 +494,21 @@ class GRPOExplorationTrainer:
                 inner_epochs = self.config.exploration_inner_epochs
                 clip_eps = self.config.exploration_clip_epsilon
 
+                def _sum_log_probs(dists_by_head):
+                    lp = sum(dists_by_head[h].log_prob(eta_01[h]) for h in self.heads)
+                    return lp.squeeze(-1) if lp.dim() > 1 else lp
+
                 if inner_epochs > 1:
                     with torch.no_grad():
                         old_output = self.exploration_policy(scene_encoding, x_ref, deterministic=True)
-                        old_lp = old_output.lat_dist.log_prob(eta_lat_01) + old_output.lon_dist.log_prob(eta_lon_01)
-                        if old_lp.dim() > 1:
-                            old_lp = old_lp.squeeze(-1)
-                        old_log_probs = old_lp.detach()
+                        old_log_probs = _sum_log_probs(old_output.dists).detach()
 
                 for inner_ep in range(inner_epochs):
                     with torch.set_grad_enabled(grad_enabled):
                         policy_output = self.exploration_policy(scene_encoding, x_ref, deterministic=True)
-                    lat_dist = policy_output.lat_dist
-                    lon_dist = policy_output.lon_dist
+                    dists = policy_output.dists
 
-                    log_probs = lat_dist.log_prob(eta_lat_01) + lon_dist.log_prob(eta_lon_01)
-                    if log_probs.dim() > 1:
-                        log_probs = log_probs.squeeze(-1)
+                    log_probs = _sum_log_probs(dists)
 
                     # Pinned slot 0 is a forced (not sampled) action — exclude it
                     # from log-prob-based policy gradients. best_sample_mse keeps
@@ -495,9 +532,9 @@ class GRPOExplorationTrainer:
                         surr2 = clipped_ratio * pg_advantages
                         ppo_loss = -torch.min(surr1, surr2).mean()
 
-                        entropy_value = (lat_dist.entropy() + lon_dist.entropy()).mean()
-                        init_lat, init_lon = _get_init_distributions(self.device)
-                        kl_value = (kl_div(lat_dist, init_lat) + kl_div(lon_dist, init_lon)).mean()
+                        entropy_value = sum(d.entropy().mean() for d in dists.values())
+                        init_dist, _ = _get_init_distributions(self.device)
+                        kl_value = sum(kl_div(d, init_dist).mean() for d in dists.values())
 
                         policy_loss = (
                             ppo_loss
@@ -509,11 +546,10 @@ class GRPOExplorationTrainer:
                             "exploration_entropy": entropy_value.item(),
                             "exploration_kl": kl_value.item(),
                             "exploration_total_loss": policy_loss.item(),
-                            "exploration_eta_lat_mean": lat_dist.mean.mean().item() * 2 - 1,
-                            "exploration_eta_lon_mean": lon_dist.mean.mean().item() * 2 - 1,
-                            "exploration_eta_lat_std": (lat_dist.variance.mean().item() * 4) ** 0.5,
-                            "exploration_eta_lon_std": (lon_dist.variance.mean().item() * 4) ** 0.5,
                         }
+                        for h, d in dists.items():
+                            policy_metrics[f"exploration_eta_{h}_mean"] = d.mean.mean().item() * 2 - 1
+                            policy_metrics[f"exploration_eta_{h}_std"] = (d.variance.mean().item() * 4) ** 0.5
 
                         if not policy_frozen:
                             self.policy_optimizer.zero_grad()
@@ -527,36 +563,29 @@ class GRPOExplorationTrainer:
                         # Unlike advantage_logprob which uses all K samples, this directly supervises
                         # the policy to output the best-reward eta for each scene.
                         best_idx = advantages_t.argmax()
-                        best_eta_lat_01 = eta_lat_01[best_idx].detach()  # target (0,1)
-                        best_eta_lon_01 = eta_lon_01[best_idx].detach()
-
-                        # MSE between policy's deterministic mean and the best eta
-                        pred_lat_mean = lat_dist.mean.squeeze()  # policy's predicted mean in (0,1)
-                        pred_lon_mean = lon_dist.mean.squeeze()
-                        rsft_loss = (
-                            (pred_lat_mean - best_eta_lat_01) ** 2
-                            + (pred_lon_mean - best_eta_lon_01) ** 2
+                        rsft_loss = sum(
+                            (dists[h].mean.squeeze() - eta_01[h][best_idx].detach()) ** 2
+                            for h in self.heads
                         )
 
                         policy_loss = rsft_loss
                         policy_metrics = {
                             "exploration_policy_loss": rsft_loss.item(),
-                            "exploration_entropy": (lat_dist.entropy() + lon_dist.entropy()).mean().item(),
+                            "exploration_entropy": float(sum(d.entropy().mean() for d in dists.values())),
                             "exploration_kl": 0.0,
                             "exploration_total_loss": rsft_loss.item(),
-                            "exploration_eta_lat_mean": lat_dist.mean.mean().item() * 2 - 1,
-                            "exploration_eta_lon_mean": lon_dist.mean.mean().item() * 2 - 1,
-                            "exploration_eta_lat_std": (lat_dist.variance.mean().item() * 4) ** 0.5,
-                            "exploration_eta_lon_std": (lon_dist.variance.mean().item() * 4) ** 0.5,
                         }
+                        for h, d in dists.items():
+                            policy_metrics[f"exploration_eta_{h}_mean"] = d.mean.mean().item() * 2 - 1
+                            policy_metrics[f"exploration_eta_{h}_std"] = (d.variance.mean().item() * 4) ** 0.5
                     else:
                         policy_loss, policy_metrics = compute_exploration_loss(
                             advantages=pg_advantages,
                             log_probs=pg_log_probs,
-                            lat_dist=lat_dist,
-                            lon_dist=lon_dist,
+                            dists=dists,
                             entropy_coef=self.config.exploration_entropy_coef,
                             kl_coef=self.config.exploration_kl_coef,
+                            action_cost_coef=self.config.exploration_action_cost,
                         )
                     # Backward pass for advantage_logprob and best_sample_mse paths
                     # (PPO path handles its own backward+step above)
@@ -575,12 +604,12 @@ class GRPOExplorationTrainer:
                 if not self.config.exploration_step_per_group:
                     n_policy_accum += 1
 
-                per_scene_eta_lat.append(lat_dist.mean.mean().item() * 2 - 1)
-                per_scene_eta_lon.append(lon_dist.mean.mean().item() * 2 - 1)
+                per_scene_eta_lat.append(dists[self.heads[0]].mean.mean().item() * 2 - 1)
+                per_scene_eta_lon.append(dists[self.heads[-1]].mean.mean().item() * 2 - 1)
             else:
                 # Random guidance: no policy to train, just track η stats
-                eta_lat_01 = group["eta_lat_01"]
-                eta_lon_01 = group["eta_lon_01"]
+                eta_lat_01 = group["eta_01"]["lateral"]
+                eta_lon_01 = group["eta_01"]["longitudinal"]
                 eta_lat_vals = 2.0 * eta_lat_01 - 1.0
                 eta_lon_vals = 2.0 * eta_lon_01 - 1.0
                 policy_metrics = {
@@ -772,19 +801,12 @@ class GRPOExplorationTrainer:
             scene_encoding = run_frozen_encoder(self.policy_model, norm_data)
 
             policy_output = self.exploration_policy(scene_encoding, x_ref, deterministic=True)
-            eta_lat = (2.0 * policy_output.lat_dist.mean - 1.0).reshape(1)
-            eta_lon = (2.0 * policy_output.lon_dist.mean - 1.0).reshape(1)
+            etas = {
+                h: (2.0 * policy_output.dists[h].mean - 1.0).reshape(1)
+                for h in self.heads
+            }
 
-            guidance_fns = [
-                GuidanceConfig(
-                    name="lateral", enabled=True, scale=1.0,
-                    params={"lambda_lat": self.lambda_lat, "eta_lat": eta_lat},
-                ),
-                GuidanceConfig(
-                    name="longitudinal", enabled=True, scale=1.0,
-                    params={"lambda_lon": self.lambda_lon, "eta_lon": eta_lon},
-                ),
-            ]
+            guidance_fns = self._build_guidance_fns(etas)
             set_cfg = GuidanceSetConfig(functions=guidance_fns, global_scale=self.guidance_scale)
             composer = GuidanceComposer(set_cfg)
 
@@ -811,8 +833,7 @@ class GRPOExplorationTrainer:
             )
             rows.append({
                 "npz_path": npz_path,
-                "eta_lat": float(eta_lat.item()),
-                "eta_lon": float(eta_lon.item()),
+                **{f"eta_{h}": float(v.item()) for h, v in etas.items()},
                 "reward": guided_bd.total,
                 "det_reward": det_bd.total,
                 "static_crossing": bool(guided_bd.static_crossing),
@@ -940,12 +961,15 @@ def aggregate_policy_eval(rows: list[dict]) -> dict[str, float]:
         "deviation_mean": _mean([r["deviation"] for r in rows]),
         "deviation_max": float(max((r["deviation"] for r in rows), default=0.0)),
         "n_avoidance_scenes": len(avoid),
-        "eta_lat_abs_avoid": _mean([abs(r["eta_lat"]) for r in avoid]),
-        "eta_lon_abs_avoid": _mean([abs(r["eta_lon"]) for r in avoid]),
-        "eta_lat_abs_normal": _mean([abs(r["eta_lat"]) for r in normal]),
-        "eta_lon_abs_normal": _mean([abs(r["eta_lon"]) for r in normal]),
         "deviation_mean_normal": _mean([r["deviation"] for r in normal]),
     }
+    eta_keys = [k for k in rows[0] if k.startswith("eta_")]
+    for k in eta_keys:
+        suffix = k[len("eta_"):]
+        # Short aliases for the original layout: lateral->lat, longitudinal->lon
+        suffix = {"lateral": "lat", "longitudinal": "lon"}.get(suffix, suffix)
+        out[f"eta_{suffix}_abs_avoid"] = _mean([abs(r[k]) for r in avoid])
+        out[f"eta_{suffix}_abs_normal"] = _mean([abs(r[k]) for r in normal])
     return out
 
 

--- a/rlvr/grpo_exploration_trainer.py
+++ b/rlvr/grpo_exploration_trainer.py
@@ -1,5 +1,11 @@
 """Joint GRPO + Exploration Policy trainer.
 
+DEPRECATED for guidance-explorer training: the canonical pipeline is
+supervised regression on sweep-derived robust labels
+(rlvr.train_explorer_regression) with optional closed-loop RL polish
+(rlvr.closed_loop.closed_loop_trainer.ClosedLoopExplorationTrainer).
+This open-loop group-GRPO trainer is kept for reproducing older runs only.
+
 Extends the standard GRPO training with a learned exploration policy that
 outputs (eta_lat, eta_lon) from Beta distributions. The policy and DiT
 planner are trained simultaneously:
@@ -424,8 +430,10 @@ class GRPOExplorationTrainer:
 
         all_metrics: dict[str, float] = {}
         num_groups = 0
-        per_scene_eta_lat: list[float] = []
-        per_scene_eta_lon: list[float] = []
+        per_scene_eta: dict[str, list[float]] = {h: [] for h in self.heads}
+        # random-guidance branch logs the legacy lateral/longitudinal pair
+        for _h in ("lateral", "longitudinal"):
+            per_scene_eta.setdefault(_h, [])
 
         if self.train_dit:
             self.policy_model.train()
@@ -604,8 +612,9 @@ class GRPOExplorationTrainer:
                 if not self.config.exploration_step_per_group:
                     n_policy_accum += 1
 
-                per_scene_eta_lat.append(dists[self.heads[0]].mean.mean().item() * 2 - 1)
-                per_scene_eta_lon.append(dists[self.heads[-1]].mean.mean().item() * 2 - 1)
+                for h in self.heads:
+                    per_scene_eta[h].append(
+                        dists[h].mean.mean().item() * 2 - 1)
             else:
                 # Random guidance: no policy to train, just track η stats
                 eta_lat_01 = group["eta_01"]["lateral"]
@@ -622,8 +631,8 @@ class GRPOExplorationTrainer:
                     "exploration_eta_lat_std": eta_lat_vals.std().item(),
                     "exploration_eta_lon_std": eta_lon_vals.std().item(),
                 }
-                per_scene_eta_lat.append(eta_lat_vals.mean().item())
-                per_scene_eta_lon.append(eta_lon_vals.mean().item())
+                per_scene_eta["lateral"].append(eta_lat_vals.mean().item())
+                per_scene_eta["longitudinal"].append(eta_lon_vals.mean().item())
 
             # Merge metrics
             for k, v in dit_metrics.items():
@@ -665,11 +674,13 @@ class GRPOExplorationTrainer:
             return _empty_metrics()
 
         result = {k: v / num_groups for k, v in all_metrics.items()}
-        # Add per-scene η variance (measures scene-dependence of policy output)
-        if per_scene_eta_lat:
-            import numpy as _np
-            result["exploration_eta_lat_scene_std"] = float(_np.std(per_scene_eta_lat))
-            result["exploration_eta_lon_scene_std"] = float(_np.std(per_scene_eta_lon))
+        # Add per-scene η variance (measures scene-dependence of policy
+        # output), keyed by the ACTUAL head name (previously heads[0]/[-1]
+        # were logged as lat/lon regardless of the head spec).
+        import numpy as _np
+        for h, vals in per_scene_eta.items():
+            if vals:
+                result[f"exploration_eta_{h}_scene_std"] = float(_np.std(vals))
         return result
 
     def train_epoch(

--- a/rlvr/grpo_exploration_trainer.py
+++ b/rlvr/grpo_exploration_trainer.py
@@ -47,6 +47,25 @@ def _load_npz(npz_path, device):
     return data
 
 
+def reward_config_from_grpo(config: GRPOConfig) -> RewardConfig:
+    """Build a RewardConfig from every GRPOConfig field that RewardConfig shares.
+
+    Field-name intersection reproduces exactly the mapping run_experiment.py
+    uses for its train_reward_config (verified: 52 shared fields, no renames),
+    and cannot silently drop newly added reward fields the way a hand-copied
+    kwargs list can (the old list here omitted all static-collision fields).
+    """
+    from dataclasses import fields as _dc_fields
+
+    reward_field_names = {f.name for f in _dc_fields(RewardConfig)}
+    kwargs = {
+        name: getattr(config, name)
+        for name in reward_field_names
+        if hasattr(config, name)
+    }
+    return RewardConfig(**kwargs)
+
+
 class GRPOExplorationTrainer:
     """Joint trainer for DiT planner (GRPO) + exploration policy.
 
@@ -67,7 +86,7 @@ class GRPOExplorationTrainer:
         self,
         policy_model: nn.Module,
         model_args,
-        dit_optimizer: optim.Optimizer,
+        dit_optimizer: optim.Optimizer | None,
         device: torch.device,
         run_dir: Path,
         config: GRPOConfig,
@@ -80,52 +99,23 @@ class GRPOExplorationTrainer:
         self.run_dir = run_dir
         self.config = config
         self.use_lora = use_lora
+        self.train_dit = config.train_dit
+
+        if self.train_dit and dit_optimizer is None:
+            raise ValueError(
+                "train_dit=True requires a dit_optimizer; pass train_dit=False "
+                "in the config for frozen-DiT policy-only training."
+            )
 
         assert config.inner_epochs == 1, (
             f"GRPOExplorationTrainer only supports on-policy training (inner_epochs=1), "
             f"got inner_epochs={config.inner_epochs}. For multi-epoch training, use GRPOTrainer."
         )
 
-        # Reward config (same as standard GRPO)
-        self.reward_config = RewardConfig(
-            w_safety=config.w_safety,
-            w_progress=config.w_progress,
-            w_smooth=config.w_smooth,
-            w_feasibility=config.w_feasibility,
-            w_centerline=config.w_centerline,
-            centerline_usage_mode=config.centerline_usage_mode,
-            rb_near_scale=config.rb_near_scale,
-            rb_wide_scale=config.rb_wide_scale,
-            rb_cont_scale=config.rb_cont_scale,
-            rb_gate_enabled=config.rb_gate_enabled,
-            rb_penalty_mode=config.rb_penalty_mode,
-            rb_cross_thresh=config.rb_cross_thresh,
-            rb_near_thresh=config.rb_near_thresh,
-            rb_wide_thresh=config.rb_wide_thresh,
-            rb_cont_thresh=config.rb_cont_thresh,
-            max_lat_accel=config.max_lat_accel,
-            lat_accel_scale=config.lat_accel_scale,
-            enable_overprogress=config.enable_overprogress,
-            overprogress_margin=config.overprogress_margin,
-            overprogress_penalty=config.overprogress_penalty,
-            stopped_penalty=config.stopped_penalty,
-            reward_mode=config.reward_mode,
-            enable_lane_departure=config.enable_lane_departure,
-            lane_gate_enabled=config.lane_gate_enabled,
-            lane_near_scale=config.lane_near_scale,
-            lane_wide_scale=config.lane_wide_scale,
-            lane_cont_scale=config.lane_cont_scale,
-            lane_cross_thresh=config.lane_cross_thresh,
-            lane_near_thresh=config.lane_near_thresh,
-            lane_wide_thresh=config.lane_wide_thresh,
-            lane_cont_thresh=config.lane_cont_thresh,
-            max_yaw_rate=config.max_yaw_rate,
-            max_steer=config.max_steer,
-            kinematic_margin=config.kinematic_margin,
-            underprogress_penalty=config.underprogress_penalty,
-            underprogress_threshold=config.underprogress_threshold,
-            underprogress_reference=config.underprogress_reference,
-        )
+        # Reward config: every GRPOConfig field shared with RewardConfig
+        # (including the static-collision sc_* family — the previous
+        # hand-copied list silently dropped them).
+        self.reward_config = reward_config_from_grpo(config)
 
         # Sampler config (only used for eval, not for policy-guided generation)
         self.sampler_config = SamplerConfig(
@@ -277,6 +267,12 @@ class GRPOExplorationTrainer:
 
                 eta_lat_01 = lat_dist.rsample((K,)).squeeze(-1)
                 eta_lon_01 = lon_dist.rsample((K,)).squeeze(-1)
+                if self.config.exploration_pin_zero_eta:
+                    # Slot 0 = forced η=0 (0.5 in Beta space): the unguided
+                    # reference the group advantages compare against. Excluded
+                    # from the policy log-prob gradient in train_on_groups.
+                    eta_lat_01[0] = 0.5
+                    eta_lon_01[0] = 0.5
                 eta_lat_vals = 2.0 * eta_lat_01 - 1.0
                 eta_lon_vals = 2.0 * eta_lon_01 - 1.0
             else:
@@ -391,13 +387,17 @@ class GRPOExplorationTrainer:
         per_scene_eta_lat: list[float] = []
         per_scene_eta_lon: list[float] = []
 
-        self.policy_model.train()
+        if self.train_dit:
+            self.policy_model.train()
+        else:
+            self.policy_model.eval()
         if self.use_explorer:
             if not policy_frozen:
                 self.exploration_policy.train()
             else:
                 self.exploration_policy.eval()
-        self.dit_optimizer.zero_grad()
+        if self.train_dit:
+            self.dit_optimizer.zero_grad()
         if self.use_explorer and not policy_frozen:
             self.policy_optimizer.zero_grad()
 
@@ -409,35 +409,38 @@ class GRPOExplorationTrainer:
             if np.all(advantages_np == 0):
                 continue
 
-            # --- DiT GRPO loss (batched) ---
-            from rlvr.grpo_loss import compute_batched_grpo_loss
-            traj_list = group["trajectories"]
-            traj_tensor = torch.tensor(
-                np.stack(traj_list) if isinstance(traj_list[0], np.ndarray) else traj_list,
-                device=self.device, dtype=torch.float32,
-            )
-            dit_loss, dit_metrics = compute_batched_grpo_loss(
-                policy_model=self.policy_model,
-                trajectories_tensor=traj_tensor,
-                advantages=advantages_np,
-                data=group["data"],
-                model_args=self.model_args,
-                config=self.config,
-                device=self.device,
-            )
-
-            scaled_dit_loss = dit_loss / self.config.grad_accum_groups
-            scaled_dit_loss.backward()
-            dit_accum += 1
-
-            if dit_accum >= self.config.grad_accum_groups:
-                torch.nn.utils.clip_grad_norm_(
-                    [p for p in self.policy_model.parameters() if p.requires_grad],
-                    max_norm=5.0,
+            # --- DiT GRPO loss (batched) — skipped entirely when the DiT is frozen ---
+            if self.train_dit:
+                from rlvr.grpo_loss import compute_batched_grpo_loss
+                traj_list = group["trajectories"]
+                traj_tensor = torch.tensor(
+                    np.stack(traj_list) if isinstance(traj_list[0], np.ndarray) else traj_list,
+                    device=self.device, dtype=torch.float32,
                 )
-                self.dit_optimizer.step()
-                self.dit_optimizer.zero_grad()
-                dit_accum = 0
+                dit_loss, dit_metrics = compute_batched_grpo_loss(
+                    policy_model=self.policy_model,
+                    trajectories_tensor=traj_tensor,
+                    advantages=advantages_np,
+                    data=group["data"],
+                    model_args=self.model_args,
+                    config=self.config,
+                    device=self.device,
+                )
+
+                scaled_dit_loss = dit_loss / self.config.grad_accum_groups
+                scaled_dit_loss.backward()
+                dit_accum += 1
+
+                if dit_accum >= self.config.grad_accum_groups:
+                    torch.nn.utils.clip_grad_norm_(
+                        [p for p in self.policy_model.parameters() if p.requires_grad],
+                        max_norm=5.0,
+                    )
+                    self.dit_optimizer.step()
+                    self.dit_optimizer.zero_grad()
+                    dit_accum = 0
+            else:
+                dit_metrics = {}
 
             # --- Exploration policy loss (advantage_logprob, best_sample_mse, or PPO) ---
             if self.use_explorer:
@@ -470,11 +473,26 @@ class GRPOExplorationTrainer:
                     if log_probs.dim() > 1:
                         log_probs = log_probs.squeeze(-1)
 
+                    # Pinned slot 0 is a forced (not sampled) action — exclude it
+                    # from log-prob-based policy gradients. best_sample_mse keeps
+                    # all slots: η=0 winning is a valid regression target.
+                    if self.config.exploration_pin_zero_eta:
+                        pg_log_probs = log_probs[1:]
+                        pg_advantages = advantages_t[1:]
+                    else:
+                        pg_log_probs = log_probs
+                        pg_advantages = advantages_t
+
                     if inner_epochs > 1:
-                        ratio = (log_probs - old_log_probs).exp()
+                        pg_old_log_probs = (
+                            old_log_probs[1:]
+                            if self.config.exploration_pin_zero_eta
+                            else old_log_probs
+                        )
+                        ratio = (pg_log_probs - pg_old_log_probs).exp()
                         clipped_ratio = ratio.clamp(1.0 - clip_eps, 1.0 + clip_eps)
-                        surr1 = ratio * advantages_t
-                        surr2 = clipped_ratio * advantages_t
+                        surr1 = ratio * pg_advantages
+                        surr2 = clipped_ratio * pg_advantages
                         ppo_loss = -torch.min(surr1, surr2).mean()
 
                         entropy_value = (lat_dist.entropy() + lon_dist.entropy()).mean()
@@ -533,8 +551,8 @@ class GRPOExplorationTrainer:
                         }
                     else:
                         policy_loss, policy_metrics = compute_exploration_loss(
-                            advantages=advantages_t,
-                            log_probs=log_probs,
+                            advantages=pg_advantages,
+                            log_probs=pg_log_probs,
                             lat_dist=lat_dist,
                             lon_dist=lon_dist,
                             entropy_coef=self.config.exploration_entropy_coef,
@@ -594,7 +612,7 @@ class GRPOExplorationTrainer:
                 })
 
         # Flush remaining DiT gradients
-        if dit_accum > 0:
+        if self.train_dit and dit_accum > 0:
             torch.nn.utils.clip_grad_norm_(
                 [p for p in self.policy_model.parameters() if p.requires_grad],
                 max_norm=5.0,
@@ -710,8 +728,130 @@ class GRPOExplorationTrainer:
             f"scene_var_lat={scene_std_lat}, scene_var_lon={scene_std_lon}"
         )
 
+    @torch.no_grad()
+    def evaluate_policy_guided(
+        self,
+        npz_paths: list[str],
+        reward_config: RewardConfig | None = None,
+        label: str = "policy-eval",
+    ) -> dict[str, float]:
+        """Deterministic policy-guided eval: per scene, run the policy with
+        deterministic=True (Beta means → η), generate ONE guided trajectory
+        (noise=0) plus the unguided det trajectory, score both.
+
+        Unlike evaluate_checkpoint (which ignores the policy and is constant
+        when the DiT is frozen), this measures what the explorer actually does.
+        Returns aggregate metrics keyed like evaluate_checkpoint (reward_mean,
+        rb_crossings, collision_rate) plus guidance-specific extras.
+        """
+        if not self.use_explorer:
+            raise ValueError("evaluate_policy_guided requires random_guidance_mode='explorer'")
+        reward_config = reward_config or self.reward_config
+
+        self.policy_model.eval()
+        self.exploration_policy.eval()
+
+        rows: list[dict] = []
+        for npz_path in tqdm(npz_paths, desc=label):
+            try:
+                data = _load_npz(npz_path, self.device)
+            except Exception as e:
+                print(f"  [{label}] skipping {npz_path}: {e}")
+                continue
+            norm_data = {
+                k: v.clone() if isinstance(v, torch.Tensor) else v
+                for k, v in data.items()
+            }
+            norm_data = self.model_args.observation_normalizer(norm_data)
+
+            x_ref_np = generate_reference_trajectory(
+                self.policy_model, self.model_args, norm_data, self.device,
+            )
+            x_ref = torch.from_numpy(x_ref_np).unsqueeze(0).to(self.device)
+            norm_data["reference_trajectory"] = x_ref
+            scene_encoding = run_frozen_encoder(self.policy_model, norm_data)
+
+            policy_output = self.exploration_policy(scene_encoding, x_ref, deterministic=True)
+            eta_lat = (2.0 * policy_output.lat_dist.mean - 1.0).reshape(1)
+            eta_lon = (2.0 * policy_output.lon_dist.mean - 1.0).reshape(1)
+
+            guidance_fns = [
+                GuidanceConfig(
+                    name="lateral", enabled=True, scale=1.0,
+                    params={"lambda_lat": self.lambda_lat, "eta_lat": eta_lat},
+                ),
+                GuidanceConfig(
+                    name="longitudinal", enabled=True, scale=1.0,
+                    params={"lambda_lon": self.lambda_lon, "eta_lon": eta_lon},
+                ),
+            ]
+            set_cfg = GuidanceSetConfig(functions=guidance_fns, global_scale=self.guidance_scale)
+            composer = GuidanceComposer(set_cfg)
+
+            guided_traj = generate_samples(
+                model=self.policy_model, model_args=self.model_args,
+                data=norm_data, noise_scale=0.0, n_samples=1,
+                composer=composer, device=self.device,
+            )[0]
+            det_traj = generate_samples(
+                model=self.policy_model, model_args=self.model_args,
+                data=norm_data, noise_scale=0.0, n_samples=1,
+                composer=None, device=self.device,
+            )[0]
+
+            traj_batch = torch.tensor(
+                np.stack([guided_traj, det_traj]),
+                device=self.device, dtype=torch.float32,
+            )
+            guided_bd, det_bd = compute_reward_batch(traj_batch, data, reward_config)
+            deviation = float(
+                np.linalg.norm(
+                    np.asarray(guided_traj)[:, :2] - np.asarray(det_traj)[:, :2], axis=-1
+                ).mean()
+            )
+            rows.append({
+                "npz_path": npz_path,
+                "eta_lat": float(eta_lat.item()),
+                "eta_lon": float(eta_lon.item()),
+                "reward": guided_bd.total,
+                "det_reward": det_bd.total,
+                "static_crossing": bool(guided_bd.static_crossing),
+                "det_static_crossing": bool(det_bd.static_crossing),
+                "sc_min_dist": float(guided_bd.sc_min_dist),
+                "det_sc_min_dist": float(det_bd.sc_min_dist),
+                "rb_crossing": bool(guided_bd.rb_crossing),
+                "collision": guided_bd.collision_step is not None,
+                "sc_n_stopped": int(guided_bd.sc_n_stopped),
+                "deviation": deviation,
+            })
+
+        self.last_eval_rows = rows  # per-scene detail for eval/viz tools
+        return aggregate_policy_eval(rows)
+
     def save_checkpoint(self, epoch: int, args_dict: dict) -> None:
-        """Save both DiT and exploration policy checkpoints."""
+        """Save both DiT and exploration policy checkpoints.
+
+        With train_dit=False only the exploration policy (+ its optimizer and
+        config) is saved — the frozen DiT is the unchanged input checkpoint.
+        """
+        if not self.train_dit:
+            torch.save(
+                self.exploration_policy.state_dict(),
+                self.run_dir / f"exploration_policy_epoch_{epoch:03d}.pth",
+            )
+            torch.save(
+                self.exploration_policy.state_dict(),
+                self.run_dir / "exploration_policy.pth",
+            )
+            torch.save(
+                self.policy_optimizer.state_dict(),
+                self.run_dir / "policy_optimizer.pth",
+            )
+            self.exploration_policy.config.to_json(
+                self.run_dir / "exploration_policy_config.json"
+            )
+            self.config.to_json(self.run_dir / "grpo_config.json")
+            return
         if self.use_lora:
             from preference_optimization.lora_utils import save_lora_checkpoint
 
@@ -766,6 +906,47 @@ class GRPOExplorationTrainer:
                 epoch_path = self.run_dir / f"epoch_{epoch:03d}.pth"
                 torch.save(checkpoint_data, epoch_path)
                 print(f"  Saved checkpoint: {epoch_path}")
+
+
+def aggregate_policy_eval(rows: list[dict]) -> dict[str, float]:
+    """Aggregate per-scene policy-guided eval rows into summary metrics.
+
+    Keys mirror evaluate_checkpoint (reward_mean, rb_crossings,
+    collision_rate) so run_experiment best-tracking works unchanged, plus
+    guidance-specific extras. Scenes are split into avoidance
+    (sc_n_stopped > 0) vs normal for the per-type |η| inertness metrics.
+    """
+    if not rows:
+        return {
+            "reward_mean": float("-inf"), "rb_crossings": 999,
+            "collision_rate": 1.0, "n_scenes": 0,
+        }
+    avoid = [r for r in rows if r["sc_n_stopped"] > 0]
+    normal = [r for r in rows if r["sc_n_stopped"] == 0]
+
+    def _mean(vals):
+        return float(np.mean(vals)) if len(vals) else 0.0
+
+    out = {
+        "n_scenes": len(rows),
+        "reward_mean": _mean([r["reward"] for r in rows]),
+        "det_reward_mean": _mean([r["det_reward"] for r in rows]),
+        "rb_crossings": int(sum(r["rb_crossing"] for r in rows)),
+        "collision_rate": _mean([float(r["collision"]) for r in rows]),
+        "static_crossings": int(sum(r["static_crossing"] for r in rows)),
+        "det_static_crossings": int(sum(r["det_static_crossing"] for r in rows)),
+        "sc_min_dist_mean": _mean([r["sc_min_dist"] for r in avoid]),
+        "det_sc_min_dist_mean": _mean([r["det_sc_min_dist"] for r in avoid]),
+        "deviation_mean": _mean([r["deviation"] for r in rows]),
+        "deviation_max": float(max((r["deviation"] for r in rows), default=0.0)),
+        "n_avoidance_scenes": len(avoid),
+        "eta_lat_abs_avoid": _mean([abs(r["eta_lat"]) for r in avoid]),
+        "eta_lon_abs_avoid": _mean([abs(r["eta_lon"]) for r in avoid]),
+        "eta_lat_abs_normal": _mean([abs(r["eta_lat"]) for r in normal]),
+        "eta_lon_abs_normal": _mean([abs(r["eta_lon"]) for r in normal]),
+        "deviation_mean_normal": _mean([r["deviation"] for r in normal]),
+    }
+    return out
 
 
 def _empty_metrics() -> dict[str, float]:

--- a/rlvr/guidance_batched.py
+++ b/rlvr/guidance_batched.py
@@ -19,7 +19,6 @@ Provided:
 """
 
 import torch
-
 from diffusion_planner.model.guidance.base import BaseGuidance
 from diffusion_planner.model.guidance.registry import register
 
@@ -226,9 +225,12 @@ def build_head_composer(
 
     Single source of truth for the head-name -> guidance-function mapping
     (lateral / collision / stretch / legacy longitudinal), shared by the
-    eval tools and the closed-loop rollout managers. Defaults are
-    envelope-v2; a legacy lateral+longitudinal trainer config reproduces
-    exactly with lat_scale=1.0, lambda_lat=2.5, lambda_lon=0.25.
+    eval tools and the closed-loop rollout managers. The scale defaults are
+    the v1-envelope calibration (lambda_lat 5.0 / lat_scale 2.0 /
+    col_scale 9.0), matching envelope="v1"; pass envelope="v2" (+ lambda_col,
+    ramp_steps) for the ramped v2 functions. A legacy lateral+longitudinal
+    trainer config reproduces exactly with lat_scale=1.0, lambda_lat=2.5,
+    lambda_lon=0.25.
     """
     from diffusion_planner.model.guidance.composer import GuidanceComposer
     from diffusion_planner.model.guidance.config import (
@@ -479,10 +481,12 @@ class FastGuidanceComposer:
 
     def _all_inert(self) -> bool:
         for fn in self._functions:
-            for attr in ("_eta_lat", "_eta_col"):
+            recognized = False
+            for attr in ("_eta_lat", "_eta_col", "_eta_lon"):
                 v = getattr(fn, attr, None)
                 if v is None:
                     continue
+                recognized = True
                 if isinstance(v, torch.Tensor):
                     if v.abs().max().item() > self._eta_eps:
                         return False
@@ -490,11 +494,17 @@ class FastGuidanceComposer:
                     return False
             stretch = getattr(fn, "_stretch", None)
             if stretch is not None:
+                recognized = True
                 if isinstance(stretch, torch.Tensor):
                     if (stretch - 1.0).abs().max().item() > self._eta_eps:
                         return False
                 elif abs(float(stretch) - 1.0) > self._eta_eps:
                     return False
+            if not recognized:
+                # A function exposing no known eta attribute (e.g. a stock
+                # speed band appended by a caller) must be treated as
+                # active — short-circuiting would silently drop it.
+                return False
         return True
 
     def __call__(self, x_in, t_input, cond, *args, **kwargs):

--- a/rlvr/guidance_batched.py
+++ b/rlvr/guidance_batched.py
@@ -203,3 +203,66 @@ class LateralBatchedGuidance(BaseGuidance):
             w[:, : self._head_protect] = 0.0
             return -(err2 * w).sum(dim=-1) / w.sum(dim=-1).clamp_min(1.0)
         return -err2.mean(dim=-1)
+
+
+def build_head_composer(
+    etas,
+    *,
+    lambda_lat: float = 5.0,
+    lat_scale: float = 2.0,
+    col_scale: float = 9.0,
+    col_range: float = 8.0,
+    lambda_spd: float = 0.2,
+    stretch_scale: float = 1.0,
+    guidance_scale: float = 0.5,
+    head_protect: int = 0,
+    lambda_lon: float = 0.25,
+):
+    """Build a GuidanceComposer from a head->eta dict (scalar or [B] tensor).
+
+    Single source of truth for the head-name -> guidance-function mapping
+    (lateral / collision / stretch / legacy longitudinal), shared by the
+    eval tools and the closed-loop rollout managers. Defaults are
+    envelope-v2; a legacy lateral+longitudinal trainer config reproduces
+    exactly with lat_scale=1.0, lambda_lat=2.5, lambda_lon=0.25.
+    """
+    from diffusion_planner.model.guidance.composer import GuidanceComposer
+    from diffusion_planner.model.guidance.config import (
+        GuidanceConfig,
+        GuidanceSetConfig,
+    )
+
+    hp = int(head_protect)
+    fns = []
+    if "lateral" in etas:
+        if hp > 0:
+            fns.append(GuidanceConfig(
+                name="lateral_batched", enabled=True, scale=lat_scale,
+                params={"lambda_lat": lambda_lat, "eta_lat": etas["lateral"],
+                        "head_protect": hp},
+            ))
+        else:
+            fns.append(GuidanceConfig(
+                name="lateral", enabled=True, scale=lat_scale,
+                params={"lambda_lat": lambda_lat, "eta_lat": etas["lateral"]},
+            ))
+    if "collision" in etas:
+        fns.append(GuidanceConfig(
+            name="collision_swerve_batched", enabled=True, scale=col_scale,
+            params={"eta_col": etas["collision"], "range": col_range,
+                    "head_protect": hp},
+        ))
+    if "stretch" in etas:
+        fns.append(GuidanceConfig(
+            name="speed_stretch_batched", enabled=True, scale=stretch_scale,
+            params={"stretch": 1.0 + lambda_spd * etas["stretch"]},
+        ))
+    if "longitudinal" in etas:
+        # Legacy head (known-broken for speed control; kept so old
+        # lateral+longitudinal configs reproduce bit-for-bit).
+        fns.append(GuidanceConfig(
+            name="longitudinal", enabled=True, scale=1.0,
+            params={"lambda_lon": lambda_lon, "eta_lon": etas["longitudinal"]},
+        ))
+    set_cfg = GuidanceSetConfig(functions=fns, global_scale=guidance_scale)
+    return GuidanceComposer(set_cfg)

--- a/rlvr/guidance_batched.py
+++ b/rlvr/guidance_batched.py
@@ -238,6 +238,11 @@ def build_head_composer(
         GuidanceSetConfig,
     )
 
+    unknown = set(etas) - {"lateral", "collision", "stretch", "longitudinal"}
+    if unknown:
+        raise ValueError(
+            f"unknown guidance head(s) {sorted(unknown)} — a head with no "
+            "function mapping would train/act as a dead head silently")
     hp = int(head_protect)
     fns = []
     if envelope == "v2":
@@ -292,8 +297,8 @@ def build_head_composer(
         ))
     set_cfg = GuidanceSetConfig(functions=fns, global_scale=guidance_scale)
     if fast:
-        # Equivalence-certified (fan battery worst |dtraj| = 0.00000 m both
-        # envelopes; bench: active 2.1x bit-identical, inert ~baseline).
+        # Equivalence-certified against GuidanceComposer (bit-identical
+        # active trajectories; inert frames short-circuit to ~unguided cost).
         return FastGuidanceComposer(set_cfg)
     return GuidanceComposer(set_cfg)
 
@@ -446,7 +451,7 @@ class FastGuidanceComposer:
     """Drop-in faster GuidanceComposer (same classifier_fn interface).
 
     Three measured wins over diffusion_planner's GuidanceComposer, with
-    identical math (see TODO_guidance_latency.md):
+    identical math:
       1. inputs inverse-normalisation cached ONCE per generation (the base
          composer inverse-normalises the full observation dict — lanes,
          neighbours — at EVERY denoise step although it never changes).
@@ -455,11 +460,12 @@ class FastGuidanceComposer:
          no x0-correction model forward, no energy autograd. With an inert
          policy (the common case on a route) the guided generation cost
          collapses to the unguided baseline.
-         CAVEAT: the v1 ``lateral`` head is not mathematically inert at
-         eta=0 — its quadratic energy still pulls toward the reference
-         trajectory. The short-circuit is exact when the reference IS the
-         model's own det trajectory (the standard explorer setup, pull ~ 0);
-         with any other reference the slow composer would apply a residual
+         CAVEAT: the v1 ``lateral`` head AND the v2 ``lateral_ramp``
+         variant are not mathematically inert at eta=0 — their quadratic
+         energies still pull toward the reference trajectory. The
+         short-circuit is exact when the reference IS the model's own det
+         trajectory (the standard explorer setup, pull ~ 0); with any
+         other reference the slow composer would apply a residual
          centering pull this fast path skips.
       3. optional skip_x0_correction: evaluate energies on the solver's
          current x directly instead of running an EXTRA full model forward

--- a/rlvr/guidance_batched.py
+++ b/rlvr/guidance_batched.py
@@ -455,6 +455,12 @@ class FastGuidanceComposer:
          no x0-correction model forward, no energy autograd. With an inert
          policy (the common case on a route) the guided generation cost
          collapses to the unguided baseline.
+         CAVEAT: the v1 ``lateral`` head is not mathematically inert at
+         eta=0 — its quadratic energy still pulls toward the reference
+         trajectory. The short-circuit is exact when the reference IS the
+         model's own det trajectory (the standard explorer setup, pull ~ 0);
+         with any other reference the slow composer would apply a residual
+         centering pull this fast path skips.
       3. optional skip_x0_correction: evaluate energies on the solver's
          current x directly instead of running an EXTRA full model forward
          to refine x0 first. Off by default (changes results slightly —

--- a/rlvr/guidance_batched.py
+++ b/rlvr/guidance_batched.py
@@ -266,3 +266,147 @@ def build_head_composer(
         ))
     set_cfg = GuidanceSetConfig(functions=fns, global_scale=guidance_scale)
     return GuidanceComposer(set_cfg)
+
+
+@register
+class CollisionSwerveV2BatchedGuidance(BaseGuidance):
+    """Bounded-target, support-normalized swerve (v2 of collision_swerve).
+
+    Fixes two defects of ``collision_swerve_batched`` measured on the
+    response-curve probe (gain varied ~40x between scenes):
+      1. The v1 energy ``eta * sum_t(w_t * y_t)`` is LINEAR in y with no
+         target — gradient magnitude scales with how many steps are in
+         range, and it keeps pushing forever (one scene reached +31 m).
+      2. No support normalization — slow approaches (many in-range steps)
+         get a huge cumulative gradient, brief encounters almost none.
+
+    v2 energy (maximised by the solver):
+        E = - sum_t( w_t * (y_t - sign(eta) * lambda_col * |eta|)^2 ) / sum_t(w_t)
+    A given eta now means the SAME bounded target offset in every scene,
+    applied only where the proximity gate w_t is active. eta = 0 keeps the
+    v1 contract: exactly zero energy and gradient.
+
+    Params:
+        eta_col (float | Tensor[B]): signed command in [-1, 1].
+        lambda_col (float): max target lateral offset in metres. Default 3.0.
+        range (float): proximity radius in metres. Default 8.0.
+        head_protect (int): zero weights on the first N future steps. Default 0.
+    """
+
+    name = "collision_swerve_v2_batched"
+    _energy_scale = 10.0
+
+    def __init__(self, config: "GuidanceConfig", **kwargs):  # noqa: F821
+        super().__init__(config)
+        self._eta_col = config.params.get("eta_col", 0.0)
+        self._lambda_col = float(config.params.get("lambda_col", 3.0))
+        self._range = float(config.params.get("range", 8.0))
+        self._head_protect = int(config.params.get("head_protect", 0))
+
+    def _compute(self, x: torch.Tensor, inputs: dict) -> torch.Tensor:
+        B = x.shape[0]
+        device = x.device
+        nb = inputs.get("neighbor_agents_past")
+        ref = inputs.get("reference_trajectory")
+        if nb is None or ref is None:
+            return torch.zeros(B, device=device)
+
+        eta = _as_batch_param(self._eta_col, B, device)
+
+        ego_xy = x[:, 0, 1:, :2]                   # [B, T, 2] (grad kept)
+        T = ego_xy.shape[1]
+        nb_cur = nb[:, :, -1, :4].detach()
+        nb_xy = nb_cur[..., :2]
+        nb_valid = nb_cur.abs().sum(dim=-1) > 0
+        if nb_valid.sum().item() == 0:
+            return torch.zeros(B, device=device)
+
+        # Proximity bump from the (detached) REFERENCE trajectory — using the
+        # current noisy x here would gate on garbage early in denoising.
+        ref = ref[:, :T, :].detach()
+        d = torch.cdist(ref[..., :2], nb_xy)       # [B, T, Pn]
+        big = torch.full_like(d, 1e6)
+        d = torch.where(nb_valid[:, None, :], d, big)
+        w = torch.clamp(1.0 - d / self._range, min=0.0).max(dim=-1).values  # [B, T]
+        if self._head_protect > 0:
+            w = w.clone()
+            w[:, : self._head_protect] = 0.0
+        support = w.sum(dim=-1)                    # [B]
+
+        # Lateral deviation from the reference (handles curved routes),
+        # identical machinery to the stock lateral energy.
+        cos_h = ref[..., 2]
+        sin_h = ref[..., 3]
+        h_norm = (cos_h ** 2 + sin_h ** 2).sqrt().clamp_min(1e-6)
+        n_perp_x, n_perp_y = -sin_h / h_norm, cos_h / h_norm
+        dx = ego_xy[..., 0] - ref[..., 0]
+        dy = ego_xy[..., 1] - ref[..., 1]
+        lateral_proj = n_perp_x * dx + n_perp_y * dy            # [B, T]
+
+        # Ramp-up-and-HOLD target profile: cummax of the proximity gate
+        # rises on approach and holds its peak after passing — the offset is
+        # demanded over the remaining horizon like the (stable) stock
+        # lateral target, instead of a bump that forces return-to-zero
+        # mid-pass (bump variants needed unstable scales to act at all:
+        # weak at scale 8, sign-inverting/divergent at 16).
+        s = torch.cummax(w, dim=-1).values                      # [B, T]
+        target = (self._lambda_col * eta)[:, None] * s          # [B, T]
+        psi = ((lateral_proj - target) ** 2).mean(dim=-1)
+        # eta == 0 -> exactly inert; negligible support -> exactly inert
+        gate = (eta.abs() > 1e-6).float() * (support > 0.05).float()
+        return -psi * gate
+
+
+@register
+class LateralRampBatchedGuidance(BaseGuidance):
+    """Lateral guidance (Eq. 2) with a kinematic feasibility RAMP (v2).
+
+    The stock ``lateral`` energy demands the full lambda*eta offset at EVERY
+    future step including t = 0.1 s — kinematically impossible, producing
+    huge near-field gradients (measured: plan-head distortion, backwards-
+    bent leading points at low speed, scene-dependent gain 2.3-6.8 m at the
+    same eta). v2 ramps the target linearly from 0 to lambda*eta over
+    ``ramp_steps`` future steps, then holds.
+
+    Params:
+        lambda_lat (float): max lateral offset in metres. Default 3.0.
+        eta_lat (float | Tensor[B]): command in [-1, 1].
+        ramp_steps (int): steps to reach the full target. Default 20 (2 s).
+    """
+
+    name = "lateral_ramp_batched"
+    _energy_scale = 10.0
+
+    def __init__(self, config: "GuidanceConfig", **kwargs):  # noqa: F821
+        super().__init__(config)
+        self._lambda_lat = float(config.params.get("lambda_lat", 3.0))
+        self._eta_lat = config.params.get("eta_lat", 0.0)
+        self._ramp_steps = int(config.params.get("ramp_steps", 20))
+
+    def _compute(self, x: torch.Tensor, inputs: dict) -> torch.Tensor:
+        B, P, T_plus1, _ = x.shape
+        T = T_plus1 - 1
+        device = x.device
+        ref = inputs.get("reference_trajectory")
+        if ref is None:
+            return torch.zeros(B, device=device)
+        ref = ref[:, :T, :]
+
+        cos_h = ref[..., 2]
+        sin_h = ref[..., 3]
+        h_norm = (cos_h ** 2 + sin_h ** 2).sqrt().clamp_min(1e-6)
+        cos_h, sin_h = cos_h / h_norm, sin_h / h_norm
+        n_perp_x, n_perp_y = -sin_h, cos_h
+
+        ego_pos = x[:, 0, 1:, :2]
+        dx = ego_pos[..., 0] - ref[..., 0]
+        dy = ego_pos[..., 1] - ref[..., 1]
+        lateral_proj = n_perp_x * dx + n_perp_y * dy        # [B, T]
+
+        eta = _as_batch_param(self._eta_lat, B, device)
+        ramp = torch.arange(1, T + 1, device=device, dtype=torch.float32)
+        ramp = (ramp / max(self._ramp_steps, 1)).clamp(max=1.0)  # [T]
+        target = (self._lambda_lat * eta)[:, None] * ramp[None, :]  # [B, T]
+
+        psi = ((lateral_proj - target) ** 2).mean(dim=-1)
+        return -psi

--- a/rlvr/guidance_batched.py
+++ b/rlvr/guidance_batched.py
@@ -220,7 +220,7 @@ def build_head_composer(
     envelope: str = "v1",
     lambda_col: float = 3.0,
     ramp_steps: int = 20,
-    fast: bool = False,
+    fast: bool = True,
 ):
     """Build a GuidanceComposer from a head->eta dict (scalar or [B] tensor).
 

--- a/rlvr/guidance_batched.py
+++ b/rlvr/guidance_batched.py
@@ -494,6 +494,13 @@ class FastGuidanceComposer:
                     return False
             stretch = getattr(fn, "_stretch", None)
             if stretch is not None:
+                # Stock SpeedGuidance carries _v_low/_v_high and at
+                # stretch==1.0 runs in BAND mode (speed clamping — active
+                # regardless of stretch). Only the dedicated stretch-mode
+                # variants (no band attrs) are inert at 1.0.
+                if (getattr(fn, "_v_low", None) is not None
+                        or getattr(fn, "_v_high", None) is not None):
+                    return False
                 recognized = True
                 if isinstance(stretch, torch.Tensor):
                     if (stretch - 1.0).abs().max().item() > self._eta_eps:
@@ -501,9 +508,8 @@ class FastGuidanceComposer:
                 elif abs(float(stretch) - 1.0) > self._eta_eps:
                     return False
             if not recognized:
-                # A function exposing no known eta attribute (e.g. a stock
-                # speed band appended by a caller) must be treated as
-                # active — short-circuiting would silently drop it.
+                # A function exposing no known eta attribute must be treated
+                # as active — short-circuiting would silently drop it.
                 return False
         return True
 

--- a/rlvr/guidance_batched.py
+++ b/rlvr/guidance_batched.py
@@ -220,6 +220,7 @@ def build_head_composer(
     envelope: str = "v1",
     lambda_col: float = 3.0,
     ramp_steps: int = 20,
+    fast: bool = False,
 ):
     """Build a GuidanceComposer from a head->eta dict (scalar or [B] tensor).
 
@@ -288,6 +289,10 @@ def build_head_composer(
             params={"lambda_lon": lambda_lon, "eta_lon": etas["longitudinal"]},
         ))
     set_cfg = GuidanceSetConfig(functions=fns, global_scale=guidance_scale)
+    if fast:
+        # Equivalence-certified (fan battery worst |dtraj| = 0.00000 m both
+        # envelopes; bench: active 2.1x bit-identical, inert ~baseline).
+        return FastGuidanceComposer(set_cfg)
     return GuidanceComposer(set_cfg)
 
 

--- a/rlvr/guidance_batched.py
+++ b/rlvr/guidance_batched.py
@@ -48,6 +48,10 @@ class CollisionSwerveBatchedGuidance(BaseGuidance):
             magnitude: push strength. 0 = inert (zero energy AND gradient).
         range (float): proximity radius in metres within which the swerve
             activates (centroid gap ego<->neighbour). Default 8.0.
+        head_protect (int): zero the guidance weight on the FIRST N future
+            steps. The closed loop executes the plan head; gradient guidance
+            distorting it stalls the ego (sideways pull eats the first-step
+            forward displacement). Default 0 = original behavior.
 
     Energy (maximised by the solver):
         E = eta_col * Σ_t  w_t * y_t
@@ -64,6 +68,7 @@ class CollisionSwerveBatchedGuidance(BaseGuidance):
         super().__init__(config)
         self._eta_col = config.params.get("eta_col", 0.0)
         self._range = float(config.params.get("range", 8.0))
+        self._head_protect = int(config.params.get("head_protect", 0))
 
     def _compute(self, x: torch.Tensor, inputs: dict) -> torch.Tensor:
         """
@@ -99,6 +104,9 @@ class CollisionSwerveBatchedGuidance(BaseGuidance):
         d = torch.where(nb_valid[:, None, :], d, big)
         w = torch.clamp(1.0 - d / self._range, min=0.0)   # [B, T, Pn]
         w = w.max(dim=-1).values                          # [B, T]
+        if self._head_protect > 0:
+            w = w.clone()
+            w[:, : self._head_protect] = 0.0
 
         y = ego_xy[..., 1]                                # [B, T] lateral, +y = left
         reward = (eta[:, None] * w.detach() * y).sum(dim=-1)  # [B]
@@ -141,3 +149,57 @@ class SpeedStretchBatchedGuidance(BaseGuidance):
         correction = disp * (stretch[:, None, None] - 1.0)
         reward = torch.sum(correction.detach() * pos[:, 1:, :2], dim=(1, 2))
         return reward
+
+
+@register
+class LateralBatchedGuidance(BaseGuidance):
+    """PlannerRFT Eq.2 lateral guidance with head protection.
+
+    Identical energy to the stock ``lateral`` (which already takes [B] eta)
+    EXCEPT the first ``head_protect`` future steps carry zero weight — the
+    closed loop executes the plan head, and bending it sideways stalls the
+    ego. head_protect=0 reproduces the stock function exactly.
+
+    Params: lambda_lat (float), eta_lat (float | Tensor[B]),
+            head_protect (int, default 0).
+    """
+
+    name = "lateral_batched"
+    _energy_scale = 10.0
+
+    def __init__(self, config: "GuidanceConfig", **kwargs):  # noqa: F821
+        super().__init__(config)
+        self._lambda_lat = config.params.get("lambda_lat", 3.0)
+        self._eta_lat = config.params.get("eta_lat", 0.0)
+        self._head_protect = int(config.params.get("head_protect", 0))
+
+    def _compute(self, x: torch.Tensor, inputs: dict) -> torch.Tensor:
+        B, P, T_plus1, _ = x.shape
+        T = T_plus1 - 1
+        device = x.device
+        ref = inputs.get("reference_trajectory")
+        if ref is None:
+            return torch.zeros(B, device=device)
+        ref = ref[:, :T, :]
+
+        cos_h = ref[..., 2]
+        sin_h = ref[..., 3]
+        h_norm = (cos_h ** 2 + sin_h ** 2).sqrt().clamp_min(1e-6)
+        n_perp_x = -sin_h / h_norm
+        n_perp_y = cos_h / h_norm
+
+        ego_pos = x[:, 0, 1:, :2]
+        dx = ego_pos[..., 0] - ref[..., 0]
+        dy = ego_pos[..., 1] - ref[..., 1]
+        lateral_proj = n_perp_x * dx + n_perp_y * dy  # [B, T]
+
+        target = self._lambda_lat * self._eta_lat
+        if isinstance(target, torch.Tensor) and target.dim() >= 1:
+            target = target.unsqueeze(-1)
+
+        err2 = (lateral_proj - target) ** 2  # [B, T]
+        if self._head_protect > 0:
+            w = torch.ones_like(err2)
+            w[:, : self._head_protect] = 0.0
+            return -(err2 * w).sum(dim=-1) / w.sum(dim=-1).clamp_min(1.0)
+        return -err2.mean(dim=-1)

--- a/rlvr/guidance_batched.py
+++ b/rlvr/guidance_batched.py
@@ -1,0 +1,143 @@
+"""Per-sample (batched) guidance functions for explorer-driven generation.
+
+These live OUTSIDE ``diffusion_planner/`` (read-only) but register into the
+same guidance registry, following the ``guidance_gui/custom_guidance.py``
+pattern. They differ from their scalar counterparts in ONE way: the action
+parameter may be a ``[B]`` tensor, giving each batch element its own guidance
+strength — required when K explorer samples are generated in a single batch.
+
+Provided:
+    collision_swerve_batched -- directional, proximity-gated lateral swerve
+        with a SIGNED per-sample ``eta_col``: +1 = full swerve LEFT,
+        -1 = full swerve RIGHT (ego frame, +y = left — note the Scene Branch
+        Editor slider shows the SCREEN direction, where + is right),
+        0 = exactly inert (zero energy, zero gradient).
+    speed_stretch_batched -- per-sample displacement stretch: ``stretch`` < 1
+        slows/shortens the trajectory, > 1 speeds it up, 1 = inert. Same
+        surrogate-gradient formulation as the scalar ``speed`` guidance's
+        stretch mode, without its scalar-only ``abs(stretch - 1)`` branch.
+"""
+
+import torch
+
+from diffusion_planner.model.guidance.base import BaseGuidance
+from diffusion_planner.model.guidance.registry import register
+
+
+def _as_batch_param(value, B: int, device) -> torch.Tensor:
+    """Normalize a scalar-or-[B]-tensor param to a [B] tensor."""
+    if isinstance(value, torch.Tensor):
+        if value.dim() == 0:
+            return value.reshape(1).expand(B).to(device)
+        if value.shape[0] != B:
+            raise ValueError(
+                f"batched guidance param has shape {tuple(value.shape)}, "
+                f"expected scalar or [{B}]"
+            )
+        return value.to(device)
+    return torch.full((B,), float(value), device=device)
+
+
+@register
+class CollisionSwerveBatchedGuidance(BaseGuidance):
+    """Directional, proximity-gated lateral swerve with per-sample signed eta.
+
+    Params:
+        eta_col (float | Tensor[B]): signed swerve command in [-1, 1].
+            sign: +1 = swerve LEFT, -1 = swerve RIGHT (ego frame, +y = left).
+            magnitude: push strength. 0 = inert (zero energy AND gradient).
+        range (float): proximity radius in metres within which the swerve
+            activates (centroid gap ego<->neighbour). Default 8.0.
+
+    Energy (maximised by the solver):
+        E = eta_col * Σ_t  w_t * y_t
+    where y_t is the ego lateral position at future step t and
+    w_t = max(0, 1 - d_t / range) is the (detached) proximity to the nearest
+    valid neighbour: a clean lateral push toward the chosen side, strongest
+    next to the obstacle, self-gating to zero when no neighbour is in range.
+    """
+
+    name = "collision_swerve_batched"
+    _energy_scale = 1.0
+
+    def __init__(self, config: "GuidanceConfig", **kwargs):  # noqa: F821
+        super().__init__(config)
+        self._eta_col = config.params.get("eta_col", 0.0)
+        self._range = float(config.params.get("range", 8.0))
+
+    def _compute(self, x: torch.Tensor, inputs: dict) -> torch.Tensor:
+        """
+        x: [B, P, T+1, 4] physical ego-centric metres.
+        inputs: observation dict in physical units (needs neighbor_agents_past).
+
+        Returns [B] energy (higher = more displacement toward the chosen side
+        near obstacles).
+        """
+        B = x.shape[0]
+        device = x.device
+
+        nb = inputs.get("neighbor_agents_past")
+        if nb is None:
+            return torch.zeros(B, device=device)
+
+        eta = _as_batch_param(self._eta_col, B, device)
+
+        # Ego future positions (keep grad on xy).
+        ego_xy = x[:, 0, 1:, :2]  # [B, T, 2]
+
+        # Static neighbour current positions + validity mask.
+        nb_cur = nb[:, :, -1, :4].detach()         # [B, Pn, 4]
+        nb_xy = nb_cur[..., :2]                    # [B, Pn, 2]
+        nb_valid = nb_cur.abs().sum(dim=-1) > 0    # [B, Pn]
+
+        if nb_valid.sum().item() == 0:
+            return torch.zeros(B, device=device)
+
+        # Centroid gap ego_t <-> neighbour (detached -> proximity gate only).
+        d = torch.cdist(ego_xy.detach(), nb_xy)    # [B, T, Pn]
+        big = torch.full_like(d, 1e6)
+        d = torch.where(nb_valid[:, None, :], d, big)
+        w = torch.clamp(1.0 - d / self._range, min=0.0)   # [B, T, Pn]
+        w = w.max(dim=-1).values                          # [B, T]
+
+        y = ego_xy[..., 1]                                # [B, T] lateral, +y = left
+        reward = (eta[:, None] * w.detach() * y).sum(dim=-1)  # [B]
+        return reward
+
+
+@register
+class SpeedStretchBatchedGuidance(BaseGuidance):
+    """Per-sample trajectory stretch (tensor-safe ``speed`` stretch mode).
+
+    Params:
+        stretch (float | Tensor[B]): per-step displacement scale factor.
+            < 1 = slow down / shorten, > 1 = speed up, 1 = inert (the
+            correction is exactly zero, unlike the scalar ``speed`` guidance
+            whose stretch mode falls back to band clamping at 1.0).
+
+    Surrogate gradient: correction = disp * (stretch - 1), energy =
+    dot(correction.detach(), pos) so grad_x(E) = correction.
+    """
+
+    name = "speed_stretch_batched"
+    _energy_scale = 1.0
+
+    def __init__(self, config: "GuidanceConfig", **kwargs):  # noqa: F821
+        super().__init__(config)
+        self._stretch = config.params.get("stretch", 1.0)
+
+    def _compute(self, x: torch.Tensor, inputs: dict) -> torch.Tensor:
+        """
+        x: [B, P, T+1, 4] physical ego-centric metres.
+
+        Returns [B] surrogate energy whose gradient pushes each point along
+        its travel direction by (stretch - 1) * displacement.
+        """
+        B = x.shape[0]
+        stretch = _as_batch_param(self._stretch, B, x.device)
+
+        pos = x[:, 0, 1:, :2]                    # [B, T, 2]
+        disp = pos[:, 1:, :] - pos[:, :-1, :]    # [B, T-1, 2]
+        correction = disp * (stretch[:, None, None] - 1.0)
+        reward = torch.sum(correction.detach() * pos[:, 1:, :2], dim=(1, 2))
+        return reward

--- a/rlvr/guidance_batched.py
+++ b/rlvr/guidance_batched.py
@@ -433,3 +433,102 @@ class LateralRampBatchedGuidance(BaseGuidance):
 
         psi = ((lateral_proj - target) ** 2).mean(dim=-1)
         return -psi
+
+
+class FastGuidanceComposer:
+    """Drop-in faster GuidanceComposer (same classifier_fn interface).
+
+    Three measured wins over diffusion_planner's GuidanceComposer, with
+    identical math (see TODO_guidance_latency.md):
+      1. inputs inverse-normalisation cached ONCE per generation (the base
+         composer inverse-normalises the full observation dict — lanes,
+         neighbours — at EVERY denoise step although it never changes).
+      2. eta~0 short-circuit: if every active function reports an inert
+         command (|eta| < eta_eps), return a zero surrogate immediately —
+         no x0-correction model forward, no energy autograd. With an inert
+         policy (the common case on a route) the guided generation cost
+         collapses to the unguided baseline.
+      3. optional skip_x0_correction: evaluate energies on the solver's
+         current x directly instead of running an EXTRA full model forward
+         to refine x0 first. Off by default (changes results slightly —
+         enable only after the equivalence battery passes).
+
+    Construction mirrors GuidanceComposer (GuidanceSetConfig), so
+    build_head_composer can emit either.
+    """
+
+    def __init__(self, set_config, eta_eps: float = 1e-3,
+                 skip_x0_correction: bool = False, **build_kwargs):
+        from diffusion_planner.model.guidance.registry import build as _build
+        self._set_config = set_config
+        self._functions = [
+            _build(fn_cfg, **build_kwargs)
+            for fn_cfg in set_config.active_functions()
+        ]
+        self._eta_eps = float(eta_eps)
+        self._skip_x0 = bool(skip_x0_correction)
+        self._inputs_phys = None  # per-generation cache
+
+    def reset_cache(self):
+        self._inputs_phys = None
+
+    def _all_inert(self) -> bool:
+        for fn in self._functions:
+            for attr in ("_eta_lat", "_eta_col"):
+                v = getattr(fn, attr, None)
+                if v is None:
+                    continue
+                if isinstance(v, torch.Tensor):
+                    if v.abs().max().item() > self._eta_eps:
+                        return False
+                elif abs(float(v)) > self._eta_eps:
+                    return False
+            stretch = getattr(fn, "_stretch", None)
+            if stretch is not None:
+                if isinstance(stretch, torch.Tensor):
+                    if (stretch - 1.0).abs().max().item() > self._eta_eps:
+                        return False
+                elif abs(float(stretch) - 1.0) > self._eta_eps:
+                    return False
+        return True
+
+    def __call__(self, x_in, t_input, cond, *args, **kwargs):
+        B = x_in.shape[0]
+        if self._all_inert():
+            # zero surrogate with a real graph so the solver's autograd
+            # produces an (all-zero) gradient of the right shape
+            return (x_in * 0.0).sum()
+
+        state_normalizer = kwargs["state_normalizer"]
+        P = x_in.shape[1]
+        x_4d = x_in.reshape(B, P, -1, 4)
+        if self._skip_x0:
+            x_corrected = x_4d
+        else:
+            model = kwargs["model"]
+            model_condition = kwargs["model_condition"]
+            x_fix = model(x_4d, t_input, **model_condition).detach() - x_4d.detach()
+            x_fix[:, :, 0] = 0.0
+            x_corrected = x_4d + x_fix
+
+        x_phys = state_normalizer.inverse(x_corrected.detach())
+        if self._inputs_phys is None:
+            self._inputs_phys = kwargs["observation_normalizer"].inverse(
+                kwargs["inputs"])
+        inputs = self._inputs_phys
+
+        t_scalar = t_input.reshape(B, -1)[:, 0] if t_input.dim() > 1 else t_input
+        x_phys_grad = x_phys.detach().requires_grad_(True)
+        raw_energy = torch.zeros(B, device=x_in.device)
+        for fn in self._functions:
+            e = fn.energy(x_phys_grad, t_scalar, inputs)
+            if torch.isnan(e).any():
+                continue
+            raw_energy = raw_energy + e
+        if raw_energy.requires_grad:
+            grad_phys = torch.autograd.grad(raw_energy.sum(), x_phys_grad)[0]
+        else:
+            grad_phys = torch.zeros_like(x_phys_grad)
+        std = state_normalizer.std.to(grad_phys.device)
+        grad_flat = (grad_phys * std).detach().reshape(x_in.shape)
+        return (grad_flat * x_in).sum()

--- a/rlvr/guidance_batched.py
+++ b/rlvr/guidance_batched.py
@@ -217,6 +217,9 @@ def build_head_composer(
     guidance_scale: float = 0.5,
     head_protect: int = 0,
     lambda_lon: float = 0.25,
+    envelope: str = "v1",
+    lambda_col: float = 3.0,
+    ramp_steps: int = 20,
 ):
     """Build a GuidanceComposer from a head->eta dict (scalar or [B] tensor).
 
@@ -234,24 +237,44 @@ def build_head_composer(
 
     hp = int(head_protect)
     fns = []
-    if "lateral" in etas:
+    if envelope == "v2":
+        # v2 set: ramped lateral target + ramp-and-hold bounded swerve.
+        # head_protect is not implemented for v2 (the ramp already spares
+        # the plan head) — fail loudly rather than silently ignore it.
         if hp > 0:
+            raise ValueError("head_protect is a v1-envelope option")
+        if "lateral" in etas:
             fns.append(GuidanceConfig(
-                name="lateral_batched", enabled=True, scale=lat_scale,
+                name="lateral_ramp_batched", enabled=True, scale=lat_scale,
                 params={"lambda_lat": lambda_lat, "eta_lat": etas["lateral"],
+                        "ramp_steps": ramp_steps},
+            ))
+        if "collision" in etas:
+            fns.append(GuidanceConfig(
+                name="collision_swerve_v2_batched", enabled=True,
+                scale=col_scale,
+                params={"eta_col": etas["collision"], "lambda_col": lambda_col,
+                        "range": col_range},
+            ))
+    else:
+        if "lateral" in etas:
+            if hp > 0:
+                fns.append(GuidanceConfig(
+                    name="lateral_batched", enabled=True, scale=lat_scale,
+                    params={"lambda_lat": lambda_lat, "eta_lat": etas["lateral"],
+                            "head_protect": hp},
+                ))
+            else:
+                fns.append(GuidanceConfig(
+                    name="lateral", enabled=True, scale=lat_scale,
+                    params={"lambda_lat": lambda_lat, "eta_lat": etas["lateral"]},
+                ))
+        if "collision" in etas:
+            fns.append(GuidanceConfig(
+                name="collision_swerve_batched", enabled=True, scale=col_scale,
+                params={"eta_col": etas["collision"], "range": col_range,
                         "head_protect": hp},
             ))
-        else:
-            fns.append(GuidanceConfig(
-                name="lateral", enabled=True, scale=lat_scale,
-                params={"lambda_lat": lambda_lat, "eta_lat": etas["lateral"]},
-            ))
-    if "collision" in etas:
-        fns.append(GuidanceConfig(
-            name="collision_swerve_batched", enabled=True, scale=col_scale,
-            params={"eta_col": etas["collision"], "range": col_range,
-                    "head_protect": hp},
-        ))
     if "stretch" in etas:
         fns.append(GuidanceConfig(
             name="speed_stretch_batched", enabled=True, scale=stretch_scale,

--- a/rlvr/test_exploration_trainer.py
+++ b/rlvr/test_exploration_trainer.py
@@ -77,7 +77,7 @@ def _make_trainer(tmp_path, config=None, dit_optimizer=None):
     )
 
 
-def _make_group(advantages, eta_lat_01=None, eta_lon_01=None):
+def _make_group(advantages, heads=("lateral", "longitudinal")):
     eta = torch.tensor([0.5, 0.3, 0.7, 0.6])
     return {
         "npz_path": "fake.npz",
@@ -90,8 +90,7 @@ def _make_group(advantages, eta_lat_01=None, eta_lon_01=None):
         "det_trajectory": np.zeros((FUTURE_LEN, 4), dtype=np.float32),
         "scene_encoding": torch.randn(1, 5, ENC_DIM),
         "x_ref": torch.randn(1, FUTURE_LEN, 4),
-        "eta_lat_01": eta_lat_01 if eta_lat_01 is not None else eta.clone(),
-        "eta_lon_01": eta_lon_01 if eta_lon_01 is not None else eta.clone(),
+        "eta_01": {h: eta.clone() for h in heads},
     }
 
 
@@ -191,10 +190,12 @@ def test_frozen_dit_unchanged_policy_updates(tmp_path):
 def _capture_loss_args(monkeypatch, calls):
     import rlvr.grpo_exploration_trainer as get_mod
 
-    def fake_loss(advantages, log_probs, lat_dist, lon_dist, entropy_coef, kl_coef):
+    def fake_loss(advantages, log_probs, dists=None, entropy_coef=0.05,
+                  kl_coef=0.01, action_cost_coef=0.0, **kwargs):
         calls["advantages"] = advantages.detach().clone()
         calls["n_log_probs"] = log_probs.shape[0]
-        loss = log_probs.sum() * 0.0 + lat_dist.mean.sum() * 0.0
+        anchor = sum(d.mean.sum() for d in dists.values()) if dists else 0.0
+        loss = log_probs.sum() * 0.0 + anchor * 0.0
         return loss, {"exploration_total_loss": 0.0}
 
     monkeypatch.setattr(get_mod, "compute_exploration_loss", fake_loss)
@@ -287,3 +288,40 @@ def test_aggregate_policy_eval_empty():
     out = aggregate_policy_eval([])
     assert out["reward_mean"] == float("-inf")
     assert out["n_scenes"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Head-spec composer (multi-head trainer path)
+# ---------------------------------------------------------------------------
+
+def test_collision_head_trainer(tmp_path):
+    """Trainer with heads=['lateral','collision'] trains the policy and
+    builds collision_swerve_batched guidance configs."""
+    cfg = _make_config(exploration_heads=["lateral", "collision"],
+                       exploration_col_scale=6.0, exploration_lat_scale=1.5)
+    trainer = _make_trainer(tmp_path, cfg)
+    assert trainer.heads == ["lateral", "collision"]
+
+    fns = trainer._build_guidance_fns({
+        "lateral": torch.zeros(K), "collision": torch.zeros(K),
+    })
+    assert [f.name for f in fns] == ["lateral", "collision_swerve_batched"]
+    assert fns[0].scale == 1.5 and fns[1].scale == 6.0
+
+    policy_before = {k: v.clone() for k, v in trainer.exploration_policy.state_dict().items()}
+    group = _make_group([0.0, 1.0, -1.0, 0.5], heads=("lateral", "collision"))
+    metrics = trainer.train_on_groups([group], epoch=1)
+    changed = any(
+        not torch.equal(v, policy_before[k])
+        for k, v in trainer.exploration_policy.state_dict().items()
+    )
+    assert changed
+    assert "exploration_eta_collision_mean" in metrics
+
+
+def test_unknown_head_raises(tmp_path):
+    trainer = _make_trainer(tmp_path, _make_config(
+        exploration_heads=["lateral", "warp_drive"]))
+    with pytest.raises(ValueError, match="unknown exploration head"):
+        trainer._build_guidance_fns({"lateral": torch.zeros(K),
+                                     "warp_drive": torch.zeros(K)})

--- a/rlvr/test_exploration_trainer.py
+++ b/rlvr/test_exploration_trainer.py
@@ -1,0 +1,289 @@
+"""Unit tests for GRPOExplorationTrainer frozen-DiT / policy-only fixes.
+
+Covers:
+- reward_config_from_grpo propagates every shared field (incl. the sc_*
+  static-collision family the old hand-copied list dropped)
+- train_dit=False config validation + trainer guard
+- frozen-DiT training: DiT params untouched, explorer params update
+- pinned zero-eta slot 0 excluded from the log-prob policy gradient
+- policy-only checkpoint round-trip
+- aggregate_policy_eval metric aggregation
+
+All tests are CPU-only and use a stub DiT (the real model is never invoked
+because train_dit=False skips the DiT loss and tests call train_on_groups
+with pre-built groups).
+"""
+
+from dataclasses import fields as dc_fields
+
+import numpy as np
+import pytest
+import torch
+from torch import nn
+
+from exploration_policy.model import ExplorationPolicy, ExplorationPolicyConfig
+from rlvr.grpo_config import GRPOConfig
+from rlvr.grpo_exploration_trainer import (
+    GRPOExplorationTrainer,
+    aggregate_policy_eval,
+    reward_config_from_grpo,
+)
+from rlvr.reward import RewardConfig
+
+DEVICE = torch.device("cpu")
+HIDDEN = 16
+ENC_DIM = 32
+FUTURE_LEN = 8
+K = 4
+
+
+class _StubArgs:
+    hidden_dim = ENC_DIM
+    future_len = FUTURE_LEN
+
+
+class _StubDiT(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc = nn.Linear(4, 4)
+
+
+def _make_config(**overrides) -> GRPOConfig:
+    base = dict(
+        use_exploration_policy=True,
+        train_dit=False,
+        use_lora=False,
+        random_guidance_mode="explorer",
+        num_generations=K,
+        noise_scale_range=[0.0, 0.0],
+        exploration_hidden_dim=HIDDEN,
+        exploration_n_attn_heads=2,
+        exploration_lr=1e-2,
+    )
+    base.update(overrides)
+    return GRPOConfig(**base)
+
+
+def _make_trainer(tmp_path, config=None, dit_optimizer=None):
+    config = config or _make_config()
+    return GRPOExplorationTrainer(
+        policy_model=_StubDiT(),
+        model_args=_StubArgs(),
+        dit_optimizer=dit_optimizer,
+        device=DEVICE,
+        run_dir=tmp_path,
+        config=config,
+        use_lora=False,
+    )
+
+
+def _make_group(advantages, eta_lat_01=None, eta_lon_01=None):
+    eta = torch.tensor([0.5, 0.3, 0.7, 0.6])
+    return {
+        "npz_path": "fake.npz",
+        "data": {},
+        "norm_data": {},
+        "trajectories": [np.zeros((FUTURE_LEN, 4), dtype=np.float32) for _ in range(K)],
+        "reward_breakdowns": None,
+        "advantages": np.asarray(advantages, dtype=np.float32),
+        "policy_meta": None,
+        "det_trajectory": np.zeros((FUTURE_LEN, 4), dtype=np.float32),
+        "scene_encoding": torch.randn(1, 5, ENC_DIM),
+        "x_ref": torch.randn(1, FUTURE_LEN, 4),
+        "eta_lat_01": eta_lat_01 if eta_lat_01 is not None else eta.clone(),
+        "eta_lon_01": eta_lon_01 if eta_lon_01 is not None else eta.clone(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# 0a. reward config field propagation
+# ---------------------------------------------------------------------------
+
+def test_reward_config_from_grpo_propagates_all_shared_fields():
+    cfg = _make_config(
+        static_collision_enabled=True,
+        sc_gate_enabled=True,
+        sc_penalty_mode="survival",
+        sc_near_scale=15.0,
+        sc_wide_scale=5.0,
+        sc_cont_scale=1.0,
+        sc_cross_thresh=0.25,
+        sc_near_thresh=0.45,
+        sc_wide_thresh=0.75,
+        sc_cont_thresh=1.05,
+        sc_neighbor_vel_thresh=0.15,
+        sc_neighbor_disp_thresh=0.55,
+        sc_ego_min_speed=1.1,
+        progress_norm_scale=33.0,
+        w_centerline=3.0,
+        stopped_penalty=100.0,
+    )
+    rc = reward_config_from_grpo(cfg)
+
+    shared = {f.name for f in dc_fields(RewardConfig)} & {f.name for f in dc_fields(GRPOConfig)}
+    assert len(shared) >= 50, f"expected ~52 shared fields, got {len(shared)}"
+    for name in sorted(shared):
+        assert getattr(rc, name) == getattr(cfg, name), f"field {name} not propagated"
+
+    # The fields the old hand-copied list silently dropped:
+    assert rc.static_collision_enabled is True
+    assert rc.sc_gate_enabled is True
+    assert rc.sc_near_scale == 15.0
+    assert rc.sc_cross_thresh == 0.25
+    assert rc.progress_norm_scale == 33.0
+
+
+def test_trainer_uses_full_reward_config(tmp_path):
+    cfg = _make_config(static_collision_enabled=True, sc_gate_enabled=True, sc_near_scale=15.0)
+    trainer = _make_trainer(tmp_path, cfg)
+    assert trainer.reward_config.static_collision_enabled is True
+    assert trainer.reward_config.sc_gate_enabled is True
+    assert trainer.reward_config.sc_near_scale == 15.0
+
+
+# ---------------------------------------------------------------------------
+# 0b. train_dit flag
+# ---------------------------------------------------------------------------
+
+def test_train_dit_false_requires_exploration_policy():
+    with pytest.raises(ValueError, match="train_dit=False"):
+        _make_config(use_exploration_policy=False)
+
+
+def test_train_dit_false_rejects_lora():
+    with pytest.raises(ValueError, match="use_lora"):
+        _make_config(use_lora=True)
+
+
+def test_train_dit_false_rejects_non_explorer_mode():
+    with pytest.raises(ValueError, match="random_guidance_mode"):
+        _make_config(random_guidance_mode="uniform")
+
+
+def test_trainer_requires_dit_optimizer_when_training_dit(tmp_path):
+    cfg = _make_config(train_dit=True)
+    with pytest.raises(ValueError, match="dit_optimizer"):
+        _make_trainer(tmp_path, cfg, dit_optimizer=None)
+
+
+def test_frozen_dit_unchanged_policy_updates(tmp_path):
+    trainer = _make_trainer(tmp_path)
+    dit_before = {k: v.clone() for k, v in trainer.policy_model.state_dict().items()}
+    policy_before = {k: v.clone() for k, v in trainer.exploration_policy.state_dict().items()}
+
+    group = _make_group([0.0, 1.0, -1.0, 0.5])
+    metrics = trainer.train_on_groups([group], epoch=1)
+
+    for k, v in trainer.policy_model.state_dict().items():
+        assert torch.equal(v, dit_before[k]), f"frozen DiT param {k} changed"
+    changed = any(
+        not torch.equal(v, policy_before[k])
+        for k, v in trainer.exploration_policy.state_dict().items()
+    )
+    assert changed, "exploration policy params did not update"
+    assert "exploration_total_loss" in metrics
+
+
+# ---------------------------------------------------------------------------
+# 0d. pinned zero-eta sample excluded from policy gradient
+# ---------------------------------------------------------------------------
+
+def _capture_loss_args(monkeypatch, calls):
+    import rlvr.grpo_exploration_trainer as get_mod
+
+    def fake_loss(advantages, log_probs, lat_dist, lon_dist, entropy_coef, kl_coef):
+        calls["advantages"] = advantages.detach().clone()
+        calls["n_log_probs"] = log_probs.shape[0]
+        loss = log_probs.sum() * 0.0 + lat_dist.mean.sum() * 0.0
+        return loss, {"exploration_total_loss": 0.0}
+
+    monkeypatch.setattr(get_mod, "compute_exploration_loss", fake_loss)
+
+
+def test_pinned_slot_excluded_from_policy_gradient(tmp_path, monkeypatch):
+    calls = {}
+    _capture_loss_args(monkeypatch, calls)
+    trainer = _make_trainer(tmp_path, _make_config(exploration_pin_zero_eta=True))
+    advantages = [9.9, 1.0, -1.0, 0.5]  # huge pinned-slot advantage must be ignored
+    trainer.train_on_groups([_make_group(advantages)], epoch=1)
+
+    assert calls["n_log_probs"] == K - 1
+    assert torch.allclose(
+        calls["advantages"],
+        torch.tensor(advantages[1:], dtype=torch.float32),
+    )
+
+
+def test_no_pin_uses_all_samples(tmp_path, monkeypatch):
+    calls = {}
+    _capture_loss_args(monkeypatch, calls)
+    trainer = _make_trainer(tmp_path, _make_config(exploration_pin_zero_eta=False))
+    trainer.train_on_groups([_make_group([0.0, 1.0, -1.0, 0.5])], epoch=1)
+    assert calls["n_log_probs"] == K
+
+
+# ---------------------------------------------------------------------------
+# 0e. policy-only checkpointing
+# ---------------------------------------------------------------------------
+
+def test_policy_only_checkpoint_roundtrip(tmp_path):
+    trainer = _make_trainer(tmp_path)
+    trainer.save_checkpoint(epoch=3, args_dict={})
+
+    epoch_path = tmp_path / "exploration_policy_epoch_003.pth"
+    assert epoch_path.exists()
+    assert (tmp_path / "exploration_policy.pth").exists()
+    assert (tmp_path / "policy_optimizer.pth").exists()
+    assert (tmp_path / "exploration_policy_config.json").exists()
+    assert (tmp_path / "grpo_config.json").exists()
+    # Frozen DiT must NOT be serialized
+    assert not (tmp_path / "latest.pth").exists()
+
+    state = torch.load(epoch_path, map_location=DEVICE)
+    fresh = ExplorationPolicy(
+        ExplorationPolicyConfig(
+            hidden_dim=HIDDEN, n_attn_heads=2, encoder_hidden_dim=ENC_DIM,
+        ),
+        ref_seq_len=FUTURE_LEN,
+    )
+    fresh.load_state_dict(state, strict=True)
+
+
+# ---------------------------------------------------------------------------
+# 0c. eval aggregation helper
+# ---------------------------------------------------------------------------
+
+def _row(sc_n_stopped, eta_lat, static_crossing=False, det_static_crossing=True,
+         deviation=0.1, sc_min_dist=0.5):
+    return {
+        "npz_path": "x.npz", "eta_lat": eta_lat, "eta_lon": 0.0,
+        "reward": 1.0, "det_reward": 0.0,
+        "static_crossing": static_crossing, "det_static_crossing": det_static_crossing,
+        "sc_min_dist": sc_min_dist, "det_sc_min_dist": 0.1,
+        "rb_crossing": False, "collision": False,
+        "sc_n_stopped": sc_n_stopped, "deviation": deviation,
+    }
+
+
+def test_aggregate_policy_eval_splits_scene_types():
+    rows = [
+        _row(sc_n_stopped=2, eta_lat=0.8),                          # avoidance
+        _row(sc_n_stopped=1, eta_lat=-0.6, static_crossing=True),   # avoidance
+        _row(sc_n_stopped=0, eta_lat=0.05, det_static_crossing=False),  # normal
+        _row(sc_n_stopped=0, eta_lat=-0.01, det_static_crossing=False, deviation=0.02),
+    ]
+    out = aggregate_policy_eval(rows)
+    assert out["n_scenes"] == 4
+    assert out["n_avoidance_scenes"] == 2
+    assert out["static_crossings"] == 1
+    assert out["det_static_crossings"] == 2
+    assert out["eta_lat_abs_avoid"] == pytest.approx(0.7)
+    assert out["eta_lat_abs_normal"] == pytest.approx(0.03)
+    assert out["rb_crossings"] == 0
+    assert out["collision_rate"] == 0.0
+
+
+def test_aggregate_policy_eval_empty():
+    out = aggregate_policy_eval([])
+    assert out["reward_mean"] == float("-inf")
+    assert out["n_scenes"] == 0

--- a/rlvr/test_guidance_batched.py
+++ b/rlvr/test_guidance_batched.py
@@ -140,7 +140,7 @@ def test_stretch_batched_per_sample():
 def test_lateral_batched_matches_stock_when_unprotected():
     from diffusion_planner.model.guidance.lateral_guidance import LateralGuidance
     x = _make_x()
-    ref = torch.zeros(2 if False else B, T, 4); ref[..., 2] = 1.0
+    ref = torch.zeros(B, T, 4); ref[..., 2] = 1.0
     inputs = {"reference_trajectory": ref}
     for eta in (0.0, 0.5, torch.tensor([0.3, -0.7, 1.0])):
         stock = LateralGuidance(GuidanceConfig(name="lateral",

--- a/rlvr/test_guidance_batched.py
+++ b/rlvr/test_guidance_batched.py
@@ -135,3 +135,27 @@ def test_stretch_batched_per_sample():
     assert (fwd_grad[0] <= 0).all() and fwd_grad[0].sum() < 0   # slow down
     assert torch.all(grad[1] == 0)                              # inert
     assert (fwd_grad[2] >= 0).all() and fwd_grad[2].sum() > 0   # speed up
+
+
+def test_lateral_batched_matches_stock_when_unprotected():
+    from diffusion_planner.model.guidance.lateral_guidance import LateralGuidance
+    x = _make_x()
+    ref = torch.zeros(2 if False else B, T, 4); ref[..., 2] = 1.0
+    inputs = {"reference_trajectory": ref}
+    for eta in (0.0, 0.5, torch.tensor([0.3, -0.7, 1.0])):
+        stock = LateralGuidance(GuidanceConfig(name="lateral",
+                                params={"lambda_lat": 4.0, "eta_lat": eta}))
+        mine = _swerve("lateral_batched", lambda_lat=4.0, eta_lat=eta, head_protect=0)
+        assert torch.allclose(stock._compute(x, inputs), mine._compute(x, inputs), atol=1e-6)
+
+
+def test_head_protect_zeroes_early_gradient():
+    x = _make_x(requires_grad=True)
+    ref = torch.zeros(B, T, 4); ref[..., 2] = 1.0
+    inputs = {"reference_trajectory": ref, **_make_inputs()}
+    lat = _swerve("lateral_batched", lambda_lat=4.0, eta_lat=1.0, head_protect=5)
+    col = _swerve("collision_swerve_batched", eta_col=1.0, range=8.0, head_protect=5)
+    out = lat._compute(x, inputs) + col._compute(x, inputs)
+    grad = torch.autograd.grad(out.sum(), x)[0]
+    assert torch.all(grad[:, 0, 1:6, :] == 0), "first 5 future steps must carry no gradient"
+    assert grad[:, 0, 6:, :].abs().sum() > 0

--- a/rlvr/test_guidance_batched.py
+++ b/rlvr/test_guidance_batched.py
@@ -180,8 +180,8 @@ def test_fast_composer_inert_detection():
     comp = build_head_composer({"lateral": 0.0, "longitudinal": 0.0})
     assert comp._all_inert()
 
-    # a function exposing NO recognized eta attribute (e.g. a stock speed
-    # band appended by a caller) must force the composer active
+    # a function exposing NO recognized eta attribute must force the
+    # composer active
     comp = build_head_composer({"lateral": 0.0, "collision": 0.0})
     assert comp._all_inert()
 
@@ -189,4 +189,13 @@ def test_fast_composer_inert_detection():
         pass
 
     comp._functions.append(_NoEtaFn())
+    assert not comp._all_inert()
+
+    # a REAL stock SpeedGuidance band fn (stretch==1.0 but v_low/v_high
+    # clamping active — the --speed_floor pattern) must force active too
+    band = build(GuidanceConfig(name="speed", enabled=True, scale=1.0,
+                                params={"v_low": 2.0, "v_high": 14.0}))
+    assert getattr(band, "_stretch", None) == 1.0  # the trap: looks inert
+    comp = build_head_composer({"lateral": 0.0, "collision": 0.0})
+    comp._functions.append(band)
     assert not comp._all_inert()

--- a/rlvr/test_guidance_batched.py
+++ b/rlvr/test_guidance_batched.py
@@ -2,12 +2,12 @@
 
 import pytest
 import torch
-
-import guidance_gui.custom_guidance  # noqa: F401 -- registers collision_swerve
-import rlvr.guidance_batched  # noqa: F401 -- registers the batched variants
 from diffusion_planner.model.guidance.config import GuidanceConfig
 from diffusion_planner.model.guidance.registry import build
 from diffusion_planner.model.guidance.speed_guidance import SpeedGuidance
+
+import guidance_gui.custom_guidance  # noqa: F401 -- registers collision_swerve
+import rlvr.guidance_batched  # noqa: F401 -- registers the batched variants
 
 B, T, PN, HIST = 3, 10, 4, 5
 
@@ -159,3 +159,34 @@ def test_head_protect_zeroes_early_gradient():
     grad = torch.autograd.grad(out.sum(), x)[0]
     assert torch.all(grad[:, 0, 1:6, :] == 0), "first 5 future steps must carry no gradient"
     assert grad[:, 0, 6:, :].abs().sum() > 0
+
+
+# ---------------------------------------------------------------------------
+# FastGuidanceComposer._all_inert
+# ---------------------------------------------------------------------------
+
+def test_fast_composer_inert_detection():
+    from rlvr.guidance_batched import build_head_composer
+
+    # truly inert: every head at its inert point
+    comp = build_head_composer(
+        {"lateral": 0.0, "collision": 0.0, "stretch": 0.0})
+    assert comp._all_inert()
+
+    # legacy longitudinal head ALONE must count as active (regression:
+    # _eta_lon was unchecked, silently disabling guidance)
+    comp = build_head_composer({"lateral": 0.0, "longitudinal": 0.7})
+    assert not comp._all_inert()
+    comp = build_head_composer({"lateral": 0.0, "longitudinal": 0.0})
+    assert comp._all_inert()
+
+    # a function exposing NO recognized eta attribute (e.g. a stock speed
+    # band appended by a caller) must force the composer active
+    comp = build_head_composer({"lateral": 0.0, "collision": 0.0})
+    assert comp._all_inert()
+
+    class _NoEtaFn:
+        pass
+
+    comp._functions.append(_NoEtaFn())
+    assert not comp._all_inert()

--- a/rlvr/test_guidance_batched.py
+++ b/rlvr/test_guidance_batched.py
@@ -1,0 +1,137 @@
+"""Unit tests for rlvr/guidance_batched.py (per-sample guidance params)."""
+
+import pytest
+import torch
+
+import guidance_gui.custom_guidance  # noqa: F401 -- registers collision_swerve
+import rlvr.guidance_batched  # noqa: F401 -- registers the batched variants
+from diffusion_planner.model.guidance.config import GuidanceConfig
+from diffusion_planner.model.guidance.registry import build
+from diffusion_planner.model.guidance.speed_guidance import SpeedGuidance
+
+B, T, PN, HIST = 3, 10, 4, 5
+
+
+def _make_x(requires_grad=False):
+    torch.manual_seed(0)
+    # Forward-moving ego with slight lateral variation per batch element.
+    x = torch.zeros(B, 1, T + 1, 4)
+    x[:, 0, :, 0] = torch.linspace(0, 20, T + 1)          # x forward
+    x[:, 0, :, 1] = torch.randn(B, 1) * 0.3                # constant lateral offset
+    x[:, 0, :, 2] = 1.0                                    # cos(0)
+    x.requires_grad_(requires_grad)
+    return x
+
+
+def _make_inputs(with_neighbors=True):
+    nb = torch.zeros(B, PN, HIST, 11)
+    if with_neighbors:
+        # One stopped neighbour 8 m ahead, slightly right; rest are empty slots.
+        nb[:, 0, -1, 0] = 8.0
+        nb[:, 0, -1, 1] = -0.5
+        nb[:, 0, -1, 2] = 1.0
+    return {"neighbor_agents_past": nb}
+
+
+def _swerve(name, **params):
+    return build(GuidanceConfig(name=name, enabled=True, scale=1.0, params=params))
+
+
+# ---------------------------------------------------------------------------
+# collision_swerve_batched
+# ---------------------------------------------------------------------------
+
+def test_swerve_batched_matches_scalar_original():
+    x = _make_x()
+    inputs = _make_inputs()
+    for side in (1.0, -1.0):
+        orig = _swerve("collision_swerve", side=side, range=8.0)
+        batched = _swerve("collision_swerve_batched", eta_col=side, range=8.0)
+        assert torch.allclose(orig._compute(x, inputs), batched._compute(x, inputs))
+
+
+def test_swerve_batched_per_sample_eta():
+    x = _make_x()
+    x.data[:, 0, :, 1] = 0.2  # identical lateral position for all batch elems
+    inputs = _make_inputs()
+    eta = torch.tensor([1.0, -1.0, 0.5])
+    fn = _swerve("collision_swerve_batched", eta_col=eta, range=8.0)
+    out = fn._compute(x, inputs)
+    assert torch.allclose(out[0], -out[1])
+    assert torch.allclose(out[2], 0.5 * out[0])
+
+
+def test_swerve_batched_zero_eta_is_inert():
+    x = _make_x(requires_grad=True)
+    fn = _swerve("collision_swerve_batched", eta_col=0.0, range=8.0)
+    out = fn._compute(x, _make_inputs())
+    assert torch.all(out == 0)
+    grad = torch.autograd.grad(out.sum(), x, allow_unused=True)[0]
+    assert grad is None or torch.all(grad == 0)
+
+
+def test_swerve_batched_no_neighbors_zero_energy():
+    fn = _swerve("collision_swerve_batched", eta_col=1.0, range=8.0)
+    out = fn._compute(_make_x(), _make_inputs(with_neighbors=False))
+    assert torch.all(out == 0)
+    out = fn._compute(_make_x(), {})
+    assert torch.all(out == 0)
+
+
+def test_swerve_batched_gradient_pushes_left_for_positive_eta():
+    x = _make_x(requires_grad=True)
+    fn = _swerve("collision_swerve_batched", eta_col=1.0, range=8.0)
+    out = fn._compute(x, _make_inputs())
+    grad = torch.autograd.grad(out.sum(), x)[0]
+    # Energy is maximised by the solver: positive dE/dy = push toward +y (left)
+    lat_grad = grad[:, 0, 1:, 1]
+    assert (lat_grad >= 0).all()
+    assert lat_grad.sum() > 0
+
+
+def test_swerve_batched_shape_mismatch_raises():
+    fn = _swerve("collision_swerve_batched", eta_col=torch.ones(B + 1), range=8.0)
+    with pytest.raises(ValueError, match="expected scalar"):
+        fn._compute(_make_x(), _make_inputs())
+
+
+def test_swerve_batched_energy_time_gated():
+    x = _make_x(requires_grad=True)
+    fn = _swerve("collision_swerve_batched", eta_col=1.0, range=8.0)
+    t_in = torch.full((B,), 0.05)   # inside (t_min, t_max) window
+    e = fn.energy(x, t_in, _make_inputs())
+    grad = torch.autograd.grad(e.sum(), x)[0]
+    assert grad.abs().sum() > 0
+
+
+# ---------------------------------------------------------------------------
+# speed_stretch_batched
+# ---------------------------------------------------------------------------
+
+def test_stretch_batched_matches_scalar_speed_guidance():
+    x = _make_x()
+    for stretch in (0.8, 1.2):
+        orig = SpeedGuidance(GuidanceConfig(name="speed", params={"stretch": stretch}))
+        batched = _swerve("speed_stretch_batched", stretch=stretch)
+        assert torch.allclose(orig._compute(x, {}), batched._compute(x, {}))
+
+
+def test_stretch_batched_one_is_inert():
+    x = _make_x(requires_grad=True)
+    fn = _swerve("speed_stretch_batched", stretch=1.0)
+    out = fn._compute(x, {})
+    assert torch.all(out == 0)
+    grad = torch.autograd.grad(out.sum(), x, allow_unused=True)[0]
+    assert grad is None or torch.all(grad == 0)
+
+
+def test_stretch_batched_per_sample():
+    x = _make_x(requires_grad=True)
+    stretch = torch.tensor([0.8, 1.0, 1.2])
+    fn = _swerve("speed_stretch_batched", stretch=stretch)
+    out = fn._compute(x, {})
+    grad = torch.autograd.grad(out.sum(), x)[0]
+    fwd_grad = grad[:, 0, 1:, 0]  # gradient along travel (+x) direction
+    assert (fwd_grad[0] <= 0).all() and fwd_grad[0].sum() < 0   # slow down
+    assert torch.all(grad[1] == 0)                              # inert
+    assert (fwd_grad[2] >= 0).all() and fwd_grad[2].sum() > 0   # speed up

--- a/rlvr/train_explorer_regression.py
+++ b/rlvr/train_explorer_regression.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Supervised regression training for the exploration policy (Stage 1).
+
+Sample-efficient alternative to on-policy REINFORCE for low scene counts:
+per-scene best guidance params come from an offline grid sweep
+(rlvr.autoresearch.tools.sweep_guidance_params), and the policy regresses its
+deterministic action (Beta mean mapped to [-1, 1]) toward them:
+
+  - sweep status "solved"        -> target = best combo etas
+  - sweep status "already_clean" -> target = 0 for every head (inertness)
+  - sweep status "unsolved"      -> EXCLUDED (no valid teaching signal)
+  - --normal_scenes              -> target = 0 for every head (inertness)
+
+The planner stays frozen; scene encodings and reference trajectories are
+precomputed once and cached, so policy training itself is seconds/epoch.
+
+Usage:
+    python -m rlvr.train_explorer_regression \
+        --model_path <base.pth> --labels <sweep_labels.json> \
+        --normal_scenes <normal.json> --output_dir <dir> \
+        --heads lateral,collision [--epochs 200] [--lr 1e-3] \
+        [--avoid_weight 5.0] [--val_frac 0.15]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+from torch import optim
+
+from exploration_policy.model import ExplorationPolicy, ExplorationPolicyConfig
+from exploration_policy.utils import generate_reference_trajectory, run_frozen_encoder
+from preference_optimization.utils import load_npz_data
+from rlvr.autoresearch.tools.eval_det_avoidance import load_model
+
+HEAD_TO_LABEL_KEY = {"lateral": "eta_lat", "collision": "eta_col", "stretch": "stretch"}
+
+
+def label_target(head: str, best: dict) -> float:
+    """Map a sweep best-combo entry to the head's eta target in [-1, 1]."""
+    key = HEAD_TO_LABEL_KEY[head]
+    v = float(best[key])
+    if head == "stretch":
+        # sweep records the stretch factor; policy eta is symmetric around 1.0
+        # via stretch = 1 + lambda_spd * eta (lambda_spd fixed downstream).
+        raise NotImplementedError(
+            "stretch head targets need the lambda_spd mapping — add when the "
+            "stretch axis joins the sweep grid."
+        )
+    return v
+
+
+def build_entries(labels_paths: list[str], normal_paths: list[str], heads: list[str]):
+    """Assemble (scene_path, target_dict, weight_class) tuples."""
+    entries = []
+    n_solved = n_clean = n_unsolved = 0
+    seen = set()
+    for lp in labels_paths:
+        with open(lp) as f:
+            data = json.load(f)
+        for r in data["scenes"]:
+            sp = r["scene_path"]
+            if sp in seen:
+                continue
+            seen.add(sp)
+            if r["status"] == "solved":
+                targets = {h: label_target(h, r["best"]) for h in heads}
+                entries.append((sp, targets, "avoid"))
+                n_solved += 1
+            elif r["status"] == "already_clean":
+                entries.append((sp, {h: 0.0 for h in heads}, "clean"))
+                n_clean += 1
+            else:
+                n_unsolved += 1
+    for sp in normal_paths:
+        if sp not in seen:
+            seen.add(sp)
+            entries.append((sp, {h: 0.0 for h in heads}, "normal"))
+    print(f"[entries] solved={n_solved} clean={n_clean} normal-added "
+          f"unsolved-excluded={n_unsolved} total={len(entries)}")
+    return entries
+
+
+@torch.no_grad()
+def precompute_features(model, model_args, entries, device, cache_path: Path):
+    """Cache scene_encoding + x_ref per scene (one det pass each)."""
+    if cache_path.exists():
+        cache = torch.load(cache_path, map_location="cpu", weights_only=False)
+        if set(cache.keys()) >= {e[0] for e in entries}:
+            print(f"[cache] loaded {len(cache)} features from {cache_path}")
+            return cache
+    cache = {}
+    for i, (sp, _, _) in enumerate(entries):
+        data = load_npz_data(sp, device)
+        norm_data = {
+            k: v.clone() if isinstance(v, torch.Tensor) else v for k, v in data.items()
+        }
+        norm_data = model_args.observation_normalizer(norm_data)
+        x_ref_np = generate_reference_trajectory(model, model_args, norm_data, device)
+        x_ref = torch.from_numpy(x_ref_np).unsqueeze(0).to(device)
+        norm_data["reference_trajectory"] = x_ref
+        enc = run_frozen_encoder(model, norm_data)
+        cache[sp] = {"scene_encoding": enc[0].cpu(), "x_ref": x_ref[0].cpu()}
+        if (i + 1) % 50 == 0:
+            print(f"  [features] {i + 1}/{len(entries)}")
+    torch.save(cache, cache_path)
+    print(f"[cache] wrote {len(cache)} features to {cache_path}")
+    return cache
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--model_path", required=True)
+    parser.add_argument("--labels", required=True, nargs="+",
+                        help="sweep_labels.json file(s)")
+    parser.add_argument("--normal_scenes", default=None)
+    parser.add_argument("--output_dir", required=True)
+    parser.add_argument("--heads", default="lateral,collision")
+    parser.add_argument("--epochs", type=int, default=300)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--batch_size", type=int, default=64)
+    parser.add_argument("--val_frac", type=float, default=0.15)
+    parser.add_argument("--avoid_weight", type=float, default=5.0,
+                        help="loss weight for solved avoidance scenes vs zero-target scenes")
+    parser.add_argument("--hidden_dim", type=int, default=128)
+    parser.add_argument("--head_raw_scale", type=float, default=10.0)
+    parser.add_argument("--dropout", type=float, default=0.1)
+    parser.add_argument("--patience", type=int, default=50)
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+
+    torch.manual_seed(args.seed)
+    np.random.seed(args.seed)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    heads = args.heads.split(",")
+    run_dir = Path(args.output_dir)
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    normal_paths = []
+    if args.normal_scenes:
+        with open(args.normal_scenes) as f:
+            normal_paths = json.load(f)
+
+    entries = build_entries(args.labels, normal_paths, heads)
+    if not entries:
+        raise SystemExit("no training entries")
+
+    model, model_args = load_model(args.model_path, device)
+    cache = precompute_features(
+        model, model_args, entries, device, run_dir / "feature_cache.pt",
+    )
+    del model
+    torch.cuda.empty_cache()
+
+    # --- Tensorize dataset ---
+    enc = torch.stack([cache[sp]["scene_encoding"] for sp, _, _ in entries]).to(device)
+    xref = torch.stack([cache[sp]["x_ref"] for sp, _, _ in entries]).to(device)
+    targets = torch.tensor(
+        [[t[h] for h in heads] for _, t, _ in entries], device=device,
+    )  # [M, H]
+    weights = torch.tensor(
+        [args.avoid_weight if cls == "avoid" else 1.0 for _, _, cls in entries],
+        device=device,
+    )
+    is_avoid = torch.tensor([cls == "avoid" for _, _, cls in entries], device=device)
+
+    # --- Stratified train/val split (keep avoidance scenes in both) ---
+    g = torch.Generator().manual_seed(args.seed)
+    val_mask = torch.zeros(len(entries), dtype=torch.bool)
+    for cls_mask in (is_avoid.cpu(), ~is_avoid.cpu()):
+        idx = torch.nonzero(cls_mask).squeeze(-1)
+        perm = idx[torch.randperm(len(idx), generator=g)]
+        n_val = max(1, int(len(idx) * args.val_frac))
+        val_mask[perm[:n_val]] = True
+    train_idx = torch.nonzero(~val_mask).squeeze(-1).to(device)
+    val_idx = torch.nonzero(val_mask).squeeze(-1).to(device)
+    print(f"[split] train={len(train_idx)} val={len(val_idx)} "
+          f"(val avoid={int(is_avoid[val_idx].sum())})")
+
+    ep_config = ExplorationPolicyConfig(
+        hidden_dim=args.hidden_dim,
+        dropout=args.dropout,
+        encoder_hidden_dim=model_args.hidden_dim,
+        head_raw_scale=args.head_raw_scale,
+        heads=heads,
+    )
+    policy = ExplorationPolicy(ep_config, ref_seq_len=model_args.future_len).to(device)
+    optimizer = optim.AdamW(policy.parameters(), lr=args.lr)
+
+    def pred_etas(idx_batch):
+        out = policy(enc[idx_batch], xref[idx_batch], deterministic=True)
+        return torch.stack([2.0 * out.dists[h].mean - 1.0 for h in heads], dim=-1)
+
+    def eval_split(idx_split):
+        policy.eval()
+        with torch.no_grad():
+            pred = pred_etas(idx_split)
+            err = (pred - targets[idx_split]) ** 2
+            mse = (err.mean(dim=-1) * weights[idx_split]).mean()
+            av = is_avoid[idx_split]
+            metrics = {"weighted_mse": float(mse)}
+            if av.any():
+                # sign accuracy of the dominant (largest-|target|) head per scene
+                t_a, p_a = targets[idx_split][av], pred[av]
+                dom = t_a.abs().argmax(dim=-1)
+                rows = torch.arange(len(t_a), device=device)
+                metrics["avoid_mse"] = float(((t_a - p_a) ** 2).mean())
+                metrics["avoid_sign_acc"] = float(
+                    (torch.sign(p_a[rows, dom]) == torch.sign(t_a[rows, dom])).float().mean()
+                )
+                metrics["avoid_pred_absmean"] = float(p_a.abs().mean())
+            if (~av).any():
+                metrics["inert_pred_absmean"] = float(pred[~av].abs().mean())
+        return metrics
+
+    best_val = float("inf")
+    best_epoch = 0
+    log_rows = []
+    for epoch in range(1, args.epochs + 1):
+        policy.train()
+        perm = train_idx[torch.randperm(len(train_idx), device=device)]
+        ep_loss, n_b = 0.0, 0
+        for s in range(0, len(perm), args.batch_size):
+            b = perm[s : s + args.batch_size]
+            pred = pred_etas(b)
+            loss = (((pred - targets[b]) ** 2).mean(dim=-1) * weights[b]).mean()
+            optimizer.zero_grad()
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(policy.parameters(), 1.0)
+            optimizer.step()
+            ep_loss += float(loss)
+            n_b += 1
+
+        val_m = eval_split(val_idx)
+        train_m = eval_split(train_idx)
+        row = {"epoch": epoch, "train_loss": ep_loss / max(n_b, 1),
+               **{f"val_{k}": v for k, v in val_m.items()},
+               **{f"train_{k}": v for k, v in train_m.items()}}
+        log_rows.append(row)
+        if epoch % 10 == 0 or epoch == 1:
+            print(f"  ep{epoch:3d} train={row['train_loss']:.4f} "
+                  f"val_mse={val_m['weighted_mse']:.4f} "
+                  f"avoid_sign={val_m.get('avoid_sign_acc', -1):.2f} "
+                  f"avoid_|p|={val_m.get('avoid_pred_absmean', -1):.3f} "
+                  f"inert_|p|={val_m.get('inert_pred_absmean', -1):.4f}")
+
+        if val_m["weighted_mse"] < best_val - 1e-5:
+            best_val = val_m["weighted_mse"]
+            best_epoch = epoch
+            torch.save(policy.state_dict(), run_dir / "exploration_policy.pth")
+        if epoch - best_epoch >= args.patience:
+            print(f"  early stop at ep{epoch} (best ep{best_epoch})")
+            break
+
+    ep_config.to_json(run_dir / "exploration_policy_config.json")
+    with open(run_dir / "train_log.json", "w") as f:
+        json.dump(log_rows, f, indent=1)
+    with open(run_dir / "train_args.json", "w") as f:
+        json.dump(vars(args), f, indent=1)
+    print(f"[done] best val_mse={best_val:.4f} @ ep{best_epoch}; "
+          f"saved {run_dir / 'exploration_policy.pth'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/train_explorer_regression.py
+++ b/rlvr/train_explorer_regression.py
@@ -131,6 +131,9 @@ def main():
     parser.add_argument("--head_raw_scale", type=float, default=10.0)
     parser.add_argument("--dropout", type=float, default=0.1)
     parser.add_argument("--patience", type=int, default=50)
+    parser.add_argument("--init_from", default=None,
+                        help="warm-start: load this exploration_policy.pth "
+                             "before training (heads/arch must match)")
     parser.add_argument("--seed", type=int, default=0)
     args = parser.parse_args()
 
@@ -190,6 +193,10 @@ def main():
         heads=heads,
     )
     policy = ExplorationPolicy(ep_config, ref_seq_len=model_args.future_len).to(device)
+    if args.init_from:
+        state = torch.load(args.init_from, map_location=device, weights_only=False)
+        policy.load_state_dict(state, strict=True)
+        print(f"[warm-start] loaded {args.init_from}")
     optimizer = optim.AdamW(policy.parameters(), lr=args.lr)
 
     def pred_etas(idx_batch):

--- a/rlvr/train_explorer_regression.py
+++ b/rlvr/train_explorer_regression.py
@@ -100,6 +100,10 @@ def precompute_features(model, model_args, entries, device, cache_path: Path,
                 f"{cached_model}, not {model_path} — delete the cache or use "
                 "a fresh --output_dir (stale encodings would be silently "
                 "served otherwise)")
+        if model_path and not cached_model:
+            print(f"[cache] WARNING: {cache_path} predates the model-path "
+                  "stamp — cannot verify it was built with "
+                  f"{model_path}. Delete it if in doubt.")
         if set(cache.keys()) - {"__model_path__"} >= {e[0] for e in entries}:
             print(f"[cache] loaded {len(cache)} features from {cache_path}")
             return cache

--- a/rlvr/train_explorer_regression.py
+++ b/rlvr/train_explorer_regression.py
@@ -56,8 +56,16 @@ def label_target(head: str, best: dict) -> float:
     return v
 
 
-def build_entries(labels_paths: list[str], normal_paths: list[str], heads: list[str]):
-    """Assemble (scene_path, target_dict, weight_class) tuples."""
+def build_entries(labels_paths: list[str], normal_paths: list[str],
+                  heads: list[str],
+                  counterfactual_paths: list[str] | None = None):
+    """Assemble (scene_path, target_dict, weight_class) tuples.
+
+    counterfactual_paths: zero-target scenes that form PAIRS with solved
+    scenes (e.g. neighbor-stripped twins). They get their own weight class
+    so the pair's discrimination signal can be weighted symmetrically
+    instead of drowning at generic-normal weight.
+    """
     entries = []
     n_solved = n_clean = n_unsolved = 0
     seen = set()
@@ -84,8 +92,14 @@ def build_entries(labels_paths: list[str], normal_paths: list[str], heads: list[
             seen.add(sp)
             entries.append((sp, {h: 0.0 for h in heads}, "normal"))
             n_normal += 1
+    n_cf = 0
+    for sp in (counterfactual_paths or []):
+        if sp not in seen:
+            seen.add(sp)
+            entries.append((sp, {h: 0.0 for h in heads}, "counterfactual"))
+            n_cf += 1
     print(f"[entries] solved={n_solved} clean={n_clean} "
-          f"normal-added={n_normal} "
+          f"normal-added={n_normal} counterfactual={n_cf} "
           f"unsolved-excluded={n_unsolved} total={len(entries)}")
     return entries
 
@@ -145,6 +159,12 @@ def main():
     parser.add_argument("--val_frac", type=float, default=0.15)
     parser.add_argument("--avoid_weight", type=float, default=5.0,
                         help="loss weight for solved avoidance scenes vs zero-target scenes")
+    parser.add_argument("--counterfactual_scenes", default=None,
+                        help="JSON list of zero-target counterfactual twins "
+                             "of solved scenes (e.g. neighbor-stripped); "
+                             "weighted by --counterfactual_weight instead "
+                             "of 1.0")
+    parser.add_argument("--counterfactual_weight", type=float, default=1.0)
     parser.add_argument("--hidden_dim", type=int, default=128)
     parser.add_argument("--head_raw_scale", type=float, default=10.0)
     parser.add_argument("--dropout", type=float, default=0.1)
@@ -167,7 +187,13 @@ def main():
         with open(args.normal_scenes) as f:
             normal_paths = json.load(f)
 
-    entries = build_entries(args.labels, normal_paths, heads)
+    cf_paths = []
+    if args.counterfactual_scenes:
+        with open(args.counterfactual_scenes) as f:
+            cf_paths = json.load(f)
+
+    entries = build_entries(args.labels, normal_paths, heads,
+                            counterfactual_paths=cf_paths)
     if not entries:
         raise SystemExit("no training entries")
 
@@ -186,7 +212,9 @@ def main():
         [[t[h] for h in heads] for _, t, _ in entries], device=device,
     )  # [M, H]
     weights = torch.tensor(
-        [args.avoid_weight if cls == "avoid" else 1.0 for _, _, cls in entries],
+        [args.avoid_weight if cls == "avoid"
+         else args.counterfactual_weight if cls == "counterfactual"
+         else 1.0 for _, _, cls in entries],
         device=device,
     )
     is_avoid = torch.tensor([cls == "avoid" for _, _, cls in entries], device=device)

--- a/rlvr/train_explorer_regression.py
+++ b/rlvr/train_explorer_regression.py
@@ -38,18 +38,21 @@ from rlvr.autoresearch.tools.eval_det_avoidance import load_model
 
 HEAD_TO_LABEL_KEY = {"lateral": "eta_lat", "collision": "eta_col", "stretch": "stretch"}
 
+LAMBDA_SPD = 0.2  # stretch = 1 + LAMBDA_SPD * eta — must match the
+                  # inference envelope's lambda_spd (build_head_composer)
+
 
 def label_target(head: str, best: dict) -> float:
     """Map a sweep best-combo entry to the head's eta target in [-1, 1]."""
     key = HEAD_TO_LABEL_KEY[head]
     v = float(best[key])
     if head == "stretch":
-        # sweep records the stretch factor; policy eta is symmetric around 1.0
-        # via stretch = 1 + lambda_spd * eta (lambda_spd fixed downstream).
-        raise NotImplementedError(
-            "stretch head targets need the lambda_spd mapping — add when the "
-            "stretch axis joins the sweep grid."
-        )
+        # The sweep records the stretch FACTOR; the policy's eta is symmetric
+        # around 1.0 via stretch = 1 + lambda_spd * eta. With lambda_spd 0.2
+        # the grid value 0.8 maps to eta -1.0 (saturation); clamp anything
+        # beyond to the Beta support.
+        eta = (v - 1.0) / LAMBDA_SPD
+        return float(max(-1.0, min(1.0, eta)))
     return v
 
 

--- a/rlvr/train_explorer_regression.py
+++ b/rlvr/train_explorer_regression.py
@@ -78,11 +78,14 @@ def build_entries(labels_paths: list[str], normal_paths: list[str], heads: list[
                 n_clean += 1
             else:
                 n_unsolved += 1
+    n_normal = 0
     for sp in normal_paths:
         if sp not in seen:
             seen.add(sp)
             entries.append((sp, {h: 0.0 for h in heads}, "normal"))
-    print(f"[entries] solved={n_solved} clean={n_clean} normal-added "
+            n_normal += 1
+    print(f"[entries] solved={n_solved} clean={n_clean} "
+          f"normal-added={n_normal} "
           f"unsolved-excluded={n_unsolved} total={len(entries)}")
     return entries
 

--- a/rlvr/train_explorer_regression.py
+++ b/rlvr/train_explorer_regression.py
@@ -88,14 +88,22 @@ def build_entries(labels_paths: list[str], normal_paths: list[str], heads: list[
 
 
 @torch.no_grad()
-def precompute_features(model, model_args, entries, device, cache_path: Path):
+def precompute_features(model, model_args, entries, device, cache_path: Path,
+                        model_path: str = ""):
     """Cache scene_encoding + x_ref per scene (one det pass each)."""
     if cache_path.exists():
         cache = torch.load(cache_path, map_location="cpu", weights_only=False)
-        if set(cache.keys()) >= {e[0] for e in entries}:
+        cached_model = cache.get("__model_path__", "")
+        if model_path and cached_model and cached_model != model_path:
+            raise ValueError(
+                f"feature cache {cache_path} was built with model "
+                f"{cached_model}, not {model_path} — delete the cache or use "
+                "a fresh --output_dir (stale encodings would be silently "
+                "served otherwise)")
+        if set(cache.keys()) - {"__model_path__"} >= {e[0] for e in entries}:
             print(f"[cache] loaded {len(cache)} features from {cache_path}")
             return cache
-    cache = {}
+    cache = {"__model_path__": model_path}
     for i, (sp, _, _) in enumerate(entries):
         data = load_npz_data(sp, device)
         norm_data = {
@@ -159,6 +167,7 @@ def main():
     model, model_args = load_model(args.model_path, device)
     cache = precompute_features(
         model, model_args, entries, device, run_dir / "feature_cache.pt",
+        model_path=args.model_path,
     )
     del model
     torch.cuda.empty_cache()

--- a/rlvr/train_explorer_regression.py
+++ b/rlvr/train_explorer_regression.py
@@ -121,10 +121,20 @@ def precompute_features(model, model_args, entries, device, cache_path: Path,
             print(f"[cache] WARNING: {cache_path} predates the model-path "
                   "stamp — cannot verify it was built with "
                   f"{model_path}. Delete it if in doubt.")
-        if set(cache.keys()) - {"__model_path__"} >= {e[0] for e in entries}:
+        have = set(cache.keys()) - {"__model_path__"}
+        need = {e[0] for e in entries}
+        if have >= need:
             print(f"[cache] loaded {len(cache)} features from {cache_path}")
             return cache
-    cache = {"__model_path__": model_path}
+        # Partial hit: top up only the missing scenes instead of a full
+        # rebuild, then re-save.
+        missing = [e for e in entries if e[0] not in have]
+        print(f"[cache] topping up {len(missing)} missing of {len(need)} "
+              f"entries in {cache_path}")
+        cache.setdefault("__model_path__", model_path)
+        entries = missing
+    else:
+        cache = {"__model_path__": model_path}
     for i, (sp, _, _) in enumerate(entries):
         data = load_npz_data(sp, device)
         norm_data = {

--- a/rlvr/train_explorer_regression.py
+++ b/rlvr/train_explorer_regression.py
@@ -198,7 +198,19 @@ def main():
     policy = ExplorationPolicy(ep_config, ref_seq_len=model_args.future_len).to(device)
     if args.init_from:
         state = torch.load(args.init_from, map_location=device, weights_only=False)
-        policy.load_state_dict(state, strict=True)
+        try:
+            policy.load_state_dict(state, strict=True)
+        except RuntimeError:
+            # Head-spec change (e.g. 2-head -> 3-head: the shared guidance
+            # head's Linear changes shape). Transfer everything that fits,
+            # report what restarts fresh — loud, not silent.
+            compat = {k: v for k, v in state.items()
+                      if k in policy.state_dict()
+                      and policy.state_dict()[k].shape == v.shape}
+            missing = [k for k in policy.state_dict() if k not in compat]
+            policy.load_state_dict(compat, strict=False)
+            print(f"[warm-start] PARTIAL: {len(compat)}/{len(policy.state_dict())} "
+                  f"tensors transferred; fresh: {missing}")
         print(f"[warm-start] loaded {args.init_from}")
     optimizer = optim.AdamW(policy.parameters(), lr=args.lr)
 

--- a/scenario_generation/explorer_runner.py
+++ b/scenario_generation/explorer_runner.py
@@ -30,6 +30,48 @@ from exploration_policy.model import ExplorationPolicy, ExplorationPolicyConfig
 from exploration_policy.utils import run_frozen_encoder
 
 
+def plan_static_clearance(
+    plan_ego_frame: np.ndarray,
+    static_boxes_ego_frame: list[tuple[float, float, float, float, float]],
+    ego_shape_wlw: tuple[float, float, float],
+    device,
+) -> float:
+    """Min OBB clearance of an ego-frame plan to static boxes (canonical fn).
+
+    Args:
+        plan_ego_frame: (T, 4) [x, y, cos, sin] ego-centric plan.
+        static_boxes_ego_frame: list of (x, y, heading, length, width) in the
+            SAME ego frame.
+        ego_shape_wlw: (wheelbase, length, width).
+
+    Returns min clearance in metres (99.0 when no static boxes). Geometry is
+    entirely compute_static_collision_penalty (no hand-rolled OBB math).
+    """
+    from rlvr.reward import RewardConfig, compute_static_collision_penalty
+
+    if not static_boxes_ego_frame:
+        return 99.0
+    T = plan_ego_frame.shape[0]
+    ego_trajs = torch.from_numpy(np.ascontiguousarray(plan_ego_frame)).float()
+    ego_trajs = ego_trajs.unsqueeze(0).to(device)
+    S = len(static_boxes_ego_frame)
+    nb = torch.zeros(S, T, 4, device=device)
+    shapes = torch.zeros(S, 2, device=device)
+    for i, (x, y, h, length, w) in enumerate(static_boxes_ego_frame):
+        nb[i, :, 0] = x
+        nb[i, :, 1] = y
+        nb[i, :, 2] = float(np.cos(h))
+        nb[i, :, 3] = float(np.sin(h))
+        shapes[i, 0] = w
+        shapes[i, 1] = length
+    valid = torch.ones(S, T, dtype=torch.bool, device=device)
+    ego_shape = torch.tensor(ego_shape_wlw, device=device, dtype=torch.float32)
+    res = compute_static_collision_penalty(
+        ego_trajs, ego_shape, nb, shapes, valid, RewardConfig(),
+    )
+    return float(res["per_timestep_min"][0, 1:].min().item())
+
+
 @dataclass
 class ExplorerEnvelope:
     """Guidance strengths; defaults = the campaign sweep envelope."""

--- a/scenario_generation/explorer_runner.py
+++ b/scenario_generation/explorer_runner.py
@@ -22,10 +22,10 @@ from pathlib import Path
 
 import numpy as np
 import torch
-
-import rlvr.guidance_batched  # noqa: F401 -- registers batched guidance
 from diffusion_planner.model.guidance.composer import GuidanceComposer
 from diffusion_planner.model.guidance.config import GuidanceConfig, GuidanceSetConfig
+
+import rlvr.guidance_batched  # noqa: F401 -- registers batched guidance
 from exploration_policy.model import ExplorationPolicy, ExplorationPolicyConfig
 from exploration_policy.utils import run_frozen_encoder
 
@@ -123,6 +123,12 @@ class ExplorerGuidanceRunner:
 
     def _composer(self, etas: dict[str, torch.Tensor]) -> GuidanceComposer:
         env = self.envelope
+        unmapped = set(etas) - {"lateral", "collision", "stretch"}
+        if unmapped:
+            raise ValueError(
+                f"policy heads {sorted(unmapped)} have no guidance mapping "
+                "in explorer_runner — running without them would silently "
+                "change the deployed behaviour")
         fns = []
         if "lateral" in etas:
             fns.append(GuidanceConfig(

--- a/scenario_generation/explorer_runner.py
+++ b/scenario_generation/explorer_runner.py
@@ -76,9 +76,9 @@ def plan_static_clearance(
 class ExplorerEnvelope:
     """Guidance strengths; defaults = the campaign sweep envelope."""
 
-    lambda_lat: float = 4.0
-    lat_scale: float = 1.5
-    col_scale: float = 6.0
+    lambda_lat: float = 5.0
+    lat_scale: float = 2.0
+    col_scale: float = 9.0
     col_range: float = 8.0
     lambda_spd: float = 0.2
     stretch_scale: float = 1.0

--- a/scenario_generation/explorer_runner.py
+++ b/scenario_generation/explorer_runner.py
@@ -116,6 +116,10 @@ class ExplorerGuidanceRunner:
         # flip-flop when the policy sits near a decision boundary mid-pass.
         # 0.0 = no smoothing (use raw per-step eta), 1.0 = frozen first eta.
         self.eta_smooth = float(eta_smooth)
+        if not 0.0 <= self.eta_smooth <= 1.0:
+            raise ValueError(
+                f"eta_smooth must be in [0, 1], got {self.eta_smooth} — "
+                "values outside invert/overshoot the EMA")
         self._eta_prev: dict[str, float] | None = None
 
     def reset(self) -> None:

--- a/scenario_generation/explorer_runner.py
+++ b/scenario_generation/explorer_runner.py
@@ -1,0 +1,159 @@
+"""Exploration-policy guidance for the closed-loop replay sim.
+
+Wraps a trained ExplorationPolicy (frozen planner, learned per-scene guidance
+etas) so `run_route_replay` can generate the EGO trajectory through the
+guidance composer each step, while all other agents keep the plain forward.
+
+Per step:
+  1. x_ref = the ego's plain det prediction from the shared batched forward
+     (already computed by the replay loop — no extra pass).
+  2. policy(scene_encoding, x_ref) -> deterministic etas per head.
+  3. One extra ego-only forward with decoder._guidance_fn = composer
+     (same private-attr pattern as rlvr.closed_loop.batched_rollout).
+
+The guidance envelope (lambda_lat / col_scale / ...) MUST match the sweep
+envelope the policy was trained against.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import torch
+
+import rlvr.guidance_batched  # noqa: F401 -- registers batched guidance
+from diffusion_planner.model.guidance.composer import GuidanceComposer
+from diffusion_planner.model.guidance.config import GuidanceConfig, GuidanceSetConfig
+from exploration_policy.model import ExplorationPolicy, ExplorationPolicyConfig
+from exploration_policy.utils import run_frozen_encoder
+
+
+@dataclass
+class ExplorerEnvelope:
+    """Guidance strengths; defaults = the campaign sweep envelope."""
+
+    lambda_lat: float = 4.0
+    lat_scale: float = 1.5
+    col_scale: float = 6.0
+    col_range: float = 8.0
+    lambda_spd: float = 0.2
+    stretch_scale: float = 1.0
+    guidance_scale: float = 0.5
+
+
+class ExplorerGuidanceRunner:
+    """Per-step explorer inference + guided ego generation for the sim."""
+
+    def __init__(
+        self,
+        policy_dir: str | Path,
+        model_args,
+        device,
+        envelope: ExplorerEnvelope | None = None,
+        eta_smooth: float = 0.5,
+    ):
+        pdir = Path(policy_dir)
+        cfg_path = pdir / "exploration_policy_config.json"
+        ckpt_path = pdir / "exploration_policy.pth"
+        if not cfg_path.exists() or not ckpt_path.exists():
+            raise FileNotFoundError(
+                f"explorer dir {pdir} must contain exploration_policy.pth and "
+                f"exploration_policy_config.json"
+            )
+        cfg = ExplorationPolicyConfig.from_json(cfg_path)
+        self.heads = cfg.heads
+        self.policy = ExplorationPolicy(cfg, ref_seq_len=model_args.future_len).to(device)
+        state = torch.load(ckpt_path, map_location=device, weights_only=False)
+        self.policy.load_state_dict(state, strict=True)
+        self.policy.eval()
+        self.device = device
+        self.envelope = envelope or ExplorerEnvelope()
+        # Exponential smoothing on etas across steps: damps left/right
+        # flip-flop when the policy sits near a decision boundary mid-pass.
+        # 0.0 = no smoothing (use raw per-step eta), 1.0 = frozen first eta.
+        self.eta_smooth = float(eta_smooth)
+        self._eta_prev: dict[str, float] | None = None
+
+    def reset(self) -> None:
+        self._eta_prev = None
+
+    def _composer(self, etas: dict[str, torch.Tensor]) -> GuidanceComposer:
+        env = self.envelope
+        fns = []
+        if "lateral" in etas:
+            fns.append(GuidanceConfig(
+                name="lateral", enabled=True, scale=env.lat_scale,
+                params={"lambda_lat": env.lambda_lat, "eta_lat": etas["lateral"]},
+            ))
+        if "collision" in etas:
+            fns.append(GuidanceConfig(
+                name="collision_swerve_batched", enabled=True, scale=env.col_scale,
+                params={"eta_col": etas["collision"], "range": env.col_range},
+            ))
+        if "stretch" in etas:
+            fns.append(GuidanceConfig(
+                name="speed_stretch_batched", enabled=True, scale=env.stretch_scale,
+                params={"stretch": 1.0 + env.lambda_spd * etas["stretch"]},
+            ))
+        return GuidanceComposer(GuidanceSetConfig(
+            functions=fns, global_scale=env.guidance_scale,
+        ))
+
+    @torch.no_grad()
+    def guided_ego_prediction(
+        self,
+        model,
+        ego_tensor_dict: dict,
+        x_ref: np.ndarray,
+    ) -> tuple[np.ndarray, dict[str, float]]:
+        """Run policy + one guided ego forward.
+
+        Args:
+            model: the (frozen) planner, eval() mode.
+            ego_tensor_dict: model-ready (normalized) tensor dict for the ego,
+                as built by tensor_converter.to_model_tensors — the same dict
+                _predict_batch would feed to model(data).
+            x_ref: (T, 4) the ego's plain det prediction this step (physical
+                ego-centric), used as the policy's reference trajectory and
+                the lateral-guidance reference.
+
+        Returns:
+            (guided_traj (T, 4) physical ego-centric, etas dict)
+        """
+        x_ref_t = torch.from_numpy(np.ascontiguousarray(x_ref)).float()
+        x_ref_t = x_ref_t.unsqueeze(0).to(self.device)
+        data = dict(ego_tensor_dict)
+        data["reference_trajectory"] = x_ref_t
+
+        enc = run_frozen_encoder(model, data)
+        out = self.policy(enc, x_ref_t, deterministic=True)
+        etas_raw = {h: float(2.0 * out.dists[h].mean.item() - 1.0) for h in self.heads}
+
+        if self.eta_smooth > 0.0 and self._eta_prev is not None:
+            etas_f = {
+                h: self.eta_smooth * self._eta_prev[h] + (1 - self.eta_smooth) * v
+                for h, v in etas_raw.items()
+            }
+        else:
+            etas_f = etas_raw
+        self._eta_prev = etas_f
+
+        etas_t = {h: torch.tensor([v], device=self.device) for h, v in etas_f.items()}
+        composer = self._composer(etas_t)
+
+        inner = model.module if hasattr(model, "module") else model
+        decoder = inner.decoder
+        saved_fn = decoder._guidance_fn
+        saved_scale = decoder._guidance_scale
+        decoder._guidance_fn = composer
+        decoder._guidance_scale = composer._set_config.global_scale
+        try:
+            _, outputs = model(data)
+            guided = outputs["prediction"][0, 0].cpu().numpy()
+        finally:
+            decoder._guidance_fn = saved_fn
+            decoder._guidance_scale = saved_scale
+
+        return guided, etas_f

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -2353,23 +2353,6 @@ def run_route_replay(
                 _eid = scene.ego_agent.id
                 if _eid in agent_predictions:
                     from scenario_generation.explorer_runner import plan_static_clearance
-                    _ego = scene.ego_agent
-                    _ex, _ey = float(_ego.current_position[0]), float(_ego.current_position[1])
-                    _eyaw = float(_ego.current_heading)
-                    _c, _s = math.cos(-_eyaw), math.sin(-_eyaw)
-                    _boxes = []
-                    for _a in scene.agents:
-                        if _a.id == _eid or not SceneNPCManager.is_static_npc(_a.id):
-                            continue
-                        _dx = float(_a.current_position[0]) - _ex
-                        _dy = float(_a.current_position[1]) - _ey
-                        _boxes.append((
-                            _c * _dx - _s * _dy, _s * _dx + _c * _dy,
-                            float(_a.current_heading) - _eyaw,
-                            float(_a.length), float(_a.width),
-                        ))
-                    _eshape = (spawn_config.ego_wheelbase,
-                               spawn_config.ego_length, spawn_config.ego_width)
                     _det_plan = agent_predictions[_eid]
                     if spawn_config.explorer_always_on:
                         from scenario_generation.tensor_converter import to_model_tensors
@@ -2382,6 +2365,25 @@ def run_route_replay(
                         )
                         agent_predictions[_eid] = _guided
                     else:
+                        # Static-NPC OBBs in the ego frame — only the gated
+                        # path needs them (clearance check).
+                        _ego = scene.ego_agent
+                        _ex, _ey = float(_ego.current_position[0]), float(_ego.current_position[1])
+                        _eyaw = float(_ego.current_heading)
+                        _c, _s = math.cos(-_eyaw), math.sin(-_eyaw)
+                        _boxes = []
+                        for _a in scene.agents:
+                            if _a.id == _eid or not SceneNPCManager.is_static_npc(_a.id):
+                                continue
+                            _dx = float(_a.current_position[0]) - _ex
+                            _dy = float(_a.current_position[1]) - _ey
+                            _boxes.append((
+                                _c * _dx - _s * _dy, _s * _dx + _c * _dy,
+                                float(_a.current_heading) - _eyaw,
+                                float(_a.length), float(_a.width),
+                            ))
+                        _eshape = (spawn_config.ego_wheelbase,
+                                   spawn_config.ego_length, spawn_config.ego_width)
                         _det_min = plan_static_clearance(_det_plan, _boxes, _eshape, device)
                         if _det_min < spawn_config.explorer_activate_clearance:
                             from scenario_generation.tensor_converter import to_model_tensors

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -246,6 +246,13 @@ class SpawnConfig:
     # slightly before the 0.2 m crossing threshold. Plans clear of statics
     # pass through untouched (inertness in closed loop).
     explorer_activate_clearance: float = 0.3
+    # Guidance envelope for the explorer — MUST match the envelope the policy
+    # was trained against (stage1_reg_v4_env2 = envelope-v2: 5.0/2.0/9.0).
+    explorer_lambda_lat: float = 5.0
+    explorer_lat_scale: float = 2.0
+    explorer_col_scale: float = 9.0
+    explorer_col_range: float = 8.0
+    explorer_guidance_scale: float = 0.5
     # Skip traffic-light state propagation entirely. Useful for MPC-gen
     # data runs where TL-driven speed drops would bias the replay ego
     # toward stop-and-go behaviour we don't want in training.
@@ -1980,9 +1987,19 @@ def run_route_replay(
     # learned guidance etas). Fails loudly if the dir is missing/incomplete.
     explorer_runner = None
     if spawn_config.explorer_dir:
-        from scenario_generation.explorer_runner import ExplorerGuidanceRunner
+        from scenario_generation.explorer_runner import (
+            ExplorerEnvelope,
+            ExplorerGuidanceRunner,
+        )
         explorer_runner = ExplorerGuidanceRunner(
             spawn_config.explorer_dir, model_args, device,
+            envelope=ExplorerEnvelope(
+                lambda_lat=spawn_config.explorer_lambda_lat,
+                lat_scale=spawn_config.explorer_lat_scale,
+                col_scale=spawn_config.explorer_col_scale,
+                col_range=spawn_config.explorer_col_range,
+                guidance_scale=spawn_config.explorer_guidance_scale,
+            ),
             eta_smooth=spawn_config.explorer_eta_smooth,
         )
         print(f"  [explorer] guidance policy loaded from {spawn_config.explorer_dir} "

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -252,7 +252,8 @@ class SpawnConfig:
     # assessment; the gated mode above is the conservative deployment flavor.
     explorer_always_on: bool = False
     # Guidance envelope for the explorer — MUST match the envelope the policy
-    # was trained against (stage1_reg_v4_env2 = envelope-v2: 5.0/2.0/9.0).
+    # was trained against (defaults = the v1-envelope calibration
+    # lambda_lat 5.0 / lat_scale 2.0 / col_scale 9.0).
     explorer_lambda_lat: float = 5.0
     explorer_lat_scale: float = 2.0
     explorer_col_scale: float = 9.0

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -241,6 +241,11 @@ class SpawnConfig:
     # Exponential smoothing factor on per-step etas (0 = raw, ->1 = frozen).
     # Damps left/right flip-flop near decision boundaries mid-avoidance.
     explorer_eta_smooth: float = 0.5
+    # Strict-certify activation: the explorer only acts when the det plan's
+    # min OBB clearance to a static NPC is below this (metres). 0.3 = act
+    # slightly before the 0.2 m crossing threshold. Plans clear of statics
+    # pass through untouched (inertness in closed loop).
+    explorer_activate_clearance: float = 0.3
     # Skip traffic-light state propagation entirely. Useful for MPC-gen
     # data runs where TL-driven speed drops would bias the replay ego
     # toward stop-and-go behaviour we don't want in training.
@@ -2314,22 +2319,52 @@ def run_route_replay(
 
             # Explorer guidance: regenerate the EGO trajectory through the
             # guidance composer, using its plain det prediction (just
-            # computed in the shared batch) as the reference. Other agents
-            # keep their plain predictions. Runs BEFORE SG smoothing so the
-            # guided trajectory gets the same smoothing as the plain one.
+            # computed in the shared batch) as the reference. STRICT-CERTIFY
+            # semantics matching the offline eval: the explorer activates
+            # ONLY when the det plan actually conflicts with a static NPC
+            # (clearance below explorer_activate_clearance), and the guided
+            # plan is kept only when it improves that clearance. Runs BEFORE
+            # SG smoothing so the guided trajectory gets the same smoothing.
             step_explorer_etas: dict[str, float] | None = None
             if explorer_runner is not None:
                 _eid = scene.ego_agent.id
                 if _eid in agent_predictions:
-                    from scenario_generation.tensor_converter import to_model_tensors
-                    _ego_dict = to_model_tensors(
-                        scene, _eid, model_args, device, map_cache=map_cache,
-                        inference_delay=spawn_config.inference_delay,
-                    )
-                    _guided, step_explorer_etas = explorer_runner.guided_ego_prediction(
-                        model, _ego_dict, agent_predictions[_eid],
-                    )
-                    agent_predictions[_eid] = _guided
+                    from scenario_generation.explorer_runner import plan_static_clearance
+                    _ego = scene.ego_agent
+                    _ex, _ey = float(_ego.current_position[0]), float(_ego.current_position[1])
+                    _eyaw = float(_ego.current_heading)
+                    _c, _s = math.cos(-_eyaw), math.sin(-_eyaw)
+                    _boxes = []
+                    for _a in scene.agents:
+                        if _a.id == _eid or not SceneNPCManager.is_static_npc(_a.id):
+                            continue
+                        _dx = float(_a.current_position[0]) - _ex
+                        _dy = float(_a.current_position[1]) - _ey
+                        _boxes.append((
+                            _c * _dx - _s * _dy, _s * _dx + _c * _dy,
+                            float(_a.current_heading) - _eyaw,
+                            float(_a.length), float(_a.width),
+                        ))
+                    _eshape = (spawn_config.ego_wheelbase,
+                               spawn_config.ego_length, spawn_config.ego_width)
+                    _det_plan = agent_predictions[_eid]
+                    _det_min = plan_static_clearance(_det_plan, _boxes, _eshape, device)
+                    if _det_min < spawn_config.explorer_activate_clearance:
+                        from scenario_generation.tensor_converter import to_model_tensors
+                        _ego_dict = to_model_tensors(
+                            scene, _eid, model_args, device, map_cache=map_cache,
+                            inference_delay=spawn_config.inference_delay,
+                        )
+                        _guided, _etas = explorer_runner.guided_ego_prediction(
+                            model, _ego_dict, _det_plan,
+                        )
+                        _g_min = plan_static_clearance(_guided, _boxes, _eshape, device)
+                        if _g_min > _det_min:
+                            agent_predictions[_eid] = _guided
+                            step_explorer_etas = _etas
+                        # else: keep det (certified fallback), smoothing state stays
+                    else:
+                        explorer_runner.reset()  # inert stretch: clear eta smoothing
 
             # Optional Savitzky-Golay smoothing on each agent's predicted
             # trajectory. Reuses the same smoother the RL ranked-SFT

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -2754,6 +2754,10 @@ def main() -> None:
     if args.explorer_dir is not None:
         cfg.explorer_dir = args.explorer_dir
     if args.explorer_eta_smooth is not None:
+        if not 0.0 <= args.explorer_eta_smooth <= 1.0:
+            raise SystemExit(
+                f"--explorer_eta_smooth must be in [0, 1], got "
+                f"{args.explorer_eta_smooth}")
         cfg.explorer_eta_smooth = args.explorer_eta_smooth
     # Re-run validation after CLI overrides so bad values (e.g. --steps 0)
     # are rejected at startup instead of much later.

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -230,6 +230,17 @@ class SpawnConfig:
     # Model inference delay: number of initial timesteps kept fixed as prefix.
     # Matches the "delay" input tensor to the diffusion decoder.
     inference_delay: int = 0
+    # Exploration-policy guidance for the EGO (frozen planner + learned
+    # per-step guidance etas). Directory must contain exploration_policy.pth
+    # + exploration_policy_config.json (rlvr.train_explorer_regression
+    # output). None = disabled (plain forward for everyone). Other agents
+    # always use the plain forward. The guidance-envelope strengths live in
+    # scenario_generation.explorer_runner.ExplorerEnvelope and must match
+    # the sweep envelope the policy was trained against.
+    explorer_dir: str | None = None
+    # Exponential smoothing factor on per-step etas (0 = raw, ->1 = frozen).
+    # Damps left/right flip-flop near decision boundaries mid-avoidance.
+    explorer_eta_smooth: float = 0.5
     # Skip traffic-light state propagation entirely. Useful for MPC-gen
     # data runs where TL-driven speed drops would bias the replay ego
     # toward stop-and-go behaviour we don't want in training.
@@ -1960,6 +1971,18 @@ def run_route_replay(
         spawn_config = SpawnConfig()
     output_dir.mkdir(parents=True, exist_ok=True)
 
+    # Optional exploration-policy guidance for the ego (frozen planner +
+    # learned guidance etas). Fails loudly if the dir is missing/incomplete.
+    explorer_runner = None
+    if spawn_config.explorer_dir:
+        from scenario_generation.explorer_runner import ExplorerGuidanceRunner
+        explorer_runner = ExplorerGuidanceRunner(
+            spawn_config.explorer_dir, model_args, device,
+            eta_smooth=spawn_config.explorer_eta_smooth,
+        )
+        print(f"  [explorer] guidance policy loaded from {spawn_config.explorer_dir} "
+              f"(heads={explorer_runner.heads}, eta_smooth={spawn_config.explorer_eta_smooth})")
+
     # Seed ALL random sources for full reproducibility across runs.
     if spawn_config.seed is not None:
         torch.manual_seed(spawn_config.seed)
@@ -2289,6 +2312,25 @@ def run_route_replay(
                     turn_indicator_keep_bias=spawn_config.turn_indicator_keep_bias,
                 )
 
+            # Explorer guidance: regenerate the EGO trajectory through the
+            # guidance composer, using its plain det prediction (just
+            # computed in the shared batch) as the reference. Other agents
+            # keep their plain predictions. Runs BEFORE SG smoothing so the
+            # guided trajectory gets the same smoothing as the plain one.
+            step_explorer_etas: dict[str, float] | None = None
+            if explorer_runner is not None:
+                _eid = scene.ego_agent.id
+                if _eid in agent_predictions:
+                    from scenario_generation.tensor_converter import to_model_tensors
+                    _ego_dict = to_model_tensors(
+                        scene, _eid, model_args, device, map_cache=map_cache,
+                        inference_delay=spawn_config.inference_delay,
+                    )
+                    _guided, step_explorer_etas = explorer_runner.guided_ego_prediction(
+                        model, _ego_dict, agent_predictions[_eid],
+                    )
+                    agent_predictions[_eid] = _guided
+
             # Optional Savitzky-Golay smoothing on each agent's predicted
             # trajectory. Reuses the same smoother the RL ranked-SFT
             # pipeline applies before its SFT loss (rlvr/grpo_sft_trainer.
@@ -2396,6 +2438,7 @@ def run_route_replay(
                     "stopped_id": sc_pair[3] if sc_pair is not None else None,
                     "moving_dist": float(mv_pair[2]) if mv_pair is not None else None,
                     "moving_id": mv_pair[3] if mv_pair is not None else None,
+                    "explorer_etas": step_explorer_etas,
                     "png": out_path.name,
                 })
 
@@ -2615,6 +2658,12 @@ def main() -> None:
                              "a config per run.")
     parser.add_argument("--device", type=str, default="cuda")
     parser.add_argument("--seed", type=int, default=None)
+    parser.add_argument("--explorer_dir", type=str, default=None,
+                        help="Exploration-policy dir (exploration_policy.pth + "
+                             "config json) for guided EGO generation. Overrides "
+                             "SpawnConfig.explorer_dir.")
+    parser.add_argument("--explorer_eta_smooth", type=float, default=None,
+                        help="Override SpawnConfig.explorer_eta_smooth (0=raw etas)")
     args = parser.parse_args()
 
     route = Route.load(args.route)
@@ -2631,6 +2680,10 @@ def main() -> None:
         cfg.spawn_probability = args.spawn_probability
     if args.seed is not None:
         cfg.seed = args.seed
+    if args.explorer_dir is not None:
+        cfg.explorer_dir = args.explorer_dir
+    if args.explorer_eta_smooth is not None:
+        cfg.explorer_eta_smooth = args.explorer_eta_smooth
     # Re-run validation after CLI overrides so bad values (e.g. --steps 0)
     # are rejected at startup instead of much later.
     cfg.validate()

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -246,6 +246,11 @@ class SpawnConfig:
     # slightly before the 0.2 m crossing threshold. Plans clear of statics
     # pass through untouched (inertness in closed loop).
     explorer_activate_clearance: float = 0.3
+    # ALWAYS-ON mode: bypass the activation gate AND the keep-only-if-improves
+    # certify rule — the policy runs every step and its guided plan is always
+    # used. This is the honest "does always-on guidance work closed-loop"
+    # assessment; the gated mode above is the conservative deployment flavor.
+    explorer_always_on: bool = False
     # Guidance envelope for the explorer — MUST match the envelope the policy
     # was trained against (stage1_reg_v4_env2 = envelope-v2: 5.0/2.0/9.0).
     explorer_lambda_lat: float = 5.0
@@ -2365,23 +2370,34 @@ def run_route_replay(
                     _eshape = (spawn_config.ego_wheelbase,
                                spawn_config.ego_length, spawn_config.ego_width)
                     _det_plan = agent_predictions[_eid]
-                    _det_min = plan_static_clearance(_det_plan, _boxes, _eshape, device)
-                    if _det_min < spawn_config.explorer_activate_clearance:
+                    if spawn_config.explorer_always_on:
                         from scenario_generation.tensor_converter import to_model_tensors
                         _ego_dict = to_model_tensors(
                             scene, _eid, model_args, device, map_cache=map_cache,
                             inference_delay=spawn_config.inference_delay,
                         )
-                        _guided, _etas = explorer_runner.guided_ego_prediction(
+                        _guided, step_explorer_etas = explorer_runner.guided_ego_prediction(
                             model, _ego_dict, _det_plan,
                         )
-                        _g_min = plan_static_clearance(_guided, _boxes, _eshape, device)
-                        if _g_min > _det_min:
-                            agent_predictions[_eid] = _guided
-                            step_explorer_etas = _etas
-                        # else: keep det (certified fallback), smoothing state stays
+                        agent_predictions[_eid] = _guided
                     else:
-                        explorer_runner.reset()  # inert stretch: clear eta smoothing
+                        _det_min = plan_static_clearance(_det_plan, _boxes, _eshape, device)
+                        if _det_min < spawn_config.explorer_activate_clearance:
+                            from scenario_generation.tensor_converter import to_model_tensors
+                            _ego_dict = to_model_tensors(
+                                scene, _eid, model_args, device, map_cache=map_cache,
+                                inference_delay=spawn_config.inference_delay,
+                            )
+                            _guided, _etas = explorer_runner.guided_ego_prediction(
+                                model, _ego_dict, _det_plan,
+                            )
+                            _g_min = plan_static_clearance(_guided, _boxes, _eshape, device)
+                            if _g_min > _det_min:
+                                agent_predictions[_eid] = _guided
+                                step_explorer_etas = _etas
+                            # else: keep det (certified fallback), smoothing state stays
+                        else:
+                            explorer_runner.reset()  # inert stretch: clear eta smoothing
 
             # Optional Savitzky-Golay smoothing on each agent's predicted
             # trajectory. Reuses the same smoother the RL ranked-SFT


### PR DESCRIPTION
## Summary
Adds the guidance-explorer pipeline: a small learned policy that outputs per-scene guidance parameters (lateral / collision-swerve etas) applied as classifier guidance during diffusion sampling, with the planner fully frozen. Includes label-generation tooling (grid sweeps, proactive-margin + robustness-aware label selection), training (cached-feature regression with grouped holdout), evaluation (batched lockstep closed-loop rollouts + videos, label-holdout eval, guided L2), data-hygiene tools (static-neighbor future repair, poison-normal screens), batched guidance functions (v1 + v2 envelopes, new opt-in registry names only), a faster drop-in guidance composer (cached observation inverse-normalization, inert short-circuit; equivalence-certified bit-identical on active frames, --slow_composer escape hatch), closed-loop RL trainer head-spec support with value-head warmup, and a distillation tool that converts guided trajectories into curated-RSFT targets.

## Notes for review
- No changes under diffusion_planner/ (new guidance functions register from rlvr/guidance_batched.py).
- Legacy paths preserved: stock lateral+longitudinal composer wiring reproduces exactly (probe-verified); old configs unaffected.
- General methodology documented in docs/guidance_explorer_framework.md and docs/guidance_framework_design.md.

## Test plan
- exploration_policy + rlvr guidance/batched test suites pass.
- Composer equivalence battery: response-fan probes both envelopes bit-identical; closed-loop divergence attributable only to the documented inert-contract fix.

## Some results
[ext86_futfix__raw_extended_46__scene_0039.webm](https://github.com/user-attachments/assets/af7eeb60-048d-4fd3-bd88-f990de1a4243)

[ext86_futfix__raw_extended_46__scene_0035.webm](https://github.com/user-attachments/assets/0239458d-9185-42d4-b37c-c9568864c102)

[ext86_futfix__raw_extended_46__scene_0023.webm](https://github.com/user-attachments/assets/b95ee5ce-523e-4ffa-8869-28de56499e03)

