### PR TITLE
refactor(metrics): split compute_reward_batch into compute_subscores_batch + _shape_reward

### DIFF
--- a/diffusion_planner/diffusion_planner/metrics/__init__.py
+++ b/diffusion_planner/diffusion_planner/metrics/__init__.py
@@ -3,6 +3,7 @@ importable without depending on ``rlvr``."""
 
 from __future__ import annotations
 
+from diffusion_planner.metrics.aggregate import compute_subscores_batch  # noqa: F401
 from diffusion_planner.metrics.config import RewardConfig  # noqa: F401  (re-export)
 from diffusion_planner.metrics.geometry import *  # noqa: F401,F403
 from diffusion_planner.metrics.subscores import *  # noqa: F401,F403

--- a/diffusion_planner/diffusion_planner/metrics/aggregate.py
+++ b/diffusion_planner/diffusion_planner/metrics/aggregate.py
@@ -40,7 +40,7 @@ def compute_subscores_batch(
     ego_trajs: torch.Tensor,
     data: dict[str, torch.Tensor],
     config: RewardConfig = RewardConfig(),
-) -> dict:
+) -> dict[str, torch.Tensor | list[int | None]]:
     """Raw per-trajectory subscores + diagnostics for ``ego_trajs`` ``(N, T, 4)``.
 
     Marshals ``data`` (ego_shape / neighbors / goal) and calls every subscore —

