### PR TITLE
feat: add rosbag provenance metadata to sidecar and route JSON

### DIFF
--- a/cpp_tools/src/autoware_diffusion_planner_tools/CMakeLists.txt
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/CMakeLists.txt
@@ -121,6 +121,7 @@ if(BUILD_TESTING)
   ament_add_gtest(test_frame_writer
     test/test_frame_writer.cpp
     src/io/frame_writer.cpp
+    src/io/bag_metadata.cpp
   )
   if(TARGET test_frame_writer)
     target_include_directories(test_frame_writer PRIVATE include src)

--- a/cpp_tools/src/autoware_diffusion_planner_tools/CMakeLists.txt
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/CMakeLists.txt
@@ -36,6 +36,7 @@ ament_auto_add_executable(data_converter
   src/cli/converter_options.cpp
   src/conversion/data_converter.cpp
   src/io/frame_writer.cpp
+  src/io/bag_metadata.cpp
   src/io/npz_frame_writer.cpp
   src/io/projector_factory.cpp
   src/processing/ego_sequence.cpp
@@ -55,6 +56,7 @@ ament_auto_add_executable(parse_rosbag_for_directory_with_map_version
   src/cli/converter_options.cpp
   src/conversion/data_converter.cpp
   src/io/frame_writer.cpp
+  src/io/bag_metadata.cpp
   src/io/npz_frame_writer.cpp
   src/io/projector_factory.cpp
   src/processing/ego_sequence.cpp
@@ -152,5 +154,14 @@ if(BUILD_TESTING)
       autoware_vehicle_msgs
       geometry_msgs
     )
+  endif()
+
+  # io/bag_metadata — self-contained JSON parsing, no ROS message deps
+  ament_add_gtest(test_bag_metadata
+    test/test_bag_metadata.cpp
+    src/io/bag_metadata.cpp
+  )
+  if(TARGET test_bag_metadata)
+    target_include_directories(test_bag_metadata PRIVATE include src)
   endif()
 endif()

--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/io/bag_metadata.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/io/bag_metadata.hpp
@@ -1,0 +1,32 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IO__BAG_METADATA_HPP_
+#define IO__BAG_METADATA_HPP_
+
+#include <string>
+
+struct BagMetadata
+{
+  std::string log_file_id;
+  std::string vehicle_id;
+  std::string project_id;
+  std::string map_version_id;
+  std::string date;
+  std::string bag_time;
+};
+
+BagMetadata load_bag_metadata(const std::string & rosbag_path);
+
+#endif  // IO__BAG_METADATA_HPP_

--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/io/bag_metadata.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/io/bag_metadata.hpp
@@ -15,6 +15,8 @@
 #ifndef IO__BAG_METADATA_HPP_
 #define IO__BAG_METADATA_HPP_
 
+#include "nlohmann/json.hpp"
+
 #include <string>
 
 struct BagMetadata
@@ -28,5 +30,7 @@ struct BagMetadata
 };
 
 BagMetadata load_bag_metadata(const std::string & rosbag_path);
+
+void write_bag_metadata(nlohmann::json & j, const BagMetadata & bag_metadata);
 
 #endif  // IO__BAG_METADATA_HPP_

--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/io/frame_writer.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/io/frame_writer.hpp
@@ -15,6 +15,7 @@
 #ifndef IO__FRAME_WRITER_HPP_
 #define IO__FRAME_WRITER_HPP_
 
+#include "io/bag_metadata.hpp"
 #include "nlohmann/json.hpp"
 #include "timestamp_stats.hpp"
 #include "types/skipping_info.hpp"
@@ -31,12 +32,14 @@
 
 nlohmann::json build_frame_json(
   const nav_msgs::msg::Odometry & kinematic_state, const int64_t timestamp,
-  const SkippingInfo & skipping_info, const std::vector<std::string> & neighbor_ids);
+  const SkippingInfo & skipping_info, const std::vector<std::string> & neighbor_ids,
+  const BagMetadata & bag_metadata);
 
 nlohmann::json build_route_json(
   const int64_t num_frames, const double traveled_distance_m, const int64_t start_timestamp,
   const int64_t end_timestamp, const SkippingInfo & skipping_info,
-  const timestamp_stats::TimestampStatsMap & timestamp_stats_map, const bool goal_pose_overwritten);
+  const timestamp_stats::TimestampStatsMap & timestamp_stats_map, const bool goal_pose_overwritten,
+  const BagMetadata & bag_metadata);
 
 // ---------------------------------------------------------------------------
 // File-writing wrappers — call the builders above, then persist to disk.
