### PR TITLE
Persist the guidance envelope in the exploration-policy config

### DIFF
--- a/docs/guidance_framework_design.md
+++ b/docs/guidance_framework_design.md
@@ -630,6 +630,15 @@ That's it. The playground UI, DPO pipeline, and GRPO reward loop can immediately
 
 ## Batched guidance v2 set (rlvr/guidance_batched.py)
 
+> **Envelope is persisted with the policy.** The guidance envelope (the
+> `lambda_lat` / `lat_scale` / `col_scale` / ... knobs + the `v1`/`v2` family)
+> is the calibration the explorer's eta labels were swept against, so it is
+> stored in `ExplorationPolicyConfig.guidance_envelope` and the guided
+> eval/deploy tools load it from the policy (CLI flags are override-only and
+> hard-fail on a disagreeing value unless `--force_envelope_override`). See
+> "Guidance envelope" in `rlvr/autoresearch/tools/README.md`. The `--envelope`
+> selection below is one such knob; a v2 policy persists `envelope: "v2"`.
+
 Opt-in registry names (the v1 functions are unchanged; select via
 `--envelope v2` in `sweep_guidance_params` / `eval_policy_avoidance` /
 `valid_predictor_guided`, or `envelope="v2"` in

--- a/exploration_policy/model.py
+++ b/exploration_policy/model.py
@@ -35,6 +35,25 @@ from exploration_policy.module.heads import GuidanceHead, ValueHead
 from exploration_policy.module.ref_fusion import RefFusionAttention
 from exploration_policy.module.ref_mixer import RefTrajectoryMixer
 
+# The v1 guidance calibration the explorer's eta labels were swept against.
+# The policy's eta outputs are ONLY meaningful at the envelope its labels were
+# generated with (the trainer is pure eta-regression — the network never sees
+# the envelope), so it MUST be persisted with the policy and reused verbatim at
+# eval/deploy. Historically this lived only in CLI flags whose defaults differed
+# across tools (the open-loop eval defaulted to a WEAKER 4.0/1.5/6.0), which
+# silently halved the applied guidance and made a certified policy look broken.
+V1_GUIDANCE_ENVELOPE = {
+    "lambda_lat": 5.0,
+    "lat_scale": 2.0,
+    "col_scale": 9.0,
+    "col_range": 8.0,
+    "lambda_spd": 0.2,
+    "stretch_scale": 1.0,
+    "guidance_scale": 0.5,
+    "envelope": "v1",
+    "lambda_col": 3.0,
+}
+
 
 @dataclass
 class ExplorationPolicyConfig:
@@ -62,6 +81,12 @@ class ExplorationPolicyConfig:
     # is the caller's job. Default matches the original 2-head layout, so old
     # checkpoints (fc2 [4, H]) load unchanged.
     heads: list[str] = field(default_factory=lambda: ["lateral", "longitudinal"])
+    # Guidance envelope the eta labels were swept against — the calibration the
+    # policy's outputs are bound to. Persisted here so eval/deploy load it
+    # instead of relying on (divergent) per-tool CLI defaults. Defaults to the
+    # v1 calibration, which is also what every pre-2026-06-14 policy was trained
+    # at, so older configs lacking this key are correct on load.
+    guidance_envelope: dict = field(default_factory=lambda: dict(V1_GUIDANCE_ENVELOPE))
 
     def to_json(self, path: str | Path) -> None:
         with open(path, "w") as f:

--- a/rlvr/autoresearch/tools/README.md
+++ b/rlvr/autoresearch/tools/README.md
@@ -419,8 +419,32 @@ python -m rlvr.autoresearch.tools.classify_avoidance_scenes \
   `--render_only_avoidance` skips normal scenes (for large sweeps);
   clearance-demoted scenes always render with a DEMOTED title carrying the
   measured clearance. The guidance envelope flags (`--lambda_lat`,
-  `--lat_scale`, `--col_scale`, `--envelope`, ...) only affect these
-  renders and must match the policy's training envelope.
+  `--lat_scale`, `--col_scale`, `--envelope`, ...) only affect these renders
+  in this tool; they default to the policy's persisted calibration (see
+  "Guidance envelope" below) and pass through to the render composer.
+
+## Guidance envelope (persisted in the policy config)
+
+The exploration policy's `eta` outputs are calibrated to a fixed **guidance
+envelope** (`lambda_lat` / `lat_scale` / `col_scale` / `col_range` /
+`lambda_spd` / `stretch_scale` / `guidance_scale` / `envelope` / `lambda_col`)
+— the one its labels were swept against. The trainer is pure eta-regression and
+never sees the envelope, so applying the etas at a different envelope silently
+mis-scales guidance. The envelope is therefore **persisted in
+`exploration_policy_config.json`** (`ExplorationPolicyConfig.guidance_envelope`,
+defaulting to the canonical v1 calibration `5.0/2.0/9.0/8.0/...`; configs
+predating this backfill to v1 on load), and `--guidance_envelope <json>` lets
+the trainer record a non-v1 calibration.
+
+The guided eval/deploy tools (`eval_policy_avoidance`, `eval_closedloop_avoidance`,
+`valid_predictor_guided`, `eval_policy_l2`, `distill_guided_targets`,
+`rollforward_avoidance_scenes`) **load the envelope from the policy** — their
+envelope CLI flags default to `None` (override-only). Per knob: an explicit flag
+wins, else the policy's persisted envelope, else v1. **A flag that DISAGREES with
+the persisted envelope hard-fails** (the etas are bound to the persisted
+envelope) unless you pass `--force_envelope_override` (a loud-warning escape
+hatch for deliberate sweeps / v2 experiments). So: omit the flags to run at the
+policy's calibration; you cannot silently mis-scale it.
 
 ## Data preparation (NPZ format / mining)
 

--- a/rlvr/autoresearch/tools/distill_guided_targets.py
+++ b/rlvr/autoresearch/tools/distill_guided_targets.py
@@ -58,15 +58,20 @@ def main():
     )
     parser.add_argument("--min_clearance", type=float, default=0.2)
     parser.add_argument("--keep_inert", action="store_true")
-    parser.add_argument("--lambda_lat", type=float, default=5.0)
-    parser.add_argument("--lat_scale", type=float, default=2.0)
-    parser.add_argument("--col_scale", type=float, default=9.0)
-    parser.add_argument("--col_range", type=float, default=8.0)
-    parser.add_argument("--lambda_spd", type=float, default=0.2)
-    parser.add_argument("--stretch_scale", type=float, default=1.0)
-    parser.add_argument("--guidance_scale", type=float, default=0.5)
-    parser.add_argument("--envelope", choices=["v1", "v2"], default="v1")
-    parser.add_argument("--lambda_col", type=float, default=3.0)
+    parser.add_argument(
+        "--lambda_lat",
+        type=float,
+        default=None,
+        help="override the policy's persisted guidance envelope",
+    )
+    parser.add_argument("--lat_scale", type=float, default=None)
+    parser.add_argument("--col_scale", type=float, default=None)
+    parser.add_argument("--col_range", type=float, default=None)
+    parser.add_argument("--lambda_spd", type=float, default=None)
+    parser.add_argument("--stretch_scale", type=float, default=None)
+    parser.add_argument("--guidance_scale", type=float, default=None)
+    parser.add_argument("--envelope", choices=["v1", "v2"], default=None)
+    parser.add_argument("--lambda_col", type=float, default=None)
     args = parser.parse_args()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -106,7 +111,9 @@ def main():
                     noise_min=0.0,
                     noise_max=0.0,
                     first_deterministic=False,
-                    composer=make_composer(etas, args),
+                    composer=make_composer(
+                        etas, args, envelope=getattr(policy, "guidance_envelope", None)
+                    ),
                     device=device,
                 )[0]
                 .cpu()

--- a/rlvr/autoresearch/tools/distill_guided_targets.py
+++ b/rlvr/autoresearch/tools/distill_guided_targets.py
@@ -70,6 +70,12 @@ def main():
     parser.add_argument("--lambda_spd", type=float, default=None)
     parser.add_argument("--stretch_scale", type=float, default=None)
     parser.add_argument("--guidance_scale", type=float, default=None)