--- a/diffusion_planner/diffusion_planner/metrics/aggregate.py
+++ b/diffusion_planner/diffusion_planner/metrics/aggregate.py
@@ -1,0 +1,230 @@
+"""Raw subscore entry point.
+
+``compute_subscores_batch`` runs the input marshalling (ego_shape / neighbors /
+goal) and every per-subscore computation, but stops before any reward *shaping*
+(weights / gates / survival aggregation). It returns the raw per-trajectory
+subscores + diagnostics as a dict; ``rlvr.reward.compute_reward_batch`` feeds
+this straight into ``_shape_reward`` (single source of truth — no duplicated
+marshalling), and the validation loop logs the continuous subscores.
+
+These are reward-shaping subscores (custom thresholds, goal-based ego-progress,
+penalty signs), i.e. EPDMS-INSPIRED, NOT a faithful EPDMS port. Single scene /
+N trajectories (map + neighbor terms use one scene's tensors): callers scoring a
+multi-scene batch (validation) must call this per scene.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from diffusion_planner.metrics.config import RewardConfig
+from diffusion_planner.metrics.subscores import (
+    compute_centerline_score_batch,
+    compute_feasibility_score_batch,
+    compute_kinematic_gate,
+    compute_lane_departure_penalty,
+    compute_progress_score_batch,
+    compute_red_light_score_batch,
+    compute_road_border_penalty,
+    compute_safety_score_batch,
+    compute_smoothness_score_batch,
+    compute_static_collision_penalty,
+    compute_ttc_score_batch,
+)
+
+__all__ = ["compute_subscores_batch"]
+
+
+@torch.no_grad()
+def compute_subscores_batch(
+    ego_trajs: torch.Tensor,
+    data: dict[str, torch.Tensor],
+    config: RewardConfig = RewardConfig(),
+) -> dict:
+    """Raw per-trajectory subscores + diagnostics for ``ego_trajs`` ``(N, T, 4)``.
+
+    Marshals ``data`` (ego_shape / neighbors / goal) and calls every subscore —
+    no weighting, gating, or aggregation. Returns a dict whose continuous
+    subscores and penalties are ``(N,)`` tensors; ``*_crossing_steps`` and
+    ``collision_step`` are length-N lists; ``rb_min_dist`` / ``sc_min_dist`` are
+    the per-trajectory minima over t>=1 (the t=0 step is not model-controllable).
+    ``data`` must carry ``ego_shape``; map / neighbor terms degrade to their
+    neutral values when the corresponding keys are absent.
+    """
+    N, T, _ = ego_trajs.shape
+    device = ego_trajs.device
+
+    # --- Ego shape --- (no silent fallback; mirrors compute_reward_batch)
+    if "ego_shape" not in data:
+        raise ValueError(
+            "compute_subscores_batch: data is missing 'ego_shape' (wheel_base, "
+            "length, width). Populate ego_shape upstream and re-run."
+        )
+    es = data["ego_shape"]
+    if es.dim() == 2:
+        es = es[0]
+    if es.numel() < 3:
+        raise ValueError(
+            f"compute_subscores_batch: ego_shape has shape {tuple(es.shape)}; "
+            "expected at least 3 elements (wheel_base, length, width)."
+        )
+    ego_shape = es[:3].to(device)
+
+    # --- Neighbor data for collision ---
+    neighbor_futures = torch.zeros(0, T, 4, device=device)
+    neighbor_shapes = torch.zeros(0, 2, device=device)
+    neighbor_valid = torch.zeros(0, T, dtype=torch.bool, device=device)
+
+    if "neighbor_agents_future" in data:
+        nf = data["neighbor_agents_future"]
+        if nf.dim() == 4:
+            nf = nf[0]
+        if nf.shape[1] >= T and nf.shape[2] >= 4:
+            nf_data = nf[:, :T, :4]  # (N_nb, T, 4) = x, y, cos, sin
+        elif nf.shape[0] > 0 and nf.shape[1] >= T and nf.shape[2] == 3:
+            raise ValueError(
+                "neighbor_agents_future has 3 columns (x, y, heading_rad) but "
+                "4 columns (x, y, cos, sin) are required. Re-generate the NPZ "
+                "with the updated tensor_converter / _backfill_neighbor_futures."
+            )
+        if nf.shape[1] >= T and nf.shape[2] >= 4:
+            slot_valid = nf_data[:, :, :2].abs().sum(dim=(1, 2)) > 1e-6
+            if slot_valid.any():
+                neighbor_futures = nf_data[slot_valid]
+                neighbor_valid = neighbor_futures[:, :, :2].abs().sum(dim=-1) > 1e-6
+
+                if "neighbor_agents_past" in data:
+                    nap = data["neighbor_agents_past"]
+                    if nap.dim() == 4:
+                        nap = nap[0]
+                    ns = nap[slot_valid, -1, :]
+                    if ns.shape[-1] >= 8:
+                        neighbor_shapes = ns[:, [6, 7]]  # width, length
+                    else:
+                        neighbor_shapes = torch.full(
+                            (neighbor_futures.shape[0], 2), 2.0, device=device
+                        )
+                else:
+                    neighbor_shapes = torch.full((neighbor_futures.shape[0], 2), 2.0, device=device)
+
+    zero_shapes = neighbor_shapes.abs().sum(dim=-1) < 1e-3
+    if zero_shapes.any():
+        neighbor_shapes[zero_shapes] = torch.tensor([2.0, 4.5], device=device)
+
+    # --- Goal pose ---
+    goal_pose = torch.zeros(4, device=device)
+    if "goal_pose" in data:
+        gp = data["goal_pose"]
+        if gp.dim() == 2:
+            gp = gp[0]
+        if gp.numel() >= 4:
+            goal_pose = gp[:4].to(device)
+
+    # --- Batched subscore computation (no shaping) ---
+    safety_scores, collision_steps = compute_safety_score_batch(
+        ego_trajs, ego_shape, neighbor_futures, neighbor_shapes, neighbor_valid, config
+    )
+    progress_scores = compute_progress_score_batch(ego_trajs, goal_pose, data)
+    smoothness_scores = compute_smoothness_score_batch(ego_trajs, config)
+    feasibility_scores, off_road_fractions = compute_feasibility_score_batch(
+        ego_trajs, ego_shape, data, config
+    )
+    centerline_scores = compute_centerline_score_batch(
+        ego_trajs,
+        ego_shape,
+        data,
+        usage_mode=config.centerline_usage_mode,
+        time_weight_min=config.centerline_time_weight_min,
+    )
+    red_light_scores = compute_red_light_score_batch(ego_trajs, data, config)
+    ttc_scores = compute_ttc_score_batch(
+        ego_trajs, ego_shape, neighbor_futures, neighbor_shapes, neighbor_valid
+    )
+    (
+        rb_crossing_gate,
+        rb_near_pen,
+        rb_wide_pen,
+        rb_crossing_steps,
+        rb_cont_penalty,
+        rb_per_ts_min,
+    ) = compute_road_border_penalty(ego_trajs, ego_shape, data, config=config)
+
+    if config.enable_lane_departure:
+        (
+            lane_crossing_gate,
+            lane_near_frac,
+            lane_wide_frac,
+            lane_crossing_steps,
+            lane_cont_penalty,
+        ) = compute_lane_departure_penalty(ego_trajs, ego_shape, data, config=config)
+    else:
+        lane_crossing_gate = torch.ones(N, device=device)
+        lane_near_frac = torch.zeros(N, device=device)
+        lane_wide_frac = torch.zeros(N, device=device)
+        lane_crossing_steps: list[int | None] = [None] * N
+        lane_cont_penalty = torch.zeros(N, device=device)
+
+    if config.static_collision_enabled:
+        sc_result = compute_static_collision_penalty(
+            ego_trajs, ego_shape, neighbor_futures, neighbor_shapes, neighbor_valid, config
+        )
+        sc_crossing_gate = sc_result["crossing_gate"]
+        sc_near_pen = sc_result["near_penalty"]
+        sc_wide_pen = sc_result["wide_penalty"]
+        sc_cont_pen = sc_result["cont_penalty"]
+        sc_crossing_steps = sc_result["first_crossing_steps"]
+        sc_per_ts_min = sc_result["per_timestep_min"]
+        sc_n_stopped_scene = int(sc_result["stopped_mask"].sum().item())
+    else:
+        sc_crossing_gate = torch.ones(N, device=device)
+        sc_near_pen = torch.zeros(N, device=device)
+        sc_wide_pen = torch.zeros(N, device=device)
+        sc_cont_pen = torch.zeros(N, device=device)
+        sc_crossing_steps: list[int | None] = [None] * N
+        sc_per_ts_min = torch.full((N, T), 99.0, device=device)
+        sc_n_stopped_scene = 0
+
+    kinematic_gate = compute_kinematic_gate(ego_trajs, config, ego_shape)
+
+    # Min clearances over t>=1 only (t=0 is not model-controllable).
+    if T > 1:
+        rb_min_dist = rb_per_ts_min[:, 1:].min(dim=1).values
+        sc_min_dist = sc_per_ts_min[:, 1:].min(dim=1).values
+    else:
+        rb_min_dist = torch.full((N,), 99.0, device=device)
+        sc_min_dist = torch.full((N,), 99.0, device=device)
+
+    return {
+        # raw subscores (signs as produced by the subscore functions)
+        "safety": safety_scores,
+        "ttc": ttc_scores,
+        "progress": progress_scores,
+        "comfort": smoothness_scores,
+        "feasibility": feasibility_scores,
+        "centerline": centerline_scores,
+        "red_light": red_light_scores,
+        "kinematic_gate": kinematic_gate,  # 1.0 feasible, 0.0 violated
+        "off_road_fraction": off_road_fractions,
+        # road-border (DAC) diagnostics
+        "rb_crossing_gate": rb_crossing_gate,  # 1.0 ok, 0.0 crossing
+        "rb_near_penalty": rb_near_pen,
+        "rb_wide_penalty": rb_wide_pen,
+        "rb_cont_penalty": rb_cont_penalty,
+        "rb_min_dist": rb_min_dist,
+        "rb_crossing_steps": rb_crossing_steps,
+        # lane-departure diagnostics
+        "lane_crossing_gate": lane_crossing_gate,
+        "lane_near_frac": lane_near_frac,
+        "lane_wide_frac": lane_wide_frac,
+        "lane_cont_penalty": lane_cont_penalty,
+        "lane_crossing_steps": lane_crossing_steps,
+        # static-collision diagnostics
+        "sc_crossing_gate": sc_crossing_gate,
+        "sc_near_penalty": sc_near_pen,
+        "sc_wide_penalty": sc_wide_pen,
+        "sc_cont_penalty": sc_cont_pen,
+        "sc_min_dist": sc_min_dist,
+        "sc_n_stopped": torch.full((N,), float(sc_n_stopped_scene), device=device),
+        "sc_crossing_steps": sc_crossing_steps,
+        "collision_step": collision_steps,
+    }

--- a/rlvr/reward.py
+++ b/rlvr/reward.py
@@ -18,6 +18,7 @@ import torch
 # *shaping* (RewardBreakdown, compute_reward_batch, GRPO advantages) and
 # re-exports every moved symbol so `from rlvr.reward import ...` keeps working.
 # ---------------------------------------------------------------------------
+from diffusion_planner.metrics.aggregate import compute_subscores_batch  # noqa: F401
 from diffusion_planner.metrics.config import RewardConfig  # noqa: F401  (re-export)
 from diffusion_planner.metrics.geometry import *  # noqa: F401,F403
 from diffusion_planner.metrics.subscores import *  # noqa: F401,F403
@@ -65,6 +66,12 @@ def compute_reward_batch(
 ) -> list[RewardBreakdown]:
     """Compute reward breakdowns for N trajectories in a single batched pass.
 