@@ -45,13 +48,15 @@ nlohmann::json build_route_json(
 void save_frame_json(
   const std::string & output_path, const std::string & rosbag_dir_name, const std::string & token,
   const nav_msgs::msg::Odometry & kinematic_state, const int64_t timestamp,
-  const SkippingInfo & skipping_info, const std::vector<std::string> & neighbor_ids);
+  const SkippingInfo & skipping_info, const std::vector<std::string> & neighbor_ids,
+  const BagMetadata & bag_metadata);
 
 void save_route_json(
   const std::string & output_path, const std::string & rosbag_dir_name,
   const std::string & identifier, const int64_t num_frames, const double traveled_distance_m,
   const int64_t start_timestamp, const int64_t end_timestamp, const SkippingInfo & skipping_info,
-  const timestamp_stats::TimestampStatsMap & timestamp_stats_map, const bool goal_pose_overwritten);
+  const timestamp_stats::TimestampStatsMap & timestamp_stats_map, const bool goal_pose_overwritten,
+  const BagMetadata & bag_metadata);
 
 // Pack-sequence mode: write all of a sequence's per-frame json objects (in frame order) as a
 // single <rosbag>_<sequence_id>.json array. Each element is a build_frame_json object.

--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/processing/frame_processor.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/processing/frame_processor.hpp
@@ -16,6 +16,7 @@
 #define PROCESSING__FRAME_PROCESSOR_HPP_
 
 #include "cli/converter_options.hpp"
+#include "io/bag_metadata.hpp"
 #include "timestamp_stats.hpp"
 #include "types/frame_data.hpp"
 
@@ -27,6 +28,7 @@ void process_sequence(
   SequenceData & seq, const int64_t seq_id, const ConverterPaths & paths,
   const ConverterOptions & options,
   const autoware::diffusion_planner::preprocess::LaneSegmentContext & lane_segment_context,
-  const timestamp_stats::TimestampStatsMap & timestamp_stats_map);
+  const timestamp_stats::TimestampStatsMap & timestamp_stats_map,
+  const BagMetadata & bag_metadata);
 
 #endif  // PROCESSING__FRAME_PROCESSOR_HPP_

--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/processing/frame_processor.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/processing/frame_processor.hpp
@@ -28,7 +28,6 @@ void process_sequence(
   SequenceData & seq, const int64_t seq_id, const ConverterPaths & paths,
   const ConverterOptions & options,
   const autoware::diffusion_planner::preprocess::LaneSegmentContext & lane_segment_context,
-  const timestamp_stats::TimestampStatsMap & timestamp_stats_map,
-  const BagMetadata & bag_metadata);
+  const timestamp_stats::TimestampStatsMap & timestamp_stats_map, const BagMetadata & bag_metadata);
 
 #endif  // PROCESSING__FRAME_PROCESSOR_HPP_

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/conversion/data_converter.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/conversion/data_converter.cpp
@@ -14,6 +14,7 @@
 
 #include "conversion/data_converter.hpp"
 
+#include "io/bag_metadata.hpp"
 #include "io/frame_writer.hpp"
 #include "io/projector_factory.hpp"
 #include "processing/frame_processor.hpp"
@@ -44,6 +45,7 @@ int run_data_converter(const ConverterPaths & paths, const ConverterOptions & co
   const autoware::diffusion_planner::preprocess::LaneSegmentContext lane_segment_context(
     lanelet_map_ptr);
   const std::string rosbag_dir_name = paths.get_rosbag_dir_name();
+  const BagMetadata bag_metadata = load_bag_metadata(paths.rosbag_path);
 
   ParsedBagData bag_data = load_rosbag(paths.rosbag_path, converter.limit);
 
@@ -56,7 +58,7 @@ int run_data_converter(const ConverterPaths & paths, const ConverterOptions & co
     std::cout << "No training samples will be generated from this rosbag." << std::endl;
     save_route_json(
       paths.save_dir, rosbag_dir_name, "missing_topics", 0, 0.0, 0, 0, missing_topics_skip.value(),
-      bag_data.timestamp_stats_map, false);
+      bag_data.timestamp_stats_map, false, bag_metadata);
     return 0;
   }
 
@@ -67,7 +69,7 @@ int run_data_converter(const ConverterPaths & paths, const ConverterOptions & co
   for (int64_t seq_id = 0; seq_id < static_cast<int64_t>(sequences.size()); ++seq_id) {
     process_sequence(
       sequences[seq_id], seq_id, paths, converter, lane_segment_context,
-      bag_data.timestamp_stats_map);
+      bag_data.timestamp_stats_map, bag_metadata);
   }
 
   std::cout << "Data conversion completed!" << std::endl;

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/io/bag_metadata.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/io/bag_metadata.cpp
@@ -31,7 +31,8 @@ std::string get_string_or_empty(const nlohmann::json & j, const std::string & ke
   return "";
 }
 
