### PR TITLE
feat(deterministic): add deterministic gpu algorithm

### DIFF
--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -196,8 +196,10 @@ def model_training(args: TrainConfig):
 
     # Deterministic
     if args.deterministic:
-        # Warn only if it is not possible to use deterministic algorithms for some operations.
-        torch.use_deterministic_algorithms(True, warn_only=True)
+        # Set CUBLAS_WORKSPACE_CONFIG to ensure deterministic behavior for cuBLAS operations.
+        # 4096:8 means 24 MiB workspace with more memory, faster
+        os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+        torch.use_deterministic_algorithms(True)
 
     # training parameters
     train_epochs = args.train_epochs

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -172,6 +172,7 @@ def model_training(args: TrainConfig):
         print("Batch size: {}".format(args.batch_size))
         print("Learning rate: {}".format(args.learning_rate))
         print("Use device: {}".format(args.device))
+        print("Deterministic mode: {}".format(args.deterministic))
 
         save_path = args.save_dir
         os.makedirs(save_path, exist_ok=True)
@@ -192,6 +193,11 @@ def model_training(args: TrainConfig):
 
     # set seed
     set_seed(args.seed + global_rank)
+
+    # Deterministic
+    if args.deterministic:
+        # Warn only if it is not possible to use deterministic algorithms for some operations.
+        torch.use_deterministic_algorithms(True, warn_only=True)
 
     # training parameters
     train_epochs = args.train_epochs

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -163,3 +163,8 @@ class TrainConfig:
     # ---------------------------------------------------------
     state_normalizer: Optional[StateNormalizer] = None
     observation_normalizer: Optional[ObservationNormalizer] = None
+
+    # ---------------------------------------------------------
+    # Deterministic
+    # ---------------------------------------------------------
+    deterministic: bool = True

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -243,6 +243,13 @@ def get_args(args_list=None):
     parser.add_argument("--closed_loop_unstick_after", type=int, default=300)
     parser.add_argument("--closed_loop_unstick_advance_m", type=float, default=5.0)
 
+    # Deterministic
+    parser.add_argument(
+        "--deterministic",
+        type=boolean,
+        default=True,
+        help="Set True to run Pytorch GPU kernels in deterministic mode (may be slightly slower).",
+    )
     args = parser.parse_args(args_list)
     return args
 

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -248,7 +248,7 @@ def get_args(args_list=None):
         "--deterministic",
         type=boolean,
         default=True,
-        help="Set True to run Pytorch GPU kernels in deterministic mode (may be slightly slower).",
+        help="Set True to run PyTorch GPU kernels in deterministic mode (may be slightly slower).",
     )
     args = parser.parse_args(args_list)
     return args


### PR DESCRIPTION
## Summary

Add:
```
os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
torch.use_deterministic_algorithms(True)
```
to have gpu kernel-level deterministic behaviour.

