### PR TITLE
Refine red-light-run skipping with configurable thresholds

### DIFF
--- a/cpp_tools/src/autoware_diffusion_planner_tools/README.md
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/README.md
@@ -123,6 +123,8 @@ Both converter commands accept these options:
 | `--collision_time_stride N` | Time stride for trajectory collision filters | `5` |
 | `--offlane_max_score M` | Off-lane filter maximum average distance from lane centerlines | `6.0` |
 | `--offlane_time_stride N` | Time stride for the off-lane filter | `1` |
+| `--red_light_run_radius_m M` | Maximum distance from a stop-line crossing to a heading-aligned red route-lane entry | `5.0` |
+| `--red_light_run_heading_tol_deg D` | Maximum heading difference used to match the ego's own red route lane | `30.0` |
 | `--write_skipped_npz 0/1` | Also write `.npz` files for skipped frames | `0` |
 
 ## Per-frame JSON sidecar (data converter)

--- a/cpp_tools/src/autoware_diffusion_planner_tools/README.md
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/README.md
@@ -123,8 +123,8 @@ Both converter commands accept these options:
 | `--collision_time_stride N` | Time stride for trajectory collision filters | `5` |
 | `--offlane_max_score M` | Off-lane filter maximum average distance from lane centerlines | `6.0` |
 | `--offlane_time_stride N` | Time stride for the off-lane filter | `1` |
-| `--red_light_run_radius_m M` | Maximum distance from a stop-line crossing to a heading-aligned red route-lane entry | `5.0` |
-| `--red_light_run_heading_tol_deg D` | Maximum heading difference used to match the ego's own red route lane | `30.0` |
+| `--red_light_run_radius_m M` | Maximum distance from a stop-line crossing to a heading-aligned red route-lane entry | `12.0` |
+| `--red_light_run_heading_tol_deg D` | Maximum heading difference used to match the ego's own red route lane | `45.0` |
 | `--write_skipped_npz 0/1` | Also write `.npz` files for skipped frames | `0` |
 
 ## Per-frame JSON sidecar (data converter)

--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/cli/converter_options.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/cli/converter_options.hpp
@@ -54,6 +54,11 @@ struct ConverterOptions
   float offlane_max_score;
   int64_t offlane_time_stride;
 
+  // Red-light-run filter. A frame is skipped only when the ego future crosses a
+  // stop line near the entry point of a heading-aligned red route lane.
+  float red_light_run_radius_m;
+  float red_light_run_heading_tol_deg;
+
   // When true, also write the npz for frame-level skipped frames (collision,
   // off-lane, red/yellow light, vehicle stopped) so they can be visualised with
   // their skip reason. Intended for inspection/testing only; off in production.

--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/processing/frame_filters.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/processing/frame_filters.hpp
@@ -234,37 +234,55 @@ inline bool check_neighbor_collision(
   return false;
 }
 