-void parse_date_and_bag_time(const std::string & log_file_name, std::string & date, std::string & bag_time)
+void parse_date_and_bag_time(
+  const std::string & log_file_name, std::string & date, std::string & bag_time)
 {
   // Pattern: {vehicle_uuid}_{YYYY-MM-DD}-{HH-MM-SS}_{suffix}
   // The date and bag_time are separated by a hyphen between DD and HH,
@@ -50,8 +51,7 @@ BagMetadata load_bag_metadata(const std::string & rosbag_path)
 {
   BagMetadata meta;
 
-  const std::filesystem::path info_path =
-    std::filesystem::path(rosbag_path) / "log_file_info.json";
+  const std::filesystem::path info_path = std::filesystem::path(rosbag_path) / "log_file_info.json";
 
   if (!std::filesystem::is_regular_file(info_path)) {
     return meta;

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/io/bag_metadata.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/io/bag_metadata.cpp
@@ -1,0 +1,78 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "io/bag_metadata.hpp"
+
+#include "nlohmann/json.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <regex>
+#include <string>
+
+namespace
+{
+std::string get_string_or_empty(const nlohmann::json & j, const std::string & key)
+{
+  if (j.contains(key) && j[key].is_string()) {
+    return j[key].get<std::string>();
+  }
+  return "";
+}
+
+void parse_date_and_bag_time(const std::string & log_file_name, std::string & date, std::string & bag_time)
+{
+  // Pattern: {vehicle_uuid}_{YYYY-MM-DD}-{HH-MM-SS}_{suffix}
+  // The date and bag_time are separated by a hyphen between DD and HH,
+  // so the full datetime portion is: YYYY-MM-DD-HH-MM-SS
+  // We look for the date-time pattern after the first underscore.
+  static const std::regex re(R"((\d{4}-\d{2}-\d{2})-(\d{2}-\d{2}-\d{2})_)");
+  std::smatch match;
+  if (std::regex_search(log_file_name, match, re)) {
+    date = match[1].str();
+    bag_time = match[2].str();
+  }
+}
+}  // namespace
+
+BagMetadata load_bag_metadata(const std::string & rosbag_path)
+{
+  BagMetadata meta;
+
+  const std::filesystem::path info_path =
+    std::filesystem::path(rosbag_path) / "log_file_info.json";
+
+  if (!std::filesystem::is_regular_file(info_path)) {
+    return meta;
+  }
+
+  try {
+    std::ifstream file(info_path);
+    const nlohmann::json j = nlohmann::json::parse(file);
+
+    meta.log_file_id = get_string_or_empty(j, "id");
+    meta.vehicle_id = get_string_or_empty(j, "vehicle_id");
+    meta.project_id = get_string_or_empty(j, "project_id");
+    meta.map_version_id = get_string_or_empty(j, "area_map_version_id");
+
+    const std::string log_file_name = get_string_or_empty(j, "log_file_name");
+    if (!log_file_name.empty()) {
+      parse_date_and_bag_time(log_file_name, meta.date, meta.bag_time);
+    }
+  } catch (...) {
+    return BagMetadata{};
+  }
+
+  return meta;
+}

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/io/bag_metadata.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/io/bag_metadata.cpp
@@ -18,7 +18,9 @@
 
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <regex>
+#include <stdexcept>
 #include <string>
 
 namespace
@@ -51,13 +53,14 @@ BagMetadata load_bag_metadata(const std::string & rosbag_path)
 {
   BagMetadata meta;
 
-  const std::filesystem::path info_path = std::filesystem::path(rosbag_path) / "log_file_info.json";
-
-  if (!std::filesystem::is_regular_file(info_path)) {
-    return meta;
-  }
-
   try {
+    const std::filesystem::path info_path =
+      std::filesystem::path(rosbag_path) / "log_file_info.json";
+
+    if (!std::filesystem::is_regular_file(info_path)) {
+      return meta;
+    }
+
     std::ifstream file(info_path);
     const nlohmann::json j = nlohmann::json::parse(file);
 
@@ -70,9 +73,21 @@ BagMetadata load_bag_metadata(const std::string & rosbag_path)
     if (!log_file_name.empty()) {
       parse_date_and_bag_time(log_file_name, meta.date, meta.bag_time);
     }
-  } catch (...) {
-    return BagMetadata{};
+  } catch (const std::exception & e) {
+    std::cerr << "Warning: failed to load bag metadata from " << rosbag_path << ": " << e.what()
+              << std::endl;
+    return meta;
   }
 
   return meta;
+}
+
+void write_bag_metadata(nlohmann::json & j, const BagMetadata & bag_metadata)
+{
+  j["log_file_id"] = bag_metadata.log_file_id;
+  j["vehicle_id"] = bag_metadata.vehicle_id;
+  j["project_id"] = bag_metadata.project_id;
+  j["map_version_id"] = bag_metadata.map_version_id;
+  j["date"] = bag_metadata.date;
+  j["bag_time"] = bag_metadata.bag_time;
 }

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/io/frame_writer.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/io/frame_writer.cpp
@@ -14,8 +14,6 @@
 
 #include "io/frame_writer.hpp"
 
-#include "io/bag_metadata.hpp"
-
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
@@ -66,12 +64,7 @@ nlohmann::json build_frame_json(
   // Perception track UUIDs aligned 1:1 with the neighbor_past slots (for the
   // reproducer's cross-frame association / interpolation).
   j["neighbor_ids"] = neighbor_ids;
-  j["log_file_id"] = bag_metadata.log_file_id;
-  j["vehicle_id"] = bag_metadata.vehicle_id;
-  j["project_id"] = bag_metadata.project_id;
-  j["map_version_id"] = bag_metadata.map_version_id;
-  j["date"] = bag_metadata.date;
-  j["bag_time"] = bag_metadata.bag_time;
+  write_bag_metadata(j, bag_metadata);
   return j;
 }
 
@@ -123,12 +116,7 @@ nlohmann::json build_route_json(
       {"rosbag_diff_stats", rosbag_diff_stats_json}};
   }
   j["timestamp_stats"] = timestamp_stats_json;
-  j["log_file_id"] = bag_metadata.log_file_id;
-  j["vehicle_id"] = bag_metadata.vehicle_id;
-  j["project_id"] = bag_metadata.project_id;
-  j["map_version_id"] = bag_metadata.map_version_id;
-  j["date"] = bag_metadata.date;
-  j["bag_time"] = bag_metadata.bag_time;
+  write_bag_metadata(j, bag_metadata);
   return j;
 }
 

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/io/frame_writer.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/io/frame_writer.cpp
@@ -14,6 +14,8 @@
 
 #include "io/frame_writer.hpp"
 
+#include "io/bag_metadata.hpp"
+
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
@@ -36,7 +38,8 @@ inline double to_millisecond(const int64_t timestamp_ns)
 
 nlohmann::json build_frame_json(
   const nav_msgs::msg::Odometry & kinematic_state, const int64_t timestamp,
-  const SkippingInfo & skipping_info, const std::vector<std::string> & neighbor_ids)
+  const SkippingInfo & skipping_info, const std::vector<std::string> & neighbor_ids,
+  const BagMetadata & bag_metadata)
 {
   std::vector<int> incomplete_types;
   for (const auto & t : skipping_info.incomplete_data_types) {
@@ -63,13 +66,20 @@ nlohmann::json build_frame_json(
   // Perception track UUIDs aligned 1:1 with the neighbor_past slots (for the
   // reproducer's cross-frame association / interpolation).
   j["neighbor_ids"] = neighbor_ids;
+  j["log_file_id"] = bag_metadata.log_file_id;
+  j["vehicle_id"] = bag_metadata.vehicle_id;
+  j["project_id"] = bag_metadata.project_id;
+  j["map_version_id"] = bag_metadata.map_version_id;
+  j["date"] = bag_metadata.date;
+  j["bag_time"] = bag_metadata.bag_time;
   return j;
 }
 
 nlohmann::json build_route_json(
   const int64_t num_frames, const double traveled_distance_m, const int64_t start_timestamp,
   const int64_t end_timestamp, const SkippingInfo & skipping_info,
-  const timestamp_stats::TimestampStatsMap & timestamp_stats_map, const bool goal_pose_overwritten)
+  const timestamp_stats::TimestampStatsMap & timestamp_stats_map, const bool goal_pose_overwritten,
+  const BagMetadata & bag_metadata)
 {
   std::vector<int> missing_types;
   for (const auto & t : skipping_info.missing_topic_types) {
@@ -113,6 +123,12 @@ nlohmann::json build_route_json(
       {"rosbag_diff_stats", rosbag_diff_stats_json}};
   }
   j["timestamp_stats"] = timestamp_stats_json;
+  j["log_file_id"] = bag_metadata.log_file_id;
+  j["vehicle_id"] = bag_metadata.vehicle_id;
+  j["project_id"] = bag_metadata.project_id;
+  j["map_version_id"] = bag_metadata.map_version_id;
+  j["date"] = bag_metadata.date;
+  j["bag_time"] = bag_metadata.bag_time;
   return j;
 }
 
@@ -123,14 +139,15 @@ nlohmann::json build_route_json(
 void save_frame_json(
   const std::string & output_path, const std::string & rosbag_dir_name, const std::string & token,
   const nav_msgs::msg::Odometry & kinematic_state, const int64_t timestamp,
-  const SkippingInfo & skipping_info, const std::vector<std::string> & neighbor_ids)
+  const SkippingInfo & skipping_info, const std::vector<std::string> & neighbor_ids,
+  const BagMetadata & bag_metadata)
 {
   namespace fs = std::filesystem;
 
   fs::create_directories(output_path);
 
   const nlohmann::json j =
-    build_frame_json(kinematic_state, timestamp, skipping_info, neighbor_ids);
+    build_frame_json(kinematic_state, timestamp, skipping_info, neighbor_ids, bag_metadata);
 
   const std::string json_filename = output_path + "/" + rosbag_dir_name + "_" + token + ".json";
   std::ofstream json_file(json_filename);
@@ -146,7 +163,8 @@ void save_route_json(
   const std::string & output_path, const std::string & rosbag_dir_name,
   const std::string & identifier, const int64_t num_frames, const double traveled_distance_m,
   const int64_t start_timestamp, const int64_t end_timestamp, const SkippingInfo & skipping_info,
-  const timestamp_stats::TimestampStatsMap & timestamp_stats_map, const bool goal_pose_overwritten)
+  const timestamp_stats::TimestampStatsMap & timestamp_stats_map, const bool goal_pose_overwritten,
+  const BagMetadata & bag_metadata)
 {
   namespace fs = std::filesystem;
 
@@ -155,7 +173,7 @@ void save_route_json(
 
   const nlohmann::json j = build_route_json(
     num_frames, traveled_distance_m, start_timestamp, end_timestamp, skipping_info,
-    timestamp_stats_map, goal_pose_overwritten);
+    timestamp_stats_map, goal_pose_overwritten, bag_metadata);
 
   const std::string json_filename = routes_dir + "/" + rosbag_dir_name + "_" + identifier + ".json";
   std::ofstream json_file(json_filename);

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_processor.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_processor.cpp
@@ -14,6 +14,7 @@
 
 #include "processing/frame_processor.hpp"
 
+#include "io/bag_metadata.hpp"
 #include "io/frame_writer.hpp"
 #include "io/npz_frame_writer.hpp"
 #include "processing/ego_sequence.hpp"
@@ -47,7 +48,8 @@ void process_sequence(
   SequenceData & seq, const int64_t seq_id, const ConverterPaths & paths,
   const ConverterOptions & options,
   const autoware::diffusion_planner::preprocess::LaneSegmentContext & lane_segment_context,
-  const timestamp_stats::TimestampStatsMap & timestamp_stats_map)
+  const timestamp_stats::TimestampStatsMap & timestamp_stats_map,
+  const BagMetadata & bag_metadata)
 {
   using autoware::diffusion_planner::INPUT_T;
   using autoware::diffusion_planner::INPUT_T_WITH_CURRENT;
@@ -89,7 +91,7 @@ void process_sequence(
               << ")" << std::endl;
     save_route_json(
       paths.save_dir, rosbag_dir_name, sequence_id_str, n, traveled_distance, start_ts, end_ts,
-      SkippingInfo::insufficient_frames(n, options.min_frames), timestamp_stats_map, false);
+      SkippingInfo::insufficient_frames(n, options.min_frames), timestamp_stats_map, false, bag_metadata);
     return;
   }
 
@@ -100,7 +102,7 @@ void process_sequence(
     save_route_json(
       paths.save_dir, rosbag_dir_name, sequence_id_str, n, traveled_distance, start_ts, end_ts,
       SkippingInfo::insufficient_distance(traveled_distance, options.min_distance),
-      timestamp_stats_map, false);
+      timestamp_stats_map, false, bag_metadata);
     return;
   }
 
