### PR TITLE
Guidance-explorer strength gate, distractor data tool, and eta-reachability cap

### DIFF
--- a/docs/guidance_explorer_framework.md
+++ b/docs/guidance_explorer_framework.md
@@ -17,6 +17,25 @@ numbers.
   through a composer. The contract per head: eta = 0 must be EXACTLY inert
   (zero energy and zero gradient), magnitude must mean roughly the same
   thing in every scene, and commands must be O(1).
+- **Optional learned strength gate (`use_strength_head`).** Instead of (or
+  alongside) relying on every eta head reaching exactly 0 to be inert, the
+  policy can emit ONE extra scalar `g in (0,1)` that the composer multiplies
+  into the *total* guidance energy (`g -> 0` = exactly the unguided plan).
+  Supervise it as a per-scene gate (target 1 when guidance is wanted, 0 when
+  not — including scenes that contain obstacles the ego does NOT need to
+  avoid). This decouples "engage? / how hard" (the scalar) from "which way"
+  (the etas) and is a strong false-positive suppressor: a single dedicated
+  gate is easier to drive to 0 than two noisy heads, and an inference-time
+  multiplier on `g` (a deploy knob) then amplifies guidance ONLY where the
+  gate is already open, so it cannot wake guidance on non-avoidance scenes.
+- **Reachable eta range (`head_max_conc`).** The deterministic Beta mean
+  saturates at the concentration cap (default 10 -> |eta| <~ 0.82), so
+  scenes whose best guidance sits at the grid edge (|eta| = 1) are
+  unreachable and stay marginal. Note this: a residual contact whose swept
+  solution needs |eta| ~ 1 is an architecture ceiling, NOT a data problem,
+  and raising `g` (energy) does NOT fix it — energy scales how hard the plan
+  tracks a target *offset* that eta itself sets, so more energy just
+  oscillates. Raise the concentration cap to let the mean reach near +-1.
 
 ## 2. Calibrate the guidances FIRST (most failures start here)
 
@@ -130,6 +149,45 @@ Findings to expect and fix:
   `--lat_thresh`/`--col_thresh`, rule any/both). Useful for mining avoidance
   scenes from large unlabeled pools and for auditing dataset composition; the
   inertness contract makes the signal bimodal, so the threshold is forgiving.
+
+## 8b. False-detection–robust recipe (discrimination data + learned gate)
+
+The most common deployment complaint is the explorer firing when nothing needs
+avoiding (false positives on normal driving). A policy trained only to react to
+the PRESENCE of a stopped agent learns the wrong invariant; the fix is to make
+the data and the architecture both encode PROXIMITY-TO-PATH instead.
+
+Data — three zero-target classes plus the positives, deliberately inert-heavy:
+- positives: a real in-path obstacle, PLUS far "distractor" stopped agents the
+  ego must ignore (place them beside the planned path, kept only if the whole
+  plan clears them by a margin via the canonical OBB clearance — so they are
+  provably non-candidates: `add_distractor_neighbors_npz`);
+- anchors: the same scenes with the in-path obstacle removed
+  (`strip_neighbors_npz`) and/or distractor-only — stopped agents present, none
+  to avoid, target 0;
+- real normals: genuine driving, target 0 (the real-domain anchor — sim-built
+  zeros ALONE teach domain blindness; real zeros keep it honest).
+Balance is normal-heavy (engage ≈ 1 : inert ≈ 5), because restraint is the hard
+skill; counter the imbalance with the avoid-weight so positives still drive
+aggressive swerves. Mix distractor / no-distractor within each class so the
+learned invariant is proximity, not distractor-presence.
+
+Architecture — a learned strength GATE (`use_strength_head`): the policy emits
+one extra scalar g in (0,1) that the composer multiplies into the TOTAL guidance
+energy (g->0 = exactly the unguided plan). Supervise it as the engage signal
+(1 on positives, 0 on every zero-target class). This is a stronger FP suppressor
+than relying on the eta heads alone (one dedicated gate drives to 0 far more
+reliably than two heads both landing on 0), and it replaces the envelope's
+hand-tuned "how aggressive" constant with a learned per-scene decision. A
+deploy-time multiplier on g is FP-safe (g~0 on normals) but pushing it above 1
+is closed-loop NEGATIVE (over-strong per-step guidance oscillates).
+
+Closing the residual avoidance gap WITHOUT regressing FPs: do NOT add energy
+gain or mid-maneuver "roll" data (both reawaken FPs / oscillate here). The
+limiter is usually eta REACHABILITY — the deterministic Beta mean saturates
+below |eta|=1 at the concentration cap, so scenes whose swept solution sits at
+the grid edge stay marginal; raise the cap (`head_max_conc`) so the mean can
+reach near +-1 while the gate keeps it FP-safe.
 
 ## 8. Failure modes checklist
 

--- a/exploration_policy/model.py
+++ b/exploration_policy/model.py
@@ -31,7 +31,7 @@ import torch
 import torch.nn as nn
 from torch.distributions import Beta
 
-from exploration_policy.module.heads import GuidanceHead, ValueHead
+from exploration_policy.module.heads import GuidanceHead, StrengthHead, ValueHead
 from exploration_policy.module.ref_fusion import RefFusionAttention
 from exploration_policy.module.ref_mixer import RefTrajectoryMixer
 
@@ -75,12 +75,20 @@ class ExplorationPolicyConfig:
     # flow through the softplus compression. Default 1.0 (no scaling).
     # Set to 10.0 to make the policy learn ~12x faster.
     head_raw_scale: float = 1.0
+    # Cap on Beta concentration in GuidanceHead. Default 10.0 caps |eta|≈0.82;
+    # raise (e.g. 50) to let the policy reach near-±1.0 etas on tight scenes.
+    head_max_conc: float = 10.0
     # Guidance heads, one Beta distribution (-> eta in [-1, 1]) each. The
     # policy itself is head-name agnostic — names define count, ordering, and
     # the dict keys of ExplorationPolicyOutput; mapping eta -> guidance params
     # is the caller's job. Default matches the original 2-head layout, so old
     # checkpoints (fc2 [4, H]) load unchanged.
     heads: list[str] = field(default_factory=lambda: ["lateral", "longitudinal"])
+    # If True, add a StrengthHead: the policy emits one extra scalar g in (0,1)
+    # that the composer multiplies into the total guidance energy (a learned
+    # per-scene guidance-strength gate; see StrengthHead). Default False so old
+    # checkpoints/configs are unchanged.
+    use_strength_head: bool = False
     # Guidance envelope the eta labels were swept against — the calibration the
     # policy's outputs are bound to. Persisted here so eval/deploy load it
     # instead of relying on (divergent) per-tool CLI defaults. Defaults to the
@@ -113,6 +121,7 @@ class ExplorationPolicyOutput:
     log_probs: dict[str, torch.Tensor]  # head -> [B] log prob of sampled eta
     value: torch.Tensor  # [B] state value estimate (Phase 2)
     dists: dict[str, Beta]  # head -> Beta distribution object
+    strength: torch.Tensor | None = None  # [B] guidance-strength gate in (0,1), or None
 
     @property
     def eta_lat(self) -> torch.Tensor:
@@ -175,8 +184,10 @@ class ExplorationPolicy(nn.Module):
             init_mode=config.head_init,
             init_std=config.head_init_std,
             raw_scale=config.head_raw_scale,
+            max_conc=config.head_max_conc,
         )
         self.value_head = ValueHead(config.hidden_dim)
+        self.strength_head = StrengthHead(config.hidden_dim) if config.use_strength_head else None
 
     def forward(
         self,
@@ -206,6 +217,9 @@ class ExplorationPolicy(nn.Module):
         # Get value estimate
         value = self.value_head(fused)  # [B]
 
+        # Optional learned guidance-strength gate
+        strength = self.strength_head(fused) if self.strength_head is not None else None
+
         etas: dict[str, torch.Tensor] = {}
         log_probs: dict[str, torch.Tensor] = {}
         dists: dict[str, Beta] = {}
@@ -220,4 +234,5 @@ class ExplorationPolicy(nn.Module):
             log_probs=log_probs,
             value=value,
             dists=dists,
+            strength=strength,
         )

