### PR TITLE
Emit 4-col futures from cpp_bin_to_npz + handle 4-col GT in annotation GUI

### DIFF
--- a/preference_optimization/annotation_gui.py
+++ b/preference_optimization/annotation_gui.py
@@ -581,16 +581,18 @@ class PreferenceAnnotator:
     def _get_gt_trajectory(self) -> np.ndarray | None:
         """Return the GT trajectory as [T, 4] (x, y, cos, sin).
 
-        The NPZ ego_agent_future is stored as [T, 3] (x, y, heading in radians) and comes
-        directly from Autoware's EKF localization with no additional smoothing applied during
-        rosbag-to-NPZ conversion (verified in both the Python and C++ converter paths). The
-        model trains on this raw EKF output as GT, so no further smoothing is applied here.
+        ``ego_agent_future`` may be 4-col [x, y, cos, sin] (current converter / scene-gen)
+        or legacy 3-col [x, y, heading_rad]; both are handled. It comes directly from
+        Autoware's EKF localization with no additional smoothing during rosbag-to-NPZ
+        conversion, and the model trains on that raw output, so none is applied here.
 
         Returns:
             GT trajectory as [T, 4] numpy array, or None on error.
         """
         try:
-            gt_raw = self.current_data["ego_agent_future"][0].cpu().numpy()  # [T, 3]
+            gt_raw = self.current_data["ego_agent_future"][0].cpu().numpy()
+            if gt_raw.shape[-1] == 4:  # already [x, y, cos, sin]
+                return gt_raw.astype(np.float32)
             cos_yaw = np.cos(gt_raw[:, 2:3])
             sin_yaw = np.sin(gt_raw[:, 2:3])
             return np.concatenate([gt_raw[:, :2], cos_yaw, sin_yaw], axis=1).astype(np.float32)

--- a/preference_optimization/annotation_gui.py
+++ b/preference_optimization/annotation_gui.py
@@ -1646,10 +1646,14 @@ class PreferenceAnnotator:
         if not np.any(valid_mask):
             return None
 
-        # Get headings - ground truth has direct heading angle in radians
-        # Include ego state heading (computed from cos/sin)
+        # Future headings: 4-col [x,y,cos,sin] -> atan2(sin,cos); legacy 3-col
+        # [x,y,heading] -> col 2 directly. Include ego state heading (from cos/sin).
+        if ego_future.shape[-1] == 4:
+            fut_headings = np.arctan2(ego_future[:, 3], ego_future[:, 2])
+        else:
+            fut_headings = ego_future[:, 2]
         ego_heading = np.arctan2(ego_state[3], ego_state[2])
-        headings = np.concatenate([[ego_heading], ego_future[:, 2]])
+        headings = np.concatenate([[ego_heading], fut_headings])
 
         # Get positions (ego + trajectory = 81 points)
         positions = np.vstack([ego_state[:2], ego_future[:, :2]])

--- a/rlvr/autoresearch/tools/cpp_bin_to_npz.py
+++ b/rlvr/autoresearch/tools/cpp_bin_to_npz.py
@@ -8,14 +8,15 @@ reference NPZs.
 
 Key transforms:
 - ego_agent_past:    cpp (31, 4) [x,y,cos,sin] → npz (31, 3) [x,y,yaw]
-- ego_agent_future:  cpp (80, 4) [x,y,cos,sin] → npz (80, 3) [x,y,yaw]
+- ego_agent_future:  cpp (80, 4) [x,y,cos,sin] → npz (80, 4) [x,y,cos,sin]  (kept 4-col)
 - goal_pose:         cpp (4,)   [x,y,cos,sin] → npz (3,)   [x,y,yaw]
-- neighbor_agents_future: cpp (320, 80, 4) → npz (320, 80, 3) [x,y,yaw]
+- neighbor_agents_future: cpp (320, 80, 4) → npz (320, 80, 4) [x,y,cos,sin]  (kept 4-col)
 - speed-limit fields: (N,) → (N, 1), int32 has-flag → bool
 
-heading is recovered with atan2(sin, cos). This avoids a double-conversion bug:
-Python `load_npz_data` applies `heading_to_cos_sin` once at load time on 3-channel
-inputs, so emit 3-channel heading here (do NOT pre-convert to cos/sin).
+FUTURES are kept 4-col [x,y,cos,sin]: the trainable/reward schema requires it and the
+reward path hard-fails on 3-col. ego_agent_past and goal_pose stay 3-col [x,y,yaw] (the
+canonical schema — the loader/model widen them, and `heading_to_cos_sin` is idempotent so
+a 4-col input would also pass through unchanged).
 """
 
 import argparse
@@ -165,9 +166,10 @@ def decode_bin(raw: bytes) -> dict[str, np.ndarray]:
     return {
         "ego_agent_past": _xyc_to_xyy(ego_past_xyc).astype(np.float32),
         "ego_current_state": ego_current.astype(np.float32),
-        "ego_agent_future": _xyc_to_xyy(ego_future_xyc).astype(np.float32),
+        # Futures stay 4-col [x,y,cos,sin] (trainable/reward schema; never 3-col).
+        "ego_agent_future": ego_future_xyc.astype(np.float32),
         "neighbor_agents_past": neighbor_past.astype(np.float32),
-        "neighbor_agents_future": _xyc_to_xyy(neighbor_future_xyc).astype(np.float32),
+        "neighbor_agents_future": neighbor_future_xyc.astype(np.float32),
         "static_objects": static_objects.astype(np.float32),
         "lanes": lanes.astype(np.float32),
         "lanes_speed_limit": lanes_speed_limit.astype(np.float32),


### PR DESCRIPTION
Closes the last two places that assumed 3-col futures.

- **cpp_bin_to_npz.py** kept the cpp's native 4-col futures down-converted to 3-col on write — the root producer of 3-col corpora. Now emits 4-col [x,y,cos,sin] for ego_agent_future and neighbor_agents_future (the reward/RSFT schema). ego_agent_past and goal_pose stay 3-col (canonical schema; the loader/model widen them, and heading_to_cos_sin is idempotent so a 4-col input would also pass through).
- **annotation_gui._get_gt_trajectory** now accepts a 4-col ego_agent_future directly instead of running cos()/sin() on it (which would cos(cos) a 4-col future). The GT-similarity path uses calculate_ade (xy-only, handles both widths), so it was already safe.

Follow-up to the merged 4-col PRs (#149/#150).