### PR TITLE
Reuse the guidance composer's DiT forward in the DPM solver (guided-sampling latency)

### DIFF
--- a/guidance_gui/generate_samples.py
+++ b/guidance_gui/generate_samples.py
@@ -22,6 +22,7 @@ def generate_samples(
     n_samples: int,
     composer: GuidanceComposer | None,
     device: torch.device,
+    use_dit_memo: bool = True,
 ) -> np.ndarray:
     """
     Generate n_samples independent ego trajectories under a shared configuration.
@@ -73,7 +74,7 @@ def generate_samples(
                 noise_scale,
             )
 
-            if composer is not None:
+            if composer is not None and use_dit_memo:
                 # dit_memo: the solver reuses the composer's x0-refinement
                 # forward at the same (x, t) — ~25% off guided frames.
                 with dit_memo(model.decoder):

--- a/guidance_gui/generate_samples.py
+++ b/guidance_gui/generate_samples.py
@@ -56,6 +56,7 @@ def generate_samples(
     # pulls in modules that import back here, so a top-level import would create
     # an import cycle. Imported once per call here (not per loop iteration).
     from rlvr.closed_loop.batched_rollout import make_initial_latent
+    from rlvr.guidance_batched import dit_memo
 
     B = data["ego_current_state"].shape[0]
     P = 1 + model_args.predicted_neighbor_num
@@ -72,7 +73,13 @@ def generate_samples(
                 noise_scale,
             )
 
-            _, decoder_output = model(data)
+            if composer is not None:
+                # dit_memo: the solver reuses the composer's x0-refinement
+                # forward at the same (x, t) — ~25% off guided frames.
+                with dit_memo(model.decoder):
+                    _, decoder_output = model(data)
+            else:
+                _, decoder_output = model(data)
             ego_trajectory = decoder_output["prediction"][0, 0].cpu().numpy()  # (OUTPUT_T, 4)
             results.append(ego_trajectory)
     finally:

--- a/guidance_gui/generate_samples.py
+++ b/guidance_gui/generate_samples.py
@@ -38,6 +38,11 @@ def generate_samples(
         composer: GuidanceComposer instance to inject for this call, or None for
                   unguided sampling.
         device: Torch device.
+        use_dit_memo: When a composer is active, reuse its x0-refinement DiT
+                      forward for the solver's noise prediction at the same
+                      (x, t) (numerically equivalent, ~halves the guided step).
+                      False = escape hatch for A/B verification. No effect when
+                      composer is None.
 
     Returns:
         (n_samples, OUTPUT_T, 4) float32 numpy array.

--- a/rlvr/autoresearch/tools/README.md
+++ b/rlvr/autoresearch/tools/README.md
@@ -130,6 +130,24 @@ python -m rlvr.autoresearch.tools.grpo_viz \
   --w_progress 1.0 --lane_near_scale 50.0
 ```
 
+### verify_dit_memo.py
+Equivalence + latency check for the guided-sampling **DiT forward memo**. During
+classifier-guided DPM-solver sampling the DiT runs twice on the same `(x, t)` —
+once for the composer's x̂₀ refinement, once for the solver's noise prediction —
+so `rlvr.guidance_batched.dit_memo` (a scoped single-slot memo around
+`decoder.dit`) serves the second from the first. It is **default-on** at every
+guided-generation entry point (`--no_dit_memo` / `use_dit_memo=False` is the A/B
+escape hatch). This tool generates each scene three ways (slow composer / fast
+composer / fast+memo) and reports pairwise max `|dtraj|` + per-leg latency:
+`fast-vs-slow` is exactly 0, `memo-vs-fast` is ~0 (one float quantum — the shared
+forward runs under `no_grad`, numerically equivalent, not bit-identical). Raises
+if the memo never fires (so a no-op can't report false equivalence).
+```bash
+python -m rlvr.autoresearch.tools.verify_dit_memo \
+  --model_path <base.pth> --scenes <json> --n_scenes 3 \
+  --etas=-0.75,0.3,0.75 --envelopes v1,v2 --repeats 2
+```
+
 ## Diagnostic Tools
 
 ### diagnose_grpo_signal.py

--- a/rlvr/autoresearch/tools/bench_explorer_latency.py
+++ b/rlvr/autoresearch/tools/bench_explorer_latency.py
@@ -59,6 +59,11 @@ def main():
     parser.add_argument("--lambda_spd", type=float, default=0.2)
     parser.add_argument("--stretch_scale", type=float, default=1.0)
     parser.add_argument("--guidance_scale", type=float, default=0.5)
+    parser.add_argument(
+        "--no_dit_memo",
+        action="store_true",
+        help="disable the guided-frame DiT forward memo (A/B escape hatch; memo is the default)",
+    )
     parser.add_argument("--output", default=None)
     args = parser.parse_args()
 
@@ -110,6 +115,7 @@ def main():
                 first_deterministic=False,
                 composer=make_composer(etas1, args),
                 device=device,
+                use_dit_memo=not args.no_dit_memo,
             )
             _sync()
             t3 = time.perf_counter()
@@ -146,6 +152,7 @@ def main():
                 first_deterministic=False,
                 composer=make_composer(etas9, args),
                 device=device,
+                use_dit_memo=not args.no_dit_memo,
             )
             _sync()
             t["k8_guided"].append(time.perf_counter() - t0)

--- a/rlvr/autoresearch/tools/eval_closedloop_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_closedloop_avoidance.py
@@ -66,6 +66,7 @@ def make_guided_predict(policy, heads, args, device):
                 first_deterministic=False,
                 composer=make_composer(etas, args),
                 device=device,
+                use_dit_memo=not args.no_dit_memo,
             )[0]
             .cpu()
             .numpy()
@@ -130,6 +131,11 @@ def main():
     parser.add_argument("--lambda_spd", type=float, default=0.2)
     parser.add_argument("--stretch_scale", type=float, default=1.0)
     parser.add_argument("--guidance_scale", type=float, default=0.5)
+    parser.add_argument(
+        "--no_dit_memo",
+        action="store_true",
+        help="disable the guided-frame DiT forward memo (A/B escape hatch; memo is the default)",
+    )
     args = parser.parse_args()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/rlvr/autoresearch/tools/eval_policy_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_policy_avoidance.py
@@ -126,6 +126,7 @@ def eval_scene(model, model_args, policy, heads, npz_path, rcfg, args, device):
                 first_deterministic=False,
                 composer=composer,
                 device=device,
+                use_dit_memo=not getattr(args, "no_dit_memo", False),
             )
             .cpu()
             .numpy()
@@ -141,6 +142,7 @@ def eval_scene(model, model_args, policy, heads, npz_path, rcfg, args, device):
             n_samples=1,
             composer=composer,
             device=device,
+            use_dit_memo=not getattr(args, "no_dit_memo", False),
         )[None, 0]
 
     det = x_ref_np  # x_ref IS the unguided det trajectory
@@ -313,6 +315,11 @@ def main():
     parser.add_argument("--guidance_scale", type=float, default=0.5)
     parser.add_argument("--envelope", choices=["v1", "v2"], default="v1")
     parser.add_argument("--lambda_col", type=float, default=3.0)
+    parser.add_argument(
+        "--no_dit_memo",
+        action="store_true",
+        help="disable the guided-frame DiT forward memo (A/B escape hatch; memo is the default)",
+    )
     parser.add_argument(
         "--slow_composer",
         action="store_true",

--- a/rlvr/autoresearch/tools/valid_predictor_guided.py
+++ b/rlvr/autoresearch/tools/valid_predictor_guided.py
@@ -82,6 +82,11 @@ def main():
     parser.add_argument("--guidance_scale", type=float, default=0.5)
     parser.add_argument("--envelope", choices=["v1", "v2"], default="v1")
     parser.add_argument("--lambda_col", type=float, default=3.0)
+    parser.add_argument(
+        "--no_dit_memo",
+        action="store_true",
+        help="disable the guided-frame DiT forward memo (A/B escape hatch; memo is the default)",
+    )
     args = parser.parse_args()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -159,10 +164,13 @@ def main():
         decoder._guidance_fn = composer
         decoder._guidance_scale = composer._set_config.global_scale
         try:
-            # dit_memo: solver reuses the composer's x0-refinement forward
-            # (same deployment-path optimization as explorer_runner).
-            with dit_memo(decoder):
+            if args.no_dit_memo:
                 _, gui_out = model(data)
+            else:
+                # dit_memo: solver reuses the composer's x0-refinement
+                # forward (same deployment optimization as explorer_runner).
+                with dit_memo(decoder):
+                    _, gui_out = model(data)
         finally:
             decoder._guidance_fn = saved_fn
             decoder._guidance_scale = saved_scale

--- a/rlvr/autoresearch/tools/valid_predictor_guided.py
+++ b/rlvr/autoresearch/tools/valid_predictor_guided.py
@@ -34,6 +34,7 @@ import rlvr.guidance_batched  # noqa: F401
 from exploration_policy.utils import run_frozen_encoder
 from rlvr.autoresearch.tools.eval_det_avoidance import load_model
 from rlvr.autoresearch.tools.eval_policy_avoidance import load_policy, make_composer
+from rlvr.guidance_batched import dit_memo
 
 
 class _LossAccum:
@@ -158,7 +159,10 @@ def main():
         decoder._guidance_fn = composer
         decoder._guidance_scale = composer._set_config.global_scale
         try:
-            _, gui_out = model(data)
+            # dit_memo: solver reuses the composer's x0-refinement forward
+            # (same deployment-path optimization as explorer_runner).
+            with dit_memo(decoder):
+                _, gui_out = model(data)
         finally:
             decoder._guidance_fn = saved_fn
             decoder._guidance_scale = saved_scale

--- a/rlvr/autoresearch/tools/verify_dit_memo.py
+++ b/rlvr/autoresearch/tools/verify_dit_memo.py
@@ -172,6 +172,18 @@ def main():
             "p95_ms": round(float(np.percentile(a, 95)), 2),
         }
 
+    # Guard against a false "equivalent" verdict from a memo that never fired:
+    # if hits == 0 everywhere, memo_vs_fast would be 0.0 simply because the memo
+    # did nothing. A real run hits once per guided solver step.
+    total_hits = sum(m["hits"] for m in memo_stats)
+    if total_hits == 0:
+        raise RuntimeError(
+            "DiT memo recorded 0 hits across all instrumented scenes — the "
+            "optimization never fired, so the equivalence numbers are vacuous. "
+            "Check that the composer is active (non-inert) and dit_memo is "
+            f"installed. memo_stats={memo_stats}"
+        )
+
     report = {
         "n_scenes": len(paths),
         "etas": etas_grid,
@@ -180,6 +192,7 @@ def main():
         "max_dtraj_m": {k: max(v) for k, v in diffs.items()},
         "active_frame_latency": {leg: ms(v) for leg, v in times.items()},
         "memo_stats": memo_stats,
+        "total_memo_hits": total_hits,
         "cases": cases,
     }
     print(json.dumps({k: v for k, v in report.items() if k != "cases"}, indent=1))

--- a/rlvr/autoresearch/tools/verify_dit_memo.py
+++ b/rlvr/autoresearch/tools/verify_dit_memo.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Equivalence + latency check for the guided-sampling DiT forward memo.
+
+For each scene x envelope x eta, generates the guided trajectory (K=1,
+zero initial latent -> deterministic) three ways:
+
+  slow : stock GuidanceComposer            (fast=False, no memo)
+  fast : FastGuidanceComposer              (memo off)
+  memo : FastGuidanceComposer + dit_memo   (the wired default)
+
+and reports the pairwise max |dtraj| over the full [T, 4] ego plan —
+the bit-identical claim requires memo-vs-fast == 0 exactly — plus
+active-frame latency (mean/p95 ms) per leg and the memo hit/miss
+counters from one instrumented generation per scene.
+
+Usage:
+    python -m rlvr.autoresearch.tools.verify_dit_memo \
+        --model_path <base.pth> --scenes <json> \
+        [--n_scenes 3] [--etas -0.75,-0.3,0.3,0.75] \
+        [--envelopes v1,v2] [--repeats 3] [--output <json>]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+
+import numpy as np
+import torch
+
+import rlvr.guidance_batched  # noqa: F401 -- registers the batched variants
+from preference_optimization.utils import load_npz_data
+from rlvr.autoresearch.tools.eval_det_avoidance import load_model
+from rlvr.autoresearch.tools.recovery_sim import deterministic_predict
+from rlvr.closed_loop.batched_rollout import _batched_generate_varied_noise
+from rlvr.grpo_trainer_batched import _normalize_batch, _stack_scene_data
+from rlvr.guidance_batched import build_head_composer, dit_memo
+
+
+def _sync():
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+def _gen(model, model_args, norm, composer, device, use_dit_memo):
+    return _batched_generate_varied_noise(
+        model,
+        model_args,
+        norm,
+        noise_min=0.0,
+        noise_max=0.0,
+        first_deterministic=False,
+        composer=composer,
+        device=device,
+        use_dit_memo=use_dit_memo,
+    )
+
+
+@torch.no_grad()
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--model_path", required=True)
+    parser.add_argument("--scenes", required=True)
+    parser.add_argument("--n_scenes", type=int, default=3)
+    parser.add_argument("--etas", default="-0.75,-0.3,0.3,0.75")
+    parser.add_argument("--envelopes", default="v1,v2")
+    parser.add_argument(
+        "--repeats", type=int, default=3, help="timing repeats per (scene, envelope, eta)"
+    )
+    parser.add_argument("--guidance_scale", type=float, default=0.5)
+    parser.add_argument("--output", default=None)
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model, model_args = load_model(args.model_path, device)
+    with open(args.scenes) as f:
+        paths = json.load(f)[: args.n_scenes]
+    etas_grid = [float(v) for v in args.etas.split(",")]
+    envelopes = args.envelopes.split(",")
+
+    legs = ("slow", "fast", "memo")
+    diffs = {"fast_vs_slow": [], "memo_vs_fast": [], "memo_vs_slow": []}
+    times = {leg: [] for leg in legs}
+    memo_stats = []
+    cases = []
+
+    for path in paths:
+        data = load_npz_data(path, device)
+        det = deterministic_predict(model, model_args, data)
+        batch = _stack_scene_data([data], device)
+        norm = _normalize_batch(batch, model_args)
+        x_ref = torch.from_numpy(np.ascontiguousarray(det)).float()
+        norm["reference_trajectory"] = x_ref.unsqueeze(0).to(device)
+
+        for env in envelopes:
+            for e in etas_grid:
+                head_etas = {"lateral": e, "collision": e, "stretch": e}
+                composers = {
+                    "slow": build_head_composer(
+                        head_etas, envelope=env, fast=False, guidance_scale=args.guidance_scale
+                    ),
+                    "fast": build_head_composer(
+                        head_etas, envelope=env, fast=True, guidance_scale=args.guidance_scale
+                    ),
+                }
+                trajs = {}
+                for rep in range(args.repeats):
+                    for leg in legs:
+                        composer = composers["slow" if leg == "slow" else "fast"]
+                        # FastGuidanceComposer caches the inverse-normalised
+                        # observations per generation; rebuild per timed run
+                        # so every repeat pays the same first-call cost.
+                        if leg != "slow":
+                            composer = build_head_composer(
+                                head_etas,
+                                envelope=env,
+                                fast=True,
+                                guidance_scale=args.guidance_scale,
+                            )
+                        _sync()
+                        t0 = time.perf_counter()
+                        traj = _gen(
+                            model, model_args, norm, composer, device, use_dit_memo=(leg == "memo")
+                        )
+                        _sync()
+                        times[leg].append(time.perf_counter() - t0)
+                        if rep == 0:
+                            trajs[leg] = traj[0].cpu()
+                case = {
+                    "scene": path,
+                    "envelope": env,
+                    "eta": e,
+                    "fast_vs_slow": float((trajs["fast"] - trajs["slow"]).abs().max()),
+                    "memo_vs_fast": float((trajs["memo"] - trajs["fast"]).abs().max()),
+                    "memo_vs_slow": float((trajs["memo"] - trajs["slow"]).abs().max()),
+                }
+                for k in diffs:
+                    diffs[k].append(case[k])
+                cases.append(case)
+
+        # one instrumented run per scene for memo hit/miss counters
+        composer = build_head_composer(
+            {"lateral": etas_grid[0], "collision": etas_grid[0], "stretch": etas_grid[0]},
+            envelope=envelopes[0],
+            fast=True,
+            guidance_scale=args.guidance_scale,
+        )
+        _orig_fn = model.decoder._guidance_fn
+        _orig_scale = model.decoder._guidance_scale
+        model.decoder._guidance_fn = composer
+        model.decoder._guidance_scale = composer._set_config.global_scale
+        P = 1 + model_args.predicted_neighbor_num
+        norm["sampled_trajectories"] = torch.zeros(
+            1, P, model_args.future_len + 1, 4, device=device
+        )
+        try:
+            with dit_memo(model.decoder) as memo:
+                model(norm)
+        finally:
+            model.decoder._guidance_fn = _orig_fn
+            model.decoder._guidance_scale = _orig_scale
+        memo_stats.append({"scene": path, "hits": memo.hits, "misses": memo.misses})
+
+    def ms(v):
+        a = np.array(v) * 1000
+        return {
+            "mean_ms": round(float(a.mean()), 2),
+            "p95_ms": round(float(np.percentile(a, 95)), 2),
+        }
+
+    report = {
+        "n_scenes": len(paths),
+        "etas": etas_grid,
+        "envelopes": envelopes,
+        "repeats": args.repeats,
+        "max_dtraj_m": {k: max(v) for k, v in diffs.items()},
+        "active_frame_latency": {leg: ms(v) for leg, v in times.items()},
+        "memo_stats": memo_stats,
+        "cases": cases,
+    }
+    print(json.dumps({k: v for k, v in report.items() if k != "cases"}, indent=1))
+    if args.output:
+        with open(args.output, "w") as f:
+            json.dump(report, f, indent=1)
+        print(f"full per-case report -> {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/verify_dit_memo.py
+++ b/rlvr/autoresearch/tools/verify_dit_memo.py
@@ -8,10 +8,13 @@ zero initial latent -> deterministic) three ways:
   fast : FastGuidanceComposer              (memo off)
   memo : FastGuidanceComposer + dit_memo   (the wired default)
 
-and reports the pairwise max |dtraj| over the full [T, 4] ego plan —
-the bit-identical claim requires memo-vs-fast == 0 exactly — plus
-active-frame latency (mean/p95 ms) per leg and the memo hit/miss
-counters from one instrumented generation per scene.
+and reports the pairwise max |dtraj| over the full [T, 4] ego plan. fast-vs-slow
+should be exactly 0; memo-vs-fast should be ~0 (a few 1e-5 m at most): the memo
+serves a single forward run under no_grad to both consumers, so kernel/backend
+selection can differ from the two-forward path by ~one float quantum — sub-mm
+and behaviorally inert, not a bug. Also reports active-frame latency (mean/p95
+ms) per leg and the memo hit/miss counters from one instrumented generation per
+scene.
 
 Usage:
     python -m rlvr.autoresearch.tools.verify_dit_memo \

--- a/rlvr/closed_loop/batched_rollout.py
+++ b/rlvr/closed_loop/batched_rollout.py
@@ -79,9 +79,11 @@ def _batched_generate(
         composer: GuidanceComposer or None.
         device: Torch device.
         use_dit_memo: Reuse the composer's x0-refinement DiT forward for the
-            solver's noise prediction at the same (x, t) (bit-identical,
-            ~halves active guided-frame cost). Only takes effect with a
-            composer; False = escape hatch for A/B verification.
+            solver's noise prediction at the same (x, t) (numerically
+            equivalent — sub-mm; the shared forward runs under no_grad, so
+            kernel selection can differ from the two-forward path by ~one
+            float quantum — and ~halves active guided-frame cost). Only takes
+            effect with a composer; False = escape hatch for A/B verification.
 
     Returns:
         [B, T, 4] ego trajectories (x, y, cos, sin).

--- a/rlvr/closed_loop/batched_rollout.py
+++ b/rlvr/closed_loop/batched_rollout.py
@@ -31,6 +31,7 @@ from rlvr.closed_loop.state_update import (
     transform_positions_to_ego_frame,
     update_scene_state,
 )
+from rlvr.guidance_batched import dit_memo
 from rlvr.reward import RewardConfig
 
 
@@ -66,6 +67,7 @@ def _batched_generate(
     noise_scale: float,
     composer: GuidanceComposer | None,
     device: torch.device,
+    use_dit_memo: bool = True,
 ) -> torch.Tensor:
     """Generate one trajectory per scene in a batch.
 
