### PR TITLE
Scene-gen: always emit 4-col (x,y,cos,sin) futures, never 3-col

### DIFF
--- a/diffusion_planner/diffusion_planner/train_epoch.py
+++ b/diffusion_planner/diffusion_planner/train_epoch.py
@@ -15,7 +15,13 @@ def heading_to_cos_sin(x):
         x: [B, T, 3] where last dimension is (x, y, heading)
     Output:
         x: [B, T, 4] where last dimension is (x, y, cos(heading), sin(heading))
+
+    Idempotent: a [..., 4] input that is already (x, y, cos, sin) is returned
+    unchanged. This guards against double-conversion (cos(cos)) now that scene-gen
+    emits 4-col futures — callers can hand it either layout safely.
     """
+    if x.shape[-1] == 4:
+        return x
     return torch.cat(
         [
             x[..., :2],

--- a/preference_optimization/utils.py
+++ b/preference_optimization/utils.py
@@ -28,7 +28,12 @@ def load_npz_data(
         data: dict[str, torch.Tensor] = {}
 
         for key, value in loaded.items():
-            if key in {"map_name", "token", "delay"}:
+            if key in {"map_name", "token", "delay", "origin"}:
+                continue
+            value = np.asarray(value)
+            # Skip string/object metadata (e.g. the reproducer extractor's "origin"
+            # tag) — only numeric model-input arrays become tensors.
+            if value.dtype.kind in ("U", "S", "O"):
                 continue
             data[key] = torch.tensor(np.expand_dims(value, axis=0)).to(device)
 

--- a/rlvr/autoresearch/tools/disturb_and_replay.py
+++ b/rlvr/autoresearch/tools/disturb_and_replay.py
@@ -94,6 +94,21 @@ def _wrap_angle(rad: float) -> float:
     return float((rad + math.pi) % (2 * math.pi) - math.pi)
 
 
+def _future_to_4col(arr: np.ndarray) -> np.ndarray:
+    """Futures are ALWAYS 4-col [x,y,cos,sin]; widen legacy 3-col [x,y,heading].
+    4-col passes through; invalid (zero) rows stay zero."""
+    arr = np.asarray(arr, dtype=np.float32)
+    if arr.shape[-1] == 4:
+        return arr
+    mask = np.abs(arr[..., :2]).sum(-1) == 0
+    h = arr[..., 2]
+    out = np.concatenate(
+        [arr[..., :2], np.cos(h)[..., None], np.sin(h)[..., None]], axis=-1
+    ).astype(np.float32)
+    out[mask] = 0.0
+    return out
+
+
 def _rotate_past_about_pivot(
     past: np.ndarray, pivot_x: float, pivot_y: float, yaw_rad: float
 ) -> np.ndarray:
@@ -531,19 +546,6 @@ def _apply_inverse_rigid_to_spatial(
         # vectorised wrap
         a = (a + np.pi) % (2 * np.pi) - np.pi
         arr[..., idx] = a.astype(arr.dtype)
-
-    def _future_to_4col(arr: np.ndarray) -> np.ndarray:
-        # Futures are ALWAYS 4-col [x,y,cos,sin]; widen legacy 3-col [x,y,heading].
-        # 4-col passes through; invalid (zero) rows stay zero.
-        if arr.shape[-1] == 4:
-            return arr
-        mask = np.abs(arr[..., :2]).sum(-1) == 0
-        h = arr[..., 2]
-        out4 = np.concatenate(
-            [arr[..., :2], np.cos(h)[..., None], np.sin(h)[..., None]], axis=-1
-        ).astype(np.float32)
-        out4[mask] = 0.0
-        return out4
 
     # --- ego_agent_past (T, 3) [x, y, yaw] ---
     if "ego_agent_past" in out:
@@ -1058,7 +1060,8 @@ def main(argv: Iterable[str] | None = None) -> None:
                 except Exception:
                     pass
 
-                perturbed["ego_agent_future"] = fut.astype(np.float32)
+                # Widen the legacy baseline prediction to 4-col; never save 3-col.
+                perturbed["ego_agent_future"] = _future_to_4col(fut.astype(np.float32))
                 np.savez(out_path, **perturbed)
             else:
                 # Skip baseline inference. Source NPZ's ego_agent_future

--- a/rlvr/autoresearch/tools/disturb_and_replay.py
+++ b/rlvr/autoresearch/tools/disturb_and_replay.py
@@ -532,6 +532,19 @@ def _apply_inverse_rigid_to_spatial(
         a = (a + np.pi) % (2 * np.pi) - np.pi
         arr[..., idx] = a.astype(arr.dtype)
 
+    def _future_to_4col(arr: np.ndarray) -> np.ndarray:
+        # Futures are ALWAYS 4-col [x,y,cos,sin]; widen legacy 3-col [x,y,heading].
+        # 4-col passes through; invalid (zero) rows stay zero.
+        if arr.shape[-1] == 4:
+            return arr
+        mask = np.abs(arr[..., :2]).sum(-1) == 0
+        h = arr[..., 2]
+        out4 = np.concatenate(
+            [arr[..., :2], np.cos(h)[..., None], np.sin(h)[..., None]], axis=-1
+        ).astype(np.float32)
+        out4[mask] = 0.0
+        return out4
+
     # --- ego_agent_past (T, 3) [x, y, yaw] ---
     if "ego_agent_past" in out:
         past = out["ego_agent_past"]
@@ -539,13 +552,14 @@ def _apply_inverse_rigid_to_spatial(
         _xy_inv(past, 0, 1)
         _wrap_yaw_inplace(past, 2)
 
-    # --- ego_agent_future (T, 3) [x, y, yaw] — zeros mark invalid steps ---
+    # --- ego_agent_future (T, 4) [x, y, cos, sin] — zeros mark invalid steps.
+    # Legacy 3-col [x,y,yaw] is widened first; we never keep/emit 3-col futures. ---
     if "ego_agent_future" in out:
-        fut = out["ego_agent_future"]
+        fut = _future_to_4col(np.asarray(out["ego_agent_future"], dtype=np.float32))
+        out["ego_agent_future"] = fut
         valid = (fut[:, 0] != 0) | (fut[:, 1] != 0)
         _xy_inv(fut, 0, 1)
-        _wrap_yaw_inplace(fut, 2)
-        # Restore zeros for originally-invalid slots
+        _dir_inv(fut, 2, 3)  # rotate the (cos,sin) heading vector, not wrap a yaw scalar
         fut[~valid] = 0
 
     # --- neighbor_agents_past (N, T, 11) ---
@@ -560,12 +574,14 @@ def _apply_inverse_rigid_to_spatial(
         # Zero out invalid slots (per parse_rosbag.py the inactive slots are all zero)
         nap[~valid] = 0
 
-    # --- neighbor_agents_future (N, T, 3) [x, y, yaw] ---
+    # --- neighbor_agents_future (N, T, 4) [x, y, cos, sin] — legacy 3-col [x,y,yaw]
+    # is widened first; never keep/emit 3-col futures. ---
     if "neighbor_agents_future" in out:
-        naf = out["neighbor_agents_future"]
+        naf = _future_to_4col(np.asarray(out["neighbor_agents_future"], dtype=np.float32))
+        out["neighbor_agents_future"] = naf
         valid = (naf[..., 0] != 0) | (naf[..., 1] != 0)
         _xy_inv(naf, 0, 1)
-        _wrap_yaw_inplace(naf, 2)
+        _dir_inv(naf, 2, 3)  # rotate the (cos,sin) heading vector, not wrap a yaw scalar
         naf[~valid] = 0
 
     # --- static_objects (5, 10) ---

--- a/rlvr/closed_loop/batched_rollout.py
+++ b/rlvr/closed_loop/batched_rollout.py
@@ -374,7 +374,7 @@ class BatchedRolloutManager:
                 if "neighbor_agents_future" in data:
                     nf = data["neighbor_agents_future"]
                     if nf.dim() == 4:
-                        nf = nf[0]  # [N_nb, T, 3]
+                        nf = nf[0]  # [N_nb, T, C] (4-col x,y,cos,sin; legacy 3 tolerated)
                 scene_data.append(data)
                 scene_paths.append(path)
                 nb_futures.append(nf)

--- a/rlvr/closed_loop/rollout.py
+++ b/rlvr/closed_loop/rollout.py
@@ -156,12 +156,12 @@ class RolloutManager:
         if "neighbor_agents_future" in data:
             nf = data["neighbor_agents_future"]
             if nf.dim() == 3:
-                neighbor_futures = nf  # [1, N_nb, T_future, 3] or [N_nb, T_future, 3]
+                neighbor_futures = nf  # [N_nb, T_future, C] (C=4 x,y,cos,sin; legacy 3)
             if nf.dim() == 4:
                 neighbor_futures = nf[0]  # remove batch dim
             else:
                 neighbor_futures = nf
-        # Ensure [N_nb, T_future, 3]
+        # Ensure [N_nb, T_future, C]  (last dim forwarded as-is; 4-col x,y,cos,sin)
         if neighbor_futures is not None and neighbor_futures.dim() == 4:
             neighbor_futures = neighbor_futures[0]
 

--- a/rlvr/grpo_logprob_loss.py
+++ b/rlvr/grpo_logprob_loss.py
@@ -69,7 +69,9 @@ def _build_model_inputs(
         nf_pn = min(nf.shape[1], Pn)
         nf_4d = torch.zeros(N, nf_pn, future_len, 4, device=device)
         nf_4d[..., :2] = nf[:, :nf_pn, :future_len, :2]
-        if nf.shape[-1] >= 3:
+        if nf.shape[-1] == 4:  # already cos/sin — copy directly (do NOT cos() it again)
+            nf_4d[..., 2:4] = nf[:, :nf_pn, :future_len, 2:4]
+        elif nf.shape[-1] == 3:  # legacy heading_rad -> cos/sin
             heading = nf[:, :nf_pn, :future_len, 2]
             nf_4d[..., 2] = torch.cos(heading)
             nf_4d[..., 3] = torch.sin(heading)
@@ -190,7 +192,9 @@ def collect_logprob_rollout(
         nf_pn = min(nf.shape[1], Pn)
         nf_4d = torch.zeros(N, nf_pn, future_len, 4, device=device)
         nf_4d[..., :2] = nf[:, :nf_pn, :future_len, :2]
-        if nf.shape[-1] >= 3:
+        if nf.shape[-1] == 4:  # already cos/sin — copy directly (do NOT cos() it again)
+            nf_4d[..., 2:4] = nf[:, :nf_pn, :future_len, 2:4]
+        elif nf.shape[-1] == 3:  # legacy heading_rad -> cos/sin
             heading = nf[:, :nf_pn, :future_len, 2]
             nf_4d[..., 2] = torch.cos(heading)
             nf_4d[..., 3] = torch.sin(heading)

--- a/rlvr/grpo_loss.py
+++ b/rlvr/grpo_loss.py
@@ -341,14 +341,16 @@ def compute_batched_trajectory_losses(
     neighbor_future_valid = None
     nf_pn = 0
     if Pn > 0 and "neighbor_agents_future" in batch_data:
-        nf = batch_data["neighbor_agents_future"]  # [N, Pn_data, T, 3] — x, y, heading_rad
+        nf = batch_data["neighbor_agents_future"]  # [N, Pn, T, 4] x,y,cos,sin (or legacy 3-col)
         nf_pn = min(nf.shape[1], Pn)
         nf_4d = torch.zeros(N, nf_pn, future_len, 4, device=device)
         nf_4d[..., :2] = nf[:, :nf_pn, :future_len, :2]  # x, y
-        if nf.shape[-1] >= 3:
-            heading = nf[:, :nf_pn, :future_len, 2]  # heading_rad
-            nf_4d[..., 2] = torch.cos(heading)  # cos_yaw
-            nf_4d[..., 3] = torch.sin(heading)  # sin_yaw
+        if nf.shape[-1] == 4:  # already cos/sin — copy directly (do NOT cos() it again)
+            nf_4d[..., 2:4] = nf[:, :nf_pn, :future_len, 2:4]
+        elif nf.shape[-1] == 3:  # legacy heading_rad -> cos/sin
+            heading = nf[:, :nf_pn, :future_len, 2]
+            nf_4d[..., 2] = torch.cos(heading)
+            nf_4d[..., 3] = torch.sin(heading)
         nf_4d_norm = (nf_4d - ego_mean) / ego_std
         gt_future[:, 1 : 1 + nf_pn, :, :] = nf_4d_norm
         # Track validity for neighbor loss
@@ -617,7 +619,9 @@ def _compute_neighbor_reg_loss(
         nf_pn = min(nf.shape[1], Pn)
         nf_4d = torch.zeros(1, nf_pn, future_len, 4, device=device)
         nf_4d[..., :2] = nf[:, :nf_pn, :future_len, :2]
-        if nf.shape[-1] >= 3:
+        if nf.shape[-1] == 4:  # already cos/sin — copy directly (do NOT cos() it again)
+            nf_4d[..., 2:4] = nf[:, :nf_pn, :future_len, 2:4]
+        elif nf.shape[-1] == 3:  # legacy heading_rad -> cos/sin
             heading = nf[:, :nf_pn, :future_len, 2]
             nf_4d[..., 2] = torch.cos(heading)
             nf_4d[..., 3] = torch.sin(heading)

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -952,24 +952,41 @@ def _min_clearance_any(neighbors_live: np.ndarray, ego_shape: np.ndarray, device
     return float((p1 - p2).norm(dim=-1).min())
 
 
+def _future_to_4col(arr: np.ndarray) -> np.ndarray:
+    """Heading future -> cos/sin future: (..., 3) [x, y, heading] -> (..., 4)
+    [x, y, cos, sin]. Already-4-col input passes through. Zero (invalid) rows stay zero.
+    The trainable / reward schema is ALWAYS 4-col for futures — never save 3-col."""
+    arr = np.asarray(arr, dtype=np.float32)
+    if arr.shape[-1] == 4:
+        return arr
+    mask = np.abs(arr[..., :2]).sum(-1) == 0
+    h = arr[..., 2]
+    out = np.concatenate(
+        [arr[..., :2], np.cos(h)[..., None], np.sin(h)[..., None]], axis=-1
+    ).astype(np.float32)
+    out[mask] = 0.0
+    return out
+
+
 def _recenter_neighbor_future(naf: np.ndarray, dx: float, dy: float, dyaw: float) -> np.ndarray:
     """Re-center a recorded neighbor_agents_future onto the live ego.
 
     naf: (Pn, T, 3) [x, y, heading] (or (Pn, T, 4) [x,y,cos,sin]) in the recorded-ego
     frame. (dx, dy, dyaw) is the live ego pose in the recorded-ego frame. Returns