--- a/exploration_policy/module/heads.py
+++ b/exploration_policy/module/heads.py
@@ -47,6 +47,11 @@ class GuidanceHead(nn.Module):
         # (|eta|=1.0) are then unreachable. Raise it to let the policy emit more
         # extreme etas on tight scenes (the gate still controls engagement).
         self.max_conc = float(max_conc)
+        # The clamp caps softplus(.)+1.0 (always >= 1.0) at max_conc; a cap below
+        # 1.0 (or NaN) would push params under 1.0 and break the unimodal-Beta
+        # invariant. Fail loudly rather than emit invalid Beta shapes.
+        if not (self.max_conc >= 1.0):
+            raise ValueError(f"max_conc must be >= 1.0 (got {max_conc!r})")
         self.fc1 = nn.Linear(hidden_dim, hidden_dim)
         self.act = nn.GELU()
         # bias=False removes a direct global offset at the output layer:

--- a/exploration_policy/module/heads.py
+++ b/exploration_policy/module/heads.py
@@ -37,9 +37,16 @@ class GuidanceHead(nn.Module):
         init_mode: str = "zeros",
         init_std: float = 0.01,
         raw_scale: float = 1.0,
+        max_conc: float = 10.0,
     ):
         super().__init__()
         self.n_heads = n_heads
+        # Cap on the Beta concentration (alpha/beta). With the default 10.0 the
+        # deterministic Beta mean saturates at ~10/11, so the mapped eta cannot
+        # exceed ~0.82 — scenes whose swept-best guidance sits at the grid edge
+        # (|eta|=1.0) are then unreachable. Raise it to let the policy emit more
+        # extreme etas on tight scenes (the gate still controls engagement).
+        self.max_conc = float(max_conc)
         self.fc1 = nn.Linear(hidden_dim, hidden_dim)
         self.act = nn.GELU()
         # bias=False removes a direct global offset at the output layer:
@@ -78,10 +85,42 @@ class GuidanceHead(nn.Module):
         scaled = raw * self.raw_scale
 
         # softplus + 1.0 ensures params >= 1.0 (unimodal Beta)
-        # Clamp to max_conc to prevent distribution collapse (alpha=10 → high concentration)
-        max_conc = 10.0
-        params = torch.clamp(F.softplus(scaled) + 1.0, max=max_conc)
+        # Clamp to max_conc to prevent distribution collapse (higher = more
+        # extreme reachable eta; see __init__).
+        params = torch.clamp(F.softplus(scaled) + 1.0, max=self.max_conc)
         return [Beta(params[:, 2 * i], params[:, 2 * i + 1]) for i in range(self.n_heads)]
+
+
+class StrengthHead(nn.Module):
+    """Scalar guidance-strength gate g in (0, 1) (sigmoid).
+
+    The policy emits ONE number per scene that controls how strongly the whole
+    guidance field is applied: at inference the composer multiplies the total
+    guidance energy (hence the guidance gradient) by g, so g=0 -> exactly the
+    unguided plan, g=1 -> the full envelope push. This decouples "engage? / how
+    hard" (this scalar) from "which way to swerve" (the per-head etas), and
+    gives an intrinsic false-positive gate: on a scene with nothing to avoid the
+    network can drive g->0 directly instead of relying on every eta head landing
+    on exactly 0.
+
+    Supervised target: 1.0 on real-avoidance scenes, 0.0 on zero-target scenes
+    (no obstacle in the ego's path — including far-distractor-only scenes).
+
+    Zero-initialized output layer -> raw 0 -> sigmoid(0)=0.5 at init (an
+    unbiased, mild gate before any learning).
+    """
+
+    def __init__(self, hidden_dim: int):
+        super().__init__()
+        self.fc1 = nn.Linear(hidden_dim, hidden_dim)
+        self.act = nn.GELU()
+        self.fc2 = nn.Linear(hidden_dim, 1)
+        nn.init.zeros_(self.fc2.weight)
+        nn.init.zeros_(self.fc2.bias)
+
+    def forward(self, fused: torch.Tensor) -> torch.Tensor:
+        """fused [B, H] -> [B] strength in (0, 1)."""
+        return torch.sigmoid(self.fc2(self.act(self.fc1(fused))).squeeze(-1))
 
 
 class ValueHead(nn.Module):

