### PR TITLE
chore: add CMAKE_EXPORT_COMPILE_COMMANDS option to build script

### DIFF
--- a/cpp_tools/build.sh
+++ b/cpp_tools/build.sh
@@ -5,7 +5,7 @@ cd $(dirname $0)
 
 if [[ "${1:-}" == "--test" ]]; then
   echo "[INFO] Build and run unit tests with colcon test"
-  colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to autoware_diffusion_planner_tools
+  colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=1 --packages-up-to autoware_diffusion_planner_tools
   colcon test --packages-select autoware_diffusion_planner_tools
   colcon test-result --all
   exit 0
@@ -15,4 +15,6 @@ colcon build \
   --symlink-install \
   --cmake-args \
   -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_EXPORT_COMPILE_COMMANDS=1 \
+  -DBUILD_TESTING=0 \
   --packages-up-to autoware_diffusion_planner_tools


### PR DESCRIPTION
This pull request updates the `cpp_tools/build.sh` script to enhance the build process by exporting compile commands and disabling test builds in non-test scenarios. These changes improve developer tooling integration and build efficiency.