-inline bool check_road_border_collision(
-  const std::vector<Corners> & ego, const std::vector<float> & line_strings, float margin)
+inline std::vector<std::array<float, 4>> collect_line_string_segments(
+  const std::vector<float> & line_strings, const int64_t type_channel)
 {
   using autoware::diffusion_planner::LINE_STRING_TYPE_NUM;
   using autoware::diffusion_planner::NUM_LINE_STRINGS;
   using autoware::diffusion_planner::POINTS_PER_LINE_STRING;
-  const int64_t dim = 2 + LINE_STRING_TYPE_NUM;  // per-point channels: [x, y, type0, type1]
+
+  const int64_t dim = 2 + LINE_STRING_TYPE_NUM;  // per-point channels: [x, y, type0, type1, ...]
   const int64_t pts = POINTS_PER_LINE_STRING;
-  constexpr int64_t border_channel = 3;  // channel 3 > 0.5 marks a road border
 
   std::vector<std::array<float, 4>> segments;  // {ax, ay, bx, by}
+
   for (int64_t n = 0; n < NUM_LINE_STRINGS; ++n) {
     const float * base = &line_strings[n * pts * dim];
-    bool is_border = false;
+
+    bool is_target_type = false;
     for (int64_t p = 0; p < pts; ++p) {
-      if (base[p * dim + border_channel] > 0.5f) {
-        is_border = true;
+      if (base[p * dim + type_channel] > 0.5f) {
+        is_target_type = true;
         break;
       }
     }
-    if (!is_border) continue;
+
+    if (!is_target_type) continue;
+
     for (int64_t p = 0; p + 1 < pts; ++p) {
       const float ax = base[p * dim + 0];
       const float ay = base[p * dim + 1];
       const float bx = base[(p + 1) * dim + 0];
       const float by = base[(p + 1) * dim + 1];
+
       const bool va = std::fabs(ax) + std::fabs(ay) > 1e-6f;
       const bool vb = std::fabs(bx) + std::fabs(by) > 1e-6f;
-      if (va && vb) segments.push_back({ax, ay, bx, by});
+
+      if (va && vb) {
+        segments.push_back({ax, ay, bx, by});
+      }
     }
   }
+
+  return segments;
+}
+
+inline bool check_road_border_collision(
+  const std::vector<Corners> & ego, const std::vector<float> & line_strings, float margin)
+{
+  constexpr int64_t border_channel = 3;  // channel 3 > 0.5 marks a road border
+  const auto segments = collect_line_string_segments(line_strings, border_channel);
+
   if (segments.empty()) return false;
 
   // 1) any ego corner within `margin` of a border segment
@@ -370,11 +388,8 @@ inline bool detect_red_light_run(
   const std::vector<float> & ego_future, const std::vector<float> & route_lanes,
   const std::vector<float> & line_strings, float red_radius_m, float head_tol_deg)
 {
-  using autoware::diffusion_planner::LINE_STRING_TYPE_NUM;
-  using autoware::diffusion_planner::NUM_LINE_STRINGS;
   using autoware::diffusion_planner::NUM_SEGMENTS_IN_ROUTE;
   using autoware::diffusion_planner::OUTPUT_T;
-  using autoware::diffusion_planner::POINTS_PER_LINE_STRING;
   using autoware::diffusion_planner::POINTS_PER_SEGMENT;
   using autoware::diffusion_planner::POSE_DIM;
   using autoware::diffusion_planner::SEGMENT_POINT_DIM;
@@ -382,22 +397,31 @@ inline bool detect_red_light_run(
   using autoware::diffusion_planner::TRAFFIC_LIGHT_ONE_HOT_DIM;
   using autoware::diffusion_planner::TRAFFIC_LIGHT_RED;
 
-  std::vector<std::array<float, 2>> ego_xy;
-  ego_xy.reserve(OUTPUT_T);
+  std::vector<std::array<float, 4>> ego_states;
+  ego_states.reserve(OUTPUT_T);
+
   for (int64_t i = 0; i < OUTPUT_T; ++i) {
     const float x = ego_future[i * POSE_DIM + 0];
     const float y = ego_future[i * POSE_DIM + 1];
+    const float cos_h = ego_future[i * POSE_DIM + 2];
+    const float sin_h = ego_future[i * POSE_DIM + 3];
+
     if (std::fabs(x) <= 1e-6f && std::fabs(y) <= 1e-6f) continue;
-    ego_xy.push_back({x, y});
+
+    ego_states.push_back({x, y, cos_h, sin_h});
   }
-  if (ego_xy.size() < 2) return false;
 
-  const auto & ego_first = ego_xy.front();
-  const auto & ego_last = ego_xy.back();
-  const float ego_heading_deg = std::atan2(ego_last[1] - ego_first[1], ego_last[0] - ego_first[0]) *
-                                180.0f / static_cast<float>(M_PI);
+  if (ego_states.size() < 2) return false;
 
-  std::vector<std::array<float, 2>> red_entries;
+  struct RedLaneEntry
+  {
+    float x;
+    float y;
+    float heading_deg;
+  };
+
+  std::vector<RedLaneEntry> red_entries;
+
   red_entries.reserve(NUM_SEGMENTS_IN_ROUTE);
   for (int64_t seg = 0; seg < NUM_SEGMENTS_IN_ROUTE; ++seg) {
     const float * segment = &route_lanes[seg * POINTS_PER_SEGMENT * SEGMENT_POINT_DIM];
@@ -426,43 +450,28 @@ inline bool detect_red_light_run(
     const float * end = &segment[last_valid * SEGMENT_POINT_DIM];
     const float lane_heading_deg =
       std::atan2(end[1] - entry[1], end[0] - entry[0]) * 180.0f / static_cast<float>(M_PI);
-    if (heading_diff_deg(lane_heading_deg, ego_heading_deg) < head_tol_deg) {
-      red_entries.push_back({entry[0], entry[1]});
-    }
+    red_entries.push_back({entry[0], entry[1], lane_heading_deg});
   }
   if (red_entries.empty()) return false;
 
-  const int64_t ls_dim = 2 + LINE_STRING_TYPE_NUM;
   const int64_t stop_channel = 2 + autoware::diffusion_planner::LINE_STRING_TYPE_STOP_LINE;
-  std::vector<std::array<float, 4>> stop_segments;
-  for (int64_t n = 0; n < NUM_LINE_STRINGS; ++n) {
-    const float * base = &line_strings[n * POINTS_PER_LINE_STRING * ls_dim];
-    bool is_stop_line = false;
-    for (int64_t p = 0; p < POINTS_PER_LINE_STRING; ++p) {
-      if (base[p * ls_dim + stop_channel] > 0.5f) {
-        is_stop_line = true;
-        break;
-      }
-    }
-    if (!is_stop_line) continue;
-    for (int64_t p = 0; p + 1 < POINTS_PER_LINE_STRING; ++p) {
-      const float ax = base[p * ls_dim + 0];
-      const float ay = base[p * ls_dim + 1];
-      const float bx = base[(p + 1) * ls_dim + 0];
-      const float by = base[(p + 1) * ls_dim + 1];
-      const bool va = std::fabs(ax) + std::fabs(ay) > 1e-6f;
-      const bool vb = std::fabs(bx) + std::fabs(by) > 1e-6f;
-      if (va && vb) stop_segments.push_back({ax, ay, bx, by});
-    }
-  }
+  const auto stop_segments = collect_line_string_segments(line_strings, stop_channel);
+
   if (stop_segments.empty()) return false;
 
   const float radius_sq = red_radius_m * red_radius_m;
-  for (size_t i = 0; i + 1 < ego_xy.size(); ++i) {
-    const float p1x = ego_xy[i][0];
-    const float p1y = ego_xy[i][1];
-    const float p2x = ego_xy[i + 1][0];
-    const float p2y = ego_xy[i + 1][1];
+  for (size_t i = 0; i + 1 < ego_states.size(); ++i) {
+    const float p1x = ego_states[i][0];
+    const float p1y = ego_states[i][1];
+    const float p2x = ego_states[i + 1][0];
+    const float p2y = ego_states[i + 1][1];
+    const float cos_h = ego_states[i][2];
+    const float sin_h = ego_states[i][3];
+    const bool has_valid_heading = std::fabs(cos_h) + std::fabs(sin_h) > 1e-6f;
+    const float ego_heading_deg =
+      has_valid_heading ? std::atan2(sin_h, cos_h) * 180.0f / static_cast<float>(M_PI)
+                        : std::atan2(p2y - p1y, p2x - p1x) * 180.0f / static_cast<float>(M_PI);
+
     for (const auto & seg : stop_segments) {
       if (!segments_intersect(p1x, p1y, p2x, p2y, seg[0], seg[1], seg[2], seg[3])) continue;
       float ix = 0.0f;
@@ -470,8 +479,12 @@ inline bool detect_red_light_run(
       if (!segment_intersection_point(p1x, p1y, p2x, p2y, seg[0], seg[1], seg[2], seg[3], ix, iy))
         continue;
       for (const auto & entry : red_entries) {
-        const float dx = ix - entry[0];
-        const float dy = iy - entry[1];
+        if (heading_diff_deg(entry.heading_deg, ego_heading_deg) >= head_tol_deg) {
+          continue;
+        }
+
+        const float dx = ix - entry.x;
+        const float dy = iy - entry.y;
         if (dx * dx + dy * dy <= radius_sq) return true;
       }
     }

--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/processing/frame_filters.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/processing/frame_filters.hpp
@@ -27,6 +27,7 @@
 // here instead of [x,y,heading], so cos/sin are used directly).
 
 #include <autoware/diffusion_planner/constants.hpp>
+#include <autoware/diffusion_planner/conversion/lanelet.hpp>
 #include <autoware/diffusion_planner/dimensions.hpp>
 
 #include <algorithm>
@@ -126,6 +127,35 @@ inline bool segments_intersect(
   const float d3 = cross2(p2x - p1x, p2y - p1y, p3x - p1x, p3y - p1y);
   const float d4 = cross2(p2x - p1x, p2y - p1y, p4x - p1x, p4y - p1y);
   return (d1 * d2 < 0.0f) && (d3 * d4 < 0.0f);
+}
+
+inline bool segment_intersection_point(
+  float p1x, float p1y, float p2x, float p2y, float p3x, float p3y, float p4x, float p4y,
+  float & out_x, float & out_y)
+{
+  const float rx = p2x - p1x;
+  const float ry = p2y - p1y;
+  const float sx = p4x - p3x;
+  const float sy = p4y - p3y;
+  const float denom = cross2(rx, ry, sx, sy);
+  if (std::fabs(denom) <= 1e-6f) return false;
+
+  const float qpx = p3x - p1x;
+  const float qpy = p3y - p1y;
+  const float t = cross2(qpx, qpy, sx, sy) / denom;
+  const float u = cross2(qpx, qpy, rx, ry) / denom;
+  if (!(t > 0.0f && t < 1.0f && u > 0.0f && u < 1.0f)) return false;
+
+  out_x = p1x + t * rx;
+  out_y = p1y + t * ry;
+  return true;
+}
+
+inline float heading_diff_deg(float a_deg, float b_deg)
+{
+  float d = std::fmod(std::fabs(a_deg - b_deg), 360.0f);
+  if (d > 180.0f) d = 360.0f - d;
+  return d;
 }
 
 // Ego bounding-box corners for each evaluated future step (every `stride`-th step).
@@ -325,6 +355,128 @@ inline OffLaneResult compute_offlane_score(
 inline bool is_off_lane(const OffLaneResult & r, float max_score)
 {
   return !r.has_centerline || r.mean_distance >= max_score;
+}
+
+// ---------------------------------------------------------------------------
+// Red-light-run detector, ported from the python NPZ filter.
+//
+// The coarse "route contains a red lane" signal is too noisy at intersections:
+// route_lanes includes perpendicular approaches whose lights may correctly be red
+// while the ego has green. This detector only fires when the ego future crosses a
+// stop-line segment near the entry point of a heading-aligned red route lane.
+// ---------------------------------------------------------------------------
+
+inline bool detect_red_light_run(
+  const std::vector<float> & ego_future, const std::vector<float> & route_lanes,
+  const std::vector<float> & line_strings, float red_radius_m, float head_tol_deg)
+{
+  using autoware::diffusion_planner::LINE_STRING_TYPE_NUM;
+  using autoware::diffusion_planner::NUM_LINE_STRINGS;
+  using autoware::diffusion_planner::NUM_SEGMENTS_IN_ROUTE;
+  using autoware::diffusion_planner::OUTPUT_T;
+  using autoware::diffusion_planner::POINTS_PER_LINE_STRING;
+  using autoware::diffusion_planner::POINTS_PER_SEGMENT;
+  using autoware::diffusion_planner::POSE_DIM;
+  using autoware::diffusion_planner::SEGMENT_POINT_DIM;
+  using autoware::diffusion_planner::TRAFFIC_LIGHT;
+  using autoware::diffusion_planner::TRAFFIC_LIGHT_ONE_HOT_DIM;
+  using autoware::diffusion_planner::TRAFFIC_LIGHT_RED;
+
+  std::vector<std::array<float, 2>> ego_xy;
+  ego_xy.reserve(OUTPUT_T);
+  for (int64_t i = 0; i < OUTPUT_T; ++i) {
+    const float x = ego_future[i * POSE_DIM + 0];
+    const float y = ego_future[i * POSE_DIM + 1];
+    if (std::fabs(x) <= 1e-6f && std::fabs(y) <= 1e-6f) continue;
+    ego_xy.push_back({x, y});
+  }
+  if (ego_xy.size() < 2) return false;
+
+  const auto & ego_first = ego_xy.front();
+  const auto & ego_last = ego_xy.back();
+  const float ego_heading_deg = std::atan2(ego_last[1] - ego_first[1], ego_last[0] - ego_first[0]) *
+                                180.0f / static_cast<float>(M_PI);
+
+  std::vector<std::array<float, 2>> red_entries;
+  red_entries.reserve(NUM_SEGMENTS_IN_ROUTE);
+  for (int64_t seg = 0; seg < NUM_SEGMENTS_IN_ROUTE; ++seg) {
+    const float * segment = &route_lanes[seg * POINTS_PER_SEGMENT * SEGMENT_POINT_DIM];
+    const float * tl = &segment[TRAFFIC_LIGHT];
+    float tl_max = tl[0];
+    int tl_argmax = 0;
+    for (int k = 1; k < TRAFFIC_LIGHT_ONE_HOT_DIM; ++k) {
+      if (tl[k] > tl_max) {
+        tl_max = tl[k];
+        tl_argmax = k;
+      }
+    }
+    if (tl_max <= 0.5f || (TRAFFIC_LIGHT + tl_argmax) != TRAFFIC_LIGHT_RED) continue;
+
+    int64_t first_valid = -1;
+    int64_t last_valid = -1;
+    for (int64_t p = 0; p < POINTS_PER_SEGMENT; ++p) {
+      const float * pt = &segment[p * SEGMENT_POINT_DIM];
+      if (std::fabs(pt[0]) <= 1e-6f && std::fabs(pt[1]) <= 1e-6f) continue;
+      if (first_valid < 0) first_valid = p;
+      last_valid = p;
+    }
+    if (first_valid < 0 || last_valid <= first_valid) continue;
+
+    const float * entry = &segment[first_valid * SEGMENT_POINT_DIM];
+    const float * end = &segment[last_valid * SEGMENT_POINT_DIM];
+    const float lane_heading_deg =
+      std::atan2(end[1] - entry[1], end[0] - entry[0]) * 180.0f / static_cast<float>(M_PI);
+    if (heading_diff_deg(lane_heading_deg, ego_heading_deg) < head_tol_deg) {
+      red_entries.push_back({entry[0], entry[1]});
+    }
+  }
+  if (red_entries.empty()) return false;
+
+  const int64_t ls_dim = 2 + LINE_STRING_TYPE_NUM;
+  const int64_t stop_channel = 2 + autoware::diffusion_planner::LINE_STRING_TYPE_STOP_LINE;
+  std::vector<std::array<float, 4>> stop_segments;
+  for (int64_t n = 0; n < NUM_LINE_STRINGS; ++n) {
+    const float * base = &line_strings[n * POINTS_PER_LINE_STRING * ls_dim];
+    bool is_stop_line = false;
+    for (int64_t p = 0; p < POINTS_PER_LINE_STRING; ++p) {
+      if (base[p * ls_dim + stop_channel] > 0.5f) {
+        is_stop_line = true;
+        break;
+      }
+    }
+    if (!is_stop_line) continue;
+    for (int64_t p = 0; p + 1 < POINTS_PER_LINE_STRING; ++p) {
+      const float ax = base[p * ls_dim + 0];
+      const float ay = base[p * ls_dim + 1];
+      const float bx = base[(p + 1) * ls_dim + 0];
+      const float by = base[(p + 1) * ls_dim + 1];
+      const bool va = std::fabs(ax) + std::fabs(ay) > 1e-6f;
+      const bool vb = std::fabs(bx) + std::fabs(by) > 1e-6f;
+      if (va && vb) stop_segments.push_back({ax, ay, bx, by});
+    }
+  }
+  if (stop_segments.empty()) return false;
+
+  const float radius_sq = red_radius_m * red_radius_m;
+  for (size_t i = 0; i + 1 < ego_xy.size(); ++i) {
+    const float p1x = ego_xy[i][0];
+    const float p1y = ego_xy[i][1];
+    const float p2x = ego_xy[i + 1][0];
+    const float p2y = ego_xy[i + 1][1];
+    for (const auto & seg : stop_segments) {
+      if (!segments_intersect(p1x, p1y, p2x, p2y, seg[0], seg[1], seg[2], seg[3])) continue;
+      float ix = 0.0f;
+      float iy = 0.0f;
+      if (!segment_intersection_point(p1x, p1y, p2x, p2y, seg[0], seg[1], seg[2], seg[3], ix, iy))
+        continue;
+      for (const auto & entry : red_entries) {
+        const float dx = ix - entry[0];
+        const float dy = iy - entry[1];
+        if (dx * dx + dy * dy <= radius_sq) return true;
+      }
+    }
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------

--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/processing/frame_skip_decision.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/processing/frame_skip_decision.hpp
@@ -32,7 +32,6 @@ struct FrameSkipInputs
   double cov_xx;                      // kinematic_state.pose.covariance[0]
   double cov_yy;                      // kinematic_state.pose.covariance[7]
   bool is_stop;                       // linear.x < 0.1
-  bool is_red_light_run;              // GT future crosses its own red-light stop line
   bool is_red_or_yellow;              // next route segment has red/yellow light
   bool is_future_forward;             // GT future mileage > 1.0 m
   int64_t stopping_count;             // consecutive ticks ego has been stopped

--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/processing/frame_skip_decision.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/processing/frame_skip_decision.hpp
@@ -32,6 +32,7 @@ struct FrameSkipInputs
   double cov_xx;                      // kinematic_state.pose.covariance[0]
   double cov_yy;                      // kinematic_state.pose.covariance[7]
   bool is_stop;                       // linear.x < 0.1
+  bool is_red_light_run;              // GT future crosses its own red-light stop line
   bool is_red_or_yellow;              // next route segment has red/yellow light
   bool is_future_forward;             // GT future mileage > 1.0 m
   int64_t stopping_count;             // consecutive ticks ego has been stopped
@@ -48,6 +49,8 @@ struct FrameFilterParams
   int64_t collision_time_stride;
   float offlane_max_score;
   int64_t offlane_time_stride;
+  float red_light_run_radius_m;
+  float red_light_run_heading_tol_deg;
 };
 
 // Pure skip-reason computation — no I/O, no ROS time, no file system.
@@ -57,7 +60,7 @@ SkippingInfo decide_frame_skip(
   const std::vector<float> & ego_shape, const std::vector<float> & static_objects,
   const std::vector<float> & neighbor_future, const std::vector<float> & neighbor_past,
   const std::vector<float> & line_strings, const std::vector<float> & lanes,
-  const FrameFilterParams & filter_params);
+  const std::vector<float> & route_lanes, const FrameFilterParams & filter_params);
 
 }  // namespace frame_processor
 

--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/types/skipping_info.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/types/skipping_info.hpp
@@ -79,8 +79,6 @@ enum class SkippingLabel {
                           // GT future — i.e. the GT pulls away from the line on red.
   StoppedAtTrafficLight,  // Sustained stop at red/yellow light (formerly VehicleStopped;
                           // contrast with NoFutureProgress for non-light stops)
-  DetectedRedLightRun,    // Detected red light run: ego future crosses a stop line segment
-                          // near the entry point of a heading-aligned red route lane
 
   // Filter skipping reasons (ported from the standalone python filter scripts)
   Collision,  // GT ego trajectory collides with a static object, neighbor, or road border
@@ -96,6 +94,8 @@ enum class SkippingLabel {
                                // (linear.x >= 0.1). Complements RedOrYellowLight, which only
                                // covers the fully-stopped case; counted separately so the
                                // extra coverage of this trigger is measurable.
+  DetectedRedLightRun,         // Detected red light run: ego future crosses a stop line segment
+                               // near the entry point of a heading-aligned red route lane
 };
 
 // Structure to hold detailed skipping information

--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/types/skipping_info.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/types/skipping_info.hpp
@@ -79,6 +79,8 @@ enum class SkippingLabel {
                           // GT future — i.e. the GT pulls away from the line on red.
   StoppedAtTrafficLight,  // Sustained stop at red/yellow light (formerly VehicleStopped;
                           // contrast with NoFutureProgress for non-light stops)
+  DetectedRedLightRun,    // Detected red light run: ego future crosses a stop line segment
+                          // near the entry point of a heading-aligned red route lane
 
   // Filter skipping reasons (ported from the standalone python filter scripts)
   Collision,  // GT ego trajectory collides with a static object, neighbor, or road border
@@ -169,6 +171,16 @@ struct SkippingInfo
     return {
       SkippingLabel::AcceleratingAtTrafficLight,
       "Accelerating into red/yellow light while moving (linear.x >= 0.1)",
+      {},
+      {}};
+  }
+
+  static SkippingInfo detected_red_light_run()
+  {
+    return {
+      SkippingLabel::DetectedRedLightRun,
+      "Detected red light run: ego future crosses a stop line segment near the entry point of a "
+      "heading-aligned red route lane",
       {},
       {}};
   }

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/cli/converter_options.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/cli/converter_options.cpp
@@ -126,8 +126,8 @@ ConverterOptions ConverterOptions::default_converter_options()
   options.offlane_time_stride = 1;
 
   // Red-light-run detector defaults match the integrated python heuristic.
-  options.red_light_run_radius_m = 5.0f;
-  options.red_light_run_heading_tol_deg = 30.0f;
+  options.red_light_run_radius_m = 12.0f;
+  options.red_light_run_heading_tol_deg = 45.0f;
 
   // Inspection-only: production keeps this off so skipped frames write no npz.
   options.write_skipped_npz = false;

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/cli/converter_options.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/cli/converter_options.cpp
@@ -72,6 +72,14 @@ void ConverterOptions::add_converter_options(CLI::App & app)
     "--offlane_time_stride", offlane_time_stride,
     "Time stride used when checking the off-lane filter.");
   app.add_option(
+    "--red_light_run_radius_m", red_light_run_radius_m,
+    "Maximum distance in meters from a stop-line crossing point to a heading-aligned red "
+    "route-lane entry for red-light-run skipping.");
+  app.add_option(
+    "--red_light_run_heading_tol_deg", red_light_run_heading_tol_deg,
+    "Maximum heading difference in degrees between ego future and a red route lane when "
+    "matching the ego's own signal.");
+  app.add_option(
     "--write_skipped_npz", write_skipped_npz,
     "Also write npz files for skipped frames when non-zero. "
     "Intended for inspection.");
@@ -117,6 +125,10 @@ ConverterOptions ConverterOptions::default_converter_options()
   options.offlane_max_score = 6.0f;
   options.offlane_time_stride = 1;
 
+  // Red-light-run detector defaults match the integrated python heuristic.
+  options.red_light_run_radius_m = 5.0f;
+  options.red_light_run_heading_tol_deg = 30.0f;
+
   // Inspection-only: production keeps this off so skipped frames write no npz.
   options.write_skipped_npz = false;
   // Full conversion by default (write npz); --sidecar_only flips to sidecar-only output.
@@ -143,6 +155,12 @@ std::optional<std::string> validate_options(const ConverterOptions & opts)
   if (opts.pack_sequence && opts.sidecar_only) {
     return "--pack_sequence and --sidecar_only are mutually exclusive "
            "(pack_sequence writes one npz per sequence; sidecar_only writes no npz).";
+  }
+  if (opts.red_light_run_radius_m < 0.0f) {
+    return "red_light_run_radius_m must be non-negative.";
+  }
+  if (opts.red_light_run_heading_tol_deg < 0.0f) {
+    return "red_light_run_heading_tol_deg must be non-negative.";
   }
   return std::nullopt;
 }

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/data_converter.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/data_converter.cpp
@@ -37,14 +37,16 @@ void print_options(const ConverterPaths & paths, const ConverterOptions & conver
     "Collision filter static_object_margin: {}, neighbor_margin: {}, road_border_margin: {}, "
     "collision_time_stride: {}\n"
     "Off-lane filter max_score: {}, offlane_time_stride: {}\n"
-    "Write skipped npz: {}, Sidecar only: {}, Pack sequence: {}\n",
+    "Write skipped npz: {}, Sidecar only: {}, Pack sequence: {}\n"
+    "Red-light-run filter radius_m: {}, heading_tol_deg: {}\n",
     converter.ego_wheel_base, converter.ego_length, converter.ego_width, paths.rosbag_path,
     paths.vector_map_path, paths.save_dir, converter.step, converter.limit, converter.min_frames,
     converter.min_distance, converter.search_nearest_route, converter.convert_yellow,
     converter.convert_red, converter.use_interpolation, converter.static_object_margin,
     converter.neighbor_margin, converter.road_border_margin, converter.collision_time_stride,
     converter.offlane_max_score, converter.offlane_time_stride, converter.write_skipped_npz,
-    converter.sidecar_only, converter.pack_sequence);
+    converter.sidecar_only, converter.pack_sequence, converter.red_light_run_radius_m,
+    converter.red_light_run_heading_tol_deg);
 }
 
 bool parse_arguments(int argc, char ** argv, ConverterPaths & paths, ConverterOptions & converter)

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_processor.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_processor.cpp
@@ -246,7 +246,6 @@ void process_sequence(
                                        point_idx * SEGMENT_POINT_DIM + TRAFFIC_LIGHT_YELLOW;
     const bool is_yellow_light = route_lanes[yellow_light_index] > 0.5 && !options.convert_yellow;
     const bool is_red_or_yellow = is_red_light || is_yellow_light;
-    const bool is_red_light_run_candidate = is_red_light;
 
     float sum_mileage = 0.0;
     for (int64_t j = 0; j < OUTPUT_T - 1; ++j) {
@@ -278,7 +277,6 @@ void process_sequence(
       covariance[0],
       covariance[7],
       is_stop,
-      is_red_light_run_candidate,
       is_red_or_yellow,
       is_future_forward,
       stopping_count,

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_processor.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_processor.cpp
@@ -285,8 +285,9 @@ void process_sequence(
       no_future_progress_count * options.step};
 
     const frame_processor::FrameFilterParams filter_params{
-      options.static_object_margin,  options.neighbor_margin,   options.road_border_margin,
-      options.collision_time_stride, options.offlane_max_score, options.offlane_time_stride,
+      options.static_object_margin,   options.neighbor_margin,
+      options.road_border_margin,     options.collision_time_stride,
+      options.offlane_max_score,      options.offlane_time_stride,
       options.red_light_run_radius_m, options.red_light_run_heading_tol_deg};
 
     const std::vector<float> ego_shape = {

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_processor.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_processor.cpp
@@ -246,6 +246,7 @@ void process_sequence(
                                        point_idx * SEGMENT_POINT_DIM + TRAFFIC_LIGHT_YELLOW;
     const bool is_yellow_light = route_lanes[yellow_light_index] > 0.5 && !options.convert_yellow;
     const bool is_red_or_yellow = is_red_light || is_yellow_light;
+    const bool is_red_light_run_candidate = is_red_light;
 
     float sum_mileage = 0.0;
     for (int64_t j = 0; j < OUTPUT_T - 1; ++j) {
@@ -277,6 +278,7 @@ void process_sequence(
       covariance[0],
       covariance[7],
       is_stop,
+      is_red_light_run_candidate,
       is_red_or_yellow,
       is_future_forward,
       stopping_count,
@@ -284,14 +286,15 @@ void process_sequence(
 
     const frame_processor::FrameFilterParams filter_params{
       options.static_object_margin,  options.neighbor_margin,   options.road_border_margin,
-      options.collision_time_stride, options.offlane_max_score, options.offlane_time_stride};
+      options.collision_time_stride, options.offlane_max_score, options.offlane_time_stride,
+      options.red_light_run_radius_m, options.red_light_run_heading_tol_deg};
 
     const std::vector<float> ego_shape = {
       options.ego_wheel_base, options.ego_length, options.ego_width};
 
     const SkippingInfo skipping_info = frame_processor::decide_frame_skip(
       skip_inputs, ego_future, ego_shape, static_objects, neighbor_future, neighbor_past,
-      line_strings, lanes, filter_params);
+      line_strings, lanes, route_lanes, filter_params);
 
     const bool is_skipped = skipping_info.label != SkippingLabel::NotSkipped;
     if (options.pack_sequence) {

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_skip_decision.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_skip_decision.cpp
@@ -41,12 +41,6 @@ SkippingInfo decide_frame_skip(
 {
   using autoware::diffusion_planner::INPUT_T;
 
-  const bool detected_red_light_run =
-    inputs.is_red_light_run &&
-    frame_filters::detect_red_light_run(
-      ego_future, route_lanes, line_strings, filter_params.red_light_run_radius_m,
-      filter_params.red_light_run_heading_tol_deg);
-
   if (inputs.max_msg_age_ns > kStaleThresholdNs) {
     return SkippingInfo::stale_data(inputs.max_msg_age_ns);
   }
@@ -60,13 +54,19 @@ SkippingInfo decide_frame_skip(
   // first, so a stopped-then-pulling-away frame keeps the RedOrYellowLight label; the
   // AcceleratingAtTrafficLight label then counts only the moving (linear.x >= 0.1) starts
   // that the stopped-only gate leaked.
-  if (detected_red_light_run) {
-    if (inputs.is_stop) {
+  if (inputs.is_red_or_yellow) {
+    if (inputs.is_stop && inputs.is_future_forward) {
       return SkippingInfo::red_or_yellow_light();
     }
     if (frame_filters::is_accelerating(frame_filters::compute_future_accel(ego_future))) {
       return SkippingInfo::accelerating_at_traffic_light();
     }
+  }
+  if (
+    frame_filters::detect_red_light_run(
+      ego_future, route_lanes, line_strings, filter_params.red_light_run_radius_m,
+      filter_params.red_light_run_heading_tol_deg)) {
+    return SkippingInfo::detected_red_light_run();
   }
 
   if (inputs.stopping_count > (INPUT_T + 5) && inputs.is_red_or_yellow) {

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_skip_decision.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_skip_decision.cpp
@@ -78,19 +78,17 @@ SkippingInfo decide_frame_skip(
     return SkippingInfo::no_future_progress(sustained_s);
   }
 
-  if (
-    const frame_filters::CollisionResult collision = frame_filters::check_collision(
-      ego_future, ego_shape, static_objects, neighbor_future, neighbor_past, line_strings,
-      filter_params.static_object_margin, filter_params.neighbor_margin,
-      filter_params.road_border_margin, filter_params.collision_time_stride);
-    collision.collided()) {
+  if (const frame_filters::CollisionResult collision = frame_filters::check_collision(
+        ego_future, ego_shape, static_objects, neighbor_future, neighbor_past, line_strings,
+        filter_params.static_object_margin, filter_params.neighbor_margin,
+        filter_params.road_border_margin, filter_params.collision_time_stride);
+      collision.collided()) {
     return SkippingInfo::collision(collision.reasons);
   }
 
-  if (
-    const frame_filters::OffLaneResult offlane =
-      frame_filters::compute_offlane_score(ego_future, lanes, filter_params.offlane_time_stride);
-    frame_filters::is_off_lane(offlane, filter_params.offlane_max_score)) {
+  if (const frame_filters::OffLaneResult offlane =
+        frame_filters::compute_offlane_score(ego_future, lanes, filter_params.offlane_time_stride);
+      frame_filters::is_off_lane(offlane, filter_params.offlane_max_score)) {
     return SkippingInfo::off_lane(offlane.mean_distance, offlane.max_distance);
   }
 

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_skip_decision.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_skip_decision.cpp
@@ -78,17 +78,19 @@ SkippingInfo decide_frame_skip(
     return SkippingInfo::no_future_progress(sustained_s);
   }
 
-  if (const frame_filters::CollisionResult collision = frame_filters::check_collision(
-        ego_future, ego_shape, static_objects, neighbor_future, neighbor_past, line_strings,
-        filter_params.static_object_margin, filter_params.neighbor_margin,
-        filter_params.road_border_margin, filter_params.collision_time_stride);
-      collision.collided()) {
+  if (
+    const frame_filters::CollisionResult collision = frame_filters::check_collision(
+      ego_future, ego_shape, static_objects, neighbor_future, neighbor_past, line_strings,
+      filter_params.static_object_margin, filter_params.neighbor_margin,
+      filter_params.road_border_margin, filter_params.collision_time_stride);
+    collision.collided()) {
     return SkippingInfo::collision(collision.reasons);
   }
 
-  if (const frame_filters::OffLaneResult offlane =
-        frame_filters::compute_offlane_score(ego_future, lanes, filter_params.offlane_time_stride);
-      frame_filters::is_off_lane(offlane, filter_params.offlane_max_score)) {
+  if (
+    const frame_filters::OffLaneResult offlane =
+      frame_filters::compute_offlane_score(ego_future, lanes, filter_params.offlane_time_stride);
+    frame_filters::is_off_lane(offlane, filter_params.offlane_max_score)) {
     return SkippingInfo::off_lane(offlane.mean_distance, offlane.max_distance);
   }
 

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_skip_decision.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_skip_decision.cpp
@@ -37,9 +37,15 @@ SkippingInfo decide_frame_skip(
   const std::vector<float> & ego_shape, const std::vector<float> & static_objects,
   const std::vector<float> & neighbor_future, const std::vector<float> & neighbor_past,
   const std::vector<float> & line_strings, const std::vector<float> & lanes,
-  const FrameFilterParams & filter_params)
+  const std::vector<float> & route_lanes, const FrameFilterParams & filter_params)
 {
   using autoware::diffusion_planner::INPUT_T;
+
+  const bool detected_red_light_run =
+    inputs.is_red_light_run &&
+    frame_filters::detect_red_light_run(
+      ego_future, route_lanes, line_strings, filter_params.red_light_run_radius_m,
+      filter_params.red_light_run_heading_tol_deg);
 
   if (inputs.max_msg_age_ns > kStaleThresholdNs) {
     return SkippingInfo::stale_data(inputs.max_msg_age_ns);
@@ -54,8 +60,8 @@ SkippingInfo decide_frame_skip(
   // first, so a stopped-then-pulling-away frame keeps the RedOrYellowLight label; the
   // AcceleratingAtTrafficLight label then counts only the moving (linear.x >= 0.1) starts
   // that the stopped-only gate leaked.
-  if (inputs.is_red_or_yellow) {
-    if (inputs.is_stop && inputs.is_future_forward) {
+  if (detected_red_light_run) {
+    if (inputs.is_stop) {
       return SkippingInfo::red_or_yellow_light();
     }
     if (frame_filters::is_accelerating(frame_filters::compute_future_accel(ego_future))) {

--- a/cpp_tools/src/autoware_diffusion_planner_tools/test/test_converter_options.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/test/test_converter_options.cpp
@@ -38,6 +38,8 @@ static ConverterOptions make_default_opts()
   o.collision_time_stride = 5;
   o.offlane_max_score = 6.0f;
   o.offlane_time_stride = 1;
+  o.red_light_run_radius_m = 5.0f;
+  o.red_light_run_heading_tol_deg = 30.0f;
   o.write_skipped_npz = false;
   o.sidecar_only = false;
   o.pack_sequence = false;
@@ -59,6 +61,8 @@ TEST(DefaultConverterOptionsTest, UsesSharedDefaults)
   EXPECT_FLOAT_EQ(opts.ego_length, -1.0f);
   EXPECT_FLOAT_EQ(opts.ego_width, -1.0f);
   EXPECT_TRUE(opts.use_interpolation);
+  EXPECT_FLOAT_EQ(opts.red_light_run_radius_m, 5.0f);
+  EXPECT_FLOAT_EQ(opts.red_light_run_heading_tol_deg, 30.0f);
   EXPECT_FALSE(opts.write_skipped_npz);
   EXPECT_FALSE(opts.sidecar_only);   // full conversion (writes npz) by default
   EXPECT_FALSE(opts.pack_sequence);  // one file per frame by default
@@ -127,4 +131,18 @@ TEST(ValidateOptionsTest, ZeroWheelBasePasses)
   opts.ego_wheel_base = 0.0f;
   // Validation requires < 0.0; zero itself is accepted.
   EXPECT_FALSE(validate_options(opts).has_value());
+}
+
+TEST(ValidateOptionsTest, NegativeRedLightRunRadiusReturnsError)
+{
+  ConverterOptions opts = make_default_opts();
+  opts.red_light_run_radius_m = -0.1f;
+  EXPECT_TRUE(validate_options(opts).has_value());
+}
+
+TEST(ValidateOptionsTest, NegativeRedLightRunHeadingToleranceReturnsError)
+{
+  ConverterOptions opts = make_default_opts();
+  opts.red_light_run_heading_tol_deg = -1.0f;
+  EXPECT_TRUE(validate_options(opts).has_value());
 }

--- a/cpp_tools/src/autoware_diffusion_planner_tools/test/test_frame_skip_decision.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/test/test_frame_skip_decision.cpp
@@ -45,7 +45,6 @@ FrameSkipInputs make_clear_inputs()
   in.cov_xx = 0.0;
   in.cov_yy = 0.0;
   in.is_stop = false;
-  in.is_red_light_run = false;
   in.is_red_or_yellow = false;
   in.is_future_forward = true;
   in.stopping_count = 0;
@@ -206,7 +205,6 @@ TEST(DecideFrameSkipTest, RedOrYellowLightSkip)
 
   FrameSkipInputs inputs = make_clear_inputs();
   inputs.is_stop = true;
-  inputs.is_red_light_run = true;
   inputs.is_red_or_yellow = true;
   inputs.is_future_forward = true;
 
@@ -229,7 +227,6 @@ TEST(DecideFrameSkipTest, AcceleratingIntoRedLightSkipsEvenWhenMoving)
 
   FrameSkipInputs inputs = make_clear_inputs();
   inputs.is_stop = false;
-  inputs.is_red_light_run = true;
   inputs.is_red_or_yellow = true;
   inputs.is_future_forward = true;
 
@@ -251,7 +248,6 @@ TEST(DecideFrameSkipTest, StoppedThenAcceleratingKeepsRedOrYellowLabel)
 
   FrameSkipInputs inputs = make_clear_inputs();
   inputs.is_stop = true;
-  inputs.is_red_light_run = true;
   inputs.is_red_or_yellow = true;
   inputs.is_future_forward = true;
 
@@ -274,7 +270,6 @@ TEST(DecideFrameSkipTest, CreepingIntoRedWhileMovingIsKept)
 
   FrameSkipInputs inputs = make_clear_inputs();
   inputs.is_stop = false;
-  inputs.is_red_light_run = true;
   inputs.is_red_or_yellow = true;
   inputs.is_future_forward = true;
 
@@ -320,7 +315,6 @@ TEST(DecideFrameSkipTest, StaleDataWinsOverRedLight)
   FrameSkipInputs inputs = make_clear_inputs();
   inputs.max_msg_age_ns = 600'000'000LL;
   inputs.is_stop = true;
-  inputs.is_red_light_run = true;
   inputs.is_red_or_yellow = true;
   inputs.is_future_forward = true;
 
@@ -352,7 +346,6 @@ TEST(DecideFrameSkipTest, PerpendicularRedLaneDoesNotCauseFalsePositive)
 
   FrameSkipInputs inputs = make_clear_inputs();
   inputs.is_stop = true;
-  inputs.is_red_light_run = true;
   inputs.is_red_or_yellow = true;
   inputs.is_future_forward = true;
 

--- a/cpp_tools/src/autoware_diffusion_planner_tools/test/test_frame_skip_decision.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/test/test_frame_skip_decision.cpp
@@ -23,8 +23,12 @@
 using namespace frame_processor;
 using autoware::diffusion_planner::INPUT_T;
 using autoware::diffusion_planner::MAX_NUM_NEIGHBORS;
+using autoware::diffusion_planner::NUM_SEGMENTS_IN_ROUTE;
 using autoware::diffusion_planner::OUTPUT_T;
+using autoware::diffusion_planner::POINTS_PER_LINE_STRING;
+using autoware::diffusion_planner::POINTS_PER_SEGMENT;
 using autoware::diffusion_planner::POSE_DIM;
+using autoware::diffusion_planner::SEGMENT_POINT_DIM;
 using autoware::diffusion_planner::STATIC_OBJECTS_SHAPE;
 
 // ---------------------------------------------------------------------------
@@ -41,6 +45,7 @@ FrameSkipInputs make_clear_inputs()
   in.cov_xx = 0.0;
   in.cov_yy = 0.0;
   in.is_stop = false;
+  in.is_red_light_run = false;
   in.is_red_or_yellow = false;
   in.is_future_forward = true;
   in.stopping_count = 0;
@@ -50,7 +55,7 @@ FrameSkipInputs make_clear_inputs()
 
 FrameFilterParams make_default_filter_params()
 {
-  return FrameFilterParams{0.0f, 0.0f, 0.0f, 5, 6.0f, 1};
+  return FrameFilterParams{0.0f, 0.0f, 0.0f, 5, 6.0f, 1, 5.0f, 30.0f};
 }
 
 // Vectors sized for a valid call with no objects/lanes (all zeros → no collision/offlane).
@@ -63,8 +68,9 @@ struct ZeroVectors
   std::vector<float> neighbor_past;
   std::vector<float> line_strings;
   std::vector<float> lanes;
+  std::vector<float> route_lanes;
 
-  ZeroVectors()
+  ZeroVectors() 
   {
     using namespace autoware::diffusion_planner;
     ego_future.assign(OUTPUT_T * POSE_DIM, 0.0f);
@@ -77,6 +83,7 @@ struct ZeroVectors
     const int64_t ls_dim = 2 + LINE_STRING_TYPE_NUM;
     line_strings.assign(NUM_LINE_STRINGS * POINTS_PER_LINE_STRING * ls_dim, 0.0f);
     lanes.assign(NUM_SEGMENTS_IN_LANE * POINTS_PER_SEGMENT * SEGMENT_POINT_DIM, 0.0f);
+    route_lanes.assign(NUM_SEGMENTS_IN_ROUTE * POINTS_PER_SEGMENT * SEGMENT_POINT_DIM, 0.0f);
   }
 };
 
@@ -84,7 +91,8 @@ SkippingInfo call_decide(const FrameSkipInputs & inputs, const ZeroVectors & vec
 {
   return decide_frame_skip(
     inputs, vecs.ego_future, vecs.ego_shape, vecs.static_objects, vecs.neighbor_future,
-    vecs.neighbor_past, vecs.line_strings, vecs.lanes, make_default_filter_params());
+    vecs.neighbor_past, vecs.line_strings, vecs.lanes, vecs.route_lanes,
+    make_default_filter_params());
 }
 
 // Fill ego_future with a straight forward trajectory whose per-step speed ramps
@@ -104,6 +112,41 @@ void set_linear_future(std::vector<float> & ego_future, float v_start, float v_e
     const float speed = v_start + (v_end - v_start) * static_cast<float>(j) / (OUTPUT_T - 1);
     x += speed * dt;
   }
+}
+
+void set_route_lane_point(
+  std::vector<float> & route_lanes, int64_t segment_idx, int64_t point_idx, float x, float y)
+{
+  const int64_t base = (segment_idx * POINTS_PER_SEGMENT + point_idx) * SEGMENT_POINT_DIM;
+  route_lanes[base + 0] = x;
+  route_lanes[base + 1] = y;
+}
+
+void set_lane_point(std::vector<float> & lanes, int64_t segment_idx, int64_t point_idx, float x, float y)
+{
+  const int64_t base = (segment_idx * POINTS_PER_SEGMENT + point_idx) * SEGMENT_POINT_DIM;
+  lanes[base + 0] = x;
+  lanes[base + 1] = y;
+}
+
+void set_route_lane_red(std::vector<float> & route_lanes, int64_t segment_idx)
+{
+  using autoware::diffusion_planner::TRAFFIC_LIGHT_RED;
+  route_lanes[(segment_idx * POINTS_PER_SEGMENT + 0) * SEGMENT_POINT_DIM + TRAFFIC_LIGHT_RED] =
+    1.0f;
+}
+
+void set_stop_line_segment(
+  std::vector<float> & line_strings, int64_t line_idx, float ax, float ay, float bx, float by)
+{
+  const int64_t ls_dim = 2 + autoware::diffusion_planner::LINE_STRING_TYPE_NUM;
+  const int64_t base = line_idx * POINTS_PER_LINE_STRING * ls_dim;
+  line_strings[base + 0] = ax;
+  line_strings[base + 1] = ay;
+  line_strings[base + 2] = 1.0f;
+  line_strings[base + ls_dim + 0] = bx;
+  line_strings[base + ls_dim + 1] = by;
+  line_strings[base + ls_dim + 2] = 1.0f;
 }
 
 }  // namespace
@@ -153,10 +196,16 @@ TEST(DecideFrameSkipTest, InvalidCovarianceBeforeOtherChecks)
 TEST(DecideFrameSkipTest, RedOrYellowLightSkip)
 {
   ZeroVectors vecs;
-  vecs.lanes[0] = 1.0f;
+  for (int64_t p = 0; p < 8; ++p) set_lane_point(vecs.lanes, 0, p, static_cast<float>(p), 0.0f);
+  set_linear_future(vecs.ego_future, 5.0f, 5.0f);
+  set_route_lane_red(vecs.route_lanes, 0);
+  set_route_lane_point(vecs.route_lanes, 0, 0, 1.0f, 0.0f);
+  set_route_lane_point(vecs.route_lanes, 0, 1, 8.0f, 0.0f);
+  set_stop_line_segment(vecs.line_strings, 0, 2.25f, -1.0f, 2.25f, 1.0f);
 
   FrameSkipInputs inputs = make_clear_inputs();
   inputs.is_stop = true;
+  inputs.is_red_light_run = true;
   inputs.is_red_or_yellow = true;
   inputs.is_future_forward = true;
 
@@ -170,11 +219,16 @@ TEST(DecideFrameSkipTest, AcceleratingIntoRedLightSkipsEvenWhenMoving)
   // this — but the GT future clearly accelerates (~0 -> ~9 m/s) into a red/yellow light,
   // so the dedicated AcceleratingAtTrafficLight trigger fires.
   ZeroVectors vecs;
-  vecs.lanes[0] = 1.0f;
+  for (int64_t p = 0; p < 8; ++p) set_lane_point(vecs.lanes, 0, p, static_cast<float>(p), 0.0f);
   set_linear_future(vecs.ego_future, 0.2f, 9.0f);
+  set_route_lane_red(vecs.route_lanes, 0);
+  set_route_lane_point(vecs.route_lanes, 0, 0, 1.0f, 0.0f);
+  set_route_lane_point(vecs.route_lanes, 0, 1, 8.0f, 0.0f);
+  set_stop_line_segment(vecs.line_strings, 0, 2.25f, -1.0f, 2.25f, 1.0f);
 
   FrameSkipInputs inputs = make_clear_inputs();
   inputs.is_stop = false;
+  inputs.is_red_light_run = true;
   inputs.is_red_or_yellow = true;
   inputs.is_future_forward = true;
 
@@ -187,11 +241,16 @@ TEST(DecideFrameSkipTest, StoppedThenAcceleratingKeepsRedOrYellowLabel)
   // When the ego is fully stopped AND the future accelerates away, the original stopped
   // gate is checked first, so the frame keeps the RedOrYellowLight label (not the new one).
   ZeroVectors vecs;
-  vecs.lanes[0] = 1.0f;
+  for (int64_t p = 0; p < 8; ++p) set_lane_point(vecs.lanes, 0, p, static_cast<float>(p), 0.0f);
   set_linear_future(vecs.ego_future, 0.2f, 9.0f);
+  set_route_lane_red(vecs.route_lanes, 0);
+  set_route_lane_point(vecs.route_lanes, 0, 0, 1.0f, 0.0f);
+  set_route_lane_point(vecs.route_lanes, 0, 1, 8.0f, 0.0f);
+  set_stop_line_segment(vecs.line_strings, 0, 2.25f, -1.0f, 2.25f, 1.0f);
 
   FrameSkipInputs inputs = make_clear_inputs();
   inputs.is_stop = true;
+  inputs.is_red_light_run = true;
   inputs.is_red_or_yellow = true;
   inputs.is_future_forward = true;
 
@@ -205,11 +264,16 @@ TEST(DecideFrameSkipTest, CreepingIntoRedWhileMovingIsKept)
   // neither the stopped gate (is_stop = false) nor the acceleration trigger fires, so the
   // frame is accepted rather than dropped.
   ZeroVectors vecs;
-  vecs.lanes[0] = 1.0f;
+  for (int64_t p = 0; p < 8; ++p) set_lane_point(vecs.lanes, 0, p, static_cast<float>(p), 0.0f);
   set_linear_future(vecs.ego_future, 1.0f, 1.0f);
+  set_route_lane_red(vecs.route_lanes, 0);
+  set_route_lane_point(vecs.route_lanes, 0, 0, 1.0f, 0.0f);
+  set_route_lane_point(vecs.route_lanes, 0, 1, 8.0f, 0.0f);
+  set_stop_line_segment(vecs.line_strings, 0, 2.25f, -1.0f, 2.25f, 1.0f);
 
   FrameSkipInputs inputs = make_clear_inputs();
   inputs.is_stop = false;
+  inputs.is_red_light_run = true;
   inputs.is_red_or_yellow = true;
   inputs.is_future_forward = true;
 
@@ -255,6 +319,7 @@ TEST(DecideFrameSkipTest, StaleDataWinsOverRedLight)
   FrameSkipInputs inputs = make_clear_inputs();
   inputs.max_msg_age_ns = 600'000'000LL;
   inputs.is_stop = true;
+  inputs.is_red_light_run = true;
   inputs.is_red_or_yellow = true;
   inputs.is_future_forward = true;
 
@@ -270,4 +335,26 @@ TEST(DecideFrameSkipTest, OffLaneSkipWhenNoCenterline)
 
   const SkippingInfo info = call_decide(inputs, vecs);
   EXPECT_EQ(info.label, SkippingLabel::OffLane);
+}
+
+TEST(DecideFrameSkipTest, PerpendicularRedLaneDoesNotCauseFalsePositive)
+{
+  ZeroVectors vecs;
+  for (int64_t p = 0; p < POINTS_PER_SEGMENT; ++p) {
+    set_lane_point(vecs.lanes, 0, p, static_cast<float>(2 * p), 0.0f);
+  }
+  set_linear_future(vecs.ego_future, 5.0f, 5.0f);
+  set_route_lane_red(vecs.route_lanes, 0);
+  set_route_lane_point(vecs.route_lanes, 0, 0, 2.0f, 0.0f);
+  set_route_lane_point(vecs.route_lanes, 0, 1, 2.0f, 8.0f);
+  set_stop_line_segment(vecs.line_strings, 0, 2.25f, -1.0f, 2.25f, 1.0f);
+
+  FrameSkipInputs inputs = make_clear_inputs();
+  inputs.is_stop = true;
+  inputs.is_red_light_run = true;
+  inputs.is_red_or_yellow = true;
+  inputs.is_future_forward = true;
+
+  const SkippingInfo info = call_decide(inputs, vecs);
+  EXPECT_EQ(info.label, SkippingLabel::NotSkipped);
 }

--- a/cpp_tools/src/autoware_diffusion_planner_tools/test/test_frame_skip_decision.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/test/test_frame_skip_decision.cpp
@@ -70,7 +70,7 @@ struct ZeroVectors
   std::vector<float> lanes;
   std::vector<float> route_lanes;
 
-  ZeroVectors() 
+  ZeroVectors()
   {
     using namespace autoware::diffusion_planner;
     ego_future.assign(OUTPUT_T * POSE_DIM, 0.0f);
@@ -122,7 +122,8 @@ void set_route_lane_point(
   route_lanes[base + 1] = y;
 }
 
-void set_lane_point(std::vector<float> & lanes, int64_t segment_idx, int64_t point_idx, float x, float y)
+void set_lane_point(
+  std::vector<float> & lanes, int64_t segment_idx, int64_t point_idx, float x, float y)
 {
   const int64_t base = (segment_idx * POINTS_PER_SEGMENT + point_idx) * SEGMENT_POINT_DIM;
   lanes[base + 0] = x;


### PR DESCRIPTION
## Summary

  This PR improves red-light-run frame skipping by replacing the coarse route-light check with a stricter detector based on:

  - ego future crossing a stop line
  - proximity to a red route-lane entry
  - heading alignment with that red route lane

  This reduces false positives at intersections, especially from perpendicular red approaches included in route_lanes.

  ## Changes

  - added stop-line-based red-light-run detection
  - made thresholds configurable via:
      - --red_light_run_radius_m
      - --red_light_run_heading_tol_deg

  - wired the new options through ConverterOptions and FrameFilterParams
  - updated README
  - added/updated unit tests

  ## Validation

  - test_frame_skip_decision passed
  - test_converter_options passed