### PR TITLE
feat(validation): log reward subscores in validate_model

### DIFF
--- a/diffusion_planner/diffusion_planner/validate_model.py
+++ b/diffusion_planner/diffusion_planner/validate_model.py
@@ -17,6 +17,52 @@ from diffusion_planner.loss import (
 )
 from diffusion_planner.train_epoch import heading_to_cos_sin
 from diffusion_planner.utils import ddp
+from planner_metrics import RewardConfig, compute_subscores_batch
+
+# Reward subscores logged as additive validation metrics (valid_loss/ego_subscore_*).
+# These are the RLVR reward's subscores (EPDMS-INSPIRED — custom thresholds,
+# goal-based ego-progress, penalty signs), NOT a faithful EPDMS port (that lives
+# in OnePlanner; see issue #142). Logging them lets best-model selection see the
+# same physical quantities the reward is built from. Best-model selection itself
+# is unchanged.
+_VAL_SUBSCORE_KEYS = (
+    "safety",
+    "ttc",
+    "progress",
+    "comfort",
+    "centerline",
+    "red_light",
+    "feasibility",
+)
+_VAL_SUBSCORE_CFG = RewardConfig()
+
+
+@torch.no_grad()
+def _reward_subscores_per_scene(ego_pred, data_batched, config, keys):
+    """Per-scene reward subscores for a validation batch.
+
+    ``compute_subscores_batch`` is single-scene / N-trajectory (its map + neighbor
+    terms use one scene's tensors), so this loops over the ``B`` scenes — each with
+    one ego prediction — and stacks the requested subscores.
+
+    Args:
+        ego_pred: ``(B, T, 4)`` ego predictions, metre ego-frame.
+        data_batched: dict of ``(B, ...)`` tensors (ego_shape / neighbors / map /
+            goal); each is sliced ``[b:b+1]`` per scene.
+        config: RewardConfig (thresholds; weights are irrelevant to raw subscores).
+        keys: subscore names to return.
+
+    Returns:
+        ``{name: (B,) tensor}`` for each requested key.
+    """
+    n = ego_pred.shape[0]
+    acc = {name: [] for name in keys}
+    for b in range(n):
+        data_b = {k: v[b : b + 1] for k, v in data_batched.items()}
+        subs_b = compute_subscores_batch(ego_pred[b : b + 1], data_b, config)
+        for name in keys:
+            acc[name].append(subs_b[name])
+    return {name: torch.cat(vals) for name, vals in acc.items()}
 
 
 @torch.no_grad()
@@ -148,6 +194,23 @@ def validate_model(model, val_loader, args, return_pred=False) -> tuple[float, f
             margin=args.road_border_margin,
         )
         total_result_dict["ego_road_border_loss"].append(rb_penalty.cpu())
+
+        # Reward subscores as additive validation metrics (logged via the ego_*
+        # machinery as valid_loss/ego_subscore_*). Same metre ego-frame tensors
+        # the rb / neighbor metrics above use; one scene per prediction.
+        data_batched = {
+            "ego_shape": inputs["ego_shape"],
+            "neighbor_agents_future": neighbors_future,
+            "neighbor_agents_past": denorm_inputs["neighbor_agents_past"],
+        }
+        for k in ("lanes", "route_lanes", "line_strings", "polygons", "goal_pose"):
+            if k in denorm_inputs:
+                data_batched[k] = denorm_inputs[k]
+        subscores = _reward_subscores_per_scene(
+            prediction[:, 0], data_batched, _VAL_SUBSCORE_CFG, _VAL_SUBSCORE_KEYS
+        )
+        for name, val in subscores.items():
+            total_result_dict[f"ego_subscore_{name}"].append(val.cpu())  # (B,)
 
     avg_loss_ego = total_loss_ego / total_samples_ego
     avg_loss_neighbor = total_loss_neighbor / max(total_samples_neighbor, 1)

--- a/diffusion_planner/diffusion_planner/validate_model.py
+++ b/diffusion_planner/diffusion_planner/validate_model.py
@@ -17,7 +17,13 @@ from diffusion_planner.loss import (
 )
 from diffusion_planner.train_epoch import heading_to_cos_sin
 from diffusion_planner.utils import ddp
-from planner_metrics import RewardConfig, compute_subscores_batch
+from planner_metrics import (
+    EPDMSLikeConfig,
+    RewardConfig,
+    compute_subscores_batch,
+    epdms_like_aggregate,
+    gt_path_length,
+)
 
 # Reward subscores logged as additive validation metrics (valid_loss/ego_subscore_*).
 # These are the RLVR reward's subscores (EPDMS-INSPIRED — custom thresholds,