@@ -116,7 +118,7 @@ void process_sequence(
 
   save_route_json(
     paths.save_dir, rosbag_dir_name, sequence_id_str, n, traveled_distance, start_ts, end_ts,
-    SkippingInfo::accepted(), timestamp_stats_map, goal_pose_overwritten);
+    SkippingInfo::accepted(), timestamp_stats_map, goal_pose_overwritten, bag_metadata);
 
   // Pack-sequence accumulators: in pack mode every frame is collected here (gap-free) and
   // flushed once after the loop into a single npz + single json array for the sequence.
@@ -313,7 +315,7 @@ void process_sequence(
         turn_indicators, ego_shape);
       nlohmann::json frame_json = build_frame_json(
         seq.data_list[i].kinematic_state, seq.data_list[i].timestamp, skipping_info,
-        neighbor_result.neighbor_ids);
+        neighbor_result.neighbor_ids, bag_metadata);
       frame_json["token"] = token;
       sequence_frames_json.push_back(std::move(frame_json));
     } else {
@@ -328,7 +330,7 @@ void process_sequence(
       }
       save_frame_json(
         paths.save_dir, rosbag_dir_name, token, seq.data_list[i].kinematic_state,
-        seq.data_list[i].timestamp, skipping_info, neighbor_result.neighbor_ids);
+        seq.data_list[i].timestamp, skipping_info, neighbor_result.neighbor_ids, bag_metadata);
     }
 
     if (i % 100 == 0) {

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_processor.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_processor.cpp
@@ -48,8 +48,7 @@ void process_sequence(
   SequenceData & seq, const int64_t seq_id, const ConverterPaths & paths,
   const ConverterOptions & options,
   const autoware::diffusion_planner::preprocess::LaneSegmentContext & lane_segment_context,
-  const timestamp_stats::TimestampStatsMap & timestamp_stats_map,
-  const BagMetadata & bag_metadata)
+  const timestamp_stats::TimestampStatsMap & timestamp_stats_map, const BagMetadata & bag_metadata)
 {
   using autoware::diffusion_planner::INPUT_T;
   using autoware::diffusion_planner::INPUT_T_WITH_CURRENT;
@@ -91,7 +90,8 @@ void process_sequence(
               << ")" << std::endl;
     save_route_json(
       paths.save_dir, rosbag_dir_name, sequence_id_str, n, traveled_distance, start_ts, end_ts,
-      SkippingInfo::insufficient_frames(n, options.min_frames), timestamp_stats_map, false, bag_metadata);
+      SkippingInfo::insufficient_frames(n, options.min_frames), timestamp_stats_map, false,
+      bag_metadata);
     return;
   }
 

