### PR TITLE
Reproducer: one-pass collision-scene save + moving-neighbor augmentation tooling

### DIFF
--- a/rlvr/autoresearch/tools/extract_collision_scenes.py
+++ b/rlvr/autoresearch/tools/extract_collision_scenes.py
@@ -44,6 +44,20 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--model_path", type=Path, required=True)
     p.add_argument("--out_dir", type=Path, required=True, help="root for the per-segment batches")
     p.add_argument("--collision_thresh", type=float, default=0.2, help="m to any neighbor")
+    p.add_argument(
+        "--include_near_miss",
+        action="store_true",
+        help="also extract NEAR-MISS segments (n_collision_steps==0 but "
+        "n_near_miss_steps>0). Those segments trigger the pre-window at "
+        "--near_miss_thresh (the closest approach) instead of --collision_thresh.",
+    )
+    p.add_argument(
+        "--near_miss_thresh",
+        type=float,
+        default=0.5,
+        help="m: trigger threshold for near-miss segments (matches the miner's "
+        "near_miss_thresh). Only used with --include_near_miss.",
+    )
     p.add_argument("--pre_steps", type=int, default=80)
     p.add_argument("--search_radius", type=float, default=1.5)
     p.add_argument("--unstick_after", type=int, default=300)
@@ -71,16 +85,28 @@ def main() -> None:
             if not line:
                 continue
             r = json.loads(line)
-            if r.get("n_collision_steps", 0) > 0:
+            is_collision = r.get("n_collision_steps", 0) > 0
+            is_near_miss = (not is_collision) and r.get("n_near_miss_steps", 0) > 0
+            if is_collision or (args.include_near_miss and is_near_miss):
+                # Collision segments trigger the pre-window at collision_thresh; a
+                # near-miss segment never gets that close, so trigger at its closest
+                # approach (near_miss_thresh).
+                r["_trigger_thresh"] = (
+                    args.collision_thresh if is_collision else args.near_miss_thresh
+                )
                 hits.append(r)
                 if args.max_hits > 0 and len(hits) >= args.max_hits:
                     break
-    print(f"collision segments to extract: {len(hits)} | device: {device}")
+    n_coll = sum(1 for r in hits if r.get("n_collision_steps", 0) > 0)
+    print(
+        f"segments to extract: {len(hits)} ({n_coll} collision, {len(hits) - n_coll} near-miss) "
+        f"| device: {device}"
+    )
 
     # Group by route so each RouteTimeline is built once.
     by_route: dict[str, list] = defaultdict(list)
     for r in hits:
-        by_route[r["route"]].append(tuple(r["segment"]))
+        by_route[r["route"]].append((*r["segment"], r["_trigger_thresh"]))
 
     args.out_dir.mkdir(parents=True, exist_ok=True)
     n_ok = 0
@@ -90,7 +116,7 @@ def main() -> None:
             print(f"  WARN route {route_key} not under --npz_root; skipping {len(segs)} segs")
             continue
         tl = RouteTimeline(routes[route_key], sidecar_dir=args.sidecar_root)
-        for start, end in segs:
+        for start, end, thresh in segs:
             od = args.out_dir / f"{route_key}_{start}_{end}"
             mani = extract_collision_scenes(
                 model,
@@ -100,14 +126,14 @@ def main() -> None:
                 end,
                 od,
                 device=device,
-                collision_thresh=args.collision_thresh,
+                collision_thresh=thresh,
                 pre_steps=args.pre_steps,
                 search_radius=args.search_radius,
                 unstick_after=args.unstick_after,
                 unstick_advance_m=args.unstick_advance_m,
             )
             if mani is None:
-                print(f"  {route_key} [{start},{end}]: no collision <= {args.collision_thresh}m")
+                print(f"  {route_key} [{start},{end}]: no approach <= {thresh}m")
                 continue
             n_ok += 1
             summary.append({"route": route_key, **mani})

--- a/rlvr/autoresearch/tools/mine_collisions_reproducer.py
+++ b/rlvr/autoresearch/tools/mine_collisions_reproducer.py
@@ -94,6 +94,46 @@ def parse_args() -> argparse.Namespace:
         default=0,
         help="render the top-N ranked hit segments to PNGs under <out>.renders/ (0=off)",
     )
+    # One-pass collision-scene save (no second extract pass). When --save_dir is set,
+    # each segment buffers its last --save_pre_steps scenes during THIS rollout and dumps
+    # them to <save_dir>/<route>_<start>_<end>/ on the first step within --save_thresh of a
+    # neighbor — so the saved scenes match the collision THIS run detected (reproducible).
+    p.add_argument(
+        "--save_dir",
+        type=Path,
+        default=None,
+        help="if set, save pre-collision scene batches in one pass (no separate extractor)",
+    )
+    p.add_argument(
+        "--save_pre_steps", type=int, default=80, help="MIN scenes saved before each hit"
+    )
+    p.add_argument(
+        "--save_pre_arc_m",
+        type=float,
+        default=1.0,
+        help="extend the window past --save_pre_steps until the ego has travelled this much "
+        "arc length (m) — so a slow creep into a stopped car still captures real approach, "
+        "not 80 near-identical frames. Capped at --save_max_scenes.",
+    )
+    p.add_argument(
+        "--save_max_scenes",
+        type=int,
+        default=160,
+        help="hard cap on scenes saved per hit (bounds buffer RAM ~1.25MB/scene/segment)",
+    )
+    p.add_argument(
+        "--save_min_post_snap_s",
+        type=float,
+        default=3.0,
+        help="DROP a hit if an unstick teleport fired less than this many seconds before it "
+        "(too little settled history; the contact is likely teleport-induced). 0=keep all.",
+    )
+    p.add_argument(
+        "--save_thresh",
+        type=float,
+        default=0.2,
+        help="m-to-neighbor trigger for saving a scene batch (use 0.5 to also catch near-misses)",
+    )
     return p.parse_args()
 
 
@@ -164,6 +204,13 @@ def main() -> None:
             n_build_threads=args.n_build_threads,
             prefetch_ahead=args.prefetch_ahead,
             timers=timers,