@@ -76,6 +78,10 @@ def _batched_generate(
         noise_scale: Noise for initial latent.
         composer: GuidanceComposer or None.
         device: Torch device.
+        use_dit_memo: Reuse the composer's x0-refinement DiT forward for the
+            solver's noise prediction at the same (x, t) (bit-identical,
+            ~halves active guided-frame cost). Only takes effect with a
+            composer; False = escape hatch for A/B verification.
 
     Returns:
         [B, T, 4] ego trajectories (x, y, cos, sin).
@@ -104,7 +110,11 @@ def _batched_generate(
     )
 
     try:
-        _, decoder_output = model(batch_data)
+        if composer is not None and use_dit_memo:
+            with dit_memo(model.decoder):
+                _, decoder_output = model(batch_data)
+        else:
+            _, decoder_output = model(batch_data)
         # [B, P, T, 4] -> [B, T, 4] (ego only, index 0)
         ego_trajs = decoder_output["prediction"][:, 0].detach()
     finally:
@@ -143,6 +153,7 @@ def _batched_generate_varied_noise(
     first_deterministic: bool,
     composer: GuidanceComposer | None,
     device: torch.device,
+    use_dit_memo: bool = True,
 ) -> torch.Tensor:
     """Generate trajectories with per-element independent noise scales.
 
@@ -153,6 +164,7 @@ def _batched_generate_varied_noise(
     Args:
         noise_min, noise_max: Range for uniform random noise scale per trajectory.
         first_deterministic: If True, element 0 gets noise=0 (deterministic).
+        use_dit_memo: See _batched_generate.
 
     Returns:
         [B, T, 4] ego trajectories.
@@ -184,7 +196,11 @@ def _batched_generate_varied_noise(
     batch_data["sampled_trajectories"] = xT
 
     try:
-        _, decoder_output = model(batch_data)
+        if composer is not None and use_dit_memo:
+            with dit_memo(model.decoder):
+                _, decoder_output = model(batch_data)
+        else:
+            _, decoder_output = model(batch_data)
         ego_trajs = decoder_output["prediction"][:, 0].detach()
     finally:
         model.decoder._guidance_fn = _orig_fn

--- a/rlvr/guidance_batched.py
+++ b/rlvr/guidance_batched.py
@@ -613,8 +613,10 @@ class DiTForwardMemo(torch.nn.Module):
     then again in ``noise_pred_fn`` for the same ``(x, t)``. Both call sites
     reshape x to ``[B, P, -1, 4]`` and pass the solver's time tensor straight
     through, so the computations are value-identical — the second call can
-    return the first call's output. That removes one full DiT forward per
-    guided solver evaluation (~2x on the active guided path).
+    return the first call's output. That removes one of the two DiT forwards
+    per guided solver evaluation: the DiT work per guided step roughly halves,
+    which measures as ~25% off the whole active guided frame (the frame also
+    pays the encoder, policy and energy autograd).
 
     Matching is exact: positional tensor args must be value-equal
     (``torch.equal`` against a detached CLONE — a plain detached view would

--- a/rlvr/guidance_batched.py
+++ b/rlvr/guidance_batched.py
@@ -602,3 +602,108 @@ class FastGuidanceComposer:
         std = state_normalizer.std.to(grad_phys.device)
         grad_flat = (grad_phys * std).detach().reshape(x_in.shape)
         return (grad_flat * x_in).sum()
+
+
+class DiTForwardMemo(torch.nn.Module):
+    """Single-slot forward memo for the decoder's DiT during guided sampling.
+
+    In ``dpm.model_wrapper``'s classifier branch every solver evaluation runs
+    the DiT twice on the same input: first inside the guidance composer's
+    x̂0-refinement (``cond_grad_fn`` → composer → ``model(x_4d, t, ...)``),
+    then again in ``noise_pred_fn`` for the same ``(x, t)``. Both call sites
+    reshape x to ``[B, P, -1, 4]`` and pass the solver's time tensor straight
+    through, so the computations are value-identical — the second call can
+    return the first call's output. That removes one full DiT forward per
+    guided solver evaluation (~2x on the active guided path).
+
+    Matching is exact: positional tensor args must be value-equal
+    (``torch.equal`` against a detached CLONE — a plain detached view would
+    alias the caller's storage and could report stale equality after an
+    in-place update), keyword tensors (the per-generation conditioning) must
+    be the same objects, and any non-tensor arg must compare ``==``. Any
+    mismatch falls through to a real forward, so a miss costs only the
+    comparison.
+
+    The wrapped forward runs under ``no_grad``: every classifier_fn in this
+    repo detaches the DiT output (straight-through x̂0 correction), and the
+    sampling call sites are already no_grad — the graph the composer's call
+    would otherwise build inside ``cond_grad_fn``'s enable_grad block is pure
+    waste. Consequently this wrapper is for SAMPLING only; never install it
+    around a training forward.
+    """
+
+    def __init__(self, dit: torch.nn.Module):
+        super().__init__()
+        # Plain-list indirection keeps the wrapped DiT out of _modules, so
+        # while the memo is installed the decoder's state_dict/apply never
+        # see a "dit.<wrapped>" level.
+        self._wrapped = [dit]
+        self._args = None
+        self._kwargs = None
+        self._out = None
+        self.hits = 0
+        self.misses = 0
+
+    def _match(self, args, kwargs) -> bool:
+        if self._out is None or len(args) != len(self._args):
+            return False
+        if set(kwargs.keys()) != set(self._kwargs.keys()):
+            return False
+        for a, c in zip(args, self._args):
+            if torch.is_tensor(a) != torch.is_tensor(c):
+                return False
+            if torch.is_tensor(a):
+                if a.shape != c.shape or not torch.equal(a, c):
+                    return False
+            elif a != c:
+                return False
+        for k, v in kwargs.items():
+            c = self._kwargs[k]
+            if torch.is_tensor(v):
+                if v is not c:
+                    return False
+            elif v != c:
+                return False
+        return True
+
+    def forward(self, *args, **kwargs):
+        if self._match(args, kwargs):
+            self.hits += 1
+            return self._out
+        with torch.no_grad():
+            out = self._wrapped[0](*args, **kwargs)
+        self._args = tuple(a.detach().clone() if torch.is_tensor(a) else a for a in args)
+        self._kwargs = dict(kwargs)
+        self._out = out
+        self.misses += 1
+        return out
+
+
+class dit_memo:
+    """Context manager: swap ``decoder.dit`` for a :class:`DiTForwardMemo`.
+
+    Usage::
+
+        with dit_memo(model.decoder) as memo:
+            _, out = model(batch_data)   # guided x_start inference
+        # memo.hits / memo.misses available after the block
+
+    Scoped install/restore mirrors the ``_guidance_fn`` swap pattern the
+    rollout helpers already use, so nothing outside the guided generation
+    ever sees the wrapper.
+    """
+
+    def __init__(self, decoder: torch.nn.Module):
+        self._decoder = decoder
+        self._orig = None
+        self.memo = None
+
+    def __enter__(self) -> DiTForwardMemo:
+        self._orig = self._decoder.dit
+        self.memo = DiTForwardMemo(self._orig)
+        self._decoder.dit = self.memo
+        return self.memo
+
+    def __exit__(self, exc_type, exc, tb):
+        self._decoder.dit = self._orig
+        return False

--- a/rlvr/test_guidance_batched.py
+++ b/rlvr/test_guidance_batched.py
@@ -206,3 +206,113 @@ def test_fast_composer_inert_detection():
     comp = build_head_composer({"lateral": 0.0, "collision": 0.0})
     comp._functions.append(band)
     assert not comp._all_inert()
+
+
+# ---------------------------------------------------------------------------
+# DiTForwardMemo / dit_memo
+# ---------------------------------------------------------------------------
+
+
+class _CountingNet(torch.nn.Module):
+    """Stand-in DiT: deterministic fn of (x, t, cross_c), counts forwards."""
+
+    def __init__(self):
+        super().__init__()
+        self.calls = 0
+
+    def forward(self, x, t, cross_c=None, neighbor_current_mask=None):
+        self.calls += 1
+        out = x * 2.0 + t.reshape(-1, *([1] * (x.dim() - 1)))
+        if cross_c is not None:
+            out = out + cross_c.mean()
+        return out
+
+
+def test_dit_memo_hit_on_equal_values_miss_on_change():
+    from rlvr.guidance_batched import DiTForwardMemo
+
+    net = _CountingNet()
+    memo = DiTForwardMemo(net)
+    x = torch.randn(2, 3, 11, 4)
+    t = torch.tensor([0.5, 0.5])
+    cond = torch.randn(2, 8)
+
+    out1 = memo(x, t, cross_c=cond)
+    assert net.calls == 1 and memo.misses == 1 and memo.hits == 0
+
+    # value-equal x in a DIFFERENT tensor (the composer detaches/reshapes)
+    # + same conditioning object -> hit, no extra forward
+    out2 = memo(x.detach().clone().requires_grad_(True), t, cross_c=cond)
+    assert net.calls == 1 and memo.hits == 1
+    assert out2 is out1
+
+    # changed x values -> miss
+    memo(x + 1e-6, t, cross_c=cond)
+    assert net.calls == 2
+
+    # same x values but a DIFFERENT conditioning tensor object -> miss
+    memo(x + 1e-6, t, cross_c=cond.clone())
+    assert net.calls == 3
+
+
+def test_dit_memo_inplace_mutation_cannot_false_hit():
+    from rlvr.guidance_batched import DiTForwardMemo
+
+    net = _CountingNet()
+    memo = DiTForwardMemo(net)
+    x = torch.randn(2, 3, 11, 4)
+    t = torch.tensor([0.5, 0.5])
+
+    out1 = memo(x, t)
+    x.add_(1.0)  # caller mutates its tensor in place after the cached call
+    out2 = memo(x, t)
+    # the cached key was cloned, so the mutated x must NOT match the stale
+    # entry — a fresh forward is required
+    assert net.calls == 2
+    assert not torch.equal(out1, out2)
+
+
+def test_dit_memo_output_matches_unwrapped_and_is_detached():
+    from rlvr.guidance_batched import DiTForwardMemo
+
+    net = _CountingNet()
+    memo = DiTForwardMemo(net)
+    x = torch.randn(2, 3, 11, 4)
+    t = torch.tensor([0.3, 0.3])
+    expected = net(x, t)
+
+    with torch.enable_grad():
+        out = memo(x.clone().requires_grad_(True), t)
+    assert torch.equal(out, expected)
+    assert not out.requires_grad  # forward runs under no_grad
+
+
+def test_dit_memo_context_manager_installs_and_restores():
+    from rlvr.guidance_batched import DiTForwardMemo, dit_memo
+
+    class _Decoder(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.dit = _CountingNet()
+
+    dec = _Decoder()
+    orig = dec.dit
+    with dit_memo(dec) as memo:
+        assert isinstance(dec.dit, DiTForwardMemo)
+        # wrapped module hidden from state_dict while installed
+        assert all(not k.startswith("dit.") for k in dec.state_dict())
+        x = torch.randn(1, 2, 11, 4)
+        t = torch.tensor([0.1])
+        dec.dit(x, t)
+        dec.dit(x.clone(), t.clone())
+        assert memo.hits == 1 and memo.misses == 1
+    assert dec.dit is orig
+    assert "dit.calls" not in dec.state_dict()  # plain restore
+
+    # exception inside the block must still restore
+    try:
+        with dit_memo(dec):
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+    assert dec.dit is orig

--- a/scenario_generation/explorer_runner.py
+++ b/scenario_generation/explorer_runner.py
@@ -101,6 +101,7 @@ class ExplorerGuidanceRunner:
         device,
         envelope: ExplorerEnvelope | None = None,
         eta_smooth: float = 0.5,
+        use_dit_memo: bool = True,
     ):
         pdir = Path(policy_dir)
         cfg_path = pdir / "exploration_policy_config.json"
@@ -117,6 +118,11 @@ class ExplorerGuidanceRunner:
         self.policy.load_state_dict(state, strict=True)
         self.policy.eval()
         self.device = device
+        # Reuse the composer's x0-refinement DiT forward in the solver
+        # (numerically equivalent, ~halves the guided step). Toggle for A/B
+        # verification, mirroring the --no_dit_memo escape hatch on the eval
+        # tools.
+        self.use_dit_memo = bool(use_dit_memo)
         self.envelope = envelope or ExplorerEnvelope()
         # Exponential smoothing on etas across steps: damps left/right
         # flip-flop when the policy sits near a decision boundary mid-pass.
@@ -225,9 +231,12 @@ class ExplorerGuidanceRunner:
         decoder._guidance_fn = composer
         decoder._guidance_scale = composer._set_config.global_scale
         try:
-            # dit_memo lets the solver reuse the composer's x0-refinement
-            # forward at the same (x, t) — ~25% off active guided frames.
-            with dit_memo(decoder):
+            if self.use_dit_memo:
+                # dit_memo lets the solver reuse the composer's x0-refinement
+                # forward at the same (x, t) — ~25% off active guided frames.
+                with dit_memo(decoder):
+                    _, outputs = model(data)
+            else:
                 _, outputs = model(data)
             guided = outputs["prediction"][0, 0].cpu().numpy()
         finally:

--- a/scenario_generation/explorer_runner.py
+++ b/scenario_generation/explorer_runner.py
@@ -28,6 +28,7 @@ from diffusion_planner.model.guidance.config import GuidanceConfig, GuidanceSetC
 import rlvr.guidance_batched  # noqa: F401 -- registers batched guidance
 from exploration_policy.model import ExplorationPolicy, ExplorationPolicyConfig
 from exploration_policy.utils import run_frozen_encoder
+from rlvr.guidance_batched import dit_memo
 
 
 def plan_static_clearance(
@@ -224,7 +225,10 @@ class ExplorerGuidanceRunner:
         decoder._guidance_fn = composer
         decoder._guidance_scale = composer._set_config.global_scale
         try:
-            _, outputs = model(data)
+            # dit_memo lets the solver reuse the composer's x0-refinement
+            # forward at the same (x, t) — ~25% off active guided frames.
+            with dit_memo(decoder):
+                _, outputs = model(data)
             guided = outputs["prediction"][0, 0].cpu().numpy()
         finally:
             decoder._guidance_fn = saved_fn


### PR DESCRIPTION
## Summary

Speeds up classifier-guided DPM-solver sampling by eliminating a redundant DiT forward per solver step. In the guidance composer path, each solver evaluation runs the DiT twice on the same `(x, t)`: once inside the composer's x̂₀ refinement (`cond_grad_fn` → composer → `model(...)`), then again in `noise_pred_fn`. This adds `DiTForwardMemo`, a single-slot memo around `decoder.dit`, so the second call returns the first call's output.

Done entirely outside `diffusion_planner/` (frozen tree): the classifier runs *before* `noise_pred_fn` in the solver's `model_fn`, so a scoped wrapper (`dit_memo` context manager) installed around guided generation is sufficient — no upstream change needed.

## Implementation

- `rlvr/guidance_batched.py`: `DiTForwardMemo` (single-slot, exact-match keyed on cloned-tensor value equality + conditioning identity; shared forward forced under `no_grad`, safe because every classifier_fn detaches the DiT output) + `dit_memo(decoder)` context manager (scoped install/restore, hidden from `state_dict`).
- Wired default-on into the guided-generation call sites: `rlvr/closed_loop/batched_rollout.py` (both generators), `guidance_gui/generate_samples.py`, `scenario_generation/explorer_runner.py`, `rlvr/autoresearch/tools/valid_predictor_guided.py`, and the policy-avoidance OL/CL evals.
- `use_dit_memo` kwarg / `--no_dit_memo` flag everywhere as an A/B escape hatch.
- `rlvr/autoresearch/tools/verify_dit_memo.py`: equivalence + latency harness (pairwise trajectory deltas slow/fast/memo, per-leg latency, memo hit counters).

## Equivalence & perf

- 17 unit tests in `rlvr/test_guidance_batched.py` cover hit/miss keying, in-place-mutation safety, no_grad output, and the context-manager install/restore.
- Equivalence harness: `fast_vs_slow` = 0.0 exactly; `memo_vs_fast` max 3.05e-5 m (one float quantum — grad vs no_grad kernel selection while sharing one forward across the two grad contexts).
- Behavioral A/B (open- and closed-loop) on a held-out avoidance set: memo vs no-memo identical on every metric (per-scene max Δ ≈ 5.7e-6 m); closed-loop contact counts bit-identical.
- Active guided frame latency: roughly −25% (the eliminated second DiT forward per guided step). Inert frames unchanged (existing short-circuit).

## Notes

Memo is for sampling only (never a training forward) — it relies on the classifier detaching the DiT output and the solver call sites being `no_grad`.