+    Thin wrapper: the raw subscores (input marshalling + per-subscore
+    computation) come from ``compute_subscores_batch``; reward shaping (weights,
+    hard gates, survival/gate aggregation) is applied by ``_shape_reward``.
+    Output is byte-identical to the pre-split implementation (pinned by the
+    golden tests).
+
     Args:
         ego_trajs: (N, T, 4) x, y, cos_yaw, sin_yaw.
         data: Observation dict from load_npz_data (with batch dim).
@@ -73,170 +80,50 @@ def compute_reward_batch(
     Returns:
         List of N RewardBreakdown instances.
     """
+    return _shape_reward(compute_subscores_batch(ego_trajs, data, config), ego_trajs, data, config)
+
+
+def _shape_reward(
+    subs: dict,
+    ego_trajs: torch.Tensor,
+    data: dict[str, torch.Tensor],
+    config: RewardConfig = RewardConfig(),
+) -> list[RewardBreakdown]:
+    """Apply reward shaping (weights, hard gates, survival/gate aggregation) to the
+    raw subscores from ``compute_subscores_batch`` and build the RewardBreakdown
+    list. RLVR-specific; the raw subscore computation is neutral (lives in
+    ``diffusion_planner.metrics``)."""
     N, T, _ = ego_trajs.shape
     device = ego_trajs.device
 
-    # --- Ego shape ---
-    # No silent fallback: the wrong default footprint silently undersized RB /
-    # lane / collision gates by ~3 m of length and 0.5 m of width on larger
-    # platforms, letting trajectories that visibly crossed the border pass the
-    # gate. The NPZ MUST carry the correct ego_shape (wheel_base, length,
-    # width); callers (parse-from-bag, disturb_and_replay, etc.) are
-    # responsible for writing it.
-    if "ego_shape" not in data:
-        raise ValueError(
-            "compute_reward_batch: data is missing 'ego_shape' (wheel_base, "
-            "length, width). Refusing to fall back to a hardcoded default — "
-            "this previously caused silent footprint undersizing. Populate "
-            "ego_shape upstream (parse-from-bag / disturb_and_replay / scene "
-            "builder) and re-run."
-        )
-    es = data["ego_shape"]
-    if es.dim() == 2:
-        es = es[0]
-    if es.numel() < 3:
-        raise ValueError(
-            f"compute_reward_batch: ego_shape has shape {tuple(es.shape)}; "
-            "expected at least 3 elements (wheel_base, length, width)."
-        )
-    ego_shape = es[:3].to(device)
-
-    # --- Neighbor data for collision ---
-    neighbor_futures = torch.zeros(0, T, 4, device=device)
-    neighbor_shapes = torch.zeros(0, 2, device=device)
-    neighbor_valid = torch.zeros(0, T, dtype=torch.bool, device=device)
-
-    if "neighbor_agents_future" in data:
-        nf = data["neighbor_agents_future"]
-        if nf.dim() == 4:
-            nf = nf[0]
-        if nf.shape[1] >= T and nf.shape[2] >= 4:
-            nf_data = nf[:, :T, :4]  # (N_nb, T, 4) = x, y, cos, sin
-        elif nf.shape[0] > 0 and nf.shape[1] >= T and nf.shape[2] == 3:
-            raise ValueError(
-                f"neighbor_agents_future has 3 columns (x, y, heading_rad) but "
-                f"4 columns (x, y, cos, sin) are required. Re-generate the NPZ "
-                f"with the updated tensor_converter / _backfill_neighbor_futures."
-            )
-        if nf.shape[1] >= T and nf.shape[2] >= 4:
-            slot_valid = nf_data[:, :, :2].abs().sum(dim=(1, 2)) > 1e-6
-            if slot_valid.any():
-                neighbor_futures = nf_data[slot_valid]
-                neighbor_valid = neighbor_futures[:, :, :2].abs().sum(dim=-1) > 1e-6
-
-                if "neighbor_agents_past" in data:
-                    nap = data["neighbor_agents_past"]
-                    if nap.dim() == 4:
-                        nap = nap[0]
-                    ns = nap[slot_valid, -1, :]
-                    if ns.shape[-1] >= 8:
-                        neighbor_shapes = ns[:, [6, 7]]  # width, length
-                    else:
-                        neighbor_shapes = torch.full(
-                            (neighbor_futures.shape[0], 2), 2.0, device=device
-                        )
-                else:
-                    neighbor_shapes = torch.full((neighbor_futures.shape[0], 2), 2.0, device=device)
-
-    zero_shapes = neighbor_shapes.abs().sum(dim=-1) < 1e-3
-    if zero_shapes.any():
-        neighbor_shapes[zero_shapes] = torch.tensor([2.0, 4.5], device=device)
-
-    # --- Goal pose ---
-    goal_pose = torch.zeros(4, device=device)
-    if "goal_pose" in data:
-        gp = data["goal_pose"]
-        if gp.dim() == 2:
-            gp = gp[0]
-        if gp.numel() >= 4:
-            goal_pose = gp[:4].to(device)
-
-    # --- Batched score computation ---
-    safety_scores, collision_steps = compute_safety_score_batch(
-        ego_trajs, ego_shape, neighbor_futures, neighbor_shapes, neighbor_valid, config
-    )
-    progress_scores = compute_progress_score_batch(ego_trajs, goal_pose, data)
-    smoothness_scores = compute_smoothness_score_batch(ego_trajs, config)
-    feasibility_scores, off_road_fractions = compute_feasibility_score_batch(
-        ego_trajs, ego_shape, data, config
-    )
-    centerline_scores = compute_centerline_score_batch(
-        ego_trajs,
-        ego_shape,
-        data,
-        usage_mode=config.centerline_usage_mode,
-        time_weight_min=config.centerline_time_weight_min,
-    )
-    red_light_scores = compute_red_light_score_batch(ego_trajs, data, config)
-    ttc_scores = compute_ttc_score_batch(
-        ego_trajs, ego_shape, neighbor_futures, neighbor_shapes, neighbor_valid
-    )
-
-    # Road border penalty using ego perimeter sampling
-    # Returns fracs or survival penalties depending on config.rb_penalty_mode
-    (
-        rb_crossing_gate,
-        rb_near_pen,
-        rb_wide_pen,
-        rb_crossing_steps,
-        rb_cont_penalty,
-        rb_per_ts_min,
-    ) = compute_road_border_penalty(
-        ego_trajs,
-        ego_shape,
-        data,
-        config=config,
-    )
-
-    # Lane departure penalty
-    if config.enable_lane_departure:
-        (
-            lane_crossing_gate,
-            lane_near_frac,
-            lane_wide_frac,
-            lane_crossing_steps,
-            lane_cont_penalty,
-        ) = compute_lane_departure_penalty(
-            ego_trajs,
-            ego_shape,
-            data,
-            config=config,
-        )
-    else:
-        lane_crossing_gate = torch.ones(N, device=device)
-        lane_near_frac = torch.zeros(N, device=device)
-        lane_wide_frac = torch.zeros(N, device=device)
-        lane_crossing_steps: list[int | None] = [None] * N
-        lane_cont_penalty = torch.zeros(N, device=device)
-
-    # Static-collision penalty (stopped-neighbor OBB clearance).
-    # Default-off: when disabled, returns safe zeros + no gate effect.
-    if config.static_collision_enabled:
-        # Check the predicted trajectory as usual.
-        sc_result = compute_static_collision_penalty(
-            ego_trajs,
-            ego_shape,
-            neighbor_futures,
-            neighbor_shapes,
-            neighbor_valid,
-            config,
-        )
-        sc_crossing_gate = sc_result["crossing_gate"]
-        sc_near_pen = sc_result["near_penalty"]
-        sc_wide_pen = sc_result["wide_penalty"]
-        sc_cont_pen = sc_result["cont_penalty"]
-        sc_crossing_steps = sc_result["first_crossing_steps"]
-        sc_per_ts_min = sc_result["per_timestep_min"]
-        sc_n_stopped_scene = int(sc_result["stopped_mask"].sum().item())
-
-    else:
-        sc_crossing_gate = torch.ones(N, device=device)
-        sc_near_pen = torch.zeros(N, device=device)
-        sc_wide_pen = torch.zeros(N, device=device)
-        sc_cont_pen = torch.zeros(N, device=device)
-        sc_crossing_steps: list[int | None] = [None] * N
-        sc_per_ts_min = torch.full((N, T), 99.0, device=device)
-        sc_n_stopped_scene = 0
+    safety_scores = subs["safety"]
+    collision_steps = subs["collision_step"]
+    red_light_scores = subs["red_light"]
+    progress_scores = subs["progress"]
+    smoothness_scores = subs["comfort"]
+    centerline_scores = subs["centerline"]
+    feasibility_scores = subs["feasibility"]
+    off_road_fractions = subs["off_road_fraction"]
+    ttc_scores = subs["ttc"]
+    kinematic_gate = subs["kinematic_gate"]
+    rb_crossing_gate = subs["rb_crossing_gate"]
+    rb_near_pen = subs["rb_near_penalty"]
+    rb_wide_pen = subs["rb_wide_penalty"]
+    rb_cont_penalty = subs["rb_cont_penalty"]
+    rb_crossing_steps = subs["rb_crossing_steps"]
+    rb_min_dist_t = subs["rb_min_dist"]
+    lane_crossing_gate = subs["lane_crossing_gate"]
+    lane_near_frac = subs["lane_near_frac"]
+    lane_wide_frac = subs["lane_wide_frac"]
+    lane_cont_penalty = subs["lane_cont_penalty"]
+    lane_crossing_steps = subs["lane_crossing_steps"]
+    sc_crossing_gate = subs["sc_crossing_gate"]
+    sc_near_pen = subs["sc_near_penalty"]
+    sc_wide_pen = subs["sc_wide_penalty"]
+    sc_cont_pen = subs["sc_cont_penalty"]
+    sc_crossing_steps = subs["sc_crossing_steps"]
+    sc_min_dist_scalar = subs["sc_min_dist"]
+    sc_n_stopped_scene = int(subs["sc_n_stopped"][0].item()) if N > 0 else 0
 
     # NAVSIM PDMS-style multiplicative reward aggregation.
     # Safety gates: binary 0/1 multipliers. If any gate is 0, total is 0.
@@ -469,20 +356,11 @@ def compute_reward_batch(
     # Kinematic feasibility hard gate: trajectories violating yaw-rate or
     # bicycle-model curvature bounds get floored. Applied after survival/gate
     # aggregation so it overrides any otherwise-positive reward.
-    kinematic_gate = compute_kinematic_gate(ego_trajs, config, ego_shape)
     totals = totals * kinematic_gate + (1.0 - kinematic_gate) * _OFFROAD_FLOOR
 
     # Also compute additive total for backward compat in breakdown
     on_road_factor = 1.0 - off_road_fractions
     adjusted_progress = progress_scores * on_road_factor
-
-    # Breakdown-friendly static-collision min-distance: min across t>=1 only.
-    # (Full per-step values live in sc_per_ts_min; the scalar breakdown
-    # field excludes t=0 since it's not model-controllable, same as rb_min_dist.)
-    if T > 1:
-        sc_min_dist_scalar = sc_per_ts_min[:, 1:].min(dim=1).values
-    else:
-        sc_min_dist_scalar = torch.full((N,), 99.0, device=device)
 
     results: list[RewardBreakdown] = []
     for i in range(N):
@@ -502,7 +380,7 @@ def compute_reward_batch(
                 rb_crossing=bool(rb_crossing_gate[i] < 0.5),
                 rb_near_penalty=float(rb_near_pen[i]),
                 rb_wide_penalty=float(rb_wide_pen[i]),
-                rb_min_dist=float(rb_per_ts_min[i, 1:].min().item()),
+                rb_min_dist=float(rb_min_dist_t[i].item()),
                 lane_crossing=bool(lane_crossing_gate[i] < 0.5),
                 lane_near_frac=float(lane_near_frac[i]),
                 lane_wide_frac=float(lane_wide_frac[i]),

--- a/rlvr/reward.py
+++ b/rlvr/reward.py
@@ -83,6 +83,7 @@ def compute_reward_batch(
     return _shape_reward(compute_subscores_batch(ego_trajs, data, config), ego_trajs, data, config)
 
 
+@torch.no_grad()
 def _shape_reward(
     subs: dict,
     ego_trajs: torch.Tensor,

--- a/rlvr/test_subscores_parity.py
+++ b/rlvr/test_subscores_parity.py
@@ -1,0 +1,98 @@
+"""Drift guard for ``diffusion_planner.metrics.compute_subscores_batch``.
+
+``compute_subscores_batch`` (used by the validation loop) re-runs the same input
+marshalling + per-subscore computation as ``rlvr.reward.compute_reward_batch``
+(used by RLVR), but stops before reward shaping. To guarantee the validation
+metric never silently diverges from what the reward is built on, this test pins
+``compute_subscores_batch`` against ``compute_reward_batch`` field-by-field on the
+shared golden scenarios. If someone edits the marshalling/subscore call in one
+place but not the other, this fails.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+repo_root = Path(__file__).resolve().parent.parent
+if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))
+
+from diffusion_planner.metrics import compute_subscores_batch  # noqa: E402
+
+from rlvr.reward import compute_reward_batch  # noqa: E402
+from rlvr.test_reward_golden import _SCENARIOS  # noqa: E402  (reuse golden scenarios)
+
+ABS_TOL = 1e-6
+REL_TOL = 1e-6
+
+# subscore-dict key -> RewardBreakdown attribute it must equal.
+_FLOAT_FIELDS = {
+    "safety": "safety",
+    "progress": "progress",  # adjusted_progress == progress_scores (off_road==0)
+    "comfort": "smoothness",
+    "feasibility": "feasibility",
+    "centerline": "centerline",
+    "red_light": "red_light",
+    "off_road_fraction": "off_road_fraction",
+    "rb_near_penalty": "rb_near_penalty",
+    "rb_wide_penalty": "rb_wide_penalty",
+    "rb_min_dist": "rb_min_dist",
+    "lane_near_frac": "lane_near_frac",
+    "lane_wide_frac": "lane_wide_frac",
+    "sc_near_penalty": "sc_near_penalty",
+    "sc_wide_penalty": "sc_wide_penalty",
+    "sc_cont_penalty": "sc_cont_penalty",
+    "sc_min_dist": "sc_min_dist",
+}
+# raw 0/1 gate key -> RewardBreakdown crossing bool (crossing == gate < 0.5).
+_GATE_FIELDS = {
+    "rb_crossing_gate": "rb_crossing",
+    "lane_crossing_gate": "lane_crossing",
+    "sc_crossing_gate": "static_crossing",
+}
+
+
+@pytest.mark.parametrize("name", sorted(_SCENARIOS))
+def test_subscores_match_reward_batch(name: str) -> None:
+    ego, data, cfg = _SCENARIOS[name]
+    subs = compute_subscores_batch(ego, data, cfg)
+    breakdowns = compute_reward_batch(ego, data, cfg)
+    assert len(breakdowns) == ego.shape[0]
+
+    for i, bd in enumerate(breakdowns):
+        for key, attr in _FLOAT_FIELDS.items():
+            got = float(subs[key][i])
+            exp = float(getattr(bd, attr))
+            assert got == pytest.approx(exp, abs=ABS_TOL, rel=REL_TOL), (
+                f"{name}[{i}] {key} vs RewardBreakdown.{attr}: {got!r} != {exp!r}"
+            )
+        for key, attr in _GATE_FIELDS.items():
+            got = bool(subs[key][i] < 0.5)  # gate < 0.5 == crossing
+            exp = bool(getattr(bd, attr))
+            assert got == exp, f"{name}[{i}] {key}: {got} != {exp}"
+
+        # kinematic gate (subscore is the 0/1 gate; RewardBreakdown stores the
+        # violated bool = gate < 0.5)
+        got_kin = bool(subs["kinematic_gate"][i] < 0.5)
+        assert got_kin == bool(bd.kinematic_violated), f"{name}[{i}] kinematic"
+
+        # collision step (list passthrough)
+        assert subs["collision_step"][i] == bd.collision_step, f"{name}[{i}] collision_step"
+
+        # scene-level stopped-neighbor count
+        assert int(subs["sc_n_stopped"][i]) == int(bd.sc_n_stopped), f"{name}[{i}] sc_n_stopped"
+
+
+def test_returns_per_trajectory_tensors() -> None:
+    """Continuous subscores come back as (N,) tensors for batch-mean logging."""
+    name = "safe_onroad_multi"
+    ego, data, cfg = _SCENARIOS[name]
+    subs = compute_subscores_batch(ego, data, cfg)
+    n = ego.shape[0]
+    for key in ("safety", "ttc", "progress", "comfort", "centerline", "red_light"):
+        assert isinstance(subs[key], torch.Tensor)
+        assert subs[key].shape == (n,), f"{key} shape {tuple(subs[key].shape)} != ({n},)"


