### PR TITLE
Add autoresearch avoidance tooling + head-aware explorer ranked-SFT + blocks12 target

### DIFF
--- a/preference_optimization/lora_utils.py
+++ b/preference_optimization/lora_utils.py
@@ -55,6 +55,14 @@ LORA_TARGET_BLOCKS_02_REGEX = (
     r"decoder\.dit\.blocks\.[02]\.(attn|cross_attn)\.(q_proj|k_proj|v_proj|out_proj)"
 )
 
+# Blocks 1+2 only (freeze block 0): forces an avoidance graft to express in blocks 1/2
+# instead of block 0. Block 0 is the subspace most coupled to neighbor-L2 damage
+# (no_blk0 ablation recovers neighbor strongly), so freezing it during a from-scratch
+# avoidance graft keeps neighbor low by construction — IF avoidance can fit in 1/2.
+LORA_TARGET_BLOCKS_12_REGEX = (
+    r"decoder\.dit\.blocks\.[12]\.(attn|cross_attn)\.(q_proj|k_proj|v_proj|out_proj)"
+)
+
 
 class UnfusedMHA(nn.Module):
     """nn.MultiheadAttention equivalent with separate q/k/v/out projection Linear layers.

--- a/rlvr/autoresearch/run_experiment.py
+++ b/rlvr/autoresearch/run_experiment.py
@@ -625,6 +625,7 @@ def run(
                     LORA_TARGET_LAST_BLOCK_REGEX,
                     apply_lora,
                 )
+
                 target = {
                     "last": LORA_TARGET_LAST_BLOCK_REGEX,
                     "first": LORA_TARGET_FIRST_BLOCK_REGEX,

--- a/rlvr/autoresearch/run_experiment.py
+++ b/rlvr/autoresearch/run_experiment.py
@@ -620,16 +620,17 @@ def run(
                 from preference_optimization.lora_utils import (
                     LORA_TARGET_BLOCKS_01_REGEX,
                     LORA_TARGET_BLOCKS_02_REGEX,
+                    LORA_TARGET_BLOCKS_12_REGEX,
                     LORA_TARGET_FIRST_BLOCK_REGEX,
                     LORA_TARGET_LAST_BLOCK_REGEX,
                     apply_lora,
                 )
-
                 target = {
                     "last": LORA_TARGET_LAST_BLOCK_REGEX,
                     "first": LORA_TARGET_FIRST_BLOCK_REGEX,
                     "blocks01": LORA_TARGET_BLOCKS_01_REGEX,
                     "blocks02": LORA_TARGET_BLOCKS_02_REGEX,
+                    "blocks12": LORA_TARGET_BLOCKS_12_REGEX,
                 }.get(grpo_config.lora_target)
                 kwargs = dict(
                     r=grpo_config.lora_rank,
@@ -861,6 +862,7 @@ def run(
                                 encoder_hidden_dim=model_args.hidden_dim,
                                 head_init=grpo_config.exploration_head_init,
                                 head_raw_scale=grpo_config.exploration_head_raw_scale,
+                                heads=list(grpo_config.exploration_heads),
                             )
                             run._cached_explorer = ExplorationPolicy(
                                 _ep_cfg,

--- a/rlvr/autoresearch/tools/build_avoiding_target.py
+++ b/rlvr/autoresearch/tools/build_avoiding_target.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Repair poison/weak curated targets by synthesizing an AVOIDING target.
+
+For scenes whose stored ego_agent_future collides with (or barely misses) a
+stopped obstacle, curated SFT teaches the collision (margin transfer is ~1:1).
+Instead of dropping those scenes, this tool regenerates the target: sample K
+trajectories from a source model, score each with the FULL reward
+(compute_reward_batch — same OBB path as eval), and keep the best-reward sample
+whose static-collision margin clears --min_margin. The winner is written into
+ego_agent_future (all other NPZ fields copied verbatim).
+
+Scenes with NO sample clearing the margin are NOT written (fail loudly,
+reported as UNREPAIRED) — a weak repair is poison with extra steps.
+
+Reuses ONLY existing fns: eval_det_avoidance.{load_model,load_npz_data},
+grpo_trainer_batched.{_stack_scene_data,_normalize_batch,generate_all_scenes_batched},
+reward.compute_reward_batch.
+
+Usage:
+    python -m rlvr.autoresearch.tools.build_avoiding_target \
+        --model <source.pth> --scenes <poison.json> --config <reward.json> \
+        --ego_shape WB,L,W --min_margin 0.3 \
+        --out_dir <dir> --out_list <repaired.json>
+"""
+
+import argparse
+import json
+import os
+
+import numpy as np
+import torch
+
+from rlvr.autoresearch.tools.eval_det_avoidance import load_model, load_npz_data
+from rlvr.autoresearch.tools.reward_config_from_json import load_reward_config
+from rlvr.grpo_trainer_batched import (
+    _normalize_batch,
+    _stack_scene_data,
+    generate_all_scenes_batched,
+)
+from rlvr.reward import compute_reward_batch
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--model", required=True, help="generation source model")
+    ap.add_argument("--scenes", required=True, help="JSON list of NPZs to repair")
+    ap.add_argument("--config", required=True, help="reward config JSON")
+    ap.add_argument("--ego_shape", required=True, help="WB,L,W")
+    ap.add_argument(
+        "--min_margin",
+        type=float,
+        required=True,
+        help="required sc_min_dist of the new target (e.g. 0.3)",
+    )
+    ap.add_argument("--out_dir", required=True)
+    ap.add_argument("--out_list", required=True)
+    ap.add_argument("--K", type=int, default=16)
+    ap.add_argument(
+        "--variant",
+        default="rsft_v2",
+        help="generation variant (noise-heavy default for diversity)",
+    )
+    ap.add_argument("--gt_max_speed", type=float, default=9.0)
+    args = ap.parse_args()
+
+    dev = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    rcfg = load_reward_config(args.config)
+    model, margs = load_model(args.model, dev)
+    paths = json.load(open(args.scenes))
+    os.makedirs(args.out_dir, exist_ok=True)
+
+    written, unrepaired = [], []
+    for p in paths:
+        d = load_npz_data(p, dev)
+        nb = _normalize_batch(_stack_scene_data([d], dev), margs)
+        trajs = generate_all_scenes_batched(
+            model,
+            margs,
+            nb,
+            K=args.K,
+            noise_range=(0.5, 2.0),
+            device=dev,
+            gen_chunk_size=args.K,
+            gt_max_speed=args.gt_max_speed,
+            generation_variant=args.variant,
+            use_route_cl_guidance=True,
+        )[0]  # (K, T, 4)
+        rewards = compute_reward_batch(trajs, d, rcfg)
+        cands = []
+        for k, r in enumerate(rewards):
+            scm = float(getattr(r, "sc_min_dist", 99.0))
+            if scm >= args.min_margin and not r.kinematic_violated and not r.stopped:
+                cands.append((float(r.total), scm, k))
+        name = os.path.basename(p)
+        if not cands:
+            best_scm = max(float(getattr(r, "sc_min_dist", 99.0)) for r in rewards)
+            unrepaired.append(p)
+            print(
+                f"  UNREPAIRED {name}: best sample sc_min={best_scm:+.3f} "
+                f"< margin {args.min_margin}"
+            )
+            continue
+        cands.sort(reverse=True)
+        total, scm, k = cands[0]
+        raw = dict(np.load(p, allow_pickle=True))
+        raw["ego_agent_future"] = trajs[k].detach().cpu().numpy().astype(np.float32)
+        out_p = os.path.join(args.out_dir, name)
+        np.savez(out_p, **raw)
+        written.append(out_p)
+        print(f"  repaired {name}: slot {k}  sc_min={scm:+.3f}  total={total:+.1f}")
+
+    json.dump(written, open(args.out_list, "w"), indent=1)
+    print(f"repaired {len(written)}/{len(paths)} -> {args.out_dir}; UNREPAIRED: {len(unrepaired)}")
+    if unrepaired:
+        ur = os.path.splitext(args.out_list)[0] + "_unrepaired.json"
+        json.dump(unrepaired, open(ur, "w"), indent=1)
+        print(f"  unrepaired list -> {ur}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/build_avoiding_target.py
+++ b/rlvr/autoresearch/tools/build_avoiding_target.py
@@ -109,7 +109,8 @@ def main():
             continue
         cands.sort(reverse=True)
         total, scm, k = cands[0]
-        raw = dict(np.load(p, allow_pickle=True))
+        with np.load(p, allow_pickle=True) as _z:
+            raw = dict(_z)
         raw["ego_agent_future"] = trajs[k].detach().cpu().numpy().astype(np.float32)
         out_p = os.path.join(args.out_dir, name)
         np.savez(out_p, **raw)

--- a/rlvr/autoresearch/tools/build_avoiding_target.py
+++ b/rlvr/autoresearch/tools/build_avoiding_target.py
@@ -45,7 +45,7 @@ def main():
     ap.add_argument("--model", required=True, help="generation source model")
     ap.add_argument("--scenes", required=True, help="JSON list of NPZs to repair")
     ap.add_argument("--config", required=True, help="reward config JSON")
-    ap.add_argument("--ego_shape", required=True, help="WB,L,W")
+    ap.add_argument("--ego_shape", required=True, help="WB,L,W — validated against each NPZ")
     ap.add_argument(
         "--min_margin",
         type=float,
@@ -66,12 +66,19 @@ def main():
     dev = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     rcfg = load_reward_config(args.config)
     model, margs = load_model(args.model, dev)
+    cli_es = np.array([float(x) for x in args.ego_shape.split(",")])
     paths = json.load(open(args.scenes))
     os.makedirs(args.out_dir, exist_ok=True)
 
     written, unrepaired = [], []
     for p in paths:
         d = load_npz_data(p, dev)
+        npz_es = d["ego_shape"].detach().cpu().numpy().reshape(-1)[:3]
+        if not np.allclose(npz_es, cli_es, atol=1e-2):
+            raise ValueError(
+                f"{p}: --ego_shape {cli_es.tolist()} != NPZ ego_shape "
+                f"{npz_es.tolist()} (platform mismatch)"
+            )
         nb = _normalize_batch(_stack_scene_data([d], dev), margs)
         trajs = generate_all_scenes_batched(
             model,

--- a/rlvr/autoresearch/tools/build_clguided_target.py
+++ b/rlvr/autoresearch/tools/build_clguided_target.py
@@ -1,0 +1,79 @@
+"""Build curated CL-GUIDED centered targets for a bias-fix graft.
+
+For each scene: generate K trajectories with strong route-centerline guidance (the
+generation_variant's cl_spd slots), score every slot with reward.compute_centerline_score_batch
+(baselink), pick the MOST-CENTERED slot, and write it into ego_agent_future as the curated
+SFT target. Unlike plain det (build_baseline_det_target, ~0.88m from an off-center start) the
+CL-guided trajectory steers toward center (~0.33m) — a real centering signal for curated SFT.
+
+Reuses ONLY existing fns: eval_det_avoidance.{load_model,load_npz_data},
+grpo_trainer_batched.{_stack_scene_data,_normalize_batch,generate_all_scenes_batched},
+reward.compute_centerline_score_batch.
+"""
+
+import argparse
+import json
+import os
+
+import numpy as np
+import torch
+
+from rlvr.autoresearch.tools.eval_det_avoidance import load_model, load_npz_data
+from rlvr.grpo_trainer_batched import (
+    _normalize_batch,
+    _stack_scene_data,
+    generate_all_scenes_batched,
+)
+from rlvr.reward import compute_centerline_score_batch
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", required=True, help="centered source (baseline)")
+    ap.add_argument("--scenes", required=True)
+    ap.add_argument("--ego_shape", required=True)
+    ap.add_argument("--out_dir", required=True)
+    ap.add_argument("--out_list", required=True)
+    ap.add_argument("--K", type=int, default=16)
+    ap.add_argument("--variant", default="rl_cl_soft_sweep_stretch")
+    ap.add_argument("--gt_max_speed", type=float, default=9.0)
+    args = ap.parse_args()
+    dev = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model, margs = load_model(args.model, dev)
+    paths = json.load(open(args.scenes))
+    os.makedirs(args.out_dir, exist_ok=True)
+    written, n_cen = [], 0
+    for p in paths:
+        d = load_npz_data(p, dev)
+        es = d["ego_shape"]
+        es_one = es[0] if es.dim() > 1 else es
+        nb = _normalize_batch(_stack_scene_data([d], dev), margs)
+        trajs = generate_all_scenes_batched(
+            model,
+            margs,
+            nb,
+            K=args.K,
+            noise_range=(0.5, 2.0),
+            device=dev,
+            gen_chunk_size=args.K,
+            gt_max_speed=args.gt_max_speed,
+            generation_variant=args.variant,
+            use_route_cl_guidance=True,
+        )[0]  # (K,T,4)
+        sc = compute_centerline_score_batch(trajs, es_one, d, usage_mode="baselink")
+        best = int(torch.argmax(sc).item())
+        if float(sc[best]) > -0.05:
+            n_cen += 1
+        raw = dict(np.load(p, allow_pickle=True))
+        raw["ego_agent_future"] = trajs[best].detach().cpu().numpy().astype(np.float32)
+        out_p = os.path.join(args.out_dir, os.path.basename(p))
+        np.savez(out_p, **raw)
+        written.append(out_p)
+    json.dump(written, open(args.out_list, "w"), indent=1)
+    print(
+        f"wrote {len(written)} CL-guided curated targets -> {args.out_dir} (centerline>-0.05: {n_cen}/{len(written)})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/build_clguided_target.py
+++ b/rlvr/autoresearch/tools/build_clguided_target.py
@@ -71,7 +71,8 @@ def main():
         best = int(torch.argmax(sc).item())
         if float(sc[best]) > -0.05:
             n_cen += 1
-        raw = dict(np.load(p, allow_pickle=True))
+        with np.load(p, allow_pickle=True) as _z:
+            raw = dict(_z)
         raw["ego_agent_future"] = trajs[best].detach().cpu().numpy().astype(np.float32)
         out_p = os.path.join(args.out_dir, os.path.basename(p))
         np.savez(out_p, **raw)

--- a/rlvr/autoresearch/tools/build_clguided_target.py
+++ b/rlvr/autoresearch/tools/build_clguided_target.py
@@ -3,8 +3,8 @@
 For each scene: generate K trajectories with strong route-centerline guidance (the
 generation_variant's cl_spd slots), score every slot with reward.compute_centerline_score_batch
 (baselink), pick the MOST-CENTERED slot, and write it into ego_agent_future as the curated
-SFT target. Unlike plain det (build_baseline_det_target, ~0.88m from an off-center start) the
-CL-guided trajectory steers toward center (~0.33m) — a real centering signal for curated SFT.
+SFT target. Unlike plain det (build_baseline_det_target), which stays near an off-center start,
+the CL-guided trajectory steers toward the route center — a real centering signal for curated SFT.
 
 Reuses ONLY existing fns: eval_det_avoidance.{load_model,load_npz_data},
 grpo_trainer_batched.{_stack_scene_data,_normalize_batch,generate_all_scenes_batched},
@@ -31,7 +31,7 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--model", required=True, help="centered source (baseline)")
     ap.add_argument("--scenes", required=True)
-    ap.add_argument("--ego_shape", required=True)
+    ap.add_argument("--ego_shape", required=True, help="WB,L,W — validated against each NPZ")
     ap.add_argument("--out_dir", required=True)
     ap.add_argument("--out_list", required=True)
     ap.add_argument("--K", type=int, default=16)
@@ -40,6 +40,7 @@ def main():
     args = ap.parse_args()
     dev = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model, margs = load_model(args.model, dev)
+    cli_es = np.array([float(x) for x in args.ego_shape.split(",")])
     paths = json.load(open(args.scenes))
     os.makedirs(args.out_dir, exist_ok=True)
     written, n_cen = [], 0
@@ -47,6 +48,12 @@ def main():
         d = load_npz_data(p, dev)
         es = d["ego_shape"]
         es_one = es[0] if es.dim() > 1 else es
+        npz_es = es_one.detach().cpu().numpy().reshape(-1)[:3]
+        if not np.allclose(npz_es, cli_es, atol=1e-2):
+            raise ValueError(
+                f"{p}: --ego_shape {cli_es.tolist()} != NPZ ego_shape "
+                f"{npz_es.tolist()} (platform mismatch)"
+            )
         nb = _normalize_batch(_stack_scene_data([d], dev), margs)
         trajs = generate_all_scenes_batched(
             model,

--- a/rlvr/autoresearch/tools/distill_closedloop_targets.py
+++ b/rlvr/autoresearch/tools/distill_closedloop_targets.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Distill v23 CLOSED-LOOP reactive trajectories into curated-RSFT targets.
+
+distill_guided_targets bakes v23's ONE-SHOT guided plan (open-loop ~4/50 on
+val50) — but v23's real strength is CLOSED-LOOP (0/50): it re-plans every step
+for 8 s and the realized motion clears obstacles a single plan cannot. This
+tool captures THAT: it runs the 80-step closed-loop rollout under v23 guidance
+(the exact rollout eval_closedloop_avoidance scores) and writes the REALIZED
+driven trajectory (positions[1:], initial ego frame) into ego_agent_future.
+
+A curated-RSFT LoRA trained on these learns to emit, in ONE plan, the reactive
+path v23 took 8 s of re-planning to produce — transferring the closed-loop
+avoidance into a deployable single-shot planner.
+
+Screens (loud in summary):
+  - only scenes whose REALIZED rollout cleared with min OBB clearance >
+    --min_clearance are written (contact/stalled rollouts skipped);
+  - inert scenes (rollout barely deviates from baseline, realized arc within
+    --inert_arc m of the baseline det arc) are skipped unless --keep_inert.
+
+Usage:
+    python -m rlvr.autoresearch.tools.distill_closedloop_targets \
+        --model_path <base.pth> --policy_dir <v23_dir> --scenes <list.json> \
+        --out_dir <dir> --out_list <json> --ego_shape WB,L,W \
+        [--steps 80] [--min_clearance 0.2] \
+        [--lambda_lat 5.0 --lat_scale 2.0 --col_scale 9.0 --col_range 8.0]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+import numpy as np
+import torch
+
+import rlvr.guidance_batched  # noqa: F401
+from preference_optimization.utils import load_npz_data
+from rlvr.autoresearch.tools.eval_closedloop_avoidance import (
+    make_guided_predict,
+    score_rollout,
+)
+from rlvr.autoresearch.tools.eval_det_avoidance import load_model
+from rlvr.autoresearch.tools.eval_policy_avoidance import load_policy
+from rlvr.autoresearch.tools.ghost_sim_common import extract_stopped_neighbors
+from rlvr.autoresearch.tools.recovery_sim import (
+    closed_loop_rollout_with_plans,
+    deterministic_predict,
+)
+from rlvr.grpo_sft_trainer import _smooth_trajectory
+
+
+@torch.no_grad()
+def main():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--model_path", required=True)
+    p.add_argument("--policy_dir", required=True)
+    p.add_argument("--scenes", required=True)
+    p.add_argument("--out_dir", required=True)
+    p.add_argument("--out_list", required=True)
+    p.add_argument("--ego_shape", required=True, help="WB,L,W — no default")
+    p.add_argument("--steps", type=int, default=80)
+    p.add_argument("--min_clearance", type=float, default=0.2)
+    p.add_argument(
+        "--inert_arc",
+        type=float,
+        default=1.0,
+        help="skip if realized arc within this many m of baseline det arc",
+    )
+    p.add_argument("--keep_inert", action="store_true")
+    # v23 certified guidance envelope (defaults = the strong cert envelope,
+    # matching policy_eval.json guidance_args — NOT the weak argparse defaults
+    # of eval_policy_avoidance).
+    p.add_argument("--lambda_lat", type=float, default=5.0)
+    p.add_argument("--lat_scale", type=float, default=2.0)
+    p.add_argument("--col_scale", type=float, default=9.0)
+    p.add_argument("--col_range", type=float, default=8.0)
+    p.add_argument("--lambda_spd", type=float, default=0.2)
+    p.add_argument("--stretch_scale", type=float, default=1.0)
+    p.add_argument("--guidance_scale", type=float, default=0.5)
+    p.add_argument("--envelope", choices=["v1", "v2"], default="v1")
+    p.add_argument("--lambda_col", type=float, default=3.0)
+    args = p.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model, margs = load_model(args.model_path, device)
+    policy, heads = load_policy(args.policy_dir, margs, device)
+    ego_shape = tuple(float(x) for x in args.ego_shape.split(","))
+    guided_predict = make_guided_predict(policy, heads, args, device)
+
+    with open(args.scenes) as f:
+        paths = json.load(f)
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    written, manifest = [], []
+    n_inert = n_unsafe = n_err = 0
+    for sp in paths:
+        try:
+            data = load_npz_data(sp, device)
+            boxes = extract_stopped_neighbors(sp)
+            # baseline det arc (inertness reference)
+            det = deterministic_predict(model, margs, data)
+            det_arc = float(np.linalg.norm(np.diff(det[:, :2], axis=0), axis=1).sum())
+            roll = closed_loop_rollout_with_plans(
+                model,
+                margs,
+                data,
+                n_steps=args.steps,
+                advance_k=0,
+                predict_fn=guided_predict,
+                sg_smooth=True,
+                trim_backward=True,
+            )
+            sc = score_rollout(roll, boxes, ego_shape, device)
+            if sc["contact"] or sc["stalled"]:
+                n_unsafe += 1
+                continue
+            if boxes and sc["min_clear"] < args.min_clearance:
+                n_unsafe += 1
+                continue
+            if (
+                not args.keep_inert
+                and abs(sc["arc"] - det_arc) < args.inert_arc
+                and (not boxes or sc["min_clear"] > 2.0)
+            ):
+                # barely deviates from baseline AND already-clear scene → nothing learned
+                n_inert += 1
+                continue
+        except Exception as e:  # noqa: BLE001
+            print(f"  [err ] {Path(sp).name}: {e}")
+            n_err += 1
+            continue
+
+        pos = np.asarray(roll["positions"])  # [steps+1, 3] initial frame
+        realized = pos[1 : args.steps + 1]  # drop t0 origin
+        traj4 = np.stack(
+            [realized[:, 0], realized[:, 1], np.cos(realized[:, 2]), np.sin(realized[:, 2])],
+            axis=-1,
+        )
+        traj4 = _smooth_trajectory(traj4.astype(np.float32), 11, 3)
+
+        raw = dict(np.load(sp, allow_pickle=True))
+        fut = raw["ego_agent_future"]
+        T = min(fut.shape[0], traj4.shape[0])
+        if fut.shape[-1] == 3:
+            new = np.stack(
+                [traj4[:T, 0], traj4[:T, 1], np.arctan2(traj4[:T, 3], traj4[:T, 2])], axis=-1
+            )
+        elif fut.shape[-1] == 4:
+            new = traj4[:T, :4]
+        else:
+            raise ValueError(f"{sp}: ego_agent_future width {fut.shape[-1]} not 3/4")
+        raw["ego_agent_future"] = new.astype(fut.dtype)
+
+        pool = Path(sp).parent.name
+        out_path = out_dir / f"{pool}__{Path(sp).stem}_cldistill.npz"
+        np.savez(out_path, **raw)
+        written.append(str(out_path))
+        manifest.append(
+            {
+                "source": sp,
+                "min_clear": sc["min_clear"],
+                "arc": sc["arc"],
+                "cleared": sc["cleared"],
+                "out": str(out_path),
+            }
+        )
+
+    with open(args.out_list, "w") as f:
+        json.dump(written, f, indent=1)
+    with open(out_dir / "manifest.json", "w") as f:
+        json.dump(manifest, f, indent=1)
+    print(
+        f"\nClosed-loop distilled {len(written)} targets "
+        f"(skipped: {n_inert} inert, {n_unsafe} unsafe/stalled, {n_err} err) -> {args.out_list}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/distill_closedloop_targets.py
+++ b/rlvr/autoresearch/tools/distill_closedloop_targets.py
@@ -162,7 +162,8 @@ def main():
         )
         traj4 = _smooth_trajectory(traj4.astype(np.float32), 11, 3)
 
-        raw = dict(np.load(sp, allow_pickle=True))
+        with np.load(sp, allow_pickle=True) as _z:
+            raw = dict(_z)
         fut = raw["ego_agent_future"]
         if traj4.shape[0] < fut.shape[0]:
             raise ValueError(

--- a/rlvr/autoresearch/tools/distill_closedloop_targets.py
+++ b/rlvr/autoresearch/tools/distill_closedloop_targets.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
-"""Distill v23 CLOSED-LOOP reactive trajectories into curated-RSFT targets.
+"""Distill a guidance policy's CLOSED-LOOP reactive trajectory into curated-SFT targets.
 
-distill_guided_targets bakes v23's ONE-SHOT guided plan (open-loop ~4/50 on
-val50) — but v23's real strength is CLOSED-LOOP (0/50): it re-plans every step
-for 8 s and the realized motion clears obstacles a single plan cannot. This
-tool captures THAT: it runs the 80-step closed-loop rollout under v23 guidance
+distill_guided_targets bakes only a guidance policy's ONE-SHOT (open-loop) plan.
+The reactive strength of such a policy is in CLOSED-LOOP: it re-plans every step
+and the realized motion can clear obstacles a single open-loop plan cannot. This
+tool captures THAT: it runs the closed-loop rollout under the policy's guidance
 (the exact rollout eval_closedloop_avoidance scores) and writes the REALIZED
 driven trajectory (positions[1:], initial ego frame) into ego_agent_future.
 
-A curated-RSFT LoRA trained on these learns to emit, in ONE plan, the reactive
-path v23 took 8 s of re-planning to produce — transferring the closed-loop
-avoidance into a deployable single-shot planner.
+A curated-SFT LoRA trained on these learns to emit, in ONE plan, the reactive
+path the policy produced over the full re-planning horizon — transferring the
+closed-loop avoidance into a deployable single-shot planner.
 
 Screens (loud in summary):
   - only scenes whose REALIZED rollout cleared with min OBB clearance >
@@ -18,19 +18,21 @@ Screens (loud in summary):
   - inert scenes (rollout barely deviates from baseline, realized arc within
     --inert_arc m of the baseline det arc) are skipped unless --keep_inert.
 
+Guidance envelope: the envelope flags default to None, meaning the policy's own
+persisted guidance_envelope (policy_eval.json) is used. Pass explicit values
+together with --force_envelope_override to override the persisted envelope.
+
 Usage:
     python -m rlvr.autoresearch.tools.distill_closedloop_targets \
-        --model_path <base.pth> --policy_dir <v23_dir> --scenes <list.json> \
+        --model_path <base.pth> --policy_dir <policy_dir> --scenes <list.json> \
         --out_dir <dir> --out_list <json> --ego_shape WB,L,W \
-        [--steps 80] [--min_clearance 0.2] \
-        [--lambda_lat 5.0 --lat_scale 2.0 --col_scale 9.0 --col_range 8.0]
+        [--steps 80] [--min_clearance 0.2]
 """
 
 from __future__ import annotations
 
 import argparse
 import json
-import math
 from pathlib import Path
 
 import numpy as np
@@ -72,18 +74,34 @@ def main():
         help="skip if realized arc within this many m of baseline det arc",
     )
     p.add_argument("--keep_inert", action="store_true")
-    # v23 certified guidance envelope (defaults = the strong cert envelope,
-    # matching policy_eval.json guidance_args — NOT the weak argparse defaults
-    # of eval_policy_avoidance).
-    p.add_argument("--lambda_lat", type=float, default=5.0)
-    p.add_argument("--lat_scale", type=float, default=2.0)
-    p.add_argument("--col_scale", type=float, default=9.0)
-    p.add_argument("--col_range", type=float, default=8.0)
-    p.add_argument("--lambda_spd", type=float, default=0.2)
-    p.add_argument("--stretch_scale", type=float, default=1.0)
-    p.add_argument("--guidance_scale", type=float, default=0.5)
-    p.add_argument("--envelope", choices=["v1", "v2"], default="v1")
-    p.add_argument("--lambda_col", type=float, default=3.0)
+    # Guidance envelope: default None -> use the policy's persisted
+    # guidance_envelope (policy_eval.json). An explicit value that disagrees
+    # with the persisted calibration hard-fails unless --force_envelope_override.
+    p.add_argument(
+        "--lambda_lat",
+        type=float,
+        default=None,
+        help="override the policy's persisted guidance envelope",
+    )
+    p.add_argument("--lat_scale", type=float, default=None)
+    p.add_argument("--col_scale", type=float, default=None)
+    p.add_argument("--col_range", type=float, default=None)
+    p.add_argument("--lambda_spd", type=float, default=None)
+    p.add_argument("--stretch_scale", type=float, default=None)
+    p.add_argument("--guidance_scale", type=float, default=None)
+    p.add_argument("--envelope", choices=["v1", "v2"], default=None)
+    p.add_argument("--lambda_col", type=float, default=None)
+    p.add_argument(
+        "--no_dit_memo",
+        action="store_true",
+        help="disable the guided-frame DiT forward memo (memo is the default)",
+    )
+    p.add_argument(
+        "--force_envelope_override",
+        action="store_true",
+        help="allow explicit envelope flags to override the policy's persisted "
+        "calibration (otherwise a disagreeing flag hard-fails)",
+    )
     args = p.parse_args()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -146,6 +164,13 @@ def main():
 
         raw = dict(np.load(sp, allow_pickle=True))
         fut = raw["ego_agent_future"]
+        if traj4.shape[0] < fut.shape[0]:
+            raise ValueError(
+                f"{sp}: realized trajectory has {traj4.shape[0]} steps < the "
+                f"{fut.shape[0]}-step future horizon; increase --steps (currently "
+                f"{args.steps}) so the distilled target fills the full SFT horizon "
+                "instead of silently writing a truncated ego_agent_future."
+            )
         T = min(fut.shape[0], traj4.shape[0])
         if fut.shape[-1] == 3:
             new = np.stack(
@@ -169,6 +194,13 @@ def main():
                 "cleared": sc["cleared"],
                 "out": str(out_path),
             }
+        )
+
+    if paths and n_err == len(paths):
+        raise RuntimeError(
+            f"all {n_err} scenes errored — this is a systematic failure (check "
+            "--policy_dir, the guidance envelope, or --no_dit_memo), not per-scene "
+            "noise. Refusing to write an empty target set."
         )
 
     with open(args.out_list, "w") as f:

--- a/rlvr/autoresearch/tools/mine_arc_and_convert.py
+++ b/rlvr/autoresearch/tools/mine_arc_and_convert.py
@@ -8,7 +8,7 @@ onto the route within [arc_lo, arc_hi], and convert each to the full trainable f
 - line_strings (60,20,2) -> (60,20,4): col2=0, col3=valid (1 where xy nonzero) [campaign approx;
   loss.py treats col3>0.5 as the road-border mask]
 - polygons (10,40,2) -> (10,40,3): col2=presence (1 where xy nonzero)
-- everything cast float32
+- the rebuilt trajectory/map arrays are cast float32 (other passthrough fields keep their dtype)
 
 Reuses scenario_generation.tools._heatmap_common for route projection (no hand-rolled geometry).
 """

--- a/rlvr/autoresearch/tools/mine_arc_and_convert.py
+++ b/rlvr/autoresearch/tools/mine_arc_and_convert.py
@@ -26,6 +26,9 @@ from scenario_generation.tools._heatmap_common import build_route_polyline, proj
 
 def _f2to4(arr):  # (...,3)[x,y,h] -> (...,4)[x,y,cos,sin]
     x, y, h = arr[..., 0], arr[..., 1], arr[..., 2]
+    # padding rows are (0,0,0); the 0.1 m floor (vs the 1e-6 used for map
+    # arrays) matches convert_3col_to_4col so near-origin trajectory points
+    # get a zero heading instead of a spurious cos/sin.
     v = (np.abs(x) + np.abs(y)) > 0.1
     cos = np.where(v, np.cos(h), 0.0)
     sin = np.where(v, np.sin(h), 0.0)

--- a/rlvr/autoresearch/tools/mine_arc_and_convert.py
+++ b/rlvr/autoresearch/tools/mine_arc_and_convert.py
@@ -1,0 +1,97 @@
+"""Mine parse_rosbag NPZs in a route arc band and convert reduced→trainable format.
+
+For HEAL/MEND: take psim-bag-parsed NPZs (reduced: ego/nbr future 3-col, 32 neighbor
+slots, line_strings 2-col, polygons 2-col), keep only frames whose ego pose projects
+onto the route within [arc_lo, arc_hi], and convert each to the full trainable format:
+- ego_agent_future / neighbor_agents_future: 3-col (x,y,heading) -> 4-col (x,y,cos,sin)
+- neighbor_agents_past (32,31,11) -> (320,31,11); neighbor_agents_future (32,80,3)->(320,80,4)
+- line_strings (60,20,2) -> (60,20,4): col2=0, col3=valid (1 where xy nonzero) [campaign approx;
+  loss.py treats col3>0.5 as the road-border mask]
+- polygons (10,40,2) -> (10,40,3): col2=presence (1 where xy nonzero)
+- everything cast float32
+
+Reuses scenario_generation.tools._heatmap_common for route projection (no hand-rolled geometry).
+"""
+
+import argparse
+import glob
+import json
+import os
+import pickle
+
+import numpy as np
+
+from scenario_generation.tools._heatmap_common import build_route_polyline, project_to_polyline
+
+
+def _f2to4(arr):  # (...,3)[x,y,h] -> (...,4)[x,y,cos,sin]
+    x, y, h = arr[..., 0], arr[..., 1], arr[..., 2]
+    v = (np.abs(x) + np.abs(y)) > 0.1
+    cos = np.where(v, np.cos(h), 0.0)
+    sin = np.where(v, np.sin(h), 0.0)
+    return np.stack([x, y, cos, sin], axis=-1).astype(np.float32)
+
+
+def convert(d):
+    out = {k: d[k] for k in d.files}
+    out["ego_agent_future"] = _f2to4(d["ego_agent_future"].astype(np.float32))
+    out["ego_agent_past"] = d["ego_agent_past"].astype(np.float32)
+    # neighbors: pad slots to 320
+    npf = d["neighbor_agents_future"].astype(np.float32)  # (32,80,3)
+    npp = d["neighbor_agents_past"].astype(np.float32)  # (32,31,11)
+    NF = np.zeros((320, npf.shape[1], 4), np.float32)
+    NF[: npf.shape[0]] = _f2to4(npf)
+    NP = np.zeros((320, npp.shape[1], 11), np.float32)
+    NP[: npp.shape[0]] = npp
+    out["neighbor_agents_future"] = NF
+    out["neighbor_agents_past"] = NP
+    # line_strings (60,20,2)->(60,20,4): col2=0, col3=valid
+    ls = d["line_strings"].astype(np.float32)
+    LS = np.zeros((ls.shape[0], ls.shape[1], 4), np.float32)
+    LS[..., :2] = ls[..., :2]
+    LS[..., 3] = ((np.abs(ls[..., 0]) + np.abs(ls[..., 1])) > 1e-6).astype(np.float32)
+    out["line_strings"] = LS
+    # polygons (10,40,2)->(10,40,3): col2=presence
+    pg = d["polygons"].astype(np.float32)
+    PG = np.zeros((pg.shape[0], pg.shape[1], 3), np.float32)
+    PG[..., :2] = pg[..., :2]
+    PG[..., 2] = ((np.abs(pg[..., 0]) + np.abs(pg[..., 1])) > 1e-6).astype(np.float32)
+    out["polygons"] = PG
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--npz_dir", required=True)
+    ap.add_argument("--route_pkl", required=True)
+    ap.add_argument("--arc_lo", type=float, required=True)
+    ap.add_argument("--arc_hi", type=float, required=True)
+    ap.add_argument("--out_dir", required=True)
+    ap.add_argument("--out_list", required=True)
+    args = ap.parse_args()
+    with open(args.route_pkl, "rb") as f:
+        route = pickle.load(f)
+    poly, arc = build_route_polyline(route)
+    os.makedirs(args.out_dir, exist_ok=True)
+    kept = []
+    files = sorted(glob.glob(os.path.join(args.npz_dir, "*.npz")))
+    for p in files:
+        d = np.load(p, allow_pickle=True)
+        ex, ey = float(d["ego_current_state"][0]), float(d["ego_current_state"][1])
+        res = project_to_polyline(np.array([ex, ey], dtype=float), poly, arc)
+        s = float(res[0])
+        if not (args.arc_lo <= s <= args.arc_hi):
+            continue
+        out = convert(d)
+        op = os.path.join(args.out_dir, os.path.basename(p))
+        np.savez(op, **out)
+        kept.append(op)
+    with open(args.out_list, "w") as f:
+        json.dump(kept, f, indent=2)
+    print(
+        f"mined {len(kept)}/{len(files)} frames in arc [{args.arc_lo},{args.arc_hi}]m -> {args.out_dir}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/mine_arc_and_convert.py
+++ b/rlvr/autoresearch/tools/mine_arc_and_convert.py
@@ -79,13 +79,13 @@ def main():
     kept = []
     files = sorted(glob.glob(os.path.join(args.npz_dir, "*.npz")))
     for p in files:
-        d = np.load(p, allow_pickle=True)
-        ex, ey = float(d["ego_current_state"][0]), float(d["ego_current_state"][1])
-        res = project_to_polyline(np.array([ex, ey], dtype=float), poly, arc)
-        s = float(res[0])
-        if not (args.arc_lo <= s <= args.arc_hi):
-            continue
-        out = convert(d)
+        with np.load(p, allow_pickle=True) as d:
+            ex, ey = float(d["ego_current_state"][0]), float(d["ego_current_state"][1])
+            res = project_to_polyline(np.array([ex, ey], dtype=float), poly, arc)
+            s = float(res[0])
+            if not (args.arc_lo <= s <= args.arc_hi):
+                continue
+            out = convert(d)
         op = os.path.join(args.out_dir, os.path.basename(p))
         np.savez(op, **out)
         kept.append(op)

--- a/rlvr/autoresearch/tools/open_loop_per_arc.py
+++ b/rlvr/autoresearch/tools/open_loop_per_arc.py
@@ -39,12 +39,15 @@ def main():
     ap.add_argument("--scenes", required=True, help="all-arc val scene list (m2t+t2m)")
     ap.add_argument("--m2t_route", required=True)
     ap.add_argument("--t2m_route", required=True)
-    ap.add_argument("--ego_shape", required=True)
+    ap.add_argument("--ego_shape", required=True, help="WB,L,W — validated against each NPZ")
     ap.add_argument("--bin_m", type=float, default=100.0)
     ap.add_argument("--models", nargs="+", required=True, help="LABEL PATH LABEL PATH ...")
     args = ap.parse_args()
+    if len(args.models) % 2:
+        ap.error("--models must be LABEL PATH pairs (even number of values)")
 
     dev = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    cli_es = np.array([float(x) for x in args.ego_shape.split(",")])
     paths = json.load(open(args.scenes))
     routes = {}
     polys = {}
@@ -57,6 +60,12 @@ def main():
     for p in paths:
         rk = "t2m" if "t2m" in os.path.basename(p) else "m2t"
         d = np.load(p, allow_pickle=True)
+        npz_es = np.asarray(d["ego_shape"]).reshape(-1)[:3]
+        if not np.allclose(npz_es, cli_es, atol=1e-2):
+            raise ValueError(
+                f"{p}: --ego_shape {cli_es.tolist()} != NPZ ego_shape "
+                f"{npz_es.tolist()} (platform mismatch)"
+            )
         ex, ey, eyaw = recover_ego_world_pose_from_goal(np.asarray(d["goal_pose"]), routes[rk])
         pts, s = polys[rk]
         arc = project_to_polyline(np.array([ex, ey]), pts, s)[0]
@@ -83,7 +92,7 @@ def main():
     maxarc = arcs.max()
     nb = int(maxarc // args.bin_m) + 1
     print(
-        f"\nOpen-loop per-arc centerline (reward.py compute_centerline_score, baselink; closer to 0 = centered)"
+        "\nOpen-loop per-arc centerline (reward.py compute_centerline_score, baselink; closer to 0 = centered)"
     )
     print(f"scenes={len(paths)} | {' | '.join(labels)}")
     hdr = "  arc-bin  | " + " | ".join(f"{l:>8}" for l in labels)

--- a/rlvr/autoresearch/tools/open_loop_per_arc.py
+++ b/rlvr/autoresearch/tools/open_loop_per_arc.py
@@ -59,14 +59,15 @@ def main():
     meta = []
     for p in paths:
         rk = "t2m" if "t2m" in os.path.basename(p) else "m2t"
-        d = np.load(p, allow_pickle=True)
-        npz_es = np.asarray(d["ego_shape"]).reshape(-1)[:3]
+        with np.load(p, allow_pickle=True) as d:
+            npz_es = np.asarray(d["ego_shape"]).reshape(-1)[:3]
+            goal_pose = np.asarray(d["goal_pose"])
         if not np.allclose(npz_es, cli_es, atol=1e-2):
             raise ValueError(
                 f"{p}: --ego_shape {cli_es.tolist()} != NPZ ego_shape "
                 f"{npz_es.tolist()} (platform mismatch)"
             )
-        ex, ey, _ = recover_ego_world_pose_from_goal(np.asarray(d["goal_pose"]), routes[rk])
+        ex, ey, _ = recover_ego_world_pose_from_goal(goal_pose, routes[rk])
         pts, s = polys[rk]
         arc = project_to_polyline(np.array([ex, ey]), pts, s)[0]
         meta.append((p, rk, arc))

--- a/rlvr/autoresearch/tools/open_loop_per_arc.py
+++ b/rlvr/autoresearch/tools/open_loop_per_arc.py
@@ -66,7 +66,7 @@ def main():
                 f"{p}: --ego_shape {cli_es.tolist()} != NPZ ego_shape "
                 f"{npz_es.tolist()} (platform mismatch)"
             )
-        ex, ey, eyaw = recover_ego_world_pose_from_goal(np.asarray(d["goal_pose"]), routes[rk])
+        ex, ey, _ = recover_ego_world_pose_from_goal(np.asarray(d["goal_pose"]), routes[rk])
         pts, s = polys[rk]
         arc = project_to_polyline(np.array([ex, ey]), pts, s)[0]
         meta.append((p, rk, arc))

--- a/rlvr/autoresearch/tools/open_loop_per_arc.py
+++ b/rlvr/autoresearch/tools/open_loop_per_arc.py
@@ -1,0 +1,104 @@
+"""Open-loop per-arc centerline comparison across models (fast psim proxy).
+
+For an all-arc validation set (scenes mined across the WHOLE route, both directions),
+run each model's deterministic trajectory, score centerline with reward.py
+(compute_centerline_score_batch, the canonical metric), and bin by route arc
+(project_to_polyline, the same arc projection psim_per_arc_metrics uses). Prints a
+per-arc table per model so you can see WHERE a model is off-center vs baseline/seed —
+without waiting for a full psim. Routes are auto-selected per scene by 'm2t'/'t2m' in
+the filename.
+
+Reuses ONLY: eval_det_avoidance.{load_model,load_npz_data,det_inference_batched},
+reward.compute_centerline_score_batch, _heatmap_common.{build_route_polyline,
+project_to_polyline,recover_ego_world_pose_from_goal}. No new metric/geometry code.
+"""
+
+import argparse
+import json
+import os
+
+import numpy as np
+import torch
+
+from rlvr.autoresearch.tools.eval_det_avoidance import (
+    det_inference_batched,
+    load_model,
+    load_npz_data,
+)
+from rlvr.reward import compute_centerline_score_batch
+from scenario_generation.route import Route
+from scenario_generation.tools._heatmap_common import (
+    build_route_polyline,
+    project_to_polyline,
+    recover_ego_world_pose_from_goal,
+)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--scenes", required=True, help="all-arc val scene list (m2t+t2m)")
+    ap.add_argument("--m2t_route", required=True)
+    ap.add_argument("--t2m_route", required=True)
+    ap.add_argument("--ego_shape", required=True)
+    ap.add_argument("--bin_m", type=float, default=100.0)
+    ap.add_argument("--models", nargs="+", required=True, help="LABEL PATH LABEL PATH ...")
+    args = ap.parse_args()
+
+    dev = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    paths = json.load(open(args.scenes))
+    routes = {}
+    polys = {}
+    for k, rp in [("m2t", args.m2t_route), ("t2m", args.t2m_route)]:
+        routes[k] = Route.load(rp)
+        polys[k] = build_route_polyline(routes[k])
+
+    # precompute per-scene arc + route key (model-independent)
+    meta = []
+    for p in paths:
+        rk = "t2m" if "t2m" in os.path.basename(p) else "m2t"
+        d = np.load(p, allow_pickle=True)
+        ex, ey, eyaw = recover_ego_world_pose_from_goal(np.asarray(d["goal_pose"]), routes[rk])
+        pts, s = polys[rk]
+        arc = project_to_polyline(np.array([ex, ey]), pts, s)[0]
+        meta.append((p, rk, arc))
+
+    labels = args.models[0::2]
+    mpaths = args.models[1::2]
+    per_model = {}
+    for lab, mp in zip(labels, mpaths):
+        model, margs = load_model(mp, dev)
+        cls = []
+        for p, rk, arc in meta:
+            d = load_npz_data(p, dev)
+            traj = det_inference_batched(model, margs, [d], dev)  # (1,T,4)
+            es = d["ego_shape"]
+            es_one = es[0] if es.dim() > 1 else es
+            cl = float(compute_centerline_score_batch(traj, es_one, d, usage_mode="baselink")[0])
+            cls.append(cl)
+        per_model[lab] = np.array(cls)
+        del model
+        torch.cuda.empty_cache()
+
+    arcs = np.array([m[2] for m in meta])
+    maxarc = arcs.max()
+    nb = int(maxarc // args.bin_m) + 1
+    print(
+        f"\nOpen-loop per-arc centerline (reward.py compute_centerline_score, baselink; closer to 0 = centered)"
+    )
+    print(f"scenes={len(paths)} | {' | '.join(labels)}")
+    hdr = "  arc-bin  | " + " | ".join(f"{l:>8}" for l in labels)
+    print(hdr)
+    print("-" * len(hdr))
+    for b in range(nb):
+        lo, hi = b * args.bin_m, (b + 1) * args.bin_m
+        mask = (arcs >= lo) & (arcs < hi)
+        if mask.sum() == 0:
+            continue
+        cells = " | ".join(f"{per_model[l][mask].mean():>8.3f}" for l in labels)
+        print(f" {int(lo):4d}-{int(hi):<4d} | {cells}   (n={int(mask.sum())})")
+    print("-" * len(hdr))
+    print(" OVERALL  | " + " | ".join(f"{per_model[l].mean():>8.3f}" for l in labels))
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/perturb_neighbors_npz.py
+++ b/rlvr/autoresearch/tools/perturb_neighbors_npz.py
@@ -25,7 +25,7 @@ Safety screens (canonical reward-path geometry, no hand-rolled OBB math):
 Usage:
     python -m rlvr.autoresearch.tools.perturb_neighbors_npz \
         --scenes <list.json> --out_dir <dir> --out_list <out.json> \
-        --ego_shape 4.76,7.24,2.29 --lat_range 0.3,0.8 --lon_range 2.0,5.0 \
+        --ego_shape WB,L,W --lat_range 0.3,0.8 --lon_range 2.0,5.0 \
         --n_per_scene 4 --min_t0_clearance 0.05 --seed 0
 """
 

--- a/rlvr/autoresearch/tools/perturb_neighbors_npz.py
+++ b/rlvr/autoresearch/tools/perturb_neighbors_npz.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Neighbor-position perturbation variants for avoidance scene NPZs.
+
+`disturb_and_replay` perturbs the EGO frame (every field moves rigidly with
+the new ego pose), so the ego-to-obstacle geometry of a scene only varies
+through ego offsets. This tool varies the OTHER side: it shifts the STOPPED
+(parked / blocking) neighbors themselves — laterally and longitudinally in
+each neighbor's own heading frame — producing new ego-to-obstacle geometries
+from the same base scene.
+
+Only stopped neighbors are moved (the avoidance-relevant obstacles, same
+detection convention as ghost_sim_common.extract_stopped_neighbors: non-empty
+slot, future displacement < 0.5 m, valid box dims). Moving traffic, map,
+ego past/future and all other fields are copied verbatim. Zero rows are
+padding and are never touched.
+
+Safety screens (canonical reward-path geometry, no hand-rolled OBB math):
+  - t0-clean: the ego pose at t=0 (origin of the ego frame) must clear the
+    SHIFTED boxes by >= --min_t0_clearance, else the variant is dropped
+    (a scene already violating at t=0 cannot teach recovery);
+  - the GT ego_agent_future clearance vs the shifted boxes is recorded in
+    the manifest and counted loudly when it crosses (downstream distillation
+    overwrites the future, but the count must be visible).
+
+Usage:
+    python -m rlvr.autoresearch.tools.perturb_neighbors_npz \
+        --scenes <list.json> --out_dir <dir> --out_list <out.json> \
+        --ego_shape 4.76,7.24,2.29 --lat_range 0.3,0.8 --lon_range 2.0,5.0 \
+        --n_per_scene 4 --min_t0_clearance 0.05 --seed 0
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from scenario_generation.explorer_runner import plan_static_clearance
+
+
+def _stopped_neighbor_indices(nb_past: np.ndarray, nb_fut: np.ndarray) -> list[int]:
+    """Indices of stopped neighbors (same criteria as extract_stopped_neighbors)."""
+    idxs = []
+    for i in range(nb_past.shape[0]):
+        xy0 = nb_past[i, -1, :2]
+        if abs(float(xy0[0])) + abs(float(xy0[1])) < 1e-6:
+            continue  # empty slot (padding)
+        fut_xy = nb_fut[i, :, :2]
+        fut_valid = np.abs(fut_xy).sum(axis=-1) > 1e-6
+        disp = (
+            0.0
+            if fut_valid.sum() < 2
+            else float(np.linalg.norm(fut_xy[fut_valid].max(0) - fut_xy[fut_valid].min(0)))
+        )
+        if disp >= 0.5:
+            continue  # moving traffic — not an avoidance obstacle
+        w = float(nb_past[i, -1, 6])
+        length = float(nb_past[i, -1, 7])
+        if w < 0.1 or length < 0.1:
+            continue
+        idxs.append(i)
+    return idxs
+
+
+def _boxes_from_arrays(nb_past: np.ndarray, idxs: list[int]):
+    """(x, y, heading, length, width) boxes for the given neighbor indices."""
+    boxes = []
+    for i in idxs:
+        x, y = float(nb_past[i, -1, 0]), float(nb_past[i, -1, 1])
+        h = math.atan2(float(nb_past[i, -1, 3]), float(nb_past[i, -1, 2]))
+        boxes.append((x, y, h, float(nb_past[i, -1, 7]), float(nb_past[i, -1, 6])))
+    return boxes
+
+
+def _shift_neighbor(
+    nb_past: np.ndarray, nb_fut: np.ndarray, i: int, dlat: float, dlon: float
+) -> None:
+    """Rigid in-place shift of neighbor i in its own heading frame.
+
+    Zero rows are padding and stay zero; only valid rows move.
+    """
+    c = float(nb_past[i, -1, 2])
+    s = float(nb_past[i, -1, 3])
+    dx = dlon * c - dlat * s
+    dy = dlon * s + dlat * c
+    past_valid = np.abs(nb_past[i, :, :2]).sum(axis=-1) > 1e-6
+    nb_past[i, past_valid, 0] += dx
+    nb_past[i, past_valid, 1] += dy
+    fut_valid = np.abs(nb_fut[i, :, :2]).sum(axis=-1) > 1e-6
+    nb_fut[i, fut_valid, 0] += dx
+    nb_fut[i, fut_valid, 1] += dy
+
+
+def _future_as_plan(fut: np.ndarray) -> np.ndarray:
+    """ego_agent_future (T,3 yaw | T,4 cos/sin) -> (T,4) [x,y,cos,sin]."""
+    if fut.shape[-1] == 4:
+        return fut.astype(np.float32)
+    if fut.shape[-1] == 3:
+        return np.stack(
+            [fut[:, 0], fut[:, 1], np.cos(fut[:, 2]), np.sin(fut[:, 2])], axis=-1
+        ).astype(np.float32)
+    raise ValueError(f"unsupported ego_agent_future width {fut.shape[-1]}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--scenes", required=True, help="JSON list of NPZ paths")
+    parser.add_argument("--out_dir", required=True)
+    parser.add_argument("--out_list", required=True)
+    parser.add_argument(
+        "--ego_shape", required=True, help="WB,L,W — no default, must match the platform"
+    )
+    parser.add_argument(
+        "--lat_range",
+        required=True,
+        help="min,max lateral |offset| in m (neighbor frame), sign randomized",
+    )
+    parser.add_argument(
+        "--lon_range",
+        required=True,
+        help="min,max longitudinal |offset| in m (neighbor frame), sign randomized",
+    )
+    parser.add_argument("--n_per_scene", type=int, required=True)
+    parser.add_argument(
+        "--min_t0_clearance",
+        type=float,
+        required=True,
+        help="variant dropped if ego t=0 pose clears shifted boxes by less",
+    )
+    parser.add_argument("--seed", type=int, required=True)
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    ego_shape = tuple(float(x) for x in args.ego_shape.split(","))
+    lat_lo, lat_hi = (float(x) for x in args.lat_range.split(","))
+    lon_lo, lon_hi = (float(x) for x in args.lon_range.split(","))
+    rng = np.random.default_rng(args.seed)
+
+    with open(args.scenes) as f:
+        paths = json.load(f)
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    written, manifest = [], []
+    n_t0_drop = n_no_stopped = n_gt_cross = 0
+    # 2 identical rows: the canonical collision fn needs >=2 timesteps.
+    t0_pose = np.array([[0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 1.0, 0.0]], dtype=np.float32)
+    for sp in paths:
+        base = dict(np.load(sp, allow_pickle=True))
+        if "neighbor_agents_past" not in base or "neighbor_agents_future" not in base:
+            raise ValueError(f"{sp}: missing neighbor arrays")
+        nb_past0 = base["neighbor_agents_past"]
+        nb_fut0 = base["neighbor_agents_future"]
+        if nb_past0.ndim == 4:
+            raise ValueError(f"{sp}: batched neighbor array — expected unbatched NPZ")
+        idxs = _stopped_neighbor_indices(nb_past0, nb_fut0)
+        if not idxs:
+            n_no_stopped += 1
+            print(f"  [skip] {Path(sp).name}: no stopped neighbors to perturb")
+            continue
+        gt_plan = _future_as_plan(base["ego_agent_future"])
+        pool = Path(sp).parent.name
+        for v in range(args.n_per_scene):
+            nb_past = nb_past0.copy()
+            nb_fut = nb_fut0.copy()
+            offsets = {}
+            for i in idxs:
+                dlat = float(rng.uniform(lat_lo, lat_hi)) * float(rng.choice([-1.0, 1.0]))
+                dlon = float(rng.uniform(lon_lo, lon_hi)) * float(rng.choice([-1.0, 1.0]))
+                _shift_neighbor(nb_past, nb_fut, i, dlat, dlon)
+                offsets[int(i)] = {"dlat": round(dlat, 3), "dlon": round(dlon, 3)}
+            boxes = _boxes_from_arrays(nb_past, idxs)
+            t0_clr = float(plan_static_clearance(t0_pose, boxes, ego_shape, device))
+            if t0_clr < args.min_t0_clearance:
+                n_t0_drop += 1
+                continue
+            gt_clr = float(plan_static_clearance(gt_plan, boxes, ego_shape, device))
+            if gt_clr < 0.0:
+                n_gt_cross += 1
+            out = dict(base)
+            out["neighbor_agents_past"] = nb_past
+            out["neighbor_agents_future"] = nb_fut
+            out_path = out_dir / f"{pool}__{Path(sp).stem}_nbr{v:02d}.npz"
+            np.savez(out_path, **out)
+            written.append(str(out_path))
+            manifest.append(
+                {
+                    "source": sp,
+                    "variant": v,
+                    "offsets": offsets,
+                    "t0_clearance": round(t0_clr, 3),
+                    "gt_future_clearance": round(gt_clr, 3),
+                    "out": str(out_path),
+                }
+            )
+
+    with open(args.out_list, "w") as f:
+        json.dump(written, f, indent=1)
+    with open(out_dir / "manifest.json", "w") as f:
+        json.dump(manifest, f, indent=1)
+    print(f"\n[perturb_nbr] {len(written)} variants from {len(paths)} scenes -> {args.out_list}")
+    print(f"  dropped: {n_t0_drop} t0-violating; skipped: {n_no_stopped} scenes w/o stopped nbrs")
+    print(
+        f"  WARNING: {n_gt_cross} variants have GT future crossing the shifted obstacle "
+        "(future must be replaced by distillation before curated SFT)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/perturb_neighbors_npz.py
+++ b/rlvr/autoresearch/tools/perturb_neighbors_npz.py
@@ -153,7 +153,8 @@ def main():
     # 2 identical rows: the canonical collision fn needs >=2 timesteps.
     t0_pose = np.array([[0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 1.0, 0.0]], dtype=np.float32)
     for sp in paths:
-        base = dict(np.load(sp, allow_pickle=True))
+        with np.load(sp, allow_pickle=True) as _z:
+            base = dict(_z)
         if "neighbor_agents_past" not in base or "neighbor_agents_future" not in base:
             raise ValueError(f"{sp}: missing neighbor arrays")
         nb_past0 = base["neighbor_agents_past"]

--- a/rlvr/autoresearch/tools/psim_per_arc_full.py
+++ b/rlvr/autoresearch/tools/psim_per_arc_full.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Per-arc FULL-distribution psim certification: centerline + road-border +
+realized comfort (lateral accel, jerk), every metric with p5/p25/p50/p95, one
+table per route, side-by-side models vs baseline.
+
+This unifies the two prior per-arc tools so a candidate is judged on the
+complete dynamic+geometric picture the campaign protocol requires:
+  - centerline |lateral| (CL bias): mean / p5 / p25 / p50 / p95
+  - road-border dist (RB): min / p5 / p25 / p50  + crossings (<rb_cross_thresh)
+  - realized lateral accel |accel.y| (felt comfort): mean / p50 / p95 / max
+  - realized lateral jerk |d(accel.y)/dt|: p50 / p95 / max
+
+Geometry (CL/RB) reuses psim_per_arc_metrics' reward-OBB path (no hand-rolled
+geometry). Comfort reuses psim_comfort_heatmap's MEASURED-twist path (accel.y
+from /localization/acceleration, jerk = SG 1st-derivative with dt from
+timestamps — never a position derivative). Both signals are binned along the
+same route arc, per bag.
+
+Usage:
+    python -m rlvr.autoresearch.tools.psim_per_arc_full \
+        --route <route.pkl> --ego_shape WB,L,W [--bin_m 100] \
+        [--front_cut 50] [--tail_cut 50] [--stride 10] \
+        --models LABEL1 BAG1 LABEL2 BAG2 ... \
+        [--output <table.json>]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from rlvr.autoresearch.tools.psim_comfort_heatmap import (
+    _extract_accel_y,
+    _extract_kinematics,
+    compute_dynamics,
+)
+from rlvr.reward import RewardConfig, _point_to_segments_min_dist
+from scenario_generation.gui.lanelet_scene_builder import LaneletSceneBuilder, _obb_corners
+from scenario_generation.tools._heatmap_common import (
+    build_route_polyline,
+    load_route,
+    project_to_polyline,
+)
+from scenario_generation.tools.heatmap_route_deviation import _extract_poses_from_bag
+
+
+def _peri(corners, n=8):
+    out = []
+    for i in range(4):
+        a, b = corners[i], corners[(i + 1) % 4]
+        for t in np.linspace(0, 1, n, endpoint=False):
+            out.append(a * (1 - t) + b * t)
+    return np.array(out, dtype=np.float32)
+
+
+def _geom_series(bag, pts, arc, seg1, seg2, wb, length, width, stride):
+    """Per realized pose: (arc, |lateral| from route CL, min road-border dist)."""
+    poses = _extract_poses_from_bag(Path(bag))[::stride]
+    out = []
+    for x, y, yaw, _sp in poses:
+        a, _sl, al = project_to_polyline(np.array([float(x), float(y)]), pts, arc)
+        peri = _peri(_obb_corners(float(x), float(y), float(yaw), length, width, wheelbase=wb))
+        rb = _point_to_segments_min_dist(torch.tensor(peri), seg1, seg2).min().item()
+        out.append((float(a), float(al), float(rb)))
+    return np.array(out)
+
+
+def _comfort_series(bag, pts, arc, stride, max_jump_speed=30.0):
+    """Per realized pose: (arc, lat_accel |accel.y|, jerk) from measured twist."""
+    t, x, y, speed, yaw_rate = _extract_kinematics(bag)
+    sl = slice(None, None, stride)
+    t, x, y, speed, yaw_rate = t[sl], x[sl], y[sl], speed[sl], yaw_rate[sl]
+    dt = float(np.median(np.diff(t))) if len(t) > 1 else 0.1
+    t_acc, accel_y = _extract_accel_y(bag)
+    lat_meas = np.interp(t, t_acc, np.abs(accel_y))
+    dyn, _ = compute_dynamics(
+        speed, yaw_rate, dt, lat_accel_meas=lat_meas, max_jump_speed=max_jump_speed
+    )
+    a_arc = np.array(
+        [project_to_polyline(np.array([float(px), float(py)]), pts, arc)[0] for px, py in zip(x, y)]
+    )
+    return a_arc, dyn["lat_accel"], dyn["jerk"]
+
+
+def _pcts(v, ps):
+    v = v[np.isfinite(v)]
+    if v.size == 0:
+        return {f"p{p}": None for p in ps}
+    return {f"p{p}": round(float(np.percentile(v, p)), 3) for p in ps}
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--route", required=True)
+    ap.add_argument("--ego_shape", required=True, help="WB,L,W (no default — fail loudly)")
+    ap.add_argument("--bin_m", type=int, default=100)
+    ap.add_argument("--front_cut", type=float, default=50.0)
+    ap.add_argument("--tail_cut", type=float, default=50.0)
+    ap.add_argument("--stride", type=int, default=10)
+    ap.add_argument("--max_jump_speed", type=float, default=30.0)
+    ap.add_argument(
+        "--models",
+        nargs="+",
+        required=True,
+        help="alternating LABEL BAG LABEL BAG ... (even count)",
+    )
+    ap.add_argument("--output", help="optional JSON path for the full per-arc table")
+    args = ap.parse_args()
+
+    parts = [float(v) for v in args.ego_shape.split(",")]
+    if len(parts) != 3 or any(v <= 0 for v in parts):
+        raise ValueError(f"--ego_shape must be 'WB,L,W' 3 positive values; got {args.ego_shape!r}")
+    wb, length, width = parts
+    if len(args.models) % 2 != 0:
+        raise ValueError("--models must be alternating LABEL BAG pairs (even count)")
+    labels, bags = args.models[0::2], args.models[1::2]
+
+    thr = RewardConfig().rb_cross_thresh
+    fc, tc = args.front_cut, args.tail_cut
+    route = load_route(Path(args.route))
+    pts, arc = build_route_polyline(route)
+    amax = float(arc.max())
+
+    b = LaneletSceneBuilder(str(route.map_path))
+    s1, s2 = [], []
+    for pl in b.road_border_polylines():
+        pl = np.asarray(pl)[:, :2]
+        if pl.shape[0] >= 2:
+            s1.append(pl[:-1])
+            s2.append(pl[1:])
+    if not s1:
+        raise SystemExit(f"map {route.map_path} has no road-border polylines — cannot score RB")
+    seg1 = torch.tensor(np.concatenate(s1), dtype=torch.float32)
+    seg2 = torch.tensor(np.concatenate(s2), dtype=torch.float32)
+
+    geom = {
+        lab: _geom_series(bg, pts, arc, seg1, seg2, wb, length, width, args.stride)
+        for lab, bg in zip(labels, bags)
+    }
+    comf = {
+        lab: _comfort_series(bg, pts, arc, args.stride, args.max_jump_speed)
+        for lab, bg in zip(labels, bags)
+    }
+
+    report = {"route": str(args.route), "bin_m": args.bin_m, "bins": [], "totals": {}}
+    print(
+        f"\n=== PER-ARC FULL DISTRIBUTIONS (bin={args.bin_m}m, route={Path(args.route).stem}) ==="
+    )
+    for lo in range(0, int(amax) + int(args.bin_m), int(args.bin_m)):
+        hi = lo + args.bin_m
+        if hi <= fc or lo >= amax - tc:
+            continue
+        binrow = {"arc": f"{lo}-{int(hi)}", "models": {}}
+        print(f"\narc {lo:>5}-{int(hi):<5}")
+        for lab in labels:
+            g = geom[lab]
+            mg = (g[:, 0] >= lo) & (g[:, 0] < hi) & (g[:, 0] >= fc) & (g[:, 0] <= amax - tc)
+            ca, la, ja = comf[lab]
+            mc = (ca >= lo) & (ca < hi) & (ca >= fc) & (ca <= amax - tc)
+            ent = {}
+            if mg.sum() > 0:
+                cl, rb = g[mg, 1], g[mg, 2]
+                ent["cl"] = {"mean": round(float(cl.mean()), 3), **_pcts(cl, [5, 25, 50, 95])}
+                ent["rb"] = {
+                    "min": round(float(rb.min()), 3),
+                    **_pcts(rb, [5, 25, 50]),
+                    "cross": int((rb < thr).sum()),
+                }
+            if mc.sum() > 0:
+                lat, jrk = la[mc], ja[mc]
+                ent["lat_accel"] = {
+                    "mean": round(float(np.nanmean(lat)), 3),
+                    **_pcts(lat, [50, 95]),
+                    "max": round(float(np.nanmax(lat)), 3),
+                }
+                ent["jerk"] = {**_pcts(jrk, [50, 95]), "max": round(float(np.nanmax(jrk)), 3)}
+            binrow["models"][lab] = ent
+            c = ent.get("cl", {})
+            r = ent.get("rb", {})
+            a = ent.get("lat_accel", {})
+            j = ent.get("jerk", {})
+            print(
+                f"  {lab:>20} | cl μ{c.get('mean', '-')} p25 {c.get('p25', '-')} p95 {c.get('p95', '-')} "
+                f"| rb min {r.get('min', '-')} p5 {r.get('p5', '-')} X{r.get('cross', '-')} "
+                f"| latA p95 {a.get('p95', '-')} max {a.get('max', '-')} | jerk p95 {j.get('p95', '-')}"
+            )
+        report["bins"].append(binrow)
+
+    # in-bounds totals: RB crossings + global comfort percentiles
+    print("\n=== IN-BOUNDS TOTALS ===")
+    for lab in labels:
+        g = geom[lab]
+        inb = (g[:, 0] >= fc) & (g[:, 0] <= amax - tc)
+        nx = int((g[inb, 2] < thr).sum())
+        ca, la, ja = comf[lab]
+        ic = (ca >= fc) & (ca <= amax - tc)
+        cl_all = g[inb, 1]
+        tot = {
+            "rb_cross": nx,
+            "cl": {"mean": round(float(cl_all.mean()), 3), **_pcts(cl_all, [50, 95])},
+            "rb": {"min": round(float(g[inb, 2].min()), 3), **_pcts(g[inb, 2], [5])},
+            "lat_accel": {
+                "mean": round(float(np.nanmean(la[ic])), 3),
+                **_pcts(la[ic], [95]),
+                "max": round(float(np.nanmax(la[ic])), 3),
+            },
+            "jerk": {**_pcts(ja[ic], [95]), "max": round(float(np.nanmax(ja[ic])), 3)},
+        }
+        report["totals"][lab] = tot
+        print(
+            f"  {lab:>20} | RB cross {nx} | cl μ{tot['cl']['mean']} p95 {tot['cl']['p95']} "
+            f"| rb min {tot['rb']['min']} p5 {tot['rb']['p5']} "
+            f"| latA mean {tot['lat_accel']['mean']} p95 {tot['lat_accel']['p95']} "
+            f"| jerk p95 {tot['jerk']['p95']}"
+        )
+
+    if args.output:
+        with open(args.output, "w") as f:
+            json.dump(report, f, indent=1)
+        print(f"\nwrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/psim_per_arc_full.py
+++ b/rlvr/autoresearch/tools/psim_per_arc_full.py
@@ -197,9 +197,14 @@ def main():
     for lab in labels:
         g = geom[lab]
         inb = (g[:, 0] >= fc) & (g[:, 0] <= amax - tc)
-        nx = int((g[inb, 2] < thr).sum())
         ca, la, ja = comf[lab]
         ic = (ca >= fc) & (ca <= amax - tc)
+        if not inb.any() or not ic.any():
+            raise RuntimeError(
+                f"{lab}: no samples within the in-bounds arc window [{fc}, {amax - tc}] "
+                "(bag too short, or front_cut+tail_cut exceed the route length)"
+            )
+        nx = int((g[inb, 2] < thr).sum())
         cl_all = g[inb, 1]
         tot = {
             "rb_cross": nx,

--- a/rlvr/autoresearch/tools/score_curated_targets.py
+++ b/rlvr/autoresearch/tools/score_curated_targets.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Score the CURATED TARGETS (ego_agent_future) of a scene list with the
+canonical reward path — the no-poison check for curated SFT datasets.
+
+A curated-SFT leg trains the model to imitate ego_agent_future. If that target
+itself collides with a stopped neighbor (or grazes inside the static-collision
+threshold), the scene can never teach avoidance — it actively teaches the
+collision. This tool feeds each scene's stored ego_agent_future through
+`compute_reward_batch` (the same reward.py OBB path eval_det_avoidance uses for
+model outputs — no reimplemented geometry) and reports per-scene
+sc_min_dist / static_crossing / rb / lane flags for the TARGET trajectory.
+
+Usage:
+    python -m rlvr.autoresearch.tools.score_curated_targets \
+        --scenes <scenes.json> --config <reward_config.json> \
+        --ego_shape WB,L,W --output <report.json>
+
+Output: per-scene rows + an aggregate, with the poison list (targets that
+cross) printed and saved for direct exclusion from training lists.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from preference_optimization.utils import load_npz_data
+from rlvr.autoresearch.tools.eval_det_avoidance import aggregate_stats
+from rlvr.autoresearch.tools.reward_config_from_json import load_reward_config
+from rlvr.reward import compute_reward_batch
+
+
+def score_targets(
+    scene_paths: list[str], rcfg, ego_shape: np.ndarray, device: torch.device
+) -> list[dict]:
+    results = []
+    for p in scene_paths:
+        try:
+            d = load_npz_data(p, device)
+            es = d["ego_shape"].cpu().numpy().reshape(-1)[:3]
+            if not np.allclose(es, ego_shape, atol=1e-2):
+                print(f"  [skip] {Path(p).name}: ego_shape={es.tolist()}")
+                continue
+            target = d["ego_agent_future"]
+            if target.dim() == 2:
+                target = target.unsqueeze(0)
+            r = compute_reward_batch(target, d, rcfg)[0]
+            results.append(
+                {
+                    "scene": Path(p).name,
+                    "scene_path": str(p),
+                    "sc_min_dist": float(getattr(r, "sc_min_dist", 99.0)),
+                    "rb_min_dist": float(getattr(r, "rb_min_dist", 99.0)),
+                    "cl": float(r.centerline),
+                    "total": float(r.total),
+                    "static_crossing": bool(r.static_crossing),
+                    "rb_cross": bool(r.rb_crossing),
+                    "lane_cross": bool(r.lane_crossing),
+                    "kin_violated": bool(r.kinematic_violated),
+                    "sc_n_stopped": int(getattr(r, "sc_n_stopped", 0)),
+                }
+            )
+        except Exception as e:  # noqa: BLE001
+            print(f"  [skip] {Path(p).name}: {e}")
+    return results
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--scenes", required=True)
+    ap.add_argument("--config", required=True, help="Reward config JSON")
+    ap.add_argument("--ego_shape", required=True, help="WB,L,W")
+    ap.add_argument("--output", required=True, help="Report JSON path")
+    args = ap.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    rcfg = load_reward_config(args.config)
+    ego_shape = np.array([float(x) for x in args.ego_shape.split(",")])
+    scene_paths = json.load(open(args.scenes))
+
+    results = score_targets(scene_paths, rcfg, ego_shape, device)
+    agg = aggregate_stats(results)
+    poison = [r for r in results if r["static_crossing"]]
+
+    out = {
+        "scenes": args.scenes,
+        "aggregate": agg,
+        "poison": [r["scene_path"] for r in poison],
+        "rows": results,
+    }
+    Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.output).write_text(json.dumps(out, indent=2))
+
+    s = agg["sc_min_dist"]
+    print(
+        f"TARGETS: {agg['n_scenes']} scored | static-crossing targets (POISON): "
+        f"{agg['static_crossings']} | rb={agg['rb_crossings']} lane={agg['lane_crossings']} "
+        f"kin={agg['kin_violated']}"
+    )
+    print(
+        f"  target sc_min: mean={s['mean']:+.3f} p5={s['p5']:+.3f} p25={s['p25']:+.3f} "
+        f"min={s['min']:+.3f}"
+    )
+    for r in poison:
+        print(f"  POISON {r['scene']}  sc={r['sc_min_dist']:+.3f}")
+    print(f"wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/score_curated_targets.py
+++ b/rlvr/autoresearch/tools/score_curated_targets.py
@@ -36,14 +36,18 @@ from rlvr.reward import compute_reward_batch
 
 def score_targets(
     scene_paths: list[str], rcfg, ego_shape: np.ndarray, device: torch.device
-) -> list[dict]:
+) -> tuple[list[dict], int, int]:
+    """Returns (rows, n_skipped_ego_shape, n_errored) so dropped scenes are
+    visible to the caller — a poison census must not silently omit scenes."""
     results = []
+    n_skip = n_err = 0
     for p in scene_paths:
         try:
             d = load_npz_data(p, device)
             es = d["ego_shape"].cpu().numpy().reshape(-1)[:3]
             if not np.allclose(es, ego_shape, atol=1e-2):
                 print(f"  [skip] {Path(p).name}: ego_shape={es.tolist()}")
+                n_skip += 1
                 continue
             target = d["ego_agent_future"]
             if target.dim() == 2:
@@ -65,8 +69,9 @@ def score_targets(
                 }
             )
         except Exception as e:  # noqa: BLE001
-            print(f"  [skip] {Path(p).name}: {e}")
-    return results
+            print(f"  [err ] {Path(p).name}: {e}")
+            n_err += 1
+    return results, n_skip, n_err
 
 
 def main() -> None:
@@ -82,13 +87,20 @@ def main() -> None:
     ego_shape = np.array([float(x) for x in args.ego_shape.split(",")])
     scene_paths = json.load(open(args.scenes))
 
-    results = score_targets(scene_paths, rcfg, ego_shape, device)
+    results, n_skip, n_err = score_targets(scene_paths, rcfg, ego_shape, device)
+    if not results:
+        raise RuntimeError(
+            f"no targets scored ({n_skip} ego_shape mismatches, {n_err} errors out of "
+            f"{len(scene_paths)} scenes) — refusing to write an empty poison census"
+        )
     agg = aggregate_stats(results)
     poison = [r for r in results if r["static_crossing"]]
 
     out = {
         "scenes": args.scenes,
         "aggregate": agg,
+        "n_skipped_ego_shape": n_skip,
+        "n_errored": n_err,
         "poison": [r["scene_path"] for r in poison],
         "rows": results,
     }
@@ -97,9 +109,9 @@ def main() -> None:
 
     s = agg["sc_min_dist"]
     print(
-        f"TARGETS: {agg['n_scenes']} scored | static-crossing targets (POISON): "
-        f"{agg['static_crossings']} | rb={agg['rb_crossings']} lane={agg['lane_crossings']} "
-        f"kin={agg['kin_violated']}"
+        f"TARGETS: {agg['n_scenes']} scored ({n_skip} skipped ego_shape, {n_err} errored) | "
+        f"static-crossing targets (POISON): {agg['static_crossings']} | "
+        f"rb={agg['rb_crossings']} lane={agg['lane_crossings']} kin={agg['kin_violated']}"
     )
     print(
         f"  target sc_min: mean={s['mean']:+.3f} p5={s['p5']:+.3f} p25={s['p25']:+.3f} "

--- a/rlvr/autoresearch/tools/sweep_full_metrics.py
+++ b/rlvr/autoresearch/tools/sweep_full_metrics.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Per-epoch FULL-metric sweep of a LoRA training run.
+
+Extends sweep_lora_epochs (avoidance-only) to the complete per-epoch metric
+array needed for honest epoch picks:
+  - deterministic avoidance on MULTIPLE scene sets (e.g. a raw base set AND a
+    perturbed hard-val set): crossings + full sc_min_dist distribution
+    (mean/p5/p25/p50/p75/min) via eval_det_avoidance (reward.py OBB path),
+  - open-loop PLAN comfort (lat-accel p95 / jerk p95 / curve speed) via
+    eval_plan_comfort — catches plan-sharpness comfort regressions that the
+    geometric metrics miss,
+  - ego/neighbor L2 on a validation list via valid_320 (DDP subprocess).
+
+For each epoch: merge lora_epoch_NNN onto --base_model with the canonical
+merge_lora CLI, score everything, append a row to <output_dir>/full_sweep.json
+and print a markdown table row. Merged checkpoints are kept under
+<output_dir>/merged_epNNN unless --no_keep_merged.
+
+Usage:
+    python -m rlvr.autoresearch.tools.sweep_full_metrics \
+        --run_dir <run with lora_epoch_NNN> \
+        --base_model <warmstart.pth (dir must hold args.json)> \
+        --epochs all|1-12|2,4,6|1-24:2 \
+        --avoid_sets base=<scenes.json> hardval=<scenes.json> \
+        --config <reward_config.json> --ego_shape WB,L,W \
+        --comfort_scenes <scenes.json> \
+        --l2_val <val_list.json> --args_json <args.json> \
+        --output_dir <dir> [--l2_port 29571] [--batch_size 32]
+
+Any of the metric groups can be skipped by omitting its flag (--avoid_sets /
+--comfort_scenes / --l2_val), so the tool also serves as a quick single-axis
+sweeper. No silent defaults: reward config and ego_shape are required whenever
+--avoid_sets is given.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from rlvr.autoresearch.tools.eval_det_avoidance import (
+    aggregate_stats,
+    load_model,
+    score_det_scenes,
+)
+from rlvr.autoresearch.tools.eval_plan_comfort import _dist, eval_plan_comfort
+from rlvr.autoresearch.tools.sweep_lora_epochs import merge_epoch, parse_epochs
+
+
+def run_l2(
+    merged: Path, args_json: Path, val_list: Path, port: int, batch_size: int
+) -> tuple[float, float]:
+    """Run valid_320 (DDP, 1 GPU) on a merged checkpoint; return (ego, neighbor)."""
+    repo = Path(__file__).resolve().parents[3]
+    cmd = [
+        sys.executable,
+        "-m",
+        "torch.distributed.run",
+        "--nproc_per_node=1",
+        "--standalone",
+        f"--master_port={port}",
+        str(repo / "scripts" / "valid_320.py"),
+        "--resume_model_path",
+        str(merged),
+        "--args_json_path",
+        str(args_json),
+        "--valid_set_list",
+        str(val_list),
+        "--batch_size",
+        str(batch_size),
+        "--ddp",
+        "true",
+    ]
+    res = subprocess.run(cmd, capture_output=True, text=True, cwd=repo)
+    m = re.search(r"avg_loss_ego=([\d.]+) avg_loss_neighbor=([\d.]+)", res.stdout)
+    if not m:
+        raise RuntimeError(
+            f"valid_320 produced no avg_loss line for {merged}:\n"
+            f"{res.stdout[-2000:]}\n{res.stderr[-2000:]}"
+        )
+    return float(m.group(1)), float(m.group(2))
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--run_dir", required=True)
+    p.add_argument(
+        "--base_model",
+        required=True,
+        help="Warmstart .pth the LoRA trains on (merge base; dir holds args.json)",
+    )
+    p.add_argument("--epochs", required=True, help='"all" | "1-24" | "2,4,6" | "1-24:2"')
+    p.add_argument(
+        "--avoid_sets",
+        nargs="*",
+        default=[],
+        help="NAME=scenes.json pairs for deterministic avoidance eval",
+    )
+    p.add_argument("--config", help="Reward config JSON (required with --avoid_sets)")
+    p.add_argument("--ego_shape", help="WB,L,W (required with --avoid_sets)")
+    p.add_argument("--comfort_scenes", help="Scene list for open-loop plan comfort")
+    p.add_argument("--l2_val", help="Validation list for ego/neighbor L2")
+    p.add_argument("--args_json", help="Model args.json (required with --l2_val)")
+    p.add_argument("--l2_port", type=int, default=29571)
+    p.add_argument("--batch_size", type=int, default=32)
+    p.add_argument("--output_dir", required=True)
+    p.add_argument(
+        "--no_keep_merged", action="store_true", help="Delete each merged checkpoint after scoring"
+    )
+    args = p.parse_args()
+
+    if args.avoid_sets and (not args.config or not args.ego_shape):
+        p.error("--avoid_sets requires --config and --ego_shape")
+    if args.l2_val and not args.args_json:
+        p.error("--l2_val requires --args_json")
+
+    run_dir, out_dir = Path(args.run_dir), Path(args.output_dir)
+    base_model = Path(args.base_model)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    avoid_sets: dict[str, list[str]] = {}
+    for spec in args.avoid_sets:
+        name, _, path = spec.partition("=")
+        if not path:
+            p.error(f"--avoid_sets entry must be NAME=path, got {spec!r}")
+        with open(path) as f:
+            avoid_sets[name] = json.load(f)
+    if avoid_sets:
+        from rlvr.autoresearch.tools.reward_config_from_json import load_reward_config
+
+        rcfg = load_reward_config(args.config)
+        ego_shape = np.array([float(x) for x in args.ego_shape.split(",")])
+    comfort_scenes = json.load(open(args.comfort_scenes)) if args.comfort_scenes else None
+
+    epochs = parse_epochs(args.epochs, run_dir)
+    print(
+        f"[full-sweep] epochs {epochs}; avoid sets "
+        f"{ {k: len(v) for k, v in avoid_sets.items()} }; "
+        f"comfort={len(comfort_scenes) if comfort_scenes else 0}; l2={args.l2_val}"
+    )
+
+    summary_path = out_dir / "full_sweep.json"
+    rows: list[dict] = json.loads(summary_path.read_text()) if summary_path.exists() else []
+    done = {r["epoch"] for r in rows}
+
+    for e in epochs:
+        if e in done:
+            print(f"[full-sweep] ep{e:03d} already in {summary_path.name}, skipping")
+            continue
+        ep = f"{e:03d}"
+        merged = out_dir / f"merged_ep{ep}" / "best_model.pth"
+        print(f"\n[full-sweep] ===== epoch {ep} =====")
+        merge_epoch(base_model, run_dir / f"lora_epoch_{ep}", merged)
+        row: dict = {"epoch": e}
+
+        model, model_args = load_model(str(merged), device)
+        for name, paths in avoid_sets.items():
+            results = score_det_scenes(
+                model, model_args, paths, rcfg, ego_shape, device, batch_size=args.batch_size
+            )
+            agg = aggregate_stats(results)
+            ep_out = out_dir / f"avoid_{name}_ep{ep}"
+            ep_out.mkdir(parents=True, exist_ok=True)
+            (ep_out / "det_avoidance_summary.json").write_text(
+                json.dumps({"aggregate": agg, "scenes": results}, indent=2)
+            )
+            scm = agg["sc_min_dist"]
+            row[name] = {
+                "n": agg["n_scenes"],
+                "static_crossings": agg["static_crossings"],
+                "rb_crossings": agg["rb_crossings"],
+                "lane_crossings": agg["lane_crossings"],
+                "sc_min": {k: scm[k] for k in ("mean", "p5", "p25", "p50", "p75", "min")},
+            }
+            print(
+                f"  [{name}] static={agg['static_crossings']}/{agg['n_scenes']} "
+                f"rb={agg['rb_crossings']} lane={agg['lane_crossings']} "
+                f"sc_min mean={scm['mean']:+.3f} p5={scm['p5']:+.3f} min={scm['min']:+.3f}"
+            )
+        if comfort_scenes:
+            la95, jk95, cspd = eval_plan_comfort(model, model_args, comfort_scenes, device)
+            row["plan_comfort"] = {
+                "lat_accel_p95": _dist(la95),
+                "jerk_p95": _dist(jk95),
+                "curve_speed": _dist(cspd),
+            }
+            la, cs = row["plan_comfort"]["lat_accel_p95"], row["plan_comfort"]["curve_speed"]
+            cs_mean = "—" if cs["mean"] is None else f"{cs['mean']:.2f}"
+            print(
+                f"  [comfort] plan lat_accel p95 mean={la['mean']:.2f} "
+                f"p95={la['p95']:.2f} | curve_speed mean={cs_mean}"
+            )
+        del model
+        torch.cuda.empty_cache()
+
+        if args.l2_val:
+            ego, nbr = run_l2(
+                merged, Path(args.args_json), Path(args.l2_val), args.l2_port, args.batch_size
+            )
+            row["l2"] = {"ego": ego, "neighbor": nbr}
+            print(f"  [l2] ego={ego:.4f} neighbor={nbr:.4f}")
+
+        if args.no_keep_merged:
+            shutil.rmtree(merged.parent, ignore_errors=True)
+        rows.append(row)
+        rows.sort(key=lambda r: r["epoch"])
+        summary_path.write_text(json.dumps(rows, indent=2))
+
+    # markdown summary table
+    lines = [
+        "| ep | "
+        + " | ".join(f"{n} static/rb/lane | {n} sc_min mean/p5/min" for n in avoid_sets)
+        + (" | plan latA p95 | curve spd |" if comfort_scenes else "")
+        + (" ego L2 | nbr L2 |" if args.l2_val else "")
+    ]
+    lines.append(
+        "|"
+        + "---|"
+        * (1 + 2 * len(avoid_sets) + (2 if comfort_scenes else 0) + (2 if args.l2_val else 0))
+    )
+    for r in rows:
+        cells = [str(r["epoch"])]
+        for n in avoid_sets:
+            if n in r:
+                a = r[n]
+                cells.append(
+                    f"{a['static_crossings']}/{a['n']} · {a['rb_crossings']} · "
+                    f"{a['lane_crossings']}"
+                )
+                s = a["sc_min"]
+                cells.append(f"{s['mean']:+.3f} / {s['p5']:+.3f} / {s['min']:+.3f}")
+            else:
+                cells += ["—", "—"]
+        if comfort_scenes:
+            pc = r.get("plan_comfort")
+            if pc:
+                cs_mean = pc["curve_speed"]["mean"]
+                cells.append(f"{pc['lat_accel_p95']['mean']:.2f}")
+                cells.append("—" if cs_mean is None else f"{cs_mean:.2f}")
+            else:
+                cells += ["—", "—"]
+        if args.l2_val:
+            l2 = r.get("l2")
+            cells += [f"{l2['ego']:.4f}", f"{l2['neighbor']:.4f}"] if l2 else ["—", "—"]
+        lines.append("| " + " | ".join(cells) + " |")
+    md = "\n".join(lines)
+    (out_dir / "full_sweep.md").write_text(md + "\n")
+    print(f"\n{md}\nWrote {summary_path} + full_sweep.md")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/sweep_full_metrics.py
+++ b/rlvr/autoresearch/tools/sweep_full_metrics.py
@@ -80,6 +80,11 @@ def run_l2(
         "true",
     ]
     res = subprocess.run(cmd, capture_output=True, text=True, cwd=repo)
+    if res.returncode != 0:
+        raise RuntimeError(
+            f"valid_320 exited with code {res.returncode} for {merged}:\n"
+            f"{res.stdout[-2000:]}\n{res.stderr[-2000:]}"
+        )
     m = re.search(r"avg_loss_ego=([\d.]+) avg_loss_neighbor=([\d.]+)", res.stdout)
     if not m:
         raise RuntimeError(

--- a/rlvr/autoresearch/tools/sweep_lora_epochs.py
+++ b/rlvr/autoresearch/tools/sweep_lora_epochs.py
@@ -121,7 +121,7 @@ def main() -> None:
     )
     parser.add_argument("--scenes", required=True, help="JSON list of NPZ paths")
     parser.add_argument("--config", required=True, help="Reward config JSON")
-    parser.add_argument("--ego_shape", required=True, help="WB,L,W e.g. 4.76,7.24,2.29")
+    parser.add_argument("--ego_shape", required=True, help="WB,L,W (wheelbase,length,width)")
     parser.add_argument("--output_dir", required=True)
     parser.add_argument("--epochs", required=True, help='"all" | "1-24" | "1-24:2" | "2,4,6"')
     parser.add_argument("--batch_size", type=int, default=32)

--- a/rlvr/autoresearch/tools/sweep_lora_epochs.py
+++ b/rlvr/autoresearch/tools/sweep_lora_epochs.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Sweep the per-epoch LoRA checkpoints of a ranked-SFT run and report
+deterministic avoidance metrics per epoch (static/rb/lane crossings + sc_min_dist
+distribution). Useful for picking the candidate epoch(s) of any LoRA training run
+before the expensive L2 / psim verdict.
+
+For each requested epoch it:
+  1. merges <run_dir>/lora_epoch_NNN into --base_model via
+     `preference_optimization.merge_lora` (the canonical merge interface),
+  2. scores --scenes with `eval_det_avoidance.score_det_scenes` (reuses the
+     reward.py OBB scoring path — no reimplemented geometry),
+  3. records the aggregate from `eval_det_avoidance.aggregate_stats`.
+
+Merged checkpoints are written under <output_dir>/merged_epNNN and deleted after
+scoring unless --keep_merged is given (each is ~230MB).
+
+Usage:
+    python -m rlvr.autoresearch.tools.sweep_lora_epochs \
+        --run_dir <run with lora_epoch_NNN> \
+        --base_model <base.pth> \
+        --scenes <scenes.json> \
+        --config <reward_config.json> \
+        --ego_shape WB,L,W \
+        --output_dir <dir> \
+        --epochs 1-24            # or "2,4,6" or "1-24:2" (stride) or "all"
+
+Outputs:
+    <output_dir>/sweep_summary.json   per-epoch aggregate table
+    <output_dir>/avoid_epNNN/det_avoidance_summary.json   per-epoch full detail
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from rlvr.autoresearch.tools.eval_det_avoidance import (
+    aggregate_stats,
+    load_model,
+    score_det_scenes,
+)
+from rlvr.autoresearch.tools.reward_config_from_json import load_reward_config
+
+
+def parse_epochs(spec: str, run_dir: Path) -> list[int]:
+    """Parse "all" | "1-24" | "1-24:2" | "2,4,6" into a sorted epoch list."""
+    available = sorted(
+        int(m.group(1))
+        for p in run_dir.glob("lora_epoch_*")
+        if (m := re.fullmatch(r"lora_epoch_(\d+)", p.name))
+    )
+    if not available:
+        raise FileNotFoundError(f"No lora_epoch_NNN dirs found in {run_dir}")
+    if spec == "all":
+        return available
+    out: set[int] = set()
+    for part in spec.split(","):
+        part = part.strip()
+        if "-" in part:
+            rng, _, stride = part.partition(":")
+            lo, hi = (int(x) for x in rng.split("-"))
+            step = int(stride) if stride else 1
+            out.update(range(lo, hi + 1, step))
+        else:
+            out.add(int(part))
+    sel = sorted(e for e in out if e in available)
+    missing = sorted(e for e in out if e not in available)
+    if missing:
+        print(f"[sweep] requested epochs not present, skipping: {missing}")
+    if not sel:
+        raise ValueError(f"None of the requested epochs exist in {run_dir}")
+    return sel
+
+
+def merge_epoch(base_model: Path, lora_dir: Path, out_pth: Path) -> None:
+    """Invoke the canonical merge_lora CLI for one epoch."""
+    out_pth.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        sys.executable,
+        "-m",
+        "preference_optimization.merge_lora",
+        "--model_path",
+        str(base_model),
+        "--lora_dir",
+        str(lora_dir),
+        "--output",
+        str(out_pth),
+    ]
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    if res.returncode != 0 or not out_pth.exists():
+        raise RuntimeError(
+            f"merge_lora failed for {lora_dir}:\n{res.stdout[-2000:]}\n{res.stderr[-2000:]}"
+        )
+    # merge_lora reads args.json from the BASE model dir; copy it next to the merged
+    # checkpoint so downstream load_model finds it.
+    base_args = base_model.parent / "args.json"
+    if base_args.exists():
+        shutil.copy(base_args, out_pth.parent / "args.json")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--run_dir", required=True, help="Training run dir containing lora_epoch_NNN/"
+    )
+    parser.add_argument(
+        "--base_model",
+        required=True,
+        help="Base .pth the LoRA was trained on (its dir must hold args.json)",
+    )
+    parser.add_argument("--scenes", required=True, help="JSON list of NPZ paths")
+    parser.add_argument("--config", required=True, help="Reward config JSON")
+    parser.add_argument("--ego_shape", required=True, help="WB,L,W e.g. 4.76,7.24,2.29")
+    parser.add_argument("--output_dir", required=True)
+    parser.add_argument("--epochs", required=True, help='"all" | "1-24" | "1-24:2" | "2,4,6"')
+    parser.add_argument("--batch_size", type=int, default=32)
+    parser.add_argument(
+        "--keep_merged",
+        action="store_true",
+        help="Keep merged .pth per epoch (default: delete to save disk)",
+    )
+    args = parser.parse_args()
+
+    run_dir = Path(args.run_dir)
+    base_model = Path(args.base_model)
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    ego_shape = np.array([float(x) for x in args.ego_shape.split(",")])
+    rcfg = load_reward_config(args.config)
+
+    with open(args.scenes) as f:
+        scene_paths = json.load(f)
+
+    epochs = parse_epochs(args.epochs, run_dir)
+    print(f"[sweep] {len(epochs)} epochs: {epochs}")
+    print(f"[sweep] {len(scene_paths)} scenes, reward={args.config}")
+
+    rows: list[dict] = []
+    for e in epochs:
+        ep = f"{e:03d}"
+        lora_dir = run_dir / f"lora_epoch_{ep}"
+        merged = out_dir / f"merged_ep{ep}" / "best_model.pth"
+        print(f"\n[sweep] ===== epoch {ep} =====")
+        merge_epoch(base_model, lora_dir, merged)
+        model, model_args = load_model(str(merged), device)
+        results = score_det_scenes(
+            model,
+            model_args,
+            scene_paths,
+            rcfg,
+            ego_shape,
+            device,
+            batch_size=args.batch_size,
+        )
+        del model
+        torch.cuda.empty_cache()
+        if not args.keep_merged:
+            shutil.rmtree(merged.parent, ignore_errors=True)
+        if not results:
+            print(f"[sweep] ep{ep}: all scenes skipped")
+            continue
+        agg = aggregate_stats(results)
+        # write per-epoch detail
+        ep_out = out_dir / f"avoid_ep{ep}"
+        ep_out.mkdir(parents=True, exist_ok=True)
+        with open(ep_out / "det_avoidance_summary.json", "w") as f:
+            json.dump({"aggregate": agg, "scenes": results}, f, indent=2)
+        scm = agg["sc_min_dist"]
+        row = {
+            "epoch": e,
+            "n": agg["n_scenes"],
+            "static_crossings": agg["static_crossings"],
+            "rb_crossings": agg["rb_crossings"],
+            "lane_crossings": agg["lane_crossings"],
+            "sc_min_mean": scm["mean"],
+            "sc_min_p5": scm["p5"],
+            "sc_min_min": scm["min"],
+        }
+        rows.append(row)
+        print(
+            f"[sweep] ep{ep}: static={row['static_crossings']}/{row['n']}  "
+            f"rb={row['rb_crossings']}  lane={row['lane_crossings']}  "
+            f"sc_min mean={scm['mean']:+.3f} p5={scm['p5']:+.3f} min={scm['min']:+.3f}"
+        )
+
+    with open(out_dir / "sweep_summary.json", "w") as f:
+        json.dump(rows, f, indent=2)
+
+    print(f"\n{'=' * 72}")
+    print(f"  Sweep summary ({len(rows)} epochs)")
+    print(f"{'=' * 72}")
+    print(
+        f"  {'ep':>3}  {'static':>7}  {'rb':>4}  {'lane':>4}  "
+        f"{'sc_mean':>8}  {'sc_p5':>7}  {'sc_min':>7}"
+    )
+    for r in rows:
+        print(
+            f"  {r['epoch']:>3}  {r['static_crossings']:>3}/{r['n']:<3}  "
+            f"{r['rb_crossings']:>4}  {r['lane_crossings']:>4}  "
+            f"{r['sc_min_mean']:>+8.3f}  {r['sc_min_p5']:>+7.3f}  {r['sc_min_min']:>+7.3f}"
+        )
+    print(f"{'=' * 72}")
+    print(f"Wrote {out_dir / 'sweep_summary.json'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/grpo_sft_trainer.py
+++ b/rlvr/grpo_sft_trainer.py
@@ -656,25 +656,26 @@ def train_epoch_ranked_sft(
 
     # 2d. Optionally use exploration policy to generate K diverse trajectories per scene
     elif exploration_policy is not None:
-        from diffusion_planner.model.guidance.composer import GuidanceComposer
-        from diffusion_planner.model.guidance.config import GuidanceConfig as _GC
-        from diffusion_planner.model.guidance.config import GuidanceSetConfig
-
         from exploration_policy.utils import generate_reference_trajectory, run_frozen_encoder
         from rlvr.closed_loop.batched_rollout import _batched_generate_varied_noise
-
+        from rlvr.guidance_batched import build_head_composer
         # NOTE: per-scene loop matches grpo_exploration_trainer's generate_policy_guided_group.
         # Batching across scenes would require handling per-scene Beta distributions in a single
         # forward pass, which is complex. For 50-500 scenes this takes ~3 min, acceptable.
-        print(f"  Explorer-guided generation: {K} samples from Beta distribution per scene...")
+        _heads = list(config.exploration_heads)
+        print(f"  Explorer-guided generation: {K} samples from Beta distribution per scene "
+              f"(heads: {_heads})...")
         exploration_policy.eval()
         model.eval()
 
-        _lat_lambda = config.exploration_lambda_lat
-        _lon_lambda = config.exploration_lambda_lon
         _guide_scale = config.exploration_guidance_scale
         noise_min, noise_max = config.noise_scale_range
         _train_explorer = exploration_optimizer is not None
+        if _train_explorer and _heads != ["lateral", "longitudinal"]:
+            raise NotImplementedError(
+                "joint explorer training in ranked-SFT only supports the legacy "
+                f"lateral+longitudinal heads, got {_heads} — freeze the explorer "
+                "(ranked_sft_freeze_explorer=true) for custom-head checkpoints")
 
         all_scene_trajs = []  # will be [N, K, T, 4]
         # Store per-scene explorer data for training
@@ -695,22 +696,18 @@ def train_epoch_ranked_sft(
                 )
                 norm_i["reference_trajectory"] = x_ref
 
-                # Get Beta distributions and sample K etas
+                # Get Beta distributions and sample K etas per configured head
                 output = exploration_policy(scene_enc, x_ref, deterministic=False)
-                eta_lat_01 = output.lat_dist.rsample((K,)).squeeze(-1)  # [K]
-                eta_lon_01 = output.lon_dist.rsample((K,)).squeeze(-1)  # [K]
-                eta_lat_vals = 2.0 * eta_lat_01 - 1.0  # map to [-1, 1]
-                eta_lon_vals = 2.0 * eta_lon_01 - 1.0
+                eta_01 = {h: output.dists[h].rsample((K,)).squeeze(-1) for h in _heads}
+                eta_vals = {h: 2.0 * v - 1.0 for h, v in eta_01.items()}  # map to [-1, 1]
 
                 if _train_explorer:
-                    _explorer_scenes.append(
-                        {
-                            "scene_enc": scene_enc.detach(),
-                            "x_ref": x_ref.detach(),
-                            "eta_lat_01": eta_lat_01.detach(),
-                            "eta_lon_01": eta_lon_01.detach(),
-                        }
-                    )
+                    _explorer_scenes.append({
+                        "scene_enc": scene_enc.detach(),
+                        "x_ref": x_ref.detach(),
+                        "eta_lat_01": eta_01["lateral"].detach(),
+                        "eta_lon_01": eta_01["longitudinal"].detach(),
+                    })
 
                 # Expand scene data from B=1 to B=K
                 K_data = {}
@@ -720,23 +717,23 @@ def train_epoch_ranked_sft(
                     else:
                         K_data[k_key] = v
 
-                # Build batched guidance with K different etas
-                guidance_fns = [
-                    _GC(
-                        "lateral",
-                        enabled=True,
-                        scale=1.0,
-                        params={"lambda_lat": _lat_lambda, "eta_lat": eta_lat_vals},
-                    ),
-                    _GC(
-                        "longitudinal",
-                        enabled=True,
-                        scale=1.0,
-                        params={"lambda_lon": _lon_lambda, "eta_lon": eta_lon_vals},
-                    ),
-                ]
-                composer = GuidanceComposer(
-                    GuidanceSetConfig(functions=guidance_fns, global_scale=_guide_scale)
+                # Build batched guidance with K different etas per head.
+                # build_head_composer is the single source of truth for the
+                # head-name -> guidance-fn mapping; the config defaults
+                # (lat_scale=1.0, lambda_lat=2.5, lambda_lon=0.25) reproduce
+                # the legacy lateral+longitudinal pair exactly.
+                composer = build_head_composer(
+                    eta_vals,
+                    lambda_lat=config.exploration_lambda_lat,
+                    lat_scale=config.exploration_lat_scale,
+                    col_scale=config.exploration_col_scale,
+                    col_range=config.exploration_col_range,
+                    lambda_spd=config.exploration_lambda_spd,
+                    stretch_scale=config.exploration_stretch_scale,
+                    guidance_scale=_guide_scale,
+                    lambda_lon=config.exploration_lambda_lon,
+                    envelope=config.exploration_envelope,
+                    lambda_col=config.exploration_lambda_col,
                 )
 
                 # Generate K trajectories (first deterministic, rest with varied noise)

--- a/rlvr/grpo_sft_trainer.py
+++ b/rlvr/grpo_sft_trainer.py
@@ -727,7 +727,8 @@ def train_epoch_ranked_sft(
                 # build_head_composer is the single source of truth for the
                 # head-name -> guidance-fn mapping; the config defaults
                 # (lat_scale=1.0, lambda_lat=2.5, lambda_lon=0.25) reproduce
-                # the legacy lateral+longitudinal pair exactly.
+                # the legacy lateral+longitudinal pair (build_head_composer
+                # returns the certified-equivalent FastGuidanceComposer).
                 composer = build_head_composer(
                     eta_vals,
                     lambda_lat=config.exploration_lambda_lat,

--- a/rlvr/grpo_sft_trainer.py
+++ b/rlvr/grpo_sft_trainer.py
@@ -659,12 +659,15 @@ def train_epoch_ranked_sft(
         from exploration_policy.utils import generate_reference_trajectory, run_frozen_encoder
         from rlvr.closed_loop.batched_rollout import _batched_generate_varied_noise
         from rlvr.guidance_batched import build_head_composer
+
         # NOTE: per-scene loop matches grpo_exploration_trainer's generate_policy_guided_group.
         # Batching across scenes would require handling per-scene Beta distributions in a single
         # forward pass, which is complex. For 50-500 scenes this takes ~3 min, acceptable.
         _heads = list(config.exploration_heads)
-        print(f"  Explorer-guided generation: {K} samples from Beta distribution per scene "
-              f"(heads: {_heads})...")
+        print(
+            f"  Explorer-guided generation: {K} samples from Beta distribution per scene "
+            f"(heads: {_heads})..."
+        )
         exploration_policy.eval()
         model.eval()
 
@@ -675,7 +678,8 @@ def train_epoch_ranked_sft(
             raise NotImplementedError(
                 "joint explorer training in ranked-SFT only supports the legacy "
                 f"lateral+longitudinal heads, got {_heads} — freeze the explorer "
-                "(ranked_sft_freeze_explorer=true) for custom-head checkpoints")
+                "(ranked_sft_freeze_explorer=true) for custom-head checkpoints"
+            )
 
         all_scene_trajs = []  # will be [N, K, T, 4]
         # Store per-scene explorer data for training
@@ -702,12 +706,14 @@ def train_epoch_ranked_sft(
                 eta_vals = {h: 2.0 * v - 1.0 for h, v in eta_01.items()}  # map to [-1, 1]
 
                 if _train_explorer:
-                    _explorer_scenes.append({
-                        "scene_enc": scene_enc.detach(),
-                        "x_ref": x_ref.detach(),
-                        "eta_lat_01": eta_01["lateral"].detach(),
-                        "eta_lon_01": eta_01["longitudinal"].detach(),
-                    })
+                    _explorer_scenes.append(
+                        {
+                            "scene_enc": scene_enc.detach(),
+                            "x_ref": x_ref.detach(),
+                            "eta_lat_01": eta_01["lateral"].detach(),
+                            "eta_lon_01": eta_01["longitudinal"].detach(),
+                        }
+                    )
 
                 # Expand scene data from B=1 to B=K
                 K_data = {}

--- a/rlvr/grpo_sft_trainer.py
+++ b/rlvr/grpo_sft_trainer.py
@@ -674,7 +674,7 @@ def train_epoch_ranked_sft(
         _guide_scale = config.exploration_guidance_scale
         noise_min, noise_max = config.noise_scale_range
         _train_explorer = exploration_optimizer is not None
-        if _train_explorer and _heads != ["lateral", "longitudinal"]:
+        if _train_explorer and set(_heads) != {"lateral", "longitudinal"}:
             raise NotImplementedError(
                 "joint explorer training in ranked-SFT only supports the legacy "
                 f"lateral+longitudinal heads, got {_heads} — freeze the explorer "

--- a/scripts/torch2onnx_320.py
+++ b/scripts/torch2onnx_320.py
@@ -1,0 +1,12 @@
+"""Wrapper to run torch2onnx with MAX_NUM_NEIGHBORS=320."""
+
+import os
+import sys
+
+import diffusion_planner.dimensions as dims
+
+dims.MAX_NUM_NEIGHBORS = 320
+dims.MAX_NUM_AGENTS = 321
+dims.NEIGHBOR_SHAPE = (1, 320, dims.INPUT_T + 1, 11)
+
+exec(open(os.path.join(os.path.dirname(__file__), "..", "ros_scripts", "torch2onnx.py")).read())

--- a/scripts/torch2onnx_320.py
+++ b/scripts/torch2onnx_320.py
@@ -1,12 +1,10 @@
 """Wrapper to run torch2onnx with MAX_NUM_NEIGHBORS=320."""
 
 import os
-import sys
 
 import diffusion_planner.dimensions as dims
 
 dims.MAX_NUM_NEIGHBORS = 320
 dims.MAX_NUM_AGENTS = 321
-dims.NEIGHBOR_SHAPE = (1, 320, dims.INPUT_T + 1, 11)
 
 exec(open(os.path.join(os.path.dirname(__file__), "..", "ros_scripts", "torch2onnx.py")).read())

--- a/scripts/torch2onnx_320.py
+++ b/scripts/torch2onnx_320.py
@@ -1,10 +1,20 @@
 """Wrapper to run torch2onnx with MAX_NUM_NEIGHBORS=320."""
 
 import os
+import runpy
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "diffusion_planner"))
 
 import diffusion_planner.dimensions as dims
 
 dims.MAX_NUM_NEIGHBORS = 320
 dims.MAX_NUM_AGENTS = 321
 
-exec(open(os.path.join(os.path.dirname(__file__), "..", "ros_scripts", "torch2onnx.py")).read())
+# Run the target as __main__ (proper module context, file handle closed by runpy).
+# The override above mutates the cached diffusion_planner.dimensions module, so the
+# target sees 320 when it reads the constants.
+runpy.run_path(
+    os.path.join(os.path.dirname(__file__), "..", "ros_scripts", "torch2onnx.py"),
+    run_name="__main__",
+)

--- a/scripts/valid_320.py
+++ b/scripts/valid_320.py
@@ -1,6 +1,7 @@
 """Wrapper to run valid_predictor with MAX_NUM_NEIGHBORS=320."""
 
 import os
+import runpy
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "diffusion_planner"))
@@ -10,8 +11,10 @@ import diffusion_planner.dimensions as dims
 dims.MAX_NUM_NEIGHBORS = 320
 dims.MAX_NUM_AGENTS = 321
 
-exec(
-    open(
-        os.path.join(os.path.dirname(__file__), "..", "diffusion_planner", "valid_predictor.py")
-    ).read()
+# Run the target as __main__ (proper module context, file handle closed by runpy).
+# The override above mutates the cached diffusion_planner.dimensions module, so the
+# target sees 320 when it reads the constants.
+runpy.run_path(
+    os.path.join(os.path.dirname(__file__), "..", "diffusion_planner", "valid_predictor.py"),
+    run_name="__main__",
 )

--- a/scripts/valid_320.py
+++ b/scripts/valid_320.py
@@ -1,0 +1,17 @@
+"""Wrapper to run valid_predictor with MAX_NUM_NEIGHBORS=320."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "diffusion_planner"))
+
+import diffusion_planner.dimensions as dims
+
+dims.MAX_NUM_NEIGHBORS = 320
+dims.MAX_NUM_AGENTS = 321
+
+exec(
+    open(
+        os.path.join(os.path.dirname(__file__), "..", "diffusion_planner", "valid_predictor.py")
+    ).read()
+)


### PR DESCRIPTION
## What

Upstreams reusable autoresearch tooling and two core trainer/config changes that have been living on a campaign worktree branch. No place names, results, or hardcoded data paths — all paths are CLI args / env.

### New standalone tools (`rlvr/autoresearch/tools/`, `scripts/`)
- **build_avoiding_target / build_clguided_target** — K-sample reward-ranked and centerline-guided SFT target synthesis with a margin floor.
- **perturb_neighbors_npz** — neighbor-position perturbation for avoidance NPZs (lat/lon shift in the neighbor heading frame, t0-clean gate + canonical OBB clearance).
- **distill_closedloop_targets** — closed-loop guidance rollout → realized trajectory as an SFT target.
- **mine_arc_and_convert / open_loop_per_arc** — per-arc scene mining and per-arc open-loop metric extraction.
- **score_curated_targets** — no-poison reward-path scoring of `ego_agent_future`.
- **sweep_full_metrics / sweep_lora_epochs** — per-epoch LoRA sweeps over avoidance distributions, plan comfort, and L2.
- **scripts/valid_320 + torch2onnx_320** — 320-neighbor validation and ONNX export wrappers.

### Core changes
- **Head-aware explorer-guided ranked-SFT** (`grpo_sft_trainer.py`, `run_experiment.py`): the explorer-guided ranked-SFT branch now builds its guidance composer from the configured exploration heads via `build_head_composer`, instead of a hardcoded lateral+longitudinal pair, so explorers with other head sets (e.g. lateral+collision) are honored.
- **blocks12 LoRA target** (`lora_utils.py`, `run_experiment.py`): freeze block 0, train blocks 1 and 2.

## Why

These tools are load-bearing across multiple avoidance/comfort campaigns and the model-evaluation protocol; keeping them on a single worktree branch strands them. The head-aware fix is a correctness bug — multi-head explorers were silently guided with the wrong heads.

## Testing
- `ruff check` + `ruff format` (pinned v0.15.16, matching `.pre-commit-config.yaml`) pass on all 15 files.
- All files parse (ast).
- The trainer/config changes are gated and have been exercised on the originating campaign branch.