@@ -35,10 +41,29 @@ _VAL_SUBSCORE_KEYS = (
     "feasibility",
 )
 _VAL_SUBSCORE_CFG = RewardConfig()
+_VAL_EPDMS_LIKE_CFG = EPDMSLikeConfig()
+# Components returned by epdms_like_aggregate, logged as ``ego_subscore_<key>``.
+# ``epdms_like`` is the single [0,1] EPDMS-structured proxy score (NOT a faithful
+# NAVSIM EPDMS; see #142); the rest are its binary gates and normalized quality
+# terms, kept for debugging why a checkpoint scores the way it does.
+_VAL_EPDMS_LIKE_KEYS = (
+    "epdms_like",
+    "gate_nc",
+    "gate_dac",
+    "gate_tlc",
+    "gate_kin",
+    "q_ttc",
+    "q_progress",
+    "q_comfort",
+    "q_lane",
+    "quality",
+)
 
 
 @torch.no_grad()
-def _reward_subscores_per_scene(ego_pred, data_batched, config, keys):
+def _reward_subscores_per_scene(
+    ego_pred, data_batched, config, keys, gt_progress=None, epdms_cfg=None
+):
     """Per-scene reward subscores for a validation batch.
 
     ``compute_subscores_batch`` is single-scene / N-trajectory (its map + neighbor
@@ -53,16 +78,26 @@ def _reward_subscores_per_scene(ego_pred, data_batched, config, keys):
         keys: subscore names to return.
 
     Returns:
-        ``{name: (B,) tensor}`` for each requested key.
+        ``{name: (B,) tensor}`` for each requested key. When ``gt_progress`` is
+        provided, the dict also includes the EPDMS-like component keys (``epdms_like``
+        plus its gates / normalized quality terms; see ``_VAL_EPDMS_LIKE_KEYS``).
     """
     n = ego_pred.shape[0]
     acc = {name: [] for name in keys}
+    want_epdms = gt_progress is not None
+    epdms_acc = {k: [] for k in _VAL_EPDMS_LIKE_KEYS} if want_epdms else {}
     for b in range(n):
         data_b = {k: v[b : b + 1] for k, v in data_batched.items()}
         subs_b = compute_subscores_batch(ego_pred[b : b + 1], data_b, config)
         for name in keys:
             acc[name].append(subs_b[name])
-    return {name: torch.cat(vals) for name, vals in acc.items()}
+        if want_epdms:
+            _, comp_b = epdms_like_aggregate(subs_b, gt_progress[b : b + 1], epdms_cfg)
+            for k in _VAL_EPDMS_LIKE_KEYS:
+                epdms_acc[k].append(comp_b[k])
+    out = {name: torch.cat(vals) for name, vals in acc.items()}
+    out.update({k: torch.cat(vals) for k, vals in epdms_acc.items()})
+    return out
 
 
 @torch.no_grad()