+    parser.add_argument(
+        "--force_envelope_override",
+        action="store_true",
+        help="allow explicit envelope flags to override the policy's persisted "
+        "calibration (otherwise a disagreeing flag hard-fails)",
+    )
     parser.add_argument("--envelope", choices=["v1", "v2"], default=None)
     parser.add_argument("--lambda_col", type=float, default=None)
     args = parser.parse_args()

--- a/rlvr/autoresearch/tools/eval_closedloop_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_closedloop_avoidance.py
@@ -143,6 +143,12 @@ def main():
         action="store_true",
         help="disable the guided-frame DiT forward memo (A/B escape hatch; memo is the default)",
     )
+    parser.add_argument(
+        "--force_envelope_override",
+        action="store_true",
+        help="allow explicit envelope flags to override the policy's persisted "
+        "calibration (otherwise a disagreeing flag hard-fails)",
+    )
     args = parser.parse_args()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/rlvr/autoresearch/tools/eval_closedloop_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_closedloop_avoidance.py
@@ -64,7 +64,9 @@ def make_guided_predict(policy, heads, args, device):
                 noise_min=0.0,
                 noise_max=0.0,
                 first_deterministic=False,
-                composer=make_composer(etas, args),
+                composer=make_composer(
+                    etas, args, envelope=getattr(policy, "guidance_envelope", None)
+                ),
                 device=device,
                 use_dit_memo=not args.no_dit_memo,
             )[0]
@@ -124,13 +126,18 @@ def main():
     parser.add_argument(
         "--ego_shape", required=True, help="WB,L,W — no default, must match the platform"
     )
