### PR TITLE
Skip converter-flagged scenes by default across training/eval

### DIFF
--- a/cpp_tools/src/autoware_diffusion_planner_tools/README.md
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/README.md
@@ -60,3 +60,22 @@ on a rosbag and writes results to an output rosbag.
 ros2 run autoware_diffusion_planner_tools inference_tool \
   <rosbag_path> <vector_map_path> <output_rosbag_path>
 ```
+
+## Per-frame JSON sidecar (data converter)
+
+The data converter writes one JSON sidecar next to each frame's `.npz`, carrying the
+absolute map ego pose plus two fields used by downstream tooling:
+
+| field | meaning |
+| --- | --- |
+| `is_skipped` (bool) | `true` if the production filter would have dropped this frame (stopped at a red/yellow light, no future progress, GT collision, off-lane, stale data). See also `skipping_info.label`. |
+| `neighbor_ids` (list[str]) | perception track UUIDs of the kept neighbors, aligned 1:1 with the `neighbor_past` slots (sorted by ego distance, trimmed). Lets a consumer associate the same agent across frames. |
+
+By default the converter **drops** flagged frames (writes only accepted ones). Pass
+`--write_skipped_npz=1` to instead write **every** 10 Hz frame, flagged in the sidecar —
+producing one unified corpus that the closed-loop perception reproducer can replay
+gap-free while training/eval skip the flagged frames (see "Skip-for-training filtering"
+in `scenario_generation/README.md`).
+
+Both fields are additive and backward-compatible: the `.npz` tensors are unchanged, and
+a sidecar lacking them is treated as "not skipped" / "no track ids".

--- a/diffusion_planner/diffusion_planner/utils/dataset.py
+++ b/diffusion_planner/diffusion_planner/utils/dataset.py
@@ -1,14 +1,21 @@
 import numpy as np
 from torch.utils.data import Dataset
 
+from diffusion_planner.utils.scene_skip import filter_scene_list
 from diffusion_planner.utils.train_utils import openjson
 
 
 class DiffusionPlannerData(Dataset):
-    def __init__(self, data_list):
+    def __init__(self, data_list, skip_filter: bool = True, sidecar_root=None):
         data = openjson(data_list)
         # Accept both legacy list format and sampling.py dict format {"seed": ..., "files": [...]}
-        self.data_list = data["files"] if isinstance(data, dict) else data
+        files = data["files"] if isinstance(data, dict) else data
+        # Drop frames the converter flagged skip_for_training (red-light creep, no-future-
+        # progress, ...): valid only for the reproducer, never for training/eval. Frames
+        # with no resolvable sidecar (older corpora) are kept -> backward compatible.
+        self.data_list = filter_scene_list(
+            files, sidecar_root=sidecar_root, enabled=skip_filter, label=str(data_list)
+        )
 
     def __len__(self):
         return len(self.data_list)

--- a/diffusion_planner/diffusion_planner/utils/scene_skip.py
+++ b/diffusion_planner/diffusion_planner/utils/scene_skip.py
@@ -38,11 +38,12 @@ def _sidecar_index(sidecar_root: Path) -> dict[str, Path]:
 
 
 def scene_entry_path(entry) -> str:
-    """The npz path of a scene-list entry: a bare string, or a dict with path/npz."""
+    """The npz path of a scene-list entry: a bare string, or a dict keyed
+    path / npz / scene_path (the forms used across the scene-list tools)."""
     if isinstance(entry, str):
         return entry
     if isinstance(entry, dict):
-        return entry.get("path") or entry.get("npz") or ""
+        return entry.get("path") or entry.get("npz") or entry.get("scene_path") or ""
     return ""
 
 

--- a/diffusion_planner/diffusion_planner/utils/scene_skip.py
+++ b/diffusion_planner/diffusion_planner/utils/scene_skip.py
@@ -24,7 +24,9 @@ import json
 from pathlib import Path
 
 # stem -> sidecar path index per sidecar_root, built once (one rglob) and reused for
-# every scene, so a large scene list doesn't pay an O(files) rglob per entry.
+# every scene, so a large scene list doesn't pay an O(files) rglob per entry. Cached for
+# the process lifetime (never invalidated) — correct for the batch train/eval CLIs here;
+# a long-lived process that writes new sidecars after the first lookup won't see them.
 _SIDECAR_INDEX_CACHE: dict[Path, dict[str, Path]] = {}
 
 

--- a/diffusion_planner/diffusion_planner/utils/scene_skip.py
+++ b/diffusion_planner/diffusion_planner/utils/scene_skip.py
@@ -1,0 +1,124 @@
+"""Skip-for-training filter for the unified NPZ corpus.
+
+The converter can emit *every* 10 Hz frame (``--write_skipped_npz=1``), including the
+ones the production filter would normally drop (red/yellow-light stop, no-future-
+progress, collision, off-lane, stale data). Each frame's JSON **sidecar** carries
+``is_skipped`` (the ``.npz`` itself has no such field). Those frames exist only so the
+closed-loop perception reproducer has a gap-free timeline — they are NOT valid
+supervision, so training / eval / data-gen must drop them.
+
+This module is the one shared place that resolves a frame's sidecar and reads the
+flag, so every consumer filters identically. It is intentionally dependency-light
+(stdlib only) and lives at the lowest package layer so the ``DiffusionPlannerData``
+loader and everything above it can import it without a circular dependency.
+
+Backward-compatible: a frame with no resolvable sidecar (older corpora, or padded
+NPZs whose sidecars live elsewhere and no ``sidecar_root`` was given) is treated as
+NOT skipped; ``filter_scene_list`` loudly logs how many were unresolved so a silent
+no-op is visible.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+# stem -> sidecar path index per sidecar_root, built once (one rglob) and reused for
+# every scene, so a large scene list doesn't pay an O(files) rglob per entry.
+_SIDECAR_INDEX_CACHE: dict[Path, dict[str, Path]] = {}
+
+
+def _sidecar_index(sidecar_root: Path) -> dict[str, Path]:
+    key = sidecar_root.resolve()
+    idx = _SIDECAR_INDEX_CACHE.get(key)
+    if idx is None:
+        idx = {p.stem: p for p in sidecar_root.rglob("*.json")}
+        _SIDECAR_INDEX_CACHE[key] = idx
+    return idx
+
+
+def scene_entry_path(entry) -> str:
+    """The npz path of a scene-list entry: a bare string, or a dict with path/npz."""
+    if isinstance(entry, str):
+        return entry
+    if isinstance(entry, dict):
+        return entry.get("path") or entry.get("npz") or ""
+    return ""
+
+
+def resolve_sidecar(npz_path: str | Path, sidecar_root: str | Path | None = None) -> Path | None:
+    """Locate a frame's pose/skip JSON sidecar: sibling ``.json`` first, then by stem
+    under ``sidecar_root`` (one cached rglob). ``None`` if not found (no raise)."""
+    npz_path = Path(npz_path)
+    sib = npz_path.with_suffix(".json")
+    if sib.is_file():
+        return sib
+    if sidecar_root is not None:
+        sidecar_root = Path(sidecar_root)
+        cand = sidecar_root / f"{npz_path.stem}.json"
+        if cand.is_file():
+            return cand
+        return _sidecar_index(sidecar_root).get(npz_path.stem)
+    return None
+
+
+def _sidecar_state(npz_path: str | Path, sidecar_root) -> tuple[bool, bool]:
+    """(is_skipped, sidecar_resolved). Missing sidecar/field => (False, resolved?)."""
+    sc = resolve_sidecar(npz_path, sidecar_root)
+    if sc is None:
+        return False, False
+    try:
+        d = json.loads(sc.read_text())
+    except (OSError, json.JSONDecodeError):
+        return False, False
+    return bool(d.get("is_skipped", False)), True
+
+
+def is_skipped(npz_path: str | Path, sidecar_root: str | Path | None = None) -> bool:
+    """True iff the frame's sidecar marks it skip_for_training (missing => False)."""
+    return _sidecar_state(npz_path, sidecar_root)[0]
+
+
+def filter_scene_list(
+    scenes: list,
+    sidecar_root: str | Path | None = None,
+    enabled: bool = True,
+    label: str = "",
+) -> list:
+    """Drop scenes flagged ``is_skipped`` in their sidecar. ``enabled=False`` returns the
+    input unchanged. Entry types (str / dict) are preserved. Frames with no resolvable
+    sidecar are kept (treated as not-skipped) and counted in a single loud log line."""
+    if not enabled or not scenes:
+        return scenes
+    kept, dropped, no_sidecar = [], 0, 0
+    for entry in scenes:
+        skipped, resolved = _sidecar_state(scene_entry_path(entry), sidecar_root)
+        if not resolved:
+            no_sidecar += 1
+        if skipped:
+            dropped += 1
+        else:
+            kept.append(entry)
+    tag = f"{label}: " if label else ""
+    print(
+        f"[skip-filter] {tag}kept {len(kept)}/{len(scenes)} "
+        f"(dropped {dropped} skip_for_training; {no_sidecar} no-sidecar->kept)"
+    )
+    return kept
+
+
+def load_scene_list(
+    path_or_dir: str | Path,
+    sidecar_root: str | Path | None = None,
+    skip_filter: bool = True,
+) -> list:
+    """Read a scene-list JSON (list, or ``{"files": [...]}``) or glob a dir of ``*.npz``,
+    then drop skip_for_training frames by default. Set ``skip_filter=False`` to keep them
+    (the reproducer's opt-out)."""
+    p = Path(path_or_dir)
+    if p.is_dir():
+        scenes: list = sorted(str(f) for f in p.rglob("*.npz"))
+    else:
+        data = json.loads(p.read_text())
+        scenes = data["files"] if isinstance(data, dict) else data
+    return filter_scene_list(scenes, sidecar_root, enabled=skip_filter, label=str(path_or_dir))

--- a/diffusion_planner/diffusion_planner/utils/scene_skip.py
+++ b/diffusion_planner/diffusion_planner/utils/scene_skip.py
@@ -67,6 +67,10 @@ def resolve_sidecar(npz_path: str | Path, sidecar_root: str | Path | None = None
 
 def _sidecar_state(npz_path: str | Path, sidecar_root) -> tuple[bool, bool]:
     """(is_skipped, sidecar_resolved). Missing sidecar/field => (False, resolved?)."""
+    # Empty/invalid entry path (e.g. an unrecognized scene-list dict) -> treat as
+    # unresolved (kept, counted no-sidecar); never let Path("") resolve a cwd .json.
+    if not npz_path or str(npz_path) in ("", "."):
+        return False, False
     sc = resolve_sidecar(npz_path, sidecar_root)
     if sc is None:
         return False, False
@@ -123,5 +127,16 @@ def load_scene_list(
         scenes: list = sorted(str(f) for f in p.rglob("*.npz"))
     else:
         data = json.loads(p.read_text())
-        scenes = data["files"] if isinstance(data, dict) else data
+        if isinstance(data, dict):
+            files = data.get("files")
+            if not isinstance(files, list):
+                raise ValueError(
+                    f"{path_or_dir}: scene-list JSON must be a list, or a dict with a list "
+                    f"'files' key (got dict keys {sorted(data)})"
+                )
+            scenes = files
+        elif isinstance(data, list):
+            scenes = data
+        else:
+            raise ValueError(f"{path_or_dir}: scene-list JSON must be a list or {{'files': [...]}}")
     return filter_scene_list(scenes, sidecar_root, enabled=skip_filter, label=str(path_or_dir))

--- a/diffusion_planner/tests/test_scene_skip.py
+++ b/diffusion_planner/tests/test_scene_skip.py
@@ -1,0 +1,86 @@
+"""scene_skip: drop only the sidecar-flagged frames, keep everything else, and be a
+no-op (backward compatible) when sidecars/flags are absent."""
+
+import json
+
+from diffusion_planner.utils.scene_skip import (
+    filter_scene_list,
+    is_skipped,
+    load_scene_list,
+    resolve_sidecar,
+)
+
+
+def _frame(tmp, stem, skipped=None):
+    """Create <stem>.npz and (optionally) a sibling <stem>.json with is_skipped."""
+    npz = tmp / f"{stem}.npz"
+    npz.write_bytes(b"")  # content irrelevant; we only resolve the sidecar
+    if skipped is not None:
+        (tmp / f"{stem}.json").write_text(json.dumps({"x": 0.0, "is_skipped": skipped}))
+    return str(npz)
+
+
+def test_is_skipped_reads_sibling_sidecar(tmp_path):
+    flagged = _frame(tmp_path, "a", skipped=True)
+    keep = _frame(tmp_path, "b", skipped=False)
+    nosc = _frame(tmp_path, "c", skipped=None)  # no sidecar
+    assert is_skipped(flagged) is True
+    assert is_skipped(keep) is False
+    assert is_skipped(nosc) is False  # missing sidecar => not skipped
+
+
+def test_filter_drops_only_flagged(tmp_path):
+    scenes = [
+        _frame(tmp_path, "a", skipped=True),
+        _frame(tmp_path, "b", skipped=False),
+        _frame(tmp_path, "c", skipped=True),
+        _frame(tmp_path, "d", skipped=False),
+    ]
+    kept = filter_scene_list(scenes, label="unit")
+    assert kept == [scenes[1], scenes[3]]
+
+
+def test_missing_sidecar_passthrough(tmp_path):
+    scenes = [_frame(tmp_path, f"n{i}", skipped=None) for i in range(3)]
+    kept = filter_scene_list(scenes)  # no sidecars => all kept (backward compatible)
+    assert kept == scenes
+
+
+def test_disabled_is_noop(tmp_path):
+    scenes = [_frame(tmp_path, "a", skipped=True), _frame(tmp_path, "b", skipped=False)]
+    assert filter_scene_list(scenes, enabled=False) == scenes
+
+
+def test_dict_entries_preserved(tmp_path):
+    a, b = _frame(tmp_path, "a", skipped=True), _frame(tmp_path, "b", skipped=False)
+    scenes = [{"path": a, "weight": 1}, {"npz": b, "weight": 2}]
+    kept = filter_scene_list(scenes)
+    assert kept == [{"npz": b, "weight": 2}]  # the flagged dict dropped, entry type kept
+
+
+def test_sidecar_root_index(tmp_path):
+    # NPZs in one dir, sidecars nested under a separate root (padded-corpus style).
+    npz_dir, sc_root = tmp_path / "npz", tmp_path / "sc" / "date" / "bag"
+    npz_dir.mkdir(parents=True)
+    sc_root.mkdir(parents=True)
+    (npz_dir / "x.npz").write_bytes(b"")
+    (sc_root / "x.json").write_text(json.dumps({"is_skipped": True}))
+    assert resolve_sidecar(npz_dir / "x.npz", sidecar_root=tmp_path / "sc") == sc_root / "x.json"
+    assert filter_scene_list([str(npz_dir / "x.npz")], sidecar_root=tmp_path / "sc") == []
+
+
+def test_load_scene_list_dir_and_json(tmp_path):
+    a = _frame(tmp_path, "a", skipped=True)
+    b = _frame(tmp_path, "b", skipped=False)
+    # dir glob
+    kept_dir = load_scene_list(tmp_path)
+    assert a not in kept_dir and b in kept_dir
+    # json list, and the {"files": [...]} dict form
+    lst = tmp_path / "list.json"
+    lst.write_text(json.dumps([a, b]))
+    assert load_scene_list(lst) == [b]
+    dct = tmp_path / "files.json"
+    dct.write_text(json.dumps({"seed": 1, "files": [a, b]}))
+    assert load_scene_list(dct) == [b]
+    # opt-out keeps everything
+    assert sorted(load_scene_list(lst, skip_filter=False)) == sorted([a, b])

--- a/preference_optimization/datasets.py
+++ b/preference_optimization/datasets.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import torch
+from diffusion_planner.utils.scene_skip import filter_scene_list, is_skipped
 from torch.utils.data import Dataset
 
 from preference_optimization.utils import load_npz_data
@@ -13,7 +14,13 @@ class DPODataset(Dataset):
     Each sample contains observation data and preferred/dispreferred trajectory pair.
     """
 
-    def __init__(self, preferences: list[dict], device: torch.device):
+    def __init__(
+        self,
+        preferences: list[dict],
+        device: torch.device,
+        skip_filter: bool = True,
+        sidecar_root=None,
+    ):
         """Initialize DPO dataset.
 
         Args:
@@ -22,7 +29,14 @@ class DPODataset(Dataset):
                 - trajectory_w: Winning trajectory
                 - trajectory_l: Losing trajectory
             device: Device to load tensors onto
+            skip_filter: drop preferences whose npz is flagged skip_for_training (default on).
+            sidecar_root: where the per-frame JSON sidecars live if not next to the NPZ.
         """
+        if skip_filter:
+            n0 = len(preferences)
+            preferences = [p for p in preferences if not is_skipped(p["npz_path"], sidecar_root)]
+            if len(preferences) < n0:
+                print(f"[skip-filter] DPODataset: kept {len(preferences)}/{n0} preferences")
         self.preferences = preferences
         self.device = device
 
@@ -52,14 +66,24 @@ class NPZDataset(Dataset):
     Used for validation visualization.
     """
 
-    def __init__(self, npz_paths: list[str], device: torch.device):
+    def __init__(
+        self,
+        npz_paths: list[str],
+        device: torch.device,
+        skip_filter: bool = True,
+        sidecar_root=None,
+    ):
         """Initialize NPZ dataset.
 
         Args:
             npz_paths: List of paths to NPZ observation files
             device: Device to load tensors onto
+            skip_filter: drop NPZs flagged skip_for_training (default on).
+            sidecar_root: where the per-frame JSON sidecars live if not next to the NPZ.
         """
-        self.npz_paths = npz_paths
+        self.npz_paths = filter_scene_list(
+            npz_paths, sidecar_root=sidecar_root, enabled=skip_filter, label="NPZDataset"
+        )
         self.device = device
 
     def __len__(self) -> int:

--- a/preference_optimization/trainer.py
+++ b/preference_optimization/trainer.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 import torch
 from diffusion_planner.model.diffusion_planner import Diffusion_Planner
+from diffusion_planner.utils.scene_skip import is_skipped
 from torch import optim
 from torch.utils.data import DataLoader
 from tqdm import tqdm
@@ -294,7 +295,8 @@ class DPOTrainer:
 
         for pref in preferences:
             npz_path = pref.get("npz_path")
-            if npz_path is None or npz_path in seen:
+            # Skip converter-flagged frames (consistent with the DPODataset training filter).
+            if npz_path is None or npz_path in seen or is_skipped(npz_path):
                 continue
             try:
                 obs = load_npz_data(npz_path, self.device)

--- a/rlvr/autoresearch/run_experiment.py
+++ b/rlvr/autoresearch/run_experiment.py
@@ -41,6 +41,8 @@ def load_npz_data(npz_path, device):
     return data
 
 
+from diffusion_planner.utils.scene_skip import filter_scene_list
+
 from rlvr.grpo_config import GRPOConfig
 from rlvr.grpo_trainer import GRPOTrainer
 from rlvr.reward import RewardConfig, compute_reward_batch
@@ -559,6 +561,14 @@ def run(
         train_paths = create_training_set(prob_100, curated_pool, n_prob, n_normal)
     else:
         train_paths = create_training_set(prob_100, normal_pool, n_prob, n_normal)
+    # Drop converter-flagged skip_for_training frames from everything we train/eval on
+    # (default on; reproducer-only frames are not valid supervision). Single chokepoint
+    # so every scene source above is covered.
+    _sk = grpo_config.skip_filtered_scenes
+    _sr = grpo_config.sidecar_root
+    train_paths = filter_scene_list(train_paths, sidecar_root=_sr, enabled=_sk, label="train")
+    prob_eval = filter_scene_list(prob_eval, sidecar_root=_sr, enabled=_sk, label="prob_eval")
+    val_50 = filter_scene_list(val_50, sidecar_root=_sr, enabled=_sk, label="val")
     n_unique = len(set(train_paths))
     n_total = len(train_paths)
     dup_msg = f" ({n_total - n_unique} DUPLICATES!)" if n_unique < n_total else ""

--- a/rlvr/autoresearch/run_experiment.py
+++ b/rlvr/autoresearch/run_experiment.py
@@ -569,6 +569,7 @@ def run(
     train_paths = filter_scene_list(train_paths, sidecar_root=_sr, enabled=_sk, label="train")
     prob_eval = filter_scene_list(prob_eval, sidecar_root=_sr, enabled=_sk, label="prob_eval")
     val_50 = filter_scene_list(val_50, sidecar_root=_sr, enabled=_sk, label="val")
+    prob_100 = filter_scene_list(prob_100, sidecar_root=_sr, enabled=_sk, label="prob_viz")
     n_unique = len(set(train_paths))
     n_total = len(train_paths)
     dup_msg = f" ({n_total - n_unique} DUPLICATES!)" if n_unique < n_total else ""

--- a/rlvr/autoresearch/tools/disturb_and_replay.py
+++ b/rlvr/autoresearch/tools/disturb_and_replay.py
@@ -901,6 +901,11 @@ def main(argv: Iterable[str] | None = None) -> None:
 
     with open(args.scenes) as f:
         scenes = json.load(f)
+    # Don't perturb/train on converter-flagged skip_for_training frames (default on;
+    # sibling-sidecar lookup, no-op on older corpora).
+    from diffusion_planner.utils.scene_skip import filter_scene_list
+
+    scenes = filter_scene_list(scenes, label="disturb_and_replay")
     if not isinstance(scenes, list) or not scenes:
         raise ValueError(f"--scenes must be a non-empty JSON list; got {type(scenes)}")
 

--- a/rlvr/autoresearch/tools/eval_centerline_metrics.py
+++ b/rlvr/autoresearch/tools/eval_centerline_metrics.py
@@ -232,6 +232,9 @@ def main():
 
     with open(args.scenes) as f:
         scene_paths = json.load(f)
+        from diffusion_planner.utils.scene_skip import filter_scene_list
+
+        scene_paths = filter_scene_list(scene_paths, label="eval_centerline_metrics")
     print(f"Evaluating centerline on {len(scene_paths)} scenes [{args.tag}]")
 
     cfg = RewardConfig()  # defaults: usage_mode="baselink", time_weight_min=0.3

--- a/rlvr/autoresearch/tools/eval_checkpoint_sweep.py
+++ b/rlvr/autoresearch/tools/eval_checkpoint_sweep.py
@@ -126,6 +126,9 @@ def main():
 
     with open(args.scenes) as f:
         scenes = json.load(f)
+        from diffusion_planner.utils.scene_skip import filter_scene_list
+
+        scenes = filter_scene_list(scenes, label="eval_checkpoint_sweep")
 
     from rlvr.autoresearch.tools.reward_config_from_json import load_reward_config
 

--- a/rlvr/autoresearch/tools/eval_closedloop_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_closedloop_avoidance.py
@@ -171,6 +171,9 @@ def main():
 
     with open(args.scenes) as f:
         paths = json.load(f)
+        from diffusion_planner.utils.scene_skip import filter_scene_list
+
+        paths = filter_scene_list(paths, label="eval_closedloop_avoidance")
 
     rows = []
     for sp in paths:

--- a/rlvr/autoresearch/tools/eval_det_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_det_avoidance.py
@@ -290,6 +290,9 @@ def main():
 
     with open(args.scenes) as f:
         scene_paths = json.load(f)
+    from diffusion_planner.utils.scene_skip import filter_scene_list
+
+    scene_paths = filter_scene_list(scene_paths, label="eval_det_avoidance")
     print(f"[eval_det_avoidance] {len(scene_paths)} scenes, model={args.model_path}")
 
     model, model_args = load_model(args.model_path, device)

--- a/rlvr/autoresearch/tools/eval_detailed_metrics.py
+++ b/rlvr/autoresearch/tools/eval_detailed_metrics.py
@@ -183,6 +183,9 @@ def main():
 
     with open(args.scenes) as f:
         scenes = json.load(f)
+        from diffusion_planner.utils.scene_skip import filter_scene_list
+
+        scenes = filter_scene_list(scenes, label="eval_detailed_metrics")
 
     labels = args.labels or [Path(l).parent.name + "/" + Path(l).name for l in args.loras]
     assert len(labels) == len(args.loras), "labels must match --loras count"

--- a/rlvr/autoresearch/tools/eval_driving_metrics.py
+++ b/rlvr/autoresearch/tools/eval_driving_metrics.py
@@ -129,6 +129,9 @@ def main():
 
     with open(args.scenes) as f:
         scene_paths = json.load(f)
+        from diffusion_planner.utils.scene_skip import filter_scene_list
+
+        scene_paths = filter_scene_list(scene_paths, label="eval_driving_metrics")
 
     print(f"Evaluating {len(scene_paths)} scenes [{args.tag}]\n")
 

--- a/rlvr/autoresearch/tools/eval_labels_holdout.py
+++ b/rlvr/autoresearch/tools/eval_labels_holdout.py
@@ -43,6 +43,9 @@ def main():
 
     with open(args.holdout) as f:
         rows = json.load(f)["scenes"]
+        from diffusion_planner.utils.scene_skip import filter_scene_list
+
+        rows = filter_scene_list(rows, label="eval_labels_holdout")
 
     preds, targs, kinds = [], [], []
     for r in rows:

--- a/rlvr/autoresearch/tools/eval_lane_border_distance.py
+++ b/rlvr/autoresearch/tools/eval_lane_border_distance.py
@@ -65,6 +65,9 @@ def main():
 
     with open(args.scenes) as f:
         scene_paths = json.load(f)
+        from diffusion_planner.utils.scene_skip import filter_scene_list
+
+        scene_paths = filter_scene_list(scene_paths, label="eval_lane_border_distance")
 
     print(f"Evaluating {len(scene_paths)} scenes [{args.tag}]")
 

--- a/rlvr/autoresearch/tools/eval_plan_comfort.py
+++ b/rlvr/autoresearch/tools/eval_plan_comfort.py
@@ -127,6 +127,9 @@ def main():
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model, model_args = load_model(args.model_path, device)
     scenes = json.load(open(args.scenes))
+    from diffusion_planner.utils.scene_skip import filter_scene_list
+
+    scenes = filter_scene_list(scenes, label="eval_plan_comfort")
     la95, jk95, cspd = eval_plan_comfort(
         model, model_args, scenes, device, args.dt, args.batch_size, args.curve_lat
     )

--- a/rlvr/autoresearch/tools/eval_policy_avoidance.py
+++ b/rlvr/autoresearch/tools/eval_policy_avoidance.py
@@ -448,8 +448,11 @@ def main():
     out_dir.mkdir(parents=True, exist_ok=True)
 
     def run_set(scene_list_path, tag):
+        from diffusion_planner.utils.scene_skip import filter_scene_list
+
         with open(scene_list_path) as f:
             paths = json.load(f)
+        paths = filter_scene_list(paths, label=f"eval_policy_avoidance:{tag}")
         rows = []
         render_dir = out_dir / f"render_{tag}"
         if args.render:

--- a/rlvr/autoresearch/tools/eval_policy_l2.py
+++ b/rlvr/autoresearch/tools/eval_policy_l2.py
@@ -135,6 +135,9 @@ def main():
 
     with open(args.scenes) as f:
         scene_paths = json.load(f)
+        from diffusion_planner.utils.scene_skip import filter_scene_list
+
+        scene_paths = filter_scene_list(scene_paths, label="eval_policy_l2")
     if args.limit:
         scene_paths = scene_paths[: args.limit]
     print(f"[policy_l2] {len(scene_paths)} scenes, heads={heads}")

--- a/rlvr/autoresearch/tools/eval_reward_vs_gt.py
+++ b/rlvr/autoresearch/tools/eval_reward_vs_gt.py
@@ -99,6 +99,9 @@ def main():
 
     with open(args.scenes) as f:
         scenes = json.load(f)
+        from diffusion_planner.utils.scene_skip import filter_scene_list
+
+        scenes = filter_scene_list(scenes, label="eval_reward_vs_gt")
 
     if args.indices:
         scene_indices = args.indices

--- a/rlvr/autoresearch/tools/filter_scenes_by_skip_flag.py
+++ b/rlvr/autoresearch/tools/filter_scenes_by_skip_flag.py
@@ -1,14 +1,19 @@
-"""Filter a training scene list by the converter's per-frame skip flag.
+"""Filter a training scene list by the converter's per-frame skip flag (CLI pre-pass).
 
-When a corpus is generated with the cpp converter's ``--write_skipped_npz=1``
-(so the closed-loop reproducer gets a gap-free timeline), every 10 Hz frame is
-written, including the ones the production filter would normally drop (stopped at
-a red light, no future progress, ...). Each frame's JSON sidecar carries
-``is_skipped`` (and ``skipping_info.label``). TRAINING must not learn from those
-frames, so this tool rewrites a scene list keeping only ``is_skipped == false``.
+When a corpus is generated with the cpp converter's ``--write_skipped_npz=1`` (so the
+closed-loop reproducer gets a gap-free timeline), every 10 Hz frame is written,
+including the ones the production filter would normally drop (stopped at a red light,
+no future progress, ...). Each frame's JSON sidecar carries ``is_skipped``. TRAINING
+must not learn from those frames.
 
-Backward-compatible: a sidecar without the field (older corpora) is treated as
-NOT skipped, so existing lists pass through unchanged.
+Most training/eval paths now drop them automatically (the loader and scene-list
+intakes call ``diffusion_planner.utils.scene_skip.filter_scene_list`` by default). This
+tool stays as an explicit pre-pass for cases where you want a pre-filtered list on disk
+(e.g. handing a list to an external script). It is a thin wrapper over the same shared
+helper, so the filtering logic lives in exactly one place.
+
+Backward-compatible: a sidecar without the field (older corpora) is treated as NOT
+skipped, so existing lists pass through unchanged.
 
 Example::
 
@@ -23,42 +28,9 @@ import argparse
 import json
 from pathlib import Path
 
-# stem -> path index per sidecar_root, built once (one rglob) and reused for every
-# scene, so a large scene list doesn't pay an O(files) rglob per entry.
-_SIDECAR_INDEX_CACHE: dict[Path, dict[str, Path]] = {}
-
-
-def _sidecar_index(sidecar_root: Path) -> dict[str, Path]:
-    key = sidecar_root.resolve()
-    idx = _SIDECAR_INDEX_CACHE.get(key)
-    if idx is None:
-        idx = {p.stem: p for p in sidecar_root.rglob("*.json")}
-        _SIDECAR_INDEX_CACHE[key] = idx
-    return idx
-
-
-def _sidecar_for(npz_path: Path, sidecar_root: Path | None) -> Path | None:
-    sib = npz_path.with_suffix(".json")
-    if sib.is_file():
-        return sib
-    if sidecar_root is not None:
-        cand = sidecar_root / f"{npz_path.stem}.json"
-        if cand.is_file():
-            return cand
-        return _sidecar_index(sidecar_root).get(npz_path.stem)
-    return None
-
-
-def is_skipped(npz_path: str | Path, sidecar_root: Path | None = None) -> bool:
-    """True if the frame's sidecar marks it skip_for_training (missing flag => False)."""
-    sc = _sidecar_for(Path(npz_path), sidecar_root)
-    if sc is None:
-        return False
-    try:
-        d = json.loads(sc.read_text())
-    except (OSError, json.JSONDecodeError):
-        return False
-    return bool(d.get("is_skipped", False))
+# Re-exported so existing importers keep working; the implementation lives in the
+# shared, dependency-light helper at the lowest package layer.
+from diffusion_planner.utils.scene_skip import filter_scene_list, is_skipped  # noqa: F401
 
 
 def parse_args() -> argparse.Namespace:
@@ -82,18 +54,10 @@ def main() -> None:
     scenes = json.loads(args.scenes.read_text())
     if not isinstance(scenes, list):
         raise ValueError(f"{args.scenes} is not a JSON list of npz paths")
-    kept, dropped = [], 0
-    for entry in scenes:
-        path = entry if isinstance(entry, str) else (entry.get("path") or entry.get("npz"))
-        if is_skipped(path, args.sidecar_root):
-            dropped += 1
-        else:
-            kept.append(entry)
+    kept = filter_scene_list(scenes, sidecar_root=args.sidecar_root, label=str(args.scenes))
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(kept))
-    print(
-        f"kept {len(kept)} / {len(scenes)} scenes (dropped {dropped} skip_for_training) -> {args.out}"
-    )
+    print(f"wrote {len(kept)} scenes -> {args.out}")
 
 
 if __name__ == "__main__":

--- a/rlvr/autoresearch/tools/mine_collisions_reproducer.py
+++ b/rlvr/autoresearch/tools/mine_collisions_reproducer.py
@@ -98,6 +98,10 @@ def parse_args() -> argparse.Namespace:
 
 
 def _enumerate_routes(npz_root: Path) -> dict[str, list[Path]]:
+    # OPT-OUT of skip-filtering on purpose: the reproducer is the ONE consumer that needs
+    # the converter's skip_for_training frames (red-light dwell etc.) so the timeline is
+    # gap-free. We deliberately do NOT call scene_skip.filter_scene_list here — every
+    # frame under npz_root is replayed (skip_filter=False is implicit).
     paths = sorted(npz_root.rglob("*.npz"))
     if not paths:
         raise FileNotFoundError(f"No .npz under {npz_root}")

--- a/rlvr/autoresearch/tools/open_loop_per_arc.py
+++ b/rlvr/autoresearch/tools/open_loop_per_arc.py
@@ -49,6 +49,9 @@ def main():
     dev = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     cli_es = np.array([float(x) for x in args.ego_shape.split(",")])
     paths = json.load(open(args.scenes))
+    from diffusion_planner.utils.scene_skip import filter_scene_list
+
+    paths = filter_scene_list(paths, label="open_loop_per_arc")
     routes = {}
     polys = {}
     for k, rp in [("m2t", args.m2t_route), ("t2m", args.t2m_route)]:

--- a/rlvr/autoresearch/tools/viz_p4_recovery.py
+++ b/rlvr/autoresearch/tools/viz_p4_recovery.py
@@ -218,6 +218,9 @@ def main() -> None:
 
     with open(args.scenes) as f:
         scene_paths = json.load(f)
+    from diffusion_planner.utils.scene_skip import filter_scene_list
+
+    scene_paths = filter_scene_list(scene_paths, label="viz_p4_recovery")
     if args.max_scenes is not None:
         scene_paths = scene_paths[: args.max_scenes]
 

--- a/rlvr/grpo_config.py
+++ b/rlvr/grpo_config.py
@@ -53,6 +53,12 @@ class GRPOConfig:
         lora_dropout: LoRA dropout probability.
     """
 
+    # Scene filtering: drop frames the converter flagged skip_for_training (red-light
+    # creep, no-future-progress, ...) — valid only for the reproducer, never training.
+    # sidecar_root: where the per-frame JSON sidecars live if not next to the NPZ.
+    skip_filtered_scenes: bool = True
+    sidecar_root: str | None = None
+
     # Core GRPO
     num_generations: int = 32
     train_epochs: int = 10

--- a/scenario_generation/README.md
+++ b/scenario_generation/README.md
@@ -440,3 +440,34 @@ python -m pytest scenario_generation/tests/ -v
 - **Heading correction**: On NPZ load, neighbor headings are checked against velocity direction. If off by >90 degrees, all headings are flipped by pi.
 - **Static agents**: Vehicles with speed <0.5 m/s and goal distance <1.0m are kept in the scene but not simulated (no model forward pass, no position update).
 - **Misdetection filtering**: When using `--use_gt_goals`, agents with fewer than 10 valid GT future timesteps are removed from the scene.
+
+## Skip-for-training filtering (unified corpus)
+
+The data converter can emit **every** 10 Hz frame (`--write_skipped_npz=1`), tagging the
+ones the production filter would normally drop (red/yellow-light creep, no-future-progress,
+GT collision, off-lane, stale data) with `is_skipped` in each frame's JSON sidecar. This
+yields **one corpus** that serves two consumers:
+
+- the **closed-loop perception reproducer** (collision miner) needs those frames for a
+  gap-free timeline, so it replays *all* of them; and
+- **training / eval / data-gen** must never learn from / score on them.
+
+`diffusion_planner/diffusion_planner/utils/scene_skip.py` is the single shared helper that
+resolves a frame's sidecar and reads the flag. Filtering is **on by default** everywhere
+that reads scenes for training/eval:
+
+- `DiffusionPlannerData(data_list, skip_filter=True, sidecar_root=None)` — the training
+  loader drops flagged frames, so the SFT/GRPO/validation entry points (and their launch
+  scripts) skip them automatically.
+- The autoresearch runner (`GRPOConfig.skip_filtered_scenes=True`, `sidecar_root`), the
+  preference-optimization datasets, and the eval/PRiSM tools filter at scene-list intake.
+- `filter_scenes_by_skip_flag` remains as an explicit CLI pre-pass for producing a filtered
+  list on disk.
+
+Resolution is sibling-`.json` first, then by stem under `sidecar_root` (a one-time cached
+index). **Backward-compatible:** a frame with no resolvable sidecar (older corpora) is kept,
+and the kept/dropped/no-sidecar counts are logged so a silent no-op is visible.
+
+**Opt-out:** the reproducer/miner (`mine_collisions_reproducer`) globs the corpus directly
+and intentionally does **not** filter (it needs the skipped frames). Programmatically, pass
+`skip_filter=False` to `load_scene_list` / the loader to keep all frames.


### PR DESCRIPTION
## Summary

Single **unified NPZ corpus**: the converter can write every 10 Hz frame (`--write_skipped_npz=1`), tagging the ones the production filter would drop (red/yellow-light creep, no-future-progress, GT collision, off-lane, stale data) with `is_skipped` in each frame's JSON sidecar. Those frames are needed by the closed-loop perception reproducer (gap-free timeline) but are **not valid supervision**. This PR makes everything that reads scenes for **training/eval drop the flagged frames by default**, while the reproducer keeps seeing all of them.

## Approach

- **`diffusion_planner/diffusion_planner/utils/scene_skip.py`** (new, stdlib-only, lowest package layer → importable everywhere without a cycle): `resolve_sidecar` (cached stem index), `is_skipped`, `filter_scene_list` (loud kept/dropped/no-sidecar log), `load_scene_list`.
- **Loader default-on:** `DiffusionPlannerData(skip_filter=True, sidecar_root=None)` filters its list, so `train_predictor` / `train_grpo_predictor` / `valid_predictor` (and their launch scripts) skip flagged frames automatically — no script edits.
- **Autoresearch:** `run_experiment` filters train/eval/val at a single chokepoint; `GRPOConfig.skip_filtered_scenes` (default `True`) + `sidecar_root`.
- **Datasets & tools:** `preference_optimization` DPO/NPZ datasets; PRiSM data-gen (`disturb_and_replay`, `viz_p4_recovery`); and all the `eval_*` tools filter at scene-list intake.
- **Left unfiltered on purpose:** viz/debug (heatmaps, `scene_search`, GUIs) — a scene-inspection tool should still show flagged frames. The **reproducer/miner** opts out explicitly (documented in `_enumerate_routes`).
- **`filter_scenes_by_skip_flag`** is now a thin CLI wrapper over the shared helper.

## Backward compatibility

A frame with **no resolvable sidecar** (older corpora, or padded NPZs without `--sidecar_root`) is treated as not-skipped and kept; the kept/dropped/no-sidecar counts are logged so a silent no-op is visible. NPZ tensors are unchanged.

## Docs

`cpp_tools` README documents the `is_skipped` / `neighbor_ids` sidecar fields + `--write_skipped_npz`; `scenario_generation` README documents the default-on skip filtering and the reproducer opt-out.

## Tests

`diffusion_planner/tests/test_scene_skip.py` (flag true/false/missing, dict + `scene_path` entries, `sidecar_root` index, disabled no-op, dir/list/`{"files"}` loads). Loader integration verified (drops flagged, opt-out keeps all, old corpus passthrough).
