### PR TITLE
Reproducer: opt-in GPU/preload speedups + drop recorded backfill in saved windows

### DIFF
--- a/rlvr/autoresearch/tools/extract_collision_scenes.py
+++ b/rlvr/autoresearch/tools/extract_collision_scenes.py
@@ -59,6 +59,14 @@ def parse_args() -> argparse.Namespace:
         "near_miss_thresh). Only used with --include_near_miss.",
     )
     p.add_argument("--pre_steps", type=int, default=80)
+    p.add_argument(
+        "--min_pre_frames",
+        type=int,
+        default=30,
+        help="skip a hit with fewer than this many live frames before the contact (the window "
+        "is all-live — no recorded backfill — so an early contact yields a shorter window or, "
+        "below this floor, is dropped).",
+    )
     p.add_argument("--search_radius", type=float, default=1.5)
     p.add_argument("--unstick_after", type=int, default=300)
     p.add_argument("--unstick_advance_m", type=float, default=5.0)
@@ -128,6 +136,7 @@ def main() -> None:
                 device=device,
                 collision_thresh=thresh,
                 pre_steps=args.pre_steps,
+                min_pre_frames=args.min_pre_frames,
                 search_radius=args.search_radius,
                 unstick_after=args.unstick_after,
                 unstick_advance_m=args.unstick_advance_m,
@@ -139,7 +148,7 @@ def main() -> None:
             summary.append({"route": route_key, **mani})
             print(
                 f"  {route_key} [{start},{end}]: collision@{mani['collision_step']} -> "
-                f"{mani['n_scenes']} scenes ({mani['n_live']} live, {mani['n_recorded']} recorded)"
+                f"{mani['n_scenes']} scenes ({mani['n_live']} live)"
             )
 
     (args.out_dir / "extract_summary.json").write_text(json.dumps(summary, indent=2))

--- a/rlvr/autoresearch/tools/mine_collisions_reproducer.py
+++ b/rlvr/autoresearch/tools/mine_collisions_reproducer.py
@@ -69,6 +69,24 @@ def parse_args() -> argparse.Namespace:
     # Throughput / coverage levers (forwarded to run_segments_batched).
     p.add_argument("--n_build_threads", type=int, default=8, help="threads for the CPU input build")
     p.add_argument(
+        "--preload",
+        action="store_true",
+        help="decompress every recorded frame of each route into the in-RAM npz cache "
+        "BEFORE rolling it out, so np.load/zlib never lands on the per-step critical path. "
+        "OFF by default: it front-loads the whole route's decompress (and holds it in RAM), "
+        "which is a net loss for short/few-segment jobs where prefetch already hides the I/O; "
+        "turn on for large multi-pass mining where the I/O half dominates.",
+    )
+    p.add_argument(
+        "--gpu_transform",
+        action="store_true",
+        help="run world_to_ego_frame on-device (one batched op) instead of per-segment numpy "
+        "on the CPU build threads. OFF by default: the transform is a small, already-overlapped "
+        "slice of the wall (the model forward dominates), and when --save_dir is set the saved "
+        "scenes must be materialized back to CPU each step, so the gain is marginal; results are "
+        "numerically equivalent to the CPU path (~1e-5, float-ordering).",
+    )
+    p.add_argument(
         "--prefetch_ahead",
         type=int,
         default=2,
@@ -211,6 +229,7 @@ def main() -> None:
             save_max_scenes=args.save_max_scenes,
             save_min_post_snap_frames=int(round(args.save_min_post_snap_s / 0.1)),
             route_keys=buf_keys,
+            gpu_transform=args.gpu_transform,
         )
         for key, res in zip(buf_keys, res_list):
             row = {"route": key, **res.metrics}
@@ -226,6 +245,10 @@ def main() -> None:
         for ri, key in enumerate(route_keys):
             with timers("timeline_build"):
                 tl = RouteTimeline(routes[key], sidecar_dir=args.sidecar_root, timers=timers)
+            if args.preload:
+                # Warm the whole route into the npz cache up front (opt-in; see flag help).
+                with timers("preload"):
+                    tl.prefetch(range(len(tl)))
             for start, end in tl.iter_segments(args.seg_len):
                 buf_units.append((tl, start, end))
                 buf_keys.append(key)

--- a/rlvr/autoresearch/tools/mine_collisions_reproducer.py
+++ b/rlvr/autoresearch/tools/mine_collisions_reproducer.py
@@ -161,6 +161,14 @@ def parse_args() -> argparse.Namespace:
         "live rollout), so an early contact yields a shorter all-live window — and is dropped "
         "entirely below this floor.",
     )
+    p.add_argument(
+        "--save_min_ego_speed",
+        type=float,
+        default=0.5,
+        help="exclude collisions where the ego is not moving: only save a hit if ego speed at "
+        "the contact step exceeds this (m/s). Filters out the ego being rear-ended / sitting "
+        "stopped against a neighbor — not a model-caused avoidance failure. 0 disables.",
+    )
     return p.parse_args()
 
 
@@ -238,6 +246,7 @@ def main() -> None:
             save_max_scenes=args.save_max_scenes,
             save_min_post_snap_frames=int(round(args.save_min_post_snap_s / 0.1)),
             save_min_pre_frames=args.save_min_pre_frames,
+            save_min_ego_speed=args.save_min_ego_speed,
             route_keys=buf_keys,
             gpu_transform=args.gpu_transform,
         )

--- a/rlvr/autoresearch/tools/mine_collisions_reproducer.py
+++ b/rlvr/autoresearch/tools/mine_collisions_reproducer.py
@@ -152,6 +152,15 @@ def parse_args() -> argparse.Namespace:
         default=0.2,
         help="m-to-neighbor trigger for saving a scene batch (use 0.5 to also catch near-misses)",
     )
+    p.add_argument(
+        "--save_min_pre_frames",
+        type=int,
+        default=30,
+        help="skip a hit if fewer than this many LIVE frames precede the contact. The saver "
+        "no longer backfills recorded frames (that spliced a discontinuous prefix onto the "
+        "live rollout), so an early contact yields a shorter all-live window — and is dropped "
+        "entirely below this floor.",
+    )
     return p.parse_args()
 
 
@@ -228,6 +237,7 @@ def main() -> None:
             save_pre_arc_m=args.save_pre_arc_m,
             save_max_scenes=args.save_max_scenes,
             save_min_post_snap_frames=int(round(args.save_min_post_snap_s / 0.1)),