## Logs
### Without the changes
```
------------- mini_split_test_running_1 -------------
Batch size: 4
Learning rate: 0.0001
Use device: cuda
Deterministic mode: False
Dataset Prepared: 4096 train data

validate (slowest rank): 100%|██████████| 256/256 [00:12<00:00, 19.97it/s]
valid_loss_ego=21.747
valid_loss_neighbor=1058.331
valid_loss_ego_position_lat_loss=0.641
valid_loss_ego_position_lon_loss=8.410
turn_indicator_accuracy=0.000
turn_indicator_change_accuracy=0.000
turn_indicator_change_total=7.000

Training:   0%|          | 0/1024 [00:00<?, ?batch/s][rank0]:[W709 16:29:57.191070348 reducer.cpp:1529] Warning: find_unused_parameters=True was specified in DDP constructor, but did not find any unused parameters in the forward pass. This flag results in an extra traversal of the autograd graph every iteration,  which can adversely affect performance. If your model indeed never has any unused parameters in the forward pass, consider turning this flag off. Note that this warning may be a false positive if your model has flow control causing later iterations to have unused parameters. (function operator())
Training:  24%|██▍       | 249/1024 [00:26<01:20,  9.64batch/s]

Step 250: loss=1.8191
Step 250: turn_indicator_accuracy=1.0000
Step 250: grad_norm=5.0165
Training:  49%|████▊     | 499/1024 [00:52<00:53,  9.87batch/s]

Step 500: loss=0.6734
Step 500: turn_indicator_accuracy=1.0000
Step 500: grad_norm=6.5283
Training:  73%|███████▎  | 749/1024 [01:17<00:28,  9.79batch/s]

Step 750: loss=0.8646
Step 750: turn_indicator_accuracy=1.0000
Step 750: grad_norm=5.5064
Training:  98%|█████████▊| 999/1024 [01:43<00:02,  9.87batch/s]

Step 1000: loss=0.6338
Step 1000: turn_indicator_accuracy=1.0000
Step 1000: grad_norm=7.6741
Training: 100%|██████████| 1024/1024 [01:45<00:00,  9.67batch/s]
epoch_mean_loss['loss']=1.1354
epoch_mean_loss['turn_indicator_accuracy']=0.9751

------------- mini_split_test_running_2 -------------
Batch size: 4
Learning rate: 0.0001
Use device: cuda
Deterministic mode: False
Dataset Prepared: 4096 train data

validate (slowest rank): 100%|██████████| 256/256 [00:12<00:00, 19.97it/s]
valid_loss_ego=21.747
valid_loss_neighbor=1058.331
valid_loss_ego_position_lat_loss=0.641
valid_loss_ego_position_lon_loss=8.410
turn_indicator_accuracy=0.000
turn_indicator_change_accuracy=0.000
turn_indicator_change_total=7.000

Training:   0%|          | 0/1024 [00:00<?, ?batch/s][rank0]:[W709 16:32:10.190171063 reducer.cpp:1529] Warning: find_unused_parameters=True was specified in DDP constructor, but did not find any unused parameters in the forward pass. This flag results in an extra traversal of the autograd graph every iteration,  which can adversely affect performance. If your model indeed never has any unused parameters in the forward pass, consider turning this flag off. Note that this warning may be a false positive if your model has flow control causing later iterations to have unused parameters. (function operator())
Training:  24%|██▍       | 249/1024 [00:25<01:18,  9.83batch/s]

Step 250: loss=1.8191
Step 250: turn_indicator_accuracy=1.0000
Step 250: grad_norm=5.0165
Training:  49%|████▊     | 499/1024 [00:52<00:56,  9.31batch/s]

Step 500: loss=0.6602
Step 500: turn_indicator_accuracy=1.0000
Step 500: grad_norm=4.2776
Training:  73%|███████▎  | 749/1024 [01:17<00:27,  9.85batch/s]

Step 750: loss=0.8491
Step 750: turn_indicator_accuracy=1.0000
Step 750: grad_norm=3.7143
Training:  98%|█████████▊| 999/1024 [01:43<00:02,  9.81batch/s]

Step 1000: loss=0.6223
Step 1000: turn_indicator_accuracy=1.0000
Step 1000: grad_norm=7.5210
Training: 100%|██████████| 1024/1024 [01:46<00:00,  9.65batch/s]
epoch_mean_loss['loss']=1.1330
epoch_mean_loss['turn_indicator_accuracy']=0.9753
```

