### PR TITLE
Use OBB clearance for TTC scoring

### DIFF
--- a/planner_metrics/aggregate.py
+++ b/planner_metrics/aggregate.py
@@ -137,9 +137,10 @@ def compute_subscores_batch(
         time_weight_min=config.centerline_time_weight_min,
     )
     red_light_scores = compute_red_light_score_batch(ego_trajs, data, config)
-    ttc_scores = compute_ttc_score_batch(
+    ttc_result = compute_ttc_score_batch(
         ego_trajs, ego_shape, neighbor_futures, neighbor_shapes, neighbor_valid
     )
+    ttc_scores = ttc_result["score"]
     (
         rb_crossing_gate,
         rb_near_pen,
@@ -198,6 +199,10 @@ def compute_subscores_batch(
         # raw subscores (signs as produced by the subscore functions)
         "safety": safety_scores,
         "ttc": ttc_scores,
+        "ttc_unsafe_at_t": ttc_result["unsafe_at_t"],
+        "ttc_first_unsafe_steps": ttc_result["first_unsafe_steps"],
+        "ttc_first_collision_steps": ttc_result["first_collision_steps"],
+        "ttc_min_clearance": ttc_result["min_clearance"],
         "progress": progress_scores,
         "comfort": smoothness_scores,
         "feasibility": feasibility_scores,

--- a/planner_metrics/subscores.py
+++ b/planner_metrics/subscores.py
@@ -223,58 +223,82 @@ def compute_ttc_score_batch(
     neighbor_futures: torch.Tensor,
     neighbor_shapes: torch.Tensor,
     neighbor_valid: torch.Tensor,
-) -> torch.Tensor:
+) -> dict[str, torch.Tensor | list[int | None]]:
     """Check if ego would collide with NPCs within TTC_HORIZON seconds.
 
-    For each trajectory timestep, extrapolates ego and NPC positions forward
-    by TTC_HORIZON using current velocity. If the extrapolated positions would
-    collide (using simplified distance check), the timestep is marked unsafe.
+    For each trajectory timestep, looks forward over the time-aligned ego/NPC
+    future poses and uses the same OBB signed-clearance primitive as moving
+    collision scoring. If any OBB overlap occurs within the horizon, that base
+    timestep is marked unsafe.
 
     Returns:
-        (N,) score: fraction of timesteps that are TTC-safe (1.0 = all safe).
+        dict with:
+          score: (N,) fraction of timesteps that are TTC-safe (1.0 = all safe).
+          unsafe_at_t: (N, T) bool, base timestep has a collision within horizon.
+          first_unsafe_steps: list[N] earliest unsafe base timestep.
+          first_collision_steps: list[N] earliest actual OBB collision timestep.
+          min_clearance: (N, T) min OBB clearance within the horizon at each base timestep.
     """
     N, T, _ = ego_trajs.shape
     device = ego_trajs.device
     N_nb = neighbor_futures.shape[0]
 
-    if N_nb == 0 or T < 3:
-        return torch.ones(N, device=device)
+    def _safe_empty() -> dict[str, torch.Tensor | list[int | None]]:
+        return {
+            "score": torch.ones(N, device=device),
+            "unsafe_at_t": torch.zeros(N, T, dtype=torch.bool, device=device),
+            "first_unsafe_steps": [None] * N,
+            "first_collision_steps": [None] * N,
+            "min_clearance": torch.full((N, T), 99.0, device=device),
+        }
 
-    # Ego velocity at each timestep
-    ego_vel = (ego_trajs[:, 1:, :2] - ego_trajs[:, :-1, :2]) / _TTC_DT  # (N, T-1, 2)
-    # Pad to match T
-    ego_vel = torch.cat([ego_vel, ego_vel[:, -1:]], dim=1)  # (N, T, 2)
+    if N_nb == 0 or T == 0:
+        return _safe_empty()
 
-    # NPC velocity
-    npc_vel = (
-        neighbor_futures[:, 1:, :2] - neighbor_futures[:, :-1, :2]
-    ) / _TTC_DT  # (N_nb, T-1, 2)
-    npc_vel = torch.cat([npc_vel, npc_vel[:, -1:]], dim=1)  # (N_nb, T, 2)
+    distances = compute_ego_neighbor_signed_clearance(
+        ego_trajs,
+        ego_shape,
+        neighbor_futures,
+        neighbor_shapes,
+        neighbor_valid,
+    )  # (N, N_nb, T)
+    collision_at_t = (distances < 0).any(dim=1)  # (N, T)
+    min_dist_at_t = distances.min(dim=1).values  # (N, T)
 
-    # Extrapolate positions TTC_HORIZON seconds ahead
-    n_steps = int(_TTC_HORIZON / _TTC_DT)
-    ego_future_pos = ego_trajs[:, :, :2] + ego_vel * _TTC_HORIZON  # (N, T, 2)
-    npc_future_pos = neighbor_futures[:, :, :2] + npc_vel * _TTC_HORIZON  # (N_nb, T, 2)
-
-    # Simple distance check between ego future and NPC future positions
-    # Use center-to-center distance with safety margin (half ego length + half NPC length)
-    ego_half_len = float(ego_shape[1]) / 2 + 0.5  # + 0.5m margin
-    npc_half_lens = neighbor_shapes[:, 1] / 2 + 0.5  # (N_nb,)
-
-    # Distance: (N, N_nb, T)
-    diff = ego_future_pos.unsqueeze(1) - npc_future_pos.unsqueeze(0)  # (N, N_nb, T, 2)
-    dist = diff.norm(dim=-1)  # (N, N_nb, T)
-
-    # Collision threshold per NPC
-    threshold = (ego_half_len + npc_half_lens).unsqueeze(0).unsqueeze(-1)  # (1, N_nb, 1)
-
-    # Mask invalid NPCs
-    ttc_collision = (dist < threshold) & neighbor_valid.unsqueeze(0)  # (N, N_nb, T)
-    ttc_unsafe_at_t = ttc_collision.any(dim=1)  # (N, T) — unsafe if ANY NPC collision predicted
+    horizon_steps = max(0, int(round(_TTC_HORIZON / _TTC_DT)))
+    ttc_unsafe_at_t = torch.zeros(N, T, dtype=torch.bool, device=device)
+    ttc_min_clearance = torch.full((N, T), float("inf"), device=device)
+    for offset in range(horizon_steps + 1):
+        if offset >= T:
+            break
+        ttc_unsafe_at_t[:, : T - offset] |= collision_at_t[:, offset:]
+        ttc_min_clearance[:, : T - offset] = torch.minimum(
+            ttc_min_clearance[:, : T - offset],
+            min_dist_at_t[:, offset:],
+        )
+    ttc_min_clearance = ttc_min_clearance.masked_fill(torch.isinf(ttc_min_clearance), 99.0)
 
     # Score: fraction of safe timesteps
     ttc_score = 1.0 - ttc_unsafe_at_t.float().mean(dim=1)  # (N,)
-    return ttc_score
+
+    has_unsafe = ttc_unsafe_at_t.any(dim=1)
+    first_unsafe_t = ttc_unsafe_at_t.float().argmax(dim=1)
+    has_collision = collision_at_t.any(dim=1)
+    first_collision_t = collision_at_t.float().argmax(dim=1)
+
+    first_unsafe_steps: list[int | None] = []
+    first_collision_steps: list[int | None] = []
+    for i in range(N):
+        first_unsafe_steps.append(int(first_unsafe_t[i].item()) if has_unsafe[i] else None)
+        first_collision_steps.append(int(first_collision_t[i].item()) if has_collision[i] else None)
+
+    return {
+        "score": ttc_score,
+        "unsafe_at_t": ttc_unsafe_at_t,
+        "first_unsafe_steps": first_unsafe_steps,
+        "first_collision_steps": first_collision_steps,
+        "min_clearance": ttc_min_clearance,
+    }
 
 
 def compute_feasibility_score_batch(

--- a/rlvr/reward_golden.json
+++ b/rlvr/reward_golden.json
@@ -343,7 +343,7 @@
       "sc_wide_penalty": 0.012658228166401386,
       "smoothness": -3.0790055461693555e-05,
       "static_crossing": false,
-      "total": 80.32427215576172
+      "total": 82.69927215576172
     }
   ],
   "static_collision_overlap": [
@@ -449,7 +449,7 @@
       "sc_wide_penalty": 0.0,
       "smoothness": -3.0790055461693555e-05,
       "static_crossing": false,
-      "total": -49.07343673706055
+      "total": -49.07500076293945
     }
   ],
   "underprogress_baseline": [

--- a/rlvr/test_static_collision.py
+++ b/rlvr/test_static_collision.py
@@ -23,6 +23,8 @@ from rlvr.reward import (
     compute_reward_batch,
     compute_safety_score_batch,
     compute_static_collision_penalty,
+    compute_subscores_batch,
+    compute_ttc_score_batch,
 )
 
 T = 80
@@ -173,6 +175,98 @@ def test_moving_and_stopped_wrappers_share_constant_neighbor_clearance():
     )
     assert collision_steps == [None]
     assert safety_scores[0].item() == pytest.approx(-(1.0 - expected_clearance), abs=1e-4)