+            save_dir=args.save_dir,
+            save_pre_steps=args.save_pre_steps,
+            save_thresh=(args.save_thresh if args.save_dir is not None else None),
+            save_pre_arc_m=args.save_pre_arc_m,
+            save_max_scenes=args.save_max_scenes,
+            save_min_post_snap_frames=int(round(args.save_min_post_snap_s / 0.1)),
+            route_keys=buf_keys,
         )
         for key, res in zip(buf_keys, res_list):
             row = {"route": key, **res.metrics}

--- a/rlvr/autoresearch/tools/perturb_neighbors_npz.py
+++ b/rlvr/autoresearch/tools/perturb_neighbors_npz.py
@@ -8,11 +8,14 @@ through ego offsets. This tool varies the OTHER side: it shifts the STOPPED
 each neighbor's own heading frame — producing new ego-to-obstacle geometries
 from the same base scene.
 
-Only stopped neighbors are moved (the avoidance-relevant obstacles, same
-detection convention as ghost_sim_common.extract_stopped_neighbors: non-empty
-slot, future displacement < 0.5 m, valid box dims). Moving traffic, map,
-ego past/future and all other fields are copied verbatim. Zero rows are
-padding and are never touched.
+By default only stopped neighbors are moved (the avoidance-relevant obstacles,
+same detection convention as ghost_sim_common.extract_stopped_neighbors:
+non-empty slot, future displacement < 0.5 m, valid box dims). With
+``--include_moving`` the MOVING neighbors are also shifted — e.g. the colliding
+NPC in a perception-reproducer moving collision — by the SAME rigid translation
+(a constant world offset applied to every past+future timestep, which preserves
+the track's shape, per-step headings and velocities). Map, ego past/future and
+all other fields are copied verbatim. Zero rows are padding and never touched.
 
 Safety screens (canonical reward-path geometry, no hand-rolled OBB math):
   - t0-clean: the ego pose at t=0 (origin of the ego frame) must clear the
@@ -41,29 +44,47 @@ import torch
 
 from scenario_generation.explorer_runner import plan_static_clearance
 
+_MOVING_DISP_THRESH = 0.5  # m of future displacement separating stopped vs moving
 
-def _stopped_neighbor_indices(nb_past: np.ndarray, nb_fut: np.ndarray) -> list[int]:
-    """Indices of stopped neighbors (same criteria as extract_stopped_neighbors)."""
-    idxs = []
+
+def _neighbor_future_disp(nb_fut_i: np.ndarray) -> float:
+    """Bounding-box future displacement (m) of one neighbor's future track."""
+    fut_xy = nb_fut_i[:, :2]
+    fut_valid = np.abs(fut_xy).sum(axis=-1) > 1e-6
+    if fut_valid.sum() < 2:
+        return 0.0
+    return float(np.linalg.norm(fut_xy[fut_valid].max(0) - fut_xy[fut_valid].min(0)))
+
+
+def _selected_neighbor_indices(
+    nb_past: np.ndarray, nb_fut: np.ndarray, include_moving: bool
+) -> tuple[list[int], set[int]]:
+    """Indices of perturbable neighbors + the subset classified as moving.
+
+    Always returns STOPPED neighbors (future displacement < 0.5 m — the
+    avoidance-relevant parked/blocking obstacles, same convention as
+    extract_stopped_neighbors). When ``include_moving`` is set, MOVING neighbors
+    (displacement >= 0.5 m, e.g. the colliding NPC in a reproducer moving
+    collision) are also selected. Empty (padding) slots and degenerate boxes are
+    excluded. Returns (selected_indices, moving_index_set).
+    """
+    selected: list[int] = []
+    moving: set[int] = set()
     for i in range(nb_past.shape[0]):
         xy0 = nb_past[i, -1, :2]
         if abs(float(xy0[0])) + abs(float(xy0[1])) < 1e-6:
             continue  # empty slot (padding)
-        fut_xy = nb_fut[i, :, :2]
-        fut_valid = np.abs(fut_xy).sum(axis=-1) > 1e-6
-        disp = (
-            0.0
-            if fut_valid.sum() < 2
-            else float(np.linalg.norm(fut_xy[fut_valid].max(0) - fut_xy[fut_valid].min(0)))
-        )
-        if disp >= 0.5:
-            continue  # moving traffic — not an avoidance obstacle
         w = float(nb_past[i, -1, 6])
         length = float(nb_past[i, -1, 7])
         if w < 0.1 or length < 0.1:
             continue
-        idxs.append(i)
-    return idxs
+        is_moving = _neighbor_future_disp(nb_fut[i]) >= _MOVING_DISP_THRESH
+        if is_moving and not include_moving:
+            continue  # moving traffic — skipped unless --include_moving
+        selected.append(i)
+        if is_moving:
+            moving.add(i)
+    return selected, moving
 
 
 def _boxes_from_arrays(nb_past: np.ndarray, idxs: list[int]):
@@ -129,6 +150,12 @@ def main():
     )
     parser.add_argument("--n_per_scene", type=int, required=True)
     parser.add_argument(
+        "--include_moving",
+        action="store_true",
+        help="also perturb MOVING neighbors (future displacement >= 0.5 m), e.g. the "
+        "colliding NPC in a reproducer moving collision. Default: stopped neighbors only.",
+    )
+    parser.add_argument(
         "--min_t0_clearance",
         type=float,
         required=True,
@@ -161,10 +188,11 @@ def main():
         nb_fut0 = base["neighbor_agents_future"]
         if nb_past0.ndim == 4:
             raise ValueError(f"{sp}: batched neighbor array — expected unbatched NPZ")
-        idxs = _stopped_neighbor_indices(nb_past0, nb_fut0)
+        idxs, moving_idxs = _selected_neighbor_indices(nb_past0, nb_fut0, args.include_moving)
         if not idxs:
             n_no_stopped += 1
-            print(f"  [skip] {Path(sp).name}: no stopped neighbors to perturb")
+            kind = "stopped/moving" if args.include_moving else "stopped"
+            print(f"  [skip] {Path(sp).name}: no {kind} neighbors to perturb")
             continue
         gt_plan = _future_as_plan(base["ego_agent_future"])
         pool = Path(sp).parent.name
@@ -177,13 +205,23 @@ def main():
                 dlon = float(rng.uniform(lon_lo, lon_hi)) * float(rng.choice([-1.0, 1.0]))
                 _shift_neighbor(nb_past, nb_fut, i, dlat, dlon)
                 offsets[int(i)] = {"dlat": round(dlat, 3), "dlon": round(dlon, 3)}
+            # t0-clean: ego at origin must clear EVERY shifted box (stopped or
+            # moving — the box is each neighbor's t=0 pose, so this is valid for both).
             boxes = _boxes_from_arrays(nb_past, idxs)
             t0_clr = float(plan_static_clearance(t0_pose, boxes, ego_shape, device))
             if t0_clr < args.min_t0_clearance:
                 n_t0_drop += 1
                 continue
-            gt_clr = float(plan_static_clearance(gt_plan, boxes, ego_shape, device))
-            if gt_clr < 0.0:
+            # GT-future-cross warning is a STATIC-obstacle concept (the GT future
+            # shouldn't pass through a parked car). It is meaningless against a
+            # moving box, so score it only over the STOPPED subset; None if all moving.
+            stopped_boxes = _boxes_from_arrays(nb_past, [i for i in idxs if i not in moving_idxs])
+            gt_clr = (
+                float(plan_static_clearance(gt_plan, stopped_boxes, ego_shape, device))
+                if stopped_boxes
+                else None
+            )
+            if gt_clr is not None and gt_clr < 0.0:
                 n_gt_cross += 1
             out = dict(base)
             out["neighbor_agents_past"] = nb_past
@@ -196,8 +234,9 @@ def main():
                     "source": sp,
                     "variant": v,
                     "offsets": offsets,
+                    "moving_slots": sorted(moving_idxs),
                     "t0_clearance": round(t0_clr, 3),
-                    "gt_future_clearance": round(gt_clr, 3),
+                    "gt_future_clearance": (round(gt_clr, 3) if gt_clr is not None else None),
                     "out": str(out_path),
                 }
             )
