### PR TITLE
Fix ego history double conversion during augmentation

### DIFF
--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -399,14 +399,7 @@ class StatePerturbation:
         #     inputs["ego_agent_past"][..., 2:4], transform_matrix
         # )
 
-        ego_past4d = torch.cat(
-            [
-                inputs["ego_agent_past"][..., :2],  # x, y
-                torch.cos(inputs["ego_agent_past"][..., 2:3]),  # cos
-                torch.sin(inputs["ego_agent_past"][..., 2:3]),  # sin
-            ],
-            dim=-1,
-        )
+        ego_past4d = inputs["ego_agent_past"]
         ego_future4d = torch.cat(
             [
                 ego_future[..., :2],  # x, y


### PR DESCRIPTION
## Summary

Related to #190.

This PR fixes a double conversion bug in the augmentation path for `ego_agent_past`.

It intentionally keeps the existing no-transform / local-history behavior for `ego_agent_past`. In the blue-vs-green discussion, this PR does not choose the green rigid-transform behavior. That should be handled separately as an augmentation-design decision or ablation.

## Root cause

The training path converts `ego_agent_past` before augmentation:

```python
inputs["ego_agent_past"] = heading_to_cos_sin(inputs["ego_agent_past"])
```

Therefore, inside `StatePerturbation`, `ego_agent_past` is already expected to be `[x, y, cos(heading), sin(heading)]`.

The previous augmentation code rebuilt `ego_past4d` by applying `cos()` / `sin()` again to `inputs["ego_agent_past"][..., 2]`. Since that channel is already `cos(heading)`, this effectively produced `cos(cos(heading))` / `sin(cos(heading))` before `smoothing_future_trajectory()`.

## Changes

- Use the already-converted 4D `ego_agent_past` directly for future smoothing.
- Keep the current blue-line / local-history augmentation behavior unchanged.
- Do not add the green-line rigid transform behavior in this PR.

## Validation

- `uv run --group dev pre-commit run --files diffusion_planner/diffusion_planner/utils/data_augmentation.py`
