### PR TITLE
feat(train): add gradient statistics

### DIFF
--- a/diffusion_planner/diffusion_planner/train_epoch.py
+++ b/diffusion_planner/diffusion_planner/train_epoch.py
@@ -5,7 +5,7 @@ from tqdm import tqdm
 from diffusion_planner.model.module.decoder import compute_training_loss
 from diffusion_planner.utils import ddp
 from diffusion_planner.utils.data_augmentation import StatePerturbation
-from diffusion_planner.utils.train_utils import get_epoch_mean_loss
+from diffusion_planner.utils.train_utils import compute_grad_stats, get_epoch_mean_loss
 
 
 def heading_to_cos_sin(x):
@@ -77,6 +77,10 @@ def train_epoch(data_loader, model, optimizer, args, ema, aug: StatePerturbation
 
         # loss backward
         loss["loss"].backward()
+
+        # Gradient statistics (computed before clipping so that exploding
+        # gradients are not masked by clip_grad_norm_).
+        loss.update(compute_grad_stats(model.parameters()))
 
         nn.utils.clip_grad_norm_(model.parameters(), 5)
         optimizer.step()

--- a/diffusion_planner/diffusion_planner/utils/train_utils.py
+++ b/diffusion_planner/diffusion_planner/utils/train_utils.py
@@ -19,6 +19,41 @@ def set_seed(CUR_SEED):
     torch.backends.cudnn.benchmark = False
 
 
+def compute_grad_stats(parameters, prefix="grad"):
+    """
+    Compute gradient statistics over all parameters to monitor
+    vanishing/exploding gradients during training.
+
+    The statistics are computed on the concatenation of every parameter's
+    gradient (i.e. the global gradient vector):
+        - L1 norm
+        - L2 norm
+        - Linf norm (max absolute value)
+        - mean
+        - standard deviation
+
+    Args:
+        parameters: iterable of model parameters (e.g. ``model.parameters()``).
+        prefix: key prefix for the returned dictionary.
+
+    Returns:
+        dict mapping ``f"{prefix}/<stat>"`` to a python float. Empty dict if
+        no parameter has a gradient.
+    """
+    grads = [p.grad.detach().flatten() for p in parameters if p.grad is not None]
+    if len(grads) == 0:
+        return {}
+
+    grads = torch.cat(grads)
+    return {
+        f"{prefix}/l1_norm": grads.abs().sum().item(),
+        f"{prefix}/l2_norm": grads.norm(2).item(),
+        f"{prefix}/linf_norm": grads.abs().max().item(),
+        f"{prefix}/mean": grads.mean().item(),
+        f"{prefix}/std": grads.std().item(),
+    }
+
+
 def get_epoch_mean_loss(epoch_loss):
     epoch_mean_loss = {}
     for current_loss in epoch_loss:


### PR DESCRIPTION
# Summary
This PR adds per-step gradient statistics to the supervised training loop so that vanishing and exploding gradients can be observed during training. The statistics are logged to Weights & Biases through the existing logging path with no additional configuration.

# What's added
A new helper `compute_grad_stats()` in `utils/train_utils.py` computes the following over the concatenation of all parameter gradients (the global gradient vector):

* $`L_1`$ norm (grad/l1_norm)
* $`L_2`$ norm (grad/l2_norm)
* $`L_\infty`$ norm (grad/linf_norm, max absolute value)
* mean (grad/mean)
* standard deviation (grad/std)

# How it works
In `train_epoch.py`, the statistics are computed right after `loss.backward()` and before `clip_grad_norm_()`, so that exploding gradients are not masked by gradient clipping:

```python
loss["loss"].backward()

# Gradient statistics (computed before clipping so that exploding
# gradients are not masked by clip_grad_norm_).
loss.update(compute_grad_stats(model.parameters()))

nn.utils.clip_grad_norm_(model.parameters(), 5)
```

The values are merged into the per-batch loss dict, so they automatically flow through the existing pipeline: `get_epoch_mean_loss()` averages them per epoch, and they are logged to wandb as `train_loss/grad/*` via the existing `train_loss/{k}` logging in `train_predictor.py`.

# Notes

No new dependencies and no API/config changes; existing wandb dashboards pick up the new metrics automatically.
The GRPO training path (grpo_epoch.py) is intentionally left unchanged because it uses a keyed all-reduce across ranks that requires a consistent metric-key set; it can be addressed separately if needed.

# Testing

Verified that train_epoch.py and train_utils.py parse without errors.