### PR DESCRIPTION
## PR2 for #130 — split `compute_reward_batch` into `compute_subscores_batch` + `_shape_reward`

Behavior-preserving refactor. `compute_reward_batch` becomes a thin wrapper:

```python
@torch.no_grad()
def compute_reward_batch(ego_trajs, data, config=RewardConfig()):
    return _shape_reward(compute_subscores_batch(ego_trajs, data, config), ego_trajs, data, config)
```

### What & why
- **`diffusion_planner/metrics/aggregate.py` → `compute_subscores_batch`** — the input marshalling (ego_shape / neighbors / goal) + every per-subscore call, returned as a raw per-trajectory dict. **No weighting / gating / aggregation.** Neutral (no `rlvr` dependency); this is the entry point the base-SFT validation loop will log (#130's goal).
- **`rlvr/reward.py` → `_shape_reward`** — applies the reward *shaping* (weights, hard gates, survival/gate aggregation) to that dict and builds `RewardBreakdown`. RLVR-specific, stays here.
- The parse + subscore-call block is **removed** from `compute_reward_batch` → single source of truth, no duplication (the validation metric and the RLVR reward now run the exact same subscore code).

These remain reward-shaping subscores (custom thresholds, goal-based ego-progress, penalty signs) — EPDMS-*inspired*, not a faithful EPDMS port.

### Verification

```
golden (compute_reward_batch byte-identical):                16 passed
parity (compute_subscores_batch == compute_reward_batch):    16 passed
full reward-importing suite:                                139 passed
dedup (neighbor marshalling count):  reward.py: 0   aggregate.py: 3
```

- **`compute_reward_batch` output is byte-identical** — pinned by the PR0 golden tests (`rlvr/test_reward_golden.py`).
- **`rlvr/test_subscores_parity.py`** (new) pins `compute_subscores_batch` field-by-field against `compute_reward_batch` on the golden scenarios, so the raw entry point and the reward can never silently drift.
- ruff (I, F401) clean.

### Notes / next
- `compute_subscores_batch` is **single-scene / N-trajectories** (inherited from `compute_reward_batch`; map subscores use one scene's tensors). The validation wiring (PR3) must therefore call it **per scene** (B scenes, 1 prediction each).
- **PR3** (separate) will call `compute_subscores_batch` in `diffusion_planner/diffusion_planner/validate_model.py` and log the continuous subscores additively (existing `avg_loss_*` outputs unchanged). Keys will be named for what they are (reward subscores), **not** `epdms/*`.