+
+
+def test_ttc_uses_obb_clearance_not_center_distance():
+    ego = _square_ego((0.0, 0.0), steps=T)
+    nf, ns, nv = _square_neighbor((0.0, 3.0), steps=T)
+
+    ttc = compute_ttc_score_batch(ego, _square_ego_shape(), nf, ns, nv)
+
+    assert ttc["score"][0].item() == pytest.approx(1.0, abs=1e-6)
+    assert ttc["first_unsafe_steps"] == [None]
+    assert ttc["first_collision_steps"] == [None]
+    assert ttc["min_clearance"][0, 0].item() == pytest.approx(1.0, abs=1e-4)
+
+
+def test_ttc_reports_first_unsafe_and_collision_steps():
+    ego = _square_ego((1.0, 0.0), steps=T)
+    nf, ns, nv = _square_neighbor((100.0, 0.0), steps=T)
+    nf[0, 30, 0] = 1.0
+    nf[0, 30, 1] = 0.0
+
+    ttc = compute_ttc_score_batch(ego, _square_ego_shape(), nf, ns, nv)
+
+    assert ttc["first_collision_steps"] == [30]
+    assert ttc["first_unsafe_steps"] == [20]
+    assert ttc["score"][0].item() == pytest.approx(69.0 / 80.0, abs=1e-6)
+
+    data = {
+        "neighbor_agents_future": nf,
+        "neighbor_agents_past": torch.zeros(1, 1, 21, 11),
+        "ego_shape": _square_ego_shape().unsqueeze(0),
+    }
+    data["neighbor_agents_past"][0, 0, -1, 6] = ns[0, 0]
+    data["neighbor_agents_past"][0, 0, -1, 7] = ns[0, 1]
+    subs = compute_subscores_batch(ego, data, RewardConfig())
+    assert subs["ttc_first_collision_steps"] == [30]
+    assert subs["ttc_first_unsafe_steps"] == [20]
+
+
+def test_ttc_ignores_invalid_neighbor_overlap_timestep():
+    ego = _square_ego((1.0, 0.0), steps=T)
+    nf, ns, nv = _square_neighbor((100.0, 0.0), steps=T)
+    nf[0, 30, 0] = 1.0
+    nf[0, 30, 1] = 0.0
+    nv[0, 30] = False
+
+    ttc = compute_ttc_score_batch(ego, _square_ego_shape(), nf, ns, nv)
+
+    assert ttc["score"][0].item() == pytest.approx(1.0, abs=1e-6)
+    assert ttc["first_unsafe_steps"] == [None]
+    assert ttc["first_collision_steps"] == [None]
+
+
+def test_ttc_multiple_neighbors_uses_earliest_collision():
+    ego = _square_ego((1.0, 0.0), steps=T)
+    nf_clean, ns_clean, nv_clean = _square_neighbor((1.0, 4.0), steps=T)
+    nf_late, ns_late, nv_late = _square_neighbor((100.0, 0.0), steps=T)
+    nf_early, ns_early, nv_early = _square_neighbor((100.0, 0.0), steps=T)
+    nf_late[0, 40, 0] = 1.0
+    nf_late[0, 40, 1] = 0.0
+    nf_early[0, 25, 0] = 1.0
+    nf_early[0, 25, 1] = 0.0
+    nf = torch.cat([nf_clean, nf_late, nf_early], dim=0)
+    ns = torch.cat([ns_clean, ns_late, ns_early], dim=0)
+    nv = torch.cat([nv_clean, nv_late, nv_early], dim=0)
+
+    ttc = compute_ttc_score_batch(ego, _square_ego_shape(), nf, ns, nv)
+
+    assert ttc["first_collision_steps"] == [25]
+    assert ttc["first_unsafe_steps"] == [15]
+    assert ttc["score"][0].item() == pytest.approx(58.0 / 80.0, abs=1e-6)
+
+
+def test_ttc_unsafe_mask_matches_obb_overlap_horizon():
+    ego = _square_ego((1.0, 0.0), steps=T)
+    nf, ns, nv = _square_neighbor((100.0, 0.0), steps=T)
+    nf[0, 12, 0] = 1.0
+    nf[0, 12, 1] = 0.0
+    nf[0, 35, 0] = 1.0
+    nf[0, 35, 1] = 0.0
+
+    distances = compute_ego_neighbor_signed_clearance(ego, _square_ego_shape(), nf, ns, nv)
+    collision_at_t = (distances < 0).any(dim=1)
+    expected = torch.zeros(1, T, dtype=torch.bool)
+    horizon_steps = 10
+    for offset in range(horizon_steps + 1):
+        expected[:, : T - offset] |= collision_at_t[:, offset:]
+
+    ttc = compute_ttc_score_batch(ego, _square_ego_shape(), nf, ns, nv)
+
+    assert torch.equal(ttc["unsafe_at_t"], expected)
+    assert ttc["first_collision_steps"] == [12]
+    assert ttc["first_unsafe_steps"] == [2]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- replace TTC center-distance approximation with the shared ego-neighbor OBB signed-clearance primitive
- expose TTC diagnostics from compute_subscores_batch: unsafe mask, first unsafe step, first collision step, and min clearance
- add synthetic TTC tests for invalid timestep masking, multiple neighbors, horizon mask equivalence, and center-distance false positives

## Comparisons

<img width="2240" height="928" alt="static_collision_near_proper_ab_t30" src="https://github.com/user-attachments/assets/b417e83d-c346-41cc-8675-1ce2d475425b" />
<img width="2240" height="928" alt="survival_mode_collision_proper_ab_t0" src="https://github.com/user-attachments/assets/e16e6dfe-5469-4536-bf2d-af4a27102ec4" />

## Tests
- .venv/bin/python -m pytest rlvr/test_static_collision.py -q
- .venv/bin/python -m pytest rlvr/test_reward_golden.py rlvr/test_subscores_parity.py rlvr/test_reward.py -q
- uvx pre-commit run --files rlvr/test_static_collision.py

Related issue: #172