### PR TITLE
converter: emit per-neighbor track UUIDs into the per-frame JSON sidecar

### DIFF
--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/io/frame_writer.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/io/frame_writer.hpp
@@ -43,7 +43,8 @@ TrainingDataBinary build_training_data(
 
 nlohmann::json build_frame_json(
   const nav_msgs::msg::Odometry & kinematic_state, const int64_t timestamp,
-  const SkippingInfo & skipping_info);
+  const SkippingInfo & skipping_info,
+  const std::vector<std::string> & neighbor_ids = {});
 
 nlohmann::json build_route_json(
   const int64_t num_frames, const double traveled_distance_m, const int64_t start_timestamp,
@@ -69,7 +70,7 @@ void save_frame_data(
 void save_frame_json(
   const std::string & output_path, const std::string & rosbag_dir_name, const std::string & token,
   const nav_msgs::msg::Odometry & kinematic_state, const int64_t timestamp,
-  const SkippingInfo & skipping_info);
+  const SkippingInfo & skipping_info, const std::vector<std::string> & neighbor_ids = {});
 
 void save_route_json(
   const std::string & output_path, const std::string & rosbag_dir_name,

--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/processing/neighbor_processor.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/processing/neighbor_processor.hpp
@@ -20,10 +20,24 @@
 #include <Eigen/Core>
 
 #include <cstdint>
+#include <string>
 #include <utility>
 #include <vector>
 
-std::pair<std::vector<float>, std::vector<float>> process_neighbor_agents_and_future(
+// Result of neighbor processing. ``neighbor_ids`` are the perception track UUIDs
+// (hex strings) of the kept agents, in the SAME order as the neighbor_past slots
+// (sorted by ego distance, trimmed to MAX_NUM_NEIGHBORS). They are persisted in
+// the per-frame JSON sidecar so the closed-loop Perception Reproducer can
+// associate the same agent across frames (enables temporal interpolation; the
+// raw neighbor arrays are slot-sorted per frame and not ID-stable on their own).
+struct NeighborResult
+{
+  std::vector<float> neighbor_past;
+  std::vector<float> neighbor_future;
+  std::vector<std::string> neighbor_ids;
+};
+
+NeighborResult process_neighbor_agents_and_future(
   const std::vector<FrameData> & data_list, const int64_t current_idx,
   const Eigen::Matrix4d & map2bl_matrix);
 

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/io/frame_writer.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/io/frame_writer.cpp
@@ -74,7 +74,7 @@ TrainingDataBinary build_training_data(
 
 nlohmann::json build_frame_json(
   const nav_msgs::msg::Odometry & kinematic_state, const int64_t timestamp,
-  const SkippingInfo & skipping_info)
+  const SkippingInfo & skipping_info, const std::vector<std::string> & neighbor_ids)
 {
   std::vector<int> incomplete_types;
   for (const auto & t : skipping_info.incomplete_data_types) {
@@ -82,6 +82,9 @@ nlohmann::json build_frame_json(
   }
 
   nlohmann::json j;
+  // is_skipped (+ skipping_info.label) is the per-frame "skip_for_training" tag:
+  // with --write_skipped_npz the frame is still written for the closed-loop
+  // reproducer (gap-free), and training filters on this flag.
   j["is_skipped"] = (skipping_info.label != SkippingLabel::NotSkipped);
   j["timestamp"] = timestamp;
   j["x"] = kinematic_state.pose.pose.position.x;
@@ -95,6 +98,9 @@ nlohmann::json build_frame_json(
     {"label", static_cast<int>(skipping_info.label)},
     {"details", skipping_info.details},
     {"incomplete_data_types", incomplete_types}};
+  // Perception track UUIDs aligned 1:1 with the neighbor_past slots (for the
+  // reproducer's cross-frame association / interpolation).
+  j["neighbor_ids"] = neighbor_ids;
   return j;
 }
 
@@ -189,13 +195,14 @@ void save_frame_data(
 void save_frame_json(
   const std::string & output_path, const std::string & rosbag_dir_name, const std::string & token,
   const nav_msgs::msg::Odometry & kinematic_state, const int64_t timestamp,
-  const SkippingInfo & skipping_info)
+  const SkippingInfo & skipping_info, const std::vector<std::string> & neighbor_ids)
 {
   namespace fs = std::filesystem;
 
   fs::create_directories(output_path);
 
-  const nlohmann::json j = build_frame_json(kinematic_state, timestamp, skipping_info);
+  const nlohmann::json j =
+    build_frame_json(kinematic_state, timestamp, skipping_info, neighbor_ids);
 
   const std::string json_filename = output_path + "/" + rosbag_dir_name + "_" + token + ".json";
   std::ofstream json_file(json_filename);

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_processor.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_processor.cpp
@@ -149,8 +149,9 @@ void process_sequence(
       seq.data_list[i].kinematic_state, seq.data_list[i].acceleration, options.ego_wheel_base);
 
     // Process neighbor agents (both past and future with consistent agent ordering)
-    const auto [neighbor_past, neighbor_future] =
-      process_neighbor_agents_and_future(seq.data_list, i, map2bl);
+    const auto neighbor_result = process_neighbor_agents_and_future(seq.data_list, i, map2bl);
+    const auto & neighbor_past = neighbor_result.neighbor_past;
+    const auto & neighbor_future = neighbor_result.neighbor_future;
 
     // Process lanes and routes
     const auto & ego_pos = seq.data_list[i].kinematic_state.pose.pose.position;
@@ -297,7 +298,7 @@ void process_sequence(
     }
     save_frame_json(
       options.save_dir, options.rosbag_dir_name, token, seq.data_list[i].kinematic_state,
-      seq.data_list[i].timestamp, skipping_info);
+      seq.data_list[i].timestamp, skipping_info, neighbor_result.neighbor_ids);
 
     if (i % 100 == 0) {
       std::cout << "Processed frame " << i << "/" << n << std::endl;

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/neighbor_processor.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/neighbor_processor.cpp
@@ -24,7 +24,7 @@
 #include <string>
 #include <unordered_map>
 
-std::pair<std::vector<float>, std::vector<float>> process_neighbor_agents_and_future(
+NeighborResult process_neighbor_agents_and_future(
   const std::vector<FrameData> & data_list, const int64_t current_idx,
   const Eigen::Matrix4d & map2bl_matrix)
 {
@@ -54,6 +54,13 @@ std::pair<std::vector<float>, std::vector<float>> process_neighbor_agents_and_fu
 
   // Build id -> AgentHistory map for future filling
   const std::vector<AgentHistory> agent_histories = transformed_histories;
+  // Ordered track UUIDs, aligned 1:1 with the neighbor_past slots (same sorted +
+  // trimmed order as flatten_histories_to_vector above). Persisted to the sidecar.
+  std::vector<std::string> neighbor_ids;
+  neighbor_ids.reserve(agent_histories.size());
+  for (const auto & h : agent_histories) {
+    neighbor_ids.push_back(h.get_latest_state().object_id);
+  }
   std::unordered_map<std::string, AgentHistory> id_to_history;
   for (size_t i = 0; i < agent_histories.size(); ++i) {
     const auto object_id = agent_histories[i].get_latest_state().object_id;
@@ -104,5 +111,5 @@ std::pair<std::vector<float>, std::vector<float>> process_neighbor_agents_and_fu
     }
   }
 
-  return std::make_pair(neighbor_past, neighbor_future);
+  return NeighborResult{neighbor_past, neighbor_future, neighbor_ids};
 }


### PR DESCRIPTION
## Summary

Adds per-neighbor track UUIDs to the converter's per-frame JSON sidecar. `process_neighbor_agents_and_future` now returns a `NeighborResult` struct (was a `pair`) that carries `neighbor_ids` — the perception track UUIDs of the kept agents, in the **same order as the `neighbor_past` slots** (sorted by ego distance, trimmed to `MAX_NUM_NEIGHBORS`). `build_frame_json`/`save_frame_json` persist them under `neighbor_ids` in the sidecar.

The raw neighbor arrays are slot-sorted per frame and therefore not ID-stable across frames; the UUIDs let a downstream consumer associate the same agent over time (e.g. temporal interpolation of neighbor poses).

## Backward compatibility

- The new function params default to `{}`, so existing callers compile unchanged (the sole caller is updated here).
- **NPZ training tensors are unchanged** — the UUIDs live only in the JSON sidecar.
- Adding a JSON field is additive; older corpora simply lack it, and consumers treat a missing `neighbor_ids` as empty.
- The `is_skipped` / `--write_skipped_npz` skip machinery is **not touched** (it already exists in `tier4-main`; default remains "drop filtered frames").

## Notes

Split out of the closed-loop perception-reproducer PR so the converter change can be reviewed/merged independently. The Python side handles a missing `neighbor_ids` gracefully, so the two PRs are order-independent.