@@ -206,8 +241,14 @@ def validate_model(model, val_loader, args, return_pred=False) -> tuple[float, f
         for k in ("lanes", "route_lanes", "line_strings", "polygons", "goal_pose"):
             if k in denorm_inputs:
                 data_batched[k] = denorm_inputs[k]
+        gt_progress = gt_path_length(ego_future)  # (B,) expert path length, metres
         subscores = _reward_subscores_per_scene(
-            prediction[:, 0], data_batched, _VAL_SUBSCORE_CFG, _VAL_SUBSCORE_KEYS
+            prediction[:, 0],
+            data_batched,
+            _VAL_SUBSCORE_CFG,
+            _VAL_SUBSCORE_KEYS,
+            gt_progress=gt_progress,
+            epdms_cfg=_VAL_EPDMS_LIKE_CFG,
         )
         for name, val in subscores.items():
             total_result_dict[f"ego_subscore_{name}"].append(val.cpu())  # (B,)

--- a/diffusion_planner/diffusion_planner/validate_model.py
+++ b/diffusion_planner/diffusion_planner/validate_model.py
@@ -42,22 +42,10 @@ _VAL_SUBSCORE_KEYS = (
 )
 _VAL_SUBSCORE_CFG = RewardConfig()
 _VAL_EPDMS_LIKE_CFG = EPDMSLikeConfig()
-# Components returned by epdms_like_aggregate, logged as ``ego_subscore_<key>``.
-# ``epdms_like`` is the single [0,1] EPDMS-structured proxy score (NOT a faithful
-# NAVSIM EPDMS; see #142); the rest are its binary gates and normalized quality
-# terms, kept for debugging why a checkpoint scores the way it does.
-_VAL_EPDMS_LIKE_KEYS = (
-    "epdms_like",
-    "gate_nc",
-    "gate_dac",
-    "gate_tlc",
-    "gate_kin",
-    "q_ttc",
-    "q_progress",
-    "q_comfort",
-    "q_lane",
-    "quality",
-)
+# epdms_like_aggregate returns the EPDMS-like components -- ``epdms_like`` (the single
+# [0,1] EPDMS-structured proxy score, NOT a faithful NAVSIM EPDMS; see #142) plus its
+# binary gates and normalized quality terms. They are logged as ``ego_subscore_<key>``;
+# the aggregate function is the single source of truth for which keys exist.
 
 
 @torch.no_grad()
@@ -80,12 +68,13 @@ def _reward_subscores_per_scene(
     Returns:
         ``{name: (B,) tensor}`` for each requested key. When ``gt_progress`` is
         provided, the dict also includes the EPDMS-like component keys (``epdms_like``
-        plus its gates / normalized quality terms; see ``_VAL_EPDMS_LIKE_KEYS``).
+        plus its gates / normalized quality terms) as returned by
+        ``epdms_like_aggregate``.
     """
     n = ego_pred.shape[0]
     acc = {name: [] for name in keys}
     want_epdms = gt_progress is not None
-    epdms_acc = {k: [] for k in _VAL_EPDMS_LIKE_KEYS} if want_epdms else {}
+    epdms_acc: dict[str, list] = {}
     for b in range(n):
         data_b = {k: v[b : b + 1] for k, v in data_batched.items()}
         subs_b = compute_subscores_batch(ego_pred[b : b + 1], data_b, config)
@@ -93,8 +82,8 @@ def _reward_subscores_per_scene(
             acc[name].append(subs_b[name])
         if want_epdms:
             _, comp_b = epdms_like_aggregate(subs_b, gt_progress[b : b + 1], epdms_cfg)
-            for k in _VAL_EPDMS_LIKE_KEYS:
-                epdms_acc[k].append(comp_b[k])
+            for k, v in comp_b.items():
+                epdms_acc.setdefault(k, []).append(v)
     out = {name: torch.cat(vals) for name, vals in acc.items()}
     out.update({k: torch.cat(vals) for k, vals in epdms_acc.items()})
     return out

--- a/diffusion_planner/diffusion_planner/validate_model.py
+++ b/diffusion_planner/diffusion_planner/validate_model.py
@@ -235,6 +235,11 @@ def validate_model(model, val_loader, args, return_pred=False) -> tuple[float, f
         # the rb / neighbor metrics above use; one scene per prediction.
         data_batched = {
             "ego_shape": inputs["ego_shape"],
+            # GT ego future (same frame as `prediction`/`all_gt`); lets
+            # compute_progress_score_batch fall back to the goal-directed GT
+            # endpoint instead of the predicted path length when goal_pose is
+            # absent/far (>100 m). Keeps the `progress`/`q_progress` term honest.
+            "ego_agent_future": ego_future,
             "neighbor_agents_future": neighbors_future,
             "neighbor_agents_past": denorm_inputs["neighbor_agents_past"],
         }

--- a/diffusion_planner/tests/test_epdms_like_aggregate.py
+++ b/diffusion_planner/tests/test_epdms_like_aggregate.py
@@ -20,8 +20,8 @@ def _subscores():
     return {
         "ttc": torch.tensor([1.0, 1.0, 1.0, 1.0], dtype=f),
         "progress": torch.tensor([10.0, 10.0, 5.0, 10.0], dtype=f),
-        "comfort": torch.tensor([0.0, 0.0, -5.0, 0.0], dtype=f),       # -mean|jerk|
-        "centerline": torch.tensor([0.0, 0.0, -4.0, 0.0], dtype=f),    # -lane_usage^2
+        "comfort": torch.tensor([0.0, 0.0, -5.0, 0.0], dtype=f),  # -mean|jerk|
+        "centerline": torch.tensor([0.0, 0.0, -4.0, 0.0], dtype=f),  # -lane_usage^2
         "red_light": torch.tensor([0.0, 0.0, 0.0, 0.0], dtype=f),
         "rb_crossing_gate": torch.tensor([1.0, 1.0, 1.0, 0.0], dtype=f),
         "kinematic_gate": torch.tensor([1.0, 1.0, 1.0, 1.0], dtype=f),

--- a/diffusion_planner/tests/test_epdms_like_aggregate.py
+++ b/diffusion_planner/tests/test_epdms_like_aggregate.py
@@ -1,0 +1,85 @@
+"""Unit tests for the single [0,1] EPDMS-like aggregate (``planner_metrics.epdms_like``)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from planner_metrics import EPDMSLikeConfig, epdms_like_aggregate, gt_path_length
+
+
+def _subscores():
+    """Four synthetic scenes, batched as ``compute_subscores_batch`` would return.
+
+    scene 0: perfect            -> score == 1.0
+    scene 1: at-fault collision -> NC gate zeros it
+    scene 2: degraded quality   -> gates pass, quality computable by hand
+    scene 3: drivable-area exit -> DAC gate zeros it
+    """
+    f = torch.float32
+    return {
+        "ttc": torch.tensor([1.0, 1.0, 1.0, 1.0], dtype=f),
+        "progress": torch.tensor([10.0, 10.0, 5.0, 10.0], dtype=f),
+        "comfort": torch.tensor([0.0, 0.0, -5.0, 0.0], dtype=f),       # -mean|jerk|
+        "centerline": torch.tensor([0.0, 0.0, -4.0, 0.0], dtype=f),    # -lane_usage^2
+        "red_light": torch.tensor([0.0, 0.0, 0.0, 0.0], dtype=f),
+        "rb_crossing_gate": torch.tensor([1.0, 1.0, 1.0, 0.0], dtype=f),
+        "kinematic_gate": torch.tensor([1.0, 1.0, 1.0, 1.0], dtype=f),
+        "collision_step": [None, 42, None, None],
+    }, torch.tensor([10.0, 10.0, 10.0, 10.0], dtype=f)  # gt_progress
+
+
+def test_score_in_unit_interval_and_known_values():
+    subs, gt = _subscores()
+    cfg = EPDMSLikeConfig()  # defaults: jerk_bound=2, lane_usage_bound=1; w=5/5/2/5
+    score, comp = epdms_like_aggregate(subs, gt, cfg)
+
+    assert score.shape == (4,)
+    assert torch.all(score >= 0.0) and torch.all(score <= 1.0)
+
+    # scene 0: everything perfect -> 1.0
+    assert score[0].item() == pytest.approx(1.0, abs=1e-6)
+
+    # scene 1: collision -> NC gate hard-zeros regardless of quality
+    assert score[1].item() == 0.0
+    assert comp["gate_nc"][1].item() == 0.0
+
+    # scene 3: drivable-area violation -> DAC gate hard-zeros
+    assert score[3].item() == 0.0
+    assert comp["gate_dac"][3].item() == 0.0
+
+    # scene 2: gates all pass; quality by hand.
+    #   ttc_q=1, progress_q=5/10=0.5, comfort_q=0 (|jerk|5 > 2), lane_q=0 (usage 2 > 1)
+    #   quality = (5*1 + 5*0.5 + 2*0 + 5*0) / (5+5+2+5) = 7.5/17
+    assert comp["q_progress"][2].item() == pytest.approx(0.5, abs=1e-6)
+    assert comp["q_comfort"][2].item() == 0.0
+    assert comp["q_lane"][2].item() == 0.0
+    assert score[2].item() == pytest.approx(7.5 / 17.0, abs=1e-5)
+
+
+def test_comfort_and_lane_thresholds_are_binary():
+    subs, gt = _subscores()
+    # Loosen bounds so scene 2 now passes comfort (|jerk|=5) and lane (usage=2).
+    cfg = EPDMSLikeConfig(jerk_bound=10.0, lane_usage_bound=3.0)
+    score, comp = epdms_like_aggregate(subs, gt, cfg)
+    assert comp["q_comfort"][2].item() == 1.0
+    assert comp["q_lane"][2].item() == 1.0
+    # quality now = (5*1 + 5*0.5 + 2*1 + 5*1) / 17 = 14.5/17
+    assert score[2].item() == pytest.approx(14.5 / 17.0, abs=1e-5)
+
+
+def test_red_light_violation_gates_score():
+    subs, gt = _subscores()
+    subs["red_light"] = torch.tensor([0.0, 0.0, 0.0, -10.0], dtype=torch.float32)
+    # also clear the DAC violation on scene 3 to isolate the TLC gate
+    subs["rb_crossing_gate"] = torch.tensor([1.0, 1.0, 1.0, 1.0], dtype=torch.float32)
+    score, comp = epdms_like_aggregate(subs, gt)
+    assert comp["gate_tlc"][3].item() == 0.0
+    assert score[3].item() == 0.0
+
+
+def test_gt_path_length_straight_line():
+    # 5 points spaced 2 m apart on a straight line -> length 8 m.
+    t = torch.arange(5, dtype=torch.float32) * 2.0
+    traj = torch.stack([t, torch.zeros_like(t)], dim=-1).unsqueeze(0)  # (1, 5, 2)
+    assert gt_path_length(traj)[0].item() == pytest.approx(8.0, abs=1e-6)

--- a/diffusion_planner/tests/test_epdms_like_aggregate.py
+++ b/diffusion_planner/tests/test_epdms_like_aggregate.py
@@ -1,3 +1,17 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Unit tests for the single [0,1] EPDMS-like aggregate (``planner_metrics.epdms_like``)."""
 
 from __future__ import annotations

--- a/diffusion_planner/tests/test_validation_subscores.py
+++ b/diffusion_planner/tests/test_validation_subscores.py
@@ -1,0 +1,67 @@
+"""Tests for the validation-loop reward-subscore wiring.
+
+`validate_model` logs the RLVR reward subscores as additive metrics by calling
+`planner_metrics.compute_subscores_batch` per scene (it is single-scene /
+N-trajectory). This pins the per-scene batched helper against a direct
+single-scene call so the batched slicing stays correct.
+"""
+
+from __future__ import annotations
+
+import torch
+from diffusion_planner.validate_model import _VAL_SUBSCORE_KEYS, _reward_subscores_per_scene
+
+from planner_metrics import RewardConfig, compute_subscores_batch
+
+T = 80
+
+
+def _ego(speed: float) -> torch.Tensor:
+    t = torch.arange(T, dtype=torch.float32)
+    return torch.stack([t * speed, torch.zeros(T), torch.ones(T), torch.zeros(T)], dim=-1)
+
+
+def _lanes() -> torch.Tensor:
+    lanes = torch.zeros(140, 20, 33)
+    for seg in range(10):
+        for pt in range(20):
+            x = (seg * 20 + pt) * 1.0
+            lanes[seg, pt, 0] = x
+            lanes[seg, pt, 2] = 1.0
+            lanes[seg, pt, 4] = x
+            lanes[seg, pt, 5] = 1.75
+            lanes[seg, pt, 6] = x
+            lanes[seg, pt, 7] = -1.75
+    return lanes
+
+
+def _batched_scene(b: int = 2) -> tuple[torch.Tensor, dict]:
+    ego_pred = torch.stack([_ego(0.5), _ego(0.3)][:b])  # (b, T, 4)
+    data_batched = {
+        "ego_shape": torch.tensor([[2.79, 4.34, 1.70]] * b),
+        "neighbor_agents_future": torch.zeros(b, 1, T, 4),
+        "neighbor_agents_past": torch.zeros(b, 1, 21, 11),
+        "lanes": torch.stack([_lanes()] * b),
+        "goal_pose": torch.tensor([[100.0, 0.0, 1.0, 0.0]] * b),
+    }
+    return ego_pred, data_batched
+
+
+def test_helper_shapes_and_finite() -> None:
+    ego_pred, data_batched = _batched_scene(2)
+    out = _reward_subscores_per_scene(ego_pred, data_batched, RewardConfig(), _VAL_SUBSCORE_KEYS)
+    assert set(out) == set(_VAL_SUBSCORE_KEYS)
+    for name in _VAL_SUBSCORE_KEYS:
+        assert out[name].shape == (2,), f"{name}: {tuple(out[name].shape)}"
+        assert torch.isfinite(out[name]).all(), f"{name} not finite"
+
+
+def test_per_scene_matches_single_scene() -> None:
+    """Per-scene batched slicing == calling compute_subscores_batch on each scene."""
+    ego_pred, data_batched = _batched_scene(2)
+    out = _reward_subscores_per_scene(ego_pred, data_batched, RewardConfig(), _VAL_SUBSCORE_KEYS)
+    for b in range(ego_pred.shape[0]):
+        data_b = {k: v[b : b + 1] for k, v in data_batched.items()}
+        subs_b = compute_subscores_batch(ego_pred[b : b + 1], data_b, RewardConfig())
+        for name in _VAL_SUBSCORE_KEYS:
+            assert float(out[name][b]) == float(subs_b[name][0]), f"scene {b} {name} mismatch"

--- a/diffusion_planner/tests/test_validation_subscores.py
+++ b/diffusion_planner/tests/test_validation_subscores.py
@@ -1,3 +1,17 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for the validation-loop reward-subscore wiring.
 
 `validate_model` logs the RLVR reward subscores as additive metrics by calling

--- a/planner_metrics/__init__.py
+++ b/planner_metrics/__init__.py
@@ -5,5 +5,10 @@ from __future__ import annotations
 
 from planner_metrics.aggregate import compute_subscores_batch  # noqa: F401
 from planner_metrics.config import RewardConfig  # noqa: F401  (re-export)
+from planner_metrics.epdms_like import (  # noqa: F401
+    EPDMSLikeConfig,
+    epdms_like_aggregate,
+    gt_path_length,
+)
 from planner_metrics.geometry import *  # noqa: F401,F403
 from planner_metrics.subscores import *  # noqa: F401,F403

--- a/planner_metrics/epdms_like.py
+++ b/planner_metrics/epdms_like.py
@@ -1,3 +1,17 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Single [0,1] EPDMS-*like* aggregate from the raw ``planner_metrics`` subscores.
 
 This is an EPDMS-**structured proxy**, NOT a faithful NAVSIM EPDMS port (the faithful
@@ -163,6 +177,11 @@ def epdms_like_aggregate(
     lane_q = (lane_usage <= cfg.lane_usage_bound).to(dtype)
 
     w_sum = cfg.w_ttc + cfg.w_progress + cfg.w_comfort + cfg.w_lane
+    if w_sum <= 0:
+        raise ValueError(
+            "EPDMSLikeConfig quality weights (w_ttc/w_progress/w_comfort/w_lane) "
+            "must sum to a positive value"
+        )
     quality = (
         cfg.w_ttc * ttc_q
         + cfg.w_progress * progress_q

--- a/planner_metrics/epdms_like.py
+++ b/planner_metrics/epdms_like.py
@@ -95,9 +95,7 @@ def _collision_gate(subscores: dict, n: int, device, dtype) -> torch.Tensor:
     if torch.is_tensor(coll):
         # Convention upstream: a negative / sentinel value means "no collision".
         return (coll.reshape(-1) < 0).to(device=device, dtype=dtype)
-    return torch.tensor(
-        [1.0 if c is None else 0.0 for c in coll], device=device, dtype=dtype
-    )
+    return torch.tensor([1.0 if c is None else 0.0 for c in coll], device=device, dtype=dtype)
 
 
 def epdms_like_aggregate(
@@ -130,9 +128,9 @@ def epdms_like_aggregate(
     gt_progress = torch.as_tensor(gt_progress, device=device, dtype=dtype).reshape(-1)
 
     # ---- gates (binary, multiplicative) ----
-    nc = _collision_gate(subscores, n, device, dtype)               # no collision
+    nc = _collision_gate(subscores, n, device, dtype)  # no collision
     dac = _as_gate(subscores, "rb_crossing_gate", n, device, dtype)  # drivable area
-    kin = _as_gate(subscores, "kinematic_gate", n, device, dtype)    # feasibility
+    kin = _as_gate(subscores, "kinematic_gate", n, device, dtype)  # feasibility
     red_light = subscores.get("red_light")
     if red_light is None:
         tlc = torch.ones(n, device=device, dtype=dtype)

--- a/planner_metrics/epdms_like.py
+++ b/planner_metrics/epdms_like.py
@@ -1,0 +1,200 @@
+"""Single [0,1] EPDMS-*like* aggregate from the raw ``planner_metrics`` subscores.
+
+This is an EPDMS-**structured proxy**, NOT a faithful NAVSIM EPDMS port (the faithful
+one lives in OnePlanner; see issue #142). It mirrors the canonical shape -- a product
+of binary gates times a weighted average of quality terms, bounded to [0,1] -- but it
+differs from real EPDMS in several material ways:
+
+    * it scores the **raw predicted waypoints**, not a controller-simulated (LQR +
+      kinematic bicycle) rollout, so it is pure open-loop;
+    * **DDC** (driving-direction compliance) is omitted -- not computed upstream;
+    * there is **no false-positive filtering** against a human reference;
+    * **comfort** uses only mean |jerk| (the repo's ``comfort`` subscore), not the full
+      lon/lat-accel + yaw-rate + extended-comfort battery;
+    * **TTC** is a graded fraction of safe steps, not the binary constant-velocity check;
+    * **progress** is normalized against the GT (expert) path length.
+
+So treat it as a closed-loop-correlated *proxy* for ranking/debugging checkpoints, not
+as the metric NAVSIM or OnePlanner reports.
+
+The subscores from :func:`planner_metrics.aggregate.compute_subscores_batch` live on
+heterogeneous scales, and the penalty-style terms (``safety``, ``comfort``,
+``centerline``, ``feasibility``, ``red_light``) follow the reward convention
+``0 = perfect, more negative = worse``. EPDMS instead wants a *score* in ``[0,1]``
+(``1 = perfect``). This module flips and bounds each term and combines them::
+
+    EPDMS_like = (PROD of binary gates in {0,1}) * (weighted avg of quality terms in [0,1])
+
+Gates (multiplicative, hard-zero the score):
+    * NC  -- no at-fault collision         (from ``collision_step``)
+    * DAC -- drivable-area compliance      (``rb_crossing_gate``)
+    * TLC -- traffic-light compliance      (``red_light`` == 0)
+    * KIN -- kinematic feasibility         (``kinematic_gate``)
+    * optionally ``lane_crossing_gate`` / ``sc_crossing_gate`` when enabled upstream
+      (they are 1.0 when their subscore feature is disabled, so including them is safe).
+
+Quality terms (weighted average, each renormalized to [0,1], higher = better):
+    * TTC      -- ``ttc`` (already a fraction of TTC-safe steps in [0,1])
+    * progress -- ``progress`` (metres) normalized by the expert's GT path length
+    * comfort  -- binary: mean |jerk| (= ``-comfort``) within ``jerk_bound``
+    * lane     -- binary: lane usage (= sqrt(-``centerline``)) within ``lane_usage_bound``
+
+NOTE: the thresholds/weights below must be calibrated so ground-truth (expert)
+trajectories score near 1.0 -- mirror the calibration note on
+``compute_kinematic_gate`` (GT must pass the gates).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass
+class EPDMSLikeConfig:
+    # --- quality thresholds (binary terms) ---
+    # Mean |jerk| (m/s^3) at or below this scores comfort = 1. Calibrate so GT passes
+    # (human driving mean |jerk| is typically well under this).
+    jerk_bound: float = 2.0
+    # Lane usage = |rear-axle lateral offset| / lane half-width. <= 1.0 means the rear
+    # axle is within the lane boundary.
+    lane_usage_bound: float = 1.0
+
+    # --- quality weights (weighted average -> [0,1]) ---
+    w_ttc: float = 5.0
+    w_progress: float = 5.0
+    w_comfort: float = 2.0
+    w_lane: float = 5.0
+
+    # Minimum GT-progress denominator (metres) so near-stationary scenes don't blow up
+    # the progress ratio. A scene where the expert barely moves contributes progress_q
+    # ~= 1 for any non-regressing plan.
+    progress_eps: float = 1.0
+
+    # Multiply in lane_crossing_gate / sc_crossing_gate when present (1.0 when the
+    # corresponding feature is disabled upstream, so this is safe to leave on).
+    include_optional_gates: bool = True
+
+
+def _as_gate(subscores: dict, key: str, n: int, device, dtype) -> torch.Tensor:
+    """Fetch a {0,1} gate tensor, defaulting to all-ones (pass) when absent."""
+    g = subscores.get(key)
+    if g is None:
+        return torch.ones(n, device=device, dtype=dtype)
+    if not torch.is_tensor(g):
+        g = torch.as_tensor(g, device=device, dtype=dtype)
+    return g.to(device=device, dtype=dtype).reshape(-1)
+
+
+def _collision_gate(subscores: dict, n: int, device, dtype) -> torch.Tensor:
+    """NC gate from ``collision_step`` (list of None|int per scene, or a tensor)."""
+    coll = subscores.get("collision_step")
+    if coll is None:
+        return torch.ones(n, device=device, dtype=dtype)
+    if torch.is_tensor(coll):
+        # Convention upstream: a negative / sentinel value means "no collision".
+        return (coll.reshape(-1) < 0).to(device=device, dtype=dtype)
+    return torch.tensor(
+        [1.0 if c is None else 0.0 for c in coll], device=device, dtype=dtype
+    )
+
+
+def epdms_like_aggregate(
+    subscores: dict,
+    gt_progress: torch.Tensor,
+    cfg: EPDMSLikeConfig | None = None,
+):
+    """Collapse the raw subscore dict into a single [0,1] EPDMS-like score per scene.
+
+    Args:
+        subscores: output of ``compute_subscores_batch`` -- batched ``(N,)`` tensors
+            for ``ttc``/``progress``/``comfort``/``centerline``/``red_light`` plus the
+            gate fields (``rb_crossing_gate``, ``kinematic_gate``, ``collision_step``,
+            optionally ``lane_crossing_gate``/``sc_crossing_gate``).
+        gt_progress: ``(N,)`` expert (ground-truth) path length in metres, used as the
+            progress-normalization reference. See :func:`gt_path_length`.
+        cfg: thresholds/weights. Defaults to :class:`EPDMSLikeConfig`.
+
+    Returns:
+        ``(score, components)`` where ``score`` is ``(N,)`` in [0,1] and ``components``
+        is a dict of the per-scene gate values and normalized quality terms (all
+        ``(N,)``) for logging/debugging.
+    """
+    cfg = cfg or EPDMSLikeConfig()
+
+    ttc = subscores["ttc"].reshape(-1)
+    device, dtype = ttc.device, ttc.dtype
+    n = ttc.shape[0]
+
+    gt_progress = torch.as_tensor(gt_progress, device=device, dtype=dtype).reshape(-1)
+
+    # ---- gates (binary, multiplicative) ----
+    nc = _collision_gate(subscores, n, device, dtype)               # no collision
+    dac = _as_gate(subscores, "rb_crossing_gate", n, device, dtype)  # drivable area
+    kin = _as_gate(subscores, "kinematic_gate", n, device, dtype)    # feasibility
+    red_light = subscores.get("red_light")
+    if red_light is None:
+        tlc = torch.ones(n, device=device, dtype=dtype)
+    else:
+        # red_light == 0 -> clean; negative -> violation.
+        tlc = (red_light.reshape(-1) >= -1e-6).to(dtype)
+
+    gates = nc * dac * kin * tlc
+    if cfg.include_optional_gates:
+        gates = (
+            gates
+            * _as_gate(subscores, "lane_crossing_gate", n, device, dtype)
+            * _as_gate(subscores, "sc_crossing_gate", n, device, dtype)
+        )
+
+    # ---- quality terms (each renormalized to [0,1]) ----
+    ttc_q = ttc.clamp(0.0, 1.0)
+
+    progress = subscores["progress"].reshape(-1)
+    denom = gt_progress.clamp(min=cfg.progress_eps)
+    progress_q = (progress / denom).clamp(0.0, 1.0)
+
+    # comfort = -mean_abs_jerk  ->  mean_abs_jerk = -comfort
+    comfort = subscores["comfort"].reshape(-1)
+    comfort_q = ((-comfort) <= cfg.jerk_bound).to(dtype)
+
+    # centerline = -lane_usage^2  ->  lane_usage = sqrt(max(0, -centerline))
+    centerline = subscores["centerline"].reshape(-1)
+    lane_usage = (-centerline).clamp(min=0.0).sqrt()
+    lane_q = (lane_usage <= cfg.lane_usage_bound).to(dtype)
+
+    w_sum = cfg.w_ttc + cfg.w_progress + cfg.w_comfort + cfg.w_lane
+    quality = (
+        cfg.w_ttc * ttc_q
+        + cfg.w_progress * progress_q
+        + cfg.w_comfort * comfort_q
+        + cfg.w_lane * lane_q
+    ) / w_sum
+
+    score = gates * quality
+
+    components = {
+        "epdms_like": score,
+        "gate_nc": nc,
+        "gate_dac": dac,
+        "gate_tlc": tlc,
+        "gate_kin": kin,
+        "q_ttc": ttc_q,
+        "q_progress": progress_q,
+        "q_comfort": comfort_q,
+        "q_lane": lane_q,
+        "quality": quality,
+    }
+    return score, components
+
+
+def gt_path_length(ego_future_xy: torch.Tensor) -> torch.Tensor:
+    """Cumulative planar path length of the expert future, used as the progress
+    reference. ``ego_future_xy`` is ``(N, T, >=2)`` (x, y, ...); returns ``(N,)``."""
+    xy = ego_future_xy[..., :2]
+    steps = torch.linalg.norm(xy[:, 1:, :] - xy[:, :-1, :], dim=-1)  # (N, T-1)
+    return steps.sum(dim=-1)
+
+
+__all__ = ["EPDMSLikeConfig", "epdms_like_aggregate", "gt_path_length"]


### PR DESCRIPTION
## Log reward subscores in `validate_model`

Surfaces the planner's rule-based reward subscores as **additive** validation metrics, so best-model selection can see the same physical quantities the training reward is built from. `avg_loss_*` and best-model selection (still `position_lat_loss`) are unchanged.

### What changed — `diffusion_planner/diffusion_planner/validate_model.py`
- **`_reward_subscores_per_scene` helper** — `compute_subscores_batch` is single-scene / N-trajectory (its map + neighbor terms use one scene's tensors), so it loops over the `B` scenes (one ego prediction each) and stacks the continuous subscores. It reuses the same metre ego-frame tensors the existing road-border / neighbor metrics already use (`prediction[:, 0]`, the masked `neighbors_future`, `denorm_inputs[...]`).
- Logged as `ego_subscore_{safety,ttc,progress,comfort,centerline,red_light,feasibility}`, picked up by `train.py`'s `mean_ego_loss` as `valid_loss/ego_subscore_*`.

### Why this is correct
- The validation dataset feeds the same npz the reward consumes (`dataset.__getitem__` just `np.load`s it), so the subscores' tensor/channel conventions match — the same reason `compute_road_border_penalty` already runs in this loop.
- The subscores are the exact same code the reward uses, guarded by the existing golden + parity tests.

### Tests
- `test_validation_subscores` (new) pins the per-scene batched helper against a direct single-scene `compute_subscores_batch` call (slicing correctness + finite values).
- Golden + parity + full reward suite green (141 passed).

### Caveats
- The subscore values should be sanity-checked on a real validation run (effective from the next run only — in-flight training is unaffected).
- The per-scene loop adds `B` `compute_subscores_batch` calls per batch to validation (per-epoch, not per-step); easy to gate behind a config flag if it proves too slow.
