### PR TITLE
Reproducer save: address Copilot review (route key, window guard, stale-file clear)

### DIFF
--- a/rlvr/autoresearch/tools/cpp_bin_to_npz.py
+++ b/rlvr/autoresearch/tools/cpp_bin_to_npz.py
@@ -223,6 +223,12 @@ def convert_dir(
                 stats["skipped_invalid"] += 1
                 continue
         out = dst_dir / f"{stem}.npz"
+        # Carry the sidecar across (for EVERY kept frame, skipped or not) so is_skipped
+        # detection + the reproducer's pose timeline survive into dst. Done BEFORE the
+        # skip_existing check so an incremental re-run still backfills the sidecar for a
+        # frame whose .npz an earlier (non-keep_skipped) pass already wrote.
+        if keep_skipped and jpath.exists():
+            shutil.copy2(jpath, dst_dir / f"{stem}.json")
         if skip_existing and out.exists():
             stats["skipped_existing"] += 1
             continue
@@ -234,9 +240,6 @@ def convert_dir(
             stats["ok"] += 1
             if is_skip:
                 stats["kept_skipped"] += 1
-            # Carry the sidecar across so is_skipped detection + pose survive into dst.
-            if keep_skipped and jpath.exists():
-                shutil.copy2(jpath, dst_dir / f"{stem}.json")
         except Exception as exc:
             print(f"ERROR on {fp}: {exc}")
             stats["errors"] += 1

--- a/rlvr/autoresearch/tools/cpp_bin_to_npz.py
+++ b/rlvr/autoresearch/tools/cpp_bin_to_npz.py
@@ -223,8 +223,10 @@ def convert_dir(
                 stats["skipped_invalid"] += 1
                 continue
         out = dst_dir / f"{stem}.npz"
-        # Carry the sidecar across (for EVERY kept frame, skipped or not) so is_skipped
-        # detection + the reproducer's pose timeline survive into dst. Done BEFORE the
+        # Carry the sidecar across for every kept frame THAT HAS ONE (skipped or not) so
+        # is_skipped detection + the reproducer's pose timeline survive into dst. Frames
+        # whose source .bin has no sibling .json get no sidecar in dst (resolve_sidecar then
+        # falls back to sidecar_root / treats them as not-skipped). Done BEFORE the
         # skip_existing check so an incremental re-run still backfills the sidecar for a
         # frame whose .npz an earlier (non-keep_skipped) pass already wrote.
         if keep_skipped and jpath.exists():

--- a/rlvr/autoresearch/tools/cpp_bin_to_npz.py
+++ b/rlvr/autoresearch/tools/cpp_bin_to_npz.py
@@ -23,6 +23,7 @@ import argparse
 import glob
 import json
 import os
+import shutil
 from pathlib import Path
 
 import numpy as np
@@ -186,18 +187,39 @@ def decode_bin(raw: bytes) -> dict[str, np.ndarray]:
     }
 
 
-def convert_dir(src_dir: Path, dst_dir: Path, skip_existing: bool = True) -> dict[str, int]:
+def convert_dir(
+    src_dir: Path, dst_dir: Path, skip_existing: bool = True, keep_skipped: bool = False
+) -> dict[str, int]:
+    """Decode every ``.bin`` in ``src_dir`` to a 320-model ``.npz`` in ``dst_dir``.
+
+    ``keep_skipped``: by DEFAULT, frames the cpp converter flagged ``is_skipped`` in their
+    sibling ``.json`` (red-light dwell, no progress, stale perception, ...) are dropped — the
+    training/eval default. Set True to KEEP them: the frame is still converted AND its ``.json``
+    sidecar is copied next to the ``.npz``, so (a) the perception reproducer gets a GAP-FREE
+    timeline and (b) the training filter (``scene_skip.is_skipped``, which reads the sibling
+    sidecar) can still exclude them. Without copying the sidecar the kept frames would lose the
+    flag and silently leak into training.
+    """
     dst_dir.mkdir(parents=True, exist_ok=True)
     bins = sorted(glob.glob(str(src_dir / "*.bin")))
-    stats = {"total": len(bins), "ok": 0, "skipped_existing": 0, "skipped_invalid": 0, "errors": 0}
+    stats = {
+        "total": len(bins),
+        "ok": 0,
+        "skipped_existing": 0,
+        "skipped_invalid": 0,
+        "kept_skipped": 0,
+        "errors": 0,
+    }
     for fp in bins:
         stem = Path(fp).stem
-        # Each .bin has a sibling .json with skipping_info — skip rejected frames
+        # Each .bin has a sibling .json with skipping_info.
         jpath = Path(fp).with_suffix(".json")
+        is_skip = False
         if jpath.exists():
             with open(jpath) as f:
                 meta = json.load(f)
-            if meta.get("is_skipped", False):
+            is_skip = bool(meta.get("is_skipped", False))
+            if is_skip and not keep_skipped:
                 stats["skipped_invalid"] += 1
                 continue
         out = dst_dir / f"{stem}.npz"
@@ -210,6 +232,11 @@ def convert_dir(src_dir: Path, dst_dir: Path, skip_existing: bool = True) -> dic
             arrs = decode_bin(raw)
             np.savez_compressed(out, **arrs)
             stats["ok"] += 1
+            if is_skip:
+                stats["kept_skipped"] += 1
+            # Carry the sidecar across so is_skipped detection + pose survive into dst.
+            if keep_skipped and jpath.exists():
+                shutil.copy2(jpath, dst_dir / f"{stem}.json")
         except Exception as exc:
             print(f"ERROR on {fp}: {exc}")
             stats["errors"] += 1
@@ -223,9 +250,18 @@ def main() -> None:
     )
     ap.add_argument("--dst", type=Path, required=True, help="dir to write .npz files")
     ap.add_argument("--overwrite", action="store_true")
+    ap.add_argument(
+        "--keep_skipped",
+        action="store_true",
+        help="keep converter-flagged is_skipped frames (and copy their .json sidecar) so the "
+        "perception reproducer gets a gap-free timeline; training/eval still filter them via "
+        "the sidecar. Default: drop them (training/eval default).",
+    )
     args = ap.parse_args()
 
-    stats = convert_dir(args.src, args.dst, skip_existing=not args.overwrite)
+    stats = convert_dir(
+        args.src, args.dst, skip_existing=not args.overwrite, keep_skipped=args.keep_skipped
+    )
     print(json.dumps(stats, indent=2))
 
 

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -1177,6 +1177,15 @@ def _dump_precollision_window(
     import json
     from pathlib import Path
 
+    out_dir = Path(out_dir)
+    # Clear any prior batch in this dir FIRST — before the skip early-return — so that a
+    # re-mine which now SKIPS this segment (or writes a shorter window) never leaves stale
+    # older-offset collision*.npz behind to be mistaken for a fresh save. Don't create the
+    # dir on a skip (avoid littering empty dirs); only clear if it already exists.
+    if out_dir.exists():
+        for stale in out_dir.glob("collision*.npz"):
+            stale.unlink()
+
     if (
         min_post_snap_frames > 0
         and last_snap_step is not None
@@ -1188,13 +1197,7 @@ def _dump_precollision_window(
         )
         return None
 
-    out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
-    # Clear any prior batch in this dir: the window length now varies (arc-length extend /
-    # snap clamp / max_scenes), so a re-run could otherwise leave stale older-offset
-    # collision*.npz mixed in with the new window.
-    for stale in out_dir.glob("collision*.npz"):
-        stale.unlink()
     live_by_step = {rec[0]: rec for rec in buf}
     poses_by_step = {rec[0]: rec[2] for rec in buf}  # step k -> world pose (for ego_future)
     fut_len = int(model_args.future_len)

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -901,6 +901,14 @@ def run_segments_batched(
     from concurrent.futures import ThreadPoolExecutor
 
     timers = timers or Timers()
+    if save_dir is not None and save_max_scenes < save_pre_steps + 1:
+        # The buffer is save_max_scenes+1 deep and the window is >= save_pre_steps frames
+        # plus the collision step. A smaller cap would silently truncate the window — fail
+        # loudly rather than save shorter-than-requested batches.
+        raise ValueError(
+            f"save_max_scenes ({save_max_scenes}) must be >= save_pre_steps + 1 "
+            f"({save_pre_steps + 1}); otherwise the saved window is silently truncated."
+        )
     results: list[SegmentResult] = []
     pool = ThreadPoolExecutor(max_workers=max(1, n_build_threads))
     try:
@@ -1127,10 +1135,15 @@ def _precollision_window_start(
 
 
 def _route_key(tl: RouteTimeline) -> str:
-    """Route key from a timeline's NPZ names, e.g. '16-24-07_00000000_00000038' -> '16-24-07_00000000'."""
+    """Route key from a timeline, using the SAME derivation as group_routes/the miner
+    (``route_timeline.route_prefix`` — strip the trailing ``_<frameidx>``), so the
+    output dir name matches the hits.jsonl ``route`` field and distinct routes that
+    only share a leading token are not collapsed together."""
     from pathlib import Path
 
-    return "_".join(Path(tl.npz_paths[0]).stem.split("_")[:2])
+    from scenario_generation.route_timeline import route_prefix
+
+    return route_prefix(Path(tl.npz_paths[0]))
 
 
 def _dump_precollision_window(
@@ -1177,6 +1190,11 @@ def _dump_precollision_window(
 
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
+    # Clear any prior batch in this dir: the window length now varies (arc-length extend /
+    # snap clamp / max_scenes), so a re-run could otherwise leave stale older-offset
+    # collision*.npz mixed in with the new window.
+    for stale in out_dir.glob("collision*.npz"):
+        stale.unlink()
     live_by_step = {rec[0]: rec for rec in buf}
     poses_by_step = {rec[0]: rec[2] for rec in buf}  # step k -> world pose (for ego_future)
     fut_len = int(model_args.future_len)

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -1312,6 +1312,13 @@ def extract_collision_scenes(
     from collections import deque
     from pathlib import Path
 
+    if max_scenes < pre_steps + 1:
+        # Same invariant the one-pass saver enforces: the window is >= pre_steps frames
+        # plus the collision step, so a smaller cap would silently truncate it.
+        raise ValueError(
+            f"max_scenes ({max_scenes}) must be >= pre_steps + 1 ({pre_steps + 1}); "
+            "otherwise the saved window is silently truncated."
+        )
     out_dir = Path(out_dir)
     cap = max_steps if max_steps is not None else 3 * (end - start)
     timers = Timers()


### PR DESCRIPTION
Follow-up to #157, addressing the Copilot review findings on the one-pass collision-scene saver.

- **Route-key collision** (`_route_key`): now uses the canonical `route_timeline.route_prefix` (strip the trailing `_<frameidx>`) instead of taking the first two `_`-separated tokens. The old form collapsed distinct routes that share a leading token (e.g. `2025-10-29_13-05-58_00000000` → `2025-10-29_13-05-58`) into one output dir; the canonical form matches the miner's `hits.jsonl` `route` field.
- **Silent window truncation**: `run_segments_batched` now raises if `save_max_scenes < save_pre_steps + 1` (the buffer/window can't satisfy the request) instead of silently saving a shorter batch.
- **Stale-file accumulation**: `_dump_precollision_window` clears existing `collision*.npz` in the output dir before writing. The window length now varies (arc-length extend / snap clamp / max_scenes), so a re-run could otherwise leave stale older-offset files mixed with the new window.

(The 4th Copilot comment — stale `save_buf` capacity comment — was already fixed in #157.)

Verified: route_prefix consistency on multi-underscore names, the guard raises, ruff clean.