### PR TITLE
feat: add `accelerating_at_traffic_light`

### DIFF
--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/processing/frame_filters.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/processing/frame_filters.hpp
@@ -26,6 +26,7 @@
 // the python filter operated on (ego_future/neighbor_future store [x,y,cos,sin]
 // here instead of [x,y,heading], so cos/sin are used directly).
 
+#include <autoware/diffusion_planner/constants.hpp>
 #include <autoware/diffusion_planner/dimensions.hpp>
 
 #include <algorithm>
@@ -320,6 +321,68 @@ inline OffLaneResult compute_offlane_score(
 inline bool is_off_lane(const OffLaneResult & r, float max_score)
 {
   return !r.has_centerline || r.mean_distance >= max_score;
+}
+
+// ---------------------------------------------------------------------------
+// "Accelerating into a red/yellow signal" detector.
+//
+// The RedOrYellowLight skip originally fired only when the ego was fully stopped
+// (linear.x < 0.1) with a forward GT future. That gate leaked every low-speed /
+// creeping start where the ego is already rolling (>= 0.1 m/s) but the GT future
+// still drives forward through a red or yellow light. Rather than loosen the speed
+// gate (which would also drop legitimate decelerate-to-stop trajectories), we look
+// at the *shape* of the GT future speed profile: a frame is flagged only when the
+// ego clearly accelerates into the signal — the peak future speed ramps well above
+// the initial speed. Pure decel-to-stop and minor creeps (peak < ~3 m/s) are kept.
+// This is meant to be OR-ed with the original stopped-at-red condition so coverage
+// only ever grows.
+// ---------------------------------------------------------------------------
+
+// Leading future steps averaged into the initial speed (0.5 s at 10 Hz).
+constexpr int64_t kAccelInitWindow = 5;
+constexpr float kAccelDeltaVThreshold = 2.0f;  // m/s gained from initial to peak
+constexpr float kAccelPeakThreshold = 3.0f;    // m/s minimum peak future speed
+constexpr float kAccelRatioThreshold = 1.3f;   // peak must exceed v_initial * this
+
+struct FutureAccelResult
+{
+  float v_initial;  // mean speed over the first kAccelInitWindow future steps (m/s)
+  float v_peak;     // max per-step speed over the future horizon (m/s)
+};
+
+// Per-step speed profile of the GT future, in the ego frame at t=0. ego_future is
+// laid out as OUTPUT_T * POSE_DIM with channels [x, y, cos, sin]; speed at step j is
+// |p_{j+1} - p_j| / dt. Matches the python analysis used to size the thresholds.
+inline FutureAccelResult compute_future_accel(const std::vector<float> & ego_future)
+{
+  using autoware::diffusion_planner::OUTPUT_T;
+  using autoware::diffusion_planner::POSE_DIM;
+  constexpr float dt =
+    static_cast<float>(autoware::diffusion_planner::constants::PREDICTION_TIME_STEP_S);
+
+  float v_peak = 0.0f;
+  double init_sum = 0.0;
+  int64_t init_count = 0;
+  for (int64_t j = 0; j + 1 < OUTPUT_T; ++j) {
+    const float dx = ego_future[(j + 1) * POSE_DIM + 0] - ego_future[j * POSE_DIM + 0];
+    const float dy = ego_future[(j + 1) * POSE_DIM + 1] - ego_future[j * POSE_DIM + 1];
+    const float speed = std::sqrt(dx * dx + dy * dy) / dt;
+    v_peak = std::max(v_peak, speed);
+    if (j < kAccelInitWindow) {
+      init_sum += speed;
+      ++init_count;
+    }
+  }
+  const float v_initial = init_count > 0 ? static_cast<float>(init_sum / init_count) : 0.0f;
+  return {v_initial, v_peak};
+}
+
+// True when the GT future clearly ramps up speed (accelerates) rather than holding
+// or decelerating — the signature of driving *into* a red/yellow light.
+inline bool is_accelerating(const FutureAccelResult & a)
+{
+  return (a.v_peak - a.v_initial > kAccelDeltaVThreshold) && (a.v_peak > kAccelPeakThreshold) &&
+         (a.v_peak > a.v_initial * kAccelRatioThreshold);
 }
 
 // Top-level: returns the list of collision reasons for one frame (empty == keep).

--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/types/skipping_info.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/types/skipping_info.hpp
@@ -75,7 +75,8 @@ enum class SkippingLabel {
   InsufficientDistance,  // Traveled distance of sequence is too short
 
   // Frame processing skipping reasons
-  RedOrYellowLight,        // At red or yellow light with forward future trajectory
+  RedOrYellowLight,        // Stopped at a red/yellow light (linear.x < 0.1) with a forward
+                           // GT future — i.e. the GT pulls away from the line on red.
   StoppedAtTrafficLight,   // Sustained stop at red/yellow light (formerly VehicleStopped;
                            // contrast with NoFutureProgress for non-light stops)
 
@@ -86,6 +87,13 @@ enum class SkippingLabel {
   // Sustained-state skipping reasons
   NoFutureProgress,  // GT future trajectory has not advanced for >=3s (ego stuck beyond
                      // just red lights, e.g. stop sign / behind another vehicle / parked).
+
+  // NOTE: append new labels below to keep the integer values of the labels above stable
+  // (they are written verbatim into the per-frame JSON and read back by analysis scripts).
+  AcceleratingAtTrafficLight,  // Accelerating into a red/yellow light while NOT fully stopped
+                               // (linear.x >= 0.1). Complements RedOrYellowLight, which only
+                               // covers the fully-stopped case; counted separately so the
+                               // extra coverage of this trigger is measurable.
 };
 
 // Structure to hold detailed skipping information
@@ -152,7 +160,16 @@ struct SkippingInfo
   {
     return {
       SkippingLabel::RedOrYellowLight,
-      "At red/yellow light with forward moving future trajectory",
+      "Stopped at red/yellow light with forward moving future trajectory",
+      {},
+      {}};
+  }
+
+  static SkippingInfo accelerating_at_traffic_light()
+  {
+    return {
+      SkippingLabel::AcceleratingAtTrafficLight,
+      "Accelerating into red/yellow light while moving (linear.x >= 0.1)",
       {},
       {}};
   }

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_skip_decision.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_skip_decision.cpp
@@ -53,8 +53,18 @@ SkippingInfo decide_frame_skip(
     return SkippingInfo::invalid_covariance(inputs.cov_xx, inputs.cov_yy);
   }
 
-  if (inputs.is_stop && inputs.is_red_or_yellow && inputs.is_future_forward) {
-    return SkippingInfo::red_or_yellow_light();
+  // Red/yellow-light run. Two complementary triggers with distinct labels so the extra
+  // coverage of the second can be counted separately. The original stopped gate is checked
+  // first, so a stopped-then-pulling-away frame keeps the RedOrYellowLight label; the
+  // AcceleratingAtTrafficLight label then counts only the moving (linear.x >= 0.1) starts
+  // that the stopped-only gate leaked.
+  if (inputs.is_red_or_yellow) {
+    if (inputs.is_stop && inputs.is_future_forward) {
+      return SkippingInfo::red_or_yellow_light();
+    }
+    if (frame_filters::is_accelerating(frame_filters::compute_future_accel(ego_future))) {
+      return SkippingInfo::accelerating_at_traffic_light();
+    }
   }
 
   if (inputs.stopping_count > (INPUT_T + 5) && inputs.is_red_or_yellow) {

--- a/cpp_tools/src/autoware_diffusion_planner_tools/test/test_frame_skip_decision.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/test/test_frame_skip_decision.cpp
@@ -87,6 +87,25 @@ SkippingInfo call_decide(const FrameSkipInputs & inputs, const ZeroVectors & vec
     vecs.neighbor_past, vecs.line_strings, vecs.lanes, make_default_filter_params());
 }
 
+// Fill ego_future with a straight forward trajectory whose per-step speed ramps
+// linearly from v_start to v_end (m/s). v_start==v_end gives a constant-speed creep.
+// Speed at step j is (x[j+1]-x[j]) / dt, which is what compute_future_accel reads.
+void set_linear_future(std::vector<float> & ego_future, float v_start, float v_end)
+{
+  using autoware::diffusion_planner::OUTPUT_T;
+  using autoware::diffusion_planner::POSE_DIM;
+  constexpr float dt = 0.1f;
+  float x = 0.0f;
+  for (int64_t j = 0; j < OUTPUT_T; ++j) {
+    ego_future[j * POSE_DIM + 0] = x;
+    ego_future[j * POSE_DIM + 1] = 0.0f;
+    ego_future[j * POSE_DIM + 2] = 1.0f;  // cos
+    ego_future[j * POSE_DIM + 3] = 0.0f;  // sin
+    const float speed = v_start + (v_end - v_start) * static_cast<float>(j) / (OUTPUT_T - 1);
+    x += speed * dt;
+  }
+}
+
 }  // namespace
 
 // ---------------------------------------------------------------------------
@@ -143,6 +162,59 @@ TEST(DecideFrameSkipTest, RedOrYellowLightSkip)
 
   const SkippingInfo info = call_decide(inputs, vecs);
   EXPECT_EQ(info.label, SkippingLabel::RedOrYellowLight);
+}
+
+TEST(DecideFrameSkipTest, AcceleratingIntoRedLightSkipsEvenWhenMoving)
+{
+  // Ego is NOT stopped (is_stop = false), so the original stopped-only gate would miss
+  // this — but the GT future clearly accelerates (~0 -> ~9 m/s) into a red/yellow light,
+  // so the dedicated AcceleratingAtTrafficLight trigger fires.
+  ZeroVectors vecs;
+  vecs.lanes[0] = 1.0f;
+  set_linear_future(vecs.ego_future, 0.2f, 9.0f);
+
+  FrameSkipInputs inputs = make_clear_inputs();
+  inputs.is_stop = false;
+  inputs.is_red_or_yellow = true;
+  inputs.is_future_forward = true;
+
+  const SkippingInfo info = call_decide(inputs, vecs);
+  EXPECT_EQ(info.label, SkippingLabel::AcceleratingAtTrafficLight);
+}
+
+TEST(DecideFrameSkipTest, StoppedThenAcceleratingKeepsRedOrYellowLabel)
+{
+  // When the ego is fully stopped AND the future accelerates away, the original stopped
+  // gate is checked first, so the frame keeps the RedOrYellowLight label (not the new one).
+  ZeroVectors vecs;
+  vecs.lanes[0] = 1.0f;
+  set_linear_future(vecs.ego_future, 0.2f, 9.0f);
+
+  FrameSkipInputs inputs = make_clear_inputs();
+  inputs.is_stop = true;
+  inputs.is_red_or_yellow = true;
+  inputs.is_future_forward = true;
+
+  const SkippingInfo info = call_decide(inputs, vecs);
+  EXPECT_EQ(info.label, SkippingLabel::RedOrYellowLight);
+}
+
+TEST(DecideFrameSkipTest, CreepingIntoRedWhileMovingIsKept)
+{
+  // Moving slowly at a near-constant ~1 m/s (a creep, peak < 3 m/s) toward a red light:
+  // neither the stopped gate (is_stop = false) nor the acceleration trigger fires, so the
+  // frame is accepted rather than dropped.
+  ZeroVectors vecs;
+  vecs.lanes[0] = 1.0f;
+  set_linear_future(vecs.ego_future, 1.0f, 1.0f);
+
+  FrameSkipInputs inputs = make_clear_inputs();
+  inputs.is_stop = false;
+  inputs.is_red_or_yellow = true;
+  inputs.is_future_forward = true;
+
+  const SkippingInfo info = call_decide(inputs, vecs);
+  EXPECT_EQ(info.label, SkippingLabel::NotSkipped);
 }
 
 TEST(DecideFrameSkipTest, StoppedAtTrafficLightSkip)


### PR DESCRIPTION
Add an acceleration-based red/yellow-light filter to the data_converter: the existing skip only dropped fully-stopped (linear.x < 0.1) frames, leaking ~20.8k training frames (0.335%, ~76% from psim) where the ego is rolling but the GT accelerates into a red/yellow light.

The new trigger fires whenever the GT future ramps up speed (peak−v0 > 2.0, peak > 3.0 m/s, peak > 1.3×v0) toward a red/yellow next route segment, recorded under a separate AcceleratingAtTrafficLight label so its extra coverage stays measurable; the original stopped-at-line condition is kept unchanged.