### PR TITLE
Fix ego history transform during augmentation

### DIFF
--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -392,21 +392,16 @@ class StatePerturbation:
         ego_future[..., 2] = heading_transform(ego_future[..., 2], transform_matrix)
 
         # ego past
-        # inputs["ego_agent_past"][..., :2] = vector_transform(
-        #     inputs["ego_agent_past"][..., :2], transform_matrix, center_xy
-        # )
-        # inputs["ego_agent_past"][..., 2:4] = vector_transform(
-        #     inputs["ego_agent_past"][..., 2:4], transform_matrix
-        # )
-
-        ego_past4d = torch.cat(
-            [
-                inputs["ego_agent_past"][..., :2],  # x, y
-                torch.cos(inputs["ego_agent_past"][..., 2:3]),  # cos
-                torch.sin(inputs["ego_agent_past"][..., 2:3]),  # sin
-            ],
-            dim=-1,
+        ego_past_mask = torch.sum(torch.ne(inputs["ego_agent_past"][..., :4], 0), dim=-1) == 0
+        inputs["ego_agent_past"][..., :2] = vector_transform(
+            inputs["ego_agent_past"][..., :2], transform_matrix, center_xy
         )
+        inputs["ego_agent_past"][..., 2:4] = vector_transform(
+            inputs["ego_agent_past"][..., 2:4], transform_matrix
+        )
+        inputs["ego_agent_past"][ego_past_mask] = 0.0
+
+        ego_past4d = inputs["ego_agent_past"]
         ego_future4d = torch.cat(
             [
                 ego_future[..., :2],  # x, y


### PR DESCRIPTION
## Summary

Fixes #190.

This PR makes data augmentation transform `ego_agent_past` into the same augmented ego-centric frame as ego current state, ego future, neighbors, and map features.

## Root cause

The augmentation path transformed the rest of the scene but left the ego history transform commented out. That could mix ego history in the original coordinate frame with future/context tensors in the augmented frame.

## Changes

- Apply the augmentation translation/rotation to `ego_agent_past[..., :2]`.
- Rotate `ego_agent_past[..., 2:4]` consistently as a cos/sin heading vector.
- Preserve padded ego-history rows as all-zero after the transform.
- Use the already-4D ego history directly for smoothing instead of converting cos/sin again.

## Validation

- `uv run --group dev pre-commit run --files diffusion_planner/diffusion_planner/utils/data_augmentation.py`