-    parser.add_argument("--lambda_lat", type=float, default=5.0)
-    parser.add_argument("--lat_scale", type=float, default=2.0)
-    parser.add_argument("--col_scale", type=float, default=9.0)
-    parser.add_argument("--col_range", type=float, default=8.0)
-    parser.add_argument("--lambda_spd", type=float, default=0.2)
-    parser.add_argument("--stretch_scale", type=float, default=1.0)
-    parser.add_argument("--guidance_scale", type=float, default=0.5)
+    parser.add_argument(
+        "--lambda_lat",
+        type=float,
+        default=None,
+        help="override the policy's persisted guidance envelope",
+    )
+    parser.add_argument("--lat_scale", type=float, default=None)
+    parser.add_argument("--col_scale", type=float, default=None)
+    parser.add_argument("--col_range", type=float, default=None)
+    parser.add_argument("--lambda_spd", type=float, default=None)
+    parser.add_argument("--stretch_scale", type=float, default=None)
+    parser.add_argument("--guidance_scale", type=float, default=None)
     parser.add_argument(
         "--no_dit_memo",
         action="store_true",

--- a/rlvr/autoresearch/tools/eval_policy_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_policy_avoidance.py
@@ -15,7 +15,10 @@ Usage:
         --model_path <base.pth> --policy_dir <run_dir with exploration_policy.pth> \
         --scenes <avoidance_val.json> [--normal_scenes <normal_val.json>] \
         --config <reward_config.json> --ego_shape WB,L,W --output_dir <dir> \
-        [--render] [--lambda_lat 4.0] [--col_scale 6.0] [--lat_scale 1.5]
+        [--render]
+
+The guidance envelope (lambda_lat / lat_scale / col_scale / ...) defaults to the
+calibration persisted in the policy's config; pass the flags only to OVERRIDE it.
 """
 
 from __future__ import annotations

--- a/rlvr/autoresearch/tools/eval_policy_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_policy_avoidance.py
@@ -46,27 +46,58 @@ def load_policy(policy_dir: str, model_args, device) -> tuple[ExplorationPolicy,
     state = torch.load(pdir / "exploration_policy.pth", map_location=device, weights_only=False)
     policy.load_state_dict(state, strict=True)
     policy.eval()
+    # Attach the calibration the policy's etas are bound to so make_composer can
+    # reuse it instead of trusting per-tool CLI defaults. Non-breaking: callers
+    # still unpack (policy, heads).
+    policy.guidance_envelope = dict(cfg.guidance_envelope)
     return policy, cfg.heads
 
 
-def make_composer(etas: dict[str, torch.Tensor], args) -> GuidanceComposer:
-    # Thin wrapper over the shared head mapping; head_protect > 0 zeroes
-    # guidance on the first N plan steps.
+# The calibrated guidance envelope: knobs the policy's etas are bound to.
+# head_protect / slow_composer are runtime toggles, not part of the envelope.
+_ENVELOPE_KEYS = (
+    "lambda_lat",
+    "lat_scale",
+    "col_scale",
+    "col_range",
+    "lambda_spd",
+    "stretch_scale",
+    "guidance_scale",
+    "envelope",
+    "lambda_col",
+)
+
+
+def make_composer(
+    etas: dict[str, torch.Tensor], args, envelope: dict | None = None
+) -> GuidanceComposer:
+    """Build a guidance composer for one set of etas.
+
+    The guidance envelope (lambda_lat / lat_scale / col_scale / ...) is the
+    calibration the policy's etas were swept against; applying the etas at a
+    different envelope silently mis-scales the guidance. Per-knob resolution:
+    an explicitly-set CLI arg wins, else the policy's persisted ``envelope``
+    (pass ``policy.guidance_envelope``), else the canonical v1 calibration.
+    There is no divergent per-tool default — that mismatch is the bug this
+    guards against. head_protect > 0 zeroes guidance on the first N plan steps.
+    """
+    from exploration_policy.model import V1_GUIDANCE_ENVELOPE
     from rlvr.guidance_batched import build_head_composer
+
+    resolved = {}
+    for key in _ENVELOPE_KEYS:
+        val = getattr(args, key, None)
+        if val is None and envelope is not None:
+            val = envelope.get(key)
+        if val is None:
+            val = V1_GUIDANCE_ENVELOPE[key]
+        resolved[key] = val
 
     return build_head_composer(
         etas,
-        lambda_lat=args.lambda_lat,
-        lat_scale=args.lat_scale,
-        col_scale=args.col_scale,
-        col_range=args.col_range,
-        lambda_spd=args.lambda_spd,
-        stretch_scale=args.stretch_scale,
-        guidance_scale=args.guidance_scale,
         head_protect=int(getattr(args, "head_protect", 0)),
-        envelope=getattr(args, "envelope", "v1"),
-        lambda_col=getattr(args, "lambda_col", 3.0),
         fast=not bool(getattr(args, "slow_composer", False)),
+        **resolved,
     )
 
 
@@ -113,7 +144,7 @@ def eval_scene(model, model_args, policy, heads, npz_path, rcfg, args, device):
                 K_data[k] = v.expand(K, *v.shape[1:]).contiguous()
             else:
                 K_data[k] = v
-        composer = make_composer(cand, args)
+        composer = make_composer(cand, args, envelope=getattr(policy, "guidance_envelope", None))
         from rlvr.closed_loop.batched_rollout import _batched_generate_varied_noise
 
         cands = (
@@ -133,7 +164,7 @@ def eval_scene(model, model_args, policy, heads, npz_path, rcfg, args, device):
         )
     else:
         cand = mean_etas
-        composer = make_composer(cand, args)
+        composer = make_composer(cand, args, envelope=getattr(policy, "guidance_envelope", None))
         cands = generate_samples(
             model=model,
             model_args=model_args,
@@ -306,15 +337,20 @@ def main():
         "(policy = prior, reward = judge). 1 = mean only.",
     )
     # Guidance envelope (must match the sweep that produced the training labels)
-    parser.add_argument("--lambda_lat", type=float, default=4.0)
-    parser.add_argument("--lat_scale", type=float, default=1.5)
-    parser.add_argument("--col_scale", type=float, default=6.0)
-    parser.add_argument("--col_range", type=float, default=8.0)
-    parser.add_argument("--lambda_spd", type=float, default=0.2)
-    parser.add_argument("--stretch_scale", type=float, default=1.0)
-    parser.add_argument("--guidance_scale", type=float, default=0.5)
-    parser.add_argument("--envelope", choices=["v1", "v2"], default="v1")
-    parser.add_argument("--lambda_col", type=float, default=3.0)
+    parser.add_argument(
+        "--lambda_lat",
+        type=float,
+        default=None,
+        help="override the policy's persisted guidance envelope",
+    )
+    parser.add_argument("--lat_scale", type=float, default=None)
+    parser.add_argument("--col_scale", type=float, default=None)
+    parser.add_argument("--col_range", type=float, default=None)
+    parser.add_argument("--lambda_spd", type=float, default=None)
+    parser.add_argument("--stretch_scale", type=float, default=None)
+    parser.add_argument("--guidance_scale", type=float, default=None)
+    parser.add_argument("--envelope", choices=["v1", "v2"], default=None)
+    parser.add_argument("--lambda_col", type=float, default=None)
     parser.add_argument(
         "--no_dit_memo",
         action="store_true",

--- a/rlvr/autoresearch/tools/eval_policy_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_policy_avoidance.py
@@ -86,9 +86,7 @@ def check_guidance_envelope_override(overrides: list[str], force: bool) -> None:
 
         print(
             "\n[GUIDANCE-ENVELOPE OVERRIDE] --force_envelope_override set; "
-            "explicit CLI flags override the policy's persisted calibration:\n  "
-            + detail
-            + "\n",
+            "explicit CLI flags override the policy's persisted calibration:\n  " + detail + "\n",
             file=sys.stderr,
         )
         return

--- a/rlvr/autoresearch/tools/eval_policy_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_policy_avoidance.py
@@ -71,26 +71,34 @@ _ENVELOPE_KEYS = (
 )
 
 
-_envelope_override_warned = False
-
-
-def warn_guidance_envelope_override(overrides: list[str]) -> None:
-    """Loudly flag (once) that explicit CLI envelope flags are overriding the
-    policy's persisted calibration. Doesn't block — sweeps / v2 experiments are
-    legitimate — but makes a stale copy-pasted flag impossible to miss in logs."""
-    global _envelope_override_warned
-    if _envelope_override_warned:
+def check_guidance_envelope_override(overrides: list[str], force: bool) -> None:
+    """Enforce that explicit CLI envelope flags may not silently disagree with
+    the policy's persisted calibration. The etas are bound to the persisted
+    envelope, so a stale copy-pasted flag mis-scales guidance exactly like the
+    bug this guards against. HARD-FAIL by default; ``force`` (the tools'
+    ``--force_envelope_override``) downgrades to a loud warning for legitimate
+    sweeps / v2 experiments."""
+    if not overrides:
         return
-    _envelope_override_warned = True
-    import sys
+    detail = "\n  ".join(overrides)
+    if force:
+        import sys
 
-    print(
-        "\n[GUIDANCE-ENVELOPE OVERRIDE WARNING] explicit CLI flags disagree with "
-        "the policy's persisted calibration — the etas are bound to the persisted "
-        "envelope; overriding mis-scales guidance unless you mean to sweep:\n  "
-        + "\n  ".join(overrides)
-        + "\nOmit the envelope flags to use the policy's persisted calibration.\n",
-        file=sys.stderr,
+        print(
+            "\n[GUIDANCE-ENVELOPE OVERRIDE] --force_envelope_override set; "
+            "explicit CLI flags override the policy's persisted calibration:\n  "
+            + detail
+            + "\n",
+            file=sys.stderr,
+        )
+        return
+    raise RuntimeError(
+        "explicit CLI envelope flags disagree with the policy's persisted "
+        "calibration — the policy's etas are bound to the persisted envelope, so "
+        "overriding mis-scales guidance:\n  "
+        + detail
+        + "\nOmit the envelope flags to use the policy's persisted calibration, "
+        "or pass --force_envelope_override to override deliberately (e.g. a sweep)."
     )
 
 
@@ -105,7 +113,9 @@ def make_composer(
     an explicitly-set CLI arg wins, else the policy's persisted ``envelope``
     (pass ``policy.guidance_envelope``), else the canonical v1 calibration.
     There is no divergent per-tool default — that mismatch is the bug this
-    guards against. head_protect > 0 zeroes guidance on the first N plan steps.
+    guards against. An explicit CLI value that DISAGREES with the persisted
+    envelope hard-fails unless ``args.force_envelope_override`` is set.
+    head_protect > 0 zeroes guidance on the first N plan steps.
     """
     from exploration_policy.model import V1_GUIDANCE_ENVELOPE
     from rlvr.guidance_batched import build_head_composer
@@ -117,8 +127,7 @@ def make_composer(
         persisted = envelope.get(key) if envelope is not None else None
         if cli is not None:
             # An explicit CLI value wins, but if it disagrees with the policy's
-            # persisted calibration, say so loudly — a stale copy-pasted flag
-            # mis-scales the etas exactly like the bug this guards against.
+            # persisted calibration, that is the stale-flag mis-scaling case.
             if persisted is not None and cli != persisted:
                 overrides.append(f"{key}: CLI={cli} overrides persisted={persisted}")
             val = cli
@@ -127,8 +136,9 @@ def make_composer(
         else:
             val = V1_GUIDANCE_ENVELOPE[key]
         resolved[key] = val
-    if overrides:
-        warn_guidance_envelope_override(overrides)
+    check_guidance_envelope_override(
+        overrides, bool(getattr(args, "force_envelope_override", False))
+    )
 
     return build_head_composer(
         etas,
@@ -386,6 +396,12 @@ def main():
     parser.add_argument("--lambda_spd", type=float, default=None)
     parser.add_argument("--stretch_scale", type=float, default=None)
     parser.add_argument("--guidance_scale", type=float, default=None)
+    parser.add_argument(
+        "--force_envelope_override",
+        action="store_true",
+        help="allow explicit envelope flags to override the policy's persisted "
+        "calibration (otherwise a disagreeing flag hard-fails)",
+    )
     parser.add_argument("--envelope", choices=["v1", "v2"], default=None)
     parser.add_argument("--lambda_col", type=float, default=None)
     parser.add_argument(

--- a/rlvr/autoresearch/tools/eval_policy_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_policy_avoidance.py
@@ -71,6 +71,29 @@ _ENVELOPE_KEYS = (
 )
 
 
+_envelope_override_warned = False
+
+
+def warn_guidance_envelope_override(overrides: list[str]) -> None:
+    """Loudly flag (once) that explicit CLI envelope flags are overriding the
+    policy's persisted calibration. Doesn't block — sweeps / v2 experiments are
+    legitimate — but makes a stale copy-pasted flag impossible to miss in logs."""
+    global _envelope_override_warned
+    if _envelope_override_warned:
+        return
+    _envelope_override_warned = True
+    import sys
+
+    print(
+        "\n[GUIDANCE-ENVELOPE OVERRIDE WARNING] explicit CLI flags disagree with "
+        "the policy's persisted calibration — the etas are bound to the persisted "
+        "envelope; overriding mis-scales guidance unless you mean to sweep:\n  "
+        + "\n  ".join(overrides)
+        + "\nOmit the envelope flags to use the policy's persisted calibration.\n",
+        file=sys.stderr,
+    )
+
+
 def make_composer(
     etas: dict[str, torch.Tensor], args, envelope: dict | None = None
 ) -> GuidanceComposer:
@@ -88,13 +111,24 @@ def make_composer(
     from rlvr.guidance_batched import build_head_composer
 
     resolved = {}
+    overrides = []
     for key in _ENVELOPE_KEYS:
-        val = getattr(args, key, None)
-        if val is None and envelope is not None:
-            val = envelope.get(key)
-        if val is None:
+        cli = getattr(args, key, None)
+        persisted = envelope.get(key) if envelope is not None else None
+        if cli is not None:
+            # An explicit CLI value wins, but if it disagrees with the policy's
+            # persisted calibration, say so loudly — a stale copy-pasted flag
+            # mis-scales the etas exactly like the bug this guards against.
+            if persisted is not None and cli != persisted:
+                overrides.append(f"{key}: CLI={cli} overrides persisted={persisted}")
+            val = cli
+        elif persisted is not None:
+            val = persisted
+        else:
             val = V1_GUIDANCE_ENVELOPE[key]
         resolved[key] = val
+    if overrides:
+        warn_guidance_envelope_override(overrides)
 
     return build_head_composer(
         etas,

--- a/rlvr/autoresearch/tools/eval_policy_l2.py
+++ b/rlvr/autoresearch/tools/eval_policy_l2.py
@@ -39,7 +39,18 @@ from rlvr.closed_loop.batched_rollout import _batched_generate_varied_noise
 from rlvr.grpo_trainer_batched import _normalize_batch, _stack_scene_data
 
 
-def make_composer(etas, args):
+def make_composer(etas, args, envelope=None):
+    # Resolve each envelope knob explicit-arg -> persisted-envelope -> v1
+    # constant, so a policy trained at a non-v1 envelope is scored for L2 at the
+    # calibration its etas are bound to, not a hardcoded default.
+    from exploration_policy.model import V1_GUIDANCE_ENVELOPE
+
+    def knob(name):
+        v = getattr(args, name, None)
+        if v is None and envelope is not None:
+            v = envelope.get(name)
+        return V1_GUIDANCE_ENVELOPE[name] if v is None else v
+
     unmapped = set(etas) - {"lateral", "collision"}
     if unmapped:
         raise ValueError(
@@ -53,8 +64,8 @@ def make_composer(etas, args):
             GuidanceConfig(
                 name="lateral",
                 enabled=True,
-                scale=args.lat_scale,
-                params={"lambda_lat": args.lambda_lat, "eta_lat": etas["lateral"]},
+                scale=knob("lat_scale"),
+                params={"lambda_lat": knob("lambda_lat"), "eta_lat": etas["lateral"]},
             )
         )
     if "collision" in etas:
@@ -62,11 +73,11 @@ def make_composer(etas, args):
             GuidanceConfig(
                 name="collision_swerve_batched",
                 enabled=True,
-                scale=args.col_scale,
-                params={"eta_col": etas["collision"], "range": args.col_range},
+                scale=knob("col_scale"),
+                params={"eta_col": etas["collision"], "range": knob("col_range")},
             )
         )
-    return GuidanceComposer(GuidanceSetConfig(functions=fns, global_scale=args.guidance_scale))
+    return GuidanceComposer(GuidanceSetConfig(functions=fns, global_scale=knob("guidance_scale")))
 
 
 def ade(pred_xy: torch.Tensor, gt_xy: torch.Tensor, gt_valid: torch.Tensor) -> torch.Tensor:
@@ -86,11 +97,16 @@ def main():
     parser.add_argument("--policy_dir", required=True)
     parser.add_argument("--scenes", required=True)
     parser.add_argument("--output_dir", required=True)
-    parser.add_argument("--lambda_lat", type=float, default=5.0)
-    parser.add_argument("--lat_scale", type=float, default=2.0)
-    parser.add_argument("--col_scale", type=float, default=9.0)
-    parser.add_argument("--col_range", type=float, default=8.0)
-    parser.add_argument("--guidance_scale", type=float, default=0.5)
+    parser.add_argument(
+        "--lambda_lat",
+        type=float,
+        default=None,
+        help="override the policy's persisted guidance envelope",
+    )
+    parser.add_argument("--lat_scale", type=float, default=None)
+    parser.add_argument("--col_scale", type=float, default=None)
+    parser.add_argument("--col_range", type=float, default=None)
+    parser.add_argument("--guidance_scale", type=float, default=None)
     parser.add_argument("--batch_size", type=int, default=32)
     parser.add_argument("--limit", type=int, default=0, help="0 = all scenes")
     args = parser.parse_args()
@@ -135,7 +151,7 @@ def main():
         enc = run_frozen_encoder(model, norm_batch_g)
         out = policy(enc, det, deterministic=True)
         etas = {h: (2.0 * out.dists[h].mean - 1.0) for h in heads}  # [B]
-        composer = make_composer(etas, args)
+        composer = make_composer(etas, args, envelope=getattr(policy, "guidance_envelope", None))
         guided = _batched_generate_varied_noise(
             model,
             model_args,

--- a/rlvr/autoresearch/tools/eval_policy_l2.py
+++ b/rlvr/autoresearch/tools/eval_policy_l2.py
@@ -44,7 +44,7 @@ def make_composer(etas, args, envelope=None):
     # constant, so a policy trained at a non-v1 envelope is scored for L2 at the
     # calibration its etas are bound to, not a hardcoded default.
     from exploration_policy.model import V1_GUIDANCE_ENVELOPE
-    from rlvr.autoresearch.tools.eval_policy_avoidance import warn_guidance_envelope_override
+    from rlvr.autoresearch.tools.eval_policy_avoidance import check_guidance_envelope_override
 
     overrides = []
 
@@ -86,8 +86,9 @@ def make_composer(etas, args, envelope=None):
     composer = GuidanceComposer(
         GuidanceSetConfig(functions=fns, global_scale=knob("guidance_scale"))
     )
-    if overrides:
-        warn_guidance_envelope_override(overrides)
+    check_guidance_envelope_override(
+        overrides, bool(getattr(args, "force_envelope_override", False))
+    )
     return composer
 
 
@@ -118,6 +119,12 @@ def main():
     parser.add_argument("--col_scale", type=float, default=None)
     parser.add_argument("--col_range", type=float, default=None)
     parser.add_argument("--guidance_scale", type=float, default=None)
+    parser.add_argument(
+        "--force_envelope_override",
+        action="store_true",
+        help="allow explicit envelope flags to override the policy's persisted "
+        "calibration (otherwise a disagreeing flag hard-fails)",
+    )
     parser.add_argument("--batch_size", type=int, default=32)
     parser.add_argument("--limit", type=int, default=0, help="0 = all scenes")
     args = parser.parse_args()

--- a/rlvr/autoresearch/tools/eval_policy_l2.py
+++ b/rlvr/autoresearch/tools/eval_policy_l2.py
@@ -44,12 +44,18 @@ def make_composer(etas, args, envelope=None):
     # constant, so a policy trained at a non-v1 envelope is scored for L2 at the
     # calibration its etas are bound to, not a hardcoded default.
     from exploration_policy.model import V1_GUIDANCE_ENVELOPE
+    from rlvr.autoresearch.tools.eval_policy_avoidance import warn_guidance_envelope_override
+
+    overrides = []
 
     def knob(name):
-        v = getattr(args, name, None)
-        if v is None and envelope is not None:
-            v = envelope.get(name)
-        return V1_GUIDANCE_ENVELOPE[name] if v is None else v
+        cli = getattr(args, name, None)
+        persisted = envelope.get(name) if envelope is not None else None
+        if cli is not None:
+            if persisted is not None and cli != persisted:
+                overrides.append(f"{name}: CLI={cli} overrides persisted={persisted}")
+            return cli
+        return persisted if persisted is not None else V1_GUIDANCE_ENVELOPE[name]
 
     unmapped = set(etas) - {"lateral", "collision"}
     if unmapped:
@@ -77,7 +83,12 @@ def make_composer(etas, args, envelope=None):
                 params={"eta_col": etas["collision"], "range": knob("col_range")},
             )
         )
-    return GuidanceComposer(GuidanceSetConfig(functions=fns, global_scale=knob("guidance_scale")))
+    composer = GuidanceComposer(
+        GuidanceSetConfig(functions=fns, global_scale=knob("guidance_scale"))
+    )
+    if overrides:
+        warn_guidance_envelope_override(overrides)
+    return composer
 
 
 def ade(pred_xy: torch.Tensor, gt_xy: torch.Tensor, gt_valid: torch.Tensor) -> torch.Tensor:

--- a/rlvr/autoresearch/tools/rollforward_avoidance_scenes.py
+++ b/rlvr/autoresearch/tools/rollforward_avoidance_scenes.py
@@ -148,8 +148,8 @@ def main():
     parser.add_argument(
         "--envelope",
         choices=["v1", "v2"],
-        default="v1",
-        help="guidance envelope — must match the policy's training labels",
+        default=None,
+        help="override the policy's persisted guidance envelope family (v1/v2)",
     )
     parser.add_argument("--lambda_col", type=float, default=None)
     args = parser.parse_args()

--- a/rlvr/autoresearch/tools/rollforward_avoidance_scenes.py
+++ b/rlvr/autoresearch/tools/rollforward_avoidance_scenes.py
@@ -146,6 +146,12 @@ def main():
     parser.add_argument("--stretch_scale", type=float, default=None)
     parser.add_argument("--guidance_scale", type=float, default=None)
     parser.add_argument(
+        "--force_envelope_override",
+        action="store_true",
+        help="allow explicit envelope flags to override the policy's persisted "
+        "calibration (otherwise a disagreeing flag hard-fails)",
+    )
+    parser.add_argument(
         "--envelope",
         choices=["v1", "v2"],
         default=None,

--- a/rlvr/autoresearch/tools/rollforward_avoidance_scenes.py
+++ b/rlvr/autoresearch/tools/rollforward_avoidance_scenes.py
@@ -69,7 +69,7 @@ def guided_trajectory(
             noise_min=0.0,
             noise_max=0.0,
             first_deterministic=False,
-            composer=make_composer(etas, args),
+            composer=make_composer(etas, args, envelope=getattr(policy, "guidance_envelope", None)),
             device=device,
         )[0]
         .cpu()
@@ -133,20 +133,25 @@ def main():
     parser.add_argument("--steps", default="5,10,15,20,25,30")
     parser.add_argument("--out_dir", required=True)
     parser.add_argument("--out_list", required=True)
-    parser.add_argument("--lambda_lat", type=float, default=5.0)
-    parser.add_argument("--lat_scale", type=float, default=2.0)
-    parser.add_argument("--col_scale", type=float, default=9.0)
-    parser.add_argument("--col_range", type=float, default=8.0)
-    parser.add_argument("--lambda_spd", type=float, default=0.2)
-    parser.add_argument("--stretch_scale", type=float, default=1.0)
-    parser.add_argument("--guidance_scale", type=float, default=0.5)
+    parser.add_argument(
+        "--lambda_lat",
+        type=float,
+        default=None,
+        help="override the policy's persisted guidance envelope",
+    )
+    parser.add_argument("--lat_scale", type=float, default=None)
+    parser.add_argument("--col_scale", type=float, default=None)
+    parser.add_argument("--col_range", type=float, default=None)
+    parser.add_argument("--lambda_spd", type=float, default=None)
+    parser.add_argument("--stretch_scale", type=float, default=None)
+    parser.add_argument("--guidance_scale", type=float, default=None)
     parser.add_argument(
         "--envelope",
         choices=["v1", "v2"],
         default="v1",
         help="guidance envelope — must match the policy's training labels",
     )
-    parser.add_argument("--lambda_col", type=float, default=3.0)
+    parser.add_argument("--lambda_col", type=float, default=None)
     args = parser.parse_args()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/rlvr/autoresearch/tools/valid_predictor_guided.py
+++ b/rlvr/autoresearch/tools/valid_predictor_guided.py
@@ -73,15 +73,20 @@ def main():
     parser.add_argument("--batch_size", type=int, default=64)
     parser.add_argument("--num_workers", type=int, default=8)
     parser.add_argument("--limit", type=int, default=0, help="0 = all scenes")
-    parser.add_argument("--lambda_lat", type=float, default=5.0)
-    parser.add_argument("--lat_scale", type=float, default=2.0)
-    parser.add_argument("--col_scale", type=float, default=9.0)
-    parser.add_argument("--col_range", type=float, default=8.0)
-    parser.add_argument("--lambda_spd", type=float, default=0.2)
-    parser.add_argument("--stretch_scale", type=float, default=1.0)
-    parser.add_argument("--guidance_scale", type=float, default=0.5)
-    parser.add_argument("--envelope", choices=["v1", "v2"], default="v1")
-    parser.add_argument("--lambda_col", type=float, default=3.0)
+    parser.add_argument(
+        "--lambda_lat",
+        type=float,
+        default=None,
+        help="override the policy's persisted guidance envelope",
+    )
+    parser.add_argument("--lat_scale", type=float, default=None)
+    parser.add_argument("--col_scale", type=float, default=None)
+    parser.add_argument("--col_range", type=float, default=None)
+    parser.add_argument("--lambda_spd", type=float, default=None)
+    parser.add_argument("--stretch_scale", type=float, default=None)
+    parser.add_argument("--guidance_scale", type=float, default=None)
+    parser.add_argument("--envelope", choices=["v1", "v2"], default=None)
+    parser.add_argument("--lambda_col", type=float, default=None)
     parser.add_argument(
         "--no_dit_memo",
         action="store_true",
@@ -160,7 +165,7 @@ def main():
         enc = run_frozen_encoder(model, data)
         pout = policy(enc, det_ego, deterministic=True)
         etas = {h: (2.0 * pout.dists[h].mean - 1.0) for h in heads}
-        composer = make_composer(etas, args)
+        composer = make_composer(etas, args, envelope=getattr(policy, "guidance_envelope", None))
         decoder._guidance_fn = composer
         decoder._guidance_scale = composer._set_config.global_scale
         try:

--- a/rlvr/autoresearch/tools/valid_predictor_guided.py
+++ b/rlvr/autoresearch/tools/valid_predictor_guided.py
@@ -85,6 +85,12 @@ def main():
     parser.add_argument("--lambda_spd", type=float, default=None)
     parser.add_argument("--stretch_scale", type=float, default=None)
     parser.add_argument("--guidance_scale", type=float, default=None)
+    parser.add_argument(
+        "--force_envelope_override",
+        action="store_true",
+        help="allow explicit envelope flags to override the policy's persisted "
+        "calibration (otherwise a disagreeing flag hard-fails)",
+    )
     parser.add_argument("--envelope", choices=["v1", "v2"], default=None)
     parser.add_argument("--lambda_col", type=float, default=None)
     parser.add_argument(

--- a/rlvr/test_guidance_envelope_persistence.py
+++ b/rlvr/test_guidance_envelope_persistence.py
@@ -2,10 +2,50 @@
 etas are bound to, and make_composer resolves from it (not divergent per-tool
 CLI defaults). Guards the v23 "non-reproduction" footgun."""
 
+import ast
 import json
 from argparse import Namespace
+from pathlib import Path
+
+import pytest
 
 from exploration_policy.model import V1_GUIDANCE_ENVELOPE, ExplorationPolicyConfig
+
+# Guided eval/deploy tools that score or bake a policy and so MUST resolve the
+# envelope from the policy's persisted calibration (CLI = override-only). Their
+# envelope argparse defaults must be None — a non-None default silently shadows
+# the persisted value and reintroduces the cross-tool drift bug.
+_CERT_DEPLOY_TOOLS = [
+    "rlvr/autoresearch/tools/eval_policy_avoidance.py",
+    "rlvr/autoresearch/tools/eval_closedloop_avoidance.py",
+    "rlvr/autoresearch/tools/valid_predictor_guided.py",
+    "rlvr/autoresearch/tools/eval_policy_l2.py",
+    "rlvr/autoresearch/tools/distill_guided_targets.py",
+    "rlvr/autoresearch/tools/rollforward_avoidance_scenes.py",
+]
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize("rel", _CERT_DEPLOY_TOOLS)
+def test_cert_deploy_tools_envelope_args_default_none(rel):
+    """No envelope knob may carry a non-None argparse default in these tools."""
+    tree = ast.parse((_REPO_ROOT / rel).read_text())
+    offenders = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and getattr(node.func, "attr", None) == "add_argument"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+        ):
+            name = str(node.args[0].value).lstrip("-")
+            if name not in V1_GUIDANCE_ENVELOPE:
+                continue
+            default = next((kw.value for kw in node.keywords if kw.arg == "default"), None)
+            # missing default kw == argparse None; only a non-None Constant is a bug.
+            if isinstance(default, ast.Constant) and default.value is not None:
+                offenders.append((name, default.value))
+    assert not offenders, f"{rel}: envelope args with non-None default: {offenders}"
 
 
 def test_config_default_envelope_is_v1():

--- a/rlvr/test_guidance_envelope_persistence.py
+++ b/rlvr/test_guidance_envelope_persistence.py
@@ -60,7 +60,8 @@ def test_config_roundtrip_preserves_envelope(tmp_path):
     cfg = ExplorationPolicyConfig(heads=["lateral", "collision"], guidance_envelope=env)
     p = tmp_path / "exploration_policy_config.json"
     cfg.to_json(p)
-    assert json.load(open(p))["guidance_envelope"]["lambda_lat"] == 7.0
+    with open(p) as f:
+        assert json.load(f)["guidance_envelope"]["lambda_lat"] == 7.0
     back = ExplorationPolicyConfig.from_json(p)
     assert back.guidance_envelope == env
 
@@ -69,7 +70,8 @@ def test_old_config_without_key_loads_as_v1(tmp_path):
     # Pre-2026-06-14 configs have no guidance_envelope key; they were trained at
     # v1, so the default must backfill to v1 (not crash, not a weak default).
     p = tmp_path / "exploration_policy_config.json"
-    json.dump({"hidden_dim": 128, "heads": ["lateral", "collision"]}, open(p, "w"))
+    with open(p, "w") as f:
+        json.dump({"hidden_dim": 128, "heads": ["lateral", "collision"]}, f)
     cfg = ExplorationPolicyConfig.from_json(p)
     assert cfg.guidance_envelope == V1_GUIDANCE_ENVELOPE
 
@@ -164,3 +166,32 @@ def test_make_composer_falls_back_to_v1_when_nothing_provided():
     comp = make_composer({"lateral": 0.5, "collision": 0.5}, args, envelope=None)
     lat = next(f for f in comp._functions if hasattr(f, "_lambda_lat"))
     assert abs(float(lat._lambda_lat) - V1_GUIDANCE_ENVELOPE["lambda_lat"]) < 1e-9
+
+
+def test_resolve_training_envelope_stretch_lambda_spd_guard(tmp_path):
+    # A stretch head decodes its labels with the module LAMBDA_SPD; persisting a
+    # different lambda_spd would mis-scale it at inference, so the trainer's
+    # resolver must reject it (the envelope/label mismatch this change prevents).
+    from rlvr.train_explorer_regression import LAMBDA_SPD, resolve_training_envelope
+
+    bad = tmp_path / "bad.json"
+    with open(bad, "w") as f:
+        json.dump({"lambda_spd": LAMBDA_SPD + 0.1}, f)
+
+    # stretch head + mismatched lambda_spd -> hard fail
+    with pytest.raises(ValueError, match="mis-scale the stretch head"):
+        resolve_training_envelope(str(bad), ["lateral", "collision", "stretch"])
+
+    # same mismatch but NO stretch head -> lambda_spd is inert, accepted
+    env = resolve_training_envelope(str(bad), ["lateral", "collision"])
+    assert env["lambda_spd"] == LAMBDA_SPD + 0.1
+
+    # stretch head + matching lambda_spd -> accepted; no override path -> v1
+    assert resolve_training_envelope(None, ["lateral", "stretch"]) == V1_GUIDANCE_ENVELOPE
+
+    # unknown knob -> rejected loudly
+    junk = tmp_path / "junk.json"
+    with open(junk, "w") as f:
+        json.dump({"not_a_knob": 1.0}, f)
+    with pytest.raises(ValueError, match="unknown knob"):
+        resolve_training_envelope(str(junk), ["lateral"])

--- a/rlvr/test_guidance_envelope_persistence.py
+++ b/rlvr/test_guidance_envelope_persistence.py
@@ -101,11 +101,9 @@ def test_make_composer_prefers_persisted_envelope_over_missing_arg():
     assert abs(float(lat._lambda_lat) - 7.0) < 1e-9
 
 
-def test_make_composer_explicit_arg_overrides_envelope():
-    from rlvr.autoresearch.tools.eval_policy_avoidance import make_composer
-
-    args = Namespace(
-        lambda_lat=3.3,
+def _envelope_args(**overrides):
+    base = dict(
+        lambda_lat=None,
         lat_scale=None,
         col_scale=None,
         col_range=None,
@@ -116,59 +114,45 @@ def test_make_composer_explicit_arg_overrides_envelope():
         lambda_col=None,
         head_protect=0,
         slow_composer=False,
+        force_envelope_override=False,
     )
+    base.update(overrides)
+    return Namespace(**base)
+
+
+def test_disagreeing_cli_without_force_hard_fails():
+    # The core guard: a stale flag that disagrees with the persisted envelope
+    # must HARD-FAIL (not silently mis-scale) unless deliberately forced.
+    from rlvr.autoresearch.tools.eval_policy_avoidance import make_composer
+
+    args = _envelope_args(lambda_lat=4.0)  # old weak value vs persisted 7.0
+    env = dict(V1_GUIDANCE_ENVELOPE, lambda_lat=7.0)
+    with pytest.raises(RuntimeError, match="disagree with the policy's persisted"):
+        make_composer({"lateral": 0.5, "collision": 0.5}, args, envelope=env)
+
+
+def test_disagreeing_cli_with_force_overrides_and_warns(capsys):
+    # --force_envelope_override downgrades the hard-fail to a loud warning and
+    # lets the explicit value win (legitimate sweeps / v2 experiments).
+    from rlvr.autoresearch.tools.eval_policy_avoidance import make_composer
+
+    args = _envelope_args(lambda_lat=3.3, force_envelope_override=True)
     env = dict(V1_GUIDANCE_ENVELOPE, lambda_lat=5.0)
     comp = make_composer({"lateral": 0.5, "collision": 0.5}, args, envelope=env)
     lat = next(f for f in comp._functions if hasattr(f, "_lambda_lat"))
-    assert abs(float(lat._lambda_lat) - 3.3) < 1e-9  # CLI override wins
+    assert abs(float(lat._lambda_lat) - 3.3) < 1e-9  # forced override wins
+    assert "OVERRIDE" in capsys.readouterr().err
 
 
-def test_explicit_cli_disagreeing_with_persisted_warns(capsys):
-    # A stale copy-pasted flag that disagrees with the persisted envelope must
-    # warn loudly to stderr (it still overrides — sweeps are legitimate).
-    import rlvr.autoresearch.tools.eval_policy_avoidance as epa
+def test_cli_matching_persisted_does_not_fail_or_warn(capsys):
+    from rlvr.autoresearch.tools.eval_policy_avoidance import make_composer
 
-    epa._envelope_override_warned = False  # reset the once-guard for the test
-    args = Namespace(
-        lambda_lat=4.0,  # the old weak value, disagreeing with persisted 7.0
-        lat_scale=None,
-        col_scale=None,
-        col_range=None,
-        lambda_spd=None,
-        stretch_scale=None,
-        guidance_scale=None,
-        envelope=None,
-        lambda_col=None,
-        head_protect=0,
-        slow_composer=False,
-    )
+    args = _envelope_args(lambda_lat=7.0)  # explicit but AGREES -> no-op
     env = dict(V1_GUIDANCE_ENVELOPE, lambda_lat=7.0)
-    epa.make_composer({"lateral": 0.5, "collision": 0.5}, args, envelope=env)
-    err = capsys.readouterr().err
-    assert "GUIDANCE-ENVELOPE OVERRIDE WARNING" in err
-    assert "lambda_lat" in err and "4.0" in err and "7.0" in err
-
-
-def test_cli_matching_persisted_does_not_warn(capsys):
-    import rlvr.autoresearch.tools.eval_policy_avoidance as epa
-
-    epa._envelope_override_warned = False
-    args = Namespace(
-        lambda_lat=7.0,  # explicit but AGREES with persisted -> no warning
-        lat_scale=None,
-        col_scale=None,
-        col_range=None,
-        lambda_spd=None,
-        stretch_scale=None,
-        guidance_scale=None,
-        envelope=None,
-        lambda_col=None,
-        head_protect=0,
-        slow_composer=False,
-    )
-    env = dict(V1_GUIDANCE_ENVELOPE, lambda_lat=7.0)
-    epa.make_composer({"lateral": 0.5, "collision": 0.5}, args, envelope=env)
-    assert "OVERRIDE WARNING" not in capsys.readouterr().err
+    comp = make_composer({"lateral": 0.5, "collision": 0.5}, args, envelope=env)
+    lat = next(f for f in comp._functions if hasattr(f, "_lambda_lat"))
+    assert abs(float(lat._lambda_lat) - 7.0) < 1e-9
+    assert "OVERRIDE" not in capsys.readouterr().err
 
 
 def test_make_composer_falls_back_to_v1_when_nothing_provided():

--- a/rlvr/test_guidance_envelope_persistence.py
+++ b/rlvr/test_guidance_envelope_persistence.py
@@ -1,0 +1,92 @@
+"""Guidance-envelope persistence: the policy config carries the calibration its
+etas are bound to, and make_composer resolves from it (not divergent per-tool
+CLI defaults). Guards the v23 "non-reproduction" footgun."""
+
+import json
+from argparse import Namespace
+
+from exploration_policy.model import V1_GUIDANCE_ENVELOPE, ExplorationPolicyConfig
+
+
+def test_config_default_envelope_is_v1():
+    cfg = ExplorationPolicyConfig()
+    assert cfg.guidance_envelope == V1_GUIDANCE_ENVELOPE
+    # a fresh dict, not the shared module constant (mutation isolation)
+    assert cfg.guidance_envelope is not V1_GUIDANCE_ENVELOPE
+
+
+def test_config_roundtrip_preserves_envelope(tmp_path):
+    env = dict(V1_GUIDANCE_ENVELOPE, lambda_lat=7.0, col_scale=12.0)
+    cfg = ExplorationPolicyConfig(heads=["lateral", "collision"], guidance_envelope=env)
+    p = tmp_path / "exploration_policy_config.json"
+    cfg.to_json(p)
+    assert json.load(open(p))["guidance_envelope"]["lambda_lat"] == 7.0
+    back = ExplorationPolicyConfig.from_json(p)
+    assert back.guidance_envelope == env
+
+
+def test_old_config_without_key_loads_as_v1(tmp_path):
+    # Pre-2026-06-14 configs have no guidance_envelope key; they were trained at
+    # v1, so the default must backfill to v1 (not crash, not a weak default).
+    p = tmp_path / "exploration_policy_config.json"
+    json.dump({"hidden_dim": 128, "heads": ["lateral", "collision"]}, open(p, "w"))
+    cfg = ExplorationPolicyConfig.from_json(p)
+    assert cfg.guidance_envelope == V1_GUIDANCE_ENVELOPE
+
+
+def test_make_composer_prefers_persisted_envelope_over_missing_arg():
+    from rlvr.autoresearch.tools.eval_policy_avoidance import make_composer
+
+    # args leave every envelope knob unset (None) -> the policy's persisted
+    # envelope must be used, NOT a weak per-tool default.
+    args = Namespace(
+        lambda_lat=None,
+        lat_scale=None,
+        col_scale=None,
+        col_range=None,
+        lambda_spd=None,
+        stretch_scale=None,
+        guidance_scale=None,
+        envelope=None,
+        lambda_col=None,
+        head_protect=0,
+        slow_composer=False,
+    )
+    env = dict(V1_GUIDANCE_ENVELOPE, lambda_lat=5.0, lat_scale=2.0, col_scale=9.0)
+    comp = make_composer({"lateral": 0.5, "collision": 0.5}, args, envelope=env)
+    # the lateral head carries lambda_lat * scale from the persisted envelope
+    lat = next(f for f in comp._functions if hasattr(f, "_lambda_lat"))
+    assert abs(float(lat._lambda_lat) - 5.0) < 1e-9
+
+
+def test_make_composer_explicit_arg_overrides_envelope():
+    from rlvr.autoresearch.tools.eval_policy_avoidance import make_composer
+
+    args = Namespace(
+        lambda_lat=3.3,
+        lat_scale=None,
+        col_scale=None,
+        col_range=None,
+        lambda_spd=None,
+        stretch_scale=None,
+        guidance_scale=None,
+        envelope=None,
+        lambda_col=None,
+        head_protect=0,
+        slow_composer=False,
+    )
+    env = dict(V1_GUIDANCE_ENVELOPE, lambda_lat=5.0)
+    comp = make_composer({"lateral": 0.5, "collision": 0.5}, args, envelope=env)
+    lat = next(f for f in comp._functions if hasattr(f, "_lambda_lat"))
+    assert abs(float(lat._lambda_lat) - 3.3) < 1e-9  # CLI override wins
+
+
+def test_make_composer_falls_back_to_v1_when_nothing_provided():
+    from rlvr.autoresearch.tools.eval_policy_avoidance import make_composer
+
+    # no envelope dict, no args knobs -> the canonical v1 constant (the single
+    # source of truth), never a divergent weak default.
+    args = Namespace(head_protect=0, slow_composer=False)
+    comp = make_composer({"lateral": 0.5, "collision": 0.5}, args, envelope=None)
+    lat = next(f for f in comp._functions if hasattr(f, "_lambda_lat"))
+    assert abs(float(lat._lambda_lat) - V1_GUIDANCE_ENVELOPE["lambda_lat"]) < 1e-9

--- a/rlvr/test_guidance_envelope_persistence.py
+++ b/rlvr/test_guidance_envelope_persistence.py
@@ -123,6 +123,54 @@ def test_make_composer_explicit_arg_overrides_envelope():
     assert abs(float(lat._lambda_lat) - 3.3) < 1e-9  # CLI override wins
 
 
+def test_explicit_cli_disagreeing_with_persisted_warns(capsys):
+    # A stale copy-pasted flag that disagrees with the persisted envelope must
+    # warn loudly to stderr (it still overrides — sweeps are legitimate).
+    import rlvr.autoresearch.tools.eval_policy_avoidance as epa
+
+    epa._envelope_override_warned = False  # reset the once-guard for the test
+    args = Namespace(
+        lambda_lat=4.0,  # the old weak value, disagreeing with persisted 7.0
+        lat_scale=None,
+        col_scale=None,
+        col_range=None,
+        lambda_spd=None,
+        stretch_scale=None,
+        guidance_scale=None,
+        envelope=None,
+        lambda_col=None,
+        head_protect=0,
+        slow_composer=False,
+    )
+    env = dict(V1_GUIDANCE_ENVELOPE, lambda_lat=7.0)
+    epa.make_composer({"lateral": 0.5, "collision": 0.5}, args, envelope=env)
+    err = capsys.readouterr().err
+    assert "GUIDANCE-ENVELOPE OVERRIDE WARNING" in err
+    assert "lambda_lat" in err and "4.0" in err and "7.0" in err
+
+
+def test_cli_matching_persisted_does_not_warn(capsys):
+    import rlvr.autoresearch.tools.eval_policy_avoidance as epa
+
+    epa._envelope_override_warned = False
+    args = Namespace(
+        lambda_lat=7.0,  # explicit but AGREES with persisted -> no warning
+        lat_scale=None,
+        col_scale=None,
+        col_range=None,
+        lambda_spd=None,
+        stretch_scale=None,
+        guidance_scale=None,
+        envelope=None,
+        lambda_col=None,
+        head_protect=0,
+        slow_composer=False,
+    )
+    env = dict(V1_GUIDANCE_ENVELOPE, lambda_lat=7.0)
+    epa.make_composer({"lateral": 0.5, "collision": 0.5}, args, envelope=env)
+    assert "OVERRIDE WARNING" not in capsys.readouterr().err
+
+
 def test_make_composer_falls_back_to_v1_when_nothing_provided():
     from rlvr.autoresearch.tools.eval_policy_avoidance import make_composer
 

--- a/rlvr/test_guidance_envelope_persistence.py
+++ b/rlvr/test_guidance_envelope_persistence.py
@@ -52,11 +52,13 @@ def test_make_composer_prefers_persisted_envelope_over_missing_arg():
         head_protect=0,
         slow_composer=False,
     )
-    env = dict(V1_GUIDANCE_ENVELOPE, lambda_lat=5.0, lat_scale=2.0, col_scale=9.0)
+    # Use a NON-v1 lambda_lat so the assertion distinguishes "read the persisted
+    # envelope" from "fell through to the v1 constant" (v1 lambda_lat is 5.0).
+    env = dict(V1_GUIDANCE_ENVELOPE, lambda_lat=7.0)
     comp = make_composer({"lateral": 0.5, "collision": 0.5}, args, envelope=env)
-    # the lateral head carries lambda_lat * scale from the persisted envelope
+    # the lateral head carries lambda_lat from the persisted envelope
     lat = next(f for f in comp._functions if hasattr(f, "_lambda_lat"))
-    assert abs(float(lat._lambda_lat) - 5.0) < 1e-9
+    assert abs(float(lat._lambda_lat) - 7.0) < 1e-9
 
 
 def test_make_composer_explicit_arg_overrides_envelope():

--- a/rlvr/test_guidance_envelope_persistence.py
+++ b/rlvr/test_guidance_envelope_persistence.py
@@ -42,9 +42,15 @@ def test_cert_deploy_tools_envelope_args_default_none(rel):
             if name not in V1_GUIDANCE_ENVELOPE:
                 continue
             default = next((kw.value for kw in node.keywords if kw.arg == "default"), None)
-            # missing default kw == argparse None; only a non-None Constant is a bug.
-            if isinstance(default, ast.Constant) and default.value is not None:
-                offenders.append((name, default.value))
+            # No default kwarg => argparse default is None => OK. Any EXPLICIT
+            # default= is an offender unless it is the literal None — including a
+            # non-literal expression (e.g. default=V1_GUIDANCE_ENVELOPE["..."]),
+            # which would silently reintroduce the drift the None default prevents.
+            if default is None:
+                continue
+            is_none_literal = isinstance(default, ast.Constant) and default.value is None
+            if not is_none_literal:
+                offenders.append((name, ast.unparse(default)))
     assert not offenders, f"{rel}: envelope args with non-None default: {offenders}"
 
 

--- a/rlvr/train_explorer_regression.py
+++ b/rlvr/train_explorer_regression.py
@@ -57,6 +57,40 @@ def label_target(head: str, best: dict) -> float:
     return v
 
 
+def resolve_training_envelope(envelope_path: str | None, heads: list[str]) -> dict:
+    """Build the guidance envelope to persist into the policy config.
+
+    Starts from the v1 calibration, optionally overlays a user JSON (rejecting
+    unknown knobs), and enforces that a trained ``stretch`` head's ``lambda_spd``
+    matches the module ``LAMBDA_SPD`` used by ``label_target`` to decode its
+    labels — otherwise the persisted envelope would apply a different lambda_spd
+    at inference than the labels were built with (a silent envelope/label
+    mismatch, the exact failure this persistence guards against).
+    """
+    from exploration_policy.model import V1_GUIDANCE_ENVELOPE
+
+    envelope = dict(V1_GUIDANCE_ENVELOPE)
+    if envelope_path:
+        with open(envelope_path) as f:
+            user_env = json.load(f)
+        unknown = set(user_env) - set(V1_GUIDANCE_ENVELOPE)
+        if unknown:
+            raise ValueError(
+                f"--guidance_envelope has unknown knob(s) {sorted(unknown)}; "
+                f"valid keys: {sorted(V1_GUIDANCE_ENVELOPE)}"
+            )
+        envelope.update(user_env)
+    if "stretch" in heads and envelope["lambda_spd"] != LAMBDA_SPD:
+        raise ValueError(
+            f"guidance_envelope lambda_spd={envelope['lambda_spd']} disagrees "
+            f"with LAMBDA_SPD={LAMBDA_SPD} used to decode the stretch labels — "
+            "the persisted envelope would mis-scale the stretch head at "
+            f"inference. Use lambda_spd={LAMBDA_SPD}, drop the stretch head, or "
+            "wire label_target to the envelope value first."
+        )
+    return envelope
+
+
 def build_entries(
     labels_paths: list[str],
     normal_paths: list[str],
@@ -274,19 +308,7 @@ def main():
         f"(val avoid={int(is_avoid[val_idx].sum())})"
     )
 
-    from exploration_policy.model import V1_GUIDANCE_ENVELOPE
-
-    guidance_envelope = dict(V1_GUIDANCE_ENVELOPE)
-    if args.guidance_envelope:
-        with open(args.guidance_envelope) as f:
-            user_env = json.load(f)
-        unknown = set(user_env) - set(V1_GUIDANCE_ENVELOPE)
-        if unknown:
-            raise ValueError(
-                f"--guidance_envelope has unknown knob(s) {sorted(unknown)}; "
-                f"valid keys: {sorted(V1_GUIDANCE_ENVELOPE)}"
-            )
-        guidance_envelope.update(user_env)
+    guidance_envelope = resolve_training_envelope(args.guidance_envelope, heads)
     print(f"[envelope] persisting guidance envelope into policy config: {guidance_envelope}")
 
     ep_config = ExplorationPolicyConfig(

--- a/rlvr/train_explorer_regression.py
+++ b/rlvr/train_explorer_regression.py
@@ -189,6 +189,13 @@ def main():
     parser.add_argument("--counterfactual_weight", type=float, default=1.0)
     parser.add_argument("--hidden_dim", type=int, default=128)
     parser.add_argument("--head_raw_scale", type=float, default=10.0)
+    parser.add_argument(
+        "--guidance_envelope",
+        default=None,
+        help="JSON file with the guidance envelope the --labels were swept at "
+        "(lambda_lat/lat_scale/col_scale/...). Persisted into the policy config "
+        "so eval/deploy reuse it. Omit to record the canonical v1 calibration.",
+    )
     parser.add_argument("--dropout", type=float, default=0.1)
     parser.add_argument("--patience", type=int, default=50)
     parser.add_argument(
@@ -267,12 +274,28 @@ def main():
         f"(val avoid={int(is_avoid[val_idx].sum())})"
     )
 
+    from exploration_policy.model import V1_GUIDANCE_ENVELOPE
+
+    guidance_envelope = dict(V1_GUIDANCE_ENVELOPE)
+    if args.guidance_envelope:
+        with open(args.guidance_envelope) as f:
+            user_env = json.load(f)
+        unknown = set(user_env) - set(V1_GUIDANCE_ENVELOPE)
+        if unknown:
+            raise ValueError(
+                f"--guidance_envelope has unknown knob(s) {sorted(unknown)}; "
+                f"valid keys: {sorted(V1_GUIDANCE_ENVELOPE)}"
+            )
+        guidance_envelope.update(user_env)
+    print(f"[envelope] persisting guidance envelope into policy config: {guidance_envelope}")
+
     ep_config = ExplorationPolicyConfig(
         hidden_dim=args.hidden_dim,
         dropout=args.dropout,
         encoder_hidden_dim=model_args.hidden_dim,
         head_raw_scale=args.head_raw_scale,
         heads=heads,
+        guidance_envelope=guidance_envelope,
     )
     policy = ExplorationPolicy(ep_config, ref_seq_len=model_args.future_len).to(device)
     if args.init_from:


### PR DESCRIPTION
## Problem

The exploration policy is trained by **pure eta-regression** (`rlvr/train_explorer_regression.py`) toward target etas that were swept at a **fixed guidance envelope** (`lambda_lat / lat_scale / col_scale / col_range / lambda_spd / stretch_scale / guidance_scale / envelope / lambda_col`). The network never sees the envelope, so its `eta ∈ [-1,1]` outputs are only meaningful at the calibration its labels were generated with.

That envelope was **not stored anywhere** — it lived only in per-tool CLI flags whose defaults had drifted apart: most tools defaulted `lambda_lat=5.0`, but the open-loop eval (`eval_policy_avoidance`) defaulted to a **weaker `4.0/1.5/6.0`** and the viz tools to `2.5`. Running an eval without passing the envelope flags silently applied ~half the intended guidance, which made a correctly-certified policy look broken (and cost real debugging time chasing a phantom "non-reproduction").

## Fix

Persist the envelope with the policy and have eval/deploy load it instead of trusting CLI defaults:

- **`ExplorationPolicyConfig.guidance_envelope`** — new field, defaults to the canonical v1 calibration (`5.0/2.0/9.0/8.0/...`). That default is also what every pre-existing policy was trained at, so older configs that lack the key load correctly (verified: existing policies backfill to v1 on load).
- **Trainer** records it (`--guidance_envelope <json>`, default v1) into the saved config, with a loud error on unknown knobs.
- **`load_policy`** attaches `policy.guidance_envelope`; **`make_composer`** resolves each knob as *explicit CLI arg → persisted envelope → v1 constant* — there is no divergent per-tool default any more.
- **`eval_policy_avoidance`** envelope args now default to `None` (override-only), so omitting them uses the policy's own calibration.

## Tests

`rlvr/test_guidance_envelope_persistence.py`: config default is v1, round-trip preserves a custom envelope, a legacy config without the key loads as v1, and `make_composer` resolution honors the precedence (persisted-over-unset, explicit-arg-override, v1-fallback). Existing `exploration_policy` / guidance tests still pass; ruff + format clean.