--- a/cpp_tools/src/autoware_diffusion_planner_tools/test/test_bag_metadata.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/test/test_bag_metadata.cpp
@@ -113,3 +113,18 @@ TEST_F(BagMetadataTest, LogFileNameWithoutDateTimePattern)
   EXPECT_EQ(meta.date, "");
   EXPECT_EQ(meta.bag_time, "");
 }
+
+TEST_F(BagMetadataTest, NonStringFieldReturnsEmpty)
+{
+  write_json(R"({
+    "id": 42,
+    "vehicle_id": true,
+    "project_id": "valid_string"
+  })");
+
+  const BagMetadata meta = load_bag_metadata(tmp_dir_.string());
+
+  EXPECT_EQ(meta.log_file_id, "");
+  EXPECT_EQ(meta.vehicle_id, "");
+  EXPECT_EQ(meta.project_id, "valid_string");
+}

--- a/cpp_tools/src/autoware_diffusion_planner_tools/test/test_bag_metadata.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/test/test_bag_metadata.cpp
@@ -1,0 +1,115 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "io/bag_metadata.hpp"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+
+namespace fs = std::filesystem;
+
+class BagMetadataTest : public ::testing::Test
+{
+protected:
+  fs::path tmp_dir_;
+
+  void SetUp() override
+  {
+    tmp_dir_ = fs::temp_directory_path() / "test_bag_metadata";
+    fs::create_directories(tmp_dir_);
+  }
+
+  void TearDown() override { fs::remove_all(tmp_dir_); }
+
+  void write_json(const std::string & content)
+  {
+    std::ofstream f(tmp_dir_ / "log_file_info.json");
+    f << content;
+  }
+};
+
+TEST_F(BagMetadataTest, ValidJsonAllFields)
+{
+  write_json(R"({
+    "id": "1a5afeae-131a-4937-9c71-f9bd2a13e0dc",
+    "vehicle_id": "cfa23601-97c4-4d47-a37e-edfc7e080d8c",
+    "project_id": "x2_dev",
+    "area_map_version_id": "1847-20250819054643702212",
+    "log_file_name": "cfa23601-97c4-4d47-a37e-edfc7e080d8c_2026-01-16-10-03-35_p0900_0.db3.zst"
+  })");
+
+  const BagMetadata meta = load_bag_metadata(tmp_dir_.string());
+
+  EXPECT_EQ(meta.log_file_id, "1a5afeae-131a-4937-9c71-f9bd2a13e0dc");
+  EXPECT_EQ(meta.vehicle_id, "cfa23601-97c4-4d47-a37e-edfc7e080d8c");
+  EXPECT_EQ(meta.project_id, "x2_dev");
+  EXPECT_EQ(meta.map_version_id, "1847-20250819054643702212");
+  EXPECT_EQ(meta.date, "2026-01-16");
+  EXPECT_EQ(meta.bag_time, "10-03-35");
+}
+
+TEST_F(BagMetadataTest, MissingFileReturnsEmptyStrings)
+{
+  const BagMetadata meta = load_bag_metadata("/nonexistent/path");
+
+  EXPECT_EQ(meta.log_file_id, "");
+  EXPECT_EQ(meta.vehicle_id, "");
+  EXPECT_EQ(meta.project_id, "");
+  EXPECT_EQ(meta.map_version_id, "");
+  EXPECT_EQ(meta.date, "");
+  EXPECT_EQ(meta.bag_time, "");
+}
+
+TEST_F(BagMetadataTest, MalformedJsonReturnsEmptyStrings)
+{
+  write_json("this is not json {{{");
+
+  const BagMetadata meta = load_bag_metadata(tmp_dir_.string());
+
+  EXPECT_EQ(meta.log_file_id, "");
+  EXPECT_EQ(meta.vehicle_id, "");
+}
+
+TEST_F(BagMetadataTest, MissingIndividualFieldsPartiallyPopulated)
+{
+  write_json(R"({
+    "id": "abc-123",
+    "project_id": "erga"
+  })");
+
+  const BagMetadata meta = load_bag_metadata(tmp_dir_.string());
+
+  EXPECT_EQ(meta.log_file_id, "abc-123");
+  EXPECT_EQ(meta.project_id, "erga");
+  EXPECT_EQ(meta.vehicle_id, "");
+  EXPECT_EQ(meta.map_version_id, "");
+  EXPECT_EQ(meta.date, "");
+  EXPECT_EQ(meta.bag_time, "");
+}
+
+TEST_F(BagMetadataTest, LogFileNameWithoutDateTimePattern)
+{
+  write_json(R"({
+    "id": "abc",
+    "log_file_name": "some_unusual_name.db3"
+  })");
+
+  const BagMetadata meta = load_bag_metadata(tmp_dir_.string());
+
+  EXPECT_EQ(meta.log_file_id, "abc");
+  EXPECT_EQ(meta.date, "");
+  EXPECT_EQ(meta.bag_time, "");
+}

