### PR TITLE
chore: update major version in training args from 4 to 5

### DIFF
--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -88,7 +88,7 @@ def model_training(args: TrainConfig):
             k: v if not isinstance(v, (StateNormalizer, ObservationNormalizer)) else v.to_dict()
             for k, v in args_dict.items()
         }
-        args_dict["major_version"] = 4
+        args_dict["major_version"] = 5
 
         with open(os.path.join(save_path, "args.json"), "w", encoding="utf-8") as f:
             json.dump(args_dict, f, indent=4)


### PR DESCRIPTION
This pull request makes a version update to the model training configuration.

Versioning:

* Updates the `major_version` field saved in the training arguments (`args.json`) from 4 to 5 in the `model_training` function in `train.py`.