@@ -207,7 +246,8 @@ def main():
     with open(out_dir / "manifest.json", "w") as f:
         json.dump(manifest, f, indent=1)
     print(f"\n[perturb_nbr] {len(written)} variants from {len(paths)} scenes -> {args.out_list}")
-    print(f"  dropped: {n_t0_drop} t0-violating; skipped: {n_no_stopped} scenes w/o stopped nbrs")
+    kind = "stopped/moving" if args.include_moving else "stopped"
+    print(f"  dropped: {n_t0_drop} t0-violating; skipped: {n_no_stopped} scenes w/o {kind} nbrs")
     print(
         f"  WARNING: {n_gt_cross} variants have GT future crossing the shifted obstacle "
         "(future must be replaced by distillation before curated SFT)"

--- a/rlvr/autoresearch/tools/viz_moving_scene.py
+++ b/rlvr/autoresearch/tools/viz_moving_scene.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Perfect-tracker WebM of a single scene NPZ with TIME-VARYING neighbor boxes.
+
+The ghost-sim renderer (``ghost_sim_common.run_ghost_sim``) draws one STATIC
+``neighbor_boxes`` set for every frame (it calls ``extract_stopped_neighbors``),
+so it cannot show MOVING neighbors. This driver reuses the same canonical
+per-step renderer (``render_ghost_step``) and the same polyline extraction, but
+feeds it the neighbor poses from ``neighbor_agents_future[:, k]`` at each step k
+— so a moving NPC's trajectory is drawn moving. The ego perfect-tracks its own
+``ego_agent_future`` (the realized/GT path stored in the NPZ); no model needed.
+
+Use it to eyeball reproducer collision scenes and their augmentations (ego-onset
+``disturb_and_replay`` / obstacle ``perturb_neighbors_npz --include_moving``) and
+confirm the moving-neighbor trajectory is preserved / relocated and headings stay
+correct.
+
+Usage:
+    python -m rlvr.autoresearch.tools.viz_moving_scene \
+        --npz <scene.npz> --out_dir <dir> --ego_shape WB,L,W [--label TEXT] [--fps 10]
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import subprocess
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from rlvr.autoresearch.tools.ghost_sim_common import (
+    GhostSimConfig,
+    extract_scene_polylines,
+    render_ghost_step,
+)
+
+
+def _unbatch(arr: np.ndarray) -> np.ndarray:
+    return arr[0] if arr.ndim >= 1 and arr.shape[0] == 1 and arr.ndim in (3, 4) else arr
+
+
+def _pose_from_4col(row: np.ndarray) -> np.ndarray:
+    """[x, y, cos, sin] -> [x, y, heading]."""
+    return np.array([float(row[0]), float(row[1]), math.atan2(float(row[3]), float(row[2]))])
+
+
+def _neighbor_boxes_at(nb_fut: np.ndarray, shapes: np.ndarray, k: int):
+    """Time-varying boxes (x, y, heading, length, width) at future step k.
+
+    nb_fut: (N, T, 4) [x, y, cos, sin]; shapes: (N, 2) [width, length].
+    """
+    boxes = []
+    for i in range(nb_fut.shape[0]):
+        x, y, cos, sin = nb_fut[i, k]
+        if abs(float(x)) + abs(float(y)) < 1e-6:
+            continue  # padding / invalid at this step
+        h = math.atan2(float(sin), float(cos))
+        w, length = float(shapes[i, 0]), float(shapes[i, 1])
+        if w < 0.1 or length < 0.1:
+            continue
+        boxes.append((float(x), float(y), h, length, w))
+    return boxes
+
+
+def render_scene(
+    npz_path: str,
+    out_dir: Path,
+    ego_shape: tuple[float, float, float],
+    label: str = "scene",
+    fps: int = 10,
+    keep_pngs: bool = False,
+) -> Path:
+    """Render one scene NPZ as a perfect-tracker WebM with time-varying neighbors.
+
+    The ego perfect-tracks its ego_agent_future; neighbors follow their
+    neighbor_agents_future (drawn moving via per-step boxes). Returns the webm path.
+    """
+    wb, length, width = ego_shape
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    data = dict(np.load(npz_path, allow_pickle=True))
+    ego_fut = _unbatch(np.asarray(data["ego_agent_future"], dtype=np.float32))
+    if ego_fut.shape[-1] != 4:
+        raise ValueError(f"ego_agent_future must be 4-col [x,y,cos,sin], got {ego_fut.shape}")
+    nb_fut = _unbatch(np.asarray(data["neighbor_agents_future"], dtype=np.float32))
+    nb_past = _unbatch(np.asarray(data["neighbor_agents_past"], dtype=np.float32))
+    if nb_fut.shape[-1] != 4:
+        raise ValueError(f"neighbor_agents_future must be 4-col, got {nb_fut.shape}")
+    shapes = nb_past[:, -1, [6, 7]]  # (N, 2) width, length
+
+    # Polylines via the canonical extractor (needs torch tensors).
+    scene_t = {
+        k: torch.from_numpy(np.asarray(v))
+        for k, v in data.items()
+        if k in ("route_lanes", "lanes", "line_strings")
+    }
+    centerlines, lefts, rights, borders, routes, cl_segs = extract_scene_polylines(scene_t)
+
+    cfg = GhostSimConfig(
+        model_a_label=label,
+        model_b_label=label,
+        ego_length=length,
+        ego_width=width,
+        ego_wheelbase=wb,
+        steps=ego_fut.shape[0],
+    )
+
+    # Ego perfect-tracks ego_agent_future; only the valid (non-zero) steps.
+    ego_valid = (np.abs(ego_fut[:, 0]) + np.abs(ego_fut[:, 1])) > 1e-6
+    T = int(np.where(ego_valid)[0].max()) + 1 if ego_valid.any() else 0
+    if T < 2:
+        raise ValueError("ego_agent_future has <2 valid steps — nothing to render")
+
+    for k in range(T):
+        pose = _pose_from_4col(ego_fut[k])
+        nxt = _pose_from_4col(ego_fut[min(k + 1, T - 1)])
+        speed = float(np.hypot(nxt[0] - pose[0], nxt[1] - pose[1])) / 0.1
+        plan = np.column_stack([ego_fut[k:T, 0], ego_fut[k:T, 1]])
+        render_ghost_step(
+            out_dir / f"step_{k:04d}.png",
+            step=k,
+            n_steps=T,
+            a_pose=pose,
+            a_speed=speed,
+            a_plan=plan,
+            b_pose=pose,
+            b_speed=speed,
+            b_plan=None,
+            centerlines=centerlines,
+            lefts=lefts,
+            rights=rights,
+            border_polylines=borders,
+            route_polylines=routes,
+            centerline_segments=cl_segs,
+            cfg=cfg,
+            neighbor_boxes=_neighbor_boxes_at(nb_fut, shapes, k),
+            extra_title=f"  {label}  t={k * 0.1:.1f}s",
+        )
+
+    webm = out_dir / f"{label}.webm"
+    cmd = [
+        "ffmpeg", "-y", "-framerate", str(fps),
+        "-i", str(out_dir / "step_%04d.png"),
+        "-c:v", "libvpx-vp9", "-b:v", "0", "-crf", "32", "-row-mt", "1",
+        "-pix_fmt", "yuv420p", str(webm),
+    ]  # fmt: skip
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode != 0:
+        raise RuntimeError(f"ffmpeg failed:\n{r.stderr[-1500:]}")
+    print(f"[viz_moving_scene] {T} frames -> {webm}")
+    if not keep_pngs:
+        for p in out_dir.glob("step_*.png"):
+            p.unlink()
+    return webm
+
+
+def render_batch_dir(
+    batch_dir: Path,
+    out_dir: Path,
+    ego_shape: tuple[float, float, float],
+    label: str = "batch",
+    fps: int = 10,
+    keep_pngs: bool = False,
+) -> Path:
+    """Render a saved collision/near-miss batch dir as a WebM, one frame per snapshot.
+
+    Each ``collision-NNNNN.npz`` is one re-centered snapshot, so the dir already IS the
+    time sequence (ordered farthest->contact). Each frame is drawn with the canonical
+    reproducer renderer ``reproducer_rollout._draw_step`` (-> ``replay.save_step_figure``),
+    which draws the ego + its plan, neighbor boxes, route/borders, AND the closest-point
+    ego<->nearest-neighbor distance LINE + value (via ``rlvr.reward._closest_points_between_rects``).
+    No ego_future needed for the contact frame — its current neighbor box is drawn directly.
+    """
+    import glob
+
+    from scenario_generation.reproducer_rollout import _draw_step
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    # Filenames are collision<offset>.npz, offset in -00080..+00000 (offset = step - t_c).
+    # Sort by the NUMERIC offset so time runs farthest->contact (lexical sort would reverse it).
+    files = sorted(
+        glob.glob(str(Path(batch_dir) / "collision*.npz")),
+        key=lambda f: int(Path(f).stem.replace("collision", "")),
+    )
+    if not files:
+        raise ValueError(f"no collision*.npz under {batch_dir}")
+    es = np.asarray(ego_shape, dtype=np.float32).reshape(-1)[:3]
+    for k, fp in enumerate(files):
+        data = dict(np.load(fp, allow_pickle=True))
+        # _draw_step squeezes a leading batch axis, so add one to every field.
+        batched = {kk: np.asarray(v)[None] for kk, v in data.items()}
+        pred = np.asarray(data["ego_agent_future"], dtype=np.float32)  # ego plan overlay
+        _draw_step(batched, pred, es, out_dir / f"step_{k:04d}.png", step=k, total=len(files))
+    webm = out_dir / f"{label}.webm"
+    cmd = [
+        "ffmpeg", "-y", "-framerate", str(fps), "-i", str(out_dir / "step_%04d.png"),
+        "-c:v", "libvpx-vp9", "-b:v", "0", "-crf", "32", "-row-mt", "1",
+        "-pix_fmt", "yuv420p", str(webm),
+    ]  # fmt: skip
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode != 0:
+        raise RuntimeError(f"ffmpeg failed:\n{r.stderr[-1500:]}")
+    print(f"[viz_moving_scene] batch {len(files)} frames -> {webm}")
+    if not keep_pngs:
+        for p in out_dir.glob("step_*.png"):
+            p.unlink()
+    return webm
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--npz", help="single scene NPZ (perfect-track its ego_future)")
+    ap.add_argument("--batch_dir", help="a saved collision batch dir (render snapshots in order)")
+    ap.add_argument("--out_dir", required=True)
+    ap.add_argument("--ego_shape", required=True, help="WB,L,W")
+    ap.add_argument("--label", default="scene")
+    ap.add_argument("--fps", type=int, default=10)
+    ap.add_argument("--keep_pngs", action="store_true")
+    args = ap.parse_args()
+    ego_shape = tuple(float(x) for x in args.ego_shape.split(","))
+    if bool(args.npz) == bool(args.batch_dir):
+        ap.error("pass exactly one of --npz or --batch_dir")
+    if args.batch_dir:
+        render_batch_dir(Path(args.batch_dir), Path(args.out_dir), ego_shape, args.label,
+                         args.fps, args.keep_pngs)  # fmt: skip
+    else:
+        render_scene(args.npz, Path(args.out_dir), ego_shape, args.label, args.fps, args.keep_pngs)
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/viz_moving_scene.py
+++ b/rlvr/autoresearch/tools/viz_moving_scene.py
@@ -111,7 +111,11 @@ def render_scene(
     ego_valid = (np.abs(ego_fut[:, 0]) + np.abs(ego_fut[:, 1])) > 1e-6
     T = int(np.where(ego_valid)[0].max()) + 1 if ego_valid.any() else 0
     if T < 2:
-        raise ValueError("ego_agent_future has <2 valid steps — nothing to render")
+        raise ValueError(
+            f"{npz_path}: ego_agent_future has <2 valid steps — nothing to perfect-track. "
+            "This is the collision frame (collision+00000, truncated at contact). Render the "
+            "whole saved batch with --batch_dir <dir> (current-state renderer) instead."
+        )
 
     for k in range(T):
         pose = _pose_from_4col(ego_fut[k])

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -365,6 +365,13 @@ class _SegState:
     unstick_advance_m: float = 5.0
     ego_stuck: int = 0
     n_snaps: int = 0
+    # One-pass collision-scene save (set when run_segments_batched gets save_dir).
+    # save_buf rolls the last save_pre_steps+1 (k, idx, live_pose, np_dict) snapshots;
+    # it is CLEARED on an unstick teleport so a saved window never crosses the jump.
+    save_buf: object = None
+    saved_collision: bool = False
+    last_snap_step: int | None = None
+    save_out_dir: object = None
 
 
 def _ego_state_from_frame(tl: RouteTimeline, idx: int) -> tuple[np.ndarray, np.ndarray, "_EgoDyn"]:
@@ -849,12 +856,29 @@ def run_segments_batched(
     n_build_threads: int = 8,
     prefetch_ahead: int = 2,
     timers: Timers | None = None,
+    save_dir=None,
+    save_pre_steps: int = 80,
+    save_thresh: float | None = None,
+    save_pre_arc_m: float = 1.0,
+    save_max_scenes: int = 160,
+    save_min_post_snap_frames: int = 30,
+    route_keys: list[str] | None = None,
 ) -> list[SegmentResult]:
     """Run many segments in lock-step: ONE batched model forward per tick.
 
     work_units: list of (RouteTimeline, start, end). Processed in chunks of
     ``batch_size`` (bound GPU memory). Segments terminate raggedly (goal / step
     cap); finished ones drop out while the rest continue.
+
+    ONE-PASS collision-scene save: when ``save_dir`` is given, each segment keeps a
+    rolling buffer of its last ``save_pre_steps`` scene snapshots and, on the FIRST
+    step within ``save_thresh`` m of a neighbor, dumps that window (+ manifest) to
+    ``save_dir/<route>_<start>_<end>/``. The scenes come from THIS run — the same one
+    that detected the collision — so they always match the hit (the legacy two-pass
+    ``extract_collision_scenes`` re-ran the rollout, which is batch-sensitive and so
+    could anchor a different/empty window). The buffer is cleared on an unstick
+    teleport so a saved window never spans the jump. ``route_keys`` (aligned to
+    ``work_units``) names the output dirs; if None it is derived from each timeline.
 
     Unstick is on by default (snap the ego forward onto the recorded GT pose after
     ``unstick_after`` steps of no progress), so a segment isn't bailed out at a
@@ -898,6 +922,14 @@ def run_segments_batched(
                 )
                 for (tl, start, end) in chunk
             ]
+            if save_dir is not None:
+                from collections import deque
+                from pathlib import Path
+
+                for off, s in enumerate(states):
+                    key = route_keys[c0 + off] if route_keys else _route_key(s.tl)
+                    s.save_buf = deque(maxlen=save_max_scenes + 1)
+                    s.save_out_dir = Path(save_dir) / f"{key}_{s.start}_{s.end}"
             active = list(states)
             while active:
                 with timers("input_build"):
@@ -926,8 +958,42 @@ def run_segments_batched(
                     for (s, _np, nb, idx), (cl, col, _M) in zip(built, score_list):
                         s.clearances[s.k] = cl
                         s.collisions[s.k] = col
+                        # One-pass save: buffer this step, then dump the window on the
+                        # FIRST collision — from THIS run, so the scenes match the hit.
+                        if s.save_buf is not None:
+                            s.save_buf.append((s.k, idx, s.live_pose.copy(), _np))
+                            if (
+                                not s.saved_collision
+                                and save_thresh is not None
+                                and cl <= save_thresh
+                            ):
+                                mani = _dump_precollision_window(
+                                    s.save_out_dir,
+                                    s.tl,
+                                    model_args,
+                                    s.k,
+                                    list(s.save_buf),
+                                    s.last_snap_step,
+                                    save_pre_steps,
+                                    save_thresh,
+                                    s.start,
+                                    s.end,
+                                    pre_arc_m=save_pre_arc_m,
+                                    max_scenes=save_max_scenes,
+                                    min_post_snap_frames=save_min_post_snap_frames,
+                                )
+                                # Consume the segment's one save only on an ACTUAL write; a
+                                # snap-skipped hit stays open for a later, settled collision.
+                                if mani is not None:
+                                    s.saved_collision = True
                     for i, (s, _np, nb, idx) in enumerate(built):
+                        prev_snaps = s.n_snaps
                         _advance_step(s, preds[i], idx, device, timers)
+                        # Clear the buffer on an unstick teleport: pre-jump frames belong
+                        # to a different ego path and must never enter a saved window.
+                        if s.save_buf is not None and s.n_snaps > prev_snaps:
+                            s.save_buf.clear()
+                            s.last_snap_step = s.k
                 active = [s for s in active if not s.done]
             results.extend(_finalize(s, timers) for s in states)
     finally:
@@ -1004,15 +1070,173 @@ def _scene_npz_from_np_dict(np_dict: dict) -> dict:
     return {k: np.asarray(v)[0] for k, v in np_dict.items()}
 
 
-@torch.no_grad()
-def _precollision_window_start(t_c: int, pre_steps: int, last_snap_step: int | None) -> int:
-    """First step of the pre-collision window, clamped so it never crosses an unstick
-    snap. Normally ``t_c - pre_steps`` (may be negative — the backtrack path then reads
-    recorded frames before the segment start). If an unstick snap fired within that window
-    (``last_snap_step`` is not None and >= the base start), start at the post-snap step
-    instead so no saved scene's realized ego_future or ego_past spans the ~5 m teleport."""
+def _precollision_window_start(
+    t_c: int,
+    pre_steps: int,
+    last_snap_step: int | None,
+    poses_by_step: dict | None = None,
+    pre_arc_m: float = 0.0,
+    max_scenes: int | None = None,
+) -> int:
+    """First step of the pre-collision window.
+
+    Baseline: ``t_c - pre_steps`` (>= ``pre_steps`` frames; may be negative -> the
+    backtrack path reads recorded frames before the segment start). Never crosses an
+    unstick snap (clamped to ``last_snap_step``).
+
+    MIN-MOVEMENT EXTEND: if ``pre_arc_m > 0`` and the ego's cumulative arc length over
+    the baseline window is below ``pre_arc_m`` (slow creep, e.g. queueing into a stopped
+    car), the window is extended further back — frame by frame — until the ego has
+    travelled ``pre_arc_m`` of arc length OR the window hits ``max_scenes`` frames (incl.
+    t_c) OR the snap / buffer start. ``poses_by_step`` maps step -> world pose (from the
+    live buffer) and supplies the arc length."""
     base = t_c - pre_steps
-    return base if last_snap_step is None else max(base, last_snap_step)
+    if last_snap_step is not None:
+        base = max(base, last_snap_step)
+    if not poses_by_step or pre_arc_m <= 0:
+        return base
+    live_ks = sorted(k for k in poses_by_step if k <= t_c)
+    if not live_ks:
+        return base
+    floor = live_ks[0]
+    if max_scenes is not None:
+        floor = max(floor, t_c - (max_scenes - 1))
+    if last_snap_step is not None:
+        floor = max(floor, last_snap_step)
+    if base <= floor:  # can't extend (early collision / snap clamp already binds)
+        return base
+
+    def _cumarc(a: int) -> float:
+        ks = [k for k in live_ks if a <= k <= t_c]
+        s = 0.0
+        for i in range(len(ks) - 1):
+            p, q = poses_by_step[ks[i]], poses_by_step[ks[i + 1]]
+            s += float(((p[0] - q[0]) ** 2 + (p[1] - q[1]) ** 2) ** 0.5)
+        return s
+
+    start_k = base
+    while start_k > floor and _cumarc(start_k) < pre_arc_m:
+        start_k -= 1
+    return start_k
+
+
+def _route_key(tl: RouteTimeline) -> str:
+    """Route key from a timeline's NPZ names, e.g. '16-24-07_00000000_00000038' -> '16-24-07_00000000'."""
+    from pathlib import Path
+
+    return "_".join(Path(tl.npz_paths[0]).stem.split("_")[:2])
+
+
+def _dump_precollision_window(
+    out_dir,
+    tl: RouteTimeline,
+    model_args,
+    t_c: int,
+    buf,
+    last_snap_step: int | None,
+    pre_steps: int,
+    collision_thresh: float,
+    seg_start: int,
+    seg_end: int,
+    pre_arc_m: float = 0.0,
+    max_scenes: int | None = None,
+    min_post_snap_frames: int = 0,
+) -> dict | None:
+    """Write the scenes before collision step ``t_c`` from a live buffer.
+
+    ``buf`` is an iterable of ``(k, idx, live_pose, np_dict)`` snapshots captured DURING
+    the rollout that detected the collision (so the saved scenes match that exact run —
+    no re-simulation). Steps before the segment start are filled from the recorded NPZs.
+    The window is >= ``pre_steps`` frames, extended backward to cover ``pre_arc_m`` of ego
+    arc length when the ego barely moved (capped at ``max_scenes``), and never crosses an
+    unstick teleport (``last_snap_step``). Returns the manifest, or None if skipped.
+
+    SKIP rule: if an unstick teleport fired fewer than ``min_post_snap_frames`` steps
+    before the collision, the ego had too little settled history after the jump — the
+    contact is likely teleport-induced, so nothing is saved (returns None).
+    """
+    import json
+    from pathlib import Path
+
+    if (
+        min_post_snap_frames > 0
+        and last_snap_step is not None
+        and (t_c - last_snap_step) < min_post_snap_frames
+    ):
+        print(
+            f"  [save] SKIP collision@{t_c}: only {t_c - last_snap_step} frames "
+            f"({(t_c - last_snap_step) * DT:.1f}s) of history since the unstick snap"
+        )
+        return None
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    live_by_step = {rec[0]: rec for rec in buf}
+    poses_by_step = {rec[0]: rec[2] for rec in buf}  # step k -> world pose (for ego_future)
+    fut_len = int(model_args.future_len)
+    saved: list[int] = []
+
+    start_k = _precollision_window_start(
+        t_c, pre_steps, last_snap_step, poses_by_step, pre_arc_m, max_scenes
+    )
+    if start_k < t_c - pre_steps:
+        print(
+            f"  [save] window extended {t_c - pre_steps} -> {start_k} "
+            f"(slow ego: {t_c - start_k} frames to cover {pre_arc_m} m arc)"
+        )
+    elif start_k > t_c - pre_steps:
+        print(f"  [save] window clamped {t_c - pre_steps} -> {start_k} (unstick snap in window)")
+    # Inclusive of t_c: the LAST saved frame (collision+00000) IS the collision step, so the
+    # window ends exactly on the contact (its current neighbor box is the one within thresh).
+    for step_k in range(start_k, t_c + 1):
+        if step_k >= 0 and step_k in live_by_step:
+            _, idx, live_pose, np_dict = live_by_step[step_k]
+            scene = _scene_npz_from_np_dict(np_dict)
+            ep = scene["ego_agent_past"]
+            scene["ego_agent_past"] = np.column_stack(
+                [ep[:, 0], ep[:, 1], np.arctan2(ep[:, 3], ep[:, 2])]
+            ).astype(np.float32)
+            g = scene["goal_pose"]
+            scene["goal_pose"] = np.array([g[0], g[1], math.atan2(g[3], g[2])], dtype=np.float32)
+            with np.load(tl.npz_paths[idx], allow_pickle=True) as z:
+                naf = z["neighbor_agents_future"] if "neighbor_agents_future" in z.files else None
+            if naf is not None:
+                dx, dy, dyaw = _rel_pose(tl.poses[idx], live_pose)
+                scene["neighbor_agents_future"] = _recenter_neighbor_future(naf, dx, dy, dyaw)
+            eaf = np.zeros((fut_len, 4), dtype=np.float32)
+            for j in range(1, fut_len + 1):
+                fk = step_k + j
+                if fk > t_c or fk not in poses_by_step:
+                    break
+                ex, ey, eh = _world_pose_to_ego(poses_by_step[fk], live_pose)
+                eaf[j - 1] = (ex, ey, math.cos(eh), math.sin(eh))
+            scene["ego_agent_future"] = eaf
+            scene["origin"] = np.array("live")
+        else:
+            frame = seg_start + step_k
+            if frame < 0 or frame >= len(tl):
+                continue
+            with np.load(tl.npz_paths[frame], allow_pickle=True) as z:
+                scene = {key: z[key] for key in z.files if key not in ("map_name", "token")}
+            for fk in ("neighbor_agents_future", "ego_agent_future"):
+                if fk in scene:
+                    scene[fk] = _future_to_4col(scene[fk])
+            scene["origin"] = np.array("recorded")
+        token = f"{step_k - t_c:+06d}"
+        np.savez_compressed(out_dir / f"collision{token}.npz", **scene)
+        saved.append(int(step_k))
+
+    manifest = {
+        "segment": [int(seg_start), int(seg_end)],
+        "collision_step": int(t_c),
+        "collision_thresh": float(collision_thresh),
+        "n_scenes": len(saved),
+        "steps_saved": saved,
+        "n_live": sum(1 for k in saved if k >= 0),
+        "n_recorded": sum(1 for k in saved if k < 0),
+    }
+    (out_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
+    return manifest
 
 
 def extract_collision_scenes(
@@ -1030,6 +1254,9 @@ def extract_collision_scenes(
     unstick_after: int = 300,
     unstick_advance_m: float = 5.0,
     max_steps: int | None = None,
+    pre_arc_m: float = 1.0,
+    max_scenes: int = 160,
+    min_post_snap_frames: int = 30,
 ) -> dict | None:
     """Mine the batch of scenes leading up to the FIRST collision in a segment.
 
@@ -1051,8 +1278,13 @@ def extract_collision_scenes(
     futures), which the full-route timeline still holds. So the batch always has
     ``pre_steps`` scenes with real, continuous ego history (subject to the route
     start). Returns a manifest dict, or None if no collision occurred.
+
+    NOTE: this is the legacy SECOND-PASS path — it re-runs the rollout to reconstruct
+    the window, so the collision it finds can differ from the one the miner detected
+    (the closed-loop rollout is sensitive to GPU batch composition). Prefer the
+    ONE-PASS save in ``run_segments_batched`` (``save_dir=...``), which dumps the
+    buffer from the SAME run that detected the collision. Kept for backward compat.
     """
-    import json
     from collections import deque
     from pathlib import Path
 
@@ -1073,9 +1305,8 @@ def extract_collision_scenes(
         unstick_after=unstick_after,
         unstick_advance_m=unstick_advance_m,
     )
-    # Rolling buffer of the last pre_steps+1 live steps; each: (k, idx, live_pose, np_dict).
-    buf: deque = deque(maxlen=pre_steps + 1)
-    live_poses: dict[int, np.ndarray] = {}  # step k -> world pose (for ego_future)
+    # Rolling buffer of the last max_scenes+1 live steps; each: (k, idx, live_pose, np_dict).
+    buf: deque = deque(maxlen=max_scenes + 1)
     t_c = None
     # Step right after the most recent unstick snap (None = no snap yet). The pre-collision
     # window must not cross a snap, or a saved scene's realized ego_future/ego_past would
@@ -1092,7 +1323,6 @@ def extract_collision_scenes(
         pred = outputs["prediction"][0, 0].cpu().numpy()
         clr = _min_clearance_any(neighbors_live, s.ego_shape, device)
         buf.append((k, idx, s.live_pose.copy(), np_dict))
-        live_poses[k] = s.live_pose.copy()
         if clr <= collision_thresh:
             t_c = k
             break
@@ -1103,75 +1333,20 @@ def extract_collision_scenes(
     if t_c is None:
         return None
 
-    # Record the collision-step world pose too (needed for ego_future of late scenes).
-    live_poses[t_c] = s.live_pose.copy()
-    out_dir.mkdir(parents=True, exist_ok=True)
-    live_by_step = {rec[0]: rec for rec in buf}
-    saved = []
-    fut_len = int(model_args.future_len)
-
-    # Clamp the window so it never crosses an unstick teleport: start no earlier than the
-    # step right after the last snap, keeping every saved scene's realized ego_future AND
-    # ego_past on one continuous (snap-free) segment.
-    start_k = _precollision_window_start(t_c, pre_steps, last_snap_step)
-    if start_k > t_c - pre_steps:
-        print(
-            f"  [extract] window clamped {t_c - pre_steps} -> {start_k} "
-            f"(unstick snap within the {pre_steps}-step pre-collision window)"
-        )
-    for step_k in range(start_k, t_c):
-        if step_k >= 0 and step_k in live_by_step:
-            _, idx, live_pose, np_dict = live_by_step[step_k]
-            scene = _scene_npz_from_np_dict(np_dict)
-            # Match the canonical recorded NPZ format: 3-col (x, y, heading) ego
-            # past + goal (np_dict carries them as cos/sin 4-col).
-            ep = scene["ego_agent_past"]
-            scene["ego_agent_past"] = np.column_stack(
-                [ep[:, 0], ep[:, 1], np.arctan2(ep[:, 3], ep[:, 2])]
-            ).astype(np.float32)
-            g = scene["goal_pose"]
-            scene["goal_pose"] = np.array([g[0], g[1], math.atan2(g[3], g[2])], dtype=np.float32)
-            # neighbor GT future (recorded), re-centered onto the live ego.
-            with np.load(tl.npz_paths[idx], allow_pickle=True) as z:
-                naf = z["neighbor_agents_future"] if "neighbor_agents_future" in z.files else None
-            if naf is not None:
-                dx, dy, dyaw = _rel_pose(tl.poses[idx], live_pose)
-                scene["neighbor_agents_future"] = _recenter_neighbor_future(naf, dx, dy, dyaw)
-            # ego_agent_future = realized live path up to the collision (zeros after),
-            # 4-col [x, y, cos, sin] (trainable/reward schema; never 3-col).
-            eaf = np.zeros((fut_len, 4), dtype=np.float32)
-            for j in range(1, fut_len + 1):
-                fk = step_k + j
-                if fk > t_c or fk not in live_poses:
-                    break
-                ex, ey, eh = _world_pose_to_ego(live_poses[fk], live_pose)
-                eaf[j - 1] = (ex, ey, math.cos(eh), math.sin(eh))
-            scene["ego_agent_future"] = eaf
-            scene["origin"] = np.array("live")
-        else:
-            # Backtrack: a recorded frame before the segment start (real GT scene).
-            frame = start + step_k
-            if frame < 0 or frame >= len(tl):
-                continue
-            with np.load(tl.npz_paths[frame], allow_pickle=True) as z:
-                scene = {key: z[key] for key in z.files if key not in ("map_name", "token")}
-            # Recorded corpora may store 3-col futures; the saved scene must be 4-col.
-            for fk in ("neighbor_agents_future", "ego_agent_future"):
-                if fk in scene:
-                    scene[fk] = _future_to_4col(scene[fk])
-            scene["origin"] = np.array("recorded")
-        token = f"{step_k - t_c:+06d}"  # offset from collision, e.g. -00080 .. -00001
-        np.savez_compressed(out_dir / f"collision{token}.npz", **scene)
-        saved.append(int(step_k))
-
-    manifest = {
-        "segment": [int(start), int(end)],
-        "collision_step": int(t_c),
-        "collision_thresh": float(collision_thresh),
-        "n_scenes": len(saved),
-        "steps_saved": saved,
-        "n_live": sum(1 for k in saved if k >= 0),
-        "n_recorded": sum(1 for k in saved if k < 0),
-    }
-    (out_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
-    return manifest
+    # buf's last entry is the collision step t_c (appended before the break), so it
+    # already carries the t_c world pose needed for the late scenes' ego_future.
+    return _dump_precollision_window(
+        out_dir,
+        tl,
+        model_args,
+        t_c,
+        list(buf),
+        last_snap_step,
+        pre_steps,
+        collision_thresh,
+        start,
+        end,
+        pre_arc_m=pre_arc_m,
+        max_scenes=max_scenes,
+        min_post_snap_frames=min_post_snap_frames,
+    )

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -366,8 +366,9 @@ class _SegState:
     ego_stuck: int = 0
     n_snaps: int = 0
     # One-pass collision-scene save (set when run_segments_batched gets save_dir).
-    # save_buf rolls the last save_pre_steps+1 (k, idx, live_pose, np_dict) snapshots;
-    # it is CLEARED on an unstick teleport so a saved window never crosses the jump.
+    # save_buf rolls the last save_max_scenes+1 (k, idx, live_pose, np_dict) snapshots
+    # (deep enough for the min-movement window extension); it is CLEARED on an unstick
+    # teleport so a saved window never crosses the jump.
     save_buf: object = None
     saved_collision: bool = False
     last_snap_step: int | None = None
@@ -1093,6 +1094,11 @@ def _precollision_window_start(
     base = t_c - pre_steps
     if last_snap_step is not None:
         base = max(base, last_snap_step)
+    # Cap to max_scenes frames even on the no-extend path, so we never request a step
+    # that was already evicted from the (max_scenes+1)-deep buffer (which would silently
+    # splice recorded GT frames into a window that should be all-live).
+    if max_scenes is not None:
+        base = max(base, t_c - (max_scenes - 1))
     if not poses_by_step or pre_arc_m <= 0:
         return base
     live_ks = sorted(k for k in poses_by_step if k <= t_c)


### PR DESCRIPTION
## Summary
Reworks how the perception-reproducer miner saves pre-collision scenes, and extends the augmentation/viz tooling to handle moving neighbors.

### `reproducer_rollout.py` — one-pass save (replaces the re-sim extract pass)
- The pre-collision scene window is now saved **during the same batched rollout that detects the hit**, from a per-segment rolling buffer — so the saved scenes always match the detected collision. The legacy two-pass `extract_collision_scenes` re-ran the rollout separately and could anchor a different/empty window; it now delegates to the shared writer and is marked superseded.
- Window selection: **≥ `pre_steps` frames, extended backward until the ego has travelled `pre_arc_m` of arc length** (capped at `max_scenes`), so a slow creep into a stopped lead captures real approach instead of ~80 near-identical frames. The window **includes the contact step**, **never crosses an unstick teleport**, and a hit is **dropped if a teleport fired fewer than `min_post_snap_frames` before it** (too little settled history).

### `mine_collisions_reproducer.py`
- New flags: `--save_dir`, `--save_pre_steps`, `--save_thresh`, `--save_pre_arc_m`, `--save_max_scenes`, `--save_min_post_snap_s` — produce trainable scene batches in one pass.

### `extract_collision_scenes.py`
- `--include_near_miss`: also extract near-miss segments, triggering the window at the closest-approach threshold.

### `perturb_neighbors_npz.py`
- `--include_moving`: also perturb moving neighbors (rigid translation preserves the track's shape, per-step heading and velocity). The GT-future static-clearance check is restricted to the stopped subset.

### `viz_moving_scene.py` (new)
- Render a scene NPZ (perfect-track its ego future) or a saved batch dir as a webm. Batch mode renders each snapshot via the canonical `save_step_figure`, so the ego↔nearest-neighbor closest-point distance line + value are drawn.

## Test
- Window-selection logic unit-tested (fast ego → min frames; slow creep → extends to cap; never extends past a snap; snap-within-threshold → skip returns None, writes nothing).
- Backward-compatible: defaults preserve prior behavior; save path is inert unless `--save_dir` is set.
- ruff check + ruff-format clean (pre-commit gate).