--- a/cpp_tools/src/autoware_diffusion_planner_tools/test/test_frame_writer.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/test/test_frame_writer.cpp
@@ -14,7 +14,17 @@
 
 #include "io/frame_writer.hpp"
 
+#include "io/bag_metadata.hpp"
+
 #include <gtest/gtest.h>
+
+namespace
+{
+BagMetadata make_test_metadata()
+{
+  return {"log-id-1", "vehicle-id-1", "x2_dev", "1847-ver", "2026-01-16", "10-03-35"};
+}
+}  // namespace
 
 // ---------------------------------------------------------------------------
 // build_frame_json
@@ -35,7 +45,7 @@ TEST(BuildFrameJsonTest, AcceptedFrameFields)
   const int64_t ts = 123456789LL;
 
   const std::vector<std::string> neighbor_ids = {"aaaa", "bbbb", "cccc"};
-  const nlohmann::json j = build_frame_json(odom, ts, info, neighbor_ids);
+  const nlohmann::json j = build_frame_json(odom, ts, info, neighbor_ids, make_test_metadata());
 
   EXPECT_FALSE(j["is_skipped"].get<bool>());
   EXPECT_EQ(j["timestamp"].get<int64_t>(), ts);
@@ -44,6 +54,12 @@ TEST(BuildFrameJsonTest, AcceptedFrameFields)
   EXPECT_DOUBLE_EQ(j["z"].get<double>(), 3.3);
   EXPECT_EQ(j["skipping_info"]["label"].get<int>(), static_cast<int>(SkippingLabel::NotSkipped));
   EXPECT_EQ(j["neighbor_ids"].get<std::vector<std::string>>(), neighbor_ids);