--- a/exploration_policy/test_exploration_policy.py
+++ b/exploration_policy/test_exploration_policy.py
@@ -410,3 +410,74 @@ def test_loss_multi_head_dists():
     assert "exploration_eta_collision_mean" in metrics
     assert "exploration_eta_lat_mean" in metrics  # legacy alias
     assert metrics["exploration_action_cost"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Strength gate (use_strength_head) + configurable Beta-concentration cap
+# ---------------------------------------------------------------------------
+
+
+def test_strength_head_disabled_by_default():
+    """Default config has no strength head; forward emits strength=None."""
+    config = ExplorationPolicyConfig(hidden_dim=64, n_attn_heads=2, encoder_hidden_dim=128)
+    assert config.use_strength_head is False
+    assert config.head_max_conc == 10.0
+    policy = ExplorationPolicy(config, ref_seq_len=20)
+    assert policy.strength_head is None
+    out = policy(torch.randn(3, 8, 128), torch.randn(3, 20, 4), deterministic=True)
+    assert out.strength is None
+
+
+def test_strength_head_enabled_shape_and_range():
+    """With the head on, strength is [B] in (0,1)."""
+    config = ExplorationPolicyConfig(
+        hidden_dim=64, n_attn_heads=2, encoder_hidden_dim=128, use_strength_head=True
+    )
+    policy = ExplorationPolicy(config, ref_seq_len=20)
+    assert policy.strength_head is not None
+    out = policy(torch.randn(5, 8, 128), torch.randn(5, 20, 4), deterministic=True)
+    assert out.strength is not None
+    assert out.strength.shape == (5,)
+    assert (out.strength > 0).all() and (out.strength < 1).all()
+    # zero-init output layer -> sigmoid(0) = 0.5 at init
+    assert torch.allclose(out.strength, torch.full((5,), 0.5), atol=1e-5)
+
+
+def test_strength_head_config_roundtrip(tmp_path):
+    """use_strength_head + head_max_conc survive JSON round-trip and rebuild."""
+    config = ExplorationPolicyConfig(
+        hidden_dim=64,
+        n_attn_heads=2,
+        encoder_hidden_dim=128,
+        use_strength_head=True,
+        head_max_conc=50.0,
+    )
+    p = tmp_path / "cfg.json"
+    config.to_json(p)
+    loaded = ExplorationPolicyConfig.from_json(p)
+    assert loaded.use_strength_head is True
+    assert loaded.head_max_conc == 50.0
+    policy = ExplorationPolicy(loaded, ref_seq_len=20)
+    assert policy.strength_head is not None
+    assert policy.guidance_head.max_conc == 50.0
+
+
+def test_head_max_conc_raises_reachable_eta():
+    """A higher concentration cap lets the deterministic |eta| exceed the
+    default-cap ceiling (~0.82) when the head is pushed off zero-init."""
+    from exploration_policy.module.heads import GuidanceHead
+
+    torch.manual_seed(0)
+    fused = torch.randn(64, 32)
+    low = GuidanceHead(
+        32, n_heads=2, init_mode="normal", init_std=1.0, raw_scale=10.0, max_conc=10.0
+    )
+    high = GuidanceHead(
+        32, n_heads=2, init_mode="normal", init_std=1.0, raw_scale=10.0, max_conc=100.0
+    )
+    # copy weights so only the cap differs
+    high.load_state_dict(low.state_dict())
+    eta_low = (2.0 * low(fused)[0].mean - 1.0).abs().max().item()
+    eta_high = (2.0 * high(fused)[0].mean - 1.0).abs().max().item()
+    assert eta_low <= 0.83  # default cap ceiling
+    assert eta_high > eta_low  # raising the cap extends reachable eta

--- a/rlvr/autoresearch/tools/README.md
+++ b/rlvr/autoresearch/tools/README.md
@@ -267,6 +267,22 @@ Comfort-aware variant of `build_clguided_target` (target *selection*, not re-tim
 ### sweep_epoch_comfort.py
 Per-epoch sweep that merges each LoRA epoch and scores it on BOTH avoidance (via `eval_det_avoidance.score_det_scenes`) and open-loop comfort (lat-accel/jerk percentiles via `eval_driving_metrics.lat_accel_smoothed`), so you can pick the epoch on the comfort↔avoidance↔L2 frontier. Pair with `valid_predictor` for L2. Usage: `python -m rlvr.autoresearch.tools.sweep_epoch_comfort --run_dir <lora_run_dir> --base_model <warmstart.pth> --scenes <json> --config <reward.json> --ego_shape WB,L,W --output_dir <dir> --epochs all`.
 
+### add_distractor_neighbors_npz.py
+Places NEW stopped (parked) "distractor" vehicles into a scene's empty neighbor slots, beside the ego path,
+to teach proximity discrimination rather than mere presence ("avoid the close one, ignore the distant ones"
+vs "avoid iff any stopped car exists"). A placed vehicle is kept only if the whole baseline `ego_agent_future`
+plan clears it by `>= --min_path_clearance` AND the t=0 ego pose clears it by `>= --min_t0_clearance`
+(canonical `plan_static_clearance` OBB — no hand-rolled geometry), so distractors are provably non-candidates.
+Use on avoidance scenes (real obstacle stays + decoys to ignore) AND on neighbor-stripped twins
+(`strip_neighbors_npz`, decoys-only — stopped cars present but none to avoid). Emits `manifest.json` with the
+placed `(slot, x, y, heading)` per scene. Handles 3- or 4-col `neighbor_agents_future`.
+```bash
+python -m rlvr.autoresearch.tools.add_distractor_neighbors_npz \
+  --scenes <list.json> --out_dir <dir> --out_list <out.json> \
+  --ego_shape WB,L,W --n_per_scene 1 --n_distractors 1,3 \
+  --lat_range 6.0,16.0 --min_path_clearance 3.0 --min_t0_clearance 1.0 --seed 0
+```
+
 ## PRiSM — Perturbation-Recovery iterative Self-Mining
 
 Tools for the self-improvement loop described in `rlvr/README.md` (see "PRiSM" section). Per round: sim NPZ pool → mine warm scenes → perturb → K=N + reward.py rank → filter → ranked-SFT warmstarted → iterate.

--- a/rlvr/autoresearch/tools/add_distractor_neighbors_npz.py
+++ b/rlvr/autoresearch/tools/add_distractor_neighbors_npz.py
@@ -203,10 +203,14 @@ def main():
             raise ValueError(f"{sp}: batched neighbor array — expected unbatched NPZ")
         plan = _future_as_plan(base["ego_agent_future"])
         valid_idx = _valid_path_indices(plan)
-        if valid_idx.size == 0:
+        # ego_agent_future is zero-padded on invalid steps; those rows would put a
+        # phantom ego at the origin and skew the clearance. Use ONLY valid waypoints,
+        # and require >=2 (plan_static_clearance reads per_timestep_min[:,1:]).
+        if valid_idx.size < 2:
             n_no_path += 1
-            print(f"  [skip] {Path(sp).name}: ego_agent_future has no valid waypoints")
+            print(f"  [skip] {Path(sp).name}: ego_agent_future has <2 valid waypoints")
             continue
+        plan_valid = plan[valid_idx]
         pool = Path(sp).parent.name
         for v in range(args.n_per_scene):
             nb_past = nb_past0.copy()
@@ -223,7 +227,7 @@ def main():
                 box = None
                 for _try in range(args.max_tries):
                     cand = _sample_distractor(plan, valid_idx, lat_lo, lat_hi, rng)
-                    path_clr = float(plan_static_clearance(plan, [cand], ego_shape, device))
+                    path_clr = float(plan_static_clearance(plan_valid, [cand], ego_shape, device))
                     t0_clr = float(plan_static_clearance(t0_pose, [cand], ego_shape, device))
                     if path_clr < args.min_path_clearance or t0_clr < args.min_t0_clearance:
                         continue

--- a/rlvr/autoresearch/tools/add_distractor_neighbors_npz.py
+++ b/rlvr/autoresearch/tools/add_distractor_neighbors_npz.py
@@ -69,6 +69,21 @@ def _empty_slots(nb_past: np.ndarray) -> list[int]:
     return [int(i) for i in np.where(mask)[0]]
 
 
+def _existing_boxes(nb_past: np.ndarray) -> list[tuple[float, float, float, float, float]]:
+    """(x,y,heading,length,width) of every non-empty neighbor (used to reject
+    distractors that would overlap a real agent)."""
+    boxes = []
+    for i in range(nb_past.shape[0]):
+        xy = nb_past[i, -1, :2]
+        if abs(float(xy[0])) + abs(float(xy[1])) < 1e-6:
+            continue
+        h = math.atan2(float(nb_past[i, -1, 3]), float(nb_past[i, -1, 2]))
+        boxes.append(
+            (float(xy[0]), float(xy[1]), h, float(nb_past[i, -1, 7]), float(nb_past[i, -1, 6]))
+        )
+    return boxes
+
+
 def _valid_path_indices(plan: np.ndarray) -> np.ndarray:
     """Indices of the ego plan with a non-zero (valid) waypoint."""
     return np.where(np.abs(plan[:, :2]).sum(axis=-1) > 1e-6)[0]
@@ -146,6 +161,13 @@ def main():
         help="distractor rejected if the t=0 ego pose clears it by less",
     )
     parser.add_argument(
+        "--min_neighbor_clearance",
+        type=float,
+        default=0.5,
+        help="reject a distractor whose OBB clears existing neighbors / already-placed "
+        "distractors by less than this (avoids overlapping/physically-impossible scenes)",
+    )
+    parser.add_argument(
         "--max_tries", type=int, default=20, help="resample attempts per distractor"
     )
     parser.add_argument("--seed", type=int, required=True)
@@ -195,19 +217,36 @@ def main():
                 continue
             n_target = int(rng.integers(nd_lo, nd_hi + 1))
             placed = []
+            placed_boxes = []  # (x,y,h,l,w) of distractors placed in THIS variant
+            existing = _existing_boxes(nb_past)  # real agents already in the scene
             for _ in range(min(n_target, len(slots))):
                 box = None
                 for _try in range(args.max_tries):
                     cand = _sample_distractor(plan, valid_idx, lat_lo, lat_hi, rng)
                     path_clr = float(plan_static_clearance(plan, [cand], ego_shape, device))
                     t0_clr = float(plan_static_clearance(t0_pose, [cand], ego_shape, device))
-                    if path_clr >= args.min_path_clearance and t0_clr >= args.min_t0_clearance:
-                        box = cand
-                        break
+                    if path_clr < args.min_path_clearance or t0_clr < args.min_t0_clearance:
+                        continue
+                    # Reject if it overlaps a real agent or an already-placed distractor.
+                    # Canonical OBB (no centroid-to-centroid): the candidate's own pose as
+                    # a 2-step plan, ego footprint as a conservative (larger) proxy box.
+                    others = existing + placed_boxes
+                    cand_pose = np.array(
+                        [[cand[0], cand[1], math.cos(cand[2]), math.sin(cand[2])]] * 2,
+                        dtype=np.float32,
+                    )
+                    if others and (
+                        float(plan_static_clearance(cand_pose, others, ego_shape, device))
+                        < args.min_neighbor_clearance
+                    ):
+                        continue
+                    box = cand
+                    break
                 if box is None:
                     continue  # could not find a safe far placement this try-budget
                 slot = slots.pop()
                 _write_distractor(nb_past, nb_fut, slot, box)
+                placed_boxes.append(box)
                 placed.append(
                     {
                         "slot": slot,

--- a/rlvr/autoresearch/tools/add_distractor_neighbors_npz.py
+++ b/rlvr/autoresearch/tools/add_distractor_neighbors_npz.py
@@ -69,20 +69,6 @@ def _empty_slots(nb_past: np.ndarray) -> list[int]:
     return [int(i) for i in np.where(mask)[0]]
 
 
-def _existing_boxes(nb_past: np.ndarray) -> list[tuple[float, float, float, float, float]]:
-    """(x,y,heading,length,width) of every non-empty neighbor (any motion)."""
-    boxes = []
-    for i in range(nb_past.shape[0]):
-        xy = nb_past[i, -1, :2]
-        if abs(float(xy[0])) + abs(float(xy[1])) < 1e-6:
-            continue
-        h = math.atan2(float(nb_past[i, -1, 3]), float(nb_past[i, -1, 2]))
-        boxes.append(
-            (float(xy[0]), float(xy[1]), h, float(nb_past[i, -1, 7]), float(nb_past[i, -1, 6]))
-        )
-    return boxes
-
-
 def _valid_path_indices(plan: np.ndarray) -> np.ndarray:
     """Indices of the ego plan with a non-zero (valid) waypoint."""
     return np.where(np.abs(plan[:, :2]).sum(axis=-1) > 1e-6)[0]
@@ -169,6 +155,11 @@ def main():
     ego_shape = tuple(float(x) for x in args.ego_shape.split(","))
     lat_lo, lat_hi = (float(x) for x in args.lat_range.split(","))
     nd_lo, nd_hi = (int(x) for x in args.n_distractors.split(","))
+    # Fail loud on reversed ranges (no silent reversed-sampling / empty draw).
+    if not (0.0 <= lat_lo <= lat_hi):
+        raise SystemExit(f"--lat_range must be 0 <= min <= max; got {args.lat_range!r}")
+    if not (1 <= nd_lo <= nd_hi):
+        raise SystemExit(f"--n_distractors must be 1 <= min <= max; got {args.n_distractors!r}")
     rng = np.random.default_rng(args.seed)
 
     with open(args.scenes) as f:

--- a/rlvr/autoresearch/tools/add_distractor_neighbors_npz.py
+++ b/rlvr/autoresearch/tools/add_distractor_neighbors_npz.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Add far-from-path STOPPED distractor vehicles to avoidance scene NPZs.
+
+Motivation (false-detection reduction for the guidance explorer): the policy
+must learn to avoid only the stopped vehicles that are actually IN the ego's
+way, not every stopped vehicle in the scene. The counterfactual `strip` tool
+teaches "no neighbor -> eta 0", but that overshoots into domain blindness
+(the policy learns to key on EMPTY road rather than on proximity). This tool
+instead places NEW stopped vehicles at locations that are deliberately FAR
+from the baseline ego trajectory, so they are NOT avoidance candidates:
+
+  - in an avoidance scene, the real close obstacle stays, plus decoys that
+    must be ignored;
+  - in a neighbor-stripped anchor scene, the only neighbors are decoys, so
+    the correct output is still eta 0 even though stopped cars are present.
+
+Together these teach the discriminative target "avoid the close one, ignore
+the distant ones" rather than "avoid iff any stopped car exists".
+
+Placement (ego frame): pick an anchor point along the ego_agent_future path,
+offset it laterally by a large signed magnitude (so it sits beside / off the
+corridor), orient it along the local path heading. A placed vehicle is KEPT
+only if the whole baseline ego plan clears it by >= --min_path_clearance
+(canonical plan_static_clearance OBB, no hand-rolled geometry) AND the t=0 ego
+pose clears it by >= --min_t0_clearance. Distractors are written into empty
+neighbor slots (320-cap); existing agents are copied verbatim.
+
+Usage:
+    python -m rlvr.autoresearch.tools.add_distractor_neighbors_npz \
+        --scenes <list.json> --out_dir <dir> --out_list <out.json> \
+        --ego_shape 4.76,7.24,2.29 \
+        --n_per_scene 1 --n_distractors 1,3 \
+        --lat_range 6.0,16.0 --min_path_clearance 3.0 --min_t0_clearance 1.0 \
+        --seed 0
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from scenario_generation.explorer_runner import plan_static_clearance
+
+# Default distractor footprint (a typical parked sedan/van; metres).
+DEFAULT_VEH_WIDTH = 2.0
+DEFAULT_VEH_LENGTH = 4.7
+
+
+def _future_as_plan(fut: np.ndarray) -> np.ndarray:
+    """ego_agent_future (T,3 yaw | T,4 cos/sin) -> (T,4) [x,y,cos,sin]."""
+    if fut.shape[-1] == 4:
+        return fut.astype(np.float32)
+    if fut.shape[-1] == 3:
+        return np.stack(
+            [fut[:, 0], fut[:, 1], np.cos(fut[:, 2]), np.sin(fut[:, 2])], axis=-1
+        ).astype(np.float32)
+    raise ValueError(f"unsupported ego_agent_future width {fut.shape[-1]}")
+
+
+def _empty_slots(nb_past: np.ndarray) -> list[int]:
+    """Indices of padding rows (xy ~ 0 at the current/last past timestep)."""
+    xy = nb_past[:, -1, :2]
+    mask = np.abs(xy).sum(axis=-1) < 1e-6
+    return [int(i) for i in np.where(mask)[0]]
+
+
+def _existing_boxes(nb_past: np.ndarray) -> list[tuple[float, float, float, float, float]]:
+    """(x,y,heading,length,width) of every non-empty neighbor (any motion)."""
+    boxes = []
+    for i in range(nb_past.shape[0]):
+        xy = nb_past[i, -1, :2]
+        if abs(float(xy[0])) + abs(float(xy[1])) < 1e-6:
+            continue
+        h = math.atan2(float(nb_past[i, -1, 3]), float(nb_past[i, -1, 2]))
+        boxes.append(
+            (float(xy[0]), float(xy[1]), h, float(nb_past[i, -1, 7]), float(nb_past[i, -1, 6]))
+        )
+    return boxes
+
+
+def _valid_path_indices(plan: np.ndarray) -> np.ndarray:
+    """Indices of the ego plan with a non-zero (valid) waypoint."""
+    return np.where(np.abs(plan[:, :2]).sum(axis=-1) > 1e-6)[0]
+
+
+def _sample_distractor(
+    plan: np.ndarray, valid_idx: np.ndarray, lat_lo: float, lat_hi: float, rng
+) -> tuple[float, float, float, float, float]:
+    """Sample one (x,y,heading,length,width) beside the ego path."""
+    t = int(rng.choice(valid_idx))
+    px, py = float(plan[t, 0]), float(plan[t, 1])
+    ph = math.atan2(float(plan[t, 3]), float(plan[t, 2]))
+    # perpendicular to the local path heading
+    nperp = (-math.sin(ph), math.cos(ph))
+    d = float(rng.uniform(lat_lo, lat_hi)) * float(rng.choice([-1.0, 1.0]))
+    x = px + d * nperp[0]
+    y = py + d * nperp[1]
+    # parked along the road (parallel), occasionally facing the other way
+    h = ph + (math.pi if rng.random() < 0.5 else 0.0)
+    return (x, y, h, DEFAULT_VEH_LENGTH, DEFAULT_VEH_WIDTH)
+
+
+def _write_distractor(nb_past: np.ndarray, nb_fut: np.ndarray, slot: int, box) -> None:
+    """Fill neighbor `slot` with a static (stopped) vehicle, in-place."""
+    x, y, h, length, width = box
+    c, s = math.cos(h), math.sin(h)
+    # past: repeated static pose, zero velocity, vehicle one-hot
+    nb_past[slot, :, :] = 0.0
+    nb_past[slot, :, 0] = x
+    nb_past[slot, :, 1] = y
+    nb_past[slot, :, 2] = c
+    nb_past[slot, :, 3] = s
+    nb_past[slot, :, 6] = width
+    nb_past[slot, :, 7] = length
+    nb_past[slot, :, 8] = 1.0  # vehicle one-hot
+    # future: same static pose (parked car), matching the future column width
+    w = nb_fut.shape[-1]
+    nb_fut[slot, :, :] = 0.0
+    nb_fut[slot, :, 0] = x
+    nb_fut[slot, :, 1] = y
+    if w == 4:
+        nb_fut[slot, :, 2] = c
+        nb_fut[slot, :, 3] = s
+    elif w == 3:
+        nb_fut[slot, :, 2] = h
+    else:
+        raise ValueError(f"unsupported neighbor_agents_future width {w}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--scenes", required=True, help="JSON list of NPZ paths")
+    parser.add_argument("--out_dir", required=True)
+    parser.add_argument("--out_list", required=True)
+    parser.add_argument("--ego_shape", required=True, help="WB,L,W — must match the platform")
+    parser.add_argument("--n_per_scene", type=int, required=True)
+    parser.add_argument(
+        "--n_distractors", required=True, help="min,max distractors per output scene"
+    )
+    parser.add_argument(
+        "--lat_range", required=True, help="min,max lateral |offset| from the ego path (m)"
+    )
+    parser.add_argument(
+        "--min_path_clearance",
+        type=float,
+        required=True,
+        help="distractor rejected if the ego plan clears it by less (keeps it a non-candidate)",
+    )
+    parser.add_argument(
+        "--min_t0_clearance",
+        type=float,
+        required=True,
+        help="distractor rejected if the t=0 ego pose clears it by less",
+    )
+    parser.add_argument(
+        "--max_tries", type=int, default=20, help="resample attempts per distractor"
+    )
+    parser.add_argument("--seed", type=int, required=True)
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    ego_shape = tuple(float(x) for x in args.ego_shape.split(","))
+    lat_lo, lat_hi = (float(x) for x in args.lat_range.split(","))
+    nd_lo, nd_hi = (int(x) for x in args.n_distractors.split(","))
+    rng = np.random.default_rng(args.seed)
+
+    with open(args.scenes) as f:
+        paths = json.load(f)
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    t0_pose = np.array([[0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 1.0, 0.0]], dtype=np.float32)
+    written, manifest = [], []
+    n_no_slot = n_no_path = n_short = 0
+    total_placed = 0
+    for sp in paths:
+        base = dict(np.load(sp, allow_pickle=True))
+        if "neighbor_agents_past" not in base or "neighbor_agents_future" not in base:
+            raise ValueError(f"{sp}: missing neighbor arrays")
+        nb_past0 = base["neighbor_agents_past"]
+        nb_fut0 = base["neighbor_agents_future"]
+        if nb_past0.ndim == 4:
+            raise ValueError(f"{sp}: batched neighbor array — expected unbatched NPZ")
+        plan = _future_as_plan(base["ego_agent_future"])
+        valid_idx = _valid_path_indices(plan)
+        if valid_idx.size == 0:
+            n_no_path += 1
+            print(f"  [skip] {Path(sp).name}: ego_agent_future has no valid waypoints")
+            continue
+        pool = Path(sp).parent.name
+        for v in range(args.n_per_scene):
+            nb_past = nb_past0.copy()
+            nb_fut = nb_fut0.copy()
+            slots = _empty_slots(nb_past)
+            if not slots:
+                n_no_slot += 1
+                continue
+            n_target = int(rng.integers(nd_lo, nd_hi + 1))
+            placed = []
+            for _ in range(min(n_target, len(slots))):
+                box = None
+                for _try in range(args.max_tries):
+                    cand = _sample_distractor(plan, valid_idx, lat_lo, lat_hi, rng)
+                    path_clr = float(plan_static_clearance(plan, [cand], ego_shape, device))
+                    t0_clr = float(plan_static_clearance(t0_pose, [cand], ego_shape, device))
+                    if path_clr >= args.min_path_clearance and t0_clr >= args.min_t0_clearance:
+                        box = cand
+                        break
+                if box is None:
+                    continue  # could not find a safe far placement this try-budget
+                slot = slots.pop()
+                _write_distractor(nb_past, nb_fut, slot, box)
+                placed.append(
+                    {
+                        "slot": slot,
+                        "x": round(box[0], 2),
+                        "y": round(box[1], 2),
+                        "heading": round(box[2], 3),
+                    }
+                )
+            if not placed:
+                n_short += 1
+                continue
+            out = dict(base)
+            out["neighbor_agents_past"] = nb_past
+            out["neighbor_agents_future"] = nb_fut
+            out_path = out_dir / f"{pool}__{Path(sp).stem}_dist{v:02d}.npz"
+            np.savez(out_path, **out)
+            written.append(str(out_path))
+            total_placed += len(placed)
+            manifest.append(
+                {"source": sp, "variant": v, "distractors": placed, "out": str(out_path)}
+            )
+
+    with open(args.out_list, "w") as f:
+        json.dump(written, f, indent=1)
+    with open(out_dir / "manifest.json", "w") as f:
+        json.dump(manifest, f, indent=1)
+    print(
+        f"\n[add_distractor] {len(written)} scenes ({total_placed} distractors) "
+        f"from {len(paths)} bases -> {args.out_list}"
+    )
+    print(f"  skipped: {n_no_path} no-path, {n_no_slot} no-empty-slot, {n_short} no-safe-placement")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/batched_closedloop_videos.py
+++ b/rlvr/autoresearch/tools/batched_closedloop_videos.py
@@ -102,7 +102,12 @@ def batched_closed_loop(
                         noise_min=0.0,
                         noise_max=0.0,
                         first_deterministic=False,
-                        composer=make_composer(etas, gargs),
+                        composer=make_composer(
+                            etas,
+                            gargs,
+                            envelope=getattr(policy, "guidance_envelope", None),
+                            strength=pout.strength,
+                        ),
                         device=device,
                     )
                     .cpu()

--- a/rlvr/autoresearch/tools/eval_closedloop_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_closedloop_avoidance.py
@@ -56,6 +56,8 @@ def make_guided_predict(policy, heads, args, device):
         enc = run_frozen_encoder(model, norm)
         out = policy(enc, x_ref, deterministic=True)
         etas = {h: (2.0 * out.dists[h].mean - 1.0).reshape(1) for h in heads}
+        gain = float(getattr(args, "strength_gain", 1.0))
+        strength = out.strength * gain if out.strength is not None else None
         return (
             _batched_generate_varied_noise(
                 model,
@@ -65,7 +67,10 @@ def make_guided_predict(policy, heads, args, device):
                 noise_max=0.0,
                 first_deterministic=False,
                 composer=make_composer(
-                    etas, args, envelope=getattr(policy, "guidance_envelope", None)
+                    etas,
+                    args,
+                    envelope=getattr(policy, "guidance_envelope", None),
+                    strength=strength,
                 ),
                 device=device,
                 use_dit_memo=not args.no_dit_memo,
@@ -138,6 +143,13 @@ def main():
     parser.add_argument("--lambda_spd", type=float, default=None)
     parser.add_argument("--stretch_scale", type=float, default=None)
     parser.add_argument("--guidance_scale", type=float, default=None)
+    parser.add_argument(
+        "--strength_gain",
+        type=float,
+        default=1.0,
+        help="deploy-time multiplier on the learned strength gate g (FP-safe: g≈0 "
+        "on non-avoidance scenes). No effect on policies without a strength head.",
+    )
     parser.add_argument(
         "--no_dit_memo",
         action="store_true",

--- a/rlvr/autoresearch/tools/eval_policy_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_policy_avoidance.py
@@ -419,10 +419,10 @@ def main():
         "--strength_gain",
         type=float,
         default=1.0,
-        help="deploy-time multiplier on the learned strength gate g (applied = "
-        "min(1.0*gain, ...) is NOT clamped; g is small on non-avoidance scenes "
-        "so a gain>1 amplifies guidance only where the gate is already open — "
-        "FP-safe by construction). No effect on policies without a strength head.",
+        help="deploy-time multiplier on the learned strength gate g (applied = g*gain, "
+        "NOT clamped). g is ~0 on non-avoidance scenes, so gain>1 amplifies guidance only "
+        "where the gate is already open — FP-safe by construction. No effect on policies "
+        "without a strength head.",
     )
     parser.add_argument("--lambda_col", type=float, default=None)
     parser.add_argument(

--- a/rlvr/autoresearch/tools/eval_policy_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_policy_avoidance.py
@@ -101,7 +101,7 @@ def check_guidance_envelope_override(overrides: list[str], force: bool) -> None:
 
 
 def make_composer(
-    etas: dict[str, torch.Tensor], args, envelope: dict | None = None
+    etas: dict[str, torch.Tensor], args, envelope: dict | None = None, strength=None
 ) -> GuidanceComposer:
     """Build a guidance composer for one set of etas.
 
@@ -142,6 +142,7 @@ def make_composer(
         etas,
         head_protect=int(getattr(args, "head_protect", 0)),
         fast=not bool(getattr(args, "slow_composer", False)),
+        guidance_strength=strength,
         **resolved,
     )
 
@@ -169,6 +170,8 @@ def eval_scene(model, model_args, policy, heads, npz_path, rcfg, args, device):
 
     out = policy(enc, x_ref, deterministic=True)
     mean_etas = {h: (2.0 * out.dists[h].mean - 1.0).reshape(1) for h in heads}
+    gain = float(getattr(args, "strength_gain", 1.0))
+    strength = out.strength * gain if out.strength is not None else None
 
     K = max(1, args.refine_k)
     if K > 1:
@@ -189,7 +192,12 @@ def eval_scene(model, model_args, policy, heads, npz_path, rcfg, args, device):
                 K_data[k] = v.expand(K, *v.shape[1:]).contiguous()
             else:
                 K_data[k] = v
-        composer = make_composer(cand, args, envelope=getattr(policy, "guidance_envelope", None))
+        composer = make_composer(
+            cand,
+            args,
+            envelope=getattr(policy, "guidance_envelope", None),
+            strength=(strength.expand(K) if strength is not None else None),
+        )
         from rlvr.closed_loop.batched_rollout import _batched_generate_varied_noise
 
         cands = (
@@ -209,7 +217,12 @@ def eval_scene(model, model_args, policy, heads, npz_path, rcfg, args, device):
         )
     else:
         cand = mean_etas
-        composer = make_composer(cand, args, envelope=getattr(policy, "guidance_envelope", None))
+        composer = make_composer(
+            cand,
+            args,
+            envelope=getattr(policy, "guidance_envelope", None),
+            strength=strength,
+        )
         cands = generate_samples(
             model=model,
             model_args=model_args,
@@ -270,6 +283,7 @@ def eval_scene(model, model_args, policy, heads, npz_path, rcfg, args, device):
         "scene": Path(npz_path).name,
         "scene_path": str(npz_path),
         "etas": {h: float(v.item()) for h, v in etas.items()},
+        "strength": (float(out.strength.item()) if out.strength is not None else None),
         "deviation": deviation,
         "guided": _row(g_bd),
         "baseline": _row(d_bd),
@@ -401,6 +415,15 @@ def main():
         "calibration (otherwise a disagreeing flag hard-fails)",
     )
     parser.add_argument("--envelope", choices=["v1", "v2"], default=None)
+    parser.add_argument(
+        "--strength_gain",
+        type=float,
+        default=1.0,
+        help="deploy-time multiplier on the learned strength gate g (applied = "
+        "min(1.0*gain, ...) is NOT clamped; g is small on non-avoidance scenes "
+        "so a gain>1 amplifies guidance only where the gate is already open — "
+        "FP-safe by construction). No effect on policies without a strength head.",
+    )
     parser.add_argument("--lambda_col", type=float, default=None)
     parser.add_argument(
         "--no_dit_memo",

--- a/rlvr/autoresearch/tools/valid_predictor_guided.py
+++ b/rlvr/autoresearch/tools/valid_predictor_guided.py
@@ -171,7 +171,12 @@ def main():
         enc = run_frozen_encoder(model, data)
         pout = policy(enc, det_ego, deterministic=True)
         etas = {h: (2.0 * pout.dists[h].mean - 1.0) for h in heads}
-        composer = make_composer(etas, args, envelope=getattr(policy, "guidance_envelope", None))
+        composer = make_composer(
+            etas,
+            args,
+            envelope=getattr(policy, "guidance_envelope", None),
+            strength=pout.strength,
+        )
         decoder._guidance_fn = composer
         decoder._guidance_scale = composer._set_config.global_scale
         try:

--- a/rlvr/guidance_batched.py
+++ b/rlvr/guidance_batched.py
@@ -219,6 +219,7 @@ def build_head_composer(
     lambda_col: float = 3.0,
     ramp_steps: int = 20,
     fast: bool = True,
+    guidance_strength=None,
 ):
     """Build a GuidanceComposer from a head->eta dict (scalar or [B] tensor).
 
@@ -334,7 +335,14 @@ def build_head_composer(
     if fast:
         # Equivalence-certified against GuidanceComposer (bit-identical
         # active trajectories; inert frames short-circuit to ~unguided cost).
-        return FastGuidanceComposer(set_cfg)
+        return FastGuidanceComposer(set_cfg, guidance_strength=guidance_strength)
+    if guidance_strength is not None:
+        # The strength gate scales the summed energy inside FastGuidanceComposer;
+        # the read-only diffusion_planner GuidanceComposer has no such hook.
+        raise ValueError(
+            "guidance_strength requires fast=True (FastGuidanceComposer); the "
+            "slow GuidanceComposer does not support the strength gate"
+        )
     return GuidanceComposer(set_cfg)
 
 
@@ -512,7 +520,12 @@ class FastGuidanceComposer:
     """
 
     def __init__(
-        self, set_config, eta_eps: float = 1e-3, skip_x0_correction: bool = False, **build_kwargs
+        self,
+        set_config,
+        eta_eps: float = 1e-3,
+        skip_x0_correction: bool = False,
+        guidance_strength=None,
+        **build_kwargs,
     ):
         from diffusion_planner.model.guidance.registry import build as _build
 
@@ -523,6 +536,19 @@ class FastGuidanceComposer:
         self._eta_eps = float(eta_eps)
         self._skip_x0 = bool(skip_x0_correction)
         self._inputs_phys = None  # per-generation cache
+        # Learned guidance-strength gate g in (0,1): scales the summed guidance
+        # energy (hence the guidance gradient) per scene. None -> no gating
+        # (full envelope). [B] tensor (or scalar) broadcast over the batch.
+        self._strength = guidance_strength
+
+    def _strength_inert(self) -> bool:
+        """True if the strength gate forces zero guidance for the whole batch."""
+        s = self._strength
+        if s is None:
+            return False
+        if isinstance(s, torch.Tensor):
+            return bool(s.abs().max().item() <= self._eta_eps)
+        return abs(float(s)) <= self._eta_eps
 
     def reset_cache(self):
         self._inputs_phys = None
@@ -565,7 +591,7 @@ class FastGuidanceComposer:
 
     def __call__(self, x_in, t_input, cond, *args, **kwargs):
         B = x_in.shape[0]
-        if self._all_inert():
+        if self._all_inert() or self._strength_inert():
             # zero surrogate with a real graph so the solver's autograd
             # produces an (all-zero) gradient of the right shape
             return (x_in * 0.0).sum()
@@ -595,6 +621,15 @@ class FastGuidanceComposer:
             if torch.isnan(e).any():
                 continue
             raw_energy = raw_energy + e
+        if self._strength is not None:
+            # Per-scene learned gate: scale the summed energy (g is constant
+            # w.r.t. x, so the guidance gradient is scaled by g per sample).
+            s = self._strength
+            if isinstance(s, torch.Tensor):
+                s = s.to(raw_energy.device).reshape(-1)
+                if s.numel() == 1:
+                    s = s.expand(B)
+            raw_energy = raw_energy * s
         if raw_energy.requires_grad:
             grad_phys = torch.autograd.grad(raw_energy.sum(), x_phys_grad)[0]
         else:

--- a/rlvr/guidance_batched.py
+++ b/rlvr/guidance_batched.py
@@ -626,9 +626,14 @@ class FastGuidanceComposer:
             # w.r.t. x, so the guidance gradient is scaled by g per sample).
             s = self._strength
             if isinstance(s, torch.Tensor):
-                s = s.to(raw_energy.device).reshape(-1)
+                # detached: only x is differentiated; s is a constant scale.
+                s = s.detach().to(raw_energy.device).reshape(-1)
                 if s.numel() == 1:
                     s = s.expand(B)
+                elif s.numel() != B:
+                    raise ValueError(
+                        f"guidance_strength has {s.numel()} elements; expected 1 or B={B}"
+                    )
             raw_energy = raw_energy * s
         if raw_energy.requires_grad:
             grad_phys = torch.autograd.grad(raw_energy.sum(), x_phys_grad)[0]

--- a/rlvr/guidance_batched.py
+++ b/rlvr/guidance_batched.py
@@ -231,6 +231,12 @@ def build_head_composer(
     ramp_steps) for the ramped v2 functions. A legacy lateral+longitudinal
     trainer config reproduces exactly with lat_scale=1.0, lambda_lat=2.5,
     lambda_lon=0.25.
+
+    guidance_strength: optional learned per-scene strength gate (scalar or [B]
+    tensor) that multiplies the TOTAL guidance energy (g->0 = unguided). Only
+    supported with fast=True (FastGuidanceComposer); passing it with fast=False
+    raises, since the read-only GuidanceComposer has no scaling hook. None
+    (default) leaves behavior exactly as before.
     """
     from diffusion_planner.model.guidance.composer import GuidanceComposer
     from diffusion_planner.model.guidance.config import (

--- a/rlvr/test_guidance_batched.py
+++ b/rlvr/test_guidance_batched.py
@@ -316,3 +316,79 @@ def test_dit_memo_context_manager_installs_and_restores():
     except RuntimeError:
         pass
     assert dec.dit is orig
+
+
+# ---------------------------------------------------------------------------
+# FastGuidanceComposer learned strength gate (guidance_strength)
+# ---------------------------------------------------------------------------
+
+
+def test_fast_composer_strength_gate():
+    from rlvr.guidance_batched import build_head_composer
+
+    etas = {"lateral": torch.tensor([0.5, 0.5]), "collision": torch.tensor([0.5, 0.5])}
+
+    # strength=None -> gate is a no-op (prior behavior preserved)
+    comp = build_head_composer(etas, guidance_strength=None)
+    assert comp._strength is None
+    assert not comp._strength_inert()
+
+    # g==0 forces the whole batch inert even though the etas are active
+    comp = build_head_composer(etas, guidance_strength=torch.zeros(2))
+    assert comp._strength_inert()
+
+    # g below eta_eps is treated as inert; a real gate value is active
+    assert build_head_composer(etas, guidance_strength=torch.full((2,), 1e-4))._strength_inert()
+    assert not build_head_composer(etas, guidance_strength=torch.tensor(0.5))._strength_inert()
+    assert not build_head_composer(
+        etas, guidance_strength=torch.tensor([0.9, 0.9])
+    )._strength_inert()
+
+
+def test_fast_composer_strength_scaling_and_shape_guard():
+    """The gate scales summed energy per-sample (g constant w.r.t. x) and a
+    wrong-length strength raises instead of silently misbroadcasting."""
+    from rlvr.guidance_batched import FastGuidanceComposer
+
+    class _E:  # minimal active function: energy = sum over the trajectory
+        _eta_lat = 1.0  # recognized, non-inert -> composer stays active
+
+        def energy(self, x, t, inputs):
+            return x.reshape(x.shape[0], -1).sum(dim=-1)
+
+    def _mk(strength):
+        c = FastGuidanceComposer.__new__(FastGuidanceComposer)
+        c._functions = [_E()]
+        c._eta_eps = 1e-3
+        c._skip_x0 = True
+        c._inputs_phys = {}
+        c._strength = strength
+        return c
+
+    B, P, T = 2, 1, 4
+
+    class _Norm:
+        std = torch.ones(4)  # broadcasts over the last (feature) dim of [B,P,T,4]
+
+        def inverse(self, x):
+            return x
+
+    kwargs = dict(state_normalizer=_Norm(), observation_normalizer=_Norm(), inputs={})
+    # x_in is reshaped to [B, P, -1, 4] inside __call__, so it must be [B, P, T*4].
+    x = torch.arange(B * P * T * 4, dtype=torch.float32).reshape(B, P, T * 4) + 1.0
+    t = torch.zeros(B)
+
+    g1 = _mk(None)(x, t, {}, **kwargs)
+    g2 = _mk(torch.tensor([2.0, 2.0]))(x, t, {}, **kwargs)
+    # surrogate is linear in the energy scale, so 2x strength -> 2x surrogate
+    assert torch.allclose(g2, 2.0 * g1)
+
+    # scalar strength broadcasts to the batch
+    assert torch.allclose(_mk(torch.tensor(2.0))(x, t, {}, **kwargs), g2)
+
+    # wrong-length strength must raise (no silent misbroadcast)
+    try:
+        _mk(torch.tensor([2.0, 2.0, 2.0]))(x, t, {}, **kwargs)
+        raise AssertionError("expected ValueError for strength length != B")
+    except ValueError:
+        pass

--- a/rlvr/train_explorer_regression.py
+++ b/rlvr/train_explorer_regression.py
@@ -30,6 +30,7 @@ from pathlib import Path
 
 import numpy as np
 import torch
+import torch.nn.functional as F
 from torch import optim
 
 from exploration_policy.model import ExplorationPolicy, ExplorationPolicyConfig
@@ -224,6 +225,12 @@ def main():
     parser.add_argument("--hidden_dim", type=int, default=128)
     parser.add_argument("--head_raw_scale", type=float, default=10.0)
     parser.add_argument(
+        "--head_max_conc",
+        type=float,
+        default=10.0,
+        help="Beta concentration cap (default 10 caps |eta|≈0.82; raise to reach near-±1.0 etas)",
+    )
+    parser.add_argument(
         "--guidance_envelope",
         default=None,
         help="JSON file with the guidance envelope the --labels were swept at "
@@ -238,6 +245,21 @@ def main():
         help="warm-start: load this exploration_policy.pth before training (heads/arch must match)",
     )
     parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--use_strength_head",
+        action="store_true",
+        help="add a learned scalar guidance-strength gate g in (0,1); target 1 "
+        "on solved avoidance scenes, 0 on every zero-target scene. At inference "
+        "the composer multiplies the total guidance energy by g (an intrinsic "
+        "false-positive gate). Replaces relying on the hand-set envelope for "
+        "engagement strength.",
+    )
+    parser.add_argument(
+        "--strength_weight",
+        type=float,
+        default=1.0,
+        help="BCE loss weight for the strength gate (only with --use_strength_head)",
+    )
     args = parser.parse_args()
 
     torch.manual_seed(args.seed)
@@ -292,6 +314,8 @@ def main():
         device=device,
     )
     is_avoid = torch.tensor([cls == "avoid" for _, _, cls in entries], device=device)
+    # Strength-gate target: 1.0 on real-avoidance scenes, 0.0 on zero-target.
+    strength_target = is_avoid.float()
 
     # --- Stratified train/val split (keep avoidance scenes in both) ---
     g = torch.Generator().manual_seed(args.seed)
@@ -316,7 +340,9 @@ def main():
         dropout=args.dropout,
         encoder_hidden_dim=model_args.hidden_dim,
         head_raw_scale=args.head_raw_scale,
+        head_max_conc=args.head_max_conc,
         heads=heads,
+        use_strength_head=args.use_strength_head,
         guidance_envelope=guidance_envelope,
     )
     policy = ExplorationPolicy(ep_config, ref_seq_len=model_args.future_len).to(device)
@@ -342,18 +368,27 @@ def main():
         print(f"[warm-start] loaded {args.init_from}")
     optimizer = optim.AdamW(policy.parameters(), lr=args.lr)
 
-    def pred_etas(idx_batch):
+    def pred_out(idx_batch):
         out = policy(enc[idx_batch], xref[idx_batch], deterministic=True)
-        return torch.stack([2.0 * out.dists[h].mean - 1.0 for h in heads], dim=-1)
+        etas = torch.stack([2.0 * out.dists[h].mean - 1.0 for h in heads], dim=-1)
+        return etas, out.strength
 
     def eval_split(idx_split):
         policy.eval()
         with torch.no_grad():
-            pred = pred_etas(idx_split)
+            pred, pred_s = pred_out(idx_split)
             err = (pred - targets[idx_split]) ** 2
             mse = (err.mean(dim=-1) * weights[idx_split]).mean()
             av = is_avoid[idx_split]
-            metrics = {"weighted_mse": float(mse)}
+            metrics = {"weighted_mse": float(mse), "sel_loss": float(mse)}
+            if args.use_strength_head:
+                bce = F.binary_cross_entropy(pred_s, strength_target[idx_split])
+                metrics["strength_bce"] = float(bce)
+                metrics["sel_loss"] = float(mse + args.strength_weight * bce)
+                if av.any():
+                    metrics["avoid_g_mean"] = float(pred_s[av].mean())
+                if (~av).any():
+                    metrics["inert_g_mean"] = float(pred_s[~av].mean())
             if av.any():
                 # sign accuracy of the dominant (largest-|target|) head per scene
                 t_a, p_a = targets[idx_split][av], pred[av]
@@ -377,8 +412,12 @@ def main():
         ep_loss, n_b = 0.0, 0
         for s in range(0, len(perm), args.batch_size):
             b = perm[s : s + args.batch_size]
-            pred = pred_etas(b)
+            pred, pred_s = pred_out(b)
             loss = (((pred - targets[b]) ** 2).mean(dim=-1) * weights[b]).mean()
+            if args.use_strength_head:
+                loss = loss + args.strength_weight * F.binary_cross_entropy(
+                    pred_s, strength_target[b]
+                )
             optimizer.zero_grad()
             loss.backward()
             torch.nn.utils.clip_grad_norm_(policy.parameters(), 1.0)
@@ -396,16 +435,23 @@ def main():
         }
         log_rows.append(row)
         if epoch % 10 == 0 or epoch == 1:
+            gate = ""
+            if args.use_strength_head:
+                gate = (
+                    f" g_avoid={val_m.get('avoid_g_mean', -1):.3f} "
+                    f"g_inert={val_m.get('inert_g_mean', -1):.3f} "
+                    f"g_bce={val_m.get('strength_bce', -1):.4f}"
+                )
             print(
                 f"  ep{epoch:3d} train={row['train_loss']:.4f} "
                 f"val_mse={val_m['weighted_mse']:.4f} "
                 f"avoid_sign={val_m.get('avoid_sign_acc', -1):.2f} "
                 f"avoid_|p|={val_m.get('avoid_pred_absmean', -1):.3f} "
-                f"inert_|p|={val_m.get('inert_pred_absmean', -1):.4f}"
+                f"inert_|p|={val_m.get('inert_pred_absmean', -1):.4f}" + gate
             )
 
-        if val_m["weighted_mse"] < best_val - 1e-5:
-            best_val = val_m["weighted_mse"]
+        if val_m["sel_loss"] < best_val - 1e-5:
+            best_val = val_m["sel_loss"]
             best_epoch = epoch
             torch.save(policy.state_dict(), run_dir / "exploration_policy.pth")
         if epoch - best_epoch >= args.patience:

--- a/rlvr/train_explorer_regression.py
+++ b/rlvr/train_explorer_regression.py
@@ -463,8 +463,9 @@ def main():
         json.dump(log_rows, f, indent=1)
     with open(run_dir / "train_args.json", "w") as f:
         json.dump(vars(args), f, indent=1)
+    sel_name = "sel_loss" if args.use_strength_head else "val_mse"
     print(
-        f"[done] best val_mse={best_val:.4f} @ ep{best_epoch}; "
+        f"[done] best {sel_name}={best_val:.4f} @ ep{best_epoch}; "
         f"saved {run_dir / 'exploration_policy.pth'}"
     )
 


### PR DESCRIPTION
## Summary

Adds an opt-in, backward-compatible extension to the guidance-explorer pipeline that makes a trained explorer far more robust to **false detections** (firing when nothing needs avoiding), while keeping its avoidance behavior. Existing policies/configs are unchanged — every new field defaults to prior behavior.

Three pieces:

### 1. Learned strength gate (`use_strength_head`)
The policy emits one extra scalar `g ∈ (0,1)` (new `StrengthHead`) that the composer multiplies into the **total** guidance energy (`g→0` = exactly the unguided plan). It is trained as a per-scene "engage?" gate (target 1 on real-avoidance scenes, 0 on zero-target scenes). This decouples *whether/how-hard to engage* from *which way to swerve* (the eta heads), and is a much stronger false-positive suppressor than relying on the eta heads alone — a single dedicated gate drives to 0 far more reliably than two heads both landing on 0. It also replaces the envelope's hand-tuned aggressiveness constant with a learned per-scene decision.

### 2. Configurable eta-reachability cap (`head_max_conc`)
`GuidanceHead`'s Beta-concentration clamp is now configurable (default `10` = prior behavior). The default caps the deterministic mean at `|eta|≈0.82`; raising it lets the policy reach near-extreme etas on tight scenes whose best guidance sits at the command range edge. The gate keeps this false-positive-safe.

### 3. `add_distractor_neighbors_npz` tool
Places far-from-path stopped "distractor" vehicles into a scene's empty neighbor slots, kept only if the whole ego plan clears them by a margin (canonical `plan_static_clearance` OBB — provably non-candidates). Used to build training data that teaches **proximity discrimination** ("avoid the in-path obstacle, ignore the distant ones") rather than presence detection.

## Eval / inference plumbing
`eval_policy_avoidance` (plus a deploy-time `--strength_gain` knob), `eval_closedloop_avoidance`, `valid_predictor_guided`, and `batched_closedloop_videos` all read and apply the policy's `strength`, so gated policies are scored and rendered at their real behavior.

## Docs
Tool README entry for `add_distractor_neighbors_npz`, and a `docs/guidance_explorer_framework.md` section on the discrimination-data + learned-gate recipe (including the "raise the reachability cap, don't add energy gain" guidance for closing the residual avoidance gap).

## Compatibility / testing
- `use_strength_head` defaults `False`, `head_max_conc` defaults `10` → old checkpoints/configs load and behave identically; config round-trips.
- pre-commit (ruff + ruff-format) passes on all touched files.
