### PR TITLE
fix: update DiTBlock forward method to include cross attention mask and modify Encoder to mask outputs based on encoding mask

### DIFF
--- a/diffusion_planner/diffusion_planner/model/module/dit.py
+++ b/diffusion_planner/diffusion_planner/model/module/dit.py
@@ -34,7 +34,7 @@ class DiTBlock(nn.Module):
             in_features=dim, hidden_features=mlp_hidden_dim, act_layer=approx_gelu, drop=0
         )
 
-    def forward(self, x, cross_c, y, attn_mask):
+    def forward(self, x, cross_c, y, attn_mask, cross_attn_mask):
         shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = self.adaLN_modulation(
             y
         ).chunk(6, dim=2)
@@ -55,7 +55,16 @@ class DiTBlock(nn.Module):
         modulated_x = modulate(self.norm2(x), shift_mlp, scale_mlp)
         x = x + gate_mlp * self.mlp1(modulated_x)
 
-        x = x + self.cross_attn(self.norm3(x), cross_c, cross_c, need_weights=False)[0]
+        x = (
+            x
+            + self.cross_attn(
+                self.norm3(x),
+                cross_c,
+                cross_c,
+                key_padding_mask=cross_attn_mask,
+                need_weights=False,
+            )[0]
+        )
         x = x + self.mlp2(self.norm4(x))
 
         return x
@@ -154,9 +163,10 @@ class DiT(nn.Module):
 
         ego_mask = torch.zeros((B, 1), dtype=torch.bool, device=x.device)
         attn_mask = torch.cat([ego_mask, neighbor_current_mask], dim=1)
+        cross_attn_mask = torch.all(cross_c == 0, dim=-1)
 
         for block in self.blocks:
-            x = block(x, cross_c, t, attn_mask)
+            x = block(x, cross_c, t, attn_mask, cross_attn_mask)
 
         x = self.final_layer(x, t)  # (B, P, output_dim)
         x = x.reshape(B, P, T, D)

--- a/diffusion_planner/diffusion_planner/model/module/encoder.py
+++ b/diffusion_planner/diffusion_planner/model/module/encoder.py
@@ -304,6 +304,7 @@ class Encoder(nn.Module):
         encoding_input = encoding_input + encoding_pos_result.view(B, self.token_num, -1)
 
         encoder_outputs = self.fusion(encoding_input, encoding_mask.view(B, self.token_num))
+        encoder_outputs = encoder_outputs.masked_fill(encoding_mask.view(B, self.token_num, 1), 0.0)
 
         return encoder_outputs
 


### PR DESCRIPTION
This pull request introduces improvements to the attention mechanism in the diffusion planner model, specifically by adding support for cross-attention masks to better handle padded or irrelevant tokens during cross-attention. Additionally, it ensures that encoder outputs are properly masked. The most important changes are grouped by theme below:

**Cross-attention mask support:**
* The `forward` method of the main block in `dit.py` now accepts an additional `cross_attn_mask` argument and passes it as `key_padding_mask` to the cross-attention layer, improving masking of irrelevant cross-attention inputs. [[1]](diffhunk://#diff-d284f9d563be9d0be7de4e1e32fdac3335dfb3af0be991913a070269a1ecfec6L37-R37) [[2]](diffhunk://#diff-d284f9d563be9d0be7de4e1e32fdac3335dfb3af0be991913a070269a1ecfec6L58-R67)
* The main model's `forward` method in `dit.py` now computes a `cross_attn_mask` based on zeroed elements in `cross_c` and passes it to each block, ensuring correct masking throughout the model.

**Encoder output masking:**
* After the fusion step in the encoder, the outputs are explicitly masked with the encoding mask to zero out positions corresponding to masked tokens, ensuring cleaner downstream representations.