+  EXPECT_EQ(j["log_file_id"].get<std::string>(), "log-id-1");
+  EXPECT_EQ(j["vehicle_id"].get<std::string>(), "vehicle-id-1");
+  EXPECT_EQ(j["project_id"].get<std::string>(), "x2_dev");
+  EXPECT_EQ(j["map_version_id"].get<std::string>(), "1847-ver");
+  EXPECT_EQ(j["date"].get<std::string>(), "2026-01-16");
+  EXPECT_EQ(j["bag_time"].get<std::string>(), "10-03-35");
 }
 
 TEST(BuildFrameJsonTest, SkippedFrameIsSkippedTrue)
@@ -51,7 +67,7 @@ TEST(BuildFrameJsonTest, SkippedFrameIsSkippedTrue)
   nav_msgs::msg::Odometry odom;
   const SkippingInfo info = SkippingInfo::stale_data(600'000'000LL);
 
-  const nlohmann::json j = build_frame_json(odom, 0LL, info, std::vector<std::string>{});
+  const nlohmann::json j = build_frame_json(odom, 0LL, info, std::vector<std::string>{}, BagMetadata{});
 
   EXPECT_TRUE(j["is_skipped"].get<bool>());
   EXPECT_EQ(
@@ -67,14 +83,17 @@ TEST(BuildRouteJsonTest, BasicFieldsPresent)
   const SkippingInfo info = SkippingInfo::accepted();
   timestamp_stats::TimestampStatsMap stats_map({});  // empty map
 
-  const nlohmann::json j = build_route_json(42, 150.5, 1000000LL, 2000000LL, info, stats_map);
+  const nlohmann::json j = build_route_json(42, 150.5, 1000000LL, 2000000LL, info, stats_map, false, make_test_metadata());
 
   EXPECT_FALSE(j["is_skipped"].get<bool>());
+  EXPECT_FALSE(j["goal_pose_overwritten"].get<bool>());
   EXPECT_EQ(j["num_frames"].get<int64_t>(), 42);
   EXPECT_DOUBLE_EQ(j["traveled_distance_m"].get<double>(), 150.5);
   EXPECT_EQ(j["start_timestamp"].get<int64_t>(), 1000000LL);
   EXPECT_EQ(j["end_timestamp"].get<int64_t>(), 2000000LL);
   EXPECT_EQ(j["skipping_info"]["label"].get<int>(), static_cast<int>(SkippingLabel::NotSkipped));
+  EXPECT_EQ(j["log_file_id"].get<std::string>(), "log-id-1");
+  EXPECT_EQ(j["vehicle_id"].get<std::string>(), "vehicle-id-1");
 }
 
 TEST(BuildRouteJsonTest, SkippedRouteFieldsPresent)