+            save_min_pre_frames=args.save_min_pre_frames,
             route_keys=buf_keys,
             gpu_transform=args.gpu_transform,
         )

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -159,6 +159,24 @@ def build_input_np(
     return recen, neighbors_live
 
 
+def build_input_raw(
+    tl: RouteTimeline,
+    idx: int,
+    live_pose: np.ndarray,
+    ego_hist_world: np.ndarray,
+    dyn: _EgoDyn,
+) -> tuple:
+    """gpu_transform variant of :func:`build_input_np`: skip the numpy
+    ``world_to_ego_frame`` (it runs once, batched, on the GPU in ``_to_torch_batch_gpu``)
+    and return the UN-transformed recorded base + the relative pose + the live-ego arrays.
+    Still threadable (only ``np.load`` + cheap live-ego construction)."""
+    base = _npz_to_model_base(tl.npz(idx))
+    dxyz = _rel_pose(tl.poses[idx], live_pose)
+    live_past = _live_ego_past(ego_hist_world, live_pose)  # (1, PAST, 4), already ego-frame
+    live_cur = _live_ego_current(dyn)  # (1, 10), already ego-frame
+    return base, dxyz, live_past, live_cur, idx
+
+
 def _to_torch_batch(np_dicts: list[dict], model_args, device: str) -> dict:
     """Concat N single-sample numpy dicts -> one batched, normalized torch dict.
 
@@ -183,6 +201,66 @@ def _to_torch_batch(np_dicts: list[dict], model_args, device: str) -> dict:
         (N, n_agents, model_args.future_len + 1, POSE_DIM), dtype=torch.float32, device=device
     )
     return model_args.observation_normalizer(data)
+
+
+def _to_torch_batch_gpu(raw_payloads: list[tuple], model_args, device: str, want_np_dicts: bool):
+    """gpu_transform build: stack the UN-transformed recorded frames, H2D once, run
+    ``world_to_ego_frame_torch`` on the whole batch on-device, swap in the live ego, then
+    normalize — so the per-segment numpy ``world_to_ego_frame`` is replaced by ONE batched
+    GPU op. Returns ``(data, neighbors_live_list, np_dict_list_or_None)`` so the caller's
+    score/save/advance path is byte-for-byte the same as the CPU build (the saved scenes
+    and ``neighbors_live`` are extracted here, pre-normalization, exactly as build_input_np
+    produced them — only the float ordering of the transform differs, ~1e-5).
+
+    ``want_np_dicts`` materializes per-segment un-normalized dicts for the save buffer; it
+    forces a D2H of the full model input each step, so it is only requested when saving.
+    """
+    import torch
+
+    from scenario_generation.transforms import world_to_ego_frame_torch
+
+    bases = [p[0] for p in raw_payloads]
+    N = len(bases)
+    batch: dict = {}
+    for k in bases[0]:
+        arr = np.concatenate([b[k] for b in bases], axis=0)
+        if k in ("lanes_has_speed_limit", "route_lanes_has_speed_limit"):
+            batch[k] = torch.from_numpy(arr).to(device)
+        elif k == "turn_indicators":
+            batch[k] = torch.from_numpy(arr).long().to(device)
+        else:
+            batch[k] = torch.from_numpy(arr.astype(np.float32)).to(device)
+
+    dx = torch.tensor([p[1][0] for p in raw_payloads], dtype=torch.float32, device=device)
+    dy = torch.tensor([p[1][1] for p in raw_payloads], dtype=torch.float32, device=device)
+    dyaw = torch.tensor([p[1][2] for p in raw_payloads], dtype=torch.float32, device=device)
+    world_to_ego_frame_torch(batch, dx, dy, dyaw)
+
+    # Swap in the live ego (already in the live-ego frame, NOT transformed) — matches
+    # build_input_np, which overwrites these AFTER world_to_ego_frame.
+    batch["ego_agent_past"] = torch.from_numpy(
+        np.concatenate([p[2] for p in raw_payloads], axis=0).astype(np.float32)
+    ).to(device)
+    batch["ego_current_state"] = torch.from_numpy(
+        np.concatenate([p[3] for p in raw_payloads], axis=0).astype(np.float32)
+    ).to(device)
+
+    # Extract scoring inputs (+ optional save dicts) BEFORE normalization, so they match
+    # the un-normalized arrays build_input_np returns.
+    nb_all = batch["neighbor_agents_past"][:, :, -1, :].detach().cpu().numpy()  # (N,320,11)
+    neighbors_live = [nb_all[i].copy() for i in range(N)]
+    np_dicts = None
+    if want_np_dicts:
+        np_dicts = [
+            {k: batch[k][i : i + 1].detach().cpu().numpy() for k in batch} for i in range(N)
+        ]
+
+    batch["delay"] = torch.zeros((N,), dtype=torch.long, device=device)
+    n_agents = 1 + model_args.predicted_neighbor_num
+    batch["sampled_trajectories"] = torch.zeros(
+        (N, n_agents, model_args.future_len + 1, POSE_DIM), dtype=torch.float32, device=device
+    )
+    return model_args.observation_normalizer(batch), neighbors_live, np_dicts
 
 
 # --------------------------------------------------------------------------- #
@@ -439,12 +517,13 @@ def _seed_state(
     )
 
 
-def _pre_step(s: _SegState):
-    """Advance the cursor + build this segment's NUMPY model input, or terminate it.
+def _pre_step(s: _SegState, gpu_transform: bool = False):
+    """Advance the cursor + build this segment's model input, or terminate it.
 
-    Returns (np_dict, neighbors_live, idx) when the segment should run this tick, or
-    None when it just terminated (s.done set, s.terminated explains why). CPU-only /
-    threadable — torch conversion happens once per batch in the caller."""
+    Returns (np_dict, neighbors_live, idx) normally, or — when ``gpu_transform`` — the raw
+    payload tuple (base, pose, live_past, live_cur, idx) for a batched on-device transform
+    (see ``_to_torch_batch_gpu``). None when the segment just terminated (s.done set).
+    CPU-only / threadable; torch conversion happens once per batch in the caller."""
     if s.done:
         return None
     if s.k >= s.max_steps:
@@ -461,6 +540,8 @@ def _pre_step(s: _SegState):
     if s.max_stuck_steps > 0 and s.stuck >= s.max_stuck_steps:
         s.terminated, s.done = "stuck", True
         return None
+    if gpu_transform:
+        return build_input_raw(s.tl, idx, s.live_pose, s.ego_hist, s.dyn)
     np_dict, neighbors_live = build_input_np(s.tl, idx, s.live_pose, s.ego_hist, s.dyn)
     return np_dict, neighbors_live, idx
 
@@ -864,6 +945,7 @@ def run_segments_batched(
     save_max_scenes: int = 160,
     save_min_post_snap_frames: int = 30,
     route_keys: list[str] | None = None,
+    gpu_transform: bool = False,
 ) -> list[SegmentResult]:
     """Run many segments in lock-step: ONE batched model forward per tick.
 
@@ -942,11 +1024,29 @@ def run_segments_batched(
             active = list(states)
             while active:
                 with timers("input_build"):
-                    pre_list = list(pool.map(_pre_step, active))
-                built = [(s, *pre) for s, pre in zip(active, pre_list) if pre is not None]
-                if built:
-                    with timers("to_torch"):
-                        data = _to_torch_batch([b[1] for b in built], model_args, device)
+                    pre_list = list(pool.map(lambda s: _pre_step(s, gpu_transform), active))
+                live = [(s, pre) for s, pre in zip(active, pre_list) if pre is not None]
+                if live:
+                    if gpu_transform:
+                        # ONE batched on-device world_to_ego_frame; downstream identical.
+                        raw_payloads = [pre for _s, pre in live]
+                        with timers("to_torch"):
+                            data, nb_list, npd_list = _to_torch_batch_gpu(
+                                raw_payloads, model_args, device, want_np_dicts=save_dir is not None
+                            )
+                        built = [
+                            (
+                                s,
+                                npd_list[i] if npd_list is not None else None,
+                                nb_list[i],
+                                raw_payloads[i][4],  # idx
+                            )
+                            for i, (s, _pre) in enumerate(live)
+                        ]
+                    else:
+                        built = [(s, *pre) for s, pre in live]
+                        with timers("to_torch"):
+                            data = _to_torch_batch([b[1] for b in built], model_args, device)
                     with timers("model_forward"):
                         # Fire-and-forget prefetch of each segment's upcoming frames
                         # so they decompress on background threads while the GPU is

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -946,6 +946,7 @@ def run_segments_batched(
     save_max_scenes: int = 160,
     save_min_post_snap_frames: int = 30,
     save_min_pre_frames: int = 30,
+    save_min_ego_speed: float = 0.5,
     route_keys: list[str] | None = None,
     gpu_transform: bool = False,
 ) -> list[SegmentResult]:
@@ -1077,6 +1078,7 @@ def run_segments_batched(
                                 not s.saved_collision
                                 and save_thresh is not None
                                 and cl <= save_thresh
+                                and s.dyn.speed > save_min_ego_speed
                             ):
                                 mani = _dump_precollision_window(
                                     s.save_out_dir,
@@ -1192,8 +1194,9 @@ def _precollision_window_start(
 ) -> int:
     """First step of the pre-collision window.
 
-    Baseline: ``t_c - pre_steps`` (>= ``pre_steps`` frames; may be negative -> the
-    backtrack path reads recorded frames before the segment start). Never crosses an
+    Baseline: ``t_c - pre_steps``, then clamped UP to the earliest live buffer step
+    (``min(poses_by_step)``, >= 0) — recorded backfill is disabled, so the window is
+    all-live and may be shorter than ``pre_steps`` for an early contact. Never crosses an
     unstick snap (clamped to ``last_snap_step``).
 
     MIN-MOVEMENT EXTEND: if ``pre_arc_m > 0`` and the ego's cumulative arc length over
@@ -1407,6 +1410,7 @@ def extract_collision_scenes(
     pre_arc_m: float = 1.0,
     max_scenes: int = 160,
     min_post_snap_frames: int = 30,
+    min_pre_frames: int = 30,
 ) -> dict | None:
     """Mine the batch of scenes leading up to the FIRST collision in a segment.
 
@@ -1506,4 +1510,5 @@ def extract_collision_scenes(
         pre_arc_m=pre_arc_m,
         max_scenes=max_scenes,
         min_post_snap_frames=min_post_snap_frames,
+        min_pre_frames=min_pre_frames,
     )

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -177,6 +177,31 @@ def build_input_raw(
     return base, dxyz, live_past, live_cur, idx
 
 
+def _arrays_to_device(arrays: dict, device: str) -> dict:
+    """H2D each model-input array with the correct dtype: the speed-limit has-flags stay
+    bool, ``turn_indicators`` is long, everything else is float32. Shared by both batch
+    builders so the two paths can't drift on dtype handling."""
+    out: dict = {}
+    for k, arr in arrays.items():
+        if k in ("lanes_has_speed_limit", "route_lanes_has_speed_limit"):
+            out[k] = torch.from_numpy(arr).to(device)
+        elif k == "turn_indicators":
+            out[k] = torch.from_numpy(arr).long().to(device)
+        else:
+            out[k] = torch.from_numpy(arr.astype(np.float32)).to(device)
+    return out
+
+
+def _add_static_inputs(data: dict, model_args, n: int, device: str) -> None:
+    """Add the per-batch ``delay`` + zero ``sampled_trajectories`` the model expects
+    (P = 1 ego + predicted neighbors, T = future_len + 1). In place."""
+    data["delay"] = torch.zeros((n,), dtype=torch.long, device=device)
+    n_agents = 1 + model_args.predicted_neighbor_num
+    data["sampled_trajectories"] = torch.zeros(
+        (n, n_agents, model_args.future_len + 1, POSE_DIM), dtype=torch.float32, device=device
+    )
+
+
 def _to_torch_batch(np_dicts: list[dict], model_args, device: str) -> dict:
     """Concat N single-sample numpy dicts -> one batched, normalized torch dict.
 
@@ -185,21 +210,9 @@ def _to_torch_batch(np_dicts: list[dict], model_args, device: str) -> dict:
     normalizer call.
     """
     N = len(np_dicts)
-    data = {}
-    for k in np_dicts[0]:
-        arr = np.concatenate([d[k] for d in np_dicts], axis=0)
-        if k in ("lanes_has_speed_limit", "route_lanes_has_speed_limit"):
-            data[k] = torch.from_numpy(arr).to(device)
-        elif k == "turn_indicators":
-            data[k] = torch.from_numpy(arr).long().to(device)
-        else:
-            data[k] = torch.from_numpy(arr.astype(np.float32)).to(device)
-    data["delay"] = torch.zeros((N,), dtype=torch.long, device=device)
-    # Match to_model_tensors: P = 1 ego + predicted neighbors, T = future_len (+1).
-    n_agents = 1 + model_args.predicted_neighbor_num
-    data["sampled_trajectories"] = torch.zeros(
-        (N, n_agents, model_args.future_len + 1, POSE_DIM), dtype=torch.float32, device=device
-    )
+    arrays = {k: np.concatenate([d[k] for d in np_dicts], axis=0) for k in np_dicts[0]}
+    data = _arrays_to_device(arrays, device)
+    _add_static_inputs(data, model_args, N, device)
     return model_args.observation_normalizer(data)
 
 
@@ -215,21 +228,13 @@ def _to_torch_batch_gpu(raw_payloads: list[tuple], model_args, device: str, want
     ``want_np_dicts`` materializes per-segment un-normalized dicts for the save buffer; it
     forces a D2H of the full model input each step, so it is only requested when saving.
     """
-    import torch
-
     from scenario_generation.transforms import world_to_ego_frame_torch
 
     bases = [p[0] for p in raw_payloads]
     N = len(bases)
-    batch: dict = {}
-    for k in bases[0]:
-        arr = np.concatenate([b[k] for b in bases], axis=0)
-        if k in ("lanes_has_speed_limit", "route_lanes_has_speed_limit"):
-            batch[k] = torch.from_numpy(arr).to(device)
-        elif k == "turn_indicators":
-            batch[k] = torch.from_numpy(arr).long().to(device)
-        else:
-            batch[k] = torch.from_numpy(arr.astype(np.float32)).to(device)
+    batch = _arrays_to_device(
+        {k: np.concatenate([b[k] for b in bases], axis=0) for k in bases[0]}, device
+    )
 
     dx = torch.tensor([p[1][0] for p in raw_payloads], dtype=torch.float32, device=device)
     dy = torch.tensor([p[1][1] for p in raw_payloads], dtype=torch.float32, device=device)
@@ -255,11 +260,7 @@ def _to_torch_batch_gpu(raw_payloads: list[tuple], model_args, device: str, want
             {k: batch[k][i : i + 1].detach().cpu().numpy() for k in batch} for i in range(N)
         ]
 
-    batch["delay"] = torch.zeros((N,), dtype=torch.long, device=device)
-    n_agents = 1 + model_args.predicted_neighbor_num
-    batch["sampled_trajectories"] = torch.zeros(
-        (N, n_agents, model_args.future_len + 1, POSE_DIM), dtype=torch.float32, device=device
-    )
+    _add_static_inputs(batch, model_args, N, device)
     return model_args.observation_normalizer(batch), neighbors_live, np_dicts
 
 
@@ -1284,8 +1285,8 @@ def _dump_precollision_window(
     SKIP rules (return None):
     - an unstick teleport fired fewer than ``min_post_snap_frames`` steps before the
       collision (too little settled history; the contact is likely teleport-induced);
-    - fewer than ``min_pre_frames`` live frames precede the contact (too short a approach to
-      be a useful pre-collision scene now that recorded backfill is disabled).
+    - fewer than ``min_pre_frames`` live frames precede the contact (too short an approach
+      to be a useful pre-collision scene now that recorded backfill is disabled).
     """
     import json
     from pathlib import Path
@@ -1341,39 +1342,37 @@ def _dump_precollision_window(
     # Inclusive of t_c: the LAST saved frame (collision+00000) IS the collision step, so the
     # window ends exactly on the contact (its current neighbor box is the one within thresh).
     for step_k in range(start_k, t_c + 1):
-        if step_k >= 0 and step_k in live_by_step:
-            _, idx, live_pose, np_dict = live_by_step[step_k]
-            scene = _scene_npz_from_np_dict(np_dict)
-            ep = scene["ego_agent_past"]
-            scene["ego_agent_past"] = np.column_stack(
-                [ep[:, 0], ep[:, 1], np.arctan2(ep[:, 3], ep[:, 2])]
-            ).astype(np.float32)
-            g = scene["goal_pose"]
-            scene["goal_pose"] = np.array([g[0], g[1], math.atan2(g[3], g[2])], dtype=np.float32)
-            with np.load(tl.npz_paths[idx], allow_pickle=True) as z:
-                naf = z["neighbor_agents_future"] if "neighbor_agents_future" in z.files else None
-            if naf is not None:
-                dx, dy, dyaw = _rel_pose(tl.poses[idx], live_pose)
-                scene["neighbor_agents_future"] = _recenter_neighbor_future(naf, dx, dy, dyaw)
-            eaf = np.zeros((fut_len, 4), dtype=np.float32)
-            for j in range(1, fut_len + 1):
-                fk = step_k + j
-                if fk > t_c or fk not in poses_by_step:
-                    break
-                ex, ey, eh = _world_pose_to_ego(poses_by_step[fk], live_pose)
-                eaf[j - 1] = (ex, ey, math.cos(eh), math.sin(eh))
-            scene["ego_agent_future"] = eaf
-            scene["origin"] = np.array("live")
-        else:
-            frame = seg_start + step_k
-            if frame < 0 or frame >= len(tl):
-                continue
-            with np.load(tl.npz_paths[frame], allow_pickle=True) as z:
-                scene = {key: z[key] for key in z.files if key not in ("map_name", "token")}
-            for fk in ("neighbor_agents_future", "ego_agent_future"):
-                if fk in scene:
-                    scene[fk] = _future_to_4col(scene[fk])
-            scene["origin"] = np.array("recorded")
+        # The window is clamped all-live (start_k >= the live buffer floor; no recorded
+        # backfill). Every step in [start_k, t_c] must therefore be in the buffer — a miss
+        # means the clamp/buffer invariant regressed, so fail loudly rather than silently
+        # splice recorded frames back in (the discontinuous seam this change removed).
+        if step_k < 0 or step_k not in live_by_step:
+            raise AssertionError(
+                f"all-live pre-collision window expected step {step_k} in the live buffer "
+                f"[{start_k}, {t_c}] but it is absent (window-clamp / buffer regression)"
+            )
+        _, idx, live_pose, np_dict = live_by_step[step_k]
+        scene = _scene_npz_from_np_dict(np_dict)
+        ep = scene["ego_agent_past"]
+        scene["ego_agent_past"] = np.column_stack(
+            [ep[:, 0], ep[:, 1], np.arctan2(ep[:, 3], ep[:, 2])]
+        ).astype(np.float32)
+        g = scene["goal_pose"]
+        scene["goal_pose"] = np.array([g[0], g[1], math.atan2(g[3], g[2])], dtype=np.float32)
+        with np.load(tl.npz_paths[idx], allow_pickle=True) as z:
+            naf = z["neighbor_agents_future"] if "neighbor_agents_future" in z.files else None
+        if naf is not None:
+            dx, dy, dyaw = _rel_pose(tl.poses[idx], live_pose)
+            scene["neighbor_agents_future"] = _recenter_neighbor_future(naf, dx, dy, dyaw)
+        eaf = np.zeros((fut_len, 4), dtype=np.float32)
+        for j in range(1, fut_len + 1):
+            fk = step_k + j
+            if fk > t_c or fk not in poses_by_step:
+                break
+            ex, ey, eh = _world_pose_to_ego(poses_by_step[fk], live_pose)
+            eaf[j - 1] = (ex, ey, math.cos(eh), math.sin(eh))
+        scene["ego_agent_future"] = eaf
+        scene["origin"] = np.array("live")
         token = f"{step_k - t_c:+06d}"
         np.savez_compressed(out_dir / f"collision{token}.npz", **scene)
         saved.append(int(step_k))
@@ -1384,8 +1383,7 @@ def _dump_precollision_window(
         "collision_thresh": float(collision_thresh),
         "n_scenes": len(saved),
         "steps_saved": saved,
-        "n_live": sum(1 for k in saved if k >= 0),
-        "n_recorded": sum(1 for k in saved if k < 0),
+        "n_live": len(saved),  # all-live by construction (no recorded backfill)
     }
     (out_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
     return manifest
@@ -1424,12 +1422,12 @@ def extract_collision_scenes(
       * ego_agent_future = the realized live ego path truncated AT the collision
         (zeros for timesteps after T_c).
 
-    When the collision is early (T_c < pre_steps), the window reaches before the
-    segment start: those earlier scenes are taken straight from the RECORDED NPZs
-    of frames before ``start`` (real GT context — ego/neighbor history + GT
-    futures), which the full-route timeline still holds. So the batch always has
-    ``pre_steps`` scenes with real, continuous ego history (subject to the route
-    start). Returns a manifest dict, or None if no collision occurred.
+    When the collision is early (T_c < pre_steps) the window is SHORTER (all-live): it
+    shares ``_dump_precollision_window``, which no longer backfills recorded frames
+    before the rollout start (splicing the recorded ego/perception onto the live state
+    produced a discontinuous clearance seam) and skips a hit with fewer than
+    ``min_pre_frames`` (default 30) live frames before the contact. Returns a manifest
+    dict, or None if no collision occurred / the window was too short.
 
     NOTE: this is the legacy SECOND-PASS path — it re-runs the rollout to reconstruct
     the window, so the collision it finds can differ from the one the miner detected

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -944,6 +944,7 @@ def run_segments_batched(
     save_pre_arc_m: float = 1.0,
     save_max_scenes: int = 160,
     save_min_post_snap_frames: int = 30,
+    save_min_pre_frames: int = 30,
     route_keys: list[str] | None = None,
     gpu_transform: bool = False,
 ) -> list[SegmentResult]:
@@ -1090,6 +1091,7 @@ def run_segments_batched(
                                     pre_arc_m=save_pre_arc_m,
                                     max_scenes=save_max_scenes,
                                     min_post_snap_frames=save_min_post_snap_frames,
+                                    min_pre_frames=save_min_pre_frames,
                                 )
                                 # Consume the segment's one save only on an ACTUAL write; a
                                 # snap-skipped hit stays open for a later, settled collision.
@@ -1200,11 +1202,16 @@ def _precollision_window_start(
     t_c) OR the snap / buffer start. ``poses_by_step`` maps step -> world pose (from the
     live buffer) and supplies the arc length."""
     base = t_c - pre_steps
+    # NEVER backfill recorded frames: clamp to the earliest LIVE step held in the buffer
+    # (>= 0; after an unstick teleport the buffer was cleared, so its min step is the
+    # post-snap floor). An early contact therefore yields a SHORTER all-live window rather
+    # than a recorded prefix that doesn't physically connect to the live rollout.
+    live_floor = min(poses_by_step) if poses_by_step else 0
+    base = max(base, live_floor)
     if last_snap_step is not None:
         base = max(base, last_snap_step)
     # Cap to max_scenes frames even on the no-extend path, so we never request a step
-    # that was already evicted from the (max_scenes+1)-deep buffer (which would silently
-    # splice recorded GT frames into a window that should be all-live).
+    # that was already evicted from the (max_scenes+1)-deep buffer.
     if max_scenes is not None:
         base = max(base, t_c - (max_scenes - 1))
     if not poses_by_step or pre_arc_m <= 0:
@@ -1260,19 +1267,25 @@ def _dump_precollision_window(
     pre_arc_m: float = 0.0,
     max_scenes: int | None = None,
     min_post_snap_frames: int = 0,
+    min_pre_frames: int = 30,
 ) -> dict | None:
     """Write the scenes before collision step ``t_c`` from a live buffer.
 
     ``buf`` is an iterable of ``(k, idx, live_pose, np_dict)`` snapshots captured DURING
     the rollout that detected the collision (so the saved scenes match that exact run —
-    no re-simulation). Steps before the segment start are filled from the recorded NPZs.
-    The window is >= ``pre_steps`` frames, extended backward to cover ``pre_arc_m`` of ego
-    arc length when the ego barely moved (capped at ``max_scenes``), and never crosses an
-    unstick teleport (``last_snap_step``). Returns the manifest, or None if skipped.
+    no re-simulation). The window is ALL-LIVE: it spans at most ``pre_steps`` frames before
+    the contact, extended backward to cover ``pre_arc_m`` of ego arc length when the ego
+    barely moved (capped at ``max_scenes``), clamped to the live buffer and never crossing
+    an unstick teleport (``last_snap_step``). Recorded frames before the rollout start are
+    NOT backfilled — splicing the recorded ego/perception onto the model-driven live state
+    produced a discontinuous clearance jump at the seam, so an early contact just yields a
+    shorter all-live window. Returns the manifest, or None if skipped.
 
-    SKIP rule: if an unstick teleport fired fewer than ``min_post_snap_frames`` steps
-    before the collision, the ego had too little settled history after the jump — the
-    contact is likely teleport-induced, so nothing is saved (returns None).
+    SKIP rules (return None):
+    - an unstick teleport fired fewer than ``min_post_snap_frames`` steps before the
+      collision (too little settled history; the contact is likely teleport-induced);
+    - fewer than ``min_pre_frames`` live frames precede the contact (too short a approach to
+      be a useful pre-collision scene now that recorded backfill is disabled).
     """
     import json
     from pathlib import Path
@@ -1306,13 +1319,25 @@ def _dump_precollision_window(
     start_k = _precollision_window_start(
         t_c, pre_steps, last_snap_step, poses_by_step, pre_arc_m, max_scenes
     )
+    # All-live window: never backfill recorded frames (start_k is clamped to the live
+    # floor). Skip the hit if too few live frames precede the contact.
+    n_pre = t_c - start_k
+    if n_pre < min_pre_frames:
+        print(
+            f"  [save] SKIP collision@{t_c}: only {n_pre} live pre-frames "
+            f"(< {min_pre_frames}); not backfilling recorded frames"
+        )
+        return None
     if start_k < t_c - pre_steps:
         print(
             f"  [save] window extended {t_c - pre_steps} -> {start_k} "
             f"(slow ego: {t_c - start_k} frames to cover {pre_arc_m} m arc)"
         )
     elif start_k > t_c - pre_steps:
-        print(f"  [save] window clamped {t_c - pre_steps} -> {start_k} (unstick snap in window)")
+        print(
+            f"  [save] window shortened {t_c - pre_steps} -> {start_k} "
+            f"(all-live: no recorded backfill / unstick floor)"
+        )
     # Inclusive of t_c: the LAST saved frame (collision+00000) IS the collision step, so the
     # window ends exactly on the contact (its current neighbor box is the one within thresh).
     for step_k in range(start_k, t_c + 1):

--- a/scenario_generation/tests/test_reproducer_save_window.py
+++ b/scenario_generation/tests/test_reproducer_save_window.py
@@ -1,0 +1,51 @@
+"""Pre-collision save window: never backfill recorded frames (the window start is
+clamped to the earliest LIVE buffer step), and shorten / bound it correctly.
+
+These guard the behaviour change that removed the recorded->live clearance seam: an
+early contact must yield a SHORTER all-live window, never a step before the live floor.
+"""
+
+import numpy as np
+
+from scenario_generation.reproducer_rollout import _precollision_window_start
+
+
+def _poses(lo, hi, step_m=1.0):
+    """step k -> world pose [x, y, yaw]; x advances ``step_m`` per step (arc length)."""
+    return {k: np.array([k * step_m, 0.0, 0.0], dtype=np.float64) for k in range(lo, hi + 1)}
+
+
+def test_early_contact_clamps_to_zero_never_backfills():
+    # t_c - pre_steps is negative; the live buffer starts at 0 -> clamp to 0 (no backfill).
+    s = _precollision_window_start(44, 80, None, _poses(0, 44), pre_arc_m=0.0, max_scenes=160)
+    assert s == 0
+
+
+def test_full_window_when_enough_history():
+    s = _precollision_window_start(120, 80, None, _poses(0, 120), pre_arc_m=0.0, max_scenes=160)
+    assert s == 40  # t_c - pre_steps, all-live
+
+
+def test_clamps_to_unstick_snap():
+    s = _precollision_window_start(120, 80, 100, _poses(0, 120), pre_arc_m=0.0, max_scenes=160)
+    assert s == 100
+
+
+def test_buffer_floor_binds_when_buffer_shorter_than_pre_steps():
+    # buffer only holds steps 50..120 (e.g. post-snap) -> floor is 50, not 40, never < 50.
+    s = _precollision_window_start(120, 80, None, _poses(50, 120), pre_arc_m=0.0, max_scenes=160)
+    assert s == 50
+
+
+def test_max_scenes_caps_window():
+    s = _precollision_window_start(120, 80, None, _poses(0, 120), pre_arc_m=0.0, max_scenes=30)
+    assert s == 120 - 29  # t_c - (max_scenes - 1)
+
+
+def test_arc_extend_never_goes_below_live_floor():
+    # short baseline (pre_steps=10 -> base=110) but the ego barely moved, so the arc-extend
+    # would reach back further; it must stop at the live floor (0), never below it.
+    s = _precollision_window_start(
+        120, 10, None, _poses(0, 120, step_m=0.001), pre_arc_m=1000.0, max_scenes=160
+    )
+    assert s == 0

--- a/scenario_generation/tests/test_reproducer_unstick.py
+++ b/scenario_generation/tests/test_reproducer_unstick.py
@@ -106,5 +106,6 @@ def test_precollision_window_clamps_across_unstick_snap():
     assert _precollision_window_start(t_c, pre, 400) == 499
     # snap INSIDE the window -> clamp to the post-snap step (shorter, snap-free window)
     assert _precollision_window_start(t_c, pre, 540) == 540
-    # early collision, no snap -> negative start preserved (backtrack path handles <0)
-    assert _precollision_window_start(50, pre, None) == -30
+    # early collision, no snap -> clamped to the live floor (0); recorded backfill is disabled,
+    # so the window is shorter/all-live rather than starting at a negative (pre-segment) step.
+    assert _precollision_window_start(50, pre, None) == 0

--- a/scenario_generation/tests/test_world_to_ego_frame_torch.py
+++ b/scenario_generation/tests/test_world_to_ego_frame_torch.py
@@ -1,9 +1,11 @@
 """world_to_ego_frame_torch (batched, on-device) must match the numpy world_to_ego_frame.
 
 The reproducer's ``--gpu_transform`` path replaces the per-segment numpy re-centering with
-ONE batched torch op. This test asserts the two are numerically equivalent (float32 ordering,
-~1e-4) across all model-input keys, including the transform-then-zero-invalid handling of
-padding rows.
+ONE batched torch op. This test asserts the two are numerically equivalent (float32 ordering, ~1e-5; asserted at
+1e-3) across all the SPATIAL model-input keys the transform touches — ego/neighbor/lane/
+route/polygon/line-string/static/goal — including the transform-then-zero-invalid handling
+of padding rows. Non-spatial keys (speed limits, has-flags, turn indicators, ego_shape) are
+passed through untouched and so are out of scope here.
 """
 
 import numpy as np

--- a/scenario_generation/tests/test_world_to_ego_frame_torch.py
+++ b/scenario_generation/tests/test_world_to_ego_frame_torch.py
@@ -1,0 +1,77 @@
+"""world_to_ego_frame_torch (batched, on-device) must match the numpy world_to_ego_frame.
+
+The reproducer's ``--gpu_transform`` path replaces the per-segment numpy re-centering with
+ONE batched torch op. This test asserts the two are numerically equivalent (float32 ordering,
+~1e-4) across all model-input keys, including the transform-then-zero-invalid handling of
+padding rows.
+"""
+
+import numpy as np
+import pytest
+
+from scenario_generation.transforms import world_to_ego_frame, world_to_ego_frame_torch
+
+torch = pytest.importorskip("torch")
+
+_SHAPES = {
+    "ego_agent_past": (1, 31, 4),
+    "ego_current_state": (1, 10),
+    "neighbor_agents_past": (1, 320, 31, 11),
+    "lanes": (1, 140, 20, 33),
+    "route_lanes": (1, 25, 20, 33),
+    "polygons": (1, 10, 40, 3),
+    "line_strings": (1, 60, 20, 4),
+    "static_objects": (1, 5, 10),
+    "goal_pose": (1, 4),
+}
+
+
+def _make_sample(rng):
+    """A random scene-frame sample with some all-zero padding rows (exercises the mask)."""
+    d = {}
+    for k, sh in _SHAPES.items():
+        a = (rng.standard_normal(sh) * 10).astype(np.float32)
+        if k == "neighbor_agents_past":
+            a[0, ::3] = 0.0
+        elif k in ("lanes", "route_lanes"):
+            a[0, ::4] = 0.0
+        elif k == "polygons":
+            a[0, ::2] = 0.0
+        elif k == "line_strings":
+            a[0, ::5] = 0.0
+        elif k == "static_objects":
+            a[0, ::2] = 0.0
+        d[k] = a
+    return d
+
+
+def test_world_to_ego_frame_torch_matches_numpy():
+    rng = np.random.default_rng(0)
+    B = 6
+    samples = [_make_sample(rng) for _ in range(B)]
+    poses = [
+        (
+            float(rng.uniform(-50, 50)),
+            float(rng.uniform(-50, 50)),
+            float(rng.uniform(-np.pi, np.pi)),
+        )
+        for _ in range(B)
+    ]
+
+    ref = [
+        world_to_ego_frame({k: v.copy() for k, v in s.items()}, *p) for s, p in zip(samples, poses)
+    ]
+
+    batch = {
+        k: torch.from_numpy(np.concatenate([s[k] for s in samples], axis=0).copy()) for k in _SHAPES
+    }
+    dx = torch.tensor([p[0] for p in poses])
+    dy = torch.tensor([p[1] for p in poses])
+    dyaw = torch.tensor([p[2] for p in poses])
+    out = world_to_ego_frame_torch(batch, dx, dy, dyaw)
+
+    for k in _SHAPES:
+        ref_stack = np.concatenate([r[k] for r in ref], axis=0)
+        got = out[k].numpy()
+        assert got.shape == ref_stack.shape, k
+        np.testing.assert_allclose(got, ref_stack, atol=1e-3, rtol=0, err_msg=k)

--- a/scenario_generation/transforms.py
+++ b/scenario_generation/transforms.py
@@ -215,3 +215,97 @@ def world_to_ego_frame(
             gp[0, 2:4] = transform_cos_sin(gp[0, 2:4].reshape(1, 2), R).flatten()
 
     return out
+
+
+def world_to_ego_frame_torch(
+    batch: dict,  # dict[str, torch.Tensor], each [B, ...] on `device`
+    dx,  # torch.Tensor [B]  ego_x per sample (scene frame)
+    dy,  # torch.Tensor [B]  ego_y per sample
+    dyaw,  # torch.Tensor [B] ego_heading per sample (radians)
+) -> dict:
+    """Batched, on-device mirror of :func:`world_to_ego_frame`.
+
+    Applies the SAME rigid transform as the numpy version, but to a stacked batch of
+    ``B`` frames each with its own ``(dx, dy, dyaw)``, entirely in torch on the tensors'
+    device. Used by the reproducer's ``--gpu_transform`` path: the recorded frames are
+    H2D'd untransformed and re-centered on the GPU (one batched op) instead of per-segment
+    numpy on the CPU. Numerically equivalent to N calls of ``world_to_ego_frame`` (verified
+    by ``scenario_generation/tests``); kept bit-for-bit faithful, INCLUDING the
+    transform-then-zero-invalid order (translated zeros are non-zero, so masked padding is
+    re-zeroed AFTER the transform).
+
+    Operates in place on the tensors in ``batch`` and returns it. Only the spatial keys
+    present are touched; non-spatial features (types, speeds, traffic lights) are untouched.
+    """
+    import torch
+
+    c = torch.cos(dyaw)
+    s = torch.sin(dyaw)
+    # R[b] = [[c, s], [-s, c]] (rotate by -heading), matching _rotation_matrix.
+    R = torch.stack(
+        [torch.stack([c, s], dim=-1), torch.stack([-s, c], dim=-1)], dim=-2
+    )  # [B, 2, 2]
+    t = torch.stack([dx, dy], dim=-1)  # [B, 2]
+
+    def _rot(vec, Rb):
+        # vec [B, ..., 2], Rb [B, 2, 2]; out[...,k] = sum_j vec[...,j] * R[k,j]
+        return torch.einsum("b...j,bkj->b...k", vec, Rb)
+
+    def _pos(vec, Rb, tb):
+        # broadcast t over the middle dims
+        tt = tb.view(tb.shape[0], *([1] * (vec.dim() - 2)), 2)
+        return _rot(vec - tt, Rb)
+
+    if batch:
+        ref = next(iter(batch.values()))
+        R = R.to(ref.dtype)
+        t = t.to(ref.dtype)
+
+    if "ego_agent_past" in batch:
+        ep = batch["ego_agent_past"]
+        ep[:, :, :2] = _pos(ep[:, :, :2], R, t)
+        ep[:, :, 2:4] = _rot(ep[:, :, 2:4], R)
+    if "ego_current_state" in batch:
+        ec = batch["ego_current_state"]
+        ec[:, :2] = _pos(ec[:, :2].unsqueeze(1), R, t).squeeze(1)
+        ec[:, 2:4] = _rot(ec[:, 2:4].unsqueeze(1), R).squeeze(1)
+        ec[:, 4:6] = _rot(ec[:, 4:6].unsqueeze(1), R).squeeze(1)
+        ec[:, 6:8] = _rot(ec[:, 6:8].unsqueeze(1), R).squeeze(1)
+    if "neighbor_agents_past" in batch:
+        nb = batch["neighbor_agents_past"]  # [B, N, T, 11]
+        m = nb[:, :, :, :6].abs().sum(-1) == 0  # pre-transform padding mask [B,N,T]
+        nb[:, :, :, :2] = _pos(nb[:, :, :, :2], R, t)
+        nb[:, :, :, 2:4] = _rot(nb[:, :, :, 2:4], R)
+        nb[:, :, :, 4:6] = _rot(nb[:, :, :, 4:6], R)
+        nb[m] = 0.0
+    for key in ("lanes", "route_lanes"):
+        if key in batch:
+            la = batch[key]  # [B, N, P, 33]
+            m = la[:, :, :, :8].abs().sum(-1) == 0
+            la[:, :, :, :2] = _pos(la[:, :, :, :2], R, t)
+            la[:, :, :, 2:4] = _rot(la[:, :, :, 2:4], R)
+            la[:, :, :, 4:6] = _rot(la[:, :, :, 4:6], R)
+            la[:, :, :, 6:8] = _rot(la[:, :, :, 6:8], R)
+            la[m] = 0.0
+    if "polygons" in batch:
+        pg = batch["polygons"]  # [B, N, 40, 3]
+        m = pg.abs().sum(-1) == 0
+        pg[:, :, :, :2] = _pos(pg[:, :, :, :2], R, t)
+        pg[m] = 0.0
+    if "line_strings" in batch:
+        ls = batch["line_strings"]  # [B, N, 20, 4]
+        m = ls.abs().sum(-1) == 0
+        ls[:, :, :, :2] = _pos(ls[:, :, :, :2], R, t)
+        ls[m] = 0.0
+    if "static_objects" in batch:
+        so = batch["static_objects"]  # [B, 5, 10]
+        m = so[:, :, :10].abs().sum(-1) == 0
+        so[:, :, :2] = _pos(so[:, :, :2], R, t)
+        so[:, :, 2:4] = _rot(so[:, :, 2:4], R)
+        so[m] = 0.0
+    if "goal_pose" in batch:
+        gp = batch["goal_pose"]  # [B, 4]
+        gp[:, :2] = _pos(gp[:, :2].unsqueeze(1), R, t).squeeze(1)
+        gp[:, 2:4] = _rot(gp[:, 2:4].unsqueeze(1), R).squeeze(1)
+
+    return batch

--- a/scenario_generation/transforms.py
+++ b/scenario_generation/transforms.py
@@ -256,10 +256,12 @@ def world_to_ego_frame_torch(
         tt = tb.view(tb.shape[0], *([1] * (vec.dim() - 2)), 2)
         return _rot(vec - tt, Rb)
 
-    if batch:
-        ref = next(iter(batch.values()))
-        R = R.to(ref.dtype)
-        t = t.to(ref.dtype)
+    # Match the float dtype of the spatial tensors. Pick the first FLOATING tensor (not just
+    # the first key) — the batch also holds bool (*_has_speed_limit) / long (turn_indicators)
+    # tensors, and R/t must stay float regardless of dict order.
+    ref_dtype = next((v.dtype for v in batch.values() if v.is_floating_point()), torch.float32)
+    R = R.to(ref_dtype)
+    t = t.to(ref_dtype)
 
     if "ego_agent_past" in batch:
         ep = batch["ego_agent_past"]


### PR DESCRIPTION
Three changes to the collision-mining reproducer, all in editable tooling (`scenario_generation/`, `rlvr/autoresearch/tools/`) — no core model changes.

## 1. Drop recorded backfill in saved pre-collision windows (correctness)
Early contacts (`collision_step < save_pre_steps`) used to backfill recorded NPZ frames to fill the pre-collision window. The recorded ego/perception (ego on its real, collision-free path) does **not** physically connect to the live model-driven rollout, so the saved window had a hard, impossible clearance discontinuity at the recorded→live seam (observed: **3.17 m → 0.76 m in one 0.1 s step**).

**Fix:** never backfill. `_precollision_window_start` clamps the window to the earliest **live** buffer step, so an early contact yields a **shorter all-live window**. New `--save_min_pre_frames` (default 30) skips a hit with fewer than that many live frames before the contact. The (now-unreachable) recorded-splice branch is replaced with a fail-loud guard.

Verified: a step-44 contact now saves 45 all-live frames, max single-step clearance change **0.06 m** (no seam); `n_live == n_scenes`.

## 2. `--gpu_transform` (opt-in, default off)
Run `world_to_ego_frame` once per tick as a batched op on the model device instead of per-segment numpy on the CPU build threads. Default off: the transform is a small, already-overlapped slice of wall time (the model forward dominates), and with a save dir the per-step scenes must be brought back to host. Adds `world_to_ego_frame_torch` (batched torch mirror) + an equivalence test. Downstream score/save/advance is unchanged; results are numerically equivalent (~1e-5; closed-loop compounding may drift sub-cm clearances). Measured ~20–25% faster end-to-end combined with `--preload`.

## 3. `--preload` (opt-in, default off)
Warm the whole route's npz cache before rollout so zlib decompress never lands on the per-step critical path. Default off: front-loads (and holds in RAM) the route's decompress — a net loss for short jobs, a win for long/multi-pass runs.

## Tests
- `test_world_to_ego_frame_torch.py` — numpy↔torch transform equivalence across all model-input keys.
- `test_reproducer_save_window.py` — the no-backfill window-start clamp (early contact, short buffer, unstick snap, max_scenes, arc-extend).
- pre-commit clean (ruff + ruff-format).