-    (Pn, T, 3) [x, y, heading] in the live-ego frame; invalid (zero) entries stay zero.
+    (Pn, T, 4) [x, y, cos, sin] in the live-ego frame (the trainable/reward schema —
+    never 3-col); invalid (zero) entries stay zero.
     """
     from scenario_generation.transforms import transform_positions
 
     naf = np.asarray(naf, dtype=np.float32)
-    if naf.shape[-1] == 4:
-        head = np.arctan2(naf[..., 3], naf[..., 2])
-        naf = np.concatenate([naf[..., :2], head[..., None]], axis=-1)
-    out = naf.copy()
-    R = _rotation_matrix(dyaw)
+    head = np.arctan2(naf[..., 3], naf[..., 2]) if naf.shape[-1] == 4 else naf[..., 2]
     mask = np.abs(naf[..., :2]).sum(-1) == 0
-    out[..., :2] = transform_positions(naf[..., :2], R, np.array([dx, dy], dtype=np.float64))
-    out[..., 2] = naf[..., 2] - dyaw
+    R = _rotation_matrix(dyaw)
+    xy = transform_positions(naf[..., :2], R, np.array([dx, dy], dtype=np.float64))
+    h = head - dyaw
+    out = np.concatenate(
+        [xy.astype(np.float32), np.cos(h)[..., None], np.sin(h)[..., None]], axis=-1
+    ).astype(np.float32)
     out[mask] = 0.0
     return out
 
@@ -1094,13 +1111,15 @@ def extract_collision_scenes(
             if naf is not None:
                 dx, dy, dyaw = _rel_pose(tl.poses[idx], live_pose)
                 scene["neighbor_agents_future"] = _recenter_neighbor_future(naf, dx, dy, dyaw)
-            # ego_agent_future = realized live path up to the collision (zeros after).
-            eaf = np.zeros((fut_len, 3), dtype=np.float32)
+            # ego_agent_future = realized live path up to the collision (zeros after),
+            # 4-col [x, y, cos, sin] (trainable/reward schema; never 3-col).
+            eaf = np.zeros((fut_len, 4), dtype=np.float32)
             for j in range(1, fut_len + 1):
                 fk = step_k + j
                 if fk > t_c or fk not in live_poses:
                     break
-                eaf[j - 1] = _world_pose_to_ego(live_poses[fk], live_pose)
+                ex, ey, eh = _world_pose_to_ego(live_poses[fk], live_pose)
+                eaf[j - 1] = (ex, ey, math.cos(eh), math.sin(eh))
             scene["ego_agent_future"] = eaf
             scene["origin"] = np.array("live")
         else:
@@ -1110,6 +1129,10 @@ def extract_collision_scenes(
                 continue
             with np.load(tl.npz_paths[frame], allow_pickle=True) as z:
                 scene = {key: z[key] for key in z.files if key not in ("map_name", "token")}
+            # Recorded corpora may store 3-col futures; the saved scene must be 4-col.
+            for fk in ("neighbor_agents_future", "ego_agent_future"):
+                if fk in scene:
+                    scene[fk] = _future_to_4col(scene[fk])
             scene["origin"] = np.array("recorded")
         token = f"{step_k - t_c:+06d}"  # offset from collision, e.g. -00080 .. -00001
         np.savez_compressed(out_dir / f"collision{token}.npz", **scene)

--- a/scenario_generation/tests/test_scene_4col.py
+++ b/scenario_generation/tests/test_scene_4col.py
@@ -1,0 +1,67 @@
+"""Scene-generation futures are ALWAYS 4-col [x,y,cos,sin], never 3-col [x,y,heading].
+
+Covers the extractor's widening/recenter helpers and that load_npz_data tolerates the
+string `origin` metadata the extractor writes.
+"""
+
+import json
+
+import numpy as np
+
+from scenario_generation.reproducer_rollout import _future_to_4col, _recenter_neighbor_future
+
+
+def test_future_to_4col_widens_and_passes_through():
+    # 3-col [x,y,heading] -> 4-col [x,y,cos,sin]
+    a = np.array([[[1.0, 2.0, 0.0], [3.0, 4.0, np.pi / 2]]], dtype=np.float32)  # (1,2,3)
+    out = _future_to_4col(a)
+    assert out.shape == (1, 2, 4)
+    assert np.allclose(out[0, 0], [1, 2, 1, 0], atol=1e-6)  # heading 0 -> cos1,sin0
+    assert np.allclose(out[0, 1], [3, 4, 0, 1], atol=1e-6)  # heading pi/2 -> cos0,sin1
+    # 4-col passes through unchanged
+    b = np.array([[[1.0, 2.0, 0.7, 0.7]]], dtype=np.float32)
+    assert np.array_equal(_future_to_4col(b), b)
+
+
+def test_future_to_4col_zero_rows_stay_zero():
+    a = np.zeros((1, 3, 3), dtype=np.float32)
+    a[0, 0] = [5.0, 0.0, 1.2]  # one valid row; others zero
+    out = _future_to_4col(a)
+    assert out.shape[-1] == 4
+    assert np.all(out[0, 1] == 0) and np.all(out[0, 2] == 0)  # invalid rows stay zero
+    assert not np.all(out[0, 0] == 0)
+
+
+def test_recenter_neighbor_future_is_4col():
+    # one neighbor, one timestep at (5,0) heading 0 in recorded frame
+    naf3 = np.zeros((320, 1, 3), dtype=np.float32)
+    naf3[0, 0] = [5.0, 0.0, 0.0]
+    out = _recenter_neighbor_future(naf3, dx=0.0, dy=0.0, dyaw=0.0)
+    assert out.shape == (320, 1, 4)  # NEVER 3-col
+    assert np.allclose(out[0, 0], [5, 0, 1, 0], atol=1e-5)
+    # +90deg live-ego yaw: neighbor (5,0) -> (0,-5), heading (cos,sin)=(0,-1)
+    out2 = _recenter_neighbor_future(naf3, dx=0.0, dy=0.0, dyaw=np.pi / 2)
+    assert np.allclose(out2[0, 0, :2], [0, -5], atol=1e-5)
+    assert np.allclose(out2[0, 0, 2:4], [0, -1], atol=1e-5)
+    # 4-col input also yields 4-col output
+    naf4 = np.zeros((320, 1, 4), dtype=np.float32)
+    naf4[0, 0] = [5.0, 0.0, 1.0, 0.0]
+    assert _recenter_neighbor_future(naf4, 0.0, 0.0, 0.0).shape == (320, 1, 4)
+
+
+def test_load_npz_data_skips_origin_string(tmp_path):
+    import torch
+
+    from preference_optimization.utils import load_npz_data
+
+    p = tmp_path / "scene.npz"
+    np.savez(
+        p,
+        ego_agent_past=np.zeros((31, 3), np.float32),
+        ego_shape=np.array([4.76, 7.24, 2.29], np.float32),
+        neighbor_agents_future=np.zeros((320, 80, 4), np.float32),
+        origin=np.array("live"),  # string metadata the extractor writes
+    )
+    data = load_npz_data(p, torch.device("cpu"))  # must not crash on the string key
+    assert "origin" not in data
+    assert "neighbor_agents_future" in data and data["neighbor_agents_future"].shape[-1] == 4

--- a/scenario_generation/tests/test_scene_4col.py
+++ b/scenario_generation/tests/test_scene_4col.py
@@ -65,3 +65,14 @@ def test_load_npz_data_skips_origin_string(tmp_path):
     data = load_npz_data(p, torch.device("cpu"))  # must not crash on the string key
     assert "origin" not in data
     assert "neighbor_agents_future" in data and data["neighbor_agents_future"].shape[-1] == 4
+
+
+def test_heading_to_cos_sin_is_idempotent():
+    """4-col [x,y,cos,sin] must pass through unchanged (no cos(cos) double-convert)."""
+    import torch
+    from diffusion_planner.train_epoch import heading_to_cos_sin
+
+    three = torch.tensor([[[1.0, 2.0, 0.0]]])  # x,y,heading=0
+    assert torch.allclose(heading_to_cos_sin(three), torch.tensor([[[1.0, 2.0, 1.0, 0.0]]]))
+    four = torch.tensor([[[1.0, 2.0, 0.7, 0.71]]])  # already cos/sin
+    assert torch.equal(heading_to_cos_sin(four), four)  # unchanged


### PR DESCRIPTION
## Summary

Scene-generation code must always emit **4-col `[x, y, cos, sin]`** neighbor AND ego futures — never 3-col `[x, y, heading]`. The reward/RSFT path (`compute_subscores_batch`) hard-fails on 3-col neighbor futures, and the cpp converter already emits 4-col. Two scene-savers still wrote 3-col, which silently broke GRPO/RSFT/guidance scoring on the generated scenes.

## Fixes

- **Reproducer collision-scene extractor** (`extract_collision_scenes`): `_recenter_neighbor_future` now returns 4-col, `ego_agent_future` is built 4-col, and the recorded-frame backtrack path widens any legacy 3-col future via a new `_future_to_4col` helper.
- **`disturb_and_replay`**: `neighbor_agents_future` and `ego_agent_future` are widened to 4-col, and the heading is frame-inverted as a `(cos,sin)` vector (`_dir_inv`) instead of wrapping a yaw scalar (which would corrupt the cos channel on a 4-col array). Legacy 3-col input is accepted and widened; 4-col passes through.
- **`load_npz_data`**: skips string/object metadata keys (e.g. the extractor's `origin` tag) so saved scenes load without a tensor-conversion crash.

## Verification

Extracted scenes are now `(320, 80, 4)` neighbor future / `(80, 4)` ego future. GRPO K=8 generation + `reward.py` scoring run end-to-end on them, and the scene renders correctly in the perfect-tracker renderer with all neighbors. `pytest scenario_generation/tests/test_reproducer_collision_scope.py` green.

Separate from the skip-filter PR (#149); cpp converter side is already merged (#148).