@@ -82,9 +101,10 @@ TEST(BuildRouteJsonTest, SkippedRouteFieldsPresent)
   const SkippingInfo info = SkippingInfo::insufficient_frames(100, 1700);
   timestamp_stats::TimestampStatsMap stats_map({});
 
-  const nlohmann::json j = build_route_json(100, 10.0, 0LL, 1000LL, info, stats_map);
+  const nlohmann::json j = build_route_json(100, 10.0, 0LL, 1000LL, info, stats_map, false, BagMetadata{});
 
   EXPECT_TRUE(j["is_skipped"].get<bool>());
   EXPECT_EQ(
     j["skipping_info"]["label"].get<int>(), static_cast<int>(SkippingLabel::InsufficientFrames));
+  EXPECT_EQ(j["log_file_id"].get<std::string>(), "");
 }

--- a/cpp_tools/src/autoware_diffusion_planner_tools/test/test_frame_writer.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/test/test_frame_writer.cpp
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "io/frame_writer.hpp"
-
 #include "io/bag_metadata.hpp"
+#include "io/frame_writer.hpp"
 
 #include <gtest/gtest.h>
 
@@ -67,7 +66,8 @@ TEST(BuildFrameJsonTest, SkippedFrameIsSkippedTrue)
   nav_msgs::msg::Odometry odom;
   const SkippingInfo info = SkippingInfo::stale_data(600'000'000LL);
 
-  const nlohmann::json j = build_frame_json(odom, 0LL, info, std::vector<std::string>{}, BagMetadata{});
+  const nlohmann::json j =
+    build_frame_json(odom, 0LL, info, std::vector<std::string>{}, BagMetadata{});
 
   EXPECT_TRUE(j["is_skipped"].get<bool>());
   EXPECT_EQ(
@@ -83,7 +83,8 @@ TEST(BuildRouteJsonTest, BasicFieldsPresent)
   const SkippingInfo info = SkippingInfo::accepted();
   timestamp_stats::TimestampStatsMap stats_map({});  // empty map
 
-  const nlohmann::json j = build_route_json(42, 150.5, 1000000LL, 2000000LL, info, stats_map, false, make_test_metadata());
+  const nlohmann::json j =
+    build_route_json(42, 150.5, 1000000LL, 2000000LL, info, stats_map, false, make_test_metadata());
 
   EXPECT_FALSE(j["is_skipped"].get<bool>());
   EXPECT_FALSE(j["goal_pose_overwritten"].get<bool>());
@@ -101,7 +102,8 @@ TEST(BuildRouteJsonTest, SkippedRouteFieldsPresent)
   const SkippingInfo info = SkippingInfo::insufficient_frames(100, 1700);
   timestamp_stats::TimestampStatsMap stats_map({});
 
-  const nlohmann::json j = build_route_json(100, 10.0, 0LL, 1000LL, info, stats_map, false, BagMetadata{});
+  const nlohmann::json j =
+    build_route_json(100, 10.0, 0LL, 1000LL, info, stats_map, false, BagMetadata{});
 
   EXPECT_TRUE(j["is_skipped"].get<bool>());
   EXPECT_EQ(


### PR DESCRIPTION
## Summary
- Add 6 provenance metadata fields (`log_file_id`, `vehicle_id`, `project_id`, `map_version_id`, `date`, `bag_time`) to both per-frame sidecar JSON and per-route JSON
- Read from `log_file_info.json` in the rosbag directory (produced by `webauto data log-file pull`)
- Graceful fallback: if `log_file_info.json` is missing or malformed, all fields default to empty strings

## Motivation
Training samples (NPZ + sidecar JSON) currently cannot be traced back to their source rosbag once moved out of the original directory structure. These fields enable full provenance tracking and enable joining with SFT cleansing data.

## Changes
- New `BagMetadata` struct and `load_bag_metadata()` function (`bag_metadata.hpp/cpp`)
- Extended `build_frame_json()` and `build_route_json()` to accept and write the 6 fields
- Threaded `BagMetadata` through `run_data_converter()` → `process_sequence()` → writer calls
- Fixed pre-existing broken tests (missing `goal_pose_overwritten` argument)
- Added comprehensive unit tests for `load_bag_metadata()` (5 test cases)

## Test plan
- [x] `test_bag_metadata`: 5 tests covering valid JSON, missing file, malformed JSON, partial fields, unusual log_file_name
- [x] `test_frame_writer`: 4 tests covering frame/route JSON with populated and empty metadata
- [x] `data_converter` and `parse_rosbag_for_directory_with_map_version` binaries build cleanly