### PR TITLE
Fix reproducer planner_metrics import + clamp extractor window across unstick snaps

### DIFF
--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -25,15 +25,15 @@ from dataclasses import dataclass, field
 import numpy as np
 import torch
 from diffusion_planner.dimensions import INPUT_T, POSE_DIM
-from diffusion_planner.metrics.geometry import (
-    _build_ego_bbox_corners,
-    _closest_points_between_rects,
-)
 from diffusion_planner.model.guidance.collision import (
     batch_signed_distance_rect,
     center_rect_to_points,
 )
 
+from planner_metrics.geometry import (
+    _build_ego_bbox_corners,
+    _closest_points_between_rects,
+)
 from scenario_generation.perception_reproducer import PerceptionReproducer
 from scenario_generation.perf_timer import Timers
 from scenario_generation.route_timeline import RouteTimeline
@@ -1005,6 +1005,16 @@ def _scene_npz_from_np_dict(np_dict: dict) -> dict:
 
 
 @torch.no_grad()
+def _precollision_window_start(t_c: int, pre_steps: int, last_snap_step: int | None) -> int:
+    """First step of the pre-collision window, clamped so it never crosses an unstick
+    snap. Normally ``t_c - pre_steps`` (may be negative — the backtrack path then reads
+    recorded frames before the segment start). If an unstick snap fired within that window
+    (``last_snap_step`` is not None and >= the base start), start at the post-snap step
+    instead so no saved scene's realized ego_future or ego_past spans the ~5 m teleport."""
+    base = t_c - pre_steps
+    return base if last_snap_step is None else max(base, last_snap_step)
+
+
 def extract_collision_scenes(
     model,
     model_args,
@@ -1067,6 +1077,10 @@ def extract_collision_scenes(
     buf: deque = deque(maxlen=pre_steps + 1)
     live_poses: dict[int, np.ndarray] = {}  # step k -> world pose (for ego_future)
     t_c = None
+    # Step right after the most recent unstick snap (None = no snap yet). The pre-collision
+    # window must not cross a snap, or a saved scene's realized ego_future/ego_past would
+    # span the ~5 m teleport.
+    last_snap_step = None
     while not s.done:
         k = s.k
         pre = _pre_step(s)
@@ -1082,7 +1096,10 @@ def extract_collision_scenes(
         if clr <= collision_thresh:
             t_c = k
             break
+        prev_snaps = s.n_snaps
         _post_step(s, pred, neighbors_live, idx, device, timers)
+        if s.n_snaps > prev_snaps:  # an unstick snap fired advancing k -> s.k
+            last_snap_step = s.k
     if t_c is None:
         return None
 
@@ -1093,7 +1110,16 @@ def extract_collision_scenes(
     saved = []
     fut_len = int(model_args.future_len)
 
-    for step_k in range(t_c - pre_steps, t_c):
+    # Clamp the window so it never crosses an unstick teleport: start no earlier than the
+    # step right after the last snap, keeping every saved scene's realized ego_future AND
+    # ego_past on one continuous (snap-free) segment.
+    start_k = _precollision_window_start(t_c, pre_steps, last_snap_step)
+    if start_k > t_c - pre_steps:
+        print(
+            f"  [extract] window clamped {t_c - pre_steps} -> {start_k} "
+            f"(unstick snap within the {pre_steps}-step pre-collision window)"
+        )
+    for step_k in range(start_k, t_c):
         if step_k >= 0 and step_k in live_by_step:
             _, idx, live_pose, np_dict = live_by_step[step_k]
             scene = _scene_npz_from_np_dict(np_dict)

--- a/scenario_generation/tests/test_reproducer_unstick.py
+++ b/scenario_generation/tests/test_reproducer_unstick.py
@@ -92,3 +92,19 @@ def test_unstick_jump_ego_past_uses_recorded_npz_history(tmp_path):
     assert not np.allclose(s.ego_hist, ego_hist_before)
     # Sanity: the last history row is the (recorded) current pose.
     assert np.allclose(s.ego_hist[-1], s.live_pose)
+
+
+def test_precollision_window_clamps_across_unstick_snap():
+    """The pre-collision window must not cross an unstick snap (else a saved scene's
+    realized ego_future/ego_past would span the ~5m teleport)."""
+    from scenario_generation.reproducer_rollout import _precollision_window_start
+
+    t_c, pre = 579, 80  # window would be [499, 579)
+    # no snap -> full window
+    assert _precollision_window_start(t_c, pre, None) == 499
+    # snap BEFORE the window -> not clamped (full window)
+    assert _precollision_window_start(t_c, pre, 400) == 499
+    # snap INSIDE the window -> clamp to the post-snap step (shorter, snap-free window)
+    assert _precollision_window_start(t_c, pre, 540) == 540
+    # early collision, no snap -> negative start preserved (backtrack path handles <0)
+    assert _precollision_window_start(50, pre, None) == -30


### PR DESCRIPTION
## Two fixes

**1. Reproducer broken on main (import).** The metrics refactor moved `diffusion_planner.metrics` -> the top-level `planner_metrics` package, but `scenario_generation/reproducer_rollout.py` still imported `diffusion_planner.metrics.geometry` (which no longer exists), so the miner/extractor failed at import. Re-point to `planner_metrics.geometry`. (The collision symbols are still re-exported from `diffusion_planner.model.guidance.collision`, so that import is unaffected.)

**2. Unstick edge case — collision within ~8 s of a snap.** If an unstick snap fires inside the pre-collision window, a saved scene's realized `ego_future` (or `ego_past`) would span the ~5 m teleport. The extractor now tracks the last snap step and clamps the window start to just after it (`_precollision_window_start`), so every saved scene sits on one continuous, snap-free segment. Early collisions still backtrack (negative window start preserved when no snap fired).

## Verify
- `import scenario_generation.reproducer_rollout` works; mine+extract run end-to-end (mined 10 segs, extracted 80 scenes).
- Unit test for the clamp (no-snap full window incl. negative backtrack; snap-before-window unchanged; snap-in-window clamps).