### With the changes
```
------------- mini_split_test_running_3 -------------
Batch size: 4
Learning rate: 0.0001
Use device: cuda
Deterministic mode: True
Dataset Prepared: 4096 train data

validate (slowest rank): 100%|██████████| 256/256 [00:12<00:00, 19.97it/s]
valid_loss_ego=21.747
valid_loss_neighbor=1058.331
valid_loss_ego_position_lat_loss=0.641
valid_loss_ego_position_lon_loss=8.410
turn_indicator_accuracy=0.000
turn_indicator_change_accuracy=0.000
turn_indicator_change_total=7.000

Training:   0%|          | 0/1024 [00:00<?, ?batch/s][rank0]:[W709 16:46:31.564796090 reducer.cpp:1529] Warning: find_unused_parameters=True was specified in DDP constructor, but did not find any unused parameters in the forward pass. This flag results in an extra traversal of the autograd graph every iteration,  which can adversely affect performance. If your model indeed never has any unused parameters in the forward pass, consider turning this flag off. Note that this warning may be a false positive if your model has flow control causing later iterations to have unused parameters. (function operator())
Training:  24%|██▍       | 249/1024 [00:31<01:39,  7.75batch/s]

Step 250: loss=1.8191
Step 250: turn_indicator_accuracy=1.0000
Step 250: grad_norm=5.0165
Training:  49%|████▊     | 499/1024 [01:03<01:09,  7.59batch/s]

Step 500: loss=0.6689
Step 500: turn_indicator_accuracy=1.0000
Step 500: grad_norm=4.5594
Training:  73%|███████▎  | 749/1024 [01:34<00:33,  8.24batch/s]

Step 750: loss=0.8698
Step 750: turn_indicator_accuracy=1.0000
Step 750: grad_norm=5.1407
Training:  98%|█████████▊| 999/1024 [02:05<00:03,  7.99batch/s]

Step 1000: loss=0.6414
Step 1000: turn_indicator_accuracy=1.0000
Step 1000: grad_norm=6.1341
Training: 100%|██████████| 1024/1024 [02:08<00:00,  7.99batch/s]
epoch_mean_loss['loss']=1.1353
epoch_mean_loss['turn_indicator_accuracy']=0.9756


------------- mini_split_test_running_4 -------------
Batch size: 4
Learning rate: 0.0001
Use device: cuda
Deterministic mode: True
Dataset Prepared: 4096 train data

validate (slowest rank): 100%|██████████| 256/256 [00:12<00:00, 19.97it/s]
valid_loss_ego=21.747
valid_loss_neighbor=1058.331
valid_loss_ego_position_lat_loss=0.641
valid_loss_ego_position_lon_loss=8.410
turn_indicator_accuracy=0.000
turn_indicator_change_accuracy=0.000
turn_indicator_change_total=7.000

Training:   0%|          | 0/1024 [00:00<?, ?batch/s][rank0]:[W709 16:49:09.666320316 reducer.cpp:1529] Warning: find_unused_parameters=True was specified in DDP constructor, but did not find any unused parameters in the forward pass. This flag results in an extra traversal of the autograd graph every iteration,  which can adversely affect performance. If your model indeed never has any unused parameters in the forward pass, consider turning this flag off. Note that this warning may be a false positive if your model has flow control causing later iterations to have unused parameters. (function operator())
Training:  24%|██▍       | 249/1024 [00:30<01:33,  8.28batch/s]

Step 250: loss=1.8191
Step 250: turn_indicator_accuracy=1.0000
Step 250: grad_norm=5.0165
Training:  49%|████▊     | 499/1024 [01:01<01:03,  8.25batch/s]

Step 500: loss=0.6689
Step 500: turn_indicator_accuracy=1.0000
Step 500: grad_norm=4.5594
Training:  73%|███████▎  | 749/1024 [01:31<00:33,  8.27batch/s]

Step 750: loss=0.8698
Step 750: turn_indicator_accuracy=1.0000
Step 750: grad_norm=5.1407
Training:  98%|█████████▊| 999/1024 [02:02<00:03,  8.26batch/s]

Step 1000: loss=0.6414
Step 1000: turn_indicator_accuracy=1.0000
Step 1000: grad_norm=6.1341
Training: 100%|██████████| 1024/1024 [02:05<00:00,  8.17batch/s]
epoch_mean_loss['loss']=1.1353
epoch_mean_loss['turn_indicator_accuracy']=0.9756
```