### PR TITLE
Perception reproducer: simulated neighbor-history mode + populated neighbor_ids sidecar

### DIFF
--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/cli/converter_options.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/cli/converter_options.hpp
@@ -59,6 +59,15 @@ struct ConverterOptions
   // their skip reason. Intended for inspection/testing only; off in production.
   bool write_skipped_npz;
 
+  // Sidecar-only mode: run the identical conversion pipeline (sequence build, neighbor
+  // association, skip decision) but write ONLY the per-frame JSON sidecars (pose +
+  // neighbor_ids + is_skipped), skipping the npz tensor serialization/compression entirely.
+  // Used to (re)generate neighbor_ids sidecars for an existing npz set produced by this same
+  // converter: the slot ordering and skip decision are byte-identical (same code path), so the
+  // emitted sidecars align to those npzs by token — and it is faster than a full re-convert
+  // because it skips the npz write. Off in production (a normal convert already emits sidecars).
+  bool sidecar_only;
+
   // Build converter defaults shared by all converter entry points.
   static ConverterOptions default_converter_options();
 

--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/io/frame_writer.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/io/frame_writer.hpp
@@ -31,7 +31,7 @@
 
 nlohmann::json build_frame_json(
   const nav_msgs::msg::Odometry & kinematic_state, const int64_t timestamp,
-  const SkippingInfo & skipping_info, const std::vector<std::string> & neighbor_ids = {});
+  const SkippingInfo & skipping_info, const std::vector<std::string> & neighbor_ids);
 
 nlohmann::json build_route_json(
   const int64_t num_frames, const double traveled_distance_m, const int64_t start_timestamp,
@@ -45,7 +45,7 @@ nlohmann::json build_route_json(
 void save_frame_json(
   const std::string & output_path, const std::string & rosbag_dir_name, const std::string & token,
   const nav_msgs::msg::Odometry & kinematic_state, const int64_t timestamp,
-  const SkippingInfo & skipping_info, const std::vector<std::string> & neighbor_ids = {});
+  const SkippingInfo & skipping_info, const std::vector<std::string> & neighbor_ids);
 
 void save_route_json(
   const std::string & output_path, const std::string & rosbag_dir_name,

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/cli/converter_options.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/cli/converter_options.cpp
@@ -75,6 +75,11 @@ void ConverterOptions::add_converter_options(CLI::App & app)
     "--write_skipped_npz", write_skipped_npz,
     "Also write npz files for skipped frames when non-zero. "
     "Intended for inspection.");
+  app.add_flag(
+    "--sidecar_only", sidecar_only,
+    "Write ONLY the per-frame JSON sidecars (pose + neighbor_ids + is_skipped), skipping all "
+    "npz output. Same pipeline/slot-ordering as a full convert, so the sidecars align to an "
+    "existing npz set from this converter; faster than re-converting (no npz write).");
 }
 
 std::string ConverterPaths::get_rosbag_dir_name() const
@@ -109,6 +114,8 @@ ConverterOptions ConverterOptions::default_converter_options()
 
   // Inspection-only: production keeps this off so skipped frames write no npz.
   options.write_skipped_npz = false;
+  // Full conversion by default (write npz); --sidecar_only flips to sidecar-only output.
+  options.sidecar_only = false;
   options.use_interpolation = static_cast<bool>(options.interpolation);
   return options;
 }

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/data_converter.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/data_converter.cpp
@@ -37,13 +37,14 @@ void print_options(const ConverterPaths & paths, const ConverterOptions & conver
     "Collision filter static_object_margin: {}, neighbor_margin: {}, road_border_margin: {}, "
     "collision_time_stride: {}\n"
     "Off-lane filter max_score: {}, offlane_time_stride: {}\n"
-    "Write skipped npz: {}\n",
+    "Write skipped npz: {}, Sidecar only: {}\n",
     converter.ego_wheel_base, converter.ego_length, converter.ego_width, paths.rosbag_path,
     paths.vector_map_path, paths.save_dir, converter.step, converter.limit, converter.min_frames,
     converter.min_distance, converter.search_nearest_route, converter.convert_yellow,
     converter.convert_red, converter.use_interpolation, converter.static_object_margin,
     converter.neighbor_margin, converter.road_border_margin, converter.collision_time_stride,
-    converter.offlane_max_score, converter.offlane_time_stride, converter.write_skipped_npz);
+    converter.offlane_max_score, converter.offlane_time_stride, converter.write_skipped_npz,
+    converter.sidecar_only);
 }
 
 bool parse_arguments(int argc, char ** argv, ConverterPaths & paths, ConverterOptions & converter)

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_processor.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_processor.cpp
@@ -289,8 +289,9 @@ void process_sequence(
       line_strings, lanes, filter_params);
 
     const bool is_skipped = skipping_info.label != SkippingLabel::NotSkipped;
-    // Accepted frames are always written; skipped frames only on request.
-    if (!is_skipped || options.write_skipped_npz) {
+    // Accepted frames are always written; skipped frames only on request. In sidecar-only mode
+    // no npz is written at all (the sidecar below still carries the exact neighbor_ids/skip).
+    if (!options.sidecar_only && (!is_skipped || options.write_skipped_npz)) {
       save_frame_data_npz(
         paths.save_dir, rosbag_dir_name, token, ego_past, ego_current, ego_future, neighbor_past,
         neighbor_future, static_objects, lanes, lanes_speed_limit, lanes_has_speed_limit,

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_processor.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_processor.cpp
@@ -299,7 +299,7 @@ void process_sequence(
     }
     save_frame_json(
       paths.save_dir, rosbag_dir_name, token, seq.data_list[i].kinematic_state,
-      seq.data_list[i].timestamp, skipping_info);
+      seq.data_list[i].timestamp, skipping_info, neighbor_result.neighbor_ids);
 
     if (i % 100 == 0) {
       std::cout << "Processed frame " << i << "/" << n << std::endl;

--- a/cpp_tools/src/autoware_diffusion_planner_tools/test/test_converter_options.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/test/test_converter_options.cpp
@@ -39,6 +39,7 @@ static ConverterOptions make_default_opts()
   o.offlane_max_score = 6.0f;
   o.offlane_time_stride = 1;
   o.write_skipped_npz = false;
+  o.sidecar_only = false;
   return o;
 }
 
@@ -57,6 +58,8 @@ TEST(DefaultConverterOptionsTest, UsesSharedDefaults)
   EXPECT_FLOAT_EQ(opts.ego_length, -1.0f);
   EXPECT_FLOAT_EQ(opts.ego_width, -1.0f);
   EXPECT_TRUE(opts.use_interpolation);
+  EXPECT_FALSE(opts.write_skipped_npz);
+  EXPECT_FALSE(opts.sidecar_only);  // full conversion (writes npz) by default
 }
 
 // ---------------------------------------------------------------------------

--- a/cpp_tools/src/autoware_diffusion_planner_tools/test/test_frame_writer.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/test/test_frame_writer.cpp
@@ -34,7 +34,8 @@ TEST(BuildFrameJsonTest, AcceptedFrameFields)
   const SkippingInfo info = SkippingInfo::accepted();
   const int64_t ts = 123456789LL;
 
-  const nlohmann::json j = build_frame_json(odom, ts, info);
+  const std::vector<std::string> neighbor_ids = {"aaaa", "bbbb", "cccc"};
+  const nlohmann::json j = build_frame_json(odom, ts, info, neighbor_ids);
 
   EXPECT_FALSE(j["is_skipped"].get<bool>());
   EXPECT_EQ(j["timestamp"].get<int64_t>(), ts);
@@ -42,6 +43,7 @@ TEST(BuildFrameJsonTest, AcceptedFrameFields)
   EXPECT_DOUBLE_EQ(j["y"].get<double>(), 2.2);
   EXPECT_DOUBLE_EQ(j["z"].get<double>(), 3.3);
   EXPECT_EQ(j["skipping_info"]["label"].get<int>(), static_cast<int>(SkippingLabel::NotSkipped));
+  EXPECT_EQ(j["neighbor_ids"].get<std::vector<std::string>>(), neighbor_ids);
 }
 
 TEST(BuildFrameJsonTest, SkippedFrameIsSkippedTrue)
@@ -49,7 +51,7 @@ TEST(BuildFrameJsonTest, SkippedFrameIsSkippedTrue)
   nav_msgs::msg::Odometry odom;
   const SkippingInfo info = SkippingInfo::stale_data(600'000'000LL);
 
-  const nlohmann::json j = build_frame_json(odom, 0LL, info);
+  const nlohmann::json j = build_frame_json(odom, 0LL, info, std::vector<std::string>{});
 
   EXPECT_TRUE(j["is_skipped"].get<bool>());
   EXPECT_EQ(

--- a/rlvr/autoresearch/tools/mine_collisions_reproducer.py
+++ b/rlvr/autoresearch/tools/mine_collisions_reproducer.py
@@ -87,6 +87,17 @@ def parse_args() -> argparse.Namespace:
         "numerically equivalent to the CPU path (~1e-5, float-ordering).",
     )
     p.add_argument(
+        "--neighbor_history_mode",
+        type=str,
+        default="recorded",
+        choices=["recorded", "sim"],
+        help="'recorded' (default, original): copy each cursor frame's own 31-step neighbor "
+        "history verbatim — a cursor-frozen moving car still reads its recorded velocity. "
+        "'sim': rebuild neighbor_agents_past from the SIMULATED shown motion (track by UUID, "
+        "interpolate between recorded anchors, velocity = finite diff of shown positions) so a "
+        "frozen neighbor reads v~0 and a moving one its true speed. Needs sidecar neighbor_ids.",
+    )
+    p.add_argument(
         "--prefetch_ahead",
         type=int,
         default=2,
@@ -249,6 +260,7 @@ def main() -> None:
             save_min_ego_speed=args.save_min_ego_speed,
             route_keys=buf_keys,
             gpu_transform=args.gpu_transform,
+            neighbor_history_mode=args.neighbor_history_mode,
         )
         for key, res in zip(buf_keys, res_list):
             row = {"route": key, **res.metrics}

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -1374,7 +1374,19 @@ def run_segments_batched(
                                         colliding_uuid is None
                                         or colliding_uuid != s.last_collision_uuid
                                     )
