### PR TITLE
Use masked mean for scene encoding pooling

### DIFF
--- a/diffusion_planner/diffusion_planner/model/module/decoder.py
+++ b/diffusion_planner/diffusion_planner/model/module/decoder.py
@@ -600,8 +600,10 @@ class Decoder(nn.Module):
         B, P, _ = current_states.shape
         assert P == (1 + self._predicted_neighbor_num)
 
-        # Pool encoding to get a fixed-size representation
-        encoding_pooled = torch.mean(encoding, dim=1)  # [B, D]
+        # Pool only valid encoder tokens. The encoder zero-fills masked tokens.
+        encoding_valid = torch.any(encoding != 0, dim=-1)  # [B, N]
+        encoding_count = encoding_valid.sum(dim=1).clamp_min(1).unsqueeze(-1)
+        encoding_pooled = (encoding * encoding_valid.unsqueeze(-1)).sum(dim=1) / encoding_count
 
         # Dispatch to training or inference
         if self.training:


### PR DESCRIPTION
## Summary

Fixes #187.

This PR changes pooled scene encoding from a plain mean over all fixed token slots to a masked mean over non-zero encoder outputs.

## Root cause

The encoder zero-fills invalid/padded tokens, but the decoder pooled all token slots with `torch.mean(encoding, dim=1)`. Increasing the number of neighbor slots can therefore dilute the pooled representation even when the actual scene content is unchanged.

## Changes

- Derive valid encoder tokens from non-zero encoder outputs.
- Sum only valid tokens.
- Divide by the valid token count with a safe `clamp_min(1)` denominator.
- Keep the decoder API unchanged.

## Validation

- `uv run --group dev pre-commit run --files diffusion_planner/diffusion_planner/model/module/decoder.py`