-                                if s.episode_eligible and not s.episode_saved:
+                                # Cheap pre-check before the (expensive) save attempt: only try
+                                # when the window's nominal start frame is CLEAR (> save_thresh).
+                                # In a sustained contact the lookback start is still in-contact, so
+                                # t0-clean would drop it anyway — skipping the _dump (npz-load +
+                                # OBB clearance) here avoids a per-step save-spam that starved the
+                                # GPU. When the prior contact scrolls out of the lookback the start
+                                # clears and we attempt (so a later clean window in the same episode
+                                # is still caught). Buffer/snap floor matches _precollision_window_start.
+                                ws = s.k - save_pre_steps
+                                if s.last_snap_step is not None:
+                                    ws = max(ws, s.last_snap_step)
+                                start_clear = ws < 0 or s.clearances[ws] > save_thresh
+                                if s.episode_eligible and not s.episode_saved and start_clear:
                                     episode_dir = Path(f"{s.save_out_dir}_tc{s.k:05d}")
                                     mani = _dump_precollision_window(
                                         episode_dir,

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -869,7 +869,7 @@ def _build_nbr_world_tracks(tl: RouteTimeline, lo: int, hi: int, eps: float = 0.
             continue
         pose = tl.poses[idx]
         c, s = math.cos(pose[2]), math.sin(pose[2])
-        nb = tl.npz(idx)["neighbor_agents_past"][:, -1]  # (320, 11) recorded-ego frame
+        nb = tl.neighbor_last(idx)  # (320, 11) recorded-ego frame — single-key load (fast)
         for slot in range(min(len(ids), nb.shape[0])):
             row = nb[slot]
             if np.abs(row[:6]).sum() == 0:

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -925,8 +925,9 @@ def _build_nbr_world_tracks(tl: RouteTimeline, lo: int, hi: int, eps: float = 0.
     interp: dict[str, tuple] = {}
     span: dict[str, tuple] = {}
     for u, lst in raw.items():
-        if len(lst) < 2:
-            continue
+        # Keep even 1-sample tracks (constant pose -> v~0). A neighbor present only at/near the
+        # segment start must still appear in sim mode so step 0 reproduces the recorded context
+        # (matches _build_neighbor_interp); _interp_pose handles a single anchor by clamping.
         kept = [lst[0]]
         for samp in lst[1:]:
             if math.hypot(samp[1] - kept[-1][1], samp[2] - kept[-1][2]) > eps:

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -250,6 +250,14 @@ def _to_torch_batch_gpu(raw_payloads: list[tuple], model_args, device: str, want
         np.concatenate([p[3] for p in raw_payloads], axis=0).astype(np.float32)
     ).to(device)
 
+    # Corrected neighbor context: replace the transformed recorded neighbor block with the
+    # simulated (shown-motion) one, already built in the live-ego frame — matches the CPU
+    # override in _pre_step. p[5] is None in recorded mode (payload is a 5-tuple).
+    if len(raw_payloads[0]) > 5 and raw_payloads[0][5] is not None:
+        batch["neighbor_agents_past"] = torch.from_numpy(
+            np.concatenate([p[5] for p in raw_payloads], axis=0).astype(np.float32)
+        ).to(device)
+
     # Extract scoring inputs (+ optional save dicts) BEFORE normalization, so they match
     # the un-normalized arrays build_input_np returns.
     nb_all = batch["neighbor_agents_past"][:, :, -1, :].detach().cpu().numpy()  # (N,320,11)
@@ -452,6 +460,9 @@ class _SegState:
     saved_collision: bool = False
     last_snap_step: int | None = None
     save_out_dir: object = None
+    # Corrected neighbor context (neighbor_history_mode="sim"): rebuild neighbor_agents_past
+    # each step from the SIMULATED shown motion (velocity from shown deltas, frozen->v~0).
+    nbr_tracker: object = None
 
 
 def _ego_state_from_frame(tl: RouteTimeline, idx: int) -> tuple[np.ndarray, np.ndarray, "_EgoDyn"]:
@@ -484,6 +495,7 @@ def _seed_state(
     max_steps=None,
     unstick_after=0,
     unstick_advance_m=5.0,
+    neighbor_history_mode="recorded",
 ) -> _SegState:
     from scenario_generation.mpc_tracker import PerfectTracker
 
@@ -494,6 +506,13 @@ def _seed_state(
     cursor = PerceptionReproducer(tl, search_radius=search_radius, timers=timers)
     cursor.reset(start)
     live_pose, ego_hist, dyn = _ego_state_from_frame(tl, start)
+    # Corrected neighbor context: one timeline sample per 0.1 s sim step (real time on a
+    # step=1 corpus). Raises if the corpus has no neighbor tracks.
+    nbr_tracker = (
+        SimNeighborTracker(tl, start, max_rec_advance=1.0)
+        if neighbor_history_mode == "sim"
+        else None
+    )
     return _SegState(
         tl=tl,
         start=start,
@@ -515,6 +534,7 @@ def _seed_state(
         max_steps=cap,
         unstick_after=int(unstick_after),
         unstick_advance_m=float(unstick_advance_m),
+        nbr_tracker=nbr_tracker,
     )
 
 
@@ -541,9 +561,18 @@ def _pre_step(s: _SegState, gpu_transform: bool = False):
     if s.max_stuck_steps > 0 and s.stuck >= s.max_stuck_steps:
         s.terminated, s.done = "stuck", True
         return None
+    sim_nb = None
+    if s.nbr_tracker is not None:
+        s.nbr_tracker.step(idx)
+        sim_nb = s.nbr_tracker.build(s.live_pose)  # (1,320,31,11) live-ego frame
     if gpu_transform:
-        return build_input_raw(s.tl, idx, s.live_pose, s.ego_hist, s.dyn)
+        # 6-tuple (..., sim_nb); sim_nb overrides the recorded neighbor block AFTER the
+        # batched world_to_ego transform (None = recorded mode, payload stays a 5-tuple).
+        return (*build_input_raw(s.tl, idx, s.live_pose, s.ego_hist, s.dyn), sim_nb)
     np_dict, neighbors_live = build_input_np(s.tl, idx, s.live_pose, s.ego_hist, s.dyn)
+    if sim_nb is not None:
+        np_dict["neighbor_agents_past"] = sim_nb
+        neighbors_live = sim_nb[0, :, -1, :].copy()
     return np_dict, neighbors_live, idx
 
 
@@ -652,6 +681,7 @@ def run_segment(
     max_steps: int | None = None,
     unstick_after: int = 300,
     unstick_advance_m: float = 5.0,
+    neighbor_history_mode: str = "recorded",
     timers: Timers | None = None,
 ) -> SegmentResult:
     """Single-segment closed-loop reproducer rollout over recorded frames [start, end).
@@ -674,6 +704,7 @@ def run_segment(
         max_steps=max_steps if max_steps is not None else 3 * (end - start),
         unstick_after=unstick_after,
         unstick_advance_m=unstick_advance_m,
+        neighbor_history_mode=neighbor_history_mode,
     )
     while not s.done:
         with timers("input_build"):
@@ -775,6 +806,162 @@ def _apply_neighbor_interp(np_dict, neighbor_ids, live_pose, idx, interp):
         lh = wh - eyaw
         nb[slot, -1, 2] = math.cos(lh)
         nb[slot, -1, 3] = math.sin(lh)
+
+
+# --------------------------------------------------------------------------- #
+# Simulated neighbor history (corrected closed-loop neighbor context)
+# --------------------------------------------------------------------------- #
+def _build_nbr_world_tracks(tl: RouteTimeline, lo: int, hi: int, eps: float = 0.05):
+    """Per-UUID recorded WORLD trajectory + box attrs + array-index span.
+
+    Scans recorded frames and, keyed by the sidecar ``neighbor_ids`` (track UUIDs),
+    collects each track's world pose, box attributes (width, length, is_veh, is_ped,
+    is_bike) and the (first, last) array index where it appears. Returns
+    ``(interp, attrs, span)`` (interp[uuid] = (idx_arr, xy_arr (N,2), heading_arr (N,))).
+    """
+    raw: dict[str, list] = {}
+    attrs: dict[str, np.ndarray] = {}
+    for idx in range(lo, hi):
+        ids = tl.neighbor_ids(idx)
+        if not ids:
+            continue
+        pose = tl.poses[idx]
+        c, s = math.cos(pose[2]), math.sin(pose[2])
+        nb = tl.npz(idx)["neighbor_agents_past"][:, -1]  # (320, 11) recorded-ego frame
+        for slot in range(min(len(ids), nb.shape[0])):
+            row = nb[slot]
+            if np.abs(row[:6]).sum() == 0:
+                continue
+            u = ids[slot]
+            wx = pose[0] + row[0] * c - row[1] * s
+            wy = pose[1] + row[0] * s + row[1] * c
+            wh = math.atan2(row[3], row[2]) + pose[2]
+            raw.setdefault(u, []).append((idx, wx, wy, wh))
+            if u not in attrs:
+                attrs[u] = row[6:11].astype(np.float32)  # width,length,is_veh,is_ped,is_bike
+    interp: dict[str, tuple] = {}
+    span: dict[str, tuple] = {}
+    for u, lst in raw.items():
+        if len(lst) < 2:
+            continue
+        kept = [lst[0]]
+        for samp in lst[1:]:
+            if math.hypot(samp[1] - kept[-1][1], samp[2] - kept[-1][2]) > eps:
+                kept.append(samp)
+        if kept[-1][0] != lst[-1][0]:
+            kept.append(lst[-1])
+        interp[u] = (
+            np.array([k[0] for k in kept]),
+            np.array([[k[1], k[2]] for k in kept], dtype=np.float64),
+            np.unwrap(np.array([k[3] for k in kept])),
+        )
+        span[u] = (int(lst[0][0]), int(lst[-1][0]))
+    return interp, attrs, span
+
+
+def _route_nbr_tracks(tl: RouteTimeline):
+    """Per-route UUID world tracks, built once and cached on the timeline."""
+    cached = getattr(tl, "_nbr_tracks", None)
+    if cached is None:
+        cached = _build_nbr_world_tracks(tl, 0, len(tl))
+        tl._nbr_tracks = cached
+    return cached
+
+
+class SimNeighborTracker:
+    """Build the model's neighbor context from the SIMULATED (shown) neighbor motion.
+
+    Recorded mode copies each cursor frame's own 31-step history verbatim, so a
+    cursor-frozen car still reads its recorded velocity (e.g. a moving car held in
+    place because the ego crept still shows ~11 m/s while it visibly never moves —
+    input and replay disagree, producing phantom collisions).
+
+    This tracker follows each neighbor by track UUID, advances a continuous
+    recorded-time cursor ``rec_t`` toward the position-keyed cursor's target frame
+    (capped at ``max_rec_advance`` array-indices per 0.1 s sim step → interpolates
+    between recorded anchors), and keeps a rolling per-sim-step world history per
+    UUID. ``neighbor_agents_past`` is rebuilt from that shown history each step:
+    velocity is the finite difference of the shown positions, so a frozen neighbor
+    reads v approx 0 (a static obstacle) and a moving one its true speed. Step 0 is
+    seeded from the recorded history so the first frame equals the original context.
+    """
+
+    def __init__(self, tl: RouteTimeline, start: int, max_rec_advance: float = 1.0):
+        self.tl = tl
+        self.interp, self.attrs, self.span = _route_nbr_tracks(tl)
+        if not self.interp:
+            raise ValueError(
+                "SimNeighborTracker: no neighbor tracks (sidecar neighbor_ids empty). Reconvert "
+                "the corpus with populated neighbor_ids, or use neighbor_history_mode=recorded."
+            )
+        self.rec_t = float(start)
+        self.max_adv = float(max_rec_advance)
+        self.hist: dict[str, list] = {}  # uuid -> rolling list[(wx,wy,wh)], len <= PAST
+        self._seed_start(start)
+
+    def _present(self, u: str, t: float) -> bool:
+        lo, hi = self.span[u]
+        return lo - 0.5 <= t <= hi + 0.5
+
+    def _seed_start(self, start: int) -> None:
+        """Seed each track present at ``start`` with the recorded 0.1 s history leading
+        up to ``start`` (from its world anchors) so step 0 reproduces the original context."""
+        for u in self.interp:
+            if not self._present(u, start):
+                continue
+            self.hist[u] = [
+                _interp_pose(self.interp[u], start - (PAST - 1) + k) for k in range(PAST - 1)
+            ]
+
+    def step(self, target_idx: int) -> None:
+        """Advance ``rec_t`` toward the cursor target (capped, never backward) and push the
+        current interpolated world pose of every present track into its rolling history."""
+        self.rec_t += min(max(float(target_idx) - self.rec_t, 0.0), self.max_adv)
+        for u in self.interp:
+            if not self._present(u, self.rec_t):
+                continue
+            p = _interp_pose(self.interp[u], self.rec_t)
+            dq = self.hist.get(u)
+            if dq is None:
+                dq = [p] * (PAST - 1)  # newly appeared -> no motion history yet (v approx 0)
+                self.hist[u] = dq
+            dq.append(p)
+            if len(dq) > PAST:
+                del dq[0]
+
+    def build(self, live_pose: np.ndarray) -> np.ndarray:
+        """(1, 320, 31, 11) neighbor_agents_past in the live-ego frame, from shown history."""
+        ex, ey, eyaw = float(live_pose[0]), float(live_pose[1]), float(live_pose[2])
+        R = _rotation_matrix(eyaw)  # world delta -> ego frame (rotates by -eyaw)
+        present = [u for u in self.hist if len(self.hist[u]) > 0 and self._present(u, self.rec_t)]
+
+        def _cur_d2(u):
+            wx, wy, _ = self.hist[u][-1]
+            d = R @ np.array([wx - ex, wy - ey])
+            return float(d[0] * d[0] + d[1] * d[1])
+
+        present.sort(key=_cur_d2)  # nearest-first, mirroring the recorded slot order
+        out = np.zeros((320, PAST, 11), dtype=np.float32)
+        for slot, u in enumerate(present[:320]):
+            dq = self.hist[u]
+            n = len(dq)
+            poses = ([dq[0]] * (PAST - n)) + list(dq) if n < PAST else list(dq)
+            world = np.asarray(poses, dtype=np.float64)  # (PAST, 3) wx, wy, wh
+            d = (world[:, :2] - np.array([ex, ey])) @ R.T  # (PAST, 2) ego-frame xy
+            lh = world[:, 2] - eyaw
+            out[slot, :, 0] = d[:, 0]
+            out[slot, :, 1] = d[:, 1]
+            out[slot, :, 2] = np.cos(lh)
+            out[slot, :, 3] = np.sin(lh)
+            vw = np.zeros((PAST, 2))
+            if PAST > 1:
+                vw[1:] = np.diff(world[:, :2], axis=0) / DT
+                vw[0] = vw[1]
+            ve = vw @ R.T  # world velocity -> ego frame
+            out[slot, :, 4] = ve[:, 0]
+            out[slot, :, 5] = ve[:, 1]
+            out[slot, :, 6:11] = self.attrs[u]
+        return out[None]
 
 
 def _polylines_from_tensor(t: np.ndarray, border_only: bool = False) -> list[np.ndarray]:
@@ -949,6 +1136,7 @@ def run_segments_batched(
     save_min_ego_speed: float = 0.5,
     route_keys: list[str] | None = None,
     gpu_transform: bool = False,
+    neighbor_history_mode: str = "recorded",
 ) -> list[SegmentResult]:
     """Run many segments in lock-step: ONE batched model forward per tick.
 
@@ -1013,6 +1201,7 @@ def run_segments_batched(
                     max_steps=max_steps_mult * (end - start),
                     unstick_after=unstick_after,
                     unstick_advance_m=unstick_advance_m,
+                    neighbor_history_mode=neighbor_history_mode,
                 )
                 for (tl, start, end) in chunk
             ]

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -395,8 +395,11 @@ def score_step_batched(
         ego_all = ego_each.repeat_interleave(counts_t, dim=0)  # (K, 4, 2)
 
     p1, p2 = _closest_points_between_rects(ego_all, npc_all)
-    clr_all = (p1 - p2).norm(dim=-1)  # (K,)
-    signed_all = batch_signed_distance_rect(ego_all, npc_all)  # (K,)
+    # Move both result vectors to host ONCE, then slice/reduce per segment in numpy — avoids
+    # the per-segment GPU->CPU syncs that min()/any()/argmin() would each force. min/argmin are
+    # pure selection, so the per-segment values stay bit-identical to the on-device reduction.
+    clr_all = (p1 - p2).norm(dim=-1).cpu().numpy()  # (K,)
+    signed_neg = (batch_signed_distance_rect(ego_all, npc_all) < 0).cpu().numpy()  # (K,)
     out: list[tuple[float, bool, int, int]] = []
     off = 0
     for seg_i, m in enumerate(counts):
@@ -404,13 +407,13 @@ def score_step_batched(
             out.append((float("inf"), False, 0, -1))
         else:
             seg_clr = clr_all[off : off + m]
-            amin = int(seg_clr.argmin().item())  # index within this segment's VALID subset
+            amin = int(seg_clr.argmin())  # index within this segment's VALID subset
             # Map the valid-subset argmin back to the original neighbor slot (build() order).
             collider_slot = int(np.flatnonzero(valids[seg_i])[amin])
             out.append(
                 (
                     float(seg_clr.min()),
-                    bool((signed_all[off : off + m] < 0).any()),
+                    bool(signed_neg[off : off + m].any()),
                     m,
                     collider_slot,
                 )
@@ -482,7 +485,7 @@ class _SegState:
     # (deep enough for the min-movement window extension); it is CLEARED on an unstick
     # teleport so a saved window never crosses the jump.
     save_buf: object = None
-    saved_collision: bool = False
+    saved_collision: bool = False  # recorded-mode latch: at most one saved window per segment
     last_snap_step: int | None = None
     save_out_dir: object = None
     # Corrected neighbor context (neighbor_history_mode="sim"): rebuild neighbor_agents_past
@@ -624,12 +627,13 @@ def _pre_step(s: _SegState, gpu_transform: bool = False):
 
 
 def _feed_turn_indicator(s: _SegState, outputs) -> None:
-    """Closed-loop turn-signal feedback for the single-segment rollout paths.
+    """Closed-loop turn-signal feedback for the single-segment ``run_segment`` rollout.
 
     Appends the model's predicted turn indicator to ``turn_hist`` (recorded seed scrolls
     out within PAST steps). No-op in recorded mode (``turn_hist`` is None there). Mirrors
-    the per-batch feedback in ``run_segments_batched`` so every sim-mode rollout — batched
-    or single-segment — evolves the turn signal identically instead of holding the seed."""
+    the per-batch feedback in ``run_segments_batched`` so a sim-mode single-segment rollout
+    evolves the turn signal identically instead of holding the seed. (``render_segment`` /
+    ``extract_collision_scenes`` are recorded-only — no ``turn_hist`` — so they don't call it.)"""
     if s.turn_hist is None:
         return
     ti = decode_turn_indicator(outputs["turn_indicator_logit"], 0.25)
@@ -1209,7 +1213,6 @@ def render_segment(
         data = _to_torch_batch([np_dict], model_args, device)
         _, outputs = model(data)
         pred = outputs["prediction"][0, 0].cpu().numpy()
-        _feed_turn_indicator(s, outputs)  # closed-loop turn signal (sim mode)
         nids = tl.neighbor_ids(idx) if (color_by_uuid or interpolate) else None
         if interpolate and nids and interp:
             _apply_neighbor_interp(np_dict, nids, s.live_pose, idx, interp)
@@ -1325,6 +1328,7 @@ def run_segments_batched(
                 for (tl, start, end) in chunk
             ]
             if save_dir is not None:
+                import shutil
                 from collections import deque
                 from pathlib import Path
 
@@ -1332,6 +1336,12 @@ def run_segments_batched(
                     key = route_keys[c0 + off] if route_keys else _route_key(s.tl)
                     s.save_buf = deque(maxlen=save_max_scenes + 1)
                     s.save_out_dir = Path(save_dir) / f"{key}_{s.start}_{s.end}"
+                    # Per-episode dirs are tagged by save step (..._tc#####), so a re-mine that
+                    # lands collisions at different steps would otherwise leave the previous run's
+                    # dirs behind and the extract step would ingest superseded scenes. Clear this
+                    # segment's stale episode dirs up front so each run starts clean.
+                    for stale in Path(save_dir).glob(f"{key}_{s.start}_{s.end}_tc*"):
+                        shutil.rmtree(stale, ignore_errors=True)
             active = list(states)
             while active:
                 with timers("input_build"):
@@ -1425,10 +1435,14 @@ def run_segments_batched(
                                 if not s.in_episode:  # entering contact from a clear -> new episode
                                     s.in_episode = True
                                     s.episode_saved = False
-                                    s.episode_eligible = (
-                                        colliding_uuid is None
-                                        or colliding_uuid != s.last_collision_uuid
-                                    )
+                                    if colliding_uuid is None:
+                                        # Recorded mode (no track UUIDs): can't tell distinct
+                                        # vehicles apart, so fall back to ONE saved window per
+                                        # segment (the pre-sim-mode behavior) instead of one per
+                                        # clear-separated contact.
+                                        s.episode_eligible = not s.saved_collision
+                                    else:
+                                        s.episode_eligible = colliding_uuid != s.last_collision_uuid
                                 # Cheap pre-check before the (expensive) save attempt: only try
                                 # when the window's nominal start frame is CLEAR (> save_thresh).
                                 # In a sustained contact the lookback start is still in-contact, so
@@ -1462,6 +1476,7 @@ def run_segments_batched(
                                     )
                                     if mani is not None:
                                         s.episode_saved = True
+                                        s.saved_collision = True  # recorded-mode one-save latch
                                         s.last_collision_uuid = colliding_uuid
                     for i, (s, _np, nb, idx, _suuid, _wbu) in enumerate(built):
                         prev_snaps = s.n_snaps
@@ -1795,6 +1810,24 @@ def _dump_precollision_window(
                 naf_sim[slots, j - 1, 1] = d[:, 1]
                 naf_sim[slots, j - 1, 2] = np.cos(h)
                 naf_sim[slots, j - 1, 3] = np.sin(h)
+            # Hold a neighbor's pose across a momentary shown-future gap (perception drop):
+            # an interior [0,0,0,0] would read as an invalid/padding slot embedded in valid
+            # motion. Forward-fill interior gaps from the prior shown pose and back-fill a
+            # leading gap from the first shown pose; trailing zeros (after the neighbor's last
+            # appearance) stay zero = gone. Only present (non-all-zero) slots are touched.
+            for slot in range(320):
+                traj = naf_sim[slot]
+                present = np.flatnonzero(np.abs(traj).sum(axis=1) > 0)
+                if len(present) == 0:
+                    continue
+                last = None
+                for j in range(present[-1] + 1):
+                    if np.abs(traj[j]).sum() > 0:
+                        last = traj[j].copy()
+                    elif last is not None:
+                        traj[j] = last
+                if present[0] > 0:  # leading gap before the first shown pose
+                    traj[: present[0]] = traj[present[0]]
             scene["neighbor_agents_future"] = naf_sim
         else:
             with np.load(tl.npz_paths[idx], allow_pickle=True) as z:
@@ -1917,7 +1950,6 @@ def extract_collision_scenes(
         data = _to_torch_batch([np_dict], model_args, device)
         _, outputs = model(data)
         pred = outputs["prediction"][0, 0].cpu().numpy()
-        _feed_turn_indicator(s, outputs)  # closed-loop turn signal (sim mode)
         clr = _min_clearance_any(neighbors_live, s.ego_shape, device)
         # 6-tuple to match the batched buffer / _dump_precollision_window unpacking; this
         # legacy extractor path is recorded-mode (no sim tracker) -> slot_uuids/world None.

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -37,6 +37,7 @@ from planner_metrics.geometry import (
 from scenario_generation.perception_reproducer import PerceptionReproducer
 from scenario_generation.perf_timer import Timers
 from scenario_generation.route_timeline import RouteTimeline
+from scenario_generation.simulate import decode_turn_indicator
 from scenario_generation.tensor_converter import _heading_to_cos_sin
 from scenario_generation.transforms import _rotation_matrix, world_to_ego_frame
 
@@ -436,6 +437,19 @@ class _SegState:
     goal_xy: np.ndarray
     clearances: np.ndarray
     collisions: np.ndarray
+    # Closed-loop turn-indicator history (INPUT_T+1,). Seeded from the recorded frame, then
+    # each step the MODEL's predicted turn indicator is fed back in (recorded seed phases out
+    # within PAST steps, exactly like ego_hist) — so the model context + saved npz never carry
+    # the recorded driver's signals, only the sim's own predictions.
+    turn_hist: np.ndarray = None
+    # Per-collision-episode save state. An episode runs while clearance <= thresh and ends on
+    # clearing; ``last_collision_uuid`` is the colliding UUID of the last SAVED collision (a new
+    # episode is distinct only if its UUID differs). ``episode_eligible`` is set once per episode
+    # (distinct?), ``episode_saved`` latches after the episode's one window is written.
+    last_collision_uuid: object = None
+    in_episode: bool = False
+    episode_eligible: bool = False
+    episode_saved: bool = False
     sim_time: float = 0.0
     stuck: int = 0
     prev_max_idx: int = 0
@@ -526,6 +540,7 @@ def _seed_state(
         live_pose=live_pose,
         ego_hist=ego_hist,
         dyn=dyn,
+        turn_hist=np.asarray(tl.npz(start)["turn_indicators"]).reshape(-1).astype(np.int64),
         ego_shape=np.asarray(tl.npz(start)["ego_shape"]).reshape(-1)[:3].astype(np.float32),
         goal_xy=tl.poses[end - 1, :2],
         clearances=np.full(cap, np.inf, dtype=np.float32),
@@ -562,18 +577,31 @@ def _pre_step(s: _SegState, gpu_transform: bool = False):
         s.terminated, s.done = "stuck", True
         return None
     sim_nb = None
+    slot_uuids = None  # slot -> UUID for the sim neighbor block (sim mode only)
+    world_by_uuid = None  # UUID -> current shown world pose (for sim-future assembly)
     if s.nbr_tracker is not None:
-        s.nbr_tracker.step(idx)
-        sim_nb = s.nbr_tracker.build(s.live_pose)  # (1,320,31,11) live-ego frame
+        s.nbr_tracker.step(idx, s.live_pose[:2])
+        sim_nb, slot_uuids, world_by_uuid = s.nbr_tracker.build(
+            s.live_pose
+        )  # (1,320,31,11) live-ego
     if gpu_transform:
-        # 6-tuple (..., sim_nb); sim_nb overrides the recorded neighbor block AFTER the
-        # batched world_to_ego transform (None = recorded mode, payload stays a 5-tuple).
-        return (*build_input_raw(s.tl, idx, s.live_pose, s.ego_hist, s.dyn), sim_nb)
+        # 8-tuple (..., sim_nb, slot_uuids, world_by_uuid); sim_nb overrides the recorded
+        # neighbor block AFTER the batched world_to_ego transform (None = recorded mode).
+        base, dxyz, live_past, live_cur, ridx = build_input_raw(
+            s.tl, idx, s.live_pose, s.ego_hist, s.dyn
+        )
+        if s.turn_hist is not None:
+            base["turn_indicators"] = s.turn_hist[None].astype(
+                np.int64
+            )  # closed-loop, not recorded
+        return (base, dxyz, live_past, live_cur, ridx, sim_nb, slot_uuids, world_by_uuid)
     np_dict, neighbors_live = build_input_np(s.tl, idx, s.live_pose, s.ego_hist, s.dyn)
     if sim_nb is not None:
         np_dict["neighbor_agents_past"] = sim_nb
         neighbors_live = sim_nb[0, :, -1, :].copy()
-    return np_dict, neighbors_live, idx
+    if s.turn_hist is not None:
+        np_dict["turn_indicators"] = s.turn_hist[None].astype(np.int64)  # closed-loop, not recorded
+    return np_dict, neighbors_live, idx, slot_uuids, world_by_uuid
 
 
 def _score_into(s: _SegState, neighbors_live, device, timers):
@@ -630,6 +658,20 @@ def _advance_step(s: _SegState, pred: np.ndarray, idx, device, timers):
                     tgt += 1
                 s.live_pose, s.ego_hist, s.dyn = _ego_state_from_frame(s.tl, tgt)
                 s.cursor.reset(tgt)
+                # Re-seed the sim machinery at the teleport target so post-snap recording is
+                # correct, not stale: the neighbor tracker's rec_t is capped at 1.0/step, so
+                # without this it would lag many steps behind the jumped ego (stale neighbors);
+                # turn_hist would carry pre-snap predictions for a different ego path. Both
+                # restart from the recorded state at tgt and phase out again (like rollout start).
+                # The save buffer is cleared on this snap (caller), so no window mixes the jump.
+                if s.nbr_tracker is not None:
+                    s.nbr_tracker = SimNeighborTracker(s.tl, tgt, max_rec_advance=1.0)
+                if s.turn_hist is not None:
+                    s.turn_hist = (
+                        np.asarray(s.tl.npz(tgt)["turn_indicators"]).reshape(-1).astype(np.int64)
+                    )
+                s.last_collision_uuid = None  # teleported -> next contact is a fresh collision
+                s.in_episode = False
                 s.prev_max_idx = s.cursor.max_idx_reached
                 s.ego_stuck = 0
                 s.n_snaps += 1
@@ -711,7 +753,7 @@ def run_segment(
             pre = _pre_step(s)
         if pre is None:
             break
-        np_dict, neighbors_live, idx = pre
+        np_dict, neighbors_live, idx, _suuid, _wbu = pre
         with timers("to_torch"):
             data = _to_torch_batch([np_dict], model_args, device)
         with timers("model_forward"):
@@ -913,10 +955,42 @@ class SimNeighborTracker:
                 _interp_pose(self.interp[u], start - (PAST - 1) + k) for k in range(PAST - 1)
             ]
 
-    def step(self, target_idx: int) -> None:
-        """Advance ``rec_t`` toward the cursor target (capped, never backward) and push the
-        current interpolated world pose of every present track into its rolling history."""
-        self.rec_t += min(max(float(target_idx) - self.rec_t, 0.0), self.max_adv)
+    def _frac_target(self, target_idx: int, live_xy) -> float:
+        """Refine the integer position-cursor frame to a FRACTIONAL recorded index by
+        projecting the live ego onto the recorded ego path around ``target_idx``.
+
+        The cursor returns the nearest *integer* recorded frame, so chasing it with an
+        integer-capped step makes ``rec_t`` snap to integers and ``_interp_pose`` never
+        actually interpolates — a slow live ego then holds a neighbor for several steps and
+        jumps a whole 0.1 s of recorded motion at once (the visible jank). Projecting the
+        live ego onto the recorded ego polyline segment around ``target_idx`` yields a
+        sub-frame fraction, so ``rec_t`` advances smoothly and the neighbor interpolates."""
+        if live_xy is None:
+            return float(target_idx)
+        poses = self.tl.poses
+        n = len(poses)
+        live = np.asarray(live_xy, dtype=np.float64)[:2]
+        best, best_d = float(target_idx), float("inf")
+        for i in (int(target_idx) - 1, int(target_idx)):
+            if i < 0 or i + 1 >= n:
+                continue
+            a = poses[i, :2].astype(np.float64)
+            ab = poses[i + 1, :2].astype(np.float64) - a
+            l2 = float(ab @ ab)
+            if l2 < 1e-9:
+                continue
+            tc = min(max(float((live - a) @ ab / l2), 0.0), 1.0)
+            d = float(np.hypot(*(live - (a + tc * ab))))
+            if d < best_d:
+                best_d, best = d, i + tc
+        return best
+
+    def step(self, target_idx: int, live_xy=None) -> None:
+        """Advance ``rec_t`` toward the (fractional) cursor target (capped, never backward)
+        and push the current interpolated world pose of every present track into its rolling
+        history. ``live_xy`` enables the sub-frame fractional advance (smooth interpolation)."""
+        target = self._frac_target(target_idx, live_xy)
+        self.rec_t += min(max(target - self.rec_t, 0.0), self.max_adv)
         for u in self.interp:
             if not self._present(u, self.rec_t):
                 continue
@@ -929,7 +1003,7 @@ class SimNeighborTracker:
             if len(dq) > PAST:
                 del dq[0]
 
-    def build(self, live_pose: np.ndarray) -> np.ndarray:
+    def build(self, live_pose: np.ndarray) -> tuple[np.ndarray, list, dict]:
         """(1, 320, 31, 11) neighbor_agents_past in the live-ego frame, from shown history."""
         ex, ey, eyaw = float(live_pose[0]), float(live_pose[1]), float(live_pose[2])
         R = _rotation_matrix(eyaw)  # world delta -> ego frame (rotates by -eyaw)
@@ -942,7 +1016,11 @@ class SimNeighborTracker:
 
         present.sort(key=_cur_d2)  # nearest-first, mirroring the recorded slot order
         out = np.zeros((320, PAST, 11), dtype=np.float32)
+        slot_uuids: list[str] = []  # slot -> track UUID (for sim-future assembly across frames)
+        world_by_uuid: dict[str, tuple] = {}  # UUID -> current shown world pose (wx, wy, wh)
         for slot, u in enumerate(present[:320]):
+            slot_uuids.append(u)
+            world_by_uuid[u] = self.hist[u][-1]
             dq = self.hist[u]
             n = len(dq)
             poses = ([dq[0]] * (PAST - n)) + list(dq) if n < PAST else list(dq)
@@ -961,7 +1039,7 @@ class SimNeighborTracker:
             out[slot, :, 4] = ve[:, 0]
             out[slot, :, 5] = ve[:, 1]
             out[slot, :, 6:11] = self.attrs[u]
-        return out[None]
+        return out[None], slot_uuids, world_by_uuid
 
 
 def _polylines_from_tensor(t: np.ndarray, border_only: bool = False) -> list[np.ndarray]:
@@ -1087,7 +1165,7 @@ def render_segment(
         pre = _pre_step(s)
         if pre is None:
             break
-        np_dict, neighbors_live, idx = pre
+        np_dict, neighbors_live, idx, _suuid, _wbu = pre
         data = _to_torch_batch([np_dict], model_args, device)
         _, outputs = model(data)
         pred = outputs["prediction"][0, 0].cpu().numpy()
@@ -1232,6 +1310,8 @@ def run_segments_batched(
                                 npd_list[i] if npd_list is not None else None,
                                 nb_list[i],
                                 raw_payloads[i][4],  # idx
+                                raw_payloads[i][6],  # slot_uuids (sim mode; None otherwise)
+                                raw_payloads[i][7],  # world_by_uuid
                             )
                             for i, (s, _pre) in enumerate(live)
                         ]
@@ -1251,47 +1331,79 @@ def run_segments_batched(
                                 pool.submit(s.tl.prefetch, range(nxt, nxt + prefetch_ahead))
                         _, outputs = model(data)
                         preds = outputs["prediction"][:, 0].cpu().numpy()  # (B,80,4)
+                        # Model's predicted turn indicator per segment, decoded with the SAME
+                        # C++-style keep-bias logic as the perfect-tracker sim (reused helper),
+                        # then fed back into turn_hist below (closed-loop, no recorded leak).
+                        ti_pred = decode_turn_indicator(outputs["turn_indicator_logit"], 0.25)
                     # Score ALL segments in one batched OBB pass, then advance each.
                     with timers("score"):
                         score_list = score_step_batched(
                             [b[2] for b in built], [b[0].ego_shape for b in built], device
                         )
-                    for (s, _np, nb, idx), (cl, col, _M) in zip(built, score_list):
+                    for (s, _np, nb, idx, suuid, wbu), (cl, col, _M) in zip(built, score_list):
                         s.clearances[s.k] = cl
                         s.collisions[s.k] = col
                         # One-pass save: buffer this step, then dump the window on the
                         # FIRST collision — from THIS run, so the scenes match the hit.
                         if s.save_buf is not None:
-                            s.save_buf.append((s.k, idx, s.live_pose.copy(), _np))
-                            if (
-                                not s.saved_collision
-                                and save_thresh is not None
-                                and cl <= save_thresh
-                                and s.dyn.speed > save_min_ego_speed
-                            ):
-                                mani = _dump_precollision_window(
-                                    s.save_out_dir,
-                                    s.tl,
-                                    model_args,
-                                    s.k,
-                                    list(s.save_buf),
-                                    s.last_snap_step,
-                                    save_pre_steps,
-                                    save_thresh,
-                                    s.start,
-                                    s.end,
-                                    pre_arc_m=save_pre_arc_m,
-                                    max_scenes=save_max_scenes,
-                                    min_post_snap_frames=save_min_post_snap_frames,
-                                    min_pre_frames=save_min_pre_frames,
-                                )
-                                # Consume the segment's one save only on an ACTUAL write; a
-                                # snap-skipped hit stays open for a later, settled collision.
-                                if mani is not None:
-                                    s.saved_collision = True
-                    for i, (s, _np, nb, idx) in enumerate(built):
+                            s.save_buf.append((s.k, idx, s.live_pose.copy(), _np, suuid, wbu))
+                            # Per-EPISODE saving. A contact EPISODE runs while clearance <= thresh
+                            # and ends when it clears (> thresh) — so a NEW distinct collision needs
+                            # collided -> NOT collided -> collided (the clear gap). An episode is
+                            # ELIGIBLE only if its colliding vehicle's UUID differs from the last
+                            # SAVED collision's (a same-vehicle re-contact after a brief jitter-clear
+                            # is the SAME collision, not a new one; UUID can change for one physical
+                            # vehicle, so this is a heuristic). Within an eligible episode we retry
+                            # every step until the FIRST clean-start window saves (the contact onset
+                            # may have <80 clear steps before it, but a slightly-later step in the
+                            # same episode often has a clean 80-step approach), then stop for that
+                            # episode. The colliding (nearest) neighbor is slot 0 (build() sorts
+                            # nearest-first), so its UUID is suuid[0]. Each save -> its own per-
+                            # episode dir tagged by the save step. Gates (t0-clean / ego-moved /
+                            # min-pre-frames) still apply, and the UUID is only consumed on an ACTUAL
+                            # save (a dropped degenerate contact must not block a later savable one).
+                            in_contact = save_thresh is not None and cl <= save_thresh
+                            if not in_contact:
+                                s.in_episode = False  # episode ended; the next contact is new
+                            else:
+                                colliding_uuid = suuid[0] if suuid else None
+                                if not s.in_episode:  # entering contact from a clear -> new episode
+                                    s.in_episode = True
+                                    s.episode_saved = False
+                                    s.episode_eligible = (
+                                        colliding_uuid is None
+                                        or colliding_uuid != s.last_collision_uuid
+                                    )
+                                if s.episode_eligible and not s.episode_saved:
+                                    episode_dir = Path(f"{s.save_out_dir}_tc{s.k:05d}")
+                                    mani = _dump_precollision_window(
+                                        episode_dir,
+                                        s.tl,
+                                        model_args,
+                                        s.k,
+                                        list(s.save_buf),
+                                        s.last_snap_step,
+                                        save_pre_steps,
+                                        save_thresh,
+                                        s.start,
+                                        s.end,
+                                        pre_arc_m=save_pre_arc_m,
+                                        max_scenes=save_max_scenes,
+                                        min_post_snap_frames=save_min_post_snap_frames,
+                                        min_pre_frames=save_min_pre_frames,
+                                        min_ego_speed=save_min_ego_speed,
+                                    )
+                                    if mani is not None:
+                                        s.episode_saved = True
+                                        s.last_collision_uuid = colliding_uuid
+                    for i, (s, _np, nb, idx, _suuid, _wbu) in enumerate(built):
                         prev_snaps = s.n_snaps
                         _advance_step(s, preds[i], idx, device, timers)
+                        # Feed the model's predicted turn indicator back into the rolling
+                        # history (recorded seed scrolls out within PAST steps) — the saved
+                        # context then carries the sim's own signals, never the recorded ones.
+                        if s.turn_hist is not None:
+                            s.turn_hist = np.append(s.turn_hist[1:], np.int64(ti_pred[i]))
                         # Clear the buffer on an unstick teleport: pre-jump frames belong
                         # to a different ego path and must never enter a saved window.
                         if s.save_buf is not None and s.n_snaps > prev_snaps:
@@ -1461,6 +1573,7 @@ def _dump_precollision_window(
     max_scenes: int | None = None,
     min_post_snap_frames: int = 0,
     min_pre_frames: int = 30,
+    min_ego_speed: float = 0.5,
 ) -> dict | None:
     """Write the scenes before collision step ``t_c`` from a live buffer.
 
@@ -1503,7 +1616,6 @@ def _dump_precollision_window(
         )
         return None
 
-    out_dir.mkdir(parents=True, exist_ok=True)
     live_by_step = {rec[0]: rec for rec in buf}
     poses_by_step = {rec[0]: rec[2] for rec in buf}  # step k -> world pose (for ego_future)
     fut_len = int(model_args.future_len)
@@ -1521,6 +1633,40 @@ def _dump_precollision_window(
             f"(< {min_pre_frames}); not backfilling recorded frames"
         )
         return None
+    # t0-clean gate: a valid pre-collision scene must START clear of the neighbor and approach
+    # INTO contact. If the window's first frame is already within collision_thresh, the ego is
+    # already in/through the neighbor (it collided earlier, then crept while the position cursor
+    # barely advanced) — that's not a recoverable approach, so drop it (nothing to learn).
+    first_np = live_by_step[start_k][3]
+    nb0 = np.asarray(first_np["neighbor_agents_past"])[0, :, -1, :]
+    es0 = np.asarray(first_np["ego_shape"]).reshape(-1)[:3].astype(np.float32)
+    c0 = _min_clearance_any(nb0, es0, "cpu")
+    if c0 <= collision_thresh:
+        print(
+            f"  [save] SKIP collision@{t_c}: window starts already in contact "
+            f"(t0 clearance {c0:.2f}m <= {collision_thresh}m) — ego already through the neighbor"
+        )
+        return None
+    # ego-moved gate (replaces the instantaneous speed-at-contact gate): the EGO must have
+    # driven across the approach — total ego path over [start_k, t_c] > min_ego_speed * window
+    # seconds * 0.3. A model creeping into a car (~0.31 m/s -> ~2.5 m over 8 s) PASSES (it's a
+    # real avoidance failure); a stopped ego rear-ended by a moving neighbor (~0 m path) is
+    # DROPPED. Uses the realized live ego poses (poses_by_step), so it's a sim quantity.
+    ks = sorted(k for k in poses_by_step if start_k <= k <= t_c)
+    ego_arc = sum(
+        float(np.hypot(*(poses_by_step[ks[i + 1]][:2] - poses_by_step[ks[i]][:2])))
+        for i in range(len(ks) - 1)
+    )
+    min_arc = min_ego_speed * (n_pre * DT) * 0.3
+    if ego_arc < min_arc:
+        print(
+            f"  [save] SKIP collision@{t_c}: ego barely moved over the approach "
+            f"(arc {ego_arc:.2f}m < {min_arc:.2f}m) — stopped/rear-ended, not an ego-caused approach"
+        )
+        return None
+    # All gates passed — only NOW create the output dir, so rejected retries (t0-clean /
+    # ego-moved / too-short) never litter empty per-episode dirs.
+    out_dir.mkdir(parents=True, exist_ok=True)
     if start_k < t_c - pre_steps:
         print(
             f"  [save] window extended {t_c - pre_steps} -> {start_k} "
@@ -1543,7 +1689,7 @@ def _dump_precollision_window(
                 f"all-live pre-collision window expected step {step_k} in the live buffer "
                 f"[{start_k}, {t_c}] but it is absent (window-clamp / buffer regression)"
             )
-        _, idx, live_pose, np_dict = live_by_step[step_k]
+        _, idx, live_pose, np_dict, slot_uuids, _wbu = live_by_step[step_k]
         scene = _scene_npz_from_np_dict(np_dict)
         ep = scene["ego_agent_past"]
         scene["ego_agent_past"] = np.column_stack(
@@ -1551,11 +1697,44 @@ def _dump_precollision_window(
         ).astype(np.float32)
         g = scene["goal_pose"]
         scene["goal_pose"] = np.array([g[0], g[1], math.atan2(g[3], g[2])], dtype=np.float32)
-        with np.load(tl.npz_paths[idx], allow_pickle=True) as z:
-            naf = z["neighbor_agents_future"] if "neighbor_agents_future" in z.files else None
-        if naf is not None:
-            dx, dy, dyaw = _rel_pose(tl.poses[idx], live_pose)
-            scene["neighbor_agents_future"] = _recenter_neighbor_future(naf, dx, dy, dyaw)
+        # neighbor_agents_future: read out of the SIMULATION's own shown future (the realized
+        # neighbor world poses at the subsequent rollout steps), UUID-matched and slot-aligned
+        # with neighbor_agents_past, expressed in this frame's live-ego frame. This keeps the
+        # target consistent with the (sim) past — a held-static neighbor stays static instead
+        # of teleporting to its recorded log. Recorded mode (no tracker) keeps the recorded GT.
+        if slot_uuids is not None:
+            naf_sim = np.zeros((320, fut_len, 4), dtype=np.float32)
+            ex0, ey0, eh0 = float(live_pose[0]), float(live_pose[1]), float(live_pose[2])
+            R = _rotation_matrix(eh0)  # world delta -> live-ego frame (matches build())
+            uuid_slots = list(enumerate(slot_uuids[:320]))
+            for j in range(1, fut_len + 1):
+                fk = step_k + j
+                if fk > t_c or fk not in live_by_step:
+                    break  # rollout ended at contact; no shown future beyond t_c
+                wbu_fk = live_by_step[fk][5] or {}
+                slots, wx, wy, wh = [], [], [], []
+                for slot, u in uuid_slots:
+                    wp = wbu_fk.get(u)
+                    if wp is not None:
+                        slots.append(slot)
+                        wx.append(wp[0])
+                        wy.append(wp[1])
+                        wh.append(wp[2])
+                if not slots:
+                    continue
+                d = (np.column_stack([wx, wy]) - np.array([ex0, ey0])) @ R.T  # (m,2) ego xy
+                h = np.asarray(wh) - eh0
+                naf_sim[slots, j - 1, 0] = d[:, 0]
+                naf_sim[slots, j - 1, 1] = d[:, 1]
+                naf_sim[slots, j - 1, 2] = np.cos(h)
+                naf_sim[slots, j - 1, 3] = np.sin(h)
+            scene["neighbor_agents_future"] = naf_sim
+        else:
+            with np.load(tl.npz_paths[idx], allow_pickle=True) as z:
+                naf = z["neighbor_agents_future"] if "neighbor_agents_future" in z.files else None
+            if naf is not None:
+                dx, dy, dyaw = _rel_pose(tl.poses[idx], live_pose)
+                scene["neighbor_agents_future"] = _recenter_neighbor_future(naf, dx, dy, dyaw)
         eaf = np.zeros((fut_len, 4), dtype=np.float32)
         for j in range(1, fut_len + 1):
             fk = step_k + j
@@ -1667,12 +1846,14 @@ def extract_collision_scenes(
         pre = _pre_step(s)
         if pre is None:
             break
-        np_dict, neighbors_live, idx = pre
+        np_dict, neighbors_live, idx, _suuid, _wbu = pre
         data = _to_torch_batch([np_dict], model_args, device)
         _, outputs = model(data)
         pred = outputs["prediction"][0, 0].cpu().numpy()
         clr = _min_clearance_any(neighbors_live, s.ego_shape, device)
-        buf.append((k, idx, s.live_pose.copy(), np_dict))
+        # 6-tuple to match the batched buffer / _dump_precollision_window unpacking; this
+        # legacy extractor path is recorded-mode (no sim tracker) -> slot_uuids/world None.
+        buf.append((k, idx, s.live_pose.copy(), np_dict, None, None))
         if clr <= collision_thresh:
             t_c = k
             break

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -826,6 +826,8 @@ def _build_neighbor_interp(tl: RouteTimeline, lo: int, hi: int, eps: float = 0.1
             row = nb[slot]
             if np.abs(row[:6]).sum() == 0:
                 continue
+            if not ids[slot]:  # skip blank UUIDs so they don't merge into one bogus track
+                continue
             wx = pose[0] + row[0] * c - row[1] * s
             wy = pose[1] + row[0] * s + row[1] * c
             wh = math.atan2(row[3], row[2]) + pose[2]
@@ -912,6 +914,8 @@ def _build_nbr_world_tracks(tl: RouteTimeline, lo: int, hi: int, eps: float = 0.
             if np.abs(row[:6]).sum() == 0:
                 continue
             u = ids[slot]
+            if not u:  # skip blank UUIDs so they don't merge into one bogus track
+                continue
             wx = pose[0] + row[0] * c - row[1] * s
             wy = pose[1] + row[0] * s + row[1] * c
             wh = math.atan2(row[3], row[2]) + pose[2]

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -253,7 +253,8 @@ def _to_torch_batch_gpu(raw_payloads: list[tuple], model_args, device: str, want
 
     # Corrected neighbor context: replace the transformed recorded neighbor block with the
     # simulated (shown-motion) one, already built in the live-ego frame — matches the CPU
-    # override in _pre_step. p[5] is None in recorded mode (payload is a 5-tuple).
+    # override in _pre_step. The gpu _pre_step always returns an 8-tuple; p[5] (sim_nb) is
+    # None in recorded mode, so the length check is just defensive.
     if len(raw_payloads[0]) > 5 and raw_payloads[0][5] is not None:
         batch["neighbor_agents_past"] = torch.from_numpy(
             np.concatenate([p[5] for p in raw_payloads], axis=0).astype(np.float32)
@@ -334,22 +335,27 @@ def score_step_batched(
     neighbors_list: list[np.ndarray],
     ego_shapes: list[np.ndarray],
     device: str,
-) -> list[tuple[float, bool, int]]:
+) -> list[tuple[float, bool, int, int]]:
     """``score_step`` for many segments at once: ONE batched OBB pass over all pairs.
 
     The OBB primitives (``_closest_points_between_rects`` / ``batch_signed_distance_rect``)
     are per-pair independent, so we concatenate every segment's (ego, neighbor) box
     pairs into one big batch, run the geometry once, then slice the result back per
-    segment. Bit-identical to calling ``score_step`` per segment (no cross-segment
-    interaction), but collapses N tiny GPU launches per tick into one — including the
-    box construction: ONE host->device transfer + ONE ``center_rect_to_points`` for
-    every neighbor across all segments (ego corners built once when shapes match, else
-    per segment and repeat-interleaved). Returns a list aligned to the inputs:
-    (min_clearance, collision, n_valid_neighbors)."""
+    segment. The (min_clearance, collision, n_valid) values are bit-identical to calling
+    ``score_step`` per segment (no cross-segment interaction), but this collapses N tiny
+    GPU launches per tick into one — including the box construction: ONE host->device
+    transfer + ONE ``center_rect_to_points`` for every neighbor across all segments (ego
+    corners built once when shapes match, else per segment and repeat-interleaved).
+    Returns a list aligned to the inputs:
+    (min_clearance, collision, n_valid_neighbors, collider_slot), where ``collider_slot``
+    is the ORIGINAL neighbor index (same order as the input ``neighbors_list`` rows, i.e.
+    the build()/slot_uuids order) achieving ``min_clearance`` — or -1 when no valid
+    neighbor. Callers use it to identify the actually-colliding agent (the OBB-closest one,
+    which can differ from the centroid-nearest slot 0)."""
     valids = [np.abs(nb[:, :6]).sum(axis=1) > 0 for nb in neighbors_list]
     counts = [int(v.sum()) for v in valids]
     if sum(counts) == 0:
-        return [(float("inf"), False, 0) for _ in neighbors_list]
+        return [(float("inf"), False, 0, -1) for _ in neighbors_list]
 
     # All valid neighbors across all segments -> one transfer -> one corner build.
     nb_all = np.concatenate(
@@ -391,17 +397,22 @@ def score_step_batched(
     p1, p2 = _closest_points_between_rects(ego_all, npc_all)
     clr_all = (p1 - p2).norm(dim=-1)  # (K,)
     signed_all = batch_signed_distance_rect(ego_all, npc_all)  # (K,)
-    out: list[tuple[float, bool, int]] = []
+    out: list[tuple[float, bool, int, int]] = []
     off = 0
-    for m in counts:
+    for seg_i, m in enumerate(counts):
         if m == 0:
-            out.append((float("inf"), False, 0))
+            out.append((float("inf"), False, 0, -1))
         else:
+            seg_clr = clr_all[off : off + m]
+            amin = int(seg_clr.argmin().item())  # index within this segment's VALID subset
+            # Map the valid-subset argmin back to the original neighbor slot (build() order).
+            collider_slot = int(np.flatnonzero(valids[seg_i])[amin])
             out.append(
                 (
-                    float(clr_all[off : off + m].min()),
+                    float(seg_clr.min()),
                     bool((signed_all[off : off + m] < 0).any()),
                     m,
+                    collider_slot,
                 )
             )
             off += m
@@ -540,7 +551,15 @@ def _seed_state(
         live_pose=live_pose,
         ego_hist=ego_hist,
         dyn=dyn,
-        turn_hist=np.asarray(tl.npz(start)["turn_indicators"]).reshape(-1).astype(np.int64),
+        # Closed-loop turn indicators are a SIM-mode feature: seed from the recorded frame,
+        # then feed the model's own prediction back each step (phasing the seed out). In
+        # recorded mode turn_hist stays None so the recorded turn_indicators flow through
+        # unchanged (the _pre_step override is gated on `turn_hist is not None`).
+        turn_hist=(
+            np.asarray(tl.npz(start)["turn_indicators"]).reshape(-1).astype(np.int64)
+            if neighbor_history_mode == "sim"
+            else None
+        ),
         ego_shape=np.asarray(tl.npz(start)["ego_shape"]).reshape(-1)[:3].astype(np.float32),
         goal_xy=tl.poses[end - 1, :2],
         clearances=np.full(cap, np.inf, dtype=np.float32),
@@ -602,6 +621,19 @@ def _pre_step(s: _SegState, gpu_transform: bool = False):
     if s.turn_hist is not None:
         np_dict["turn_indicators"] = s.turn_hist[None].astype(np.int64)  # closed-loop, not recorded
     return np_dict, neighbors_live, idx, slot_uuids, world_by_uuid
+
+
+def _feed_turn_indicator(s: _SegState, outputs) -> None:
+    """Closed-loop turn-signal feedback for the single-segment rollout paths.
+
+    Appends the model's predicted turn indicator to ``turn_hist`` (recorded seed scrolls
+    out within PAST steps). No-op in recorded mode (``turn_hist`` is None there). Mirrors
+    the per-batch feedback in ``run_segments_batched`` so every sim-mode rollout — batched
+    or single-segment — evolves the turn signal identically instead of holding the seed."""
+    if s.turn_hist is None:
+        return
+    ti = decode_turn_indicator(outputs["turn_indicator_logit"], 0.25)
+    s.turn_hist = np.append(s.turn_hist[1:], np.int64(np.asarray(ti).reshape(-1)[0]))
 
 
 def _score_into(s: _SegState, neighbors_live, device, timers):
@@ -759,6 +791,7 @@ def run_segment(
         with timers("model_forward"):
             _, outputs = model(data)
             pred = outputs["prediction"][0, 0].cpu().numpy()
+        _feed_turn_indicator(s, outputs)  # closed-loop turn signal (sim mode)
         _post_step(s, pred, neighbors_live, idx, device, timers)
     return _finalize(s, timers)
 
@@ -1176,6 +1209,7 @@ def render_segment(
         data = _to_torch_batch([np_dict], model_args, device)
         _, outputs = model(data)
         pred = outputs["prediction"][0, 0].cpu().numpy()
+        _feed_turn_indicator(s, outputs)  # closed-loop turn signal (sim mode)
         nids = tl.neighbor_ids(idx) if (color_by_uuid or interpolate) else None
         if interpolate and nids and interp:
             _apply_neighbor_interp(np_dict, nids, s.live_pose, idx, interp)
@@ -1341,13 +1375,21 @@ def run_segments_batched(
                         # Model's predicted turn indicator per segment, decoded with the SAME
                         # C++-style keep-bias logic as the perfect-tracker sim (reused helper),
                         # then fed back into turn_hist below (closed-loop, no recorded leak).
-                        ti_pred = decode_turn_indicator(outputs["turn_indicator_logit"], 0.25)
+                        # Only sim-mode segments carry turn_hist; skip the decode (a GPU->CPU
+                        # sync) entirely when none do (e.g. recorded mode).
+                        ti_pred = (
+                            decode_turn_indicator(outputs["turn_indicator_logit"], 0.25)
+                            if any(st.turn_hist is not None for st, *_ in built)
+                            else None
+                        )
                     # Score ALL segments in one batched OBB pass, then advance each.
                     with timers("score"):
                         score_list = score_step_batched(
                             [b[2] for b in built], [b[0].ego_shape for b in built], device
                         )
-                    for (s, _np, nb, idx, suuid, wbu), (cl, col, _M) in zip(built, score_list):
+                    for (s, _np, nb, idx, suuid, wbu), (cl, col, _M, collider_slot) in zip(
+                        built, score_list
+                    ):
                         s.clearances[s.k] = cl
                         s.collisions[s.k] = col
                         # One-pass save: buffer this step, then dump the window on the
@@ -1364,16 +1406,22 @@ def run_segments_batched(
                             # every step until the FIRST clean-start window saves (the contact onset
                             # may have <80 clear steps before it, but a slightly-later step in the
                             # same episode often has a clean 80-step approach), then stop for that
-                            # episode. The colliding (nearest) neighbor is slot 0 (build() sorts
-                            # nearest-first), so its UUID is suuid[0]. Each save -> its own per-
-                            # episode dir tagged by the save step. Gates (t0-clean / ego-moved /
-                            # min-pre-frames) still apply, and the UUID is only consumed on an ACTUAL
-                            # save (a dropped degenerate contact must not block a later savable one).
+                            # episode. The colliding vehicle is the OBB-CLOSEST neighbor at contact
+                            # (score_step_batched returns its slot, which can differ from the
+                            # centroid-nearest slot 0 for long/rotated boxes), so its UUID is
+                            # suuid[collider_slot]. Each save -> its own per-episode dir tagged by
+                            # the save step. Gates (t0-clean / ego-moved / min-pre-frames) still
+                            # apply, and the UUID is only consumed on an ACTUAL save (a dropped
+                            # degenerate contact must not block a later savable one).
                             in_contact = save_thresh is not None and cl <= save_thresh
                             if not in_contact:
                                 s.in_episode = False  # episode ended; the next contact is new
                             else:
-                                colliding_uuid = suuid[0] if suuid else None
+                                colliding_uuid = (
+                                    suuid[collider_slot]
+                                    if (suuid and 0 <= collider_slot < len(suuid))
+                                    else None
+                                )
                                 if not s.in_episode:  # entering contact from a clear -> new episode
                                     s.in_episode = True
                                     s.episode_saved = False
@@ -1421,7 +1469,7 @@ def run_segments_batched(
                         # Feed the model's predicted turn indicator back into the rolling
                         # history (recorded seed scrolls out within PAST steps) — the saved
                         # context then carries the sim's own signals, never the recorded ones.
-                        if s.turn_hist is not None:
+                        if s.turn_hist is not None and ti_pred is not None:
                             s.turn_hist = np.append(s.turn_hist[1:], np.int64(ti_pred[i]))
                         # Clear the buffer on an unstick teleport: pre-jump frames belong
                         # to a different ego path and must never enter a saved window.
@@ -1869,6 +1917,7 @@ def extract_collision_scenes(
         data = _to_torch_batch([np_dict], model_args, device)
         _, outputs = model(data)
         pred = outputs["prediction"][0, 0].cpu().numpy()
+        _feed_turn_indicator(s, outputs)  # closed-loop turn signal (sim mode)
         clr = _min_clearance_any(neighbors_live, s.ego_shape, device)
         # 6-tuple to match the batched buffer / _dump_precollision_window unpacking; this
         # legacy extractor path is recorded-mode (no sim tracker) -> slot_uuids/world None.

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -1339,9 +1339,12 @@ def run_segments_batched(
                     # Per-episode dirs are tagged by save step (..._tc#####), so a re-mine that
                     # lands collisions at different steps would otherwise leave the previous run's
                     # dirs behind and the extract step would ingest superseded scenes. Clear this
-                    # segment's stale episode dirs up front so each run starts clean.
-                    for stale in Path(save_dir).glob(f"{key}_{s.start}_{s.end}_tc*"):
-                        shutil.rmtree(stale, ignore_errors=True)
+                    # segment's stale episode dirs up front so each run starts clean. Match by
+                    # literal prefix (not glob) so a metacharacter in the route key can't mis-match.
+                    stale_prefix = f"{key}_{s.start}_{s.end}_tc"
+                    for stale in Path(save_dir).iterdir():
+                        if stale.is_dir() and stale.name.startswith(stale_prefix):
+                            shutil.rmtree(stale, ignore_errors=True)
             active = list(states)
             while active:
                 with timers("input_build"):

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -1015,30 +1015,37 @@ class SimNeighborTracker:
             return float(d[0] * d[0] + d[1] * d[1])
 
         present.sort(key=_cur_d2)  # nearest-first, mirroring the recorded slot order
+        present = present[:320]
         out = np.zeros((320, PAST, 11), dtype=np.float32)
-        slot_uuids: list[str] = []  # slot -> track UUID (for sim-future assembly across frames)
-        world_by_uuid: dict[str, tuple] = {}  # UUID -> current shown world pose (wx, wy, wh)
-        for slot, u in enumerate(present[:320]):
-            slot_uuids.append(u)
-            world_by_uuid[u] = self.hist[u][-1]
-            dq = self.hist[u]
-            n = len(dq)
-            poses = ([dq[0]] * (PAST - n)) + list(dq) if n < PAST else list(dq)
-            world = np.asarray(poses, dtype=np.float64)  # (PAST, 3) wx, wy, wh
-            d = (world[:, :2] - np.array([ex, ey])) @ R.T  # (PAST, 2) ego-frame xy
-            lh = world[:, 2] - eyaw
-            out[slot, :, 0] = d[:, 0]
-            out[slot, :, 1] = d[:, 1]
-            out[slot, :, 2] = np.cos(lh)
-            out[slot, :, 3] = np.sin(lh)
-            vw = np.zeros((PAST, 2))
+        slot_uuids = list(present)  # slot -> track UUID (for sim-future assembly across frames)
+        world_by_uuid = {u: self.hist[u][-1] for u in present}  # UUID -> current shown world pose
+        m = len(present)
+        if m:
+            # Stack all present tracks' padded (PAST,3) world histories into (M,PAST,3) and do
+            # the world->ego transform ONCE (vectorized), instead of a per-slot Python loop +
+            # per-slot matmul (this loop was a chunk of input_build). Front-pad short histories
+            # with their oldest pose (same as the old per-slot path).
+            world = np.empty((m, PAST, 3), dtype=np.float64)
+            for i, u in enumerate(present):
+                dq = self.hist[u]
+                n = len(dq)
+                world[i] = np.asarray(
+                    ([dq[0]] * (PAST - n)) + list(dq) if n < PAST else dq, np.float64
+                )
+            d = (world[:, :, :2] - np.array([ex, ey])) @ R.T  # (M,PAST,2) ego-frame xy
+            lh = world[:, :, 2] - eyaw  # (M,PAST)
+            vw = np.zeros((m, PAST, 2))
             if PAST > 1:
-                vw[1:] = np.diff(world[:, :2], axis=0) / DT
-                vw[0] = vw[1]
-            ve = vw @ R.T  # world velocity -> ego frame
-            out[slot, :, 4] = ve[:, 0]
-            out[slot, :, 5] = ve[:, 1]
-            out[slot, :, 6:11] = self.attrs[u]
+                vw[:, 1:] = np.diff(world[:, :, :2], axis=1) / DT
+                vw[:, 0] = vw[:, 1]
+            ve = vw @ R.T  # world velocity -> ego frame (M,PAST,2)
+            out[:m, :, 0] = d[:, :, 0]
+            out[:m, :, 1] = d[:, :, 1]
+            out[:m, :, 2] = np.cos(lh)
+            out[:m, :, 3] = np.sin(lh)
+            out[:m, :, 4] = ve[:, :, 0]
+            out[:m, :, 5] = ve[:, :, 1]
+            out[:m, :, 6:11] = np.stack([self.attrs[u] for u in present])[:, None, :]
         return out[None], slot_uuids, world_by_uuid
 
 

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -1341,10 +1341,14 @@ def run_segments_batched(
                     # dirs behind and the extract step would ingest superseded scenes. Clear this
                     # segment's stale episode dirs up front so each run starts clean. Match by
                     # literal prefix (not glob) so a metacharacter in the route key can't mis-match.
+                    # save_dir may not exist yet on the first run (window dirs are created lazily
+                    # only after gating), so guard the scan — nothing to clean if it's absent.
+                    save_root = Path(save_dir)
                     stale_prefix = f"{key}_{s.start}_{s.end}_tc"
-                    for stale in Path(save_dir).iterdir():
-                        if stale.is_dir() and stale.name.startswith(stale_prefix):
-                            shutil.rmtree(stale, ignore_errors=True)
+                    if save_root.is_dir():
+                        for stale in save_root.iterdir():
+                            if stale.is_dir() and stale.name.startswith(stale_prefix):
+                                shutil.rmtree(stale, ignore_errors=True)
             active = list(states)
             while active:
                 with timers("input_build"):

--- a/scenario_generation/route_timeline.py
+++ b/scenario_generation/route_timeline.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import json
 import re
+import threading
 from collections import OrderedDict
 from pathlib import Path
 
@@ -175,6 +176,11 @@ class RouteTimeline:
         # frames is plenty; evicting the rest keeps per-route RAM ~<1GB so many routes can batch.
         self._npz_cache: OrderedDict[int, dict[str, np.ndarray]] = OrderedDict()
         self._npz_cache_max = 768
+        # The cache is read by the build threads (pool.map(_pre_step)) AND mutated by the
+        # background prefetch threads concurrently, all sharing one timeline. OrderedDict's
+        # move_to_end / popitem are not mutually atomic, so a get()+touch can race an evicting
+        # popitem (KeyError on the touch / corrupted link order). Guard every cache access.
+        self._cache_lock = threading.Lock()
 
     def _compute_speeds(self, base_dt: float = 0.1) -> np.ndarray:
         n = len(self.npz_paths)
@@ -207,17 +213,22 @@ class RouteTimeline:
 
     def npz(self, idx: int) -> dict[str, np.ndarray]:
         """Lazy-load + cache the model-input arrays for recorded frame ``idx``."""
-        cached = self._npz_cache.get(idx)
-        if cached is not None:
-            self._npz_cache.move_to_end(idx)  # LRU touch
-            return cached
+        with self._cache_lock:
+            cached = self._npz_cache.get(idx)
+            if cached is not None:
+                self._npz_cache.move_to_end(idx)  # LRU touch
+                return cached
+        # Decompress OUTSIDE the lock (the expensive part) so concurrent build threads
+        # don't serialize on np.load; a rare double-decompress of the same idx is benign.
         with self.timers("timeline_load_npz"):
             with np.load(self.npz_paths[idx], allow_pickle=True) as z:
                 # Only decompress the keys we need (skip GT futures) — lazy npz access.
                 data = {k: z[k] for k in _NEEDED_KEYS if k in z.files}
-        self._npz_cache[idx] = data
-        if len(self._npz_cache) > self._npz_cache_max:
-            self._npz_cache.popitem(last=False)  # evict least-recently-used
+        with self._cache_lock:
+            self._npz_cache[idx] = data
+            self._npz_cache.move_to_end(idx)  # mark MRU even if another thread inserted it
+            while len(self._npz_cache) > self._npz_cache_max:
+                self._npz_cache.popitem(last=False)  # evict least-recently-used
         return data
 
     def neighbor_last(self, idx: int) -> np.ndarray:
@@ -236,10 +247,11 @@ class RouteTimeline:
 
         Called from a background thread while the GPU runs the model forward, so the
         next rollout tick's input build hits the cache instead of paying the np.load
-        decompress on the critical path. ``npz`` already caches; loading an
-        already-cached or out-of-range frame is a benign no-op (double-decompress at
-        worst, same value), so this is safe to call concurrently with the build
-        threads."""
+        decompress on the critical path. ``npz`` is internally locked, so this is safe
+        to call concurrently with the build threads; loading an already-cached or
+        out-of-range frame is a benign no-op (a rare double-decompress at worst, same
+        value). The ``in`` check is a best-effort skip — ``npz`` re-checks under the
+        lock, so a race here only risks a redundant (idempotent) decompress."""
         n = len(self.npz_paths)
         for i in indices:
             if 0 <= i < n and i not in self._npz_cache:

--- a/scenario_generation/route_timeline.py
+++ b/scenario_generation/route_timeline.py
@@ -220,6 +220,17 @@ class RouteTimeline:
             self._npz_cache.popitem(last=False)  # evict least-recently-used
         return data
 
+    def neighbor_last(self, idx: int) -> np.ndarray:
+        """Load ONLY ``neighbor_agents_past[:, -1]`` (current neighbor row, (320, 11)) for a frame.
+
+        The sim-mode track-build scans EVERY frame of the route and needs only this slice — not
+        the lanes/routes/polygons/etc. that ``npz()`` decompresses. ``np.load`` is lazy per-key,
+        so reading just this one key is ~10x cheaper per frame (it dominated timeline_load_npz).
+        Not cached: the track-build touches each frame once."""
+        with self.timers("timeline_load_npz"):
+            with np.load(self.npz_paths[idx], allow_pickle=True) as z:
+                return z["neighbor_agents_past"][:, -1]
+
     def prefetch(self, indices) -> None:
         """Decompress + cache the given recorded frames if not already cached.
 

--- a/scenario_generation/route_timeline.py
+++ b/scenario_generation/route_timeline.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import json
 import re
+from collections import OrderedDict
 from pathlib import Path
 
 import numpy as np
@@ -167,7 +168,13 @@ class RouteTimeline:
         # frames don't inflate the speed. Used by the cursor's speed-gap guard.
         self.speeds = self._compute_speeds()
 
-        self._npz_cache: dict[int, dict[str, np.ndarray]] = {}
+        # BOUNDED LRU cache of decompressed frames. Unbounded caching loaded the WHOLE route
+        # into RAM (~1.5MB/frame x 18k frames ~= 27GB on the big route), which capped mining to
+        # one route at a time and OOM'd any cross-route batch. The rollout only touches a sliding
+        # window (cursor + prefetch_ahead) and the track-build scans sequentially, so a few hundred
+        # frames is plenty; evicting the rest keeps per-route RAM ~<1GB so many routes can batch.
+        self._npz_cache: OrderedDict[int, dict[str, np.ndarray]] = OrderedDict()
+        self._npz_cache_max = 768
 
     def _compute_speeds(self, base_dt: float = 0.1) -> np.ndarray:
         n = len(self.npz_paths)
@@ -202,12 +209,15 @@ class RouteTimeline:
         """Lazy-load + cache the model-input arrays for recorded frame ``idx``."""
         cached = self._npz_cache.get(idx)
         if cached is not None:
+            self._npz_cache.move_to_end(idx)  # LRU touch
             return cached
         with self.timers("timeline_load_npz"):
             with np.load(self.npz_paths[idx], allow_pickle=True) as z:
                 # Only decompress the keys we need (skip GT futures) — lazy npz access.
                 data = {k: z[k] for k in _NEEDED_KEYS if k in z.files}
         self._npz_cache[idx] = data
+        if len(self._npz_cache) > self._npz_cache_max:
+            self._npz_cache.popitem(last=False)  # evict least-recently-used
         return data
 
     def prefetch(self, indices) -> None:

--- a/scenario_generation/route_timeline.py
+++ b/scenario_generation/route_timeline.py
@@ -247,14 +247,13 @@ class RouteTimeline:
 
         Called from a background thread while the GPU runs the model forward, so the
         next rollout tick's input build hits the cache instead of paying the np.load
-        decompress on the critical path. ``npz`` is internally locked, so this is safe
-        to call concurrently with the build threads; loading an already-cached or
-        out-of-range frame is a benign no-op (a rare double-decompress at worst, same
-        value). The ``in`` check is a best-effort skip — ``npz`` re-checks under the
-        lock, so a race here only risks a redundant (idempotent) decompress."""
+        decompress on the critical path. Delegates straight to ``npz`` (which does the
+        cached-check, insert and eviction under ``_cache_lock``) — no unlocked cache read
+        here — so it's safe to call concurrently with the build threads; an already-cached
+        frame is a cheap locked hit and an out-of-range index is skipped."""
         n = len(self.npz_paths)
         for i in indices:
-            if 0 <= i < n and i not in self._npz_cache:
+            if 0 <= i < n:
                 self.npz(i)
 
     def pose(self, idx: int) -> np.ndarray:

--- a/scenario_generation/simulate.py
+++ b/scenario_generation/simulate.py
@@ -577,6 +577,19 @@ def _predict_as_ego(
 
 
 @torch.no_grad()
+def decode_turn_indicator(ti_logit, keep_bias: float = 0.25):
+    """Model ``turn_indicator_logit`` -> class id(s), C++ ``TurnIndicatorManager`` style.
+
+    Subtracts ``keep_bias`` (0.25 = the cpp planner's value) from the KEEP (class 4) logit
+    before argmax, then returns the argmax over the last dim as a numpy array. Shared by
+    ``_predict_batch`` (perfect-tracker sim) and the perception reproducer so both decode the
+    closed-loop turn signal identically. Classes: 0 NONE / 1 DISABLE / 2 LEFT / 3 RIGHT / 4 KEEP."""
+    biased = ti_logit.clone()
+    if keep_bias != 0.0 and biased.shape[-1] > 4:
+        biased[..., 4] -= keep_bias
+    return biased.argmax(dim=-1).cpu().numpy()
+
+
 def _predict_batch(
     model,
     model_args,
@@ -639,10 +652,7 @@ def _predict_batch(
         ti_logit = outputs.get("turn_indicator_logit")
         ti = {}
         if ti_logit is not None:
-            biased = ti_logit[0].clone()
-            if turn_indicator_keep_bias != 0.0 and biased.shape[-1] > 4:
-                biased[..., 4] -= turn_indicator_keep_bias
-            ti[agent_ids[0]] = int(biased.argmax(dim=-1).cpu().item())
+            ti[agent_ids[0]] = int(decode_turn_indicator(ti_logit[0], turn_indicator_keep_bias))
         return preds, ti
 
     batched = _cat_tensor_dicts(tensor_dicts)
@@ -654,10 +664,7 @@ def _predict_batch(
     ti_logit = outputs.get("turn_indicator_logit")
     ti: dict[str, int] = {}
     if ti_logit is not None:
-        biased = ti_logit.clone()
-        if turn_indicator_keep_bias != 0.0 and biased.shape[-1] > 4:
-            biased[..., 4] -= turn_indicator_keep_bias
-        ti_cls = biased.argmax(dim=-1).cpu().numpy()
+        ti_cls = decode_turn_indicator(ti_logit, turn_indicator_keep_bias)
         for i, aid in enumerate(agent_ids):
             ti[aid] = int(ti_cls[i])
     return preds, ti

--- a/scenario_generation/tests/test_reproducer_collision_scope.py
+++ b/scenario_generation/tests/test_reproducer_collision_scope.py
@@ -86,6 +86,9 @@ def test_batched_scorer_matches_per_segment():
         single = [score_step(nb, sh, 5.0, "cpu") for nb, sh in zip(segs, shapes)]
         batched = score_step_batched(segs, shapes, "cpu")
         for a, b in zip(single, batched):
-            # Same ops in the same order -> exact equality, not just close ("bit-identical").
+            # score_step returns a 3-tuple (min_clearance, collision, n_valid); score_step_batched
+            # intentionally returns a 4-tuple that appends collider_slot — its first three elements
+            # are bit-identical to score_step (same ops, same order), the 4th is extra.
+            assert len(a) == 3 and len(b) == 4
             assert a[0] == b[0] or (a[0] != a[0] and b[0] != b[0])  # equal, or both NaN/inf
             assert a[1] == b[1] and a[2] == b[2]

--- a/scenario_generation/tests/test_reproducer_sim_neighbor.py
+++ b/scenario_generation/tests/test_reproducer_sim_neighbor.py
@@ -13,12 +13,12 @@ import json
 import numpy as np
 import torch
 
-from scenario_generation.reproducer_rollout import (
-    SimNeighborTracker,
-    _build_nbr_world_tracks,
-    decode_turn_indicator,
-)
+from scenario_generation.reproducer_rollout import SimNeighborTracker, _build_nbr_world_tracks
 from scenario_generation.route_timeline import RouteTimeline
+
+# decode_turn_indicator is defined in simulate.py (shared by _predict_batch + the reproducer);
+# import it from there so these tests unambiguously cover that canonical implementation.
+from scenario_generation.simulate import decode_turn_indicator
 
 EGO_SHAPE = np.array([4.76, 7.24, 2.29], dtype=np.float32)
 N_FRAMES = 40

--- a/scenario_generation/tests/test_reproducer_sim_neighbor.py
+++ b/scenario_generation/tests/test_reproducer_sim_neighbor.py
@@ -1,0 +1,107 @@
+"""Unit tests for the simulated neighbor-history mode + the shared turn-indicator decode.
+
+Covers the invariants Copilot flagged on PR #164:
+  - ``decode_turn_indicator`` KEEP-bias behavior + scalar/batched shapes.
+  - ``SimNeighborTracker`` derives neighbor velocity from the SHOWN motion, not the recorded
+    velocity field: a neighbor whose position is held constant reads v approx 0 even when its
+    recorded velocity column says it is moving fast (the phantom-collision the sim mode fixes),
+    while a neighbor whose shown position advances reads a real, non-zero velocity.
+"""
+
+import json
+
+import numpy as np
+import torch
+
+from scenario_generation.reproducer_rollout import SimNeighborTracker, decode_turn_indicator
+from scenario_generation.route_timeline import RouteTimeline
+
+EGO_SHAPE = np.array([4.76, 7.24, 2.29], dtype=np.float32)
+N_FRAMES = 40
+FROZEN = "frozen-uuid"
+MOVER = "mover-uuid"
+MOVER_STEP_M = 0.5  # shown +x per frame (0.1 s) -> ~5 m/s in the rebuilt history
+
+
+def _nbr_row(x, y, recorded_vx):
+    """One neighbor_agents_past row: [x, y, cos, sin, vx, vy, width, length, veh, ped, bike].
+
+    ``recorded_vx`` is the (ignored-by-sim-mode) recorded velocity column — set it large for the
+    frozen track to prove the tracker does NOT read it.
+    """
+    return np.array([x, y, 1.0, 0.0, recorded_vx, 0.0, 2.0, 4.5, 1.0, 0.0, 0.0], dtype=np.float32)
+
+
+def _make_neighbor_route(tmp_path):
+    """Ego static at the origin (yaw 0, so ego-frame == world); two tracked neighbors:
+
+    slot 0 FROZEN — constant ego-frame position but a big fake recorded velocity (11 m/s);
+    slot 1 MOVER  — ego-frame x advances ``MOVER_STEP_M``/frame, recorded velocity column 0.
+    """
+    paths = []
+    for i in range(N_FRAMES):
+        nb = np.zeros((320, 31, 11), dtype=np.float32)
+        frozen_row = _nbr_row(10.0, 0.0, recorded_vx=11.0)  # held still, "moving" per recorded vx
+        mover_row = _nbr_row(10.0 + MOVER_STEP_M * i, 3.0, recorded_vx=0.0)  # moves, recorded vx 0
+        nb[0, :, :] = (
+            frozen_row  # whole 31-step history is the current row (neighbor_last = [:,-1])
+        )
+        nb[1, :, :] = mover_row
+        p = tmp_path / f"route_{i:010d}.npz"
+        np.savez_compressed(
+            p,
+            neighbor_agents_past=nb,
+            ego_agent_past=np.zeros((31, 3), dtype=np.float32),
+            ego_shape=EGO_SHAPE,
+        )
+        sidecar = {
+            "timestamp": float(i),
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0,
+            "qx": 0.0,
+            "qy": 0.0,
+            "qz": 0.0,
+            "qw": 1.0,
+            "neighbor_ids": [FROZEN, MOVER] + [""] * 318,
+        }
+        (tmp_path / f"route_{i:010d}.json").write_text(json.dumps(sidecar))
+        paths.append(p)
+    return RouteTimeline(paths)
+
+
+def test_decode_turn_indicator_keep_bias():
+    # KEEP (class 4) wins the raw argmax (1.0) but loses to class 2 (0.9) after the 0.25 bias.
+    logit = torch.tensor([0.0, 0.0, 0.9, 0.0, 1.0])
+    assert int(decode_turn_indicator(logit, keep_bias=0.0)) == 4  # no bias -> KEEP
+    assert int(decode_turn_indicator(logit, keep_bias=0.25)) == 2  # 0.9 > 1.0 - 0.25
+
+
+def test_decode_turn_indicator_batched_shape():
+    # Row 0: KEEP survives the bias (1.0 - 0.25 = 0.75 > 0). Row 1: class 2 dominates.
+    batch = torch.tensor([[0.0, 0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 5.0, 0.0, 1.0]])
+    out = decode_turn_indicator(batch, keep_bias=0.25)
+    assert out.shape == (2,)
+    assert out.tolist() == [4, 2]
+
+
+def test_sim_neighbor_velocity_from_shown_motion(tmp_path):
+    tl = _make_neighbor_route(tmp_path)
+    trk = SimNeighborTracker(tl, start=5, max_rec_advance=1.0)
+    ego = np.array([0.0, 0.0, 0.0])  # static ego at origin
+    for t in range(6, 20):
+        trk.step(t, ego[:2])
+    out, slot_uuids, _ = trk.build(ego)  # (1, 320, PAST, 11)
+
+    assert FROZEN in slot_uuids and MOVER in slot_uuids
+    nb = out[0]
+    fi, mi = slot_uuids.index(FROZEN), slot_uuids.index(MOVER)
+    # Velocity is rebuilt from the SHOWN positions (cols 4,5), regardless of the recorded vx.
+    frozen_v = float(np.linalg.norm(nb[fi, -1, 4:6]))
+    mover_v = float(np.linalg.norm(nb[mi, -1, 4:6]))
+    assert frozen_v < 0.3, (
+        f"held-still neighbor must read ~0 velocity (got {frozen_v}) despite recorded vx=11"
+    )
+    assert mover_v > 1.0, f"moving neighbor must read its shown velocity (got {mover_v})"
+    # And the held-still neighbor's shown position stayed put.
+    assert abs(float(nb[fi, -1, 0]) - 10.0) < 0.5 and abs(float(nb[fi, -1, 1])) < 0.5

--- a/scenario_generation/tests/test_reproducer_sim_neighbor.py
+++ b/scenario_generation/tests/test_reproducer_sim_neighbor.py
@@ -13,7 +13,11 @@ import json
 import numpy as np
 import torch
 
-from scenario_generation.reproducer_rollout import SimNeighborTracker, decode_turn_indicator
+from scenario_generation.reproducer_rollout import (
+    SimNeighborTracker,
+    _build_nbr_world_tracks,
+    decode_turn_indicator,
+)
 from scenario_generation.route_timeline import RouteTimeline
 
 EGO_SHAPE = np.array([4.76, 7.24, 2.29], dtype=np.float32)
@@ -105,3 +109,44 @@ def test_sim_neighbor_velocity_from_shown_motion(tmp_path):
     assert mover_v > 1.0, f"moving neighbor must read its shown velocity (got {mover_v})"
     # And the held-still neighbor's shown position stayed put.
     assert abs(float(nb[fi, -1, 0]) - 10.0) < 0.5 and abs(float(nb[fi, -1, 1])) < 0.5
+
+
+def test_sim_neighbor_keeps_single_frame_track(tmp_path):
+    """A neighbor present in only ONE recorded frame must still be tracked (kept as a constant,
+    v~0) instead of dropped, so step 0 reproduces the recorded context."""
+    blip = "blip-uuid"
+    blip_frame = 3
+    paths = []
+    for i in range(6):
+        nb = np.zeros((320, 31, 11), dtype=np.float32)
+        ids = [""] * 320
+        if i == blip_frame:  # the neighbor appears in exactly one frame
+            nb[0, :, :] = _nbr_row(8.0, 1.0, recorded_vx=0.0)
+            ids[0] = blip
+        p = tmp_path / f"r_{i:010d}.npz"
+        np.savez_compressed(
+            p,
+            neighbor_agents_past=nb,
+            ego_agent_past=np.zeros((31, 3), dtype=np.float32),
+            ego_shape=EGO_SHAPE,
+        )
+        (tmp_path / f"r_{i:010d}.json").write_text(
+            json.dumps(
+                {
+                    "timestamp": float(i),
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0,
+                    "qx": 0.0,
+                    "qy": 0.0,
+                    "qz": 0.0,
+                    "qw": 1.0,
+                    "neighbor_ids": ids,
+                }
+            )
+        )
+        paths.append(p)
+    tl = RouteTimeline(paths)
+    interp, _attrs, span = _build_nbr_world_tracks(tl, 0, len(tl))
+    assert blip in interp, "single-frame neighbor was dropped (should be kept as a constant track)"
+    assert span[blip] == (blip_frame, blip_frame)


### PR DESCRIPTION
## Summary

Adds a **simulated neighbor-history mode** to the perception reproducer (closed-loop collision mining) and makes the C++ converter populate `neighbor_ids` in the per-frame JSON sidecar so the reproducer can key neighbors by track UUID.

### Why
The reproducer drives ego closed-loop in a perfect tracker while replaying recorded neighbors via a position-keyed cursor. In the original **recorded** mode, each cursor frame copies that frame's own 31-step neighbor history verbatim — so a cursor-frozen moving agent still reads its *recorded* velocity while held in place, producing phantom collisions. Sim mode rebuilds neighbor history from the actually-shown motion.

### Changes
**`scenario_generation/` (reproducer):**
- `--neighbor_history_mode {recorded,sim}` (recorded = unchanged default).
- **`SimNeighborTracker`**: follows each neighbor by track UUID, advances a continuous recorded-time cursor toward the position-keyed target (one timeline sample per 0.1 s, interpolating between anchors), and rebuilds `neighbor_agents_past` from the rolling shown motion — velocity is the finite difference of shown positions, so a frozen neighbor reads ~0 and a moving one reads its true speed. Step 0 is seeded from recorded history, then phases out.
- Saved windows get **sim-rebuilt 4-col `neighbor_agents_future`** (UUID-matched, slot-aligned) and **closed-loop turn indicators** (model-predicted, decoded via the shared `simulate.decode_turn_indicator`), not recorded GT.
- Episode-based saving: one window per *distinct* collision (clear → contact rising edge with a different colliding UUID), with t0-clean and ego-moved gates.
- Perf: bounded LRU npz cache, single-key neighbor-track loads, and a vectorized per-step neighbor-context build (numerically identical to the prior per-slot loop).

**`cpp_tools/` (converter sidecar):**
- `frame_processor` now passes the resolved `neighbor_result.neighbor_ids` (slot-aligned to `neighbor_agents_past`) to `save_frame_json` — previously it fell back to the empty default, so sidecars carried no UUIDs. Default argument removed to fail loud; test updated.

### Testing
- The simulated-neighbor mining path was run at corpus scale (the full collision-mining campaign) on an earlier revision of these changes. The rebase onto `tier4-main` and every subsequent review fix (round-1/2 + Copilot) were then verified by closed-loop smoke mining runs in both `sim` and `recorded` modes plus the unit tests (`test_reproducer_sim_neighbor`, `test_reproducer_collision_scope`, ...). A full corpus re-mine was not repeated on the final revision.
- **C++ change built + unit-tested** under the pilot-auto.x2 autoware underlay: `data_converter` and `test_frame_writer` build clean and the `BuildFrameJsonTest` gtest (now asserting the populated `neighbor_ids`) passes. (The package-level `colcon build` also builds `benchmark_tool`/`inference_tool`, which fail against my local underlay due to pre-existing single-step-inference API drift — unrelated to the converter/sidecar path this PR touches.)
