### PR TITLE
feat: add cluster-weighted sampler for training

### DIFF
--- a/diffusion_planner/diffusion_planner/model/module/decoder.py
+++ b/diffusion_planner/diffusion_planner/model/module/decoder.py
@@ -254,11 +254,12 @@ def compute_training_loss(
     assert not torch.isnan(dpm_loss).sum(), f"loss cannot be nan, z={z}"
 
     turn_indicator_logit = decoder_output["turn_indicator_logit"]  # [B, TURN_INDICATOR_OUTPUT_KEEP]
-    turn_indicator_gt = make_turn_indicator_gt(inputs["turn_indicators"])  # [B,]
+    turn_indicators_for_gt = inputs.get("turn_indicators_gt_source", inputs["turn_indicators"])
+    turn_indicator_gt = make_turn_indicator_gt(turn_indicators_for_gt)  # [B,]
     turn_indicator_loss = nn.functional.cross_entropy(
         turn_indicator_logit, turn_indicator_gt, reduction="none"
     )
-    turn_indicator_change = inputs["turn_indicators"][:, -2] != inputs["turn_indicators"][:, -1]
+    turn_indicator_change = turn_indicators_for_gt[:, -2] != turn_indicators_for_gt[:, -1]
     turn_indicator_coeff = torch.where(turn_indicator_change, 1.0, 0.05)
     turn_indicator_loss = (turn_indicator_loss * turn_indicator_coeff).mean()
     loss["turn_indicator_loss"] = turn_indicator_loss

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -337,6 +337,16 @@ def model_training(args: TrainConfig):
                 )
             )
 
+    if global_rank == 0 and args.cluster_json:
+        import json as _json
+
+        with open(args.cluster_json, "r") as f:
+            _clusters = _json.load(f)
+        _cluster_sizes = {k: len(v) for k, v in _clusters.items()}
+        print("Cluster distribution:")
+        for k, v in sorted(_cluster_sizes.items()):
+            print(f"  {k}: {v} samples")
+
     if args.ddp:
         torch.distributed.barrier()
 

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -21,7 +21,12 @@ from diffusion_planner.utils.data_augmentation_bridge import (
     StatePerturbation as BridgeStatePerturbation,
 )
 from diffusion_planner.utils.dataset import DiffusionPlannerData, DiffusionPlannerPairData
-from diffusion_planner.utils.forced_augmentation import build_aug_pipeline
+from diffusion_planner.utils.forced_augmentation import (
+    ForcedAugmentationSelector,
+    build_aug_pipeline,
+    duplicate_path_warning,
+    validate_forced_aug_flags,
+)
 from diffusion_planner.utils.lr_schedule import CosineAnnealingWarmUpRestarts
 from diffusion_planner.utils.normalizer import ObservationNormalizer, StateNormalizer
 from diffusion_planner.utils.onnx_export import export_checkpoint_onnx_guarded
@@ -269,13 +274,26 @@ def model_training(args: TrainConfig):
     # Ordered (name, aug) pairs. train_epoch applies them in this order and looks up
     # each one's force mask by name.
     aug_pipeline = build_aug_pipeline({"state_perturbation": aug})
-    aug_selector = None
+
+    # Validate before the dataset scan: a bad flag must not surface after model init.
+    try:
+        repeat_aug_pool, pool_warnings = validate_forced_aug_flags(args, aug_pipeline)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    if global_rank == 0:
+        for message in pool_warnings:
+            print(f"WARNING: {message}")
 
     # prepare dataset
     train_set = DiffusionPlannerData(args.train_set_list)
     valid_set = DiffusionPlannerData(args.valid_set_list)
 
     train_set.data_list = train_set.data_list[:: args.train_subsample_step]
+
+    if repeat_aug_pool and global_rank == 0:
+        duplicate_message = duplicate_path_warning(train_set.data_list)
+        if duplicate_message is not None:
+            print(f"WARNING: {duplicate_message}")
 
     if args.cluster_json:
         train_sampler = ClusterWeightedDistributedSampler(
@@ -285,6 +303,7 @@ def model_training(args: TrainConfig):
             rank=global_rank,
             seed=args.seed,
             alpha=args.cluster_weight_alpha,
+            track_repeats=bool(repeat_aug_pool),
         )
         if global_rank == 0:
             print(f"Using cluster-weighted sampling from {args.cluster_json}")
@@ -297,6 +316,14 @@ def model_training(args: TrainConfig):
         train_sampler = DistributedSampler(
             train_set, num_replicas=ddp.get_world_size(), rank=global_rank, shuffle=True
         )
+
+    if repeat_aug_pool:
+        aug_selector = ForcedAugmentationSelector(repeat_aug_pool, seed=args.seed)
+        if global_rank == 0:
+            print(f"Forcing one augmentation on repeat draws from pool: {repeat_aug_pool}")
+    else:
+        aug_selector = None
+
     train_loader = DataLoader(
         train_set,
         sampler=train_sampler,
@@ -384,6 +411,12 @@ def model_training(args: TrainConfig):
             "cluster_counts": ordered_counts,
             "cluster_multipliers": {
                 k: train_sampler.cluster_multipliers[k] for k in ordered_counts
+            },
+            # Configuration only. This file is written once at startup, so any
+            # forced/noop row counters here would be structurally always zero.
+            "forced_augmentation": {
+                "enabled": bool(repeat_aug_pool),
+                "pool": list(repeat_aug_pool),
             },
         }
         if save_path is not None:

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -344,7 +344,18 @@ def model_training(args: TrainConfig):
             f"(matched {train_sampler.matched_count}/{len(train_set.data_list)} data paths, "
             f"alpha={args.cluster_weight_alpha:.2f}):"
         )
-        for k, v in sorted(train_sampler.cluster_counts.items()):
+
+        def _cluster_sort_key(item):
+            """Sort cluster_id<N> numerically so id10 follows id2, not id1.
+
+            Falls back to lexicographic order for keys that do not match the
+            ``cluster_id<N>`` shape -- a logging line must never crash training.
+            """
+            key = item[0]
+            suffix = key.replace("cluster_id", "", 1) if key.startswith("cluster_id") else key
+            return (0, int(suffix), "") if suffix.isdigit() else (1, 0, key)
+
+        for k, v in sorted(train_sampler.cluster_counts.items(), key=_cluster_sort_key):
             print(f"  {k}: {v} samples  {train_sampler.cluster_multipliers[k]:.2f}x")
 
     if args.ddp:

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -29,6 +29,12 @@ from diffusion_planner.utils.forced_augmentation import (
 )
 from diffusion_planner.utils.lr_schedule import CosineAnnealingWarmUpRestarts
 from diffusion_planner.utils.normalizer import ObservationNormalizer, StateNormalizer
+from diffusion_planner.utils.online_augmentations import (
+    FlipAugmentation,
+    NeighborDropoutAugmentation,
+    NeighborNoiseAugmentation,
+    TurnIndicatorDropoutAugmentation,
+)
 from diffusion_planner.utils.onnx_export import export_checkpoint_onnx_guarded
 from diffusion_planner.utils.train_utils import resume_model, set_seed
 from diffusion_planner.utils.weighted_sampler import ClusterWeightedDistributedSampler
@@ -271,9 +277,39 @@ def model_training(args: TrainConfig):
     else:
         aug = None
 
+    flip_aug = FlipAugmentation(args.flip_prob, args.device) if args.use_flip_augment else None
+    neighbor_dropout = (
+        NeighborDropoutAugmentation(args.neighbor_dropout_prob, args.device)
+        if args.use_neighbor_dropout
+        else None
+    )
+    neighbor_noise = (
+        NeighborNoiseAugmentation(
+            args.neighbor_noise_pos_std,
+            args.neighbor_noise_vel_std,
+            args.neighbor_noise_heading_std,
+            args.device,
+        )
+        if args.use_neighbor_noise
+        else None
+    )
+    turn_indicator_dropout = (
+        TurnIndicatorDropoutAugmentation(args.turn_indicator_dropout_prob, args.device)
+        if args.use_turn_indicator_dropout
+        else None
+    )
+
     # Ordered (name, aug) pairs. train_epoch applies them in this order and looks up
     # each one's force mask by name.
-    aug_pipeline = build_aug_pipeline({"state_perturbation": aug})
+    aug_pipeline = build_aug_pipeline(
+        {
+            "flip": flip_aug,
+            "neighbor_dropout": neighbor_dropout,
+            "neighbor_noise": neighbor_noise,
+            "turn_indicator": turn_indicator_dropout,
+            "state_perturbation": aug,
+        }
+    )
 
     # Validate before the dataset scan: a bad flag must not surface after model init.
     try:

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -338,13 +338,11 @@ def model_training(args: TrainConfig):
             )
 
     if global_rank == 0 and args.cluster_json:
-        import json as _json
-
-        with open(args.cluster_json, "r") as f:
-            _clusters = _json.load(f)
-        _cluster_sizes = {k: len(v) for k, v in _clusters.items()}
-        print("Cluster distribution:")
-        for k, v in sorted(_cluster_sizes.items()):
+        print(
+            f"Cluster distribution "
+            f"(matched {train_sampler.matched_count}/{len(train_set.data_list)} data paths):"
+        )
+        for k, v in sorted(train_sampler.cluster_counts.items()):
             print(f"  {k}: {v} samples")
 
     if args.ddp:

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -21,6 +21,7 @@ from diffusion_planner.utils.data_augmentation_bridge import (
     StatePerturbation as BridgeStatePerturbation,
 )
 from diffusion_planner.utils.dataset import DiffusionPlannerData, DiffusionPlannerPairData
+from diffusion_planner.utils.forced_augmentation import build_aug_pipeline
 from diffusion_planner.utils.lr_schedule import CosineAnnealingWarmUpRestarts
 from diffusion_planner.utils.normalizer import ObservationNormalizer, StateNormalizer
 from diffusion_planner.utils.onnx_export import export_checkpoint_onnx_guarded
@@ -264,6 +265,11 @@ def model_training(args: TrainConfig):
             )
     else:
         aug = None
+
+    # Ordered (name, aug) pairs. train_epoch applies them in this order and looks up
+    # each one's force mask by name.
+    aug_pipeline = build_aug_pipeline({"state_perturbation": aug})
+    aug_selector = None
 
     # prepare dataset
     train_set = DiffusionPlannerData(args.train_set_list)
@@ -519,6 +525,9 @@ def model_training(args: TrainConfig):
             torch.distributed.barrier()
 
         train_sampler.set_epoch(epoch)
+        # train_epoch binds the selector's repeat flags lazily on its first batch and
+        # needs to know which epoch it is stamping against.
+        args.current_epoch = epoch
 
         # Adjust learning rate for final 10 epochs
         final_epoch_count = 10
@@ -535,7 +544,7 @@ def model_training(args: TrainConfig):
 
         # training step
         train_loss, train_total_loss = train_epoch(
-            train_loader, diffusion_planner, optimizer, args, model_ema, aug
+            train_loader, diffusion_planner, optimizer, args, model_ema, aug_pipeline, aug_selector
         )
 
         valid_dict = validate_model(diffusion_planner, valid_loader, args)

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -25,6 +25,7 @@ from diffusion_planner.utils.lr_schedule import CosineAnnealingWarmUpRestarts
 from diffusion_planner.utils.normalizer import ObservationNormalizer, StateNormalizer
 from diffusion_planner.utils.onnx_export import export_checkpoint_onnx_guarded
 from diffusion_planner.utils.train_utils import resume_model, set_seed
+from diffusion_planner.utils.weighted_sampler import ClusterWeightedDistributedSampler
 from diffusion_planner.validate_model import (
     aggregate_replan_consistency_metrics,
     aggregate_valid_metrics,
@@ -270,9 +271,20 @@ def model_training(args: TrainConfig):
 
     train_set.data_list = train_set.data_list[:: args.train_subsample_step]
 
-    train_sampler = DistributedSampler(
-        train_set, num_replicas=ddp.get_world_size(), rank=global_rank, shuffle=True
-    )
+    if args.cluster_json:
+        train_sampler = ClusterWeightedDistributedSampler(
+            train_set.data_list,
+            args.cluster_json,
+            num_replicas=ddp.get_world_size(),
+            rank=global_rank,
+            seed=args.seed,
+        )
+        if global_rank == 0:
+            print(f"Using cluster-weighted sampling from {args.cluster_json}")
+    else:
+        train_sampler = DistributedSampler(
+            train_set, num_replicas=ddp.get_world_size(), rank=global_rank, shuffle=True
+        )
     train_loader = DataLoader(
         train_set,
         sampler=train_sampler,

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -278,6 +278,7 @@ def model_training(args: TrainConfig):
             num_replicas=ddp.get_world_size(),
             rank=global_rank,
             seed=args.seed,
+            alpha=args.cluster_weight_alpha,
         )
         if global_rank == 0:
             print(f"Using cluster-weighted sampling from {args.cluster_json}")
@@ -340,10 +341,11 @@ def model_training(args: TrainConfig):
     if global_rank == 0 and args.cluster_json:
         print(
             f"Cluster distribution "
-            f"(matched {train_sampler.matched_count}/{len(train_set.data_list)} data paths):"
+            f"(matched {train_sampler.matched_count}/{len(train_set.data_list)} data paths, "
+            f"alpha={args.cluster_weight_alpha:.2f}):"
         )
         for k, v in sorted(train_sampler.cluster_counts.items()):
-            print(f"  {k}: {v} samples")
+            print(f"  {k}: {v} samples  {train_sampler.cluster_multipliers[k]:.2f}x")
 
     if args.ddp:
         torch.distributed.barrier()

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -473,6 +473,8 @@ def model_training(args: TrainConfig):
         if args.ddp:
             torch.distributed.barrier()
 
+        train_sampler.set_epoch(epoch)
+
         # Adjust learning rate for final 10 epochs
         final_epoch_count = 10
         if epoch >= train_epochs - final_epoch_count:
@@ -623,7 +625,6 @@ def model_training(args: TrainConfig):
                 )
 
         scheduler.step()
-        train_sampler.set_epoch(epoch + 1)
 
     if global_rank == 0 and wandb.run is not None:
         wandb.finish()

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -283,6 +283,11 @@ def model_training(args: TrainConfig):
         if global_rank == 0:
             print(f"Using cluster-weighted sampling from {args.cluster_json}")
     else:
+        if global_rank == 0 and args.cluster_weight_alpha != 1.0:
+            print(
+                f"WARNING: --cluster_weight_alpha {args.cluster_weight_alpha} is ignored "
+                "without --cluster_json; using the default DistributedSampler."
+            )
         train_sampler = DistributedSampler(
             train_set, num_replicas=ddp.get_world_size(), rank=global_rank, shuffle=True
         )
@@ -355,8 +360,31 @@ def model_training(args: TrainConfig):
             suffix = key.replace("cluster_id", "", 1) if key.startswith("cluster_id") else key
             return (0, int(suffix), "") if suffix.isdigit() else (1, 0, key)
 
-        for k, v in sorted(train_sampler.cluster_counts.items(), key=_cluster_sort_key):
+        ordered_counts = dict(sorted(train_sampler.cluster_counts.items(), key=_cluster_sort_key))
+        for k, v in ordered_counts.items():
             print(f"  {k}: {v} samples  {train_sampler.cluster_multipliers[k]:.2f}x")
+
+        # Persist what was actually applied. The multipliers are derived from the
+        # LIVE, post---train_subsample_step data_list, so they cannot be
+        # reconstructed from args.json (which records only cluster_json and
+        # cluster_weight_alpha). Without this file the run's sampling distribution
+        # is lost the moment stdout is.
+        cluster_sampling = {
+            "cluster_json": args.cluster_json,
+            "cluster_weight_alpha": args.cluster_weight_alpha,
+            "train_subsample_step": args.train_subsample_step,
+            "data_list_size": len(train_set.data_list),
+            "matched_count": train_sampler.matched_count,
+            "cluster_counts": ordered_counts,
+            "cluster_multipliers": {
+                k: train_sampler.cluster_multipliers[k] for k in ordered_counts
+            },
+        }
+        if save_path is not None:
+            with open(os.path.join(save_path, "cluster_sampling.json"), "w", encoding="utf-8") as f:
+                json.dump(cluster_sampling, f, indent=4)
+    else:
+        cluster_sampling = None
 
     if args.ddp:
         torch.distributed.barrier()
@@ -428,6 +456,10 @@ def model_training(args: TrainConfig):
         )
 
         wandb.config.update(args_dict)
+        if cluster_sampling is not None:
+            # args_dict carries only the requested alpha; this carries the applied
+            # per-cluster multipliers, so runs at different alphas are comparable.
+            wandb.config.update({"cluster_sampling": cluster_sampling})
 
         # this function creates dataset artifacts and associate them with wandb run
         # if wandb_run_id is given, the input artifact is assumed to be created externally and will not be executed

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -26,6 +26,7 @@ class TrainConfig:
     train_set_list: str
     valid_set_list: str
     train_subsample_step: int
+    cluster_json: str = ""
 
     # ---------------------------------------------------------
     # Data Dimensions

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -28,6 +28,11 @@ class TrainConfig:
     train_subsample_step: int
     cluster_json: str = ""
     cluster_weight_alpha: float = 1.0
+    force_aug_on_repeat: bool = False
+    # Must default to "" and never None: resolve_repeat_aug_pool calls .split(",") on it,
+    # so a None default turns a misconfiguration into an AttributeError traceback
+    # instead of the intended launch-time ValueError.
+    repeat_aug_pool: str = ""
 
     # ---------------------------------------------------------
     # Data Dimensions

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -27,6 +27,7 @@ class TrainConfig:
     valid_set_list: str
     train_subsample_step: int
     cluster_json: str = ""
+    cluster_weight_alpha: float = 1.0
 
     # ---------------------------------------------------------
     # Data Dimensions

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -65,6 +65,16 @@ class TrainConfig:
     use_data_augment: bool = True
     augment_prob: float = 0.5
     augment_type: Literal["quintic", "bridge"] = "quintic"
+    use_flip_augment: bool = False
+    flip_prob: float = 0.5
+    use_neighbor_dropout: bool = False
+    neighbor_dropout_prob: float = 0.1
+    use_neighbor_noise: bool = False
+    neighbor_noise_pos_std: float = 0.2
+    neighbor_noise_vel_std: float = 0.3
+    neighbor_noise_heading_std: float = 0.05
+    use_turn_indicator_dropout: bool = False
+    turn_indicator_dropout_prob: float = 0.1
     num_refine: int = 20
     ego_past_noise_std: float = 0.1
     use_smoothing_future_trajectory: bool = True

--- a/diffusion_planner/diffusion_planner/train_epoch.py
+++ b/diffusion_planner/diffusion_planner/train_epoch.py
@@ -4,7 +4,7 @@ from tqdm import tqdm
 
 from diffusion_planner.model.module.decoder import compute_training_loss
 from diffusion_planner.utils import ddp
-from diffusion_planner.utils.data_augmentation import StatePerturbation
+from diffusion_planner.utils.forced_augmentation import ForcedAugmentationSelector
 from diffusion_planner.utils.train_utils import compute_grad_stats, get_epoch_mean_loss
 
 
@@ -32,7 +32,15 @@ def heading_to_cos_sin(x):
     )
 
 
-def train_epoch(data_loader, model, optimizer, args, ema, aug: StatePerturbation = None):
+def train_epoch(
+    data_loader,
+    model,
+    optimizer,
+    args,
+    ema,
+    aug_pipeline: list | None = None,
+    aug_selector: ForcedAugmentationSelector | None = None,
+):
     if len(data_loader) == 0:
         empty = {"loss": 0.0, "turn_indicator_accuracy": 0.0}
         return empty, 0.0
@@ -44,6 +52,10 @@ def train_epoch(data_loader, model, optimizer, args, ema, aug: StatePerturbation
     if args.ddp:
         torch.cuda.synchronize()
 
+    # Captured before the tqdm wrap: tqdm does not forward attribute access to the
+    # iterable it wraps, so reading .sampler off the wrapper would return None.
+    train_sampler = getattr(data_loader, "sampler", None)
+
     if ddp.get_rank() == 0:
         data_loader = tqdm(data_loader, desc="Training", unit="batch")
 
@@ -54,9 +66,38 @@ def train_epoch(data_loader, model, optimizer, args, ema, aug: StatePerturbation
 
         ego_future = inputs["ego_agent_future"]
         neighbors_future = inputs["neighbor_agents_future"]
-        # Normalize to ego-centric
-        if aug is not None:
-            inputs, ego_future, neighbors_future = aug(inputs, ego_future, neighbors_future)
+        # Bind this epoch's repeat flags on the first batch, never before. repeat_flags
+        # is regenerated inside the sampler's __iter__, which the DataLoader only calls
+        # once iteration starts -- binding in train.py would read the previous epoch's.
+        if aug_selector is not None and not aug_selector.is_bound:
+            if train_sampler is None:
+                raise RuntimeError(
+                    "forced augmentation needs a sampler exposing repeat_flags, but the "
+                    "data_loader has no .sampler attribute"
+                )
+            aug_selector.start_epoch(
+                args.current_epoch,
+                getattr(train_sampler, "repeat_flags", None),
+                getattr(train_sampler, "repeat_flags_epoch", None),
+            )
+
+        # One force mask per pool member for this batch. batch_size comes off the batch
+        # itself rather than args.batch_size // world_size: that is a floor division and
+        # a computed offset would drift on any partial batch.
+        if aug_selector is not None:
+            force_masks = aug_selector.masks_for_batch(
+                inputs["ego_current_state"].shape[0], args.device
+            )
+        else:
+            force_masks = {}
+
+        # Normalize to ego-centric. Canonical order; state_perturbation runs last
+        # because it ends with centric_transform, which the others assume has not yet
+        # happened.
+        for aug_name, aug in aug_pipeline or []:
+            inputs, ego_future, neighbors_future = aug(
+                inputs, ego_future, neighbors_future, force=force_masks.get(aug_name)
+            )
 
         # heading to cos sin
         ego_future = heading_to_cos_sin(ego_future)

--- a/diffusion_planner/diffusion_planner/train_epoch.py
+++ b/diffusion_planner/diffusion_planner/train_epoch.py
@@ -69,7 +69,10 @@ def train_epoch(
         # Bind this epoch's repeat flags on the first batch, never before. repeat_flags
         # is regenerated inside the sampler's __iter__, which the DataLoader only calls
         # once iteration starts -- binding in train.py would read the previous epoch's.
-        if aug_selector is not None and not aug_selector.is_bound:
+        # Gate on bound_epoch, NOT is_bound: is_bound only records that a bind has ever
+        # happened, so epoch 2 kept epoch 1's flags and cursor and died on its first
+        # batch. Comparing epochs rebinds once per epoch, for the whole run.
+        if aug_selector is not None and aug_selector.bound_epoch != args.current_epoch:
             if train_sampler is None:
                 raise RuntimeError(
                     "forced augmentation needs a sampler exposing repeat_flags, but the "

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -162,6 +162,10 @@ class StatePerturbation:
         self.num_refine = num_refine
         self.time_interval = TIME_INTERVAL
 
+        # Accumulated as a device tensor and read once per epoch. A per-batch .item()
+        # here would add a GPU->CPU sync inside the training loop.
+        self.forced_noop_count: torch.Tensor | None = None
+
         REFINE_HORIZON = num_refine * TIME_INTERVAL
 
         T = REFINE_HORIZON + TIME_INTERVAL
@@ -184,8 +188,8 @@ class StatePerturbation:
             torch.arange(6).unsqueeze(0),
         ).to(device=device)  # shape (B, N+1)
 
-    def __call__(self, inputs, ego_future, neighbors_future):
-        aug_flag, aug_ego_current_state = self.augment(inputs)
+    def __call__(self, inputs, ego_future, neighbors_future, force=None):
+        aug_flag, aug_ego_current_state = self.augment(inputs, force=force)
 
         # Interpolate future trajectory
         interpolated_ego_future = self.interpolation_future_trajectory(
@@ -214,15 +218,20 @@ class StatePerturbation:
 
         return self.centric_transform(inputs, ego_future, neighbors_future)
 
-    def augment(self, inputs):
+    def augment(self, inputs, force=None):
         # Only aug current state
         ego_current_state = inputs["ego_current_state"].clone()
         wheel_base = inputs["ego_shape"][:, 0]  # (B,)
 
         B = ego_current_state.shape[0]
-        aug_flag = (torch.rand(B) < self._augment_prob).bool().to(self._device) & ~(
-            abs(ego_current_state[:, 4]) < 2.0
-        )
+        # The Bernoulli mask is built on CPU and then moved; force arrives already on
+        # the augmentation's device. OR-ing before the .to() would mix CPU and GPU
+        # tensors and throw, so the OR happens after.
+        bernoulli = (torch.rand(B) < self._augment_prob).bool().to(self._device)
+        if force is not None:
+            bernoulli = bernoulli | force.to(self._device)
+        speed_ok = ~(abs(ego_current_state[:, 4]) < 2.0)
+        aug_flag = bernoulli & speed_ok
 
         random_tensor = torch.rand(B, len(self._low)).to(self._device)
         scaled_random_tensor = self._low + (self._high - self._low) * random_tensor
@@ -265,7 +274,24 @@ class StatePerturbation:
         collision = self._check_aug_validity(ego_current_state, inputs)
         aug_flag = aug_flag & ~collision
 
+        if force is not None:
+            # "Forced but not applied": the low-speed gate or the collision check
+            # vetoed it. Counted, not retried -- a retry would be another whole-batch
+            # augmentation pass.
+            noop = (force.to(self._device) & ~aug_flag).sum()
+            self.forced_noop_count = (
+                noop if self.forced_noop_count is None else self.forced_noop_count + noop
+            )
+
         return aug_flag, ego_current_state
+
+    def pop_forced_noop_count(self) -> int:
+        """Read and reset the forced-but-unchanged counter. Syncs; call once per epoch."""
+        if self.forced_noop_count is None:
+            return 0
+        count = int(self.forced_noop_count.item())
+        self.forced_noop_count = None
+        return count
 
     def _check_aug_validity(self, aug_ego_state: torch.Tensor, inputs: dict) -> torch.Tensor:
         """

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_bridge.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_bridge.py
@@ -1035,8 +1035,14 @@ class StatePerturbation:
         self.time_interval = TIME_INTERVAL
         self.dense_sample_ds = dense_sample_ds
 
-    def __call__(self, inputs, ego_future, neighbors_future):
-        aug_flag, aug_current_state, aug_ego_past, aug_ego_future = self.augment(inputs, ego_future)
+        # Accumulated as a device tensor and read once per epoch. A per-batch .item()
+        # here would add a GPU->CPU sync inside the training loop.
+        self.forced_noop_count: torch.Tensor | None = None
+
+    def __call__(self, inputs, ego_future, neighbors_future, force=None):
+        aug_flag, aug_current_state, aug_ego_past, aug_ego_future = self.augment(
+            inputs, ego_future, force=force
+        )
 
         inputs["ego_current_state"][aug_flag] = aug_current_state[aug_flag]
         inputs["ego_agent_past"][aug_flag] = aug_ego_past[aug_flag]
@@ -1328,7 +1334,15 @@ class StatePerturbation:
             wheel_base=self._wheel_base,
         )
 
-    def augment(self, inputs, ego_future):
+    def pop_forced_noop_count(self) -> int:
+        """Read and reset the forced-but-unchanged counter. Syncs; call once per epoch."""
+        if self.forced_noop_count is None:
+            return 0
+        count = int(self.forced_noop_count.item())
+        self.forced_noop_count = None
+        return count
+
+    def augment(self, inputs, ego_future, force=None):
         ego_current_state = inputs["ego_current_state"].clone()
         ego_agent_past = inputs["ego_agent_past"].clone()
         aug_ego_future = ego_future.clone()
@@ -1343,6 +1357,14 @@ class StatePerturbation:
             & valid_speed
             & valid_offset
         )
+        if force is not None:
+            # Forced rows still have to clear valid_speed and valid_offset -- without a
+            # real offset the search has nothing to solve for.
+            aug_flag = aug_flag | (force.to(self._device) & valid_speed & valid_offset)
+            noop = (force.to(self._device) & ~aug_flag).sum()
+            self.forced_noop_count = (
+                noop if self.forced_noop_count is None else self.forced_noop_count + noop
+            )
 
         for batch_index in torch.nonzero(aug_flag, as_tuple=False).flatten():
             lateral_offset = lateral_offsets[batch_index]

--- a/diffusion_planner/diffusion_planner/utils/forced_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/forced_augmentation.py
@@ -151,6 +151,12 @@ class ForcedAugmentationSelector:
         # False until this epoch's flags are bound. train_epoch binds lazily on the
         # first batch and uses this to do it exactly once per epoch.
         self.is_bound = False
+        # Which epoch the currently-bound flags belong to, or None if unbound. This is
+        # what callers must gate on -- NOT is_bound, which only records that a bind has
+        # happened at some point. A bare is_bound check made epoch 2 reuse epoch 1's
+        # flags and cursor, so the first batch of epoch 2 always overran the flag list
+        # and every run died there.
+        self.bound_epoch: int | None = None
         self._flags: list[bool] | None = None
         self._generator: torch.Generator | None = None
 
@@ -160,8 +166,14 @@ class ForcedAugmentationSelector:
         repeat_flags: list[bool] | None,
         repeat_flags_epoch: int | None,
     ) -> None:
-        """Bind this epoch's flags. Must be called after the loader's iterator exists."""
+        """Bind this epoch's flags. Must be called after the loader's iterator exists.
+
+        Safe to call once per epoch for the whole run: it resets the cursor, the
+        counters and the choice generator, so binding epoch N never inherits epoch
+        N-1's state.
+        """
         self.is_bound = False
+        self.bound_epoch = None
         if repeat_flags is None:
             raise ValueError(
                 "sampler produced no repeat_flags; construct "
@@ -184,6 +196,7 @@ class ForcedAugmentationSelector:
         self._generator = torch.Generator()
         self._generator.manual_seed(self.seed + epoch)
         self.is_bound = True
+        self.bound_epoch = epoch
 
     def masks_for_batch(self, batch_size: int, device) -> dict[str, torch.Tensor]:
         if self._flags is None or self._generator is None:
@@ -193,9 +206,12 @@ class ForcedAugmentationSelector:
         if end > len(self._flags):
             raise RuntimeError(
                 f"reading past the end of repeat_flags: need rows "
-                f"[{self.rows_consumed}, {end}) of {len(self._flags)}. The loader "
-                f"delivered more rows than the sampler drew -- most likely a second "
-                f"DataLoader iterator was created within one epoch."
+                f"[{self.rows_consumed}, {end}) of {len(self._flags)} "
+                f"(bound_epoch={self.bound_epoch}). The cursor has consumed more rows "
+                f"than the sampler drew for the bound epoch. Most likely start_epoch "
+                f"was not called for the current epoch, so this epoch is reusing the "
+                f"previous epoch's flags and cursor -- gate the bind on "
+                f"`bound_epoch != epoch`, not on `is_bound`."
             )
         flags = self._flags[self.rows_consumed : end]
         self.rows_consumed = end

--- a/diffusion_planner/diffusion_planner/utils/forced_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/forced_augmentation.py
@@ -1,0 +1,124 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Registry and per-batch force-mask dispatch for augmentation on repeat draws."""
+
+# Canonical application order. NOT user-configurable: "state_perturbation" must run
+# last because it terminates with centric_transform(), which every other augmentation
+# assumes has not yet happened. This order reproduces the sequence the individual
+# augmentation PRs established in train_epoch.
+AUG_ORDER: tuple[str, ...] = (
+    "flip",
+    "neighbor_dropout",
+    "neighbor_noise",
+    "turn_indicator",
+    "traffic_light",
+    "state_perturbation",
+)
+
+# Registry name -> the CLI flag that enables it, for error messages that tell the
+# operator what to actually type.
+_USE_FLAG: dict[str, str] = {
+    "flip": "--use_flip_augment",
+    "neighbor_dropout": "--use_neighbor_dropout",
+    "neighbor_noise": "--use_neighbor_noise",
+    "turn_indicator": "--use_turn_indicator_dropout",
+    "traffic_light": "--use_traffic_light_dropout",
+    "state_perturbation": "--use_data_augment",
+}
+
+
+def build_aug_pipeline(augmentations: dict) -> list[tuple[str, object]]:
+    """Order enabled augmentations canonically.
+
+    ``augmentations`` maps registry name -> augmentation object or None. Entries that
+    are None are treated as disabled and omitted. Returns ``[(name, aug), ...]`` in
+    AUG_ORDER.
+    """
+    unknown = sorted(set(augmentations) - set(AUG_ORDER))
+    if unknown:
+        raise ValueError(
+            f"unknown augmentation name(s) {unknown}; valid names are {list(AUG_ORDER)}"
+        )
+    return [
+        (name, augmentations[name]) for name in AUG_ORDER if augmentations.get(name) is not None
+    ]
+
+
+def resolve_repeat_aug_pool(
+    pool_spec: str,
+    pipeline: list[tuple[str, object]],
+    augment_type: str,
+) -> tuple[list[str], list[str]]:
+    """Resolve --repeat_aug_pool into concrete registry names.
+
+    Returns ``(pool_names, warnings)``. ``pool_names`` is in AUG_ORDER. Raises
+    ValueError for anything that would make the run silently do the wrong thing --
+    these are surfaced at launch, before the dataset scan.
+    """
+    enabled = [name for name, _ in pipeline]
+    if not enabled:
+        raise ValueError(
+            "--force_aug_on_repeat was requested but no augmentations are enabled; "
+            "enable at least one (e.g. --use_data_augment True)"
+        )
+
+    warnings: list[str] = []
+    requested = [part.strip() for part in pool_spec.split(",")]
+    requested = [part for part in requested if part]
+
+    if requested:
+        unknown = [name for name in requested if name not in AUG_ORDER]
+        if unknown:
+            raise ValueError(
+                f"--repeat_aug_pool names unknown augmentation(s) {unknown}; "
+                f"valid names are {list(AUG_ORDER)}"
+            )
+        not_enabled = [name for name in requested if name not in enabled]
+        if not_enabled:
+            flags = [_USE_FLAG[name] for name in not_enabled]
+            raise ValueError(
+                f"--repeat_aug_pool names {not_enabled}, which are not enabled. "
+                f"Enable them with {flags} or drop them from the pool."
+            )
+        pool = [name for name in AUG_ORDER if name in set(requested)]
+        if augment_type == "bridge" and "state_perturbation" in pool:
+            warnings.append(
+                "--repeat_aug_pool names state_perturbation while --augment_type bridge. "
+                "Bridge forcing is NOT cost-neutral: its augment() searches per flagged row "
+                "at roughly 912 ms/sample, so forcing adds proportional wall-time."
+            )
+    else:
+        pool = list(enabled)
+        if augment_type == "bridge" and "state_perturbation" in pool:
+            # Excluded by default rather than silently doubling an already-prohibitive
+            # cost. Nameable explicitly (above) for anyone who wants it anyway.
+            pool = [name for name in pool if name != "state_perturbation"]
+        if not pool:
+            raise ValueError(
+                "--repeat_aug_pool resolved to an empty pool. state_perturbation is "
+                "excluded from the default pool under --augment_type bridge, and it is "
+                "the only enabled augmentation. Either enable another augmentation, "
+                "switch to --augment_type quintic, or name it explicitly with "
+                "--repeat_aug_pool state_perturbation."
+            )
+
+    if pool == ["flip"]:
+        warnings.append(
+            "--repeat_aug_pool resolves to flip alone. Forced flip is deterministic, so "
+            "two forced occurrences of the same sample mirror identically and remain "
+            "duplicates of each other. Add another augmentation to the pool."
+        )
+
+    return pool, warnings

--- a/diffusion_planner/diffusion_planner/utils/forced_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/forced_augmentation.py
@@ -209,3 +209,39 @@ class ForcedAugmentationSelector:
         return {
             name: (repeat & (choice == index)).to(device) for index, name in enumerate(self.pool)
         }
+
+
+def validate_forced_aug_flags(args, pipeline: list[tuple[str, object]]) -> tuple[list, list]:
+    """Validate forced-augmentation flags at launch, before the dataset scan.
+
+    Returns ``(pool_names, warnings)``; an empty pool means the feature is off. All
+    failures raise ValueError here rather than surfacing after model init and a
+    150,000-file dataset load.
+    """
+    if not args.force_aug_on_repeat:
+        return [], []
+    if not args.cluster_json:
+        raise ValueError(
+            "--force_aug_on_repeat requires --cluster_json. Without the "
+            "cluster-weighted sampler, draws are without replacement and no sample "
+            "repeats within an epoch, so the flag would silently do nothing."
+        )
+    return resolve_repeat_aug_pool(args.repeat_aug_pool, pipeline, args.augment_type)
+
+
+def duplicate_path_warning(data_list: list) -> str | None:
+    """Warn if data_list repeats a path; dedup is by INDEX, so repeats evade it.
+
+    Two entries for the same NPZ are distinct indices, so both are marked first
+    occurrences and the identical scene trains twice unflagged. A warning rather than
+    an error: a duplicated data_list is a dataset-generation problem that predates
+    this feature and should not block a launch.
+    """
+    duplicates = len(data_list) - len(set(data_list))
+    if duplicates == 0:
+        return None
+    return (
+        f"data_list contains {duplicates} duplicate path(s). Repeat detection is by "
+        f"dataset index, so duplicated paths are treated as distinct samples and the "
+        f"same scene can train twice without being force-augmented."
+    )

--- a/diffusion_planner/diffusion_planner/utils/forced_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/forced_augmentation.py
@@ -148,6 +148,9 @@ class ForcedAugmentationSelector:
         self.seed = seed
         self.forced_count = 0
         self.rows_consumed = 0
+        # False until this epoch's flags are bound. train_epoch binds lazily on the
+        # first batch and uses this to do it exactly once per epoch.
+        self.is_bound = False
         self._flags: list[bool] | None = None
         self._generator: torch.Generator | None = None
 
@@ -158,6 +161,7 @@ class ForcedAugmentationSelector:
         repeat_flags_epoch: int | None,
     ) -> None:
         """Bind this epoch's flags. Must be called after the loader's iterator exists."""
+        self.is_bound = False
         if repeat_flags is None:
             raise ValueError(
                 "sampler produced no repeat_flags; construct "
@@ -179,6 +183,7 @@ class ForcedAugmentationSelector:
         self.forced_count = 0
         self._generator = torch.Generator()
         self._generator.manual_seed(self.seed + epoch)
+        self.is_bound = True
 
     def masks_for_batch(self, batch_size: int, device) -> dict[str, torch.Tensor]:
         if self._flags is None or self._generator is None:

--- a/diffusion_planner/diffusion_planner/utils/forced_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/forced_augmentation.py
@@ -14,6 +14,8 @@
 
 """Registry and per-batch force-mask dispatch for augmentation on repeat draws."""
 
+import torch
+
 # Canonical application order. NOT user-configurable: "state_perturbation" must run
 # last because it terminates with centric_transform(), which every other augmentation
 # assumes has not yet happened. This order reproduces the sequence the individual
@@ -122,3 +124,83 @@ def resolve_repeat_aug_pool(
         )
 
     return pool, warnings
+
+
+class ForcedAugmentationSelector:
+    """Turns per-draw repeat flags into one force mask per augmentation name.
+
+    For each repeat-flagged row exactly one pool member is chosen uniformly and forced
+    on; the rest keep their own probability. Forcing the whole stack instead would mean
+    rare clusters only ever see maximally-corrupted scenes.
+
+    Flags are consumed with a running cursor advanced by each batch's ACTUAL row count.
+    A computed ``j * batch_size`` offset would silently drift on any partial batch and
+    misattribute every later mask.
+    """
+
+    def __init__(self, pool: list[str], seed: int = 0):
+        if not pool:
+            raise ValueError("pool must not be empty")
+        unknown = sorted(set(pool) - set(AUG_ORDER))
+        if unknown:
+            raise ValueError(f"pool contains unknown augmentation(s) {unknown}")
+        self.pool = list(pool)
+        self.seed = seed
+        self.forced_count = 0
+        self.rows_consumed = 0
+        self._flags: list[bool] | None = None
+        self._generator: torch.Generator | None = None
+
+    def start_epoch(
+        self,
+        epoch: int,
+        repeat_flags: list[bool] | None,
+        repeat_flags_epoch: int | None,
+    ) -> None:
+        """Bind this epoch's flags. Must be called after the loader's iterator exists."""
+        if repeat_flags is None:
+            raise ValueError(
+                "sampler produced no repeat_flags; construct "
+                "ClusterWeightedDistributedSampler with track_repeats=True"
+            )
+        # repeat_flags is regenerated inside __iter__, so reading it before iterating
+        # returns the PREVIOUS epoch's flags. The stamp turns that silent misalignment
+        # into a crash. It cannot catch set_epoch never being called at all -- both
+        # values then stay equally stale -- which is covered by test coverage on
+        # set_epoch instead.
+        if repeat_flags_epoch != epoch:
+            raise ValueError(
+                f"stale repeat_flags: stamped for epoch {repeat_flags_epoch} but the "
+                f"current epoch is {epoch}. Bind flags after the DataLoader's iterator "
+                f"has been created."
+            )
+        self._flags = repeat_flags
+        self.rows_consumed = 0
+        self.forced_count = 0
+        self._generator = torch.Generator()
+        self._generator.manual_seed(self.seed + epoch)
+
+    def masks_for_batch(self, batch_size: int, device) -> dict[str, torch.Tensor]:
+        if self._flags is None or self._generator is None:
+            raise RuntimeError("start_epoch must be called before masks_for_batch")
+
+        end = self.rows_consumed + batch_size
+        if end > len(self._flags):
+            raise RuntimeError(
+                f"reading past the end of repeat_flags: need rows "
+                f"[{self.rows_consumed}, {end}) of {len(self._flags)}. The loader "
+                f"delivered more rows than the sampler drew -- most likely a second "
+                f"DataLoader iterator was created within one epoch."
+            )
+        flags = self._flags[self.rows_consumed : end]
+        self.rows_consumed = end
+
+        # Built on CPU because the flags originate as a Python list, then moved once.
+        # Reading a mask back off the GPU would add a sync per batch.
+        repeat = torch.tensor(flags, dtype=torch.bool)
+        choice = torch.randint(len(self.pool), (batch_size,), generator=self._generator)
+        self.forced_count += int(repeat.sum())
+
+        return {
+            name: (repeat & (choice == index)).to(device) for index, name in enumerate(self.pool)
+        }

--- a/diffusion_planner/diffusion_planner/utils/online_augmentations.py
+++ b/diffusion_planner/diffusion_planner/utils/online_augmentations.py
@@ -1,0 +1,198 @@
+"""Online GPU augmentations integrated with repeat-draw force masks."""
+
+import torch
+
+from diffusion_planner.dimensions import (
+    LB_X,
+    LB_Y,
+    LINE_TYPE_LEFT_START,
+    LINE_TYPE_NUM,
+    LINE_TYPE_RIGHT_START,
+    RB_X,
+    RB_Y,
+    TURN_INDICATOR_OUTPUT_ENABLE_LEFT,
+    TURN_INDICATOR_OUTPUT_ENABLE_RIGHT,
+    Y,
+    dY,
+)
+
+
+def _force_mask(force: torch.Tensor | None, batch_size: int, device: torch.device) -> torch.Tensor:
+    if force is None:
+        return torch.zeros(batch_size, dtype=torch.bool, device=device)
+    return force.to(device=device, dtype=torch.bool)
+
+
+class FlipAugmentation:
+    """Mirror complete scenes across the ego longitudinal axis."""
+
+    def __init__(self, flip_prob: float, device: torch.device | str) -> None:
+        if not 0.0 <= flip_prob <= 1.0:
+            raise ValueError(f"flip_prob must be in [0, 1], got {flip_prob}")
+        self._flip_prob = flip_prob
+        self._device = torch.device(device)
+
+    @staticmethod
+    def _negate_(x, channels, flip):
+        signs = torch.ones((x.shape[0], x.shape[-1]), dtype=x.dtype, device=x.device)
+        signs[:, channels] = (1 - 2 * flip.to(dtype=x.dtype))[:, None]
+        x.mul_(signs.reshape(x.shape[0], *([1] * (x.ndim - 2)), x.shape[-1]))
+        return x
+
+    @staticmethod
+    def _swap_slices_(x, left, right, flip):
+        left_values = x[..., left]
+        right_values = x[..., right]
+        saved_left = left_values.clone()
+        cond = flip.reshape(-1, *([1] * (x.ndim - 1)))
+        left_values.copy_(torch.where(cond, right_values, left_values))
+        right_values.copy_(torch.where(cond, saved_left, right_values))
+
+    def _flip_lanes(self, lanes, flip):
+        self._negate_(lanes, [Y, dY, LB_Y, RB_Y], flip)
+        self._swap_slices_(lanes, slice(LB_X, LB_Y + 1), slice(RB_X, RB_Y + 1), flip)
+        left = slice(LINE_TYPE_LEFT_START, LINE_TYPE_LEFT_START + LINE_TYPE_NUM)
+        right = slice(LINE_TYPE_RIGHT_START, LINE_TYPE_RIGHT_START + LINE_TYPE_NUM)
+        self._swap_slices_(lanes, left, right, flip)
+        return lanes
+
+    @staticmethod
+    def _future_flip_channels(future):
+        if future.shape[-1] == 3:
+            return [1, 2]
+        if future.shape[-1] == 4:
+            return [1, 3]
+        raise ValueError(f"unsupported future shape {tuple(future.shape)}")
+
+    def __call__(self, inputs, ego_future, neighbors_future, force=None):
+        batch_size = ego_future.shape[0]
+        flip = torch.rand(batch_size, device=ego_future.device) < self._flip_prob
+        flip |= _force_mask(force, batch_size, ego_future.device)
+
+        self._negate_(inputs["ego_current_state"], [1, 3, 5, 7, 8, 9], flip)
+        self._negate_(inputs["ego_agent_past"], [1, 3], flip)
+        self._negate_(inputs["goal_pose"], [1, 3], flip)
+        self._negate_(inputs["neighbor_agents_past"], [1, 3, 5], flip)
+        self._negate_(inputs["static_objects"], [1, 3], flip)
+        self._negate_(inputs["polygons"], [1], flip)
+        self._negate_(inputs["line_strings"], [1], flip)
+        inputs["lanes"] = self._flip_lanes(inputs["lanes"], flip)
+        inputs["route_lanes"] = self._flip_lanes(inputs["route_lanes"], flip)
+
+        indicators = inputs["turn_indicators"]
+        swapped = torch.where(
+            indicators == TURN_INDICATOR_OUTPUT_ENABLE_LEFT,
+            torch.full_like(indicators, TURN_INDICATOR_OUTPUT_ENABLE_RIGHT),
+            torch.where(
+                indicators == TURN_INDICATOR_OUTPUT_ENABLE_RIGHT,
+                torch.full_like(indicators, TURN_INDICATOR_OUTPUT_ENABLE_LEFT),
+                indicators,
+            ),
+        )
+        indicators.copy_(torch.where(flip[:, None], swapped, indicators))
+
+        self._negate_(ego_future, self._future_flip_channels(ego_future), flip)
+        self._negate_(neighbors_future, self._future_flip_channels(neighbors_future), flip)
+        inputs["ego_agent_future"] = ego_future
+        inputs["neighbor_agents_future"] = neighbors_future
+        return inputs, ego_future, neighbors_future
+
+
+class NeighborDropoutAugmentation:
+    """Drop complete neighbor tracks from both inputs and prediction targets."""
+
+    def __init__(self, dropout_prob: float, device: torch.device | str) -> None:
+        if not 0.0 <= dropout_prob <= 1.0:
+            raise ValueError(f"dropout_prob must be in [0, 1], got {dropout_prob}")
+        self._dropout_prob = dropout_prob
+        self._device = torch.device(device)
+
+    def __call__(self, inputs, ego_future, neighbors_future, force=None):
+        past = inputs["neighbor_agents_past"]
+        batch_size, neighbor_count = past.shape[:2]
+        valid = torch.count_nonzero(past, dim=(-2, -1)).ne(0)
+        drop = valid & (
+            torch.rand(batch_size, neighbor_count, device=past.device) < self._dropout_prob
+        )
+
+        # A forced row drops one valid neighbor when its normal roll dropped none.
+        forced = _force_mask(force, batch_size, past.device)
+        needs_drop = forced & valid.any(dim=1) & ~drop.any(dim=1)
+        rows = torch.nonzero(needs_drop, as_tuple=False).flatten()
+        if rows.numel():
+            first_valid = valid[rows].to(torch.int64).argmax(dim=1)
+            drop[rows, first_valid] = True
+
+        drop = drop.view(batch_size, neighbor_count, 1, 1)
+        past.masked_fill_(drop, 0.0)
+        neighbors_future.masked_fill_(drop, 0.0)
+        return inputs, ego_future, neighbors_future
+
+
+class NeighborNoiseAugmentation:
+    """Add tracking-like Gaussian noise to valid neighbor-history frames."""
+
+    def __init__(
+        self,
+        pos_noise_std: float,
+        vel_noise_std: float,
+        heading_noise_std: float,
+        device: torch.device | str,
+    ) -> None:
+        self._pos_noise_std = pos_noise_std
+        self._vel_noise_std = vel_noise_std
+        self._heading_noise_std = heading_noise_std
+        self._device = torch.device(device)
+
+    def __call__(self, inputs, ego_future, neighbors_future, force=None):
+        del force  # Noise already runs on every enabled sample with independent draws.
+        past = inputs["neighbor_agents_past"]
+        batch_size, neighbor_count, time_count, _ = past.shape
+        valid = torch.ne(past[..., 0], 0)
+        for feature_idx in range(1, 8):
+            valid.logical_or_(torch.ne(past[..., feature_idx], 0))
+        invalid = ~valid
+
+        noise = torch.randn(
+            batch_size,
+            neighbor_count,
+            time_count,
+            2,
+            device=past.device,
+            dtype=past.dtype,
+        )
+        noise.masked_fill_(invalid.unsqueeze(-1), 0.0)
+        past[..., 0:2].add_(noise, alpha=self._pos_noise_std)
+        noise.normal_()
+        noise.masked_fill_(invalid.unsqueeze(-1), 0.0)
+        past[..., 4:6].add_(noise, alpha=self._vel_noise_std)
+
+        heading = torch.atan2(past[..., 3], past[..., 2])
+        heading.add_(
+            torch.randn_like(heading),
+            alpha=self._heading_noise_std,
+        )
+        past[..., 2].copy_(torch.cos(heading)).masked_fill_(invalid, 0.0)
+        past[..., 3].copy_(torch.sin(heading)).masked_fill_(invalid, 0.0)
+        return inputs, ego_future, neighbors_future
+
+
+class TurnIndicatorDropoutAugmentation:
+    """Drop indicator inputs per sample while preserving classification GT."""
+
+    def __init__(self, dropout_prob: float, device: torch.device | str) -> None:
+        if not 0.0 <= dropout_prob <= 1.0:
+            raise ValueError(f"dropout_prob must be in [0, 1], got {dropout_prob}")
+        self._dropout_prob = dropout_prob
+        self._device = torch.device(device)
+
+    def __call__(self, inputs, ego_future, neighbors_future, force=None):
+        indicators = inputs["turn_indicators"]
+        batch_size = indicators.shape[0]
+        inputs["turn_indicators_gt_source"] = indicators.clone()
+        drop = torch.rand(batch_size, device=indicators.device) < self._dropout_prob
+        drop |= _force_mask(force, batch_size, indicators.device)
+        inputs["turn_indicators"] = torch.where(
+            drop[:, None], torch.zeros_like(indicators), indicators
+        )
+        return inputs, ego_future, neighbors_future

--- a/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
+++ b/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
@@ -71,11 +71,6 @@ class ClusterWeightedDistributedSampler(Sampler):
                 f"No paths in data_list matched cluster JSON "
                 f"({len(path_to_cluster)} cluster entries). Check path formats."
             )
-        if matched < len(self.data_list) // 2:
-            warnings.warn(
-                f"Only {matched}/{len(self.data_list)} paths matched cluster JSON. "
-                f"Check path formats."
-            )
 
         # Compute frequencies from live counts
         cluster_freq = {cid: count / matched for cid, count in live_counts.items()}
@@ -85,6 +80,17 @@ class ClusterWeightedDistributedSampler(Sampler):
         for i, cid in enumerate(sample_cluster):
             if cid is not None:
                 weights[i] = 1.0 / (cluster_freq[cid] + 1e-8)
+
+        if matched < len(self.data_list):
+            matched_mask = torch.tensor(
+                [c is not None for c in sample_cluster], dtype=torch.bool
+            )
+            mean_matched = weights[matched_mask].mean().item()
+            weights[~matched_mask] = mean_matched
+            warnings.warn(
+                f"{matched}/{len(self.data_list)} paths matched cluster JSON. "
+                f"Unmatched paths assigned neutral weight."
+            )
 
         weights = weights / weights.mean()
         return weights, live_counts, matched

--- a/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
+++ b/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
@@ -67,8 +67,14 @@ class ClusterWeightedDistributedSampler(Sampler):
             self.weights, self.total_size, replacement=True, generator=g
         ).tolist()
 
+        # Pad indices to ensure every rank gets exactly num_samples indices.
+        # Pad by repeating from the front to reach num_samples * num_replicas length.
+        padded_length = self.num_samples * self.num_replicas
+        if len(indices) < padded_length:
+            indices.extend(indices[: padded_length - len(indices)])
+
         # Shard across ranks
-        indices = indices[self.rank : self.total_size : self.num_replicas]
+        indices = indices[self.rank : padded_length : self.num_replicas]
         return iter(indices)
 
     def __len__(self) -> int:

--- a/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
+++ b/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
@@ -1,5 +1,6 @@
 import json
 import math
+import warnings
 
 import torch
 from torch.utils.data import Sampler
@@ -29,9 +30,13 @@ class ClusterWeightedDistributedSampler(Sampler):
         self.total_size = len(data_list)
         self.num_samples = math.ceil(self.total_size / self.num_replicas)
 
-        self.weights = self._compute_weights(cluster_json_path)
+        self.weights, self.cluster_counts, self.matched_count = self._compute_weights(
+            cluster_json_path
+        )
 
-    def _compute_weights(self, cluster_json_path: str) -> torch.Tensor:
+    def _compute_weights(
+        self, cluster_json_path: str
+    ) -> tuple[torch.Tensor, dict[str, int], int]:
         with open(cluster_json_path, "r") as f:
             clusters = json.load(f)
 
@@ -47,14 +52,27 @@ class ClusterWeightedDistributedSampler(Sampler):
         total_in_clusters = sum(cluster_counts.values())
         cluster_freq = {cid: count / total_in_clusters for cid, count in cluster_counts.items()}
 
+        matched = 0
         weights = torch.ones(len(self.data_list), dtype=torch.float64)
         for i, path in enumerate(self.data_list):
             cluster_id = path_to_cluster.get(path)
             if cluster_id is not None:
+                matched += 1
                 weights[i] = 1.0 / (cluster_freq[cluster_id] + 1e-8)
 
+        if matched == 0:
+            raise ValueError(
+                f"No paths in data_list matched cluster JSON "
+                f"({len(path_to_cluster)} cluster entries). Check path formats."
+            )
+        if matched < len(self.data_list) // 2:
+            warnings.warn(
+                f"Only {matched}/{len(self.data_list)} paths matched cluster JSON. "
+                f"Check path formats."
+            )
+
         weights = weights / weights.mean()
-        return weights
+        return weights, cluster_counts, matched
 
     def set_epoch(self, epoch: int) -> None:
         self.epoch = epoch

--- a/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
+++ b/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
@@ -12,8 +12,20 @@ class ClusterWeightedDistributedSampler(Sampler):
     """Inverse-frequency weighted sampler compatible with DDP.
 
     Reads a cluster assignment JSON (Fumiya's cluster.py output format) and assigns
-    each sample a weight of 1/cluster_frequency. Rare clusters are sampled more often;
-    no data is discarded.
+    each sample a weight of ``(1 / cluster_frequency) ** alpha``. Rare clusters are
+    sampled more often; no data is discarded.
+
+    ``alpha`` controls how aggressive the reweighting is. At ``alpha=1.0`` (the
+    default) every cluster receives an equal share of draws regardless of size.
+    At ``alpha=0.0`` all weights are 1.0 and sampling is uniform -- note this is
+    still sampling *with* replacement, so it is not identical to
+    ``DistributedSampler``, which samples without replacement. Intermediate
+    values interpolate: the multiplier ratio between any two clusters goes from
+    ``R`` at alpha=1.0 to ``R ** alpha``.
+
+    Weights are normalized to mean 1.0, so a sample's weight equals its
+    oversampling multiplier. Per-cluster multipliers are exposed as
+    ``cluster_multipliers`` for logging and tuning.
 
     Paths are canonicalized via ``data_path_to_rel`` before matching, so
     different prefixes (absolute vs relative, different mount points) are
@@ -27,6 +39,7 @@ class ClusterWeightedDistributedSampler(Sampler):
         num_replicas: int = 1,
         rank: int = 0,
         seed: int = 0,
+        alpha: float = 1.0,
     ):
         self.data_list = data_list
         if len(data_list) > 2**24:
@@ -34,18 +47,26 @@ class ClusterWeightedDistributedSampler(Sampler):
                 f"data_list has {len(data_list)} entries, exceeding "
                 f"torch.multinomial's 2^24 ({2**24:,}) category limit on CPU."
             )
+        if alpha < 0:
+            raise ValueError(f"alpha={alpha} must be >= 0 (1.0 = full inverse, 0.0 = uniform)")
         self.num_replicas = num_replicas
         self.rank = rank
         self.seed = seed
+        self.alpha = alpha
         self.epoch = 0
         self.total_size = len(data_list)
         self.num_samples = math.ceil(self.total_size / self.num_replicas)
 
-        self.weights, self.cluster_counts, self.matched_count = self._compute_weights(
-            cluster_json_path
-        )
+        (
+            self.weights,
+            self.cluster_counts,
+            self.matched_count,
+            self.cluster_multipliers,
+        ) = self._compute_weights(cluster_json_path)
 
-    def _compute_weights(self, cluster_json_path: str) -> tuple[torch.Tensor, dict[str, int], int]:
+    def _compute_weights(
+        self, cluster_json_path: str
+    ) -> tuple[torch.Tensor, dict[str, int], int, dict[str, float]]:
         clusters = openjson(cluster_json_path)
 
         path_to_cluster: dict[str, str] = {}
@@ -84,12 +105,10 @@ class ClusterWeightedDistributedSampler(Sampler):
         weights = torch.ones(len(self.data_list), dtype=torch.float64)
         for i, cid in enumerate(sample_cluster):
             if cid is not None:
-                weights[i] = 1.0 / (cluster_freq[cid] + 1e-8)
+                weights[i] = (1.0 / (cluster_freq[cid] + 1e-8)) ** self.alpha
 
         if matched < len(self.data_list):
-            matched_mask = torch.tensor(
-                [c is not None for c in sample_cluster], dtype=torch.bool
-            )
+            matched_mask = torch.tensor([c is not None for c in sample_cluster], dtype=torch.bool)
             mean_matched = weights[matched_mask].mean().item()
             weights[~matched_mask] = mean_matched
             warnings.warn(
@@ -98,7 +117,15 @@ class ClusterWeightedDistributedSampler(Sampler):
             )
 
         weights = weights / weights.mean()
-        return weights, live_counts, matched
+
+        # Weights are mean-normalized, so a sample's weight is its oversampling
+        # multiplier. Record one representative per cluster.
+        multipliers: dict[str, float] = {}
+        for i, cid in enumerate(sample_cluster):
+            if cid is not None and cid not in multipliers:
+                multipliers[cid] = weights[i].item()
+
+        return weights, live_counts, matched, multipliers
 
     def set_epoch(self, epoch: int) -> None:
         self.epoch = epoch

--- a/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
+++ b/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
@@ -29,6 +29,11 @@ class ClusterWeightedDistributedSampler(Sampler):
         seed: int = 0,
     ):
         self.data_list = data_list
+        if len(data_list) > 2**24:
+            raise ValueError(
+                f"data_list has {len(data_list)} entries, exceeding "
+                f"torch.multinomial's 2^24 ({2**24:,}) category limit on CPU."
+            )
         self.num_replicas = num_replicas
         self.rank = rank
         self.seed = seed

--- a/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
+++ b/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
@@ -15,9 +15,9 @@ class ClusterWeightedDistributedSampler(Sampler):
     each sample a weight of 1/cluster_frequency. Rare clusters are sampled more often;
     no data is discarded.
 
-    The cluster JSON must contain the exact same path strings as the training
-    data_list JSON. Run cluster.py with the same --data_list file used for
-    --train_set_list to ensure paths match.
+    Paths are canonicalized via ``data_path_to_rel`` before matching, so
+    different prefixes (absolute vs relative, different mount points) are
+    handled automatically.
     """
 
     def __init__(

--- a/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
+++ b/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
@@ -47,8 +47,13 @@ class ClusterWeightedDistributedSampler(Sampler):
                 f"data_list has {len(data_list)} entries, exceeding "
                 f"torch.multinomial's 2^24 ({2**24:,}) category limit on CPU."
             )
-        if alpha < 0:
-            raise ValueError(f"alpha={alpha} must be >= 0 (1.0 = full inverse, 0.0 = uniform)")
+        # ``not alpha >= 0`` rather than ``alpha < 0`` so NaN is rejected too:
+        # every comparison with NaN is False, and a NaN alpha would otherwise
+        # make every weight NaN and surface as an opaque torch.multinomial error.
+        if not alpha >= 0:
+            raise ValueError(
+                f"alpha={alpha} must be a number >= 0 (1.0 = full inverse, 0.0 = uniform)"
+            )
         self.num_replicas = num_replicas
         self.rank = rank
         self.seed = seed

--- a/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
+++ b/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
@@ -83,17 +83,11 @@ class ClusterWeightedDistributedSampler(Sampler):
         g = torch.Generator()
         g.manual_seed(self.seed + self.epoch)
 
+        padded_length = self.num_samples * self.num_replicas
         indices = torch.multinomial(
-            self.weights, self.total_size, replacement=True, generator=g
+            self.weights, padded_length, replacement=True, generator=g
         ).tolist()
 
-        # Pad indices to ensure every rank gets exactly num_samples indices.
-        # Pad by repeating from the front to reach num_samples * num_replicas length.
-        padded_length = self.num_samples * self.num_replicas
-        if len(indices) < padded_length:
-            indices.extend(indices[: padded_length - len(indices)])
-
-        # Shard across ranks
         indices = indices[self.rank : padded_length : self.num_replicas]
         return iter(indices)
 

--- a/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
+++ b/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
@@ -48,20 +48,17 @@ class ClusterWeightedDistributedSampler(Sampler):
             for p in paths:
                 path_to_cluster[str(data_path_to_rel(p))] = cluster_id
 
-        cluster_counts: dict[str, int] = {}
-        for cluster_id, paths in clusters.items():
-            cluster_counts[cluster_id] = len(paths)
-
-        total_in_clusters = sum(cluster_counts.values())
-        cluster_freq = {cid: count / total_in_clusters for cid, count in cluster_counts.items()}
-
+        # First pass: identify cluster membership and count live matches
+        sample_cluster = [None] * len(self.data_list)
+        live_counts: dict[str, int] = {}
         matched = 0
-        weights = torch.ones(len(self.data_list), dtype=torch.float64)
+
         for i, path in enumerate(self.data_list):
-            cluster_id = path_to_cluster.get(str(data_path_to_rel(path)))
-            if cluster_id is not None:
+            cid = path_to_cluster.get(str(data_path_to_rel(path)))
+            if cid is not None:
                 matched += 1
-                weights[i] = 1.0 / (cluster_freq[cluster_id] + 1e-8)
+                sample_cluster[i] = cid
+                live_counts[cid] = live_counts.get(cid, 0) + 1
 
         if matched == 0:
             raise ValueError(
@@ -74,8 +71,17 @@ class ClusterWeightedDistributedSampler(Sampler):
                 f"Check path formats."
             )
 
+        # Compute frequencies from live counts
+        cluster_freq = {cid: count / matched for cid, count in live_counts.items()}
+
+        # Second pass: assign weights using live frequencies
+        weights = torch.ones(len(self.data_list), dtype=torch.float64)
+        for i, cid in enumerate(sample_cluster):
+            if cid is not None:
+                weights[i] = 1.0 / (cluster_freq[cid] + 1e-8)
+
         weights = weights / weights.mean()
-        return weights, cluster_counts, matched
+        return weights, live_counts, matched
 
     def set_epoch(self, epoch: int) -> None:
         self.epoch = epoch

--- a/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
+++ b/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
@@ -41,6 +41,7 @@ class ClusterWeightedDistributedSampler(Sampler):
         rank: int = 0,
         seed: int = 0,
         alpha: float = 1.0,
+        track_repeats: bool = False,
     ):
         self.data_list = data_list
         if len(data_list) > 2**24:
@@ -84,6 +85,11 @@ class ClusterWeightedDistributedSampler(Sampler):
         self.seed = seed
         self.alpha = alpha
         self.epoch = 0
+        # Opt-in so a run that does not use forced augmentation pays nothing at all --
+        # not even the once-per-epoch marking loop.
+        self.track_repeats = track_repeats
+        self.repeat_flags: list[bool] | None = None
+        self.repeat_flags_epoch: int | None = None
         self.total_size = len(data_list)
         self.num_samples = math.ceil(self.total_size / self.num_replicas)
 
@@ -191,11 +197,26 @@ class ClusterWeightedDistributedSampler(Sampler):
         g.manual_seed(self.seed + self.epoch)
 
         padded_length = self.num_samples * self.num_replicas
-        indices = torch.multinomial(
+        draws = torch.multinomial(
             self.weights, padded_length, replacement=True, generator=g
         ).tolist()
 
-        indices = indices[self.rank : padded_length : self.num_replicas]
+        if self.track_repeats:
+            # Ordinals are computed on the GLOBAL draw list, BEFORE sharding, so a
+            # sample drawn on rank 0 and rank 3 in the same step yields one first
+            # occurrence and one repeat -- not two first occurrences. This needs no
+            # collective: every rank seeds an identical generator with seed + epoch and
+            # holds identical weights, so every rank computes the same `draws` and
+            # differs only in which stride it slices.
+            seen: set[int] = set()
+            repeat: list[bool] = []
+            for idx in draws:
+                repeat.append(idx in seen)
+                seen.add(idx)
+            self.repeat_flags = repeat[self.rank : padded_length : self.num_replicas]
+            self.repeat_flags_epoch = self.epoch
+
+        indices = draws[self.rank : padded_length : self.num_replicas]
         return iter(indices)
 
     def __len__(self) -> int:

--- a/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
+++ b/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
@@ -12,6 +12,10 @@ class ClusterWeightedDistributedSampler(Sampler):
     Reads a cluster assignment JSON (Fumiya's cluster.py output format) and assigns
     each sample a weight of 1/cluster_frequency. Rare clusters are sampled more often;
     no data is discarded.
+
+    The cluster JSON must contain the exact same path strings as the training
+    data_list JSON. Run cluster.py with the same --data_list file used for
+    --train_set_list to ensure paths match.
     """
 
     def __init__(
@@ -34,9 +38,7 @@ class ClusterWeightedDistributedSampler(Sampler):
             cluster_json_path
         )
 
-    def _compute_weights(
-        self, cluster_json_path: str
-    ) -> tuple[torch.Tensor, dict[str, int], int]:
+    def _compute_weights(self, cluster_json_path: str) -> tuple[torch.Tensor, dict[str, int], int]:
         with open(cluster_json_path, "r") as f:
             clusters = json.load(f)
 

--- a/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
+++ b/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
@@ -15,13 +15,14 @@ class ClusterWeightedDistributedSampler(Sampler):
     each sample a weight of ``(1 / cluster_frequency) ** alpha``. Rare clusters are
     sampled more often; no data is discarded.
 
-    ``alpha`` controls how aggressive the reweighting is. At ``alpha=1.0`` (the
-    default) every cluster receives an equal share of draws regardless of size.
-    At ``alpha=0.0`` all weights are 1.0 and sampling is uniform -- note this is
-    still sampling *with* replacement, so it is not identical to
+    ``alpha`` controls how aggressive the reweighting is and must lie in ``[0, 1]``.
+    At ``alpha=1.0`` (the default) every cluster receives an equal share of draws
+    regardless of size. At ``alpha=0.0`` all weights are 1.0 and sampling is uniform
+    -- note this is still sampling *with* replacement, so it is not identical to
     ``DistributedSampler``, which samples without replacement. Intermediate
     values interpolate: the multiplier ratio between any two clusters goes from
-    ``R`` at alpha=1.0 to ``R ** alpha``.
+    ``R`` at alpha=1.0 to ``R ** alpha``. Values above 1.0 are rejected because they
+    invert the weighting and starve the largest cluster.
 
     Weights are normalized to mean 1.0, so a sample's weight equals its
     oversampling multiplier. Per-cluster multipliers are exposed as
@@ -51,12 +52,33 @@ class ClusterWeightedDistributedSampler(Sampler):
         # alone would let ``inf`` through: it makes every weight NaN (inf/inf), logs
         # ``nan x`` multipliers, and only dies at the first ``__iter__`` with an
         # opaque "invalid multinomial distribution" -- after model init and dataset
-        # load, wasting a whole training launch. Very large finite alphas also raise
-        # a bare OverflowError from ``float.__pow__``. Fail here instead, legibly.
-        if not (math.isfinite(alpha) and alpha >= 0):
+        # load, wasting a whole training launch.
+        #
+        # The upper bound matters just as much. Draws per cluster scale as
+        # ``matched ** alpha * n_c ** (1 - alpha)``, so above alpha=1 the exponent on
+        # ``n_c`` turns negative and the weighting INVERTS: the largest cluster is
+        # starved. Measured on an 18,000 + 10 split over 18,010 draws/epoch --
+        # alpha=1.0 gives 8,935/9,075 with 6,991 distinct samples, alpha=2.0 gives
+        # 7/18,003 with 17 distinct, alpha=5.0 gives 0/18,010 with 10 distinct. That
+        # trains on ten scenes while the loss falls, DDP stays healthy, and the only
+        # hint is a ``0.00x`` in the startup log.
+        if not (math.isfinite(alpha) and 0 <= alpha <= 1):
             raise ValueError(
-                f"alpha={alpha} must be a finite number >= 0 (1.0 = full inverse, 0.0 = uniform)"
+                f"alpha={alpha} must be a finite number in [0, 1] "
+                f"(1.0 = full inverse weighting, 0.0 = uniform). alpha > 1 over-inverts: "
+                f"draws scale as n_c ** (1 - alpha), starving the LARGEST cluster and "
+                f"collapsing the epoch onto a handful of samples."
             )
+        # ``DistributedSampler`` validates these; a silently out-of-range rank is
+        # worse here than a crash. ``indices[rank::num_replicas]`` yields a SHORT
+        # shard when ``rank >= num_replicas`` while ``__len__`` still reports
+        # ``ceil(N / num_replicas)``, so that rank runs fewer optimizer steps than
+        # its peers and the job hangs on the next collective until the NCCL
+        # timeout -- hours in, with no error explaining why.
+        if num_replicas < 1:
+            raise ValueError(f"num_replicas={num_replicas} must be >= 1")
+        if not 0 <= rank < num_replicas:
+            raise ValueError(f"rank={rank} must be in [0, {num_replicas - 1}]")
         self.num_replicas = num_replicas
         self.rank = rank
         self.seed = seed
@@ -78,9 +100,33 @@ class ClusterWeightedDistributedSampler(Sampler):
         clusters = openjson(cluster_json_path)
 
         path_to_cluster: dict[str, str] = {}
+        # A canonical key claimed twice would otherwise be silently last-write-wins,
+        # and the offending sample lands in whichever cluster the JSON happens to
+        # iterate last. Two ways it happens: the same path listed under two cluster
+        # ids, or two distinct NPZs whose ``data_path_to_rel`` keys collide (that
+        # helper anchors on the first "train"/"valid" component, so files under
+        # different dataset roots sharing a location/date/time/frame layout collapse
+        # to one key). Both cases make ``matched_count`` still read 100% while an
+        # arbitrary subset carries the wrong cluster's weight -- unfixable from the
+        # logs. cluster.py never emits duplicates, so this only fires on a
+        # hand-edited or cross-machine JSON.
+        collisions: dict[str, tuple[str, str]] = {}
         for cluster_id, paths in clusters.items():
             for p in paths:
-                path_to_cluster[str(data_path_to_rel(p))] = cluster_id
+                key = str(data_path_to_rel(p))
+                if key in path_to_cluster and path_to_cluster[key] != cluster_id:
+                    collisions[key] = (path_to_cluster[key], cluster_id)
+                path_to_cluster[key] = cluster_id
+        if collisions:
+            shown = list(collisions.items())[:5]
+            detail = "; ".join(f"{k} in both {a} and {b}" for k, (a, b) in shown)
+            raise ValueError(
+                f"Cluster JSON assigns {len(collisions)} canonical path(s) to more than "
+                f"one cluster: {detail}"
+                f"{' ...' if len(collisions) > len(shown) else ''}. "
+                f"Assignments must be disjoint -- otherwise the applied cluster depends "
+                f"on JSON iteration order and matched_count still reports a full match."
+            )
 
         if not path_to_cluster:
             raise ValueError(
@@ -110,6 +156,8 @@ class ClusterWeightedDistributedSampler(Sampler):
         cluster_freq = {cid: count / matched for cid, count in live_counts.items()}
 
         # Second pass: assign weights using live frequencies
+        # ``alpha <= 1`` bounds every weight by ``matched``, which the 2^24 guard in
+        # __init__ already caps -- so ``float.__pow__`` cannot overflow here.
         weights = torch.ones(len(self.data_list), dtype=torch.float64)
         for i, cid in enumerate(sample_cluster):
             if cid is not None:

--- a/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
+++ b/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
@@ -47,12 +47,15 @@ class ClusterWeightedDistributedSampler(Sampler):
                 f"data_list has {len(data_list)} entries, exceeding "
                 f"torch.multinomial's 2^24 ({2**24:,}) category limit on CPU."
             )
-        # ``not alpha >= 0`` rather than ``alpha < 0`` so NaN is rejected too:
-        # every comparison with NaN is False, and a NaN alpha would otherwise
-        # make every weight NaN and surface as an opaque torch.multinomial error.
-        if not alpha >= 0:
+        # Reject negatives *and* non-finite values (NaN, +/-inf). ``not alpha >= 0``
+        # alone would let ``inf`` through: it makes every weight NaN (inf/inf), logs
+        # ``nan x`` multipliers, and only dies at the first ``__iter__`` with an
+        # opaque "invalid multinomial distribution" -- after model init and dataset
+        # load, wasting a whole training launch. Very large finite alphas also raise
+        # a bare OverflowError from ``float.__pow__``. Fail here instead, legibly.
+        if not (math.isfinite(alpha) and alpha >= 0):
             raise ValueError(
-                f"alpha={alpha} must be a number >= 0 (1.0 = full inverse, 0.0 = uniform)"
+                f"alpha={alpha} must be a finite number >= 0 (1.0 = full inverse, 0.0 = uniform)"
             )
         self.num_replicas = num_replicas
         self.rank = rank

--- a/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
+++ b/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
@@ -48,6 +48,12 @@ class ClusterWeightedDistributedSampler(Sampler):
             for p in paths:
                 path_to_cluster[str(data_path_to_rel(p))] = cluster_id
 
+        if not path_to_cluster:
+            raise ValueError(
+                f"Cluster JSON contains no paths "
+                f"({len(clusters)} clusters, all empty). Check cluster JSON."
+            )
+
         # First pass: identify cluster membership and count live matches
         sample_cluster = [None] * len(self.data_list)
         live_counts: dict[str, int] = {}

--- a/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
+++ b/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
@@ -1,0 +1,75 @@
+import json
+import math
+
+import torch
+from torch.utils.data import Sampler
+
+
+class ClusterWeightedDistributedSampler(Sampler):
+    """Inverse-frequency weighted sampler compatible with DDP.
+
+    Reads a cluster assignment JSON (Fumiya's cluster.py output format) and assigns
+    each sample a weight of 1/cluster_frequency. Rare clusters are sampled more often;
+    no data is discarded.
+    """
+
+    def __init__(
+        self,
+        data_list: list[str],
+        cluster_json_path: str,
+        num_replicas: int = 1,
+        rank: int = 0,
+        seed: int = 0,
+    ):
+        self.data_list = data_list
+        self.num_replicas = num_replicas
+        self.rank = rank
+        self.seed = seed
+        self.epoch = 0
+        self.total_size = len(data_list)
+        self.num_samples = math.ceil(self.total_size / self.num_replicas)
+
+        self.weights = self._compute_weights(cluster_json_path)
+
+    def _compute_weights(self, cluster_json_path: str) -> torch.Tensor:
+        with open(cluster_json_path, "r") as f:
+            clusters = json.load(f)
+
+        path_to_cluster: dict[str, str] = {}
+        for cluster_id, paths in clusters.items():
+            for p in paths:
+                path_to_cluster[p] = cluster_id
+
+        cluster_counts: dict[str, int] = {}
+        for cluster_id, paths in clusters.items():
+            cluster_counts[cluster_id] = len(paths)
+
+        total_in_clusters = sum(cluster_counts.values())
+        cluster_freq = {cid: count / total_in_clusters for cid, count in cluster_counts.items()}
+
+        weights = torch.ones(len(self.data_list), dtype=torch.float64)
+        for i, path in enumerate(self.data_list):
+            cluster_id = path_to_cluster.get(path)
+            if cluster_id is not None:
+                weights[i] = 1.0 / (cluster_freq[cluster_id] + 1e-8)
+
+        weights = weights / weights.mean()
+        return weights
+
+    def set_epoch(self, epoch: int) -> None:
+        self.epoch = epoch
+
+    def __iter__(self):
+        g = torch.Generator()
+        g.manual_seed(self.seed + self.epoch)
+
+        indices = torch.multinomial(
+            self.weights, self.total_size, replacement=True, generator=g
+        ).tolist()
+
+        # Shard across ranks
+        indices = indices[self.rank : self.total_size : self.num_replicas]
+        return iter(indices)
+
+    def __len__(self) -> int:
+        return self.num_samples

--- a/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
+++ b/diffusion_planner/diffusion_planner/utils/weighted_sampler.py
@@ -1,9 +1,11 @@
-import json
 import math
 import warnings
 
 import torch
 from torch.utils.data import Sampler
+
+from diffusion_planner.utils.path_key import data_path_to_rel
+from diffusion_planner.utils.train_utils import openjson
 
 
 class ClusterWeightedDistributedSampler(Sampler):
@@ -39,13 +41,12 @@ class ClusterWeightedDistributedSampler(Sampler):
         )
 
     def _compute_weights(self, cluster_json_path: str) -> tuple[torch.Tensor, dict[str, int], int]:
-        with open(cluster_json_path, "r") as f:
-            clusters = json.load(f)
+        clusters = openjson(cluster_json_path)
 
         path_to_cluster: dict[str, str] = {}
         for cluster_id, paths in clusters.items():
             for p in paths:
-                path_to_cluster[p] = cluster_id
+                path_to_cluster[str(data_path_to_rel(p))] = cluster_id
 
         cluster_counts: dict[str, int] = {}
         for cluster_id, paths in clusters.items():
@@ -57,7 +58,7 @@ class ClusterWeightedDistributedSampler(Sampler):
         matched = 0
         weights = torch.ones(len(self.data_list), dtype=torch.float64)
         for i, path in enumerate(self.data_list):
-            cluster_id = path_to_cluster.get(path)
+            cluster_id = path_to_cluster.get(str(data_path_to_rel(path)))
             if cluster_id is not None:
                 matched += 1
                 weights[i] = 1.0 / (cluster_freq[cluster_id] + 1e-8)

--- a/diffusion_planner/sampling/README.md
+++ b/diffusion_planner/sampling/README.md
@@ -143,6 +143,17 @@ python visualize_cluster_report.py \
 - `render-video-txt` on PATH (`pip install -e /path/to/clip-review-tool`)
 - `ffmpeg` on PATH (for video rendering; also used for GIF conversion in standalone mode)
 
+**Caveat — the report and training must describe the same population:**
+
+The report derives cluster frequencies from the cluster JSON's own totals, while
+training derives them from the live, post-subsample training file list. The two
+agree only when the cluster JSON and the training file list cover the same set of
+samples. In particular, `--train_subsample_step > 1`, or a cluster JSON that is a
+superset of `--train_set_list`, will make the report's **Weight** column diverge
+from the multipliers training actually applies — even when `--cluster_weight_alpha`
+matches. Training's startup log (`Cluster distribution ... alpha=...`, printed with
+one `Nx` multiplier per cluster) is the authoritative record of what was applied.
+
 **Report contents:**
 - Pipeline overview (trajectory → PCA → KMeans)
 - Cluster distribution table + bar chart (sorted by sample count)

--- a/diffusion_planner/sampling/README.md
+++ b/diffusion_planner/sampling/README.md
@@ -28,7 +28,7 @@ sampling/
 | `visualize_cluster.py` | Reads the result JSON from `cluster.py` and produces a grid of subplots, one per cluster, showing overlaid ego future trajectories. |
 | `visualize_cluster_report.py` | Generates an HTML diagnostic report with cluster stats, sampling weights, and BEV video examples per cluster via clip-review-tool. Supports `--standalone` mode for self-contained shareable HTML with embedded GIFs. |
 | `utils/elbow.py` | Utilities for computing WCSS (within-cluster sum of squares), finding the elbow point, and fitting KMeans. |
-| `utils/pipeline.py` | Feature extraction from NPZ files, the `ClusteringStrategy` abstract interface, the `ElbowKMeansStrategy` concrete implementation, and the `cluster_trajectories` pipeline function. |
+| `utils/pipeline.py` | Feature extraction from NPZ files (`extract_features`, `extract_features_enriched`), the `ClusteringStrategy` abstract interface, the `ElbowKMeansStrategy` concrete implementation, and the `cluster_trajectories` / `cluster_trajectories_enriched` pipeline functions. |
 
 ---
 
@@ -42,7 +42,11 @@ python cluster.py \
     --output    /path/to/result.json \
     [--k_max 20] \
     [--pca_components 50] \
-    [--seed 42]
+    [--seed 42] \
+    [--mode trajectory] \
+    [--top_k_neighbors 20] \
+    [--neighbor_pca_components 50] \
+    [--temporal_hz 2]
 ```
 
 | Argument | Required | Default | Description |
@@ -50,8 +54,20 @@ python cluster.py \
 | `--data_list` | ✓ | — | Path to a JSON file listing NPZ file paths |
 | `--output` | ✓ | — | Output path for the clustering result JSON |
 | `--k_max` | | `20` | Upper bound on the number of clusters to evaluate |
-| `--pca_components` | | `50` | Number of PCA components for dimensionality reduction |
-| `--seed` | | `42` | Random seed |
+| `--pca_components` | | `50` | Number of PCA components for the final dimensionality reduction |
+| `--seed` | | `42` | Random seed (reaches KMeans; the PCA solver is separately fixed at 0) |
+| `--mode` | | `trajectory` | `trajectory` = ego future only; `enriched` = ego + neighbors + ego state |
+| `--top_k_neighbors` | | `20` | **Enriched only.** Number of nearest neighbors to keep per frame |
+| `--neighbor_pca_components` | | `50` | **Enriched only.** PCA components for the neighbor block (stage 1) |
+| `--temporal_hz` | | `2` | **Enriched only.** Temporal downsample rate; must evenly divide 10 |
+
+> **Enriched mode is opt-in and less tested than trajectory mode.** It reads
+> `neighbor_agents_past` / `neighbor_agents_future` from every NPZ, so it is far more
+> I/O and memory hungry than trajectory mode, and it assumes every NPZ in the data list
+> shares one array layout. A corpus mixing npz v2 (3-col `neighbor_agents_future`) with
+> npz v3 (4-col `[x, y, cos, sin]`) produces different-width feature vectors and fails
+> when they are stacked. Trajectory mode reads only `ego_agent_future`, whose
+> `[x, y, heading]` layout is stable across both versions.
 
 **Input JSON format (`--data_list`)**
 
@@ -137,7 +153,7 @@ python visualize_cluster_report.py \
 | `--workers` | | `1` | Parallel video rendering workers |
 | `--seed` | | `42` | Random seed for video subsampling |
 | `--standalone` | | `False` | Embed GIFs (240px, 3fps) as base64 in a single HTML file |
-| `--cluster_weight_alpha` | | `1.0` | Weight exponent to model in the report. Must match training's `--cluster_weight_alpha` for the Weight column to reflect actual oversampling. |
+| `--cluster_weight_alpha` | | `1.0` | Weight exponent to model in the report, in `[0, 1]`. Must match training's `--cluster_weight_alpha` for the Weight column to reflect actual oversampling. |
 
 **Prerequisites:**
 - `render-video-txt` on PATH (`pip install -e /path/to/clip-review-tool`)
@@ -207,12 +223,20 @@ python3 train_run.py \
 | Argument | Required | Default | Description |
 |---|---|---|---|
 | `--cluster_json` | | — | Cluster assignment JSON from `cluster.py`. Enables weighted sampling. |
-| `--cluster_weight_alpha` | | `1.0` | Exponent on the inverse-frequency weights. `1.0` gives every cluster an equal share of draws; `0.0` is uniform sampling. |
+| `--cluster_weight_alpha` | | `1.0` | Exponent on the inverse-frequency weights, in `[0, 1]`. `1.0` gives every cluster an equal share of draws; `0.0` is uniform sampling. Values outside `[0, 1]` are rejected. |
 
 Each sample's weight is `(1 / cluster_frequency) ** alpha`, normalized to mean
 1.0 — so a sample's weight *is* its oversampling multiplier. Lowering `alpha`
 softens the reweighting: the multiplier ratio between any two clusters goes
 from `R` at `alpha=1.0` to `R ** alpha`.
+
+`alpha` is capped at 1.0 on purpose. Draws per cluster scale as
+`matched ** alpha * n_c ** (1 - alpha)`, so above 1.0 the exponent on `n_c` turns
+negative and the weighting *inverts* — the largest cluster is starved. On an
+18,000 + 10 split over 18,010 draws per epoch, `alpha=2.0` sends 7 draws to the
+18,000-sample cluster and leaves 17 distinct samples in the epoch; `alpha=5.0`
+leaves 10. Loss still falls (the model memorizes) and DDP stays healthy, so the
+failure is invisible without this guard.
 
 Note that `alpha=0.0` makes every sample equally likely but still draws *with
 replacement*, so it is not the same as omitting `--cluster_json` (which uses a
@@ -228,11 +252,24 @@ Cluster distribution (matched 48231/48231 data paths, alpha=0.50):
   cluster_id7: 1204 samples  1.53x
 ```
 
+The same numbers are written to `<save_dir>/cluster_sampling.json` and pushed into
+`wandb.config` under `cluster_sampling`. Prefer that file over the log: the
+multipliers are computed from the *live*, post-`--train_subsample_step` data list,
+so they cannot be reconstructed from `args.json`, which records only `cluster_json`
+and `cluster_weight_alpha`.
+
 The cluster JSON must reference the same NPZ files as `--train_set_list`.
 Paths are canonicalized before matching, so differing prefixes (absolute vs
 relative, different mount points) are handled automatically. Paths present in
 the data list but absent from the JSON receive the mean matched weight and a
 warning is emitted.
+
+Cluster assignments must be **disjoint**. If one canonical path appears under two
+cluster ids, training refuses to start: last-write-wins would let JSON iteration
+order decide the applied cluster while `matched_count` still reported a full match.
+Note that canonicalization anchors on the first `train`/`valid` path component, so
+two NPZs under different dataset roots that share a `location/split/date/time/frame`
+layout collide and trip the same check.
 
 ### Step 4: Trajectory Visualization (`visualize_cluster.py`)
 
@@ -254,6 +291,8 @@ python visualize_cluster.py \
 ---
 
 ## Processing Pipeline
+
+### `--mode trajectory` (default)
 
 ```
 NPZ files
@@ -277,6 +316,39 @@ ClusteringStrategy.fit_predict(features)
      ▼                 ▼
 result.json  (NPZ paths grouped by cluster ID)
 ```
+
+### `--mode enriched`
+
+```
+NPZ files
+     │
+     ├──────────────────────────────┐
+     ▼                              ▼
+ego block                       neighbor block
+  ego_agent_past    (downsampled to temporal_hz)
+  ego_agent_future  (downsampled, last step always kept)
+  ego_current_state              neighbor_agents_past   (top_k nearest)
+  top_k neighbor distances       neighbor_agents_future (top_k nearest)
+     │                              │
+     ▼                              ▼
+Z-score                         Z-score
+     │                              │
+     │                              ▼
+     │                    PCA (→ neighbor_pca_components)   ← stage 1
+     │                              │
+     └──────────► hstack ◄──────────┘
+                    │
+                    ▼
+              Z-score  →  PCA (→ pca_components)            ← stage 2
+                    │
+                    ▼
+      ClusteringStrategy.fit_predict(features)
+```
+
+Both stages re-standardize, so every retained neighbor PCA component carries equal
+weight in the final space, and the ego:neighbor influence ratio is set implicitly by
+the two blocks' dimension counts (at defaults the ego block is the larger of the two).
+Tune `--neighbor_pca_components` with that in mind.
 
 The clustering step is implemented as a **Strategy pattern**.
 The preprocessing steps (feature extraction, Z-score normalization, PCA) are fixed,

--- a/diffusion_planner/sampling/README.md
+++ b/diffusion_planner/sampling/README.md
@@ -9,12 +9,13 @@ By grouping ego future trajectories into clusters, it helps avoid sampling bias 
 
 ```
 sampling/
-├── cluster.py            # CLI entry point — argument parsing and file I/O
-├── sampling.py           # Balanced sampling from cluster result JSON
-├── visualize_cluster.py  # Visualize clustering results as trajectory plots
+├── cluster.py                    # CLI entry point — argument parsing and file I/O
+├── sampling.py                   # Balanced sampling from cluster result JSON
+├── visualize_cluster.py          # Visualize clustering results as trajectory plots
+├── visualize_cluster_report.py   # HTML diagnostic report with BEV videos per cluster
 ├── utils/
-│   ├── elbow.py          # WCSS computation, elbow detection, KMeans fitting
-│   └── pipeline.py       # Feature extraction, ClusteringStrategy interface, and pipeline
+│   ├── elbow.py                  # WCSS computation, elbow detection, KMeans fitting
+│   └── pipeline.py               # Feature extraction, ClusteringStrategy interface, and pipeline
 └── README.md
 ```
 
@@ -25,6 +26,7 @@ sampling/
 | `cluster.py` | CLI entry point. Reads an NPZ file list, runs the clustering pipeline, and writes the result JSON. |
 | `sampling.py` | Reads the cluster result JSON and samples an equal number of files from each cluster (equal to the smallest cluster size). Outputs a JSON list suitable for `train_run.py`. |
 | `visualize_cluster.py` | Reads the result JSON from `cluster.py` and produces a grid of subplots, one per cluster, showing overlaid ego future trajectories. |
+| `visualize_cluster_report.py` | Generates an HTML diagnostic report with cluster stats, sampling weights, and BEV video examples per cluster via clip-review-tool. Supports `--standalone` mode for self-contained shareable HTML with embedded GIFs. |
 | `utils/elbow.py` | Utilities for computing WCSS (within-cluster sum of squares), finding the elbow point, and fitting KMeans. |
 | `utils/pipeline.py` | Feature extraction from NPZ files, the `ClusteringStrategy` abstract interface, the `ElbowKMeansStrategy` concrete implementation, and the `cluster_trajectories` pipeline function. |
 
@@ -108,7 +110,46 @@ python3 train_run.py \
   --resume_model_path /path/to/sft.pth
 ```
 
-### Step 3: Visualization (`visualize_cluster.py`)
+### Step 3: Cluster Diagnostic Report (`visualize_cluster_report.py`)
+
+Generates an HTML diagnostic report with cluster statistics, sampling behavior documentation, and BEV video examples per cluster rendered by [clip-review-tool](https://github.com/tier4/clip-review-tool).
+
+```bash
+# Standard mode: report.html + videos/ directory with MP4s
+python visualize_cluster_report.py \
+    --cluster_json /path/to/cluster_result.json \
+    --output_dir   /path/to/report_output/ \
+    --max_videos 3 --workers 4
+
+# Standalone mode: single self-contained HTML with embedded GIFs
+# Shareable via Slack, Google Drive, email — no extra files needed
+python visualize_cluster_report.py \
+    --cluster_json /path/to/cluster_result.json \
+    --output_dir   /path/to/report_output/ \
+    --max_videos 3 --workers 4 --standalone
+```
+
+| Argument | Required | Default | Description |
+|---|---|---|---|
+| `--cluster_json` | ✓ | — | Cluster assignment JSON from `cluster.py` |
+| `--output_dir` | ✓ | — | Output directory for report.html (and videos/ in standard mode) |
+| `--max_videos` | | `3` | Max BEV video examples to render per cluster |
+| `--workers` | | `1` | Parallel video rendering workers |
+| `--seed` | | `42` | Random seed for video subsampling |
+| `--standalone` | | `False` | Embed GIFs (240px, 3fps) as base64 in a single HTML file |
+
+**Prerequisites:**
+- `render-video-txt` on PATH (`pip install -e /path/to/clip-review-tool`)
+- `ffmpeg` on PATH (for video rendering; also used for GIF conversion in standalone mode)
+
+**Report contents:**
+- Pipeline overview (trajectory → PCA → KMeans)
+- Cluster distribution table + bar chart (sorted by sample count)
+- Sampling behavior summary (oversampling, unmatched samples, total draws)
+- Per-cluster BEV video gallery (3 examples each by default)
+- Render error diagnostics
+
+### Step 4: Trajectory Visualization (`visualize_cluster.py`)
 
 ```bash
 python visualize_cluster.py \

--- a/diffusion_planner/sampling/README.md
+++ b/diffusion_planner/sampling/README.md
@@ -137,6 +137,7 @@ python visualize_cluster_report.py \
 | `--workers` | | `1` | Parallel video rendering workers |
 | `--seed` | | `42` | Random seed for video subsampling |
 | `--standalone` | | `False` | Embed GIFs (240px, 3fps) as base64 in a single HTML file |
+| `--cluster_weight_alpha` | | `1.0` | Weight exponent to model in the report. Must match training's `--cluster_weight_alpha` for the Weight column to reflect actual oversampling. |
 
 **Prerequisites:**
 - `render-video-txt` on PATH (`pip install -e /path/to/clip-review-tool`)

--- a/diffusion_planner/sampling/README.md
+++ b/diffusion_planner/sampling/README.md
@@ -149,6 +149,34 @@ python visualize_cluster_report.py \
 - Per-cluster BEV video gallery (3 examples each by default)
 - Render error diagnostics
 
+**Sharing the report:**
+
+The standalone HTML file (~30-40MB) can be shared via Slack, Google Drive, email, or any file-sharing tool. To publish to Confluence with inline GIFs:
+
+```bash
+# 1. Generate the report with videos
+python visualize_cluster_report.py \
+    --cluster_json /path/to/cluster_result.json \
+    --output_dir   /path/to/report_output/ \
+    --max_videos 3 --workers 4
+
+# 2. Convert MP4s to GIFs (240px, 3fps)
+find /path/to/report_output/videos -name "*.mp4" -exec sh -c '
+    ffmpeg -i "$1" -vf "fps=3,scale=240:-1:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse" -y "${1%.mp4}.gif"
+' _ {} \;
+
+# 3. Create a Confluence page and upload chart + GIFs as attachments
+#    Then reference them in the page body with:
+#    <ac:image ac:width="240"><ri:attachment ri:filename="cluster_id0_sample0.gif" /></ac:image>
+#
+#    See the Confluence REST API docs for creating pages and uploading attachments:
+#    POST /wiki/rest/api/content                          (create page)
+#    POST /wiki/rest/api/content/{pageId}/child/attachment (upload files)
+#    PUT  /wiki/rest/api/content/{pageId}                  (update page body)
+#
+#    Authentication: Basic auth with your Atlassian email + API token.
+```
+
 ### Step 4: Trajectory Visualization (`visualize_cluster.py`)
 
 ```bash

--- a/diffusion_planner/sampling/README.md
+++ b/diffusion_planner/sampling/README.md
@@ -13,6 +13,7 @@ sampling/
 ├── sampling.py                   # Balanced sampling from cluster result JSON
 ├── visualize_cluster.py          # Visualize clustering results as trajectory plots
 ├── visualize_cluster_report.py   # HTML diagnostic report with BEV videos per cluster
+├── replay_repeats.py             # Offline replay of a run's sampler → repeat-draw counts
 ├── utils/
 │   ├── elbow.py                  # WCSS computation, elbow detection, KMeans fitting
 │   └── pipeline.py               # Feature extraction, ClusteringStrategy interface, and pipeline
@@ -27,6 +28,7 @@ sampling/
 | `sampling.py` | Reads the cluster result JSON and samples an equal number of files from each cluster (equal to the smallest cluster size). Outputs a JSON list suitable for `train_run.py`. |
 | `visualize_cluster.py` | Reads the result JSON from `cluster.py` and produces a grid of subplots, one per cluster, showing overlaid ego future trajectories. |
 | `visualize_cluster_report.py` | Generates an HTML diagnostic report with cluster stats, sampling weights, and BEV video examples per cluster via clip-review-tool. Supports `--standalone` mode for self-contained shareable HTML with embedded GIFs. |
+| `replay_repeats.py` | Replays a finished or in-flight run's `ClusterWeightedDistributedSampler` offline (CPU only, opens no NPZ files) and reports per-epoch repeat draws and forced-augmentation row counts that training never logged. |
 | `utils/elbow.py` | Utilities for computing WCSS (within-cluster sum of squares), finding the elbow point, and fitting KMeans. |
 | `utils/pipeline.py` | Feature extraction from NPZ files (`extract_features`, `extract_features_enriched`), the `ClusteringStrategy` abstract interface, the `ElbowKMeansStrategy` concrete implementation, and the `cluster_trajectories` / `cluster_trajectories_enriched` pipeline functions. |
 
@@ -270,6 +272,65 @@ order decide the applied cluster while `matched_count` still reported a full mat
 Note that canonicalization anchors on the first `train`/`valid` path component, so
 two NPZs under different dataset roots that share a `location/split/date/time/frame`
 layout collide and trip the same check.
+
+### Recovering Repeat-Draw Counts After the Fact (`replay_repeats.py`)
+
+Training does not log how many rows `--force_aug_on_repeat` actually forced.
+The sampler is fully deterministic, so the number is exactly reconstructible
+offline — no GPU, no rerun, and **no NPZ reads** (`_compute_weights` only parses
+the cluster JSON and canonicalizes path strings), which makes this safe to run on
+a training server without competing for NVMe I/O. 80 epochs over a 150,000-sample
+list at world size 8 takes ~17 s and ~640 MB RSS.
+
+```bash
+cd diffusion_planner
+uv run --no-sync python sampling/replay_repeats.py \
+  --run_dir /mnt/nvme/training_result/20260722-101500_my_exp \
+  --world_size 8 \
+  --json /mnt/nvme/training_result/20260722-101500_my_exp/repeat_replay.json
+```
+
+| Argument | Required | Default | Description |
+|---|---|---|---|
+| `--run_dir` | | — | Run directory holding `args.json`. Supplies `cluster_json`, `train_set_list`, `train_subsample_step`, `seed`, `cluster_weight_alpha`, `batch_size`, `train_epochs`, and the forced-aug flags. |
+| `--world_size` | ✓ | — | DDP world size of the original run. **Not recorded anywhere in the run dir** — `TrainConfig` has no such field, and `train_run.py` passes `--nproc-per-node=gpu_count()` straight to `torchrun`. Recover it with `grep -o 'global_rank=[0-9]*' <run_dir>/train_log.txt \| sort -u \| wc -l`. |
+| `--epochs` / `--start_epoch` | | `train_epochs` / `0` | Epoch range to replay. Set `--start_epoch` for a resumed run (train.py iterates `range(init_epoch, train_epochs)`). |
+| `--batch_size` | | from `args.json` | Global batch size, used to model the training DataLoader's `drop_last=True`. |
+| `--cluster_json`, `--train_set_list`, `--train_subsample_step`, `--seed`, `--cluster_weight_alpha`, `--repeat_aug_pool`, `--force_aug_on_repeat` | | from `args.json` | Override any resolved value, or replay a hypothetical config with no `--run_dir` at all. |
+| `--json` | | — | Also write machine-readable results here. |
+| `--allow_data_list_mismatch` | | off | Downgrade the `cluster_sampling.json` data-list-size cross-check to a warning. |
+
+Every number is **global** across all DDP ranks: the sampler assigns repeat
+ordinals on the global draw list *before* sharding, so a sample drawn on rank 0
+and rank 3 in the same step is one first occurrence and one repeat. The replay
+iterates the real sampler once per rank, reassembles the global draw list from the
+shards, and recomputes the flags on it independently — a mismatch raises instead of
+printing plausible numbers.
+
+```
+ epoch   total_draws     distinct      repeats  repeat_frac   forced_rows  per_pool_member
+------------------------------------------------------------------------------------------
+     0       150,000       66,028       83,972       0.5598        83,893         20,973.2
+     1       150,000       65,915       84,085       0.5606        84,002         21,000.5
+   ...
+    79       150,000       65,920       84,080       0.5605        83,995         20,998.8
+------------------------------------------------------------------------------------------
+ TOTAL    12,000,000      150,000    6,713,192       0.5594     6,706,575      1,676,643.8
+```
+
+`forced_rows` is smaller than `repeats` on purpose. The training DataLoader uses
+`drop_last=True` with `batch_size // world_size` rows per rank, so each rank's
+partial tail batch is never delivered and `ForcedAugmentationSelector` never
+consumes its flags. `repeats` is the draw-level count (an upper bound);
+`forced_rows` is what actually got augmented. Without a resolvable `batch_size`
+the tool reports draw-level counts only and says so.
+
+`per_pool_member` is `forced_rows / len(pool)`: the selector picks one pool member
+uniformly per forced row, so each member's expected share is an equal split.
+
+The reconstruction is cross-checked against `cluster_sampling.json` when the run
+wrote one. A `data_list_size` mismatch is a hard error — it means `--train_set_list`
+or `--train_subsample_step` is wrong, and every count would be wrong with it.
 
 ### Step 4: Trajectory Visualization (`visualize_cluster.py`)
 

--- a/diffusion_planner/sampling/README.md
+++ b/diffusion_planner/sampling/README.md
@@ -177,6 +177,51 @@ find /path/to/report_output/videos -name "*.mp4" -exec sh -c '
 #    Authentication: Basic auth with your Atlassian email + API token.
 ```
 
+### Weighted Sampling During Training
+
+Instead of pre-sampling a balanced file list with `sampling.py`, training can
+consume the full dataset and oversample rare clusters on the fly. Pass the
+cluster result JSON to `train_run.py`:
+
+```bash
+python3 train_run.py \
+  --exp_name my_exp \
+  --train_set_list /path/to/train.json \
+  --valid_set_list /path/to/valid.json \
+  --cluster_json /path/to/cluster_result.json \
+  --cluster_weight_alpha 0.5
+```
+
+| Argument | Required | Default | Description |
+|---|---|---|---|
+| `--cluster_json` | | — | Cluster assignment JSON from `cluster.py`. Enables weighted sampling. |
+| `--cluster_weight_alpha` | | `1.0` | Exponent on the inverse-frequency weights. `1.0` gives every cluster an equal share of draws; `0.0` is uniform sampling. |
+
+Each sample's weight is `(1 / cluster_frequency) ** alpha`, normalized to mean
+1.0 — so a sample's weight *is* its oversampling multiplier. Lowering `alpha`
+softens the reweighting: the multiplier ratio between any two clusters goes
+from `R` at `alpha=1.0` to `R ** alpha`.
+
+Note that `alpha=0.0` makes every sample equally likely but still draws *with
+replacement*, so it is not the same as omitting `--cluster_json` (which uses a
+plain `DistributedSampler` and draws without replacement).
+
+Training prints the resulting multipliers at startup, which is how you tune
+`alpha`:
+
+```
+Using cluster-weighted sampling from /path/to/cluster_result.json
+Cluster distribution (matched 48231/48231 data paths, alpha=0.50):
+  cluster_id0: 18402 samples  0.78x
+  cluster_id7: 1204 samples  1.53x
+```
+
+The cluster JSON must reference the same NPZ files as `--train_set_list`.
+Paths are canonicalized before matching, so differing prefixes (absolute vs
+relative, different mount points) are handled automatically. Paths present in
+the data list but absent from the JSON receive the mean matched weight and a
+warning is emitted.
+
 ### Step 4: Trajectory Visualization (`visualize_cluster.py`)
 
 ```bash

--- a/diffusion_planner/sampling/cluster.py
+++ b/diffusion_planner/sampling/cluster.py
@@ -18,7 +18,11 @@ Usage:
     python cluster.py \\
         --data_list /path/to/data_list.json \\
         --output    /path/to/result.json \\
-        [--k_max 20] [--pca_components 50] [--seed 42]
+        [--k_max 20] [--pca_components 50] [--seed 42] \\
+        [--mode trajectory|enriched]
+
+    Enriched mode only (ignored with --mode trajectory):
+        [--top_k_neighbors 20] [--neighbor_pca_components 50] [--temporal_hz 2]
 
 Input JSON format (same as train_predictor.py):
     ["path/to/sample_0.npz", "path/to/sample_1.npz", ...]
@@ -33,6 +37,7 @@ Output JSON format:
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -103,6 +108,25 @@ def get_args():
 def main():
     args = get_args()
 
+    # Validate before the extraction pass, not after it. --temporal_hz is otherwise
+    # only checked per-file inside cluster_trajectories_enriched's swallowed
+    # try/except, so a bad value warns 150,000 times and then raises
+    # "No valid NPZ files found." -- which blames the data, not the flag.
+    if args.mode == "enriched":
+        if args.top_k_neighbors < 1:
+            raise SystemExit(f"--top_k_neighbors must be >= 1, got {args.top_k_neighbors}")
+        if args.neighbor_pca_components < 1:
+            raise SystemExit(
+                f"--neighbor_pca_components must be >= 1, got {args.neighbor_pca_components}"
+            )
+        if args.temporal_hz < 1 or 10 % args.temporal_hz != 0:
+            raise SystemExit(
+                f"--temporal_hz must be a positive divisor of 10 (1, 2, 5, 10), "
+                f"got {args.temporal_hz}"
+            )
+    if args.pca_components < 1:
+        raise SystemExit(f"--pca_components must be >= 1, got {args.pca_components}")
+
     npz_paths = load_npz_paths(args.data_list)
     print(f"Loaded {len(npz_paths)} NPZ paths from {args.data_list}")
 
@@ -120,10 +144,15 @@ def main():
         result = cluster_trajectories(npz_paths, strategy, pca_components=args.pca_components)
     print(f"Optimal k = {strategy.n_clusters_}")
 
+    # Write-then-rename. A plain open(..., "w") truncates the destination first, so a
+    # crash mid-dump -- or a training job reading the file at that moment -- sees a
+    # half-written JSON. os.replace is atomic within a filesystem.
     output_path = Path(args.output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, "w", encoding="utf-8") as f:
+    tmp_path = output_path.with_suffix(output_path.suffix + ".tmp")
+    with open(tmp_path, "w", encoding="utf-8") as f:
         json.dump(result, f, indent=4)
+    os.replace(tmp_path, output_path)
 
     print(f"Saved clustering result to {args.output}")
     for cluster_key, paths in result.items():

--- a/diffusion_planner/sampling/cluster.py
+++ b/diffusion_planner/sampling/cluster.py
@@ -37,7 +37,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from utils.pipeline import ElbowKMeansStrategy, cluster_trajectories
+from utils.pipeline import ElbowKMeansStrategy, cluster_trajectories, cluster_trajectories_enriched
 
 
 def load_npz_paths(data_list_json: str) -> list:
@@ -72,6 +72,31 @@ def get_args():
         help="Number of PCA components used to reduce the trajectory feature dimension (default: 50)",
     )
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--mode",
+        type=str,
+        default="trajectory",
+        choices=["trajectory", "enriched"],
+        help="Clustering mode: 'trajectory' (ego future only) or 'enriched' (ego + neighbors + state)",
+    )
+    parser.add_argument(
+        "--top_k_neighbors",
+        type=int,
+        default=20,
+        help="Number of nearest neighbors to keep (enriched mode only, default: 20)",
+    )
+    parser.add_argument(
+        "--neighbor_pca_components",
+        type=int,
+        default=50,
+        help="PCA components for neighbor block (enriched mode only, default: 50)",
+    )
+    parser.add_argument(
+        "--temporal_hz",
+        type=int,
+        default=2,
+        help="Temporal downsample rate in hz (enriched mode only, default: 2)",
+    )
     return parser.parse_args()
 
 
@@ -82,7 +107,17 @@ def main():
     print(f"Loaded {len(npz_paths)} NPZ paths from {args.data_list}")
 
     strategy = ElbowKMeansStrategy(k_max=args.k_max, random_state=args.seed)
-    result = cluster_trajectories(npz_paths, strategy, pca_components=args.pca_components)
+    if args.mode == "enriched":
+        result = cluster_trajectories_enriched(
+            npz_paths,
+            strategy,
+            pca_components=args.pca_components,
+            neighbor_pca_components=args.neighbor_pca_components,
+            top_k=args.top_k_neighbors,
+            temporal_hz=args.temporal_hz,
+        )
+    else:
+        result = cluster_trajectories(npz_paths, strategy, pca_components=args.pca_components)
     print(f"Optimal k = {strategy.n_clusters_}")
 
     output_path = Path(args.output)

--- a/diffusion_planner/sampling/replay_repeats.py
+++ b/diffusion_planner/sampling/replay_repeats.py
@@ -1,0 +1,733 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Replay a run's ClusterWeightedDistributedSampler offline to recover repeat-draw counts.
+
+The sampler draws WITH replacement, so samples repeat within an epoch, and
+``--force_aug_on_repeat`` forces one pool augmentation onto every repeat draw. Training
+does not log how many rows that was. It is exactly reconstructible: the draws depend only
+on the cluster JSON, the data list, ``seed``, ``cluster_weight_alpha``, the DDP world size
+and the epoch index. ``_compute_weights`` reads the cluster JSON and canonicalizes path
+strings -- it opens no NPZ files -- so this replay is CPU-only, needs no GPU, and is safe
+to run next to a live training job.
+
+Numbers are GLOBAL (all DDP ranks), because the sampler assigns repeat ordinals on the
+global draw list before sharding. The replay iterates the real sampler once per rank and
+reassembles the global draw list from the shards, then cross-checks the reassembled list
+against the per-rank flags -- a mismatch raises instead of printing plausible numbers.
+
+Usage:
+    # Recover the numbers for a finished or in-flight run
+    python replay_repeats.py \\
+        --run_dir /mnt/nvme/training_result/20260722-101500_my_exp \\
+        --world_size 8 \\
+        [--epochs 80] [--json /tmp/repeats.json]
+
+    # Replay a hypothetical config (no run dir); any flag also overrides args.json
+    python replay_repeats.py \\
+        --cluster_json /path/to/clusters.json \\
+        --train_set_list /path/to/train_list.json \\
+        --train_subsample_step 1 \\
+        --seed 3407 --cluster_weight_alpha 1.0 \\
+        --world_size 8 --epochs 80 \\
+        --repeat_aug_pool flip,neighbor_noise
+
+``--world_size`` is required whenever the run dir does not record it: ``padded_length =
+ceil(N / world_size) * world_size``, so guessing 1 would silently report wrong totals.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from diffusion_planner.utils.forced_augmentation import AUG_ORDER, resolve_repeat_aug_pool
+from diffusion_planner.utils.train_utils import openjson
+from diffusion_planner.utils.weighted_sampler import ClusterWeightedDistributedSampler
+
+# train.py's build_aug_pipeline() call site, mirrored: TrainConfig flag -> registry name.
+# Only these five are wired into the training pipeline; "traffic_light" exists in
+# AUG_ORDER but train.py never passes it, so it can never be in a run's pool.
+USE_FLAG_TO_AUG: dict[str, str] = {
+    "use_flip_augment": "flip",
+    "use_neighbor_dropout": "neighbor_dropout",
+    "use_neighbor_noise": "neighbor_noise",
+    "use_turn_indicator_dropout": "turn_indicator",
+    "use_data_augment": "state_perturbation",
+}
+
+# TrainConfig defaults, used only in no---run_dir mode. Every resolved value is echoed in
+# the report header with its source, so a default is never silently load-bearing.
+DEFAULTS: dict[str, object] = {
+    "seed": 3407,
+    "cluster_weight_alpha": 1.0,
+    "train_subsample_step": 1,
+    "augment_type": "quintic",
+}
+
+# Keys args.json may carry for the DDP world size. TrainConfig has no such field today
+# (train_run.py passes --nproc-per-node=gpu_count() to torchrun and it is never
+# persisted), so this normally resolves to nothing and --world_size is required. Listed
+# anyway so the tool picks the value up for free if a field is ever added.
+WORLD_SIZE_KEYS: tuple[str, ...] = (
+    "world_size",
+    "num_replicas",
+    "nproc_per_node",
+    "ddp_world_size",
+)
+
+
+class ReplayError(Exception):
+    """A configuration problem that must stop the replay rather than skew the counts."""
+
+
+def load_json_file(path: Path) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def load_run_dir(run_dir: str) -> tuple[dict, dict | None]:
+    """Read ``args.json`` (required) and ``cluster_sampling.json`` (optional) from a run.
+
+    ``args.json`` is ``vars(TrainConfig)`` dumped by train.py at startup on global rank 0.
+    ``cluster_sampling.json`` is written next to it when ``--cluster_json`` is set and
+    records the LIVE, post-subsample data list size plus the resolved forced-aug pool --
+    the cross-check that catches a wrong ``train_set_list`` before it skews every count.
+    """
+    root = Path(run_dir)
+    args_path = root / "args.json"
+    if not args_path.is_file():
+        raise ReplayError(
+            f"{args_path} not found. --run_dir must point at a training run directory "
+            f"(train.py writes args.json there at startup on global rank 0)."
+        )
+    run_args = load_json_file(args_path)
+    cluster_sampling_path = root / "cluster_sampling.json"
+    cluster_sampling = (
+        load_json_file(cluster_sampling_path) if cluster_sampling_path.is_file() else None
+    )
+    return run_args, cluster_sampling
+
+
+def build_data_list(train_set_list: str, train_subsample_step: int) -> list[str]:
+    """Reproduce train.py's live data list exactly.
+
+    train.py does ``DiffusionPlannerData(args.train_set_list)`` -- which is
+    ``openjson(train_set_list)`` -- then ``data_list = data_list[:: train_subsample_step]``.
+    Both steps matter: the sampler weights, the draw count and therefore every number in
+    this report are computed on the sliced list.
+    """
+    if train_subsample_step < 1:
+        raise ReplayError(f"--train_subsample_step must be >= 1, got {train_subsample_step}")
+    data_list = openjson(train_set_list)
+    if not isinstance(data_list, list):
+        raise ReplayError(
+            f"{train_set_list} must contain a JSON list of NPZ paths, got {type(data_list).__name__}"
+        )
+    return data_list[::train_subsample_step]
+
+
+def enabled_aug_names(run_args: dict) -> list[str]:
+    """Registry names train.py would have put in the pipeline, in AUG_ORDER."""
+    enabled = {
+        aug_name for flag, aug_name in USE_FLAG_TO_AUG.items() if bool(run_args.get(flag, False))
+    }
+    return [name for name in AUG_ORDER if name in enabled]
+
+
+def resolve_pool(
+    run_args: dict | None,
+    pool_override: str | None,
+    force_override: bool | None,
+) -> tuple[list[str], list[str]]:
+    """Resolve the forced-augmentation pool the run used (or a hypothetical one).
+
+    With a run dir this defers to ``resolve_repeat_aug_pool``, the same function train.py
+    validates with, so pool defaulting and the ``--augment_type bridge`` exclusion match
+    the run. Without one there is no pipeline to resolve against, so an explicit
+    ``--repeat_aug_pool`` is taken literally (names still validated).
+
+    Returns ``(pool, warnings)``; an empty pool means forcing was off for this config.
+    """
+    warnings: list[str] = []
+    requested = None if pool_override is None else [p.strip() for p in pool_override.split(",")]
+    requested = None if requested is None else [p for p in requested if p]
+
+    if run_args is None:
+        if not requested:
+            return [], []
+        unknown = [name for name in requested if name not in AUG_ORDER]
+        if unknown:
+            raise ReplayError(
+                f"--repeat_aug_pool names unknown augmentation(s) {unknown}; "
+                f"valid names are {list(AUG_ORDER)}"
+            )
+        return [name for name in AUG_ORDER if name in set(requested)], warnings
+
+    forced_on = (
+        bool(run_args.get("force_aug_on_repeat", False))
+        if force_override is None
+        else bool(force_override)
+    )
+    if not forced_on:
+        return [], warnings
+
+    pipeline_names = enabled_aug_names(run_args)
+    if bool(run_args.get("use_traffic_light_dropout", False)):
+        warnings.append(
+            "args.json sets use_traffic_light_dropout, but train.py does not wire "
+            "traffic_light into the augmentation pipeline, so it cannot be in the pool."
+        )
+    # resolve_repeat_aug_pool only reads the names off the pipeline pairs, never the
+    # augmentation objects, so placeholders reproduce its decisions without importing
+    # torch modules that would want a device.
+    pipeline = [(name, object()) for name in pipeline_names]
+    pool_spec = run_args.get("repeat_aug_pool", "") if pool_override is None else pool_override
+    augment_type = str(run_args.get("augment_type", DEFAULTS["augment_type"]))
+    try:
+        pool, pool_warnings = resolve_repeat_aug_pool(pool_spec or "", pipeline, augment_type)
+    except ValueError as exc:
+        raise ReplayError(str(exc)) from exc
+    return pool, warnings + pool_warnings
+
+
+def replay_epochs(
+    data_list: list[str],
+    cluster_json: str,
+    seed: int,
+    alpha: float,
+    world_size: int,
+    start_epoch: int,
+    epochs: int,
+    pool_size: int,
+    per_rank_batch: int | None = None,
+) -> tuple[list[dict], dict, dict]:
+    """Replay the sampler and return ``(per_epoch, total, sampler_info)``.
+
+    One sampler is built (the cluster JSON is parsed once) and iterated once per rank with
+    ``rank`` retargeted between passes. Every rank seeds an identical generator with
+    ``seed + epoch`` and holds identical weights, so each pass regenerates the same global
+    draw list and differs only in which stride it slices -- the shards therefore partition
+    the global list and reassemble into it exactly.
+    """
+    sampler = ClusterWeightedDistributedSampler(
+        data_list,
+        cluster_json,
+        num_replicas=world_size,
+        rank=0,
+        seed=seed,
+        alpha=alpha,
+        track_repeats=True,
+    )
+    padded_length = sampler.num_samples * world_size
+    sampler_info = {
+        "data_list_size": len(data_list),
+        "num_samples_per_rank": sampler.num_samples,
+        "padded_length": padded_length,
+        "matched_count": sampler.matched_count,
+        "num_clusters": len(sampler.cluster_counts),
+    }
+
+    per_epoch: list[dict] = []
+    union: set[int] = set()
+    for epoch in range(start_epoch, start_epoch + epochs):
+        sampler.set_epoch(epoch)
+        global_draws: list[int] = [-1] * padded_length
+        global_flags: list[bool] = [False] * padded_length
+        repeats = 0
+        forced_rows = 0
+        delivered_rows = 0
+        for rank in range(world_size):
+            sampler.rank = rank
+            indices = list(sampler)
+            flags = sampler.repeat_flags
+            if flags is None or sampler.repeat_flags_epoch != epoch:
+                raise ReplayError(
+                    f"sampler produced no repeat_flags for epoch {epoch} "
+                    f"(stamp={sampler.repeat_flags_epoch}); this build of "
+                    f"weighted_sampler.py does not track repeats as expected."
+                )
+            if len(indices) != sampler.num_samples or len(flags) != len(indices):
+                raise ReplayError(
+                    f"rank {rank} shard is {len(indices)} indices / {len(flags)} flags, "
+                    f"expected {sampler.num_samples} of each."
+                )
+            global_draws[rank:padded_length:world_size] = indices
+            global_flags[rank:padded_length:world_size] = flags
+            repeats += sum(flags)
+            if per_rank_batch:
+                # The training DataLoader is drop_last=True, so the tail of each rank's
+                # shard that cannot fill a batch is never delivered and its repeat flags
+                # are never consumed by ForcedAugmentationSelector.
+                delivered = (len(indices) // per_rank_batch) * per_rank_batch
+                delivered_rows += delivered
+                forced_rows += sum(flags[:delivered])
+
+        # Independent recomputation on the reassembled global list. If the shards did not
+        # come from one shared draw list, or the interleaving is wrong, these disagree.
+        seen: set[int] = set()
+        expected_flags = []
+        for idx in global_draws:
+            expected_flags.append(idx in seen)
+            seen.add(idx)
+        if expected_flags != global_flags:
+            raise ReplayError(
+                f"epoch {epoch}: per-rank repeat flags do not match the flags recomputed "
+                f"from the reassembled global draw list. The replay does not reproduce "
+                f"this run's sampler; refusing to report counts."
+            )
+        distinct = len(seen)
+        if distinct + repeats != padded_length:
+            raise ReplayError(
+                f"epoch {epoch}: distinct({distinct}) + repeats({repeats}) != "
+                f"total draws({padded_length}); aggregation is inconsistent."
+            )
+
+        union |= seen
+        row = {
+            "epoch": epoch,
+            "total_draws": padded_length,
+            "distinct_samples": distinct,
+            "repeat_draws": repeats,
+            "repeat_fraction": repeats / padded_length if padded_length else 0.0,
+            "expected_forced_per_pool_member": (repeats / pool_size) if pool_size else None,
+        }
+        if per_rank_batch:
+            row["delivered_rows"] = delivered_rows
+            row["dropped_rows"] = padded_length - delivered_rows
+            row["forced_rows"] = forced_rows
+            row["forced_per_pool_member"] = (forced_rows / pool_size) if pool_size else None
+        per_epoch.append(row)
+
+    total_draws = sum(r["total_draws"] for r in per_epoch)
+    total_repeats = sum(r["repeat_draws"] for r in per_epoch)
+    total: dict = {
+        "epochs": len(per_epoch),
+        "total_draws": total_draws,
+        "distinct_samples_union": len(union),
+        "repeat_draws": total_repeats,
+        "repeat_fraction": (total_repeats / total_draws) if total_draws else 0.0,
+        "expected_forced_per_pool_member": (total_repeats / pool_size) if pool_size else None,
+    }
+    if per_rank_batch:
+        total_forced = sum(r["forced_rows"] for r in per_epoch)
+        total["delivered_rows"] = sum(r["delivered_rows"] for r in per_epoch)
+        total["dropped_rows"] = sum(r["dropped_rows"] for r in per_epoch)
+        total["forced_rows"] = total_forced
+        total["forced_per_pool_member"] = (total_forced / pool_size) if pool_size else None
+    return per_epoch, total, sampler_info
+
+
+def format_report(result: dict) -> str:
+    """Render the stdout report. ``result`` is the same dict written by --json."""
+    config = result["config"]
+    info = result["sampler"]
+    pool = config["repeat_aug_pool"]
+    has_rows = "forced_rows" in result["total"]
+
+    lines: list[str] = []
+    lines.append("=" * 96)
+    lines.append("Offline repeat-draw replay (ClusterWeightedDistributedSampler)")
+    lines.append("=" * 96)
+    if config.get("run_dir"):
+        lines.append(f"  run_dir              : {config['run_dir']}")
+    for key in (
+        "train_set_list",
+        "cluster_json",
+        "train_subsample_step",
+        "seed",
+        "cluster_weight_alpha",
+        "world_size",
+        "batch_size",
+        "start_epoch",
+        "epochs",
+    ):
+        if config.get(key) is None:
+            continue
+        lines.append(f"  {key:<21}: {config[key]}  [{config['sources'].get(key, 'flag')}]")
+    lines.append(
+        f"  data_list_size       : {info['data_list_size']:,} "
+        f"(after [::{config['train_subsample_step']}]);  "
+        f"cluster-matched {info['matched_count']:,} in {info['num_clusters']} clusters"
+    )
+    lines.append(
+        f"  draws per epoch      : {info['padded_length']:,} "
+        f"= ceil({info['data_list_size']:,}/{config['world_size']}) "
+        f"x {config['world_size']} = {info['num_samples_per_rank']:,} per rank"
+    )
+    lines.append(
+        f"  repeat_aug_pool      : {', '.join(pool) if pool else '(forcing DISABLED)'}"
+        f"{f'  ({len(pool)} members)' if pool else ''}"
+    )
+    if has_rows:
+        lines.append(
+            f"  delivered rows/epoch : {result['per_epoch'][0]['delivered_rows']:,} "
+            f"of {info['padded_length']:,} "
+            f"({result['per_epoch'][0]['dropped_rows']:,} dropped by DataLoader "
+            f"drop_last=True, per-rank batch {config['per_rank_batch']})"
+        )
+    for message in result.get("warnings", []):
+        lines.append(f"  WARNING: {message}")
+    lines.append("")
+
+    head = f"{'epoch':>6} {'total_draws':>13} {'distinct':>12} {'repeats':>12} {'repeat_frac':>12}"
+    if has_rows:
+        head += f" {'forced_rows':>13} {'per_pool_member':>16}"
+    else:
+        head += f" {'per_pool_member':>16}"
+    lines.append(head)
+    lines.append("-" * len(head))
+    for row in result["per_epoch"]:
+        line = (
+            f"{row['epoch']:>6} {row['total_draws']:>13,} {row['distinct_samples']:>12,} "
+            f"{row['repeat_draws']:>12,} {row['repeat_fraction']:>12.4f}"
+        )
+        if has_rows:
+            member = row["forced_per_pool_member"]
+            line += f" {row['forced_rows']:>13,}"
+            line += f" {member:>16,.1f}" if member is not None else f" {'-':>16}"
+        else:
+            member = row["expected_forced_per_pool_member"]
+            line += f" {member:>16,.1f}" if member is not None else f" {'-':>16}"
+        lines.append(line)
+    lines.append("-" * len(head))
+
+    total = result["total"]
+    line = (
+        f"{'TOTAL':>6} {total['total_draws']:>13,} {total['distinct_samples_union']:>12,} "
+        f"{total['repeat_draws']:>12,} {total['repeat_fraction']:>12.4f}"
+    )
+    if has_rows:
+        member = total["forced_per_pool_member"]
+        line += f" {total['forced_rows']:>13,}"
+        line += f" {member:>16,.1f}" if member is not None else f" {'-':>16}"
+    else:
+        member = total["expected_forced_per_pool_member"]
+        line += f" {member:>16,.1f}" if member is not None else f" {'-':>16}"
+    lines.append(line)
+    lines.append("")
+    lines.append(
+        f"  distinct column is per-epoch; TOTAL distinct is the UNION over "
+        f"{total['epochs']} epoch(s), not a sum."
+    )
+    if has_rows:
+        lines.append(
+            "  forced_rows is the count that actually got force-augmented: repeat draws "
+            "among the\n  rows the DataLoader delivered (drop_last=True discards each "
+            "rank's partial tail batch)."
+        )
+        lines.append(
+            f"  repeats not forced (dropped tail): {total['repeat_draws'] - total['forced_rows']:,}"
+        )
+    else:
+        lines.append(
+            "  No batch_size resolved, so drop_last is not modelled: repeats is an UPPER "
+            "bound on\n  forced rows. Pass --batch_size to get the delivered-row count."
+        )
+    if pool:
+        lines.append(
+            f"  per_pool_member = rows / {len(pool)}: the selector picks one pool member "
+            f"uniformly per\n  forced row, so each member's expected share is an equal split."
+        )
+    lines.append("=" * 96)
+    return "\n".join(lines)
+
+
+def get_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Replay a training run's cluster-weighted sampler offline and report "
+        "per-epoch repeat-draw / forced-augmentation counts (CPU only, opens no NPZ files)."
+    )
+    parser.add_argument(
+        "--run_dir",
+        type=str,
+        default=None,
+        help="Training run directory containing args.json (and cluster_sampling.json). "
+        "Any flag below overrides the value read from it.",
+    )
+    parser.add_argument("--cluster_json", type=str, default=None, help="Cluster assignment JSON")
+    parser.add_argument("--train_set_list", type=str, default=None, help="JSON list of NPZ paths")
+    parser.add_argument(
+        "--train_subsample_step",
+        type=int,
+        default=None,
+        help="Stride applied as data_list[::step], exactly as train.py does",
+    )
+    parser.add_argument("--seed", type=int, default=None, help="Run seed (sampler uses seed+epoch)")
+    parser.add_argument(
+        "--cluster_weight_alpha",
+        type=float,
+        default=None,
+        help="Inverse-frequency exponent in [0, 1]",
+    )
+    parser.add_argument(
+        "--world_size",
+        type=int,
+        default=None,
+        help="DDP world size of the original run. REQUIRED unless args.json records it: "
+        "padded draws = ceil(N / world_size) * world_size.",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=None,
+        help="GLOBAL batch size, to model the training DataLoader's drop_last=True and "
+        "report the rows that actually got forced. Read from args.json when available.",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=None,
+        help="Number of epochs to replay (default: train_epochs from args.json)",
+    )
+    parser.add_argument(
+        "--start_epoch",
+        type=int,
+        default=0,
+        help="First epoch index, matching train.py's range(init_epoch, train_epochs). "
+        "Set this for a resumed run (default: 0).",
+    )
+    parser.add_argument(
+        "--repeat_aug_pool",
+        type=str,
+        default=None,
+        help="Comma-separated pool override. With --run_dir it is resolved exactly as "
+        "train.py resolves it; without one it is taken literally.",
+    )
+    parser.add_argument(
+        "--force_aug_on_repeat",
+        action="store_true",
+        default=None,
+        help="Treat forcing as enabled even if args.json says it was off (hypothetical replay)",
+    )
+    parser.add_argument(
+        "--allow_data_list_mismatch",
+        action="store_true",
+        help="Downgrade the cluster_sampling.json data-list-size cross-check to a warning",
+    )
+    parser.add_argument("--json", type=str, default=None, help="Write results to this JSON path")
+    return parser.parse_args(argv)
+
+
+def resolve_config(args: argparse.Namespace) -> tuple[dict, dict | None, list[str]]:
+    """Merge args.json with explicit flags. Returns ``(config, cluster_sampling, warnings)``."""
+    run_args: dict | None = None
+    cluster_sampling: dict | None = None
+    if args.run_dir:
+        run_args, cluster_sampling = load_run_dir(args.run_dir)
+
+    sources: dict[str, str] = {}
+    warnings: list[str] = []
+
+    def pick(name: str, json_key: str | None = None, required: bool = True):
+        json_key = json_key or name
+        value = getattr(args, name)
+        if value is not None:
+            sources[name] = "flag"
+            return value
+        if run_args is not None and run_args.get(json_key) is not None:
+            sources[name] = "args.json"
+            return run_args[json_key]
+        if name in DEFAULTS:
+            sources[name] = "default"
+            return DEFAULTS[name]
+        if required:
+            raise ReplayError(
+                f"--{name} is required (not given, and not recoverable from "
+                f"{'args.json' if run_args is not None else 'any run dir'})."
+            )
+        sources[name] = "unset"
+        return None
+
+    config: dict = {
+        "run_dir": args.run_dir,
+        "cluster_json": pick("cluster_json"),
+        "train_set_list": pick("train_set_list"),
+        "train_subsample_step": int(pick("train_subsample_step")),
+        "seed": int(pick("seed")),
+        "cluster_weight_alpha": float(pick("cluster_weight_alpha")),
+        "epochs": pick("epochs", json_key="train_epochs"),
+        "start_epoch": args.start_epoch,
+        "batch_size": pick("batch_size", required=False),
+    }
+    if not config["cluster_json"]:
+        raise ReplayError(
+            "cluster_json is empty. Without --cluster_json the run used a plain "
+            "DistributedSampler, which draws WITHOUT replacement: no sample repeats "
+            "within an epoch, so there is nothing to replay."
+        )
+    config["epochs"] = int(config["epochs"])
+    if config["epochs"] < 1:
+        raise ReplayError(f"--epochs must be >= 1, got {config['epochs']}")
+
+    world_size = args.world_size
+    if world_size is not None:
+        sources["world_size"] = "flag"
+    elif run_args is not None:
+        for key in WORLD_SIZE_KEYS:
+            if run_args.get(key) is not None:
+                world_size, sources["world_size"] = int(run_args[key]), f"args.json[{key}]"
+                break
+    if world_size is None:
+        raise ReplayError(
+            "--world_size is required: the run directory does not record the DDP world "
+            "size (TrainConfig has no such field, so args.json cannot carry it), and "
+            "guessing 1 would silently report wrong totals -- padded draws per epoch are "
+            "ceil(N / world_size) * world_size.\n"
+            "Recover it from the run's log, e.g.:\n"
+            "  grep -o 'global_rank=[0-9]*' <run_dir>/train_log.txt | sort -u | wc -l\n"
+            "(train.py prints 'global_rank=..., rank=...' once per rank at startup.)"
+        )
+    if world_size < 1:
+        raise ReplayError(f"--world_size must be >= 1, got {world_size}")
+    config["world_size"] = world_size
+
+    per_rank_batch = None
+    if config["batch_size"] is not None:
+        config["batch_size"] = int(config["batch_size"])
+        # train.py: DataLoader(batch_size=batch_size // world_size, drop_last=True)
+        per_rank_batch = config["batch_size"] // world_size
+        if per_rank_batch < 1:
+            warnings.append(
+                f"batch_size {config['batch_size']} // world_size {world_size} == 0, so "
+                f"drop_last cannot be modelled; reporting draw-level counts only."
+            )
+            per_rank_batch = None
+    config["per_rank_batch"] = per_rank_batch
+    config["sources"] = sources
+
+    pool, pool_warnings = resolve_pool(run_args, args.repeat_aug_pool, args.force_aug_on_repeat)
+    config["repeat_aug_pool"] = pool
+    warnings.extend(pool_warnings)
+    if not pool:
+        warnings.append(
+            "Forced augmentation resolves to an empty pool (force_aug_on_repeat off, or "
+            "no pool given without --run_dir): repeat counts below are reported, but no "
+            "rows were force-augmented."
+        )
+    return config, cluster_sampling, warnings
+
+
+def cross_check(config: dict, cluster_sampling: dict | None, data_list_size: int) -> list[str]:
+    """Compare the reconstruction against cluster_sampling.json. Returns warnings."""
+    warnings: list[str] = []
+    if cluster_sampling is None:
+        if config.get("run_dir"):
+            warnings.append(
+                "cluster_sampling.json not found in the run dir, so the reconstructed "
+                "data list size cannot be cross-checked against what training used."
+            )
+        return warnings
+    recorded = cluster_sampling.get("data_list_size")
+    if recorded is not None and int(recorded) != data_list_size:
+        raise ReplayError(
+            f"reconstructed data list has {data_list_size:,} entries but the run's "
+            f"cluster_sampling.json records {int(recorded):,}. Every count would be wrong. "
+            f"Check the inputs: train_set_list={config['train_set_list']!r}, "
+            f"train_subsample_step={config['train_subsample_step']} "
+            f"(the run recorded train_subsample_step="
+            f"{cluster_sampling.get('train_subsample_step')}). The path list itself may "
+            f"also have been regenerated since the run started. Re-run with "
+            f"--allow_data_list_mismatch to report anyway."
+        )
+    for key, recorded_key in (
+        ("cluster_json", "cluster_json"),
+        ("cluster_weight_alpha", "cluster_weight_alpha"),
+        ("train_subsample_step", "train_subsample_step"),
+    ):
+        recorded_value = cluster_sampling.get(recorded_key)
+        if recorded_value is not None and recorded_value != config[key]:
+            warnings.append(
+                f"{key}={config[key]!r} differs from cluster_sampling.json's "
+                f"{recorded_value!r} (replaying a hypothetical config)."
+            )
+    recorded_pool = (cluster_sampling.get("forced_augmentation") or {}).get("pool")
+    if recorded_pool is not None and list(recorded_pool) != list(config["repeat_aug_pool"]):
+        warnings.append(
+            f"repeat_aug_pool {config['repeat_aug_pool']} differs from "
+            f"cluster_sampling.json's {list(recorded_pool)}; per-member numbers reflect "
+            f"the pool used here."
+        )
+    return warnings
+
+
+def run_from_args(args: argparse.Namespace) -> dict:
+    """Full replay. Returns the result dict; raises ReplayError on bad configuration."""
+    config, cluster_sampling, warnings = resolve_config(args)
+
+    data_list = build_data_list(config["train_set_list"], config["train_subsample_step"])
+    if not data_list:
+        raise ReplayError(
+            f"data list is empty after [::{config['train_subsample_step']}] "
+            f"({config['train_set_list']})."
+        )
+    try:
+        warnings += cross_check(config, cluster_sampling, len(data_list))
+    except ReplayError as exc:
+        if not args.allow_data_list_mismatch:
+            raise
+        warnings.append(f"data-list cross-check FAILED (ignored): {exc}")
+
+    per_epoch, total, sampler_info = replay_epochs(
+        data_list=data_list,
+        cluster_json=config["cluster_json"],
+        seed=config["seed"],
+        alpha=config["cluster_weight_alpha"],
+        world_size=config["world_size"],
+        start_epoch=config["start_epoch"],
+        epochs=config["epochs"],
+        pool_size=len(config["repeat_aug_pool"]),
+        per_rank_batch=config["per_rank_batch"],
+    )
+    return {
+        "config": config,
+        "sampler": sampler_info,
+        "warnings": warnings,
+        "per_epoch": per_epoch,
+        "total": total,
+    }
+
+
+def run(argv: list[str] | None = None) -> dict:
+    """Parse ``argv`` and replay. Convenience entry point for tests and importers."""
+    return run_from_args(get_args(argv))
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = get_args(argv)
+    try:
+        result = run_from_args(args)
+    except ReplayError as exc:
+        # SystemExit rather than a traceback: every ReplayError is an operator-fixable
+        # configuration problem, and a stack trace buries the instruction.
+        raise SystemExit(f"replay_repeats: {exc}") from exc
+
+    print(format_report(result))
+    if args.json:
+        out = Path(args.json)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        # Write-then-rename: a truncating open leaves a half-written JSON behind if this
+        # dies mid-dump, and the file is meant to be machine-read.
+        tmp = out.with_suffix(out.suffix + ".tmp")
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(result, f, indent=4)
+        tmp.replace(out)
+        print(f"Wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/diffusion_planner/sampling/utils/pipeline.py
+++ b/diffusion_planner/sampling/utils/pipeline.py
@@ -93,6 +93,55 @@ def extract_features(npz_path: str) -> np.ndarray:
     return ego_future.flatten()
 
 
+def extract_features_enriched(
+    npz_path: str,
+    top_k: int = 20,
+    temporal_hz: int = 2,
+) -> tuple:
+    """Extract ego block and neighbor block feature vectors for enriched clustering.
+
+    Returns:
+        (ego_block, neighbor_block) — two 1-D float arrays.
+    """
+    if 10 % temporal_hz != 0:
+        raise ValueError(f"temporal_hz={temporal_hz} must evenly divide 10")
+
+    data = np.load(npz_path, allow_pickle=True)
+    step = 10 // temporal_hz
+    past_idx = np.arange(0, 31, step)
+    future_idx = np.arange(0, 80, step)
+
+    ego_past = data["ego_agent_past"].astype(float)[past_idx]
+    ego_future = data["ego_agent_future"].astype(float)[future_idx]
+    ego_state = data["ego_current_state"].astype(float)
+
+    nbr_past = data["neighbor_agents_past"].astype(float)
+    nbr_future = data["neighbor_agents_future"].astype(float)
+
+    active_mask = np.any(nbr_past.reshape(nbr_past.shape[0], -1) != 0, axis=1)
+    nbr_pos = nbr_past[:, -1, :2]
+    distances = np.linalg.norm(nbr_pos, axis=1)
+    distances[~active_mask] = np.inf
+
+    sorted_idx = np.argsort(distances)[:top_k]
+    topk_past = nbr_past[sorted_idx][:, past_idx]
+    topk_future = nbr_future[sorted_idx][:, future_idx]
+    topk_dist = distances[sorted_idx].copy()
+    topk_dist[topk_dist == np.inf] = 0.0
+
+    ego_block = np.concatenate([
+        ego_past.flatten(),
+        ego_future.flatten(),
+        ego_state,
+        topk_dist,
+    ])
+    neighbor_block = np.concatenate([
+        topk_past.flatten(),
+        topk_future.flatten(),
+    ])
+    return ego_block, neighbor_block
+
+
 # ──────────────────────────── Pipeline ───────────────────────────────────────
 
 

--- a/diffusion_planner/sampling/utils/pipeline.py
+++ b/diffusion_planner/sampling/utils/pipeline.py
@@ -203,3 +203,75 @@ def cluster_trajectories(
     return {
         k: clusters[k] for k in sorted(clusters, key=lambda x: int(x.replace("cluster_id", "")))
     }
+
+
+def cluster_trajectories_enriched(
+    npz_paths: list,
+    strategy: ClusteringStrategy,
+    pca_components: int = 50,
+    neighbor_pca_components: int = 50,
+    top_k: int = 20,
+    temporal_hz: int = 2,
+) -> dict:
+    """Run the enriched two-stage PCA clustering pipeline.
+
+    Stage 1: Z-score ego and neighbor blocks independently, PCA the neighbor block.
+    Stage 2: Concatenate, Z-score, final PCA, then delegate to strategy.
+    """
+    ego_list = []
+    nbr_list = []
+    valid_paths = []
+    for path in tqdm(npz_paths, desc="Extracting enriched features", unit="file"):
+        try:
+            ego, nbr = extract_features_enriched(path, top_k=top_k, temporal_hz=temporal_hz)
+            ego_list.append(ego)
+            nbr_list.append(nbr)
+            valid_paths.append(path)
+        except Exception as e:
+            tqdm.write(f"  [warn] skipping {path}: {e}")
+
+    if not ego_list:
+        raise RuntimeError("No valid NPZ files found.")
+
+    ego_features = np.array(ego_list)
+    nbr_features = np.array(nbr_list)
+
+    ego_mean = ego_features.mean(axis=0)
+    ego_std = ego_features.std(axis=0) + 1e-8
+    ego_norm = (ego_features - ego_mean) / ego_std
+
+    nbr_mean = nbr_features.mean(axis=0)
+    nbr_std = nbr_features.std(axis=0) + 1e-8
+    nbr_norm = (nbr_features - nbr_mean) / nbr_std
+
+    n_nbr = min(neighbor_pca_components, nbr_norm.shape[0], nbr_norm.shape[1])
+    nbr_pca = PCA(n_components=n_nbr, random_state=0)
+    nbr_reduced = nbr_pca.fit_transform(nbr_norm)
+    print(
+        f"Neighbor PCA: {nbr_norm.shape[1]}-dim → {n_nbr}-dim "
+        f"({nbr_pca.explained_variance_ratio_.sum() * 100:.1f}% variance explained)"
+    )
+
+    combined = np.hstack([ego_norm, nbr_reduced])
+    comb_mean = combined.mean(axis=0)
+    comb_std = combined.std(axis=0) + 1e-8
+    combined_norm = (combined - comb_mean) / comb_std
+
+    n_final = min(pca_components, combined_norm.shape[0], combined_norm.shape[1])
+    final_pca = PCA(n_components=n_final, random_state=0)
+    features_pca = final_pca.fit_transform(combined_norm)
+    print(
+        f"Final PCA: {combined_norm.shape[1]}-dim → {n_final}-dim "
+        f"({final_pca.explained_variance_ratio_.sum() * 100:.1f}% variance explained)"
+    )
+
+    labels = strategy.fit_predict(features_pca)
+
+    clusters = defaultdict(list)
+    for path, label in zip(valid_paths, labels):
+        clusters[f"cluster_id{label}"].append(path)
+
+    return {
+        k: clusters[k]
+        for k in sorted(clusters, key=lambda x: int(x.replace("cluster_id", "")))
+    }

--- a/diffusion_planner/sampling/utils/pipeline.py
+++ b/diffusion_planner/sampling/utils/pipeline.py
@@ -133,16 +133,20 @@ def extract_features_enriched(
     topk_dist = distances[sorted_idx].copy()
     topk_dist[topk_dist == np.inf] = -1.0
 
-    ego_block = np.concatenate([
-        ego_past.flatten(),
-        ego_future.flatten(),
-        ego_state,
-        topk_dist,
-    ])
-    neighbor_block = np.concatenate([
-        topk_past.flatten(),
-        topk_future.flatten(),
-    ])
+    ego_block = np.concatenate(
+        [
+            ego_past.flatten(),
+            ego_future.flatten(),
+            ego_state,
+            topk_dist,
+        ]
+    )
+    neighbor_block = np.concatenate(
+        [
+            topk_past.flatten(),
+            topk_future.flatten(),
+        ]
+    )
     return ego_block, neighbor_block
 
 
@@ -276,6 +280,5 @@ def cluster_trajectories_enriched(
         clusters[f"cluster_id{label}"].append(path)
 
     return {
-        k: clusters[k]
-        for k in sorted(clusters, key=lambda x: int(x.replace("cluster_id", "")))
+        k: clusters[k] for k in sorted(clusters, key=lambda x: int(x.replace("cluster_id", "")))
     }

--- a/diffusion_planner/sampling/utils/pipeline.py
+++ b/diffusion_planner/sampling/utils/pipeline.py
@@ -127,10 +127,31 @@ def extract_features_enriched(
     distances = np.linalg.norm(nbr_pos, axis=1)
     distances[~active_mask] = np.inf
 
+    # ``past_idx``/``future_idx`` come from the EGO array lengths and are then applied
+    # to the neighbor arrays. Shorter neighbor horizons raise IndexError (swallowed by
+    # the caller's per-file except, so it looks like a bad file rather than a schema
+    # mismatch); longer ones silently drop the tail. Say so explicitly.
+    if nbr_past.shape[1] != n_past or nbr_future.shape[1] != n_future:
+        raise ValueError(
+            f"neighbor/ego horizon mismatch: neighbor_agents_past T="
+            f"{nbr_past.shape[1]} vs ego_agent_past T={n_past}, "
+            f"neighbor_agents_future T={nbr_future.shape[1]} vs "
+            f"ego_agent_future T={n_future}"
+        )
+
     sorted_idx = np.argsort(distances)[:top_k]
+    # ``[:top_k]`` silently truncates when the file has fewer neighbor slots than
+    # top_k, producing a NARROWER feature vector than its peers. That only surfaces
+    # later, when every vector is stacked into one matrix. Pad to exactly top_k with
+    # zero trajectories and the -1.0 "absent" distance sentinel instead.
+    n_pad = top_k - len(sorted_idx)
     topk_past = nbr_past[sorted_idx][:, past_idx]
     topk_future = nbr_future[sorted_idx][:, future_idx]
     topk_dist = distances[sorted_idx].copy()
+    if n_pad > 0:
+        topk_past = np.concatenate([topk_past, np.zeros((n_pad, *topk_past.shape[1:]))])
+        topk_future = np.concatenate([topk_future, np.zeros((n_pad, *topk_future.shape[1:]))])
+        topk_dist = np.concatenate([topk_dist, np.full(n_pad, np.inf)])
     topk_dist[topk_dist == np.inf] = -1.0
 
     ego_block = np.concatenate(
@@ -226,20 +247,66 @@ def cluster_trajectories_enriched(
     Stage 1: Z-score ego and neighbor blocks independently, PCA the neighbor block.
     Stage 2: Concatenate, Z-score, final PCA, then delegate to strategy.
     """
+    if top_k < 1:
+        raise ValueError(f"top_k={top_k} must be >= 1")
+    if neighbor_pca_components < 1:
+        raise ValueError(f"neighbor_pca_components={neighbor_pca_components} must be >= 1")
+    if pca_components < 1:
+        raise ValueError(f"pca_components={pca_components} must be >= 1")
+
     ego_list = []
     nbr_list = []
     valid_paths = []
+    # Width of the first accepted file. Every later file must match it: a corpus
+    # mixing npz v2 (3-col neighbor_agents_future) with npz v3 (4-col [x,y,cos,sin]),
+    # or differing horizons, yields ragged vectors that only blow up at
+    # ``np.array(nbr_list)`` -- after all 150,000 files have been read off storage.
+    # Fail on file 2, not file 150,000.
+    widths: tuple[int, int] | None = None
     for path in tqdm(npz_paths, desc="Extracting enriched features", unit="file"):
         try:
             ego, nbr = extract_features_enriched(path, top_k=top_k, temporal_hz=temporal_hz)
-            ego_list.append(ego)
-            nbr_list.append(nbr)
-            valid_paths.append(path)
+            if not (np.all(np.isfinite(ego)) and np.all(np.isfinite(nbr))):
+                # NaN/Inf survive extraction and only fail inside PCA, at the end.
+                raise ValueError("feature vector contains NaN or Inf")
         except Exception as e:
             tqdm.write(f"  [warn] skipping {path}: {e}")
+            continue
+
+        # Deliberately OUTSIDE the try: a width mismatch is a corpus-level problem,
+        # not a bad file. Skipping it would silently drop every minority-layout file
+        # and emit a cluster JSON covering only part of the dataset.
+        if widths is None:
+            widths = (ego.size, nbr.size)
+        elif (ego.size, nbr.size) != widths:
+            raise ValueError(
+                f"{path}: feature width {(ego.size, nbr.size)} != {widths} from the "
+                f"first accepted file. Mixed NPZ layouts (e.g. npz v2's 3-col "
+                f"neighbor_agents_future vs npz v3's 4-col [x, y, cos, sin]) cannot be "
+                f"clustered together. Normalize the corpus to one layout first."
+            )
+
+        ego_list.append(ego)
+        nbr_list.append(nbr)
+        valid_paths.append(path)
 
     if not ego_list:
         raise RuntimeError("No valid NPZ files found.")
+
+    skipped = len(npz_paths) - len(valid_paths)
+    print(
+        f"Extracted {len(valid_paths)}/{len(npz_paths)} files "
+        f"({skipped} skipped, {100.0 * skipped / len(npz_paths):.1f}%)"
+    )
+    if skipped:
+        # Skipped files stay in the training data_list, where the sampler gives them
+        # neutral weight -- so a high skip rate quietly defeats the balancing this
+        # pipeline exists to provide.
+        print(
+            "  [warn] skipped files are absent from the cluster JSON; training will "
+            "assign them neutral weight. Investigate before using this JSON if the "
+            "skip rate is material."
+        )
 
     ego_features = np.array(ego_list)
     nbr_features = np.array(nbr_list)

--- a/diffusion_planner/sampling/utils/pipeline.py
+++ b/diffusion_planner/sampling/utils/pipeline.py
@@ -103,20 +103,24 @@ def extract_features_enriched(
     Returns:
         (ego_block, neighbor_block) — two 1-D float arrays.
     """
+    if temporal_hz <= 0:
+        raise ValueError(f"temporal_hz={temporal_hz} must be positive")
     if 10 % temporal_hz != 0:
         raise ValueError(f"temporal_hz={temporal_hz} must evenly divide 10")
 
-    data = np.load(npz_path, allow_pickle=True)
-    step = 10 // temporal_hz
-    past_idx = np.arange(0, 31, step)
-    future_idx = np.arange(0, 80, step)
+    with np.load(npz_path, allow_pickle=True) as data:
+        step = 10 // temporal_hz
+        n_past = data["ego_agent_past"].shape[0]
+        n_future = data["ego_agent_future"].shape[0]
+        past_idx = np.arange(0, n_past, step)
+        future_idx = np.unique(np.append(np.arange(0, n_future, step), n_future - 1))
 
-    ego_past = data["ego_agent_past"].astype(float)[past_idx]
-    ego_future = data["ego_agent_future"].astype(float)[future_idx]
-    ego_state = data["ego_current_state"].astype(float)
+        ego_past = data["ego_agent_past"].astype(float)[past_idx]
+        ego_future = data["ego_agent_future"].astype(float)[future_idx]
+        ego_state = data["ego_current_state"].astype(float)
 
-    nbr_past = data["neighbor_agents_past"].astype(float)
-    nbr_future = data["neighbor_agents_future"].astype(float)
+        nbr_past = data["neighbor_agents_past"].astype(float)
+        nbr_future = data["neighbor_agents_future"].astype(float)
 
     active_mask = np.any(nbr_past.reshape(nbr_past.shape[0], -1) != 0, axis=1)
     nbr_pos = nbr_past[:, -1, :2]
@@ -127,7 +131,7 @@ def extract_features_enriched(
     topk_past = nbr_past[sorted_idx][:, past_idx]
     topk_future = nbr_future[sorted_idx][:, future_idx]
     topk_dist = distances[sorted_idx].copy()
-    topk_dist[topk_dist == np.inf] = 0.0
+    topk_dist[topk_dist == np.inf] = -1.0
 
     ego_block = np.concatenate([
         ego_past.flatten(),

--- a/diffusion_planner/sampling/visualize_cluster_report.py
+++ b/diffusion_planner/sampling/visualize_cluster_report.py
@@ -30,6 +30,11 @@ from __future__ import annotations
 import base64
 import io
 import json
+import random
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
 
 import matplotlib
 matplotlib.use("Agg")
@@ -91,3 +96,70 @@ def render_bar_chart(stats: list[dict]) -> str:
     buf.seek(0)
     b64 = base64.b64encode(buf.read()).decode("ascii")
     return f"data:image/png;base64,{b64}"
+
+
+def subsample_cluster_paths(
+    clusters: dict[str, list[str]], max_videos: int, seed: int
+) -> dict[str, list[str]]:
+    result = {}
+    for cid, paths in clusters.items():
+        rng = random.Random(seed + int(cid.replace("cluster_id", "")))
+        if len(paths) <= max_videos:
+            result[cid] = list(paths)
+        else:
+            result[cid] = rng.sample(paths, max_videos)
+    return result
+
+
+def render_cluster_videos(
+    subsampled: dict[str, list[str]], output_dir: str, workers: int
+) -> tuple[dict[str, list[str]], list[dict]]:
+    if not shutil.which("render-video-txt"):
+        raise RuntimeError(
+            "render-video-txt not found on PATH. "
+            "Install clip-review-tool: pip install -e /path/to/clip-review-tool"
+        )
+
+    videos_dir = Path(output_dir) / "videos"
+    rendered: dict[str, list[str]] = {}
+    errors: list[dict] = []
+
+    for cluster_id, paths in subsampled.items():
+        if not paths:
+            rendered[cluster_id] = []
+            continue
+
+        cluster_dir = videos_dir / cluster_id
+        cluster_dir.mkdir(parents=True, exist_ok=True)
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".txt", delete=False
+        ) as f:
+            for p in paths:
+                f.write(p + "\n")
+            txt_path = f.name
+
+        try:
+            subprocess.run(
+                ["render-video-txt", txt_path, str(cluster_dir),
+                 "--workers", str(workers)],
+                check=False,
+            )
+        finally:
+            Path(txt_path).unlink(missing_ok=True)
+
+        mp4s = sorted(str(p) for p in cluster_dir.glob("*.mp4"))
+        rendered[cluster_id] = mp4s
+
+        log_path = cluster_dir / "render_log.jsonl"
+        if log_path.exists():
+            for line in log_path.read_text().splitlines():
+                entry = json.loads(line)
+                if entry.get("status") == "error":
+                    errors.append({
+                        "cluster_id": cluster_id,
+                        "file": entry.get("file", ""),
+                        "reason": entry.get("reason", "unknown"),
+                    })
+
+    return rendered, errors

--- a/diffusion_planner/sampling/visualize_cluster_report.py
+++ b/diffusion_planner/sampling/visualize_cluster_report.py
@@ -18,11 +18,14 @@ Usage:
     python visualize_cluster_report.py \\
         --cluster_json /path/to/cluster_result.json \\
         --output_dir   /path/to/report_output/ \\
-        [--max_videos 3] [--workers 1] [--seed 42]
+        [--max_videos 3] [--workers 1] [--seed 42] [--standalone]
 
 Reads the cluster assignment JSON from cluster.py, computes sampling
 statistics, renders BEV video examples per cluster via render-video-txt
 (clip-review-tool), and assembles an HTML report.
+
+With --standalone, MP4 videos are converted to GIFs (240px, 3fps) and
+embedded as base64 in the HTML, producing a single shareable file.
 """
 
 from __future__ import annotations
@@ -86,14 +89,15 @@ def compute_cluster_stats(clusters: dict[str, list[str]]) -> list[dict]:
 
 
 def render_bar_chart(stats: list[dict]) -> str:
-    ids = [s["cluster_id"].replace("cluster_id", "") for s in stats]
-    counts = [s["count"] for s in stats]
+    stats_sorted = sorted(stats, key=lambda s: s["count"], reverse=True)
+    ids = [s["cluster_id"].replace("cluster_id", "") for s in stats_sorted]
+    counts = [s["count"] for s in stats_sorted]
 
     fig, ax = plt.subplots(figsize=(max(6, len(ids) * 0.6), 4))
     ax.bar(ids, counts, color="#4C72B0", edgecolor="white", linewidth=0.5)
     ax.set_xlabel("Cluster ID")
     ax.set_ylabel("Sample Count")
-    ax.set_title("Cluster Size Distribution")
+    ax.set_title("Cluster Size Distribution (sorted by count)")
     ax.tick_params(axis="x", rotation=45 if len(ids) > 15 else 0)
     fig.tight_layout()
 
@@ -177,6 +181,21 @@ def render_cluster_videos(
     return rendered, errors
 
 
+def convert_mp4_to_gif(mp4_path: str) -> str:
+    gif_path = str(Path(mp4_path).with_suffix(".gif"))
+    if Path(gif_path).exists():
+        return gif_path
+    result = subprocess.run(
+        ["ffmpeg", "-i", mp4_path,
+         "-vf", "fps=3,scale=240:-1:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse",
+         "-y", gif_path],
+        capture_output=True, check=False,
+    )
+    if result.returncode != 0:
+        warnings.warn(f"ffmpeg failed for {mp4_path}: {result.stderr.decode()[-200:]}")
+    return gif_path
+
+
 def _render_errors_section(errors: list[dict]) -> str:
     if not errors:
         return ""
@@ -204,15 +223,19 @@ def generate_html_report(
     errors: list[dict],
     cluster_json_path: str,
     output_dir: str,
+    standalone: bool = False,
 ) -> str:
     total = sum(s["count"] for s in stats)
     n_clusters = len(stats)
     now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     output_path = Path(output_dir) / "report.html"
 
+    # --- sort by sample count (largest first) for display ---
+    stats_sorted = sorted(stats, key=lambda s: s["count"], reverse=True)
+
     # --- stats table rows ---
     table_rows = ""
-    for s in stats:
+    for s in stats_sorted:
         table_rows += (
             f"<tr>"
             f"<td>{escape(s['cluster_id'])}</td>"
@@ -225,26 +248,37 @@ def generate_html_report(
             f"</tr>\n"
         )
 
-    # --- per-cluster video galleries ---
+    # --- per-cluster video/gif galleries ---
     galleries = ""
-    for s in stats:
+    for s in stats_sorted:
         cid = s["cluster_id"]
         mp4s = rendered.get(cid, [])
-        video_tags = ""
-        for mp4_path in mp4s:
-            rel = str(Path(mp4_path).relative_to(output_dir))
-            video_tags += (
-                f'<video controls preload="none" width="360">'
-                f'<source src="{escape(rel)}" type="video/mp4">'
-                f"</video>\n"
-            )
+        media_tags = ""
+        if standalone:
+            for mp4_path in mp4s:
+                gif_path = convert_mp4_to_gif(mp4_path)
+                if Path(gif_path).exists():
+                    with open(gif_path, "rb") as f:
+                        b64 = base64.b64encode(f.read()).decode("ascii")
+                    media_tags += (
+                        f'<img src="data:image/gif;base64,{b64}" '
+                        f'style="border-radius:4px;background:#1a1a1a"> '
+                    )
+        else:
+            for mp4_path in mp4s:
+                rel = str(Path(mp4_path).relative_to(output_dir))
+                media_tags += (
+                    f'<video controls preload="none" width="360">'
+                    f'<source src="{escape(rel)}" type="video/mp4">'
+                    f"</video>\n"
+                )
         if not mp4s:
-            video_tags = "<p><em>No videos rendered for this cluster.</em></p>"
+            media_tags = "<p><em>No videos rendered for this cluster.</em></p>"
         galleries += f"""
         <div class="cluster-gallery">
             <h3>{escape(cid)} &mdash; {s['count']:,} samples, weight {s['weight']:.3f},
                 ~{s['repeats_per_sample']:.1f}x repeats/sample/epoch</h3>
-            <div class="video-grid">{video_tags}</div>
+            <div class="video-grid">{media_tags}</div>
         </div>
         """
 
@@ -343,6 +377,10 @@ def get_args() -> argparse.Namespace:
         help="Parallel video rendering workers (default: 1)",
     )
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--standalone", action="store_true",
+        help="Produce a single self-contained HTML with embedded GIFs (240px, 3fps)",
+    )
     return parser.parse_args()
 
 
@@ -373,8 +411,13 @@ def main() -> None:
     print("Generating HTML report...")
     report_path = generate_html_report(
         stats, chart_uri, rendered, errors, args.cluster_json, args.output_dir,
+        standalone=args.standalone,
     )
     print(f"Report saved to {report_path}")
+    if args.standalone:
+        import os
+        size_mb = os.path.getsize(report_path) / 1024 / 1024
+        print(f"  Standalone mode: {size_mb:.1f}MB self-contained HTML")
 
 
 if __name__ == "__main__":

--- a/diffusion_planner/sampling/visualize_cluster_report.py
+++ b/diffusion_planner/sampling/visualize_cluster_report.py
@@ -27,7 +27,13 @@ statistics, renders BEV video examples per cluster via render-video-txt
 
 from __future__ import annotations
 
+import base64
+import io
 import json
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
 
 
 def load_cluster_json(path: str) -> dict[str, list[str]]:
@@ -65,3 +71,23 @@ def compute_cluster_stats(clusters: dict[str, list[str]]) -> list[dict]:
             "repeats_per_sample": draws / count if count > 0 else 0.0,
         })
     return stats
+
+
+def render_bar_chart(stats: list[dict]) -> str:
+    ids = [s["cluster_id"].replace("cluster_id", "") for s in stats]
+    counts = [s["count"] for s in stats]
+
+    fig, ax = plt.subplots(figsize=(max(6, len(ids) * 0.6), 4))
+    bars = ax.bar(ids, counts, color="#4C72B0", edgecolor="white", linewidth=0.5)
+    ax.set_xlabel("Cluster ID")
+    ax.set_ylabel("Sample Count")
+    ax.set_title("Cluster Size Distribution")
+    ax.tick_params(axis="x", rotation=45 if len(ids) > 15 else 0)
+    fig.tight_layout()
+
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=100, bbox_inches="tight")
+    plt.close(fig)
+    buf.seek(0)
+    b64 = base64.b64encode(buf.read()).decode("ascii")
+    return f"data:image/png;base64,{b64}"

--- a/diffusion_planner/sampling/visualize_cluster_report.py
+++ b/diffusion_planner/sampling/visualize_cluster_report.py
@@ -41,6 +41,7 @@ import shutil
 import subprocess
 import tempfile
 import warnings
+import zlib
 from datetime import datetime
 from html import escape
 from pathlib import Path
@@ -56,21 +57,51 @@ def load_cluster_json(path: str) -> dict[str, list[str]]:
         return json.load(f)
 
 
+def cluster_index(cluster_id: str) -> tuple[int, int, str]:
+    """Sort key that orders ``cluster_id<N>`` numerically (id10 after id2).
+
+    Falls back to lexicographic order for keys that do not match that shape. The
+    report reads a JSON that may have been hand-edited or produced elsewhere, so a
+    key like ``noise`` must not crash it with a bare ``invalid literal for int()``.
+    Mirrors the tolerant ordering train.py uses for its startup log.
+    """
+    suffix = (
+        cluster_id.replace("cluster_id", "", 1)
+        if cluster_id.startswith("cluster_id")
+        else cluster_id
+    )
+    return (0, int(suffix), "") if suffix.isdigit() else (1, 0, cluster_id)
+
+
 def compute_cluster_stats(clusters: dict[str, list[str]], alpha: float = 1.0) -> list[dict]:
     """Compute per-cluster stats. ``alpha`` must match training's --cluster_weight_alpha."""
-    # Reject negatives *and* non-finite values (NaN, +/-inf). ``not alpha >= 0``
-    # alone would let ``inf`` through, silently rendering an all-nan Weight column
-    # that still looks like output -- worse than crashing. Matches the guard in
-    # ClusterWeightedDistributedSampler.
-    if not (math.isfinite(alpha) and alpha >= 0):
+    # Reject non-finite values (NaN, +/-inf) and anything outside [0, 1]. ``inf``
+    # would silently render an all-nan Weight column that still looks like output,
+    # and alpha > 1 inverts the weighting. Matches the guard in
+    # ClusterWeightedDistributedSampler so the two cannot disagree on what is valid.
+    if not (math.isfinite(alpha) and 0 <= alpha <= 1):
         raise ValueError(
-            f"alpha={alpha} must be a finite number >= 0 (1.0 = full inverse, 0.0 = uniform)"
+            f"alpha={alpha} must be a finite number in [0, 1] "
+            f"(1.0 = full inverse weighting, 0.0 = uniform)"
         )
 
-    sorted_ids = sorted(clusters.keys(), key=lambda x: int(x.replace("cluster_id", "")))
+    # Drop zero-count clusters. ``freq`` would be 0, so ``(1/(0 + 1e-8)) ** alpha``
+    # renders a weight of ~1e8 in the Weight column -- a number training never
+    # applies, because the sampler builds cluster_counts/cluster_multipliers from
+    # live matches and omits empty clusters entirely. This report is read to pick
+    # alpha, so a phantom 1e8 row is worse than no row.
+    sorted_ids = [
+        cid for cid in sorted(clusters.keys(), key=cluster_index) if len(clusters[cid]) > 0
+    ]
     total = sum(len(v) for v in clusters.values())
+    # ClusterWeightedDistributedSampler raises on an all-empty cluster JSON. Silently
+    # emitting a report with "Total samples: 0" would have this tool -- the one built
+    # to catch a broken cluster JSON before a training launch -- call it fine.
     if total == 0:
-        return []
+        raise ValueError(
+            f"Cluster JSON contains no paths ({len(clusters)} clusters, all empty). "
+            f"Check cluster JSON."
+        )
 
     raw_weights = {}
     for cid in sorted_ids:
@@ -128,7 +159,13 @@ def subsample_cluster_paths(
 ) -> dict[str, list[str]]:
     result = {}
     for cid, paths in clusters.items():
-        rng = random.Random(seed + int(cid.replace("cluster_id", "")))
+        # Per-cluster seed offset. Tolerant of non-``cluster_id<N>`` keys so a
+        # hand-edited JSON picks videos reproducibly instead of dying on int().
+        # crc32, not hash(): str hashing is salted per process, which would make
+        # --seed non-reproducible across runs.
+        kind, index, _ = cluster_index(cid)
+        offset = index if kind == 0 else zlib.crc32(cid.encode()) % 100_000
+        rng = random.Random(seed + offset)
         if len(paths) <= max_videos:
             result[cid] = list(paths)
         else:
@@ -180,7 +217,15 @@ def render_cluster_videos(
         log_path = cluster_dir / "render_log.jsonl"
         if log_path.exists():
             for line in log_path.read_text().splitlines():
-                entry = json.loads(line)
+                # render-video-txt is an external tool; a blank or truncated line
+                # must not throw away a completed render pass.
+                if not line.strip():
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    warnings.warn(f"Skipping malformed render_log.jsonl line in {cluster_id}")
+                    continue
                 if entry.get("status") == "error":
                     errors.append(
                         {
@@ -292,8 +337,16 @@ def generate_html_report(
                     f'<source src="{escape(rel)}" type="video/mp4">'
                     f"</video>\n"
                 )
-        if not mp4s:
-            media_tags = "<p><em>No videos rendered for this cluster.</em></p>"
+        # Key the placeholder on whether any tag was actually produced, not on
+        # whether MP4s existed: in --standalone mode every ffmpeg conversion can
+        # fail (which only warns), leaving an empty gallery with no explanation.
+        if not media_tags:
+            media_tags = (
+                "<p><em>No videos rendered for this cluster.</em></p>"
+                if not mp4s
+                else f"<p><em>{len(mp4s)} video(s) rendered but GIF conversion failed "
+                "&mdash; check the ffmpeg warnings.</em></p>"
+            )
         galleries += f"""
         <div class="cluster-gallery">
             <h3>{escape(cid)} &mdash; {s["count"]:,} samples, weight {s["weight"]:.3f},
@@ -333,9 +386,15 @@ video {{ border-radius: 4px; background: #1a1a1a; }}
    Total samples: {total:,} | Clusters: {n_clusters}</p>
 
 <h2>Pipeline Overview</h2>
-<p>Ego future trajectories (80 timesteps &times; [x, y, heading]) &rarr;
-   flatten (240-dim) &rarr; Z-score normalization &rarr; PCA (50 components)
-   &rarr; Elbow KMeans &rarr; {n_clusters} clusters</p>
+<p>Features extracted from each NPZ &rarr; Z-score normalization &rarr; PCA
+   &rarr; Elbow KMeans &rarr; {n_clusters} clusters.</p>
+<p class="meta">The specific feature set and PCA width depend on how
+   <code>cluster.py</code> was invoked and are not recorded in the cluster JSON:
+   <code>--mode trajectory</code> (the default) flattens the ego future trajectory
+   only, while <code>--mode enriched</code> adds neighbor and ego-state blocks
+   through a two-stage PCA. Check the <code>cluster.py</code> command line for the
+   actual <code>--pca_components</code> / <code>--neighbor_pca_components</code>
+   values used.</p>
 
 <h2>Cluster Distribution</h2>
 <div class="chart"><img src="{chart_uri}" alt="Cluster size distribution"></div>
@@ -413,7 +472,7 @@ def get_args() -> argparse.Namespace:
         "--cluster_weight_alpha",
         type=float,
         default=1.0,
-        help="Exponent on inverse-frequency weights, matching training's "
+        help="Exponent on inverse-frequency weights in [0, 1], matching training's "
         "--cluster_weight_alpha (1.0 = full inverse, 0.0 = uniform)",
     )
     parser.add_argument(
@@ -426,6 +485,15 @@ def get_args() -> argparse.Namespace:
 
 def main() -> None:
     args = get_args()
+
+    # Preflight ffmpeg alongside render-video-txt. Without this, --standalone renders
+    # every cluster's videos first and only then dies with FileNotFoundError inside
+    # generate_html_report -- throwing away the entire expensive render pass.
+    if args.standalone and not shutil.which("ffmpeg"):
+        raise RuntimeError(
+            "--standalone needs ffmpeg on PATH to convert MP4s to embedded GIFs, "
+            "and it was not found. Install ffmpeg or drop --standalone."
+        )
 
     print(f"Loading cluster JSON: {args.cluster_json}")
     clusters = load_cluster_json(args.cluster_json)
@@ -461,9 +529,7 @@ def main() -> None:
     )
     print(f"Report saved to {report_path}")
     if args.standalone:
-        import os
-
-        size_mb = os.path.getsize(report_path) / 1024 / 1024
+        size_mb = Path(report_path).stat().st_size / 1024 / 1024
         print(f"  Standalone mode: {size_mb:.1f}MB self-contained HTML")
 
 

--- a/diffusion_planner/sampling/visualize_cluster_report.py
+++ b/diffusion_planner/sampling/visualize_cluster_report.py
@@ -27,6 +27,7 @@ statistics, renders BEV video examples per cluster via render-video-txt
 
 from __future__ import annotations
 
+import argparse
 import base64
 import io
 import json
@@ -38,6 +39,7 @@ from datetime import datetime
 from pathlib import Path
 
 import matplotlib
+
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
@@ -305,3 +307,62 @@ video {{ border-radius: 4px; background: #1a1a1a; }}
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(html, encoding="utf-8")
     return str(output_path)
+
+
+def get_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate an HTML diagnostic report for cluster-weighted sampling"
+    )
+    parser.add_argument(
+        "--cluster_json", type=str, required=True,
+        help="Path to the clustering result JSON produced by cluster.py",
+    )
+    parser.add_argument(
+        "--output_dir", type=str, required=True,
+        help="Output directory for report.html and videos/",
+    )
+    parser.add_argument(
+        "--max_videos", type=int, default=3,
+        help="Max BEV video examples to render per cluster (default: 3)",
+    )
+    parser.add_argument(
+        "--workers", type=int, default=1,
+        help="Parallel video rendering workers (default: 1)",
+    )
+    parser.add_argument("--seed", type=int, default=42)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = get_args()
+
+    print(f"Loading cluster JSON: {args.cluster_json}")
+    clusters = load_cluster_json(args.cluster_json)
+    total = sum(len(v) for v in clusters.values())
+    print(f"  {len(clusters)} clusters, {total:,} total samples")
+
+    print("Computing cluster statistics...")
+    stats = compute_cluster_stats(clusters)
+
+    print("Rendering bar chart...")
+    chart_uri = render_bar_chart(stats)
+
+    print(f"Subsampling {args.max_videos} videos per cluster...")
+    subsampled = subsample_cluster_paths(clusters, args.max_videos, args.seed)
+    n_videos = sum(len(v) for v in subsampled.values())
+    print(f"  {n_videos} videos to render across {len(subsampled)} clusters")
+
+    print(f"Rendering videos (workers={args.workers})...")
+    rendered, errors = render_cluster_videos(subsampled, args.output_dir, args.workers)
+    if errors:
+        print(f"  {len(errors)} file(s) failed to render")
+
+    print("Generating HTML report...")
+    report_path = generate_html_report(
+        stats, chart_uri, rendered, errors, args.cluster_json, args.output_dir,
+    )
+    print(f"Report saved to {report_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/diffusion_planner/sampling/visualize_cluster_report.py
+++ b/diffusion_planner/sampling/visualize_cluster_report.py
@@ -35,7 +35,9 @@ import random
 import shutil
 import subprocess
 import tempfile
+import warnings
 from datetime import datetime
+from html import escape
 from pathlib import Path
 
 import matplotlib
@@ -52,6 +54,8 @@ def load_cluster_json(path: str) -> dict[str, list[str]]:
 def compute_cluster_stats(clusters: dict[str, list[str]]) -> list[dict]:
     sorted_ids = sorted(clusters.keys(), key=lambda x: int(x.replace("cluster_id", "")))
     total = sum(len(v) for v in clusters.values())
+    if total == 0:
+        return []
 
     raw_weights = {}
     for cid in sorted_ids:
@@ -86,7 +90,7 @@ def render_bar_chart(stats: list[dict]) -> str:
     counts = [s["count"] for s in stats]
 
     fig, ax = plt.subplots(figsize=(max(6, len(ids) * 0.6), 4))
-    bars = ax.bar(ids, counts, color="#4C72B0", edgecolor="white", linewidth=0.5)
+    ax.bar(ids, counts, color="#4C72B0", edgecolor="white", linewidth=0.5)
     ax.set_xlabel("Cluster ID")
     ax.set_ylabel("Sample Count")
     ax.set_title("Cluster Size Distribution")
@@ -143,11 +147,16 @@ def render_cluster_videos(
             txt_path = f.name
 
         try:
-            subprocess.run(
+            result = subprocess.run(
                 ["render-video-txt", txt_path, str(cluster_dir),
                  "--workers", str(workers)],
                 check=False,
             )
+            if result.returncode != 0:
+                warnings.warn(
+                    f"render-video-txt exited with code {result.returncode} "
+                    f"for {cluster_id}"
+                )
         finally:
             Path(txt_path).unlink(missing_ok=True)
 
@@ -173,7 +182,11 @@ def _render_errors_section(errors: list[dict]) -> str:
         return ""
     rows = ""
     for e in errors:
-        rows += f"<tr><td>{e['cluster_id']}</td><td>{e['file']}</td><td>{e['reason']}</td></tr>\n"
+        rows += (
+            f"<tr><td>{escape(e['cluster_id'])}</td>"
+            f"<td>{escape(e['file'])}</td>"
+            f"<td>{escape(e['reason'])}</td></tr>\n"
+        )
     return f"""
     <h2>Render Errors</h2>
     <p>{len(errors)} file(s) failed to render:</p>
@@ -262,7 +275,7 @@ video {{ border-radius: 4px; background: #1a1a1a; }}
 <body>
 
 <h1>Cluster Diagnostic Report</h1>
-<p class="meta">Generated: {now} | Source: <code>{cluster_json_path}</code> |
+<p class="meta">Generated: {now} | Source: <code>{escape(cluster_json_path)}</code> |
    Total samples: {total:,} | Clusters: {n_clusters}</p>
 
 <h2>Pipeline Overview</h2>

--- a/diffusion_planner/sampling/visualize_cluster_report.py
+++ b/diffusion_planner/sampling/visualize_cluster_report.py
@@ -1,0 +1,67 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate an HTML diagnostic report for cluster-weighted sampling.
+
+Usage:
+    python visualize_cluster_report.py \\
+        --cluster_json /path/to/cluster_result.json \\
+        --output_dir   /path/to/report_output/ \\
+        [--max_videos 3] [--workers 1] [--seed 42]
+
+Reads the cluster assignment JSON from cluster.py, computes sampling
+statistics, renders BEV video examples per cluster via render-video-txt
+(clip-review-tool), and assembles an HTML report.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+def load_cluster_json(path: str) -> dict[str, list[str]]:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def compute_cluster_stats(clusters: dict[str, list[str]]) -> list[dict]:
+    sorted_ids = sorted(clusters.keys(), key=lambda x: int(x.replace("cluster_id", "")))
+    total = sum(len(v) for v in clusters.values())
+
+    raw_weights = {}
+    for cid in sorted_ids:
+        freq = len(clusters[cid]) / total
+        raw_weights[cid] = 1.0 / (freq + 1e-8)
+
+    mean_weight = sum(raw_weights[cid] * len(clusters[cid]) for cid in sorted_ids) / total
+    weights = {cid: w / mean_weight for cid, w in raw_weights.items()}
+
+    total_weight = sum(weights[cid] * len(clusters[cid]) for cid in sorted_ids)
+
+    stats = []
+    for cid in sorted_ids:
+        count = len(clusters[cid])
+        w = weights[cid]
+        sampling_rate = (w * count) / total_weight
+        draws = sampling_rate * total
+        stats.append({
+            "cluster_id": cid,
+            "count": count,
+            "pct": 100.0 * count / total,
+            "weight": w,
+            "sampling_rate": sampling_rate,
+            "draws_per_epoch": draws,
+            "repeats_per_sample": draws / count if count > 0 else 0.0,
+        })
+    return stats

--- a/diffusion_planner/sampling/visualize_cluster_report.py
+++ b/diffusion_planner/sampling/visualize_cluster_report.py
@@ -215,7 +215,7 @@ def generate_html_report(
     for s in stats:
         table_rows += (
             f"<tr>"
-            f"<td>{s['cluster_id']}</td>"
+            f"<td>{escape(s['cluster_id'])}</td>"
             f"<td>{s['count']:,}</td>"
             f"<td>{s['pct']:.1f}%</td>"
             f"<td>{s['weight']:.3f}</td>"
@@ -235,14 +235,14 @@ def generate_html_report(
             rel = str(Path(mp4_path).relative_to(output_dir))
             video_tags += (
                 f'<video controls preload="none" width="360">'
-                f'<source src="{rel}" type="video/mp4">'
+                f'<source src="{escape(rel)}" type="video/mp4">'
                 f"</video>\n"
             )
         if not mp4s:
             video_tags = "<p><em>No videos rendered for this cluster.</em></p>"
         galleries += f"""
         <div class="cluster-gallery">
-            <h3>{cid} &mdash; {s['count']:,} samples, weight {s['weight']:.3f},
+            <h3>{escape(cid)} &mdash; {s['count']:,} samples, weight {s['weight']:.3f},
                 ~{s['repeats_per_sample']:.1f}x repeats/sample/epoch</h3>
             <div class="video-grid">{video_tags}</div>
         </div>

--- a/diffusion_planner/sampling/visualize_cluster_report.py
+++ b/diffusion_planner/sampling/visualize_cluster_report.py
@@ -35,6 +35,7 @@ import argparse
 import base64
 import io
 import json
+import math
 import random
 import shutil
 import subprocess
@@ -57,12 +58,14 @@ def load_cluster_json(path: str) -> dict[str, list[str]]:
 
 def compute_cluster_stats(clusters: dict[str, list[str]], alpha: float = 1.0) -> list[dict]:
     """Compute per-cluster stats. ``alpha`` must match training's --cluster_weight_alpha."""
-    # ``not alpha >= 0`` rather than ``alpha < 0`` so NaN is rejected too:
-    # every comparison with NaN is False, and a NaN alpha would otherwise fill
-    # the whole report with nan weights instead of failing here. Matches the
-    # guard in ClusterWeightedDistributedSampler.
-    if not alpha >= 0:
-        raise ValueError(f"alpha={alpha} must be a number >= 0 (1.0 = full inverse, 0.0 = uniform)")
+    # Reject negatives *and* non-finite values (NaN, +/-inf). ``not alpha >= 0``
+    # alone would let ``inf`` through, silently rendering an all-nan Weight column
+    # that still looks like output -- worse than crashing. Matches the guard in
+    # ClusterWeightedDistributedSampler.
+    if not (math.isfinite(alpha) and alpha >= 0):
+        raise ValueError(
+            f"alpha={alpha} must be a finite number >= 0 (1.0 = full inverse, 0.0 = uniform)"
+        )
 
     sorted_ids = sorted(clusters.keys(), key=lambda x: int(x.replace("cluster_id", "")))
     total = sum(len(v) for v in clusters.values())

--- a/diffusion_planner/sampling/visualize_cluster_report.py
+++ b/diffusion_planner/sampling/visualize_cluster_report.py
@@ -18,7 +18,8 @@ Usage:
     python visualize_cluster_report.py \\
         --cluster_json /path/to/cluster_result.json \\
         --output_dir   /path/to/report_output/ \\
-        [--max_videos 3] [--workers 1] [--seed 42] [--standalone]
+        [--max_videos 3] [--workers 1] [--seed 42] [--standalone] \\
+        [--cluster_weight_alpha 1.0]
 
 Reads the cluster assignment JSON from cluster.py, computes sampling
 statistics, renders BEV video examples per cluster via render-video-txt
@@ -54,7 +55,15 @@ def load_cluster_json(path: str) -> dict[str, list[str]]:
         return json.load(f)
 
 
-def compute_cluster_stats(clusters: dict[str, list[str]]) -> list[dict]:
+def compute_cluster_stats(clusters: dict[str, list[str]], alpha: float = 1.0) -> list[dict]:
+    """Compute per-cluster stats. ``alpha`` must match training's --cluster_weight_alpha."""
+    # ``not alpha >= 0`` rather than ``alpha < 0`` so NaN is rejected too:
+    # every comparison with NaN is False, and a NaN alpha would otherwise fill
+    # the whole report with nan weights instead of failing here. Matches the
+    # guard in ClusterWeightedDistributedSampler.
+    if not alpha >= 0:
+        raise ValueError(f"alpha={alpha} must be a number >= 0 (1.0 = full inverse, 0.0 = uniform)")
+
     sorted_ids = sorted(clusters.keys(), key=lambda x: int(x.replace("cluster_id", "")))
     total = sum(len(v) for v in clusters.values())
     if total == 0:
@@ -63,7 +72,7 @@ def compute_cluster_stats(clusters: dict[str, list[str]]) -> list[dict]:
     raw_weights = {}
     for cid in sorted_ids:
         freq = len(clusters[cid]) / total
-        raw_weights[cid] = 1.0 / (freq + 1e-8)
+        raw_weights[cid] = (1.0 / (freq + 1e-8)) ** alpha
 
     mean_weight = sum(raw_weights[cid] * len(clusters[cid]) for cid in sorted_ids) / total
     weights = {cid: w / mean_weight for cid, w in raw_weights.items()}
@@ -76,15 +85,17 @@ def compute_cluster_stats(clusters: dict[str, list[str]]) -> list[dict]:
         w = weights[cid]
         sampling_rate = (w * count) / total_weight
         draws = sampling_rate * total
-        stats.append({
-            "cluster_id": cid,
-            "count": count,
-            "pct": 100.0 * count / total,
-            "weight": w,
-            "sampling_rate": sampling_rate,
-            "draws_per_epoch": draws,
-            "repeats_per_sample": draws / count if count > 0 else 0.0,
-        })
+        stats.append(
+            {
+                "cluster_id": cid,
+                "count": count,
+                "pct": 100.0 * count / total,
+                "weight": w,
+                "sampling_rate": sampling_rate,
+                "draws_per_epoch": draws,
+                "repeats_per_sample": draws / count if count > 0 else 0.0,
+            }
+        )
     return stats
 
 
@@ -143,23 +154,19 @@ def render_cluster_videos(
         cluster_dir = videos_dir / cluster_id
         cluster_dir.mkdir(parents=True, exist_ok=True)
 
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".txt", delete=False
-        ) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
             for p in paths:
                 f.write(p + "\n")
             txt_path = f.name
 
         try:
             result = subprocess.run(
-                ["render-video-txt", txt_path, str(cluster_dir),
-                 "--workers", str(workers)],
+                ["render-video-txt", txt_path, str(cluster_dir), "--workers", str(workers)],
                 check=False,
             )
             if result.returncode != 0:
                 warnings.warn(
-                    f"render-video-txt exited with code {result.returncode} "
-                    f"for {cluster_id}"
+                    f"render-video-txt exited with code {result.returncode} for {cluster_id}"
                 )
         finally:
             Path(txt_path).unlink(missing_ok=True)
@@ -172,11 +179,13 @@ def render_cluster_videos(
             for line in log_path.read_text().splitlines():
                 entry = json.loads(line)
                 if entry.get("status") == "error":
-                    errors.append({
-                        "cluster_id": cluster_id,
-                        "file": entry.get("file", ""),
-                        "reason": entry.get("reason", "unknown"),
-                    })
+                    errors.append(
+                        {
+                            "cluster_id": cluster_id,
+                            "file": entry.get("file", ""),
+                            "reason": entry.get("reason", "unknown"),
+                        }
+                    )
 
     return rendered, errors
 
@@ -186,10 +195,17 @@ def convert_mp4_to_gif(mp4_path: str) -> str:
     if Path(gif_path).exists():
         return gif_path
     result = subprocess.run(
-        ["ffmpeg", "-i", mp4_path,
-         "-vf", "fps=3,scale=240:-1:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse",
-         "-y", gif_path],
-        capture_output=True, check=False,
+        [
+            "ffmpeg",
+            "-i",
+            mp4_path,
+            "-vf",
+            "fps=3,scale=240:-1:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse",
+            "-y",
+            gif_path,
+        ],
+        capture_output=True,
+        check=False,
     )
     if result.returncode != 0:
         warnings.warn(f"ffmpeg failed for {mp4_path}: {result.stderr.decode()[-200:]}")
@@ -224,6 +240,7 @@ def generate_html_report(
     cluster_json_path: str,
     output_dir: str,
     standalone: bool = False,
+    alpha: float = 1.0,
 ) -> str:
     total = sum(s["count"] for s in stats)
     n_clusters = len(stats)
@@ -276,8 +293,8 @@ def generate_html_report(
             media_tags = "<p><em>No videos rendered for this cluster.</em></p>"
         galleries += f"""
         <div class="cluster-gallery">
-            <h3>{escape(cid)} &mdash; {s['count']:,} samples, weight {s['weight']:.3f},
-                ~{s['repeats_per_sample']:.1f}x repeats/sample/epoch</h3>
+            <h3>{escape(cid)} &mdash; {s["count"]:,} samples, weight {s["weight"]:.3f},
+                ~{s["repeats_per_sample"]:.1f}x repeats/sample/epoch</h3>
             <div class="video-grid">{media_tags}</div>
         </div>
         """
@@ -339,6 +356,10 @@ video {{ border-radius: 4px; background: #1a1a1a; }}
 <p><strong>What happens to unmatched samples?</strong> Samples not in any cluster
    receive the mean of matched weights (neutral rate). They are neither
    boosted nor starved. A warning is emitted.</p>
+<p><strong>Weight exponent (alpha)</strong> = {alpha:.2f}. Each sample's weight is
+   <code>(1 / cluster_frequency) ** alpha</code>, normalized to mean 1.0 &mdash; so the
+   Weight column above is the oversampling multiplier. alpha=1.0 gives every
+   cluster an equal share of draws; lower values soften it; 0.0 is uniform.</p>
 <p><strong>Total draws per epoch</strong> = <code>len(data_list)</code>
    ({total:,}), same as vanilla DistributedSampler.</p>
 </div>
@@ -361,24 +382,40 @@ def get_args() -> argparse.Namespace:
         description="Generate an HTML diagnostic report for cluster-weighted sampling"
     )
     parser.add_argument(
-        "--cluster_json", type=str, required=True,
+        "--cluster_json",
+        type=str,
+        required=True,
         help="Path to the clustering result JSON produced by cluster.py",
     )
     parser.add_argument(
-        "--output_dir", type=str, required=True,
+        "--output_dir",
+        type=str,
+        required=True,
         help="Output directory for report.html and videos/",
     )
     parser.add_argument(
-        "--max_videos", type=int, default=3,
+        "--max_videos",
+        type=int,
+        default=3,
         help="Max BEV video examples to render per cluster (default: 3)",
     )
     parser.add_argument(
-        "--workers", type=int, default=1,
+        "--workers",
+        type=int,
+        default=1,
         help="Parallel video rendering workers (default: 1)",
     )
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument(
-        "--standalone", action="store_true",
+        "--cluster_weight_alpha",
+        type=float,
+        default=1.0,
+        help="Exponent on inverse-frequency weights, matching training's "
+        "--cluster_weight_alpha (1.0 = full inverse, 0.0 = uniform)",
+    )
+    parser.add_argument(
+        "--standalone",
+        action="store_true",
         help="Produce a single self-contained HTML with embedded GIFs (240px, 3fps)",
     )
     return parser.parse_args()
@@ -393,7 +430,7 @@ def main() -> None:
     print(f"  {len(clusters)} clusters, {total:,} total samples")
 
     print("Computing cluster statistics...")
-    stats = compute_cluster_stats(clusters)
+    stats = compute_cluster_stats(clusters, alpha=args.cluster_weight_alpha)
 
     print("Rendering bar chart...")
     chart_uri = render_bar_chart(stats)
@@ -410,12 +447,19 @@ def main() -> None:
 
     print("Generating HTML report...")
     report_path = generate_html_report(
-        stats, chart_uri, rendered, errors, args.cluster_json, args.output_dir,
+        stats,
+        chart_uri,
+        rendered,
+        errors,
+        args.cluster_json,
+        args.output_dir,
         standalone=args.standalone,
+        alpha=args.cluster_weight_alpha,
     )
     print(f"Report saved to {report_path}")
     if args.standalone:
         import os
+
         size_mb = os.path.getsize(report_path) / 1024 / 1024
         print(f"  Standalone mode: {size_mb:.1f}MB self-contained HTML")
 

--- a/diffusion_planner/sampling/visualize_cluster_report.py
+++ b/diffusion_planner/sampling/visualize_cluster_report.py
@@ -34,6 +34,7 @@ import random
 import shutil
 import subprocess
 import tempfile
+from datetime import datetime
 from pathlib import Path
 
 import matplotlib
@@ -163,3 +164,144 @@ def render_cluster_videos(
                     })
 
     return rendered, errors
+
+
+def _render_errors_section(errors: list[dict]) -> str:
+    if not errors:
+        return ""
+    rows = ""
+    for e in errors:
+        rows += f"<tr><td>{e['cluster_id']}</td><td>{e['file']}</td><td>{e['reason']}</td></tr>\n"
+    return f"""
+    <h2>Render Errors</h2>
+    <p>{len(errors)} file(s) failed to render:</p>
+    <table>
+    <tr><th>Cluster</th><th>File</th><th>Reason</th></tr>
+    {rows}
+    </table>
+    """
+
+
+def generate_html_report(
+    stats: list[dict],
+    chart_uri: str,
+    rendered: dict[str, list[str]],
+    errors: list[dict],
+    cluster_json_path: str,
+    output_dir: str,
+) -> str:
+    total = sum(s["count"] for s in stats)
+    n_clusters = len(stats)
+    now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    output_path = Path(output_dir) / "report.html"
+
+    # --- stats table rows ---
+    table_rows = ""
+    for s in stats:
+        table_rows += (
+            f"<tr>"
+            f"<td>{s['cluster_id']}</td>"
+            f"<td>{s['count']:,}</td>"
+            f"<td>{s['pct']:.1f}%</td>"
+            f"<td>{s['weight']:.3f}</td>"
+            f"<td>{s['sampling_rate']:.4f}</td>"
+            f"<td>{s['draws_per_epoch']:.1f}</td>"
+            f"<td>{s['repeats_per_sample']:.2f}</td>"
+            f"</tr>\n"
+        )
+
+    # --- per-cluster video galleries ---
+    galleries = ""
+    for s in stats:
+        cid = s["cluster_id"]
+        mp4s = rendered.get(cid, [])
+        video_tags = ""
+        for mp4_path in mp4s:
+            rel = str(Path(mp4_path).relative_to(output_dir))
+            video_tags += (
+                f'<video controls preload="none" width="360">'
+                f'<source src="{rel}" type="video/mp4">'
+                f"</video>\n"
+            )
+        if not mp4s:
+            video_tags = "<p><em>No videos rendered for this cluster.</em></p>"
+        galleries += f"""
+        <div class="cluster-gallery">
+            <h3>{cid} &mdash; {s['count']:,} samples, weight {s['weight']:.3f},
+                ~{s['repeats_per_sample']:.1f}x repeats/sample/epoch</h3>
+            <div class="video-grid">{video_tags}</div>
+        </div>
+        """
+
+    html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Cluster Diagnostic Report</title>
+<style>
+body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+       max-width: 1400px; margin: 0 auto; padding: 20px; background: #f8f9fa; color: #212529; }}
+h1, h2, h3 {{ color: #1a1a2e; }}
+table {{ border-collapse: collapse; width: 100%; margin: 16px 0; }}
+th, td {{ border: 1px solid #dee2e6; padding: 8px 12px; text-align: right; }}
+th {{ background: #343a40; color: white; }}
+tr:nth-child(even) {{ background: #f1f3f5; }}
+td:first-child, th:first-child {{ text-align: left; }}
+.chart {{ text-align: center; margin: 20px 0; }}
+.chart img {{ max-width: 100%; }}
+.info-box {{ background: #e7f5ff; border-left: 4px solid #339af0; padding: 16px; margin: 20px 0; }}
+.cluster-gallery {{ margin: 24px 0; padding: 16px; background: white; border-radius: 8px;
+                     box-shadow: 0 1px 3px rgba(0,0,0,0.1); }}
+.video-grid {{ display: flex; flex-wrap: wrap; gap: 12px; }}
+video {{ border-radius: 4px; background: #1a1a1a; }}
+.meta {{ color: #868e96; font-size: 0.9em; }}
+</style>
+</head>
+<body>
+
+<h1>Cluster Diagnostic Report</h1>
+<p class="meta">Generated: {now} | Source: <code>{cluster_json_path}</code> |
+   Total samples: {total:,} | Clusters: {n_clusters}</p>
+
+<h2>Pipeline Overview</h2>
+<p>Ego future trajectories (80 timesteps &times; [x, y, heading]) &rarr;
+   flatten (240-dim) &rarr; Z-score normalization &rarr; PCA (50 components)
+   &rarr; Elbow KMeans &rarr; {n_clusters} clusters</p>
+
+<h2>Cluster Distribution</h2>
+<div class="chart"><img src="{chart_uri}" alt="Cluster size distribution"></div>
+<div style="overflow-x: auto;">
+<table>
+<tr>
+  <th>Cluster ID</th><th>Sample Count</th><th>% of Total</th>
+  <th>Weight</th><th>Sampling Rate</th><th>Draws/Epoch</th>
+  <th>Repeats/Sample</th>
+</tr>
+{table_rows}
+</table>
+</div>
+
+<h2>Sampling Behavior</h2>
+<div class="info-box">
+<p><strong>Does it oversample (repeat)?</strong> Yes. The sampler uses
+   <code>torch.multinomial(weights, total, replacement=True)</code>.
+   Samples from rare clusters appear multiple times per epoch.
+   Samples from common clusters may be skipped in some epochs.</p>
+<p><strong>What happens to unmatched samples?</strong> Samples not in any cluster
+   receive the mean of matched weights (neutral rate). They are neither
+   boosted nor starved. A warning is emitted.</p>
+<p><strong>Total draws per epoch</strong> = <code>len(data_list)</code>
+   ({total:,}), same as vanilla DistributedSampler.</p>
+</div>
+
+<h2>Per-Cluster Video Examples</h2>
+{galleries}
+
+{_render_errors_section(errors)}
+
+</body>
+</html>"""
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(html, encoding="utf-8")
+    return str(output_path)

--- a/diffusion_planner/tests/test_cluster.py
+++ b/diffusion_planner/tests/test_cluster.py
@@ -201,7 +201,7 @@ def test_extract_enriched_top_k_selection():
         for i, dist in enumerate([1.0, 5.0, 3.0]):
             nbr_past[i, :, :] = 0.01  # make all values nonzero (active)
             nbr_past[i, -1, 0] = dist  # x at t=0
-            nbr_past[i, -1, 1] = 0.0   # y at t=0
+            nbr_past[i, -1, 1] = 0.0  # y at t=0
             nbr_future[i, :, :] = float(i + 1)  # distinguishable values
 
         np.savez(
@@ -230,9 +230,7 @@ def test_extract_enriched_fewer_than_k_neighbors():
     assert ego.shape == (99,), f"Expected (99,), got {ego.shape}"
     # Last 10 elements are distances; 3 active (>0), 7 inactive (== -1)
     distances = ego[-10:]
-    assert np.sum(distances > 0) == 3, (
-        f"Expected 3 positive distances, got {np.sum(distances > 0)}"
-    )
+    assert np.sum(distances > 0) == 3, f"Expected 3 positive distances, got {np.sum(distances > 0)}"
     assert np.sum(distances == -1.0) == 7, (
         f"Expected 7 sentinel distances, got {np.sum(distances == -1.0)}"
     )
@@ -692,8 +690,12 @@ def test_enriched_pipeline_returns_dict():
         npz_paths = _make_enriched_dataset(tmp, n=30)
         strategy = ElbowKMeansStrategy(k_max=5, random_state=42)
         result = cluster_trajectories_enriched(
-            npz_paths, strategy, pca_components=10,
-            neighbor_pca_components=10, top_k=5, temporal_hz=2,
+            npz_paths,
+            strategy,
+            pca_components=10,
+            neighbor_pca_components=10,
+            top_k=5,
+            temporal_hz=2,
         )
     assert isinstance(result, dict)
     assert isinstance(strategy.n_clusters_, int)
@@ -705,8 +707,12 @@ def test_enriched_pipeline_all_paths_present():
     with tempfile.TemporaryDirectory() as tmp:
         npz_paths = _make_enriched_dataset(tmp, n=20)
         result = cluster_trajectories_enriched(
-            npz_paths, ElbowKMeansStrategy(k_max=5, random_state=42),
-            pca_components=10, neighbor_pca_components=10, top_k=5, temporal_hz=2,
+            npz_paths,
+            ElbowKMeansStrategy(k_max=5, random_state=42),
+            pca_components=10,
+            neighbor_pca_components=10,
+            top_k=5,
+            temporal_hz=2,
         )
     all_out = [p for paths in result.values() for p in paths]
     assert sorted(all_out) == sorted(npz_paths)
@@ -716,8 +722,10 @@ def test_enriched_pipeline_no_valid_files_raises():
     strategy = ElbowKMeansStrategy(k_max=3)
     try:
         cluster_trajectories_enriched(
-            ["/nonexistent/a.npz"], strategy,
-            pca_components=10, neighbor_pca_components=10,
+            ["/nonexistent/a.npz"],
+            strategy,
+            pca_components=10,
+            neighbor_pca_components=10,
         )
         assert False, "Should have raised RuntimeError"
     except RuntimeError:
@@ -728,8 +736,12 @@ def test_enriched_pipeline_no_duplicates():
     with tempfile.TemporaryDirectory() as tmp:
         npz_paths = _make_enriched_dataset(tmp, n=25)
         result = cluster_trajectories_enriched(
-            npz_paths, ElbowKMeansStrategy(k_max=5, random_state=42),
-            pca_components=10, neighbor_pca_components=10, top_k=5, temporal_hz=2,
+            npz_paths,
+            ElbowKMeansStrategy(k_max=5, random_state=42),
+            pca_components=10,
+            neighbor_pca_components=10,
+            top_k=5,
+            temporal_hz=2,
         )
     all_paths = [p for paths in result.values() for p in paths]
     assert len(all_paths) == len(set(all_paths))
@@ -749,15 +761,24 @@ def test_main_enriched_end_to_end():
         output_path = str(Path(tmp) / "result.json")
         argv = [
             "cluster.py",
-            "--data_list", data_list_path,
-            "--output", output_path,
-            "--mode", "enriched",
-            "--k_max", "5",
-            "--pca_components", "10",
-            "--neighbor_pca_components", "10",
-            "--top_k_neighbors", "5",
-            "--temporal_hz", "2",
-            "--seed", "42",
+            "--data_list",
+            data_list_path,
+            "--output",
+            output_path,
+            "--mode",
+            "enriched",
+            "--k_max",
+            "5",
+            "--pca_components",
+            "10",
+            "--neighbor_pca_components",
+            "10",
+            "--top_k_neighbors",
+            "5",
+            "--temporal_hz",
+            "2",
+            "--seed",
+            "42",
         ]
         with patch("sys.argv", argv):
             main()
@@ -785,10 +806,14 @@ def test_main_trajectory_mode_unchanged():
 
         base_argv = [
             "cluster.py",
-            "--data_list", data_list_path,
-            "--k_max", "5",
-            "--pca_components", "10",
-            "--seed", "42",
+            "--data_list",
+            data_list_path,
+            "--k_max",
+            "5",
+            "--pca_components",
+            "10",
+            "--seed",
+            "42",
         ]
 
         with patch("sys.argv", base_argv + ["--output", out_default]):

--- a/diffusion_planner/tests/test_cluster.py
+++ b/diffusion_planner/tests/test_cluster.py
@@ -37,6 +37,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
+import pytest
 
 SAMPLING_DIR = Path(__file__).resolve().parent.parent / "sampling"
 sys.path.insert(0, str(SAMPLING_DIR))
@@ -543,7 +544,7 @@ def _make_enriched_dataset(tmp_dir: str, n: int = 30, seed: int = 0) -> list:
     ]
     paths = []
     for i in range(n):
-        pattern = patterns[i % 3].copy().astype(np.float32)
+        pattern = patterns[i % len(patterns)].copy().astype(np.float32)
         pattern += rng.normal(0, 0.05, pattern.shape).astype(np.float32)
 
         n_nbrs = rng.integers(2, 15)
@@ -903,3 +904,123 @@ if __name__ == "__main__":
         sys.exit(1)
     else:
         print("All tests passed!")
+
+
+# ───────────────────── enriched schema fail-fast ─────────────────────────────
+
+
+def _make_enriched_npz_custom(
+    path: str,
+    n_slots: int = 320,
+    nbr_future_cols: int = 3,
+    nbr_future_t: int = 80,
+    seed: int = 0,
+) -> None:
+    """Enriched NPZ with a tunable neighbor layout, for schema-mismatch tests."""
+    rng = np.random.default_rng(seed)
+    np.savez(
+        path,
+        ego_agent_past=rng.standard_normal((31, 4)).astype(np.float32),
+        ego_agent_future=rng.standard_normal((80, 3)).astype(np.float32),
+        ego_current_state=rng.standard_normal(10).astype(np.float32),
+        neighbor_agents_past=rng.standard_normal((n_slots, 31, 11)).astype(np.float32),
+        neighbor_agents_future=rng.standard_normal((n_slots, nbr_future_t, nbr_future_cols)).astype(
+            np.float32
+        ),
+    )
+
+
+def test_extract_enriched_pads_when_fewer_slots_than_top_k():
+    """Truncating to the available slots would yield a narrower vector than peers,
+    which only blows up later when every vector is stacked into one matrix."""
+    with tempfile.TemporaryDirectory() as tmp:
+        few = str(Path(tmp) / "few.npz")
+        many = str(Path(tmp) / "many.npz")
+        _make_enriched_npz_custom(few, n_slots=5)
+        _make_enriched_npz_custom(many, n_slots=320)
+
+        ego_few, nbr_few = extract_features_enriched(few, top_k=20, temporal_hz=2)
+        ego_many, nbr_many = extract_features_enriched(many, top_k=20, temporal_hz=2)
+
+    assert ego_few.shape == ego_many.shape
+    assert nbr_few.shape == nbr_many.shape
+    # 15 padded slots carry the -1.0 "absent" sentinel.
+    assert np.sum(ego_few[-20:] == -1.0) == 15
+
+
+def test_extract_enriched_rejects_neighbor_ego_horizon_mismatch():
+    """Shorter neighbor horizon would IndexError; longer would silently drop the tail."""
+    with tempfile.TemporaryDirectory() as tmp:
+        p = str(Path(tmp) / "short.npz")
+        _make_enriched_npz_custom(p, nbr_future_t=40)
+        with pytest.raises(ValueError, match="horizon mismatch"):
+            extract_features_enriched(p, top_k=5, temporal_hz=2)
+
+
+def test_enriched_pipeline_fails_fast_on_mixed_npz_widths():
+    """A v2/v3 mixed corpus must abort on the second file, not after reading all of
+    them and dying inside np.array()."""
+    with tempfile.TemporaryDirectory() as tmp:
+        paths = []
+        for i in range(4):
+            p = str(Path(tmp) / f"v2_{i}.npz")
+            _make_enriched_npz_custom(p, nbr_future_cols=3, seed=i)
+            paths.append(p)
+        v3 = str(Path(tmp) / "v3.npz")
+        _make_enriched_npz_custom(v3, nbr_future_cols=4, seed=99)
+        paths.append(v3)
+
+        with pytest.raises(ValueError, match="feature width"):
+            cluster_trajectories_enriched(
+                paths,
+                ElbowKMeansStrategy(k_max=3, random_state=42),
+                pca_components=3,
+                neighbor_pca_components=3,
+                top_k=5,
+                temporal_hz=2,
+            )
+
+
+def test_enriched_pipeline_skips_unreadable_files_and_keeps_alignment():
+    """Skipped files must drop out of valid_paths in lockstep with the feature lists,
+    or every path after the first skip lands in the wrong cluster."""
+    with tempfile.TemporaryDirectory() as tmp:
+        good = _make_enriched_dataset(tmp, n=20)
+        bad = str(Path(tmp) / "truncated.npz")
+        Path(bad).write_bytes(b"not an npz")
+
+        result = cluster_trajectories_enriched(
+            good[:10] + [bad] + good[10:],
+            ElbowKMeansStrategy(k_max=4, random_state=42),
+            pca_components=5,
+            neighbor_pca_components=5,
+            top_k=5,
+            temporal_hz=2,
+        )
+
+    clustered = [p for paths in result.values() for p in paths]
+    assert sorted(clustered) == sorted(good)
+    assert len(clustered) == len(set(clustered))
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"top_k": 0},
+        {"neighbor_pca_components": 0},
+        {"pca_components": 0},
+    ],
+)
+def test_enriched_pipeline_rejects_nonpositive_dims(kwargs):
+    """These would otherwise fail inside PCA, after the whole extraction pass."""
+    base = {
+        "pca_components": 5,
+        "neighbor_pca_components": 5,
+        "top_k": 5,
+        "temporal_hz": 2,
+    }
+    base.update(kwargs)
+    with pytest.raises(ValueError, match="must be >= 1"):
+        cluster_trajectories_enriched(
+            ["/nonexistent.npz"], ElbowKMeansStrategy(k_max=2, random_state=42), **base
+        )

--- a/diffusion_planner/tests/test_cluster.py
+++ b/diffusion_planner/tests/test_cluster.py
@@ -47,6 +47,7 @@ from utils.pipeline import (
     ClusteringStrategy,
     ElbowKMeansStrategy,
     cluster_trajectories,
+    cluster_trajectories_enriched,
     extract_features,
     extract_features_enriched,
 )
@@ -501,6 +502,43 @@ def _make_synthetic_dataset(tmp_dir: str, n: int = 30, seed: int = 0) -> list[st
     return paths
 
 
+def _make_enriched_dataset(tmp_dir: str, n: int = 30, seed: int = 0) -> list:
+    """Create n NPZ files with enriched fields and distinct trajectory patterns."""
+    rng = np.random.default_rng(seed)
+    patterns = [
+        np.column_stack([np.linspace(0, 20, 80), np.zeros(80), np.zeros(80)]),
+        np.column_stack(
+            [np.linspace(0, 10, 80), np.linspace(0, 10, 80), np.linspace(0, np.pi / 2, 80)]
+        ),
+        np.column_stack(
+            [np.linspace(0, 10, 80), np.linspace(0, -10, 80), np.linspace(0, -np.pi / 2, 80)]
+        ),
+    ]
+    paths = []
+    for i in range(n):
+        pattern = patterns[i % 3].copy().astype(np.float32)
+        pattern += rng.normal(0, 0.05, pattern.shape).astype(np.float32)
+
+        n_nbrs = rng.integers(2, 15)
+        nbr_past = np.zeros((320, 31, 11), dtype=np.float32)
+        nbr_future = np.zeros((320, 80, 3), dtype=np.float32)
+        for j in range(n_nbrs):
+            nbr_past[j] = rng.standard_normal((31, 11)).astype(np.float32)
+            nbr_future[j] = rng.standard_normal((80, 3)).astype(np.float32)
+
+        npz_path = str(Path(tmp_dir) / f"sample_{i:04d}.npz")
+        np.savez(
+            npz_path,
+            ego_agent_past=rng.standard_normal((31, 4)).astype(np.float32),
+            ego_agent_future=pattern,
+            ego_current_state=rng.standard_normal(10).astype(np.float32),
+            neighbor_agents_past=nbr_past,
+            neighbor_agents_future=nbr_future,
+        )
+        paths.append(npz_path)
+    return paths
+
+
 def test_main_end_to_end():
     with tempfile.TemporaryDirectory() as tmp:
         npz_paths = _make_synthetic_dataset(tmp, n=30)
@@ -617,6 +655,57 @@ def test_main_output_keys_sorted():
     print("  [PASS] main end-to-end: output keys are sorted")
 
 
+# ─────────────────────── cluster_trajectories_enriched ─────────────────────
+
+
+def test_enriched_pipeline_returns_dict():
+    with tempfile.TemporaryDirectory() as tmp:
+        npz_paths = _make_enriched_dataset(tmp, n=30)
+        strategy = ElbowKMeansStrategy(k_max=5, random_state=42)
+        result = cluster_trajectories_enriched(
+            npz_paths, strategy, pca_components=10,
+            neighbor_pca_components=10, top_k=5, temporal_hz=2,
+        )
+    assert isinstance(result, dict)
+    assert isinstance(strategy.n_clusters_, int)
+    for key in result:
+        assert key.startswith("cluster_id")
+
+
+def test_enriched_pipeline_all_paths_present():
+    with tempfile.TemporaryDirectory() as tmp:
+        npz_paths = _make_enriched_dataset(tmp, n=20)
+        result = cluster_trajectories_enriched(
+            npz_paths, ElbowKMeansStrategy(k_max=5, random_state=42),
+            pca_components=10, neighbor_pca_components=10, top_k=5, temporal_hz=2,
+        )
+    all_out = [p for paths in result.values() for p in paths]
+    assert sorted(all_out) == sorted(npz_paths)
+
+
+def test_enriched_pipeline_no_valid_files_raises():
+    strategy = ElbowKMeansStrategy(k_max=3)
+    try:
+        cluster_trajectories_enriched(
+            ["/nonexistent/a.npz"], strategy,
+            pca_components=10, neighbor_pca_components=10,
+        )
+        assert False, "Should have raised RuntimeError"
+    except RuntimeError:
+        pass
+
+
+def test_enriched_pipeline_no_duplicates():
+    with tempfile.TemporaryDirectory() as tmp:
+        npz_paths = _make_enriched_dataset(tmp, n=25)
+        result = cluster_trajectories_enriched(
+            npz_paths, ElbowKMeansStrategy(k_max=5, random_state=42),
+            pca_components=10, neighbor_pca_components=10, top_k=5, temporal_hz=2,
+        )
+    all_paths = [p for paths in result.values() for p in paths]
+    assert len(all_paths) == len(set(all_paths))
+
+
 # ──────────────────────────────── runner ────────────────────────────────────
 
 
@@ -658,6 +747,10 @@ ALL_TESTS = [
     test_main_end_to_end,
     test_main_output_no_duplicates,
     test_main_output_keys_sorted,
+    test_enriched_pipeline_returns_dict,
+    test_enriched_pipeline_all_paths_present,
+    test_enriched_pipeline_no_valid_files_raises,
+    test_enriched_pipeline_no_duplicates,
 ]
 
 

--- a/diffusion_planner/tests/test_cluster.py
+++ b/diffusion_planner/tests/test_cluster.py
@@ -167,15 +167,15 @@ def test_extract_features_dtype_is_float():
 
 
 def test_extract_enriched_shapes_default():
-    """Default 2hz, top_k=20: ego_block=(106,), neighbor_block=(2500,)."""
+    """Default 2hz, top_k=20: ego_block=(109,), neighbor_block=(2560,)."""
     with tempfile.TemporaryDirectory() as tmp:
         npz_path = str(Path(tmp) / "sample.npz")
         _make_enriched_npz(npz_path, n_active_neighbors=25)
         ego, nbr = extract_features_enriched(npz_path, top_k=20, temporal_hz=2)
-    # ego: 7*4 + 16*3 + 10 + 20 = 106
-    assert ego.shape == (106,), f"Expected (106,), got {ego.shape}"
-    # neighbor: 20*(7*11 + 16*3) = 20*(77+48) = 2500
-    assert nbr.shape == (2500,), f"Expected (2500,), got {nbr.shape}"
+    # ego: 7*4 + 17*3 + 10 + 20 = 109  (17 future indices: endpoint always included)
+    assert ego.shape == (109,), f"Expected (109,), got {ego.shape}"
+    # neighbor: 20*(7*11 + 17*3) = 20*(77+51) = 2560
+    assert nbr.shape == (2560,), f"Expected (2560,), got {nbr.shape}"
 
 
 def test_extract_enriched_shapes_10hz():
@@ -221,17 +221,20 @@ def test_extract_enriched_top_k_selection():
 
 
 def test_extract_enriched_fewer_than_k_neighbors():
-    """When fewer active neighbors than top_k, remaining are zero-padded."""
+    """When fewer active neighbors than top_k, inactive get sentinel -1.0."""
     with tempfile.TemporaryDirectory() as tmp:
         npz_path = str(Path(tmp) / "sample.npz")
         _make_enriched_npz(npz_path, n_active_neighbors=3)
         ego, nbr = extract_features_enriched(npz_path, top_k=10, temporal_hz=2)
-    # ego: 7*4 + 16*3 + 10 + 10 = 96
-    assert ego.shape == (96,), f"Expected (96,), got {ego.shape}"
-    # Last 10 elements are distances; only 3 are non-zero
+    # ego: 7*4 + 17*3 + 10 + 10 = 99
+    assert ego.shape == (99,), f"Expected (99,), got {ego.shape}"
+    # Last 10 elements are distances; 3 active (>0), 7 inactive (== -1)
     distances = ego[-10:]
-    assert np.count_nonzero(distances) == 3, (
-        f"Expected 3 non-zero distances, got {np.count_nonzero(distances)}"
+    assert np.sum(distances > 0) == 3, (
+        f"Expected 3 positive distances, got {np.sum(distances > 0)}"
+    )
+    assert np.sum(distances == -1.0) == 7, (
+        f"Expected 7 sentinel distances, got {np.sum(distances == -1.0)}"
     )
 
 
@@ -242,6 +245,32 @@ def test_extract_enriched_invalid_temporal_hz():
         _make_enriched_npz(npz_path)
         try:
             extract_features_enriched(npz_path, temporal_hz=3)
+            assert False, "Should have raised ValueError"
+        except ValueError:
+            pass
+
+
+def test_extract_enriched_zero_temporal_hz():
+    """temporal_hz=0 raises ValueError (not ZeroDivisionError)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        npz_path = str(Path(tmp) / "sample.npz")
+        _make_enriched_npz(npz_path)
+        try:
+            extract_features_enriched(npz_path, temporal_hz=0)
+            assert False, "Should have raised ValueError"
+        except ValueError:
+            pass
+        except ZeroDivisionError:
+            assert False, "Got ZeroDivisionError instead of ValueError"
+
+
+def test_extract_enriched_negative_temporal_hz():
+    """temporal_hz=-2 raises ValueError."""
+    with tempfile.TemporaryDirectory() as tmp:
+        npz_path = str(Path(tmp) / "sample.npz")
+        _make_enriched_npz(npz_path)
+        try:
+            extract_features_enriched(npz_path, temporal_hz=-2)
             assert False, "Should have raised ValueError"
         except ValueError:
             pass
@@ -790,6 +819,8 @@ ALL_TESTS = [
     test_extract_enriched_top_k_selection,
     test_extract_enriched_fewer_than_k_neighbors,
     test_extract_enriched_invalid_temporal_hz,
+    test_extract_enriched_zero_temporal_hz,
+    test_extract_enriched_negative_temporal_hz,
     test_extract_enriched_dtype_is_float,
     test_compute_wcss_length,
     test_compute_wcss_monotone,

--- a/diffusion_planner/tests/test_cluster.py
+++ b/diffusion_planner/tests/test_cluster.py
@@ -48,6 +48,7 @@ from utils.pipeline import (
     ElbowKMeansStrategy,
     cluster_trajectories,
     extract_features,
+    extract_features_enriched,
 )
 
 # ─────────────────────────────── helpers ────────────────────────────────────
@@ -58,6 +59,33 @@ def _make_npz(path: str, ego_future: np.ndarray | None = None) -> None:
     if ego_future is None:
         ego_future = np.random.randn(80, 3).astype(np.float32)
     np.savez(path, ego_agent_future=ego_future)
+
+
+def _make_enriched_npz(
+    path: str,
+    n_active_neighbors: int = 5,
+    seed: int = 0,
+) -> None:
+    """Write an NPZ file with all fields needed for enriched clustering."""
+    rng = np.random.default_rng(seed)
+    ego_past = rng.standard_normal((31, 4)).astype(np.float32)
+    ego_future = rng.standard_normal((80, 3)).astype(np.float32)
+    ego_state = rng.standard_normal(10).astype(np.float32)
+
+    nbr_past = np.zeros((320, 31, 11), dtype=np.float32)
+    nbr_future = np.zeros((320, 80, 3), dtype=np.float32)
+    for i in range(n_active_neighbors):
+        nbr_past[i] = rng.standard_normal((31, 11)).astype(np.float32)
+        nbr_future[i] = rng.standard_normal((80, 3)).astype(np.float32)
+
+    np.savez(
+        path,
+        ego_agent_past=ego_past,
+        ego_agent_future=ego_future,
+        ego_current_state=ego_state,
+        neighbor_agents_past=nbr_past,
+        neighbor_agents_future=nbr_future,
+    )
 
 
 def _synthetic_clusters(n_per_cluster: int = 10, n_clusters: int = 3, seed: int = 42) -> np.ndarray:
@@ -132,6 +160,99 @@ def test_extract_features_dtype_is_float():
         feat = extract_features(npz_path)
     assert np.issubdtype(feat.dtype, np.floating), f"Expected float dtype, got {feat.dtype}"
     print("  [PASS] extract_features dtype is float")
+
+
+# ─────────────────────── extract_features_enriched ─────────────────────────
+
+
+def test_extract_enriched_shapes_default():
+    """Default 2hz, top_k=20: ego_block=(106,), neighbor_block=(2500,)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        npz_path = str(Path(tmp) / "sample.npz")
+        _make_enriched_npz(npz_path, n_active_neighbors=25)
+        ego, nbr = extract_features_enriched(npz_path, top_k=20, temporal_hz=2)
+    # ego: 7*4 + 16*3 + 10 + 20 = 106
+    assert ego.shape == (106,), f"Expected (106,), got {ego.shape}"
+    # neighbor: 20*(7*11 + 16*3) = 20*(77+48) = 2500
+    assert nbr.shape == (2500,), f"Expected (2500,), got {nbr.shape}"
+
+
+def test_extract_enriched_shapes_10hz():
+    """At 10hz (no downsampling): ego_block=(394,), neighbor_block=(11620,)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        npz_path = str(Path(tmp) / "sample.npz")
+        _make_enriched_npz(npz_path, n_active_neighbors=25)
+        ego, nbr = extract_features_enriched(npz_path, top_k=20, temporal_hz=10)
+    # ego: 31*4 + 80*3 + 10 + 20 = 394
+    assert ego.shape == (394,), f"Expected (394,), got {ego.shape}"
+    # neighbor: 20*(31*11 + 80*3) = 20*(341+240) = 11620
+    assert nbr.shape == (11620,), f"Expected (11620,), got {nbr.shape}"
+
+
+def test_extract_enriched_top_k_selection():
+    """Closest neighbors are selected; farthest are dropped."""
+    with tempfile.TemporaryDirectory() as tmp:
+        npz_path = str(Path(tmp) / "sample.npz")
+
+        nbr_past = np.zeros((320, 31, 11), dtype=np.float32)
+        nbr_future = np.zeros((320, 80, 3), dtype=np.float32)
+        # Place 3 neighbors at known distances (position is in last past timestep, cols 0:2)
+        for i, dist in enumerate([1.0, 5.0, 3.0]):
+            nbr_past[i, :, :] = 0.01  # make all values nonzero (active)
+            nbr_past[i, -1, 0] = dist  # x at t=0
+            nbr_past[i, -1, 1] = 0.0   # y at t=0
+            nbr_future[i, :, :] = float(i + 1)  # distinguishable values
+
+        np.savez(
+            npz_path,
+            ego_agent_past=np.zeros((31, 4), dtype=np.float32),
+            ego_agent_future=np.zeros((80, 3), dtype=np.float32),
+            ego_current_state=np.zeros(10, dtype=np.float32),
+            neighbor_agents_past=nbr_past,
+            neighbor_agents_future=nbr_future,
+        )
+        ego, nbr = extract_features_enriched(npz_path, top_k=2, temporal_hz=10)
+
+    # Top-2 should be neighbor 0 (dist=1) and neighbor 2 (dist=3)
+    # Distances in ego block are the last 2 elements
+    distances = ego[-2:]
+    np.testing.assert_allclose(distances, [1.0, 3.0], atol=1e-6)
+
+
+def test_extract_enriched_fewer_than_k_neighbors():
+    """When fewer active neighbors than top_k, remaining are zero-padded."""
+    with tempfile.TemporaryDirectory() as tmp:
+        npz_path = str(Path(tmp) / "sample.npz")
+        _make_enriched_npz(npz_path, n_active_neighbors=3)
+        ego, nbr = extract_features_enriched(npz_path, top_k=10, temporal_hz=2)
+    # ego: 7*4 + 16*3 + 10 + 10 = 96
+    assert ego.shape == (96,), f"Expected (96,), got {ego.shape}"
+    # Last 10 elements are distances; only 3 are non-zero
+    distances = ego[-10:]
+    assert np.count_nonzero(distances) == 3, (
+        f"Expected 3 non-zero distances, got {np.count_nonzero(distances)}"
+    )
+
+
+def test_extract_enriched_invalid_temporal_hz():
+    """temporal_hz that doesn't divide 10 raises ValueError."""
+    with tempfile.TemporaryDirectory() as tmp:
+        npz_path = str(Path(tmp) / "sample.npz")
+        _make_enriched_npz(npz_path)
+        try:
+            extract_features_enriched(npz_path, temporal_hz=3)
+            assert False, "Should have raised ValueError"
+        except ValueError:
+            pass
+
+
+def test_extract_enriched_dtype_is_float():
+    with tempfile.TemporaryDirectory() as tmp:
+        npz_path = str(Path(tmp) / "sample.npz")
+        _make_enriched_npz(npz_path)
+        ego, nbr = extract_features_enriched(npz_path)
+    assert np.issubdtype(ego.dtype, np.floating)
+    assert np.issubdtype(nbr.dtype, np.floating)
 
 
 # ──────────────────────────── compute_wcss ──────────────────────────────────
@@ -506,6 +627,12 @@ ALL_TESTS = [
     test_extract_features_values,
     test_extract_features_missing_key,
     test_extract_features_dtype_is_float,
+    test_extract_enriched_shapes_default,
+    test_extract_enriched_shapes_10hz,
+    test_extract_enriched_top_k_selection,
+    test_extract_enriched_fewer_than_k_neighbors,
+    test_extract_enriched_invalid_temporal_hz,
+    test_extract_enriched_dtype_is_float,
     test_compute_wcss_length,
     test_compute_wcss_monotone,
     test_compute_wcss_k1_max_inertia,

--- a/diffusion_planner/tests/test_cluster.py
+++ b/diffusion_planner/tests/test_cluster.py
@@ -706,6 +706,75 @@ def test_enriched_pipeline_no_duplicates():
     assert len(all_paths) == len(set(all_paths))
 
 
+# ──────────────────────── integration: main enriched ──────────────────────
+
+
+def test_main_enriched_end_to_end():
+    """End-to-end test with --mode enriched."""
+    with tempfile.TemporaryDirectory() as tmp:
+        npz_paths = _make_enriched_dataset(tmp, n=30)
+        data_list_path = str(Path(tmp) / "data_list.json")
+        with open(data_list_path, "w") as f:
+            json.dump(npz_paths, f)
+
+        output_path = str(Path(tmp) / "result.json")
+        argv = [
+            "cluster.py",
+            "--data_list", data_list_path,
+            "--output", output_path,
+            "--mode", "enriched",
+            "--k_max", "5",
+            "--pca_components", "10",
+            "--neighbor_pca_components", "10",
+            "--top_k_neighbors", "5",
+            "--temporal_hz", "2",
+            "--seed", "42",
+        ]
+        with patch("sys.argv", argv):
+            main()
+
+        assert Path(output_path).exists()
+        with open(output_path) as f:
+            result = json.load(f)
+
+        for key in result:
+            assert key.startswith("cluster_id")
+        all_out = [p for paths in result.values() for p in paths]
+        assert sorted(all_out) == sorted(npz_paths)
+
+
+def test_main_trajectory_mode_unchanged():
+    """--mode trajectory produces identical results to no --mode flag (regression)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        npz_paths = _make_synthetic_dataset(tmp, n=20)
+        data_list_path = str(Path(tmp) / "data_list.json")
+        with open(data_list_path, "w") as f:
+            json.dump(npz_paths, f)
+
+        out_default = str(Path(tmp) / "default.json")
+        out_explicit = str(Path(tmp) / "explicit.json")
+
+        base_argv = [
+            "cluster.py",
+            "--data_list", data_list_path,
+            "--k_max", "5",
+            "--pca_components", "10",
+            "--seed", "42",
+        ]
+
+        with patch("sys.argv", base_argv + ["--output", out_default]):
+            main()
+        with patch("sys.argv", base_argv + ["--output", out_explicit, "--mode", "trajectory"]):
+            main()
+
+        with open(out_default) as f:
+            result_default = json.load(f)
+        with open(out_explicit) as f:
+            result_explicit = json.load(f)
+
+        assert result_default == result_explicit
+
+
 # ──────────────────────────────── runner ────────────────────────────────────
 
 
@@ -751,6 +820,8 @@ ALL_TESTS = [
     test_enriched_pipeline_all_paths_present,
     test_enriched_pipeline_no_valid_files_raises,
     test_enriched_pipeline_no_duplicates,
+    test_main_enriched_end_to_end,
+    test_main_trajectory_mode_unchanged,
 ]
 
 

--- a/diffusion_planner/tests/test_forced_augmentation.py
+++ b/diffusion_planner/tests/test_forced_augmentation.py
@@ -1,10 +1,14 @@
+from types import SimpleNamespace
+
 import pytest
 import torch
 from diffusion_planner.utils.forced_augmentation import (
     AUG_ORDER,
     ForcedAugmentationSelector,
     build_aug_pipeline,
+    duplicate_path_warning,
     resolve_repeat_aug_pool,
+    validate_forced_aug_flags,
 )
 
 
@@ -277,3 +281,57 @@ class TestForcedAugmentationSelector:
         assert sum(counts) == n
         for count in counts:
             assert 0.25 * n < count < 0.42 * n, counts
+
+
+class TestValidateForcedAugFlags:
+    def _args(self, **overrides):
+        base = dict(
+            force_aug_on_repeat=True,
+            repeat_aug_pool="",
+            cluster_json="/tmp/clusters.json",
+            augment_type="quintic",
+        )
+        base.update(overrides)
+        return SimpleNamespace(**base)
+
+    def _pipeline(self, *names):
+        return [(n, _FakeAug(n)) for n in AUG_ORDER if n in names]
+
+    def test_disabled_returns_empty_pool_and_no_warnings(self):
+        pool, warnings = validate_forced_aug_flags(
+            self._args(force_aug_on_repeat=False), self._pipeline("flip")
+        )
+        assert pool == []
+        assert warnings == []
+
+    def test_requires_cluster_json(self):
+        """Without the weighted sampler there are no repeat draws at all."""
+        with pytest.raises(ValueError, match="--cluster_json"):
+            validate_forced_aug_flags(self._args(cluster_json=""), self._pipeline("flip"))
+
+    def test_returns_resolved_pool(self):
+        pool, _ = validate_forced_aug_flags(self._args(), self._pipeline("flip", "neighbor_noise"))
+        assert pool == ["flip", "neighbor_noise"]
+
+    def test_propagates_pool_resolution_errors(self):
+        with pytest.raises(ValueError, match="--use_neighbor_noise"):
+            validate_forced_aug_flags(
+                self._args(repeat_aug_pool="neighbor_noise"), self._pipeline("flip")
+            )
+
+    def test_propagates_warnings(self):
+        _, warnings = validate_forced_aug_flags(
+            self._args(repeat_aug_pool="flip"), self._pipeline("flip")
+        )
+        assert any("deterministic" in w for w in warnings)
+
+
+class TestDuplicatePathWarning:
+    def test_reports_duplicate_paths(self):
+        data_list = ["/d/a.npz", "/d/b.npz", "/d/a.npz", "/d/c.npz", "/d/b.npz"]
+        message = duplicate_path_warning(data_list)
+        assert message is not None
+        assert "2" in message
+
+    def test_none_when_unique(self):
+        assert duplicate_path_warning(["/d/a.npz", "/d/b.npz"]) is None

--- a/diffusion_planner/tests/test_forced_augmentation.py
+++ b/diffusion_planner/tests/test_forced_augmentation.py
@@ -190,6 +190,20 @@ class TestForcedAugmentationSelector:
         assert second.tolist() == [False, True]
         assert sel.rows_consumed == 4
 
+    def test_cursor_handles_heterogeneous_batch_sizes(self):
+        """Partial batches are the production path (drop_last=False).
+
+        A computed j * batch_size offset passes the uniform-size tests and
+        misattributes masks here, so this is what pins the running cursor.
+        """
+        sel = self._selector(pool=("flip",))
+        sel.start_epoch(0, [True, False, False, True], 0)
+        first = sel.masks_for_batch(3, torch.device("cpu"))["flip"]
+        second = sel.masks_for_batch(1, torch.device("cpu"))["flip"]
+        assert first.tolist() == [True, False, False]
+        assert second.tolist() == [True]
+        assert sel.rows_consumed == 4
+
     def test_reading_past_flag_list_raises(self):
         sel = self._selector()
         sel.start_epoch(0, [True, False], 0)

--- a/diffusion_planner/tests/test_forced_augmentation.py
+++ b/diffusion_planner/tests/test_forced_augmentation.py
@@ -145,6 +145,12 @@ class TestForcedAugmentationSelector:
         with pytest.raises(ValueError, match="pool must not be empty"):
             ForcedAugmentationSelector([])
 
+    def test_is_bound_reflects_start_epoch(self):
+        sel = self._selector()
+        assert not sel.is_bound
+        sel.start_epoch(0, [True], 0)
+        assert sel.is_bound
+
     def test_exactly_one_aug_forced_per_repeat_row(self):
         sel = self._selector()
         flags = [False, True, True, False, True]

--- a/diffusion_planner/tests/test_forced_augmentation.py
+++ b/diffusion_planner/tests/test_forced_augmentation.py
@@ -155,6 +155,65 @@ class TestForcedAugmentationSelector:
         sel.start_epoch(0, [True], 0)
         assert sel.is_bound
 
+    def test_bound_epoch_tracks_which_epoch_is_bound(self):
+        sel = self._selector()
+        assert sel.bound_epoch is None
+        sel.start_epoch(0, [True], 0)
+        assert sel.bound_epoch == 0
+        sel.start_epoch(1, [True], 1)
+        assert sel.bound_epoch == 1
+
+    def test_multi_epoch_loop_gated_on_bound_epoch_survives(self):
+        """Regression: every run died on the first batch of epoch 2.
+
+        `is_bound` is a permanent latch, so gating the bind on it meant epoch 2 kept
+        epoch 1's flags and cursor. With drop_last the cursor was already near the end
+        of the flag list, so the next batch always overran it. Gating on `bound_epoch`
+        rebinds once per epoch. This drives several epochs the way train_epoch does.
+        """
+        sel = self._selector(pool=("flip",))
+        flags_per_epoch = {
+            0: [True, False, True, False],
+            1: [False, True, True, True],
+            2: [True] * 4,
+        }
+        batch_size = 2
+
+        for epoch in range(3):
+            flags = flags_per_epoch[epoch]
+            for batch_index in range(len(flags) // batch_size):
+                # Exactly train_epoch's guard.
+                if sel.bound_epoch != epoch:
+                    sel.start_epoch(epoch, flags, epoch)
+                masks = sel.masks_for_batch(batch_size, torch.device("cpu"))
+                expected = flags[batch_index * batch_size : (batch_index + 1) * batch_size]
+                assert masks["flip"].tolist() == expected, (epoch, batch_index)
+            assert sel.bound_epoch == epoch
+            assert sel.rows_consumed == len(flags)
+
+    def test_is_bound_gate_would_have_crashed_on_epoch_two(self):
+        """Pins WHY the gate changed: the old `is_bound` check still fails here.
+
+        If someone reverts to gating on `is_bound`, this test fails, naming the exact
+        production failure rather than an abstract state bug.
+        """
+        sel = self._selector(pool=("flip",))
+        flags = [True, False, True, False]
+        batch_size = 2
+
+        # Epoch 0 under the OLD guard: binds once, consumes the whole flag list.
+        for _ in range(len(flags) // batch_size):
+            if not sel.is_bound:  # the old, buggy guard
+                sel.start_epoch(0, flags, 0)
+            sel.masks_for_batch(batch_size, torch.device("cpu"))
+        assert sel.rows_consumed == len(flags)
+
+        # Epoch 1 under the OLD guard: is_bound is still True, so no rebind happens and
+        # the cursor is already exhausted.
+        assert sel.is_bound
+        with pytest.raises(RuntimeError, match="reading past the end of repeat_flags"):
+            sel.masks_for_batch(batch_size, torch.device("cpu"))
+
     def test_exactly_one_aug_forced_per_repeat_row(self):
         sel = self._selector()
         flags = [False, True, True, False, True]

--- a/diffusion_planner/tests/test_forced_augmentation.py
+++ b/diffusion_planner/tests/test_forced_augmentation.py
@@ -1,6 +1,8 @@
 import pytest
+import torch
 from diffusion_planner.utils.forced_augmentation import (
     AUG_ORDER,
+    ForcedAugmentationSelector,
     build_aug_pipeline,
     resolve_repeat_aug_pool,
 )
@@ -133,3 +135,125 @@ class TestResolveRepeatAugPool:
         pool, warnings = resolve_repeat_aug_pool("flip", pipeline, augment_type="quintic")
         assert pool == ["flip"]
         assert any("deterministic" in w for w in warnings)
+
+
+class TestForcedAugmentationSelector:
+    def _selector(self, pool=("flip", "neighbor_noise"), seed=0):
+        return ForcedAugmentationSelector(list(pool), seed=seed)
+
+    def test_empty_pool_raises(self):
+        with pytest.raises(ValueError, match="pool must not be empty"):
+            ForcedAugmentationSelector([])
+
+    def test_exactly_one_aug_forced_per_repeat_row(self):
+        sel = self._selector()
+        flags = [False, True, True, False, True]
+        sel.start_epoch(0, flags, 0)
+        masks = sel.masks_for_batch(5, torch.device("cpu"))
+        stacked = torch.stack([masks["flip"], masks["neighbor_noise"]])
+        per_row = stacked.sum(dim=0)
+        assert per_row.tolist() == [0, 1, 1, 0, 1]
+
+    def test_non_repeat_rows_forced_nowhere(self):
+        sel = self._selector()
+        sel.start_epoch(0, [False, False, False], 0)
+        masks = sel.masks_for_batch(3, torch.device("cpu"))
+        for mask in masks.values():
+            assert not mask.any()
+
+    def test_mask_keys_are_exactly_the_pool(self):
+        sel = self._selector(pool=("flip",))
+        sel.start_epoch(0, [True, True], 0)
+        masks = sel.masks_for_batch(2, torch.device("cpu"))
+        assert set(masks) == {"flip"}
+
+    def test_single_member_pool_forces_that_member(self):
+        sel = self._selector(pool=("neighbor_noise",))
+        sel.start_epoch(0, [True, False, True], 0)
+        masks = sel.masks_for_batch(3, torch.device("cpu"))
+        assert masks["neighbor_noise"].tolist() == [True, False, True]
+
+    def test_masks_are_bool_on_requested_device(self):
+        sel = self._selector()
+        sel.start_epoch(0, [True], 0)
+        masks = sel.masks_for_batch(1, torch.device("cpu"))
+        for mask in masks.values():
+            assert mask.dtype == torch.bool
+            assert mask.device == torch.device("cpu")
+
+    def test_cursor_advances_across_batches(self):
+        sel = self._selector(pool=("flip",))
+        sel.start_epoch(0, [True, False, False, True], 0)
+        first = sel.masks_for_batch(2, torch.device("cpu"))["flip"]
+        second = sel.masks_for_batch(2, torch.device("cpu"))["flip"]
+        assert first.tolist() == [True, False]
+        assert second.tolist() == [False, True]
+        assert sel.rows_consumed == 4
+
+    def test_reading_past_flag_list_raises(self):
+        sel = self._selector()
+        sel.start_epoch(0, [True, False], 0)
+        with pytest.raises(RuntimeError, match="past the end"):
+            sel.masks_for_batch(3, torch.device("cpu"))
+
+    def test_start_epoch_resets_cursor(self):
+        sel = self._selector(pool=("flip",))
+        sel.start_epoch(0, [True, True], 0)
+        sel.masks_for_batch(2, torch.device("cpu"))
+        sel.start_epoch(1, [False, True], 1)
+        assert sel.rows_consumed == 0
+        assert sel.masks_for_batch(2, torch.device("cpu"))["flip"].tolist() == [False, True]
+
+    def test_stale_flags_raise(self):
+        """Flags stamped for a different epoch mean __iter__ has not run yet."""
+        sel = self._selector()
+        with pytest.raises(ValueError, match="stale"):
+            sel.start_epoch(3, [True, False], 2)
+
+    def test_missing_flags_raise(self):
+        sel = self._selector()
+        with pytest.raises(ValueError, match="track_repeats"):
+            sel.start_epoch(0, None, None)
+
+    def test_masks_before_start_epoch_raise(self):
+        sel = self._selector()
+        with pytest.raises(RuntimeError, match="start_epoch"):
+            sel.masks_for_batch(2, torch.device("cpu"))
+
+    def test_deterministic_for_same_seed_and_epoch(self):
+        flags = [True] * 8
+        a, b = self._selector(seed=7), self._selector(seed=7)
+        a.start_epoch(2, flags, 2)
+        b.start_epoch(2, flags, 2)
+        assert a.masks_for_batch(8, torch.device("cpu"))["flip"].tolist() == (
+            b.masks_for_batch(8, torch.device("cpu"))["flip"].tolist()
+        )
+
+    def test_choice_stream_differs_across_epochs(self):
+        """A forgotten set_epoch would replay the same choices every epoch."""
+        flags = [True] * 64
+        sel = self._selector(seed=7)
+        sel.start_epoch(0, flags, 0)
+        epoch0 = sel.masks_for_batch(64, torch.device("cpu"))["flip"].tolist()
+        sel.start_epoch(1, flags, 1)
+        epoch1 = sel.masks_for_batch(64, torch.device("cpu"))["flip"].tolist()
+        assert epoch0 != epoch1
+
+    def test_forced_count_accumulates(self):
+        sel = self._selector()
+        sel.start_epoch(0, [True, False, True, True], 0)
+        sel.masks_for_batch(2, torch.device("cpu"))
+        sel.masks_for_batch(2, torch.device("cpu"))
+        assert sel.forced_count == 3
+
+    def test_pool_members_are_used_roughly_uniformly(self):
+        """Uniform choice over the pool, not a fixed member."""
+        pool = ("flip", "neighbor_noise", "state_perturbation")
+        sel = self._selector(pool=pool, seed=1)
+        n = 3000
+        sel.start_epoch(0, [True] * n, 0)
+        masks = sel.masks_for_batch(n, torch.device("cpu"))
+        counts = [int(masks[name].sum()) for name in pool]
+        assert sum(counts) == n
+        for count in counts:
+            assert 0.25 * n < count < 0.42 * n, counts

--- a/diffusion_planner/tests/test_forced_augmentation.py
+++ b/diffusion_planner/tests/test_forced_augmentation.py
@@ -1,0 +1,135 @@
+import pytest
+from diffusion_planner.utils.forced_augmentation import (
+    AUG_ORDER,
+    build_aug_pipeline,
+    resolve_repeat_aug_pool,
+)
+
+
+class _FakeAug:
+    """Stand-in for an augmentation object; identity is all these tests need."""
+
+    def __init__(self, name):
+        self.name = name
+
+
+class TestAugOrder:
+    def test_state_perturbation_is_last(self):
+        """It terminates with centric_transform, which the others assume has not run."""
+        assert AUG_ORDER[-1] == "state_perturbation"
+
+    def test_order_matches_todays_train_epoch_sequence(self):
+        assert AUG_ORDER == (
+            "flip",
+            "neighbor_dropout",
+            "neighbor_noise",
+            "turn_indicator",
+            "traffic_light",
+            "state_perturbation",
+        )
+
+
+class TestBuildAugPipeline:
+    def test_orders_canonically_regardless_of_dict_order(self):
+        augs = {
+            "state_perturbation": _FakeAug("sp"),
+            "flip": _FakeAug("flip"),
+            "neighbor_noise": _FakeAug("nn"),
+        }
+        pipeline = build_aug_pipeline(augs)
+        assert [name for name, _ in pipeline] == ["flip", "neighbor_noise", "state_perturbation"]
+
+    def test_skips_none_entries(self):
+        augs = {"flip": None, "state_perturbation": _FakeAug("sp")}
+        pipeline = build_aug_pipeline(augs)
+        assert [name for name, _ in pipeline] == ["state_perturbation"]
+
+    def test_empty_dict_yields_empty_pipeline(self):
+        assert build_aug_pipeline({}) == []
+
+    def test_unknown_name_raises(self):
+        with pytest.raises(ValueError, match="unknown augmentation"):
+            build_aug_pipeline({"route_input": _FakeAug("r")})
+
+
+class TestResolveRepeatAugPool:
+    def _pipeline(self, *names):
+        return [(n, _FakeAug(n)) for n in AUG_ORDER if n in names]
+
+    def test_empty_spec_defaults_to_all_enabled(self):
+        pipeline = self._pipeline("flip", "neighbor_noise")
+        pool, warnings = resolve_repeat_aug_pool("", pipeline, augment_type="quintic")
+        assert pool == ["flip", "neighbor_noise"]
+        assert warnings == []
+
+    def test_explicit_spec_restricts_pool(self):
+        pipeline = self._pipeline("flip", "neighbor_noise", "state_perturbation")
+        pool, _ = resolve_repeat_aug_pool("neighbor_noise", pipeline, augment_type="quintic")
+        assert pool == ["neighbor_noise"]
+
+    def test_explicit_spec_is_reordered_canonically(self):
+        pipeline = self._pipeline("flip", "neighbor_noise")
+        pool, _ = resolve_repeat_aug_pool("neighbor_noise,flip", pipeline, augment_type="quintic")
+        assert pool == ["flip", "neighbor_noise"]
+
+    def test_whitespace_and_empty_entries_tolerated(self):
+        pipeline = self._pipeline("flip", "neighbor_noise")
+        pool, _ = resolve_repeat_aug_pool(" flip , ,neighbor_noise ", pipeline, "quintic")
+        assert pool == ["flip", "neighbor_noise"]
+
+    def test_unknown_name_raises_listing_valid_names(self):
+        pipeline = self._pipeline("flip")
+        with pytest.raises(ValueError) as exc:
+            resolve_repeat_aug_pool("nonsense", pipeline, augment_type="quintic")
+        assert "nonsense" in str(exc.value)
+        assert "flip" in str(exc.value)
+
+    def test_name_not_enabled_raises_naming_the_use_flag(self):
+        pipeline = self._pipeline("flip")
+        with pytest.raises(ValueError) as exc:
+            resolve_repeat_aug_pool("neighbor_noise", pipeline, augment_type="quintic")
+        assert "--use_neighbor_noise" in str(exc.value)
+
+    def test_empty_pipeline_raises(self):
+        with pytest.raises(ValueError, match="no augmentations are enabled"):
+            resolve_repeat_aug_pool("", [], augment_type="quintic")
+
+    def test_bridge_excludes_state_perturbation_from_default_pool(self):
+        """912 ms/sample per-row search: forcing it is not cost-neutral."""
+        pipeline = self._pipeline("flip", "state_perturbation")
+        pool, warnings = resolve_repeat_aug_pool("", pipeline, augment_type="bridge")
+        assert pool == ["flip"]
+        assert not any("bridge" in w for w in warnings)
+
+    def test_bridge_default_pool_collapsing_to_flip_still_warns(self):
+        """Operator did not ask for flip-alone; bridge reduced it. Warn anyway."""
+        pipeline = self._pipeline("flip", "state_perturbation")
+        pool, warnings = resolve_repeat_aug_pool("", pipeline, augment_type="bridge")
+        assert pool == ["flip"]
+        assert any("deterministic" in w for w in warnings)
+
+    def test_bridge_allows_explicit_state_perturbation_with_warning(self):
+        pipeline = self._pipeline("flip", "state_perturbation")
+        pool, warnings = resolve_repeat_aug_pool(
+            "state_perturbation", pipeline, augment_type="bridge"
+        )
+        assert pool == ["state_perturbation"]
+        assert any("bridge" in w for w in warnings)
+
+    def test_bridge_only_state_perturbation_enabled_raises(self):
+        """Default pool would be empty, which is a misconfiguration, not a silent no-op."""
+        pipeline = self._pipeline("state_perturbation")
+        with pytest.raises(ValueError, match="empty"):
+            resolve_repeat_aug_pool("", pipeline, augment_type="bridge")
+
+    def test_quintic_keeps_state_perturbation_in_default_pool(self):
+        pipeline = self._pipeline("flip", "state_perturbation")
+        pool, _ = resolve_repeat_aug_pool("", pipeline, augment_type="quintic")
+        assert pool == ["flip", "state_perturbation"]
+
+    def test_flip_only_pool_warns_about_determinism(self):
+        """Forced flip is deterministic: two forced occurrences mirror identically."""
+        pipeline = self._pipeline("flip")
+        pool, warnings = resolve_repeat_aug_pool("flip", pipeline, augment_type="quintic")
+        assert pool == ["flip"]
+        assert any("deterministic" in w for w in warnings)

--- a/diffusion_planner/tests/test_forced_augmentation_wiring.py
+++ b/diffusion_planner/tests/test_forced_augmentation_wiring.py
@@ -17,6 +17,8 @@
 import pytest
 import torch
 from diffusion_planner.utils.data_augmentation import StatePerturbation
+from diffusion_planner.utils.forced_augmentation import ForcedAugmentationSelector
+from torch.utils.data import DataLoader, Dataset
 
 
 def _perturbation(augment_prob: float) -> StatePerturbation:
@@ -88,3 +90,66 @@ class TestForceParameterContract:
         aug = _perturbation(1.0)
         aug.augment(_inputs(2))
         assert aug.pop_forced_noop_count() == 0
+
+
+class _IndexDataset(Dataset):
+    """Returns its own index so a test can prove flag-to-sample alignment."""
+
+    def __init__(self, size):
+        self.size = size
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, idx):
+        return {"idx": torch.tensor(idx, dtype=torch.long)}
+
+
+class _RecordingSampler:
+    """Deterministic index stream with a known repeat pattern."""
+
+    def __init__(self, indices):
+        self.indices = list(indices)
+        seen, flags = set(), []
+        for idx in self.indices:
+            flags.append(idx in seen)
+            seen.add(idx)
+        self.repeat_flags = flags
+        self.repeat_flags_epoch = 0
+
+    def __iter__(self):
+        return iter(self.indices)
+
+    def __len__(self):
+        return len(self.indices)
+
+
+class TestCursorAlignsWithDataLoaderOrder:
+    """The cursor is positional, so alignment is the thing most worth proving."""
+
+    @pytest.mark.parametrize("num_workers", [0, 2])
+    def test_force_mask_lands_on_the_repeated_samples(self, num_workers):
+        indices = [3, 1, 3, 0, 1, 1, 2, 0]
+        sampler = _RecordingSampler(indices)
+        loader = DataLoader(
+            _IndexDataset(4),
+            sampler=sampler,
+            batch_size=2,
+            num_workers=num_workers,
+            drop_last=True,
+        )
+        selector = ForcedAugmentationSelector(["neighbor_noise"], seed=0)
+        selector.start_epoch(0, sampler.repeat_flags, sampler.repeat_flags_epoch)
+
+        forced_indices, delivered = [], []
+        for batch in loader:
+            size = batch["idx"].shape[0]
+            masks = selector.masks_for_batch(size, torch.device("cpu"))
+            for row in range(size):
+                delivered.append(int(batch["idx"][row]))
+                if masks["neighbor_noise"][row]:
+                    forced_indices.append(int(batch["idx"][row]))
+
+        assert delivered == indices, "DataLoader must preserve sampler order"
+        expected = [idx for idx, flag in zip(indices, sampler.repeat_flags) if flag]
+        assert forced_indices == expected

--- a/diffusion_planner/tests/test_forced_augmentation_wiring.py
+++ b/diffusion_planner/tests/test_forced_augmentation_wiring.py
@@ -1,0 +1,90 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wiring tests for forced augmentation: the force= contract and cursor alignment."""
+
+import pytest
+import torch
+from diffusion_planner.utils.data_augmentation import StatePerturbation
+
+
+def _perturbation(augment_prob: float) -> StatePerturbation:
+    """StatePerturbation with every required argument supplied."""
+    return StatePerturbation(
+        augment_prob=augment_prob,
+        num_refine=1,
+        device="cpu",
+        ego_past_noise_std=0.0,
+        use_smoothing_future_trajectory=False,
+    )
+
+
+def _inputs(batch_size: int, speed: float = 10.0) -> dict:
+    """Minimal ego_current_state batch. Column 4 is vx, which gates augmentation."""
+    ego_current_state = torch.zeros(batch_size, 10)
+    ego_current_state[:, 2] = 1.0  # cos(heading)
+    ego_current_state[:, 4] = speed  # vx
+    return {
+        "ego_current_state": ego_current_state,
+        "ego_shape": torch.full((batch_size, 3), 2.5),
+    }
+
+
+class TestForceParameterContract:
+    def test_augment_accepts_force_and_defaults_to_none(self):
+        aug = _perturbation(0.0)
+        flag_default, _ = aug.augment(_inputs(4))
+        assert flag_default.shape == (4,)
+        assert not flag_default.any(), "prob=0 and no force must flag nothing"
+
+    def test_force_flags_a_row_that_probability_would_not(self):
+        """prob=0.0 means the Bernoulli mask is all-False; only force can flag."""
+        aug = _perturbation(0.0)
+        force = torch.tensor([True, False, True, False])
+        flag, _ = aug.augment(_inputs(4), force=force)
+        assert flag.tolist() == [True, False, True, False]
+
+    def test_force_cannot_bypass_the_low_speed_validity_gate(self):
+        """Forcing raises the chance of augmenting, never of an invalid scene."""
+        aug = _perturbation(0.0)
+        force = torch.tensor([True, True])
+        flag, _ = aug.augment(_inputs(2, speed=0.5), force=force)
+        assert not flag.any(), "|vx| < 2.0 must still veto a forced row"
+
+    def test_prob_one_without_force_is_unchanged(self):
+        aug = _perturbation(1.0)
+        flag, _ = aug.augment(_inputs(4))
+        assert flag.all()
+
+    def test_forced_noop_count_records_vetoed_rows(self):
+        aug = _perturbation(0.0)
+        force = torch.tensor([True, True])
+        aug.augment(_inputs(2, speed=0.5), force=force)
+        assert aug.pop_forced_noop_count() == 2
+
+    def test_forced_noop_count_zero_when_force_takes_effect(self):
+        aug = _perturbation(0.0)
+        aug.augment(_inputs(2, speed=10.0), force=torch.tensor([True, True]))
+        assert aug.pop_forced_noop_count() == 0
+
+    def test_pop_forced_noop_count_resets(self):
+        aug = _perturbation(0.0)
+        aug.augment(_inputs(2, speed=0.5), force=torch.tensor([True, True]))
+        aug.pop_forced_noop_count()
+        assert aug.pop_forced_noop_count() == 0
+
+    def test_pop_forced_noop_count_is_zero_without_forcing(self):
+        aug = _perturbation(1.0)
+        aug.augment(_inputs(2))
+        assert aug.pop_forced_noop_count() == 0

--- a/diffusion_planner/tests/test_online_augmentations.py
+++ b/diffusion_planner/tests/test_online_augmentations.py
@@ -1,0 +1,120 @@
+import sys
+from pathlib import Path
+
+import torch
+
+PROJECT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_DIR))
+
+from diffusion_planner.dimensions import SEGMENT_POINT_DIM
+from diffusion_planner.utils.forced_augmentation import (
+    build_aug_pipeline,
+    validate_forced_aug_flags,
+)
+from diffusion_planner.utils.online_augmentations import (
+    FlipAugmentation,
+    NeighborDropoutAugmentation,
+    NeighborNoiseAugmentation,
+    TurnIndicatorDropoutAugmentation,
+)
+from train_predictor import get_args
+
+
+def _batch(batch_size=2):
+    return {
+        "ego_current_state": torch.ones(batch_size, 10),
+        "ego_agent_past": torch.ones(batch_size, 2, 4),
+        "goal_pose": torch.ones(batch_size, 4),
+        "neighbor_agents_past": torch.ones(batch_size, 2, 2, 11),
+        "static_objects": torch.ones(batch_size, 1, 10),
+        "polygons": torch.ones(batch_size, 1, 2, 3),
+        "line_strings": torch.ones(batch_size, 1, 2, 4),
+        "lanes": torch.ones(batch_size, 1, 2, SEGMENT_POINT_DIM),
+        "route_lanes": torch.ones(batch_size, 1, 2, SEGMENT_POINT_DIM),
+        "turn_indicators": torch.ones(batch_size, 2, dtype=torch.long),
+    }
+
+
+def test_forced_flip_overrides_zero_probability():
+    inputs = _batch()
+    ego_future = torch.ones(2, 2, 3)
+    neighbors_future = torch.ones(2, 2, 2, 3)
+
+    FlipAugmentation(0.0, "cpu")(
+        inputs, ego_future, neighbors_future, force=torch.tensor([True, False])
+    )
+
+    assert torch.equal(ego_future[:, 0, 1], torch.tensor([-1.0, 1.0]))
+
+
+def test_forced_neighbor_dropout_drops_one_when_probability_is_zero():
+    inputs = _batch()
+    ego_future = torch.ones(2, 2, 3)
+    neighbors_future = torch.ones(2, 2, 2, 3)
+
+    NeighborDropoutAugmentation(0.0, "cpu")(
+        inputs, ego_future, neighbors_future, force=torch.tensor([True, False])
+    )
+
+    assert torch.count_nonzero(inputs["neighbor_agents_past"][0, 0]) == 0
+    assert torch.count_nonzero(inputs["neighbor_agents_past"][1]) > 0
+
+
+def test_forced_turn_indicator_dropout_preserves_gt():
+    inputs = _batch()
+    original = inputs["turn_indicators"].clone()
+
+    TurnIndicatorDropoutAugmentation(0.0, "cpu")(
+        inputs,
+        torch.ones(2, 2, 3),
+        torch.ones(2, 2, 2, 3),
+        force=torch.tensor([True, False]),
+    )
+
+    assert torch.count_nonzero(inputs["turn_indicators"][0]) == 0
+    assert torch.equal(inputs["turn_indicators"][1], original[1])
+    assert torch.equal(inputs["turn_indicators_gt_source"], original)
+
+
+def test_real_classes_build_requested_pipeline_and_cli_flags_parse():
+    classes = {
+        "flip": FlipAugmentation(0.5, "cpu"),
+        "neighbor_dropout": NeighborDropoutAugmentation(0.1, "cpu"),
+        "neighbor_noise": NeighborNoiseAugmentation(0.2, 0.3, 0.05, "cpu"),
+        "turn_indicator": TurnIndicatorDropoutAugmentation(0.1, "cpu"),
+    }
+    assert [name for name, _ in build_aug_pipeline(classes)] == list(classes)
+
+    args = get_args(
+        [
+            "--exp_name",
+            "test",
+            "--save_dir",
+            "/tmp/test",
+            "--train_set_list",
+            "train.json",
+            "--valid_set_list",
+            "valid.json",
+            "--cluster_json",
+            "clusters.json",
+            "--force_aug_on_repeat",
+            "True",
+            "--repeat_aug_pool",
+            "flip,neighbor_dropout,neighbor_noise,turn_indicator",
+            "--use_flip_augment",
+            "True",
+            "--use_neighbor_dropout",
+            "True",
+            "--use_neighbor_noise",
+            "True",
+            "--use_turn_indicator_dropout",
+            "True",
+        ]
+    )
+    assert args.use_flip_augment
+    assert args.use_neighbor_dropout
+    assert args.use_neighbor_noise
+    assert args.use_turn_indicator_dropout
+    pool, warnings = validate_forced_aug_flags(args, build_aug_pipeline(classes))
+    assert pool == ["flip", "neighbor_dropout", "neighbor_noise", "turn_indicator"]
+    assert warnings == []

--- a/diffusion_planner/tests/test_replay_repeats.py
+++ b/diffusion_planner/tests/test_replay_repeats.py
@@ -1,0 +1,652 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for diffusion_planner/sampling/replay_repeats.py.
+
+The load-bearing tests are the equivalence tests: they build real
+``ClusterWeightedDistributedSampler`` instances (one per rank, independent of the tool's
+own iteration strategy), iterate them, count repeats off ``repeat_flags``, and assert the
+tool reports exactly those numbers. Also covers the drop_last-adjusted forced-row count
+against ``ForcedAugmentationSelector.forced_count``, data-list reconstruction, and the
+refusal to guess a world size.
+
+Usage:
+    pytest diffusion_planner/tests/test_replay_repeats.py -q
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from diffusion_planner.utils.forced_augmentation import ForcedAugmentationSelector
+from diffusion_planner.utils.weighted_sampler import ClusterWeightedDistributedSampler
+
+SAMPLING_DIR = Path(__file__).resolve().parent.parent / "sampling"
+sys.path.insert(0, str(SAMPLING_DIR))
+
+import replay_repeats  # noqa: E402
+
+SEED = 3407
+ALPHA = 1.0
+
+
+def make_inputs(tmp_path: Path, n: int = 240) -> tuple[str, str, list[str]]:
+    """Write a train_set_list and a skewed 3-cluster JSON. Returns (list, clusters, paths)."""
+    paths = [f"/data/loc/train/2026-01-01/12-00-00/frame_{i:06d}.npz" for i in range(n)]
+    list_path = tmp_path / "train_list.json"
+    cluster_path = tmp_path / "clusters.json"
+    rare = max(2, n // 40)
+    medium = max(4, n // 8)
+    clusters = {
+        "cluster_id0": paths[:rare],
+        "cluster_id1": paths[rare : rare + medium],
+        "cluster_id2": paths[rare + medium :],
+    }
+    list_path.write_text(json.dumps(paths))
+    cluster_path.write_text(json.dumps(clusters))
+    return str(list_path), str(cluster_path), paths
+
+
+def write_run_dir(
+    tmp_path: Path,
+    list_path: str,
+    cluster_path: str,
+    *,
+    train_epochs: int = 3,
+    batch_size: int | None = None,
+    subsample_step: int = 1,
+    pool_spec: str = "",
+    augment_type: str = "quintic",
+    force: bool = True,
+    data_list_size: int | None = None,
+    extra: dict | None = None,
+) -> Path:
+    """Write an args.json (+ cluster_sampling.json) shaped like train.py's."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(exist_ok=True)
+    args = {
+        "exp_name": "unit_test",
+        "save_dir": str(run_dir),
+        "train_set_list": list_path,
+        "valid_set_list": "/unused/valid.json",
+        "train_subsample_step": subsample_step,
+        "cluster_json": cluster_path,
+        "cluster_weight_alpha": ALPHA,
+        "force_aug_on_repeat": force,
+        "repeat_aug_pool": pool_spec,
+        "augment_type": augment_type,
+        "use_data_augment": True,
+        "use_flip_augment": True,
+        "use_neighbor_dropout": True,
+        "use_neighbor_noise": False,
+        "use_turn_indicator_dropout": False,
+        "seed": SEED,
+        "train_epochs": train_epochs,
+        "ddp": True,
+        "major_version": 5,
+    }
+    if batch_size is not None:
+        args["batch_size"] = batch_size
+    args.update(extra or {})
+    (run_dir / "args.json").write_text(json.dumps(args, indent=4))
+    if data_list_size is not None:
+        (run_dir / "cluster_sampling.json").write_text(
+            json.dumps(
+                {
+                    "cluster_json": cluster_path,
+                    "cluster_weight_alpha": ALPHA,
+                    "train_subsample_step": subsample_step,
+                    "data_list_size": data_list_size,
+                    "matched_count": data_list_size,
+                    "forced_augmentation": {"enabled": force, "pool": []},
+                },
+                indent=4,
+            )
+        )
+    return run_dir
+
+
+def ground_truth(
+    data_list: list[str],
+    cluster_path: str,
+    world_size: int,
+    epoch: int,
+) -> dict:
+    """Iterate a fresh sampler per rank and aggregate GLOBAL counts the obvious way.
+
+    Deliberately independent of the tool: separate sampler objects per rank, no rank
+    mutation, flags summed rather than reassembled.
+    """
+    total = 0
+    repeats = 0
+    drawn: set[int] = set()
+    per_rank_flags: list[list[bool]] = []
+    for rank in range(world_size):
+        sampler = ClusterWeightedDistributedSampler(
+            data_list,
+            cluster_path,
+            num_replicas=world_size,
+            rank=rank,
+            seed=SEED,
+            alpha=ALPHA,
+            track_repeats=True,
+        )
+        sampler.set_epoch(epoch)
+        indices = list(sampler)
+        flags = sampler.repeat_flags
+        total += len(indices)
+        repeats += sum(flags)
+        drawn.update(indices)
+        per_rank_flags.append(list(flags))
+    return {
+        "total_draws": total,
+        "distinct_samples": len(drawn),
+        "repeat_draws": repeats,
+        "per_rank_flags": per_rank_flags,
+    }
+
+
+class TestEquivalenceWithTheRealSampler:
+    @pytest.mark.parametrize("world_size", [1, 2, 4, 8])
+    def test_replay_matches_direct_sampler_iteration(self, tmp_path, world_size):
+        list_path, cluster_path, paths = make_inputs(tmp_path, n=240)
+        result = replay_repeats.run(
+            [
+                "--train_set_list",
+                list_path,
+                "--cluster_json",
+                cluster_path,
+                "--seed",
+                str(SEED),
+                "--cluster_weight_alpha",
+                str(ALPHA),
+                "--world_size",
+                str(world_size),
+                "--epochs",
+                "1",
+                "--repeat_aug_pool",
+                "flip,neighbor_dropout",
+            ]
+        )
+        truth = ground_truth(paths, cluster_path, world_size, epoch=0)
+        row = result["per_epoch"][0]
+        assert row["total_draws"] == truth["total_draws"]
+        assert row["distinct_samples"] == truth["distinct_samples"]
+        assert row["repeat_draws"] == truth["repeat_draws"]
+        assert row["repeat_fraction"] == pytest.approx(truth["repeat_draws"] / truth["total_draws"])
+        assert row["expected_forced_per_pool_member"] == pytest.approx(truth["repeat_draws"] / 2)
+        # A non-trivial fixture: repeats must actually happen, or the test proves nothing.
+        assert truth["repeat_draws"] > 0
+
+    def test_replay_matches_direct_sampler_every_epoch(self, tmp_path):
+        """Each epoch reseeds with seed + epoch, so every epoch must match individually."""
+        list_path, cluster_path, paths = make_inputs(tmp_path, n=200)
+        world_size = 4
+        epochs = 5
+        result = replay_repeats.run(
+            [
+                "--train_set_list",
+                list_path,
+                "--cluster_json",
+                cluster_path,
+                "--seed",
+                str(SEED),
+                "--world_size",
+                str(world_size),
+                "--epochs",
+                str(epochs),
+                "--repeat_aug_pool",
+                "flip,neighbor_noise,state_perturbation",
+            ]
+        )
+        assert len(result["per_epoch"]) == epochs
+        for epoch in range(epochs):
+            truth = ground_truth(paths, cluster_path, world_size, epoch=epoch)
+            row = result["per_epoch"][epoch]
+            assert row["epoch"] == epoch
+            assert row["repeat_draws"] == truth["repeat_draws"], f"epoch {epoch}"
+            assert row["distinct_samples"] == truth["distinct_samples"], f"epoch {epoch}"
+        # Epochs must not be identical, otherwise the per-epoch match is vacuous.
+        assert len({row["repeat_draws"] for row in result["per_epoch"]}) > 1
+        assert result["total"]["repeat_draws"] == sum(
+            row["repeat_draws"] for row in result["per_epoch"]
+        )
+        assert result["total"]["total_draws"] == sum(
+            row["total_draws"] for row in result["per_epoch"]
+        )
+
+    def test_start_epoch_shifts_the_replayed_epochs(self, tmp_path):
+        list_path, cluster_path, paths = make_inputs(tmp_path, n=160)
+        result = replay_repeats.run(
+            [
+                "--train_set_list",
+                list_path,
+                "--cluster_json",
+                cluster_path,
+                "--seed",
+                str(SEED),
+                "--world_size",
+                "2",
+                "--epochs",
+                "2",
+                "--start_epoch",
+                "40",
+            ]
+        )
+        assert [row["epoch"] for row in result["per_epoch"]] == [40, 41]
+        for row in result["per_epoch"]:
+            truth = ground_truth(paths, cluster_path, 2, epoch=row["epoch"])
+            assert row["repeat_draws"] == truth["repeat_draws"]
+
+    def test_padded_length_accounts_for_world_size(self, tmp_path):
+        """N=250 over 8 ranks pads to 256 draws; a world_size guess of 1 would say 250."""
+        list_path, cluster_path, _ = make_inputs(tmp_path, n=250)
+        result = replay_repeats.run(
+            [
+                "--train_set_list",
+                list_path,
+                "--cluster_json",
+                cluster_path,
+                "--world_size",
+                "8",
+                "--epochs",
+                "1",
+            ]
+        )
+        assert result["sampler"]["num_samples_per_rank"] == 32
+        assert result["sampler"]["padded_length"] == 256
+        assert result["per_epoch"][0]["total_draws"] == 256
+
+    def test_inconsistent_flags_are_refused_not_reported(self, tmp_path, monkeypatch):
+        """The cross-check on the reassembled global draw list must not be dead code."""
+
+        class CorruptingSampler(ClusterWeightedDistributedSampler):
+            def __iter__(self):
+                indices = super().__iter__()
+                if self.rank == 1 and self.repeat_flags:
+                    flipped = list(self.repeat_flags)
+                    flipped[0] = not flipped[0]
+                    self.repeat_flags = flipped
+                return indices
+
+        monkeypatch.setattr(replay_repeats, "ClusterWeightedDistributedSampler", CorruptingSampler)
+        list_path, cluster_path, _ = make_inputs(tmp_path, n=120)
+        with pytest.raises(replay_repeats.ReplayError, match="do not match the flags recomputed"):
+            replay_repeats.run(
+                [
+                    "--train_set_list",
+                    list_path,
+                    "--cluster_json",
+                    cluster_path,
+                    "--world_size",
+                    "4",
+                    "--epochs",
+                    "1",
+                ]
+            )
+
+    def test_distinct_plus_repeats_equals_total(self, tmp_path):
+        list_path, cluster_path, _ = make_inputs(tmp_path, n=300)
+        result = replay_repeats.run(
+            [
+                "--train_set_list",
+                list_path,
+                "--cluster_json",
+                cluster_path,
+                "--world_size",
+                "4",
+                "--epochs",
+                "3",
+            ]
+        )
+        for row in result["per_epoch"]:
+            assert row["distinct_samples"] + row["repeat_draws"] == row["total_draws"]
+
+
+class TestForcedRowsMatchTheSelector:
+    def test_forced_rows_equals_selector_forced_count(self, tmp_path):
+        """The delivered-row count must equal what ForcedAugmentationSelector would tally.
+
+        The training DataLoader is ``drop_last=True`` with ``batch_size // world_size`` per
+        rank, so each rank's partial tail batch is never delivered and its repeat flags are
+        never consumed. This replays that consumption per rank with the real selector.
+        """
+        list_path, cluster_path, paths = make_inputs(tmp_path, n=250)
+        world_size = 4
+        batch_size = 32
+        per_rank_batch = batch_size // world_size
+        run_dir = write_run_dir(
+            tmp_path,
+            list_path,
+            cluster_path,
+            train_epochs=2,
+            batch_size=batch_size,
+        )
+        result = replay_repeats.run(["--run_dir", str(run_dir), "--world_size", str(world_size)])
+        assert result["config"]["per_rank_batch"] == per_rank_batch
+        pool = result["config"]["repeat_aug_pool"]
+
+        for row in result["per_epoch"]:
+            truth = ground_truth(paths, cluster_path, world_size, epoch=row["epoch"])
+            selector_total = 0
+            for flags in truth["per_rank_flags"]:
+                selector = ForcedAugmentationSelector(pool, seed=SEED)
+                selector.start_epoch(row["epoch"], flags, row["epoch"])
+                offset = 0
+                while offset + per_rank_batch <= len(flags):  # drop_last=True
+                    selector.masks_for_batch(per_rank_batch, "cpu")
+                    offset += per_rank_batch
+                selector_total += selector.forced_count
+            assert row["forced_rows"] == selector_total, f"epoch {row['epoch']}"
+            # Non-trivial: the tail really is dropped for this shape.
+            assert row["dropped_rows"] > 0
+            assert row["forced_rows"] < row["repeat_draws"]
+
+    def test_forced_rows_equals_repeats_when_shard_divides_evenly(self, tmp_path):
+        list_path, cluster_path, _ = make_inputs(tmp_path, n=256)
+        run_dir = write_run_dir(tmp_path, list_path, cluster_path, train_epochs=1, batch_size=32)
+        result = replay_repeats.run(["--run_dir", str(run_dir), "--world_size", "4"])
+        row = result["per_epoch"][0]
+        assert row["dropped_rows"] == 0
+        assert row["forced_rows"] == row["repeat_draws"]
+
+    def test_no_batch_size_omits_delivered_rows(self, tmp_path):
+        list_path, cluster_path, _ = make_inputs(tmp_path, n=200)
+        result = replay_repeats.run(
+            [
+                "--train_set_list",
+                list_path,
+                "--cluster_json",
+                cluster_path,
+                "--world_size",
+                "2",
+                "--epochs",
+                "1",
+            ]
+        )
+        assert "forced_rows" not in result["per_epoch"][0]
+        assert "forced_rows" not in result["total"]
+        assert "drop_last is not modelled" in replay_repeats.format_report(result)
+
+
+class TestDataListReconstruction:
+    @pytest.mark.parametrize("step", [1, 2, 3, 7])
+    def test_mirrors_train_subsample_step(self, tmp_path, step):
+        list_path, cluster_path, paths = make_inputs(tmp_path, n=210)
+        expected = paths[::step]
+        data_list = replay_repeats.build_data_list(list_path, step)
+        assert data_list == expected
+
+    def test_subsample_step_changes_every_count(self, tmp_path):
+        list_path, cluster_path, paths = make_inputs(tmp_path, n=210)
+        run_dir = write_run_dir(tmp_path, list_path, cluster_path, train_epochs=1, subsample_step=3)
+        result = replay_repeats.run(["--run_dir", str(run_dir), "--world_size", "2"])
+        assert result["sampler"]["data_list_size"] == len(paths[::3])
+        truth = ground_truth(paths[::3], cluster_path, 2, epoch=0)
+        assert result["per_epoch"][0]["repeat_draws"] == truth["repeat_draws"]
+
+    def test_rejects_non_positive_step(self, tmp_path):
+        list_path, _, _ = make_inputs(tmp_path, n=20)
+        with pytest.raises(replay_repeats.ReplayError, match="train_subsample_step"):
+            replay_repeats.build_data_list(list_path, 0)
+
+    def test_rejects_non_list_json(self, tmp_path):
+        bad = tmp_path / "bad.json"
+        bad.write_text(json.dumps({"not": "a list"}))
+        with pytest.raises(replay_repeats.ReplayError, match="JSON list"):
+            replay_repeats.build_data_list(str(bad), 1)
+
+
+class TestWorldSize:
+    def test_missing_world_size_exits_with_instructions(self, tmp_path):
+        list_path, cluster_path, _ = make_inputs(tmp_path, n=100)
+        run_dir = write_run_dir(tmp_path, list_path, cluster_path)
+        with pytest.raises(SystemExit) as excinfo:
+            replay_repeats.main(["--run_dir", str(run_dir)])
+        message = str(excinfo.value)
+        assert "--world_size is required" in message
+        assert "train_log.txt" in message
+
+    def test_world_size_read_from_args_json_when_present(self, tmp_path):
+        list_path, cluster_path, _ = make_inputs(tmp_path, n=100)
+        run_dir = write_run_dir(
+            tmp_path, list_path, cluster_path, train_epochs=1, extra={"world_size": 4}
+        )
+        result = replay_repeats.run(["--run_dir", str(run_dir)])
+        assert result["config"]["world_size"] == 4
+        assert result["config"]["sources"]["world_size"] == "args.json[world_size]"
+
+    def test_flag_overrides_args_json(self, tmp_path):
+        list_path, cluster_path, _ = make_inputs(tmp_path, n=100)
+        run_dir = write_run_dir(
+            tmp_path, list_path, cluster_path, train_epochs=1, extra={"world_size": 4}
+        )
+        result = replay_repeats.run(["--run_dir", str(run_dir), "--world_size", "2"])
+        assert result["config"]["world_size"] == 2
+        assert result["config"]["sources"]["world_size"] == "flag"
+
+    def test_rejects_zero_world_size(self, tmp_path):
+        list_path, cluster_path, _ = make_inputs(tmp_path, n=100)
+        with pytest.raises(replay_repeats.ReplayError, match="world_size must be >= 1"):
+            replay_repeats.run(
+                [
+                    "--train_set_list",
+                    list_path,
+                    "--cluster_json",
+                    cluster_path,
+                    "--world_size",
+                    "0",
+                    "--epochs",
+                    "1",
+                ]
+            )
+
+
+class TestPoolResolution:
+    def test_empty_pool_spec_resolves_to_enabled_augmentations(self, tmp_path):
+        list_path, cluster_path, _ = make_inputs(tmp_path, n=100)
+        run_dir = write_run_dir(tmp_path, list_path, cluster_path, train_epochs=1)
+        result = replay_repeats.run(["--run_dir", str(run_dir), "--world_size", "2"])
+        assert result["config"]["repeat_aug_pool"] == [
+            "flip",
+            "neighbor_dropout",
+            "state_perturbation",
+        ]
+
+    def test_bridge_excludes_state_perturbation_from_default_pool(self, tmp_path):
+        list_path, cluster_path, _ = make_inputs(tmp_path, n=100)
+        run_dir = write_run_dir(
+            tmp_path, list_path, cluster_path, train_epochs=1, augment_type="bridge"
+        )
+        result = replay_repeats.run(["--run_dir", str(run_dir), "--world_size", "2"])
+        assert result["config"]["repeat_aug_pool"] == ["flip", "neighbor_dropout"]
+
+    def test_pool_naming_a_disabled_augmentation_is_rejected(self, tmp_path):
+        list_path, cluster_path, _ = make_inputs(tmp_path, n=100)
+        run_dir = write_run_dir(
+            tmp_path, list_path, cluster_path, train_epochs=1, pool_spec="neighbor_noise"
+        )
+        with pytest.raises(replay_repeats.ReplayError, match="not enabled"):
+            replay_repeats.run(["--run_dir", str(run_dir), "--world_size", "2"])
+
+    def test_forcing_off_reports_empty_pool_and_warns(self, tmp_path):
+        list_path, cluster_path, _ = make_inputs(tmp_path, n=100)
+        run_dir = write_run_dir(tmp_path, list_path, cluster_path, train_epochs=1, force=False)
+        result = replay_repeats.run(["--run_dir", str(run_dir), "--world_size", "2"])
+        assert result["config"]["repeat_aug_pool"] == []
+        assert result["per_epoch"][0]["expected_forced_per_pool_member"] is None
+        assert any("empty pool" in w for w in result["warnings"])
+        assert "forcing DISABLED" in replay_repeats.format_report(result)
+
+    def test_force_flag_enables_hypothetical_replay(self, tmp_path):
+        list_path, cluster_path, _ = make_inputs(tmp_path, n=100)
+        run_dir = write_run_dir(tmp_path, list_path, cluster_path, train_epochs=1, force=False)
+        result = replay_repeats.run(
+            ["--run_dir", str(run_dir), "--world_size", "2", "--force_aug_on_repeat"]
+        )
+        assert result["config"]["repeat_aug_pool"] == [
+            "flip",
+            "neighbor_dropout",
+            "state_perturbation",
+        ]
+
+    def test_unknown_pool_name_rejected_without_run_dir(self, tmp_path):
+        list_path, cluster_path, _ = make_inputs(tmp_path, n=100)
+        with pytest.raises(replay_repeats.ReplayError, match="unknown augmentation"):
+            replay_repeats.run(
+                [
+                    "--train_set_list",
+                    list_path,
+                    "--cluster_json",
+                    cluster_path,
+                    "--world_size",
+                    "1",
+                    "--epochs",
+                    "1",
+                    "--repeat_aug_pool",
+                    "flip,not_an_aug",
+                ]
+            )
+
+
+class TestCrossChecksAndErrors:
+    def test_data_list_size_mismatch_raises(self, tmp_path):
+        list_path, cluster_path, _ = make_inputs(tmp_path, n=100)
+        run_dir = write_run_dir(
+            tmp_path, list_path, cluster_path, train_epochs=1, data_list_size=999
+        )
+        with pytest.raises(replay_repeats.ReplayError, match="Every count would be wrong"):
+            replay_repeats.run(["--run_dir", str(run_dir), "--world_size", "2"])
+
+    def test_data_list_size_mismatch_can_be_overridden(self, tmp_path):
+        list_path, cluster_path, _ = make_inputs(tmp_path, n=100)
+        run_dir = write_run_dir(
+            tmp_path, list_path, cluster_path, train_epochs=1, data_list_size=999
+        )
+        result = replay_repeats.run(
+            [
+                "--run_dir",
+                str(run_dir),
+                "--world_size",
+                "2",
+                "--allow_data_list_mismatch",
+            ]
+        )
+        assert any("cross-check FAILED" in w for w in result["warnings"])
+
+    def test_matching_cluster_sampling_json_passes_quietly(self, tmp_path):
+        list_path, cluster_path, _ = make_inputs(tmp_path, n=100)
+        run_dir = write_run_dir(
+            tmp_path, list_path, cluster_path, train_epochs=1, data_list_size=100
+        )
+        result = replay_repeats.run(["--run_dir", str(run_dir), "--world_size", "2"])
+        assert not any("cross-check" in w for w in result["warnings"])
+
+    def test_missing_args_json_is_a_clear_error(self, tmp_path):
+        empty = tmp_path / "not_a_run"
+        empty.mkdir()
+        with pytest.raises(replay_repeats.ReplayError, match="args.json not found"):
+            replay_repeats.run(["--run_dir", str(empty), "--world_size", "1"])
+
+    def test_run_without_cluster_json_is_rejected(self, tmp_path):
+        list_path, cluster_path, _ = make_inputs(tmp_path, n=100)
+        run_dir = write_run_dir(tmp_path, list_path, cluster_path, train_epochs=1)
+        args = json.loads((run_dir / "args.json").read_text())
+        args["cluster_json"] = ""
+        (run_dir / "args.json").write_text(json.dumps(args))
+        with pytest.raises(replay_repeats.ReplayError, match="WITHOUT replacement"):
+            replay_repeats.run(["--run_dir", str(run_dir), "--world_size", "2"])
+
+    def test_epochs_required_without_run_dir(self, tmp_path):
+        list_path, cluster_path, _ = make_inputs(tmp_path, n=100)
+        with pytest.raises(replay_repeats.ReplayError, match="--epochs is required"):
+            replay_repeats.run(
+                [
+                    "--train_set_list",
+                    list_path,
+                    "--cluster_json",
+                    cluster_path,
+                    "--world_size",
+                    "1",
+                ]
+            )
+
+    def test_train_set_list_required_without_run_dir(self, tmp_path):
+        _, cluster_path, _ = make_inputs(tmp_path, n=100)
+        with pytest.raises(replay_repeats.ReplayError, match="--train_set_list is required"):
+            replay_repeats.run(
+                ["--cluster_json", cluster_path, "--world_size", "1", "--epochs", "1"]
+            )
+
+
+class TestCliOutput:
+    def test_main_prints_table_and_writes_json(self, tmp_path, capsys):
+        list_path, cluster_path, paths = make_inputs(tmp_path, n=250)
+        run_dir = write_run_dir(
+            tmp_path,
+            list_path,
+            cluster_path,
+            train_epochs=2,
+            batch_size=32,
+            data_list_size=250,
+        )
+        out_json = tmp_path / "nested" / "repeats.json"
+        code = replay_repeats.main(
+            [
+                "--run_dir",
+                str(run_dir),
+                "--world_size",
+                "4",
+                "--json",
+                str(out_json),
+            ]
+        )
+        assert code == 0
+        printed = capsys.readouterr().out
+        assert "Offline repeat-draw replay" in printed
+        assert "TOTAL" in printed
+        assert "forced_rows" in printed
+
+        payload = json.loads(out_json.read_text())
+        assert len(payload["per_epoch"]) == 2
+        truth = ground_truth(paths, cluster_path, 4, epoch=0)
+        assert payload["per_epoch"][0]["repeat_draws"] == truth["repeat_draws"]
+        assert payload["total"]["repeat_draws"] == sum(
+            row["repeat_draws"] for row in payload["per_epoch"]
+        )
+        assert payload["config"]["world_size"] == 4
+        assert payload["sampler"]["data_list_size"] == 250
+
+    def test_total_distinct_is_a_union_not_a_sum(self, tmp_path):
+        list_path, cluster_path, _ = make_inputs(tmp_path, n=200)
+        result = replay_repeats.run(
+            [
+                "--train_set_list",
+                list_path,
+                "--cluster_json",
+                cluster_path,
+                "--world_size",
+                "2",
+                "--epochs",
+                "4",
+            ]
+        )
+        per_epoch_sum = sum(row["distinct_samples"] for row in result["per_epoch"])
+        union = result["total"]["distinct_samples_union"]
+        assert union <= 200
+        assert union < per_epoch_sum
+        assert union >= max(row["distinct_samples"] for row in result["per_epoch"])

--- a/diffusion_planner/tests/test_train_run.py
+++ b/diffusion_planner/tests/test_train_run.py
@@ -1,0 +1,68 @@
+import sys
+from argparse import Namespace
+from pathlib import Path
+
+PROJECT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_DIR))
+
+from train_run import build_optional_args, parse_args
+
+
+def _required_args() -> list[str]:
+    return [
+        "--exp_name",
+        "test",
+        "--train_set_list",
+        "train.json",
+        "--valid_set_list",
+        "valid.json",
+    ]
+
+
+def test_repeat_augmentation_flags_default_to_not_forwarded():
+    args = parse_args(_required_args())
+
+    assert args.force_aug_on_repeat is None
+    assert args.repeat_aug_pool is None
+    assert "--force_aug_on_repeat" not in build_optional_args(args)
+    assert "--repeat_aug_pool" not in build_optional_args(args)
+
+
+def test_repeat_augmentation_flags_are_parsed_and_forwarded(tmp_path):
+    cluster_json = tmp_path / "clusters.json"
+    cluster_json.write_text("{}")
+    args = parse_args(
+        [
+            *_required_args(),
+            "--cluster_json",
+            str(cluster_json),
+            "--force_aug_on_repeat",
+            "True",
+            "--repeat_aug_pool",
+            "flip,state_perturbation",
+        ]
+    )
+
+    optional = build_optional_args(args)
+
+    assert args.force_aug_on_repeat is True
+    assert optional[-4:] == [
+        "--force_aug_on_repeat",
+        "True",
+        "--repeat_aug_pool",
+        "flip,state_perturbation",
+    ]
+
+
+def test_explicit_false_is_forwarded():
+    args = Namespace(
+        resume_model_path=None,
+        wandb_run_id=None,
+        wandb_project_name=None,
+        cluster_json=None,
+        cluster_weight_alpha=None,
+        force_aug_on_repeat=False,
+        repeat_aug_pool=None,
+    )
+
+    assert build_optional_args(args) == ["--force_aug_on_repeat", "False"]

--- a/diffusion_planner/tests/test_train_run.py
+++ b/diffusion_planner/tests/test_train_run.py
@@ -66,3 +66,30 @@ def test_explicit_false_is_forwarded():
     )
 
     assert build_optional_args(args) == ["--force_aug_on_repeat", "False"]
+
+
+def test_multi_augmentation_enable_flags_are_forwarded():
+    args = parse_args(
+        [
+            *_required_args(),
+            "--use_flip_augment",
+            "True",
+            "--use_neighbor_dropout",
+            "True",
+            "--use_neighbor_noise",
+            "True",
+            "--use_turn_indicator_dropout",
+            "True",
+        ]
+    )
+
+    assert build_optional_args(args)[-8:] == [
+        "--use_flip_augment",
+        "True",
+        "--use_neighbor_dropout",
+        "True",
+        "--use_neighbor_noise",
+        "True",
+        "--use_turn_indicator_dropout",
+        "True",
+    ]

--- a/diffusion_planner/tests/test_visualize_cluster_report.py
+++ b/diffusion_planner/tests/test_visualize_cluster_report.py
@@ -50,6 +50,7 @@ class TestLoadClusterJson:
 
     def test_raises_on_missing_file(self):
         import pytest
+
         with pytest.raises(FileNotFoundError):
             load_cluster_json("/nonexistent/path.json")
 
@@ -93,16 +94,100 @@ class TestComputeClusterStats:
         ids = [s["cluster_id"] for s in stats]
         assert ids == ["cluster_id0", "cluster_id1", "cluster_id2"]
 
+    def test_alpha_zero_gives_uniform_weights(self):
+        clusters = {
+            "cluster_id0": [f"/a/{i}.npz" for i in range(90)],
+            "cluster_id1": [f"/b/{i}.npz" for i in range(10)],
+        }
+        stats = compute_cluster_stats(clusters, alpha=0.0)
+        for s in stats:
+            assert abs(s["weight"] - 1.0) < 1e-6
+
+    def test_alpha_softens_weight_ratio(self):
+        clusters = {
+            "cluster_id0": [f"/a/{i}.npz" for i in range(90)],
+            "cluster_id1": [f"/b/{i}.npz" for i in range(10)],
+        }
+        full = compute_cluster_stats(clusters, alpha=1.0)
+        half = compute_cluster_stats(clusters, alpha=0.5)
+
+        def ratio(stats):
+            s0 = next(s for s in stats if s["cluster_id"] == "cluster_id0")
+            s1 = next(s for s in stats if s["cluster_id"] == "cluster_id1")
+            return s1["weight"] / s0["weight"]
+
+        assert abs(ratio(half) - ratio(full) ** 0.5) < 1e-4
+
+    def test_default_alpha_is_one(self):
+        clusters = {
+            "cluster_id0": [f"/a/{i}.npz" for i in range(90)],
+            "cluster_id1": [f"/b/{i}.npz" for i in range(10)],
+        }
+        assert compute_cluster_stats(clusters) == compute_cluster_stats(clusters, alpha=1.0)
+
+    def test_negative_alpha_raises(self):
+        import pytest
+
+        clusters = {"cluster_id0": ["/a.npz"]}
+        with pytest.raises(ValueError, match="alpha"):
+            compute_cluster_stats(clusters, alpha=-1.0)
+
+    def test_nan_alpha_raises(self):
+        """NaN must be rejected, matching the sampler: it would yield nan weights."""
+        import pytest
+
+        clusters = {"cluster_id0": ["/a.npz"]}
+        with pytest.raises(ValueError, match="alpha"):
+            compute_cluster_stats(clusters, alpha=float("nan"))
+
+    def test_report_weight_matches_sampler_weight(self):
+        """The report must reproduce the sampler's multiplier exactly."""
+        import json as _json
+        import tempfile as _tempfile
+
+        from diffusion_planner.utils.weighted_sampler import (
+            ClusterWeightedDistributedSampler,
+        )
+
+        data_list = [f"/data/sample_{i}.npz" for i in range(100)]
+        clusters = {"cluster_id0": data_list[:10], "cluster_id1": data_list[10:]}
+        with _tempfile.TemporaryDirectory() as tmp:
+            cluster_path = str(Path(tmp) / "clusters.json")
+            with open(cluster_path, "w") as f:
+                _json.dump(clusters, f)
+
+            for alpha in (1.0, 0.5, 0.0):
+                sampler = ClusterWeightedDistributedSampler(
+                    data_list, cluster_path, num_replicas=1, rank=0, seed=42, alpha=alpha
+                )
+                stats = compute_cluster_stats(clusters, alpha=alpha)
+                for s in stats:
+                    assert abs(s["weight"] - sampler.cluster_multipliers[s["cluster_id"]]) < 1e-6, (
+                        f"alpha={alpha} cluster={s['cluster_id']}"
+                    )
+
 
 class TestRenderBarChart:
     def test_returns_base64_data_uri(self):
         stats = [
-            {"cluster_id": "cluster_id0", "count": 90, "pct": 90.0,
-             "weight": 0.5, "sampling_rate": 0.5, "draws_per_epoch": 50,
-             "repeats_per_sample": 0.56},
-            {"cluster_id": "cluster_id1", "count": 10, "pct": 10.0,
-             "weight": 4.5, "sampling_rate": 0.5, "draws_per_epoch": 50,
-             "repeats_per_sample": 5.0},
+            {
+                "cluster_id": "cluster_id0",
+                "count": 90,
+                "pct": 90.0,
+                "weight": 0.5,
+                "sampling_rate": 0.5,
+                "draws_per_epoch": 50,
+                "repeats_per_sample": 0.56,
+            },
+            {
+                "cluster_id": "cluster_id1",
+                "count": 10,
+                "pct": 10.0,
+                "weight": 4.5,
+                "sampling_rate": 0.5,
+                "draws_per_epoch": 50,
+                "repeats_per_sample": 5.0,
+            },
         ]
         result = render_bar_chart(stats)
         assert result.startswith("data:image/png;base64,")
@@ -144,8 +229,12 @@ class TestRenderClusterVideos:
             "cluster_id0": ["/a/0.npz", "/a/1.npz"],
             "cluster_id1": ["/b/0.npz"],
         }
-        with patch("visualize_cluster_report.shutil.which", return_value="/usr/bin/render-video-txt"), \
-             patch("visualize_cluster_report.subprocess.run") as mock_run:
+        with (
+            patch(
+                "visualize_cluster_report.shutil.which", return_value="/usr/bin/render-video-txt"
+            ),
+            patch("visualize_cluster_report.subprocess.run") as mock_run,
+        ):
             mock_run.return_value = MagicMock(returncode=0)
             rendered, errors = render_cluster_videos(subsampled, str(tmp_path), workers=1)
             assert mock_run.call_count == 2
@@ -154,8 +243,12 @@ class TestRenderClusterVideos:
         subsampled = {
             "cluster_id0": ["/a/0.npz"],
         }
-        with patch("visualize_cluster_report.shutil.which", return_value="/usr/bin/render-video-txt"), \
-             patch("visualize_cluster_report.subprocess.run") as mock_run:
+        with (
+            patch(
+                "visualize_cluster_report.shutil.which", return_value="/usr/bin/render-video-txt"
+            ),
+            patch("visualize_cluster_report.subprocess.run") as mock_run,
+        ):
             mock_run.return_value = MagicMock(returncode=0)
             rendered, errors = render_cluster_videos(subsampled, str(tmp_path), workers=1)
             assert (tmp_path / "videos" / "cluster_id0").is_dir()
@@ -163,6 +256,7 @@ class TestRenderClusterVideos:
     def test_checks_render_video_txt_available(self):
         with patch("visualize_cluster_report.shutil.which", return_value=None):
             import pytest
+
             with pytest.raises(RuntimeError, match="render-video-txt not found"):
                 render_cluster_videos({"cluster_id0": ["/a.npz"]}, "/tmp/out", workers=1)
 
@@ -175,8 +269,12 @@ class TestRenderClusterVideos:
             log_path.write_text(log_content)
             return MagicMock(returncode=0)
 
-        with patch("visualize_cluster_report.shutil.which", return_value="/usr/bin/render-video-txt"), \
-             patch("visualize_cluster_report.subprocess.run", side_effect=fake_run):
+        with (
+            patch(
+                "visualize_cluster_report.shutil.which", return_value="/usr/bin/render-video-txt"
+            ),
+            patch("visualize_cluster_report.subprocess.run", side_effect=fake_run),
+        ):
             rendered, errors = render_cluster_videos(subsampled, str(tmp_path), workers=1)
             assert len(errors) == 1
             assert errors[0]["cluster_id"] == "cluster_id0"
@@ -186,12 +284,24 @@ class TestRenderClusterVideos:
 class TestGenerateHtmlReport:
     def test_creates_report_html(self, tmp_path):
         stats = [
-            {"cluster_id": "cluster_id0", "count": 90, "pct": 90.0,
-             "weight": 0.56, "sampling_rate": 0.5, "draws_per_epoch": 50,
-             "repeats_per_sample": 0.56},
-            {"cluster_id": "cluster_id1", "count": 10, "pct": 10.0,
-             "weight": 4.5, "sampling_rate": 0.5, "draws_per_epoch": 50,
-             "repeats_per_sample": 5.0},
+            {
+                "cluster_id": "cluster_id0",
+                "count": 90,
+                "pct": 90.0,
+                "weight": 0.56,
+                "sampling_rate": 0.5,
+                "draws_per_epoch": 50,
+                "repeats_per_sample": 0.56,
+            },
+            {
+                "cluster_id": "cluster_id1",
+                "count": 10,
+                "pct": 10.0,
+                "weight": 4.5,
+                "sampling_rate": 0.5,
+                "draws_per_epoch": 50,
+                "repeats_per_sample": 5.0,
+            },
         ]
         chart_uri = "data:image/png;base64,AAAA"
         rendered = {
@@ -213,17 +323,22 @@ class TestGenerateHtmlReport:
 
     def test_video_tags_use_relative_paths(self, tmp_path):
         stats = [
-            {"cluster_id": "cluster_id0", "count": 1, "pct": 100.0,
-             "weight": 1.0, "sampling_rate": 1.0, "draws_per_epoch": 1,
-             "repeats_per_sample": 1.0},
+            {
+                "cluster_id": "cluster_id0",
+                "count": 1,
+                "pct": 100.0,
+                "weight": 1.0,
+                "sampling_rate": 1.0,
+                "draws_per_epoch": 1,
+                "repeats_per_sample": 1.0,
+            },
         ]
         vid_path = tmp_path / "videos" / "cluster_id0" / "sample.mp4"
         vid_path.parent.mkdir(parents=True)
         vid_path.touch()
         rendered = {"cluster_id0": [str(vid_path)]}
         path = generate_html_report(
-            stats, "data:image/png;base64,AAAA", rendered, [],
-            "/fake/cluster.json", str(tmp_path)
+            stats, "data:image/png;base64,AAAA", rendered, [], "/fake/cluster.json", str(tmp_path)
         )
         html = Path(path).read_text()
         assert "videos/cluster_id0/sample.mp4" in html
@@ -234,6 +349,7 @@ class TestGenerateHtmlReport:
 class TestGetArgs:
     def test_required_args(self):
         from unittest.mock import patch
+
         with patch("sys.argv", ["prog", "--cluster_json", "/a.json", "--output_dir", "/out"]):
             args = get_args()
             assert args.cluster_json == "/a.json"
@@ -244,10 +360,50 @@ class TestGetArgs:
 
     def test_optional_args(self):
         from unittest.mock import patch
-        with patch("sys.argv", ["prog", "--cluster_json", "/a.json",
-                                "--output_dir", "/out", "--max_videos", "5",
-                                "--workers", "4", "--seed", "99"]):
+
+        with patch(
+            "sys.argv",
+            [
+                "prog",
+                "--cluster_json",
+                "/a.json",
+                "--output_dir",
+                "/out",
+                "--max_videos",
+                "5",
+                "--workers",
+                "4",
+                "--seed",
+                "99",
+            ],
+        ):
             args = get_args()
             assert args.max_videos == 5
             assert args.workers == 4
             assert args.seed == 99
+
+    def test_cluster_weight_alpha_default(self):
+        argv = [
+            "visualize_cluster_report.py",
+            "--cluster_json",
+            "/tmp/c.json",
+            "--output_dir",
+            "/tmp/out",
+        ]
+        with patch.object(sys, "argv", argv):
+            args = get_args()
+        assert args.cluster_weight_alpha == 1.0
+
+    def test_cluster_weight_alpha_override(self):
+        argv = [
+            "visualize_cluster_report.py",
+            "--cluster_json",
+            "/tmp/c.json",
+            "--output_dir",
+            "/tmp/out",
+            "--cluster_weight_alpha",
+            "0.25",
+        ]
+        with patch.object(sys, "argv", argv):
+            args = get_args()
+        assert args.cluster_weight_alpha == 0.25

--- a/diffusion_planner/tests/test_visualize_cluster_report.py
+++ b/diffusion_planner/tests/test_visualize_cluster_report.py
@@ -29,12 +29,12 @@ from unittest.mock import MagicMock, patch
 from visualize_cluster_report import (
     compute_cluster_stats,
     generate_html_report,
+    get_args,
     load_cluster_json,
     render_bar_chart,
     render_cluster_videos,
     subsample_cluster_paths,
 )
-
 
 
 class TestLoadClusterJson:
@@ -229,3 +229,25 @@ class TestGenerateHtmlReport:
         assert "videos/cluster_id0/sample.mp4" in html
         # Should NOT contain absolute path
         assert str(tmp_path) not in html.split('src="')[1].split('"')[0]
+
+
+class TestGetArgs:
+    def test_required_args(self):
+        from unittest.mock import patch
+        with patch("sys.argv", ["prog", "--cluster_json", "/a.json", "--output_dir", "/out"]):
+            args = get_args()
+            assert args.cluster_json == "/a.json"
+            assert args.output_dir == "/out"
+            assert args.max_videos == 3
+            assert args.workers == 1
+            assert args.seed == 42
+
+    def test_optional_args(self):
+        from unittest.mock import patch
+        with patch("sys.argv", ["prog", "--cluster_json", "/a.json",
+                                "--output_dir", "/out", "--max_videos", "5",
+                                "--workers", "4", "--seed", "99"]):
+            args = get_args()
+            assert args.max_videos == 5
+            assert args.workers == 4
+            assert args.seed == 99

--- a/diffusion_planner/tests/test_visualize_cluster_report.py
+++ b/diffusion_planner/tests/test_visualize_cluster_report.py
@@ -24,7 +24,7 @@ from pathlib import Path
 SAMPLING_DIR = Path(__file__).resolve().parent.parent / "sampling"
 sys.path.insert(0, str(SAMPLING_DIR))
 
-from visualize_cluster_report import compute_cluster_stats, load_cluster_json
+from visualize_cluster_report import compute_cluster_stats, load_cluster_json, render_bar_chart
 
 
 class TestLoadClusterJson:
@@ -82,3 +82,19 @@ class TestComputeClusterStats:
         stats = compute_cluster_stats(clusters)
         ids = [s["cluster_id"] for s in stats]
         assert ids == ["cluster_id0", "cluster_id1", "cluster_id2"]
+
+
+class TestRenderBarChart:
+    def test_returns_base64_data_uri(self):
+        stats = [
+            {"cluster_id": "cluster_id0", "count": 90, "pct": 90.0,
+             "weight": 0.5, "sampling_rate": 0.5, "draws_per_epoch": 50,
+             "repeats_per_sample": 0.56},
+            {"cluster_id": "cluster_id1", "count": 10, "pct": 10.0,
+             "weight": 4.5, "sampling_rate": 0.5, "draws_per_epoch": 50,
+             "repeats_per_sample": 5.0},
+        ]
+        result = render_bar_chart(stats)
+        assert result.startswith("data:image/png;base64,")
+        # Should be a reasonable-length base64 string
+        assert len(result) > 100

--- a/diffusion_planner/tests/test_visualize_cluster_report.py
+++ b/diffusion_planner/tests/test_visualize_cluster_report.py
@@ -140,6 +140,14 @@ class TestComputeClusterStats:
         with pytest.raises(ValueError, match="alpha"):
             compute_cluster_stats(clusters, alpha=float("nan"))
 
+    def test_inf_alpha_raises(self):
+        """inf must be rejected, matching the sampler: it would render an all-nan table."""
+        import pytest
+
+        clusters = {"cluster_id0": ["/a.npz"]}
+        with pytest.raises(ValueError, match="alpha"):
+            compute_cluster_stats(clusters, alpha=float("inf"))
+
     def test_report_weight_matches_sampler_weight(self):
         """The report must reproduce the sampler's multiplier exactly."""
         import json as _json

--- a/diffusion_planner/tests/test_visualize_cluster_report.py
+++ b/diffusion_planner/tests/test_visualize_cluster_report.py
@@ -24,7 +24,16 @@ from pathlib import Path
 SAMPLING_DIR = Path(__file__).resolve().parent.parent / "sampling"
 sys.path.insert(0, str(SAMPLING_DIR))
 
-from visualize_cluster_report import compute_cluster_stats, load_cluster_json, render_bar_chart
+from unittest.mock import MagicMock, patch
+
+from visualize_cluster_report import (
+    compute_cluster_stats,
+    load_cluster_json,
+    render_bar_chart,
+    render_cluster_videos,
+    subsample_cluster_paths,
+)
+
 
 
 class TestLoadClusterJson:
@@ -98,3 +107,76 @@ class TestRenderBarChart:
         assert result.startswith("data:image/png;base64,")
         # Should be a reasonable-length base64 string
         assert len(result) > 100
+
+
+class TestSubsampleClusterPaths:
+    def test_caps_at_max_videos(self):
+        clusters = {
+            "cluster_id0": [f"/a/{i}.npz" for i in range(100)],
+        }
+        result = subsample_cluster_paths(clusters, max_videos=3, seed=42)
+        assert len(result["cluster_id0"]) == 3
+
+    def test_keeps_all_if_under_max(self):
+        clusters = {
+            "cluster_id0": ["/a/0.npz", "/a/1.npz"],
+        }
+        result = subsample_cluster_paths(clusters, max_videos=5, seed=42)
+        assert len(result["cluster_id0"]) == 2
+
+    def test_deterministic_with_seed(self):
+        clusters = {"cluster_id0": [f"/a/{i}.npz" for i in range(50)]}
+        r1 = subsample_cluster_paths(clusters, max_videos=3, seed=42)
+        r2 = subsample_cluster_paths(clusters, max_videos=3, seed=42)
+        assert r1 == r2
+
+    def test_different_seed_different_result(self):
+        clusters = {"cluster_id0": [f"/a/{i}.npz" for i in range(50)]}
+        r1 = subsample_cluster_paths(clusters, max_videos=3, seed=42)
+        r2 = subsample_cluster_paths(clusters, max_videos=3, seed=99)
+        assert r1 != r2
+
+
+class TestRenderClusterVideos:
+    def test_calls_render_video_txt_per_cluster(self, tmp_path):
+        subsampled = {
+            "cluster_id0": ["/a/0.npz", "/a/1.npz"],
+            "cluster_id1": ["/b/0.npz"],
+        }
+        with patch("visualize_cluster_report.shutil.which", return_value="/usr/bin/render-video-txt"), \
+             patch("visualize_cluster_report.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            rendered, errors = render_cluster_videos(subsampled, str(tmp_path), workers=1)
+            assert mock_run.call_count == 2
+
+    def test_creates_cluster_subdirectories(self, tmp_path):
+        subsampled = {
+            "cluster_id0": ["/a/0.npz"],
+        }
+        with patch("visualize_cluster_report.shutil.which", return_value="/usr/bin/render-video-txt"), \
+             patch("visualize_cluster_report.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            rendered, errors = render_cluster_videos(subsampled, str(tmp_path), workers=1)
+            assert (tmp_path / "videos" / "cluster_id0").is_dir()
+
+    def test_checks_render_video_txt_available(self):
+        with patch("visualize_cluster_report.shutil.which", return_value=None):
+            import pytest
+            with pytest.raises(RuntimeError, match="render-video-txt not found"):
+                render_cluster_videos({"cluster_id0": ["/a.npz"]}, "/tmp/out", workers=1)
+
+    def test_collects_errors_from_render_log(self, tmp_path):
+        subsampled = {"cluster_id0": ["/a/0.npz"]}
+        log_content = '{"file": "a__0", "status": "error", "reason": "corrupt file"}\n'
+
+        def fake_run(cmd, **kwargs):
+            log_path = tmp_path / "videos" / "cluster_id0" / "render_log.jsonl"
+            log_path.write_text(log_content)
+            return MagicMock(returncode=0)
+
+        with patch("visualize_cluster_report.shutil.which", return_value="/usr/bin/render-video-txt"), \
+             patch("visualize_cluster_report.subprocess.run", side_effect=fake_run):
+            rendered, errors = render_cluster_videos(subsampled, str(tmp_path), workers=1)
+            assert len(errors) == 1
+            assert errors[0]["cluster_id"] == "cluster_id0"
+            assert errors[0]["reason"] == "corrupt file"

--- a/diffusion_planner/tests/test_visualize_cluster_report.py
+++ b/diffusion_planner/tests/test_visualize_cluster_report.py
@@ -28,6 +28,7 @@ from unittest.mock import MagicMock, patch
 
 from visualize_cluster_report import (
     compute_cluster_stats,
+    generate_html_report,
     load_cluster_json,
     render_bar_chart,
     render_cluster_videos,
@@ -180,3 +181,51 @@ class TestRenderClusterVideos:
             assert len(errors) == 1
             assert errors[0]["cluster_id"] == "cluster_id0"
             assert errors[0]["reason"] == "corrupt file"
+
+
+class TestGenerateHtmlReport:
+    def test_creates_report_html(self, tmp_path):
+        stats = [
+            {"cluster_id": "cluster_id0", "count": 90, "pct": 90.0,
+             "weight": 0.56, "sampling_rate": 0.5, "draws_per_epoch": 50,
+             "repeats_per_sample": 0.56},
+            {"cluster_id": "cluster_id1", "count": 10, "pct": 10.0,
+             "weight": 4.5, "sampling_rate": 0.5, "draws_per_epoch": 50,
+             "repeats_per_sample": 5.0},
+        ]
+        chart_uri = "data:image/png;base64,AAAA"
+        rendered = {
+            "cluster_id0": [str(tmp_path / "videos/cluster_id0/a.mp4")],
+            "cluster_id1": [],
+        }
+        errors = [{"cluster_id": "cluster_id1", "file": "b__0", "reason": "corrupt"}]
+        path = generate_html_report(
+            stats, chart_uri, rendered, errors, "/fake/cluster.json", str(tmp_path)
+        )
+        assert Path(path).exists()
+        html = Path(path).read_text()
+        assert "cluster_id0" in html
+        assert "cluster_id1" in html
+        assert "90.0" in html
+        assert 'preload="none"' in html
+        assert "Sampling Behavior" in html
+        assert "corrupt" in html
+
+    def test_video_tags_use_relative_paths(self, tmp_path):
+        stats = [
+            {"cluster_id": "cluster_id0", "count": 1, "pct": 100.0,
+             "weight": 1.0, "sampling_rate": 1.0, "draws_per_epoch": 1,
+             "repeats_per_sample": 1.0},
+        ]
+        vid_path = tmp_path / "videos" / "cluster_id0" / "sample.mp4"
+        vid_path.parent.mkdir(parents=True)
+        vid_path.touch()
+        rendered = {"cluster_id0": [str(vid_path)]}
+        path = generate_html_report(
+            stats, "data:image/png;base64,AAAA", rendered, [],
+            "/fake/cluster.json", str(tmp_path)
+        )
+        html = Path(path).read_text()
+        assert "videos/cluster_id0/sample.mp4" in html
+        # Should NOT contain absolute path
+        assert str(tmp_path) not in html.split('src="')[1].split('"')[0]

--- a/diffusion_planner/tests/test_visualize_cluster_report.py
+++ b/diffusion_planner/tests/test_visualize_cluster_report.py
@@ -21,6 +21,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+import pytest
+
 SAMPLING_DIR = Path(__file__).resolve().parent.parent / "sampling"
 sys.path.insert(0, str(SAMPLING_DIR))
 
@@ -49,7 +51,6 @@ class TestLoadClusterJson:
         assert result == data
 
     def test_raises_on_missing_file(self):
-        import pytest
 
         with pytest.raises(FileNotFoundError):
             load_cluster_json("/nonexistent/path.json")
@@ -126,7 +127,6 @@ class TestComputeClusterStats:
         assert compute_cluster_stats(clusters) == compute_cluster_stats(clusters, alpha=1.0)
 
     def test_negative_alpha_raises(self):
-        import pytest
 
         clusters = {"cluster_id0": ["/a.npz"]}
         with pytest.raises(ValueError, match="alpha"):
@@ -134,7 +134,6 @@ class TestComputeClusterStats:
 
     def test_nan_alpha_raises(self):
         """NaN must be rejected, matching the sampler: it would yield nan weights."""
-        import pytest
 
         clusters = {"cluster_id0": ["/a.npz"]}
         with pytest.raises(ValueError, match="alpha"):
@@ -142,7 +141,6 @@ class TestComputeClusterStats:
 
     def test_inf_alpha_raises(self):
         """inf must be rejected, matching the sampler: it would render an all-nan table."""
-        import pytest
 
         clusters = {"cluster_id0": ["/a.npz"]}
         with pytest.raises(ValueError, match="alpha"):
@@ -150,19 +148,16 @@ class TestComputeClusterStats:
 
     def test_report_weight_matches_sampler_weight(self):
         """The report must reproduce the sampler's multiplier exactly."""
-        import json as _json
-        import tempfile as _tempfile
-
         from diffusion_planner.utils.weighted_sampler import (
             ClusterWeightedDistributedSampler,
         )
 
         data_list = [f"/data/sample_{i}.npz" for i in range(100)]
         clusters = {"cluster_id0": data_list[:10], "cluster_id1": data_list[10:]}
-        with _tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory() as tmp:
             cluster_path = str(Path(tmp) / "clusters.json")
             with open(cluster_path, "w") as f:
-                _json.dump(clusters, f)
+                json.dump(clusters, f)
 
             for alpha in (1.0, 0.5, 0.0):
                 sampler = ClusterWeightedDistributedSampler(
@@ -244,7 +239,7 @@ class TestRenderClusterVideos:
             patch("visualize_cluster_report.subprocess.run") as mock_run,
         ):
             mock_run.return_value = MagicMock(returncode=0)
-            rendered, errors = render_cluster_videos(subsampled, str(tmp_path), workers=1)
+            render_cluster_videos(subsampled, str(tmp_path), workers=1)
             assert mock_run.call_count == 2
 
     def test_creates_cluster_subdirectories(self, tmp_path):
@@ -258,13 +253,11 @@ class TestRenderClusterVideos:
             patch("visualize_cluster_report.subprocess.run") as mock_run,
         ):
             mock_run.return_value = MagicMock(returncode=0)
-            rendered, errors = render_cluster_videos(subsampled, str(tmp_path), workers=1)
+            render_cluster_videos(subsampled, str(tmp_path), workers=1)
             assert (tmp_path / "videos" / "cluster_id0").is_dir()
 
     def test_checks_render_video_txt_available(self):
         with patch("visualize_cluster_report.shutil.which", return_value=None):
-            import pytest
-
             with pytest.raises(RuntimeError, match="render-video-txt not found"):
                 render_cluster_videos({"cluster_id0": ["/a.npz"]}, "/tmp/out", workers=1)
 
@@ -356,7 +349,6 @@ class TestGenerateHtmlReport:
 
 class TestGetArgs:
     def test_required_args(self):
-        from unittest.mock import patch
 
         with patch("sys.argv", ["prog", "--cluster_json", "/a.json", "--output_dir", "/out"]):
             args = get_args()
@@ -367,7 +359,6 @@ class TestGetArgs:
             assert args.seed == 42
 
     def test_optional_args(self):
-        from unittest.mock import patch
 
         with patch(
             "sys.argv",
@@ -415,3 +406,80 @@ class TestGetArgs:
         with patch.object(sys, "argv", argv):
             args = get_args()
         assert args.cluster_weight_alpha == 0.25
+
+
+class TestEmptyClusterRows:
+    def test_zero_count_clusters_are_dropped(self):
+        """An empty cluster would otherwise render weight ~1e8 -- a number training
+        never applies, because the sampler builds its multipliers from live matches
+        and omits empty clusters entirely. This report is read to pick alpha.
+        """
+        stats = compute_cluster_stats(
+            {"cluster_id0": [f"/a/{i}.npz" for i in range(100)], "cluster_id1": []}
+        )
+        assert [s["cluster_id"] for s in stats] == ["cluster_id0"]
+        assert stats[0]["weight"] == pytest.approx(1.0)
+
+    def test_all_empty_clusters_raise_like_the_sampler(self):
+        """ClusterWeightedDistributedSampler raises on an all-empty cluster JSON.
+        The report must not exit 0 with "Total samples: 0" -- it exists to catch
+        exactly this before a training launch."""
+        with pytest.raises(ValueError, match="no paths"):
+            compute_cluster_stats({"cluster_id0": [], "cluster_id1": []})
+        with pytest.raises(ValueError, match="no paths"):
+            compute_cluster_stats({})
+
+    def test_non_numeric_cluster_keys_are_tolerated(self):
+        """train.py's log sort deliberately never crashes on odd keys; the report
+        must not disagree with a bare ``invalid literal for int()``."""
+        stats = compute_cluster_stats(
+            {"cluster_id1": ["/a.npz"] * 10, "noise": ["/b.npz"] * 90, "cluster_id0": ["/c.npz"]}
+        )
+        # cluster_id<N> first in numeric order, non-conforming keys after.
+        assert [s["cluster_id"] for s in stats] == ["cluster_id0", "cluster_id1", "noise"]
+
+    def test_subsample_tolerates_non_numeric_keys(self):
+        result = subsample_cluster_paths(
+            {"noise": [f"/a/{i}.npz" for i in range(10)]}, max_videos=3, seed=42
+        )
+        assert len(result["noise"]) == 3
+        # crc32-based offset, so the pick is reproducible across processes.
+        again = subsample_cluster_paths(
+            {"noise": [f"/a/{i}.npz" for i in range(10)]}, max_videos=3, seed=42
+        )
+        assert result == again
+
+
+class TestRenderLogParsing:
+    def _run(self, tmp_path, log_lines):
+        subsampled = {"cluster_id0": ["/a/0.npz"]}
+
+        def fake_run(cmd, **kwargs):
+            log = Path(cmd[2]) / "render_log.jsonl"
+            log.write_text(log_lines)
+            return MagicMock(returncode=0)
+
+        with (
+            patch(
+                "visualize_cluster_report.shutil.which", return_value="/usr/bin/render-video-txt"
+            ),
+            patch("visualize_cluster_report.subprocess.run", side_effect=fake_run),
+        ):
+            return render_cluster_videos(subsampled, str(tmp_path), workers=1)
+
+    def test_blank_lines_do_not_discard_a_completed_render(self, tmp_path):
+        """render-video-txt is external; a trailing blank line must not raise
+        JSONDecodeError after every video has already been rendered."""
+        _, errors = self._run(
+            tmp_path, '{"status": "error", "file": "/a/0.npz", "reason": "corrupt"}\n\n'
+        )
+        assert len(errors) == 1
+        assert errors[0]["reason"] == "corrupt"
+
+    def test_malformed_line_warns_and_continues(self, tmp_path):
+        with pytest.warns(UserWarning, match="malformed render_log"):
+            _, errors = self._run(
+                tmp_path,
+                'not json\n{"status": "error", "file": "/a/0.npz", "reason": "corrupt"}\n',
+            )
+        assert len(errors) == 1

--- a/diffusion_planner/tests/test_visualize_cluster_report.py
+++ b/diffusion_planner/tests/test_visualize_cluster_report.py
@@ -1,0 +1,84 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for sampling/visualize_cluster_report.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+SAMPLING_DIR = Path(__file__).resolve().parent.parent / "sampling"
+sys.path.insert(0, str(SAMPLING_DIR))
+
+from visualize_cluster_report import compute_cluster_stats, load_cluster_json
+
+
+class TestLoadClusterJson:
+    def test_loads_valid_json(self, tmp_path):
+        data = {
+            "cluster_id0": ["/a/0.npz", "/a/1.npz"],
+            "cluster_id1": ["/a/2.npz"],
+        }
+        p = tmp_path / "clusters.json"
+        p.write_text(json.dumps(data))
+        result = load_cluster_json(str(p))
+        assert result == data
+
+    def test_raises_on_missing_file(self):
+        import pytest
+        with pytest.raises(FileNotFoundError):
+            load_cluster_json("/nonexistent/path.json")
+
+
+class TestComputeClusterStats:
+    def test_two_clusters(self):
+        clusters = {
+            "cluster_id0": [f"/a/{i}.npz" for i in range(90)],
+            "cluster_id1": [f"/b/{i}.npz" for i in range(10)],
+        }
+        stats = compute_cluster_stats(clusters)
+
+        assert len(stats) == 2
+        s0 = next(s for s in stats if s["cluster_id"] == "cluster_id0")
+        s1 = next(s for s in stats if s["cluster_id"] == "cluster_id1")
+
+        assert s0["count"] == 90
+        assert s1["count"] == 10
+        assert abs(s0["pct"] - 90.0) < 0.01
+        assert abs(s1["pct"] - 10.0) < 0.01
+
+        # Rare cluster should have higher weight
+        assert s1["weight"] > s0["weight"]
+
+        # Weights normalized to mean 1.0
+        mean_w = (s0["weight"] * 90 + s1["weight"] * 10) / 100
+        assert abs(mean_w - 1.0) < 0.01
+
+        # Expected draws: rare cluster gets more than natural 10%
+        assert s1["draws_per_epoch"] > 10
+        # Expected repeats: rare cluster repeats more per sample
+        assert s1["repeats_per_sample"] > s0["repeats_per_sample"]
+
+    def test_sorted_by_cluster_id(self):
+        clusters = {
+            "cluster_id2": ["/a.npz"],
+            "cluster_id0": ["/b.npz"],
+            "cluster_id1": ["/c.npz"],
+        }
+        stats = compute_cluster_stats(clusters)
+        ids = [s["cluster_id"] for s in stats]
+        assert ids == ["cluster_id0", "cluster_id1", "cluster_id2"]

--- a/diffusion_planner/tests/test_weighted_sampler.py
+++ b/diffusion_planner/tests/test_weighted_sampler.py
@@ -388,6 +388,68 @@ class TestAlpha:
                     data_list, cluster_path, num_replicas=1, rank=0, seed=42, alpha=-0.5
                 )
 
+    def test_nan_alpha_raises(self):
+        """NaN must be rejected up front: it would silently make every weight NaN."""
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(10)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            with pytest.raises(ValueError, match="alpha"):
+                ClusterWeightedDistributedSampler(
+                    data_list,
+                    cluster_path,
+                    num_replicas=1,
+                    rank=0,
+                    seed=42,
+                    alpha=float("nan"),
+                )
+
+    def test_softened_alpha_with_unmatched_paths_keeps_ordering(self):
+        """Regression guard on hunk ordering in ``_compute_weights``.
+
+        The neutral-weight assignment for unmatched paths must run BEFORE the
+        mean normalization, at *every* alpha -- not just the default. If someone
+        moves normalization above the neutral block in the softened path, the
+        unmatched weights stop landing between rare and common and this fails.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(10)]
+            clusters = {
+                "cluster_id0": data_list[:2],
+                "cluster_id1": data_list[2:6],
+            }
+            cluster_path = str(Path(tmp) / "clusters.json")
+            with open(cluster_path, "w") as f:
+                json.dump(clusters, f)
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                sampler = ClusterWeightedDistributedSampler(
+                    data_list, cluster_path, num_replicas=1, rank=0, seed=42, alpha=0.5
+                )
+
+            assert sampler.matched_count == 6
+            rare_weight = sampler.weights[0].item()
+            common_weight = sampler.weights[3].item()
+            unmatched_weight = sampler.weights[7].item()
+
+            assert rare_weight > unmatched_weight > common_weight, (
+                f"alpha=0.5: expected rare ({rare_weight:.3f}) > "
+                f"unmatched ({unmatched_weight:.3f}) > common ({common_weight:.3f})"
+            )
+            for i in range(6, 10):
+                assert sampler.weights[i].item() == pytest.approx(unmatched_weight)
+
+            # Assigning the neutral weight *before* normalization makes the overall
+            # mean equal the matched mean, so the neutral weight normalizes to
+            # exactly 1.0. Normalizing first leaves it at mean_matched / overall
+            # mean != 1.0. This is the assertion that pins the hunk order.
+            assert unmatched_weight == pytest.approx(1.0, rel=1e-9)
+            assert sampler.weights.mean().item() == pytest.approx(1.0, rel=1e-9)
+
+            # The softening must still be in effect (full inverse would give 2.0).
+            assert rare_weight / common_weight == pytest.approx(2.0**0.5, rel=1e-4)
+
     def test_cluster_multipliers_match_normalized_weights(self):
         with tempfile.TemporaryDirectory() as tmp:
             data_list = [f"/data/sample_{i}.npz" for i in range(100)]
@@ -405,17 +467,39 @@ class TestAlpha:
                 sampler.weights[2].item()
             )
 
-    def test_multipliers_average_to_one(self):
-        """Multipliers weighted by cluster size average to 1.0 — no net inflation."""
+    def test_multipliers_predict_observed_draw_counts(self):
+        """A multiplier must be the *observed* oversampling factor, not just a number.
+
+        Draws are accumulated over many epochs and compared against
+        ``multiplier * cluster_size`` draws per epoch. This is what makes the
+        multiplier meaningful for tuning alpha, and it fails if the recorded
+        multipliers ever drift from the weights actually handed to
+        ``torch.multinomial`` (e.g. if they were captured before normalization).
+        """
+        n_epochs = 100
         with tempfile.TemporaryDirectory() as tmp:
             data_list = [f"/data/sample_{i}.npz" for i in range(100)]
-            cluster_path, _ = _make_cluster_json(tmp, data_list)
+            cluster_path, clusters = _make_cluster_json(tmp, data_list)
 
             sampler = ClusterWeightedDistributedSampler(
                 data_list, cluster_path, num_replicas=1, rank=0, seed=42, alpha=0.5
             )
-            weighted = sum(
-                sampler.cluster_multipliers[cid] * count
-                for cid, count in sampler.cluster_counts.items()
-            )
-            assert weighted / len(data_list) == pytest.approx(1.0, rel=1e-6)
+            index_to_cluster = {
+                data_list.index(p): cid for cid, paths in clusters.items() for p in paths
+            }
+
+            observed = {cid: 0 for cid in clusters}
+            for epoch in range(n_epochs):
+                sampler.set_epoch(epoch)
+                for idx in sampler:
+                    observed[index_to_cluster[idx]] += 1
+
+            total_draws = sum(observed.values())
+            assert total_draws == n_epochs * len(data_list)
+
+            for cid, count in sampler.cluster_counts.items():
+                expected = sampler.cluster_multipliers[cid] * count * n_epochs
+                assert observed[cid] == pytest.approx(expected, rel=0.08), (
+                    f"{cid}: multiplier {sampler.cluster_multipliers[cid]:.3f} predicts "
+                    f"{expected:.0f} draws over {n_epochs} epochs, observed {observed[cid]}"
+                )

--- a/diffusion_planner/tests/test_weighted_sampler.py
+++ b/diffusion_planner/tests/test_weighted_sampler.py
@@ -239,3 +239,30 @@ class TestEdgeCases:
             )
             assert sampler.cluster_counts == {"cluster_id0": 2, "cluster_id1": 18}
             assert sampler.matched_count == 20
+
+    def test_prefix_mismatched_paths_still_match(self):
+        """Cluster JSON with different path prefix still matches via canonicalization."""
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [
+                f"data/train/20230101/1200/frame_{i}.npz" for i in range(10)
+            ]
+            clusters = {
+                "cluster_id0": [
+                    f"/mnt/nfs/data/train/20230101/1200/frame_{i}.npz"
+                    for i in range(2)
+                ],
+                "cluster_id1": [
+                    f"/mnt/nfs/data/train/20230101/1200/frame_{i}.npz"
+                    for i in range(2, 10)
+                ],
+            }
+            cluster_path = str(Path(tmp) / "clusters.json")
+            with open(cluster_path, "w") as f:
+                json.dump(clusters, f)
+
+            sampler = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42
+            )
+            assert sampler.matched_count == 10, (
+                f"Expected all 10 paths to match, got {sampler.matched_count}"
+            )

--- a/diffusion_planner/tests/test_weighted_sampler.py
+++ b/diffusion_planner/tests/test_weighted_sampler.py
@@ -4,7 +4,6 @@ import warnings
 from pathlib import Path
 
 import pytest
-
 from diffusion_planner.utils.weighted_sampler import ClusterWeightedDistributedSampler
 
 
@@ -131,6 +130,25 @@ class TestDDP:
             )
             assert len(list(s0)) == 11
             assert len(list(s1)) == 11
+
+    def test_tiny_dataset_ddp_equal_shards(self):
+        """Every rank gets equal shard length even when total_size < num_replicas."""
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(2)]
+            clusters = {"cluster_id0": data_list[:1], "cluster_id1": data_list[1:]}
+            cluster_path = str(Path(tmp) / "clusters.json")
+            with open(cluster_path, "w") as f:
+                json.dump(clusters, f)
+
+            num_replicas = 8
+            for rank in range(num_replicas):
+                sampler = ClusterWeightedDistributedSampler(
+                    data_list, cluster_path, num_replicas=num_replicas, rank=rank, seed=42
+                )
+                indices = list(sampler)
+                assert len(indices) == sampler.num_samples, (
+                    f"Rank {rank}: got {len(indices)} indices, expected {sampler.num_samples}"
+                )
 
     def test_set_epoch_changes_order(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/diffusion_planner/tests/test_weighted_sampler.py
+++ b/diffusion_planner/tests/test_weighted_sampler.py
@@ -4,6 +4,7 @@ import warnings
 from pathlib import Path
 
 import pytest
+import torch
 from diffusion_planner.utils.weighted_sampler import ClusterWeightedDistributedSampler
 
 
@@ -201,9 +202,7 @@ class TestEdgeCases:
                 sampler = ClusterWeightedDistributedSampler(
                     data_list, cluster_path, num_replicas=1, rank=0, seed=42
                 )
-                matching_warnings = [
-                    x for x in w if "paths matched cluster JSON" in str(x.message)
-                ]
+                matching_warnings = [x for x in w if "paths matched cluster JSON" in str(x.message)]
                 assert len(matching_warnings) == 1
 
             assert len(sampler.weights) == 10
@@ -299,17 +298,13 @@ class TestEdgeCases:
     def test_prefix_mismatched_paths_still_match(self):
         """Cluster JSON with different path prefix still matches via canonicalization."""
         with tempfile.TemporaryDirectory() as tmp:
-            data_list = [
-                f"data/train/20230101/1200/frame_{i}.npz" for i in range(10)
-            ]
+            data_list = [f"data/train/20230101/1200/frame_{i}.npz" for i in range(10)]
             clusters = {
                 "cluster_id0": [
-                    f"/mnt/nfs/data/train/20230101/1200/frame_{i}.npz"
-                    for i in range(2)
+                    f"/mnt/nfs/data/train/20230101/1200/frame_{i}.npz" for i in range(2)
                 ],
                 "cluster_id1": [
-                    f"/mnt/nfs/data/train/20230101/1200/frame_{i}.npz"
-                    for i in range(2, 10)
+                    f"/mnt/nfs/data/train/20230101/1200/frame_{i}.npz" for i in range(2, 10)
                 ],
             }
             cluster_path = str(Path(tmp) / "clusters.json")
@@ -322,3 +317,105 @@ class TestEdgeCases:
             assert sampler.matched_count == 10, (
                 f"Expected all 10 paths to match, got {sampler.matched_count}"
             )
+
+
+class TestAlpha:
+    def test_default_alpha_is_one(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(100)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            default = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42
+            )
+            explicit = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42, alpha=1.0
+            )
+            assert default.alpha == 1.0
+            assert torch.equal(default.weights, explicit.weights)
+
+    def test_alpha_zero_gives_uniform_weights(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(100)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            sampler = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42, alpha=0.0
+            )
+            for w in sampler.weights.tolist():
+                assert w == pytest.approx(1.0)
+
+    def test_alpha_half_is_sqrt_of_full_ratio(self):
+        """The rare/common weight ratio must go from R to R**alpha."""
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(100)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            full = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42, alpha=1.0
+            )
+            half = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42, alpha=0.5
+            )
+            # index 0 is in the rare cluster (2 samples), index 2 in the common one (98)
+            ratio_full = full.weights[0].item() / full.weights[2].item()
+            ratio_half = half.weights[0].item() / half.weights[2].item()
+
+            assert ratio_full == pytest.approx(49.0, rel=1e-4)
+            assert ratio_half == pytest.approx(ratio_full**0.5, rel=1e-4)
+
+    def test_alpha_reduces_oversampling_multiplier(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(100)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            full = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42, alpha=1.0
+            )
+            soft = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42, alpha=0.25
+            )
+            assert soft.cluster_multipliers["cluster_id0"] < full.cluster_multipliers["cluster_id0"]
+            assert soft.cluster_multipliers["cluster_id0"] > 1.0
+
+    def test_negative_alpha_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(10)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            with pytest.raises(ValueError, match="alpha"):
+                ClusterWeightedDistributedSampler(
+                    data_list, cluster_path, num_replicas=1, rank=0, seed=42, alpha=-0.5
+                )
+
+    def test_cluster_multipliers_match_normalized_weights(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(100)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            sampler = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42
+            )
+            assert set(sampler.cluster_multipliers) == {"cluster_id0", "cluster_id1"}
+            # index 0 -> cluster_id0, index 2 -> cluster_id1
+            assert sampler.cluster_multipliers["cluster_id0"] == pytest.approx(
+                sampler.weights[0].item()
+            )
+            assert sampler.cluster_multipliers["cluster_id1"] == pytest.approx(
+                sampler.weights[2].item()
+            )
+
+    def test_multipliers_average_to_one(self):
+        """Multipliers weighted by cluster size average to 1.0 — no net inflation."""
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(100)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            sampler = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42, alpha=0.5
+            )
+            weighted = sum(
+                sampler.cluster_multipliers[cid] * count
+                for cid, count in sampler.cluster_counts.items()
+            )
+            assert weighted / len(data_list) == pytest.approx(1.0, rel=1e-6)

--- a/diffusion_planner/tests/test_weighted_sampler.py
+++ b/diffusion_planner/tests/test_weighted_sampler.py
@@ -404,6 +404,27 @@ class TestAlpha:
                     alpha=float("nan"),
                 )
 
+    def test_inf_alpha_raises(self):
+        """inf must be rejected at construction, not at the first __iter__.
+
+        ``inf`` passes ``alpha >= 0``, but makes every weight NaN (inf/inf) and
+        only fails later inside torch.multinomial -- after model init and dataset
+        load, wasting a training launch.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(10)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            with pytest.raises(ValueError, match="alpha"):
+                ClusterWeightedDistributedSampler(
+                    data_list,
+                    cluster_path,
+                    num_replicas=1,
+                    rank=0,
+                    seed=42,
+                    alpha=float("inf"),
+                )
+
     def test_softened_alpha_with_unmatched_paths_keeps_ordering(self):
         """Regression guard on hunk ordering in ``_compute_weights``.
 

--- a/diffusion_planner/tests/test_weighted_sampler.py
+++ b/diffusion_planner/tests/test_weighted_sampler.py
@@ -524,3 +524,169 @@ class TestAlpha:
                     f"{cid}: multiplier {sampler.cluster_multipliers[cid]:.3f} predicts "
                     f"{expected:.0f} draws over {n_epochs} epochs, observed {observed[cid]}"
                 )
+
+
+class TestShardConfigValidation:
+    """A bad rank/num_replicas must crash, not silently hand out a short shard.
+
+    ``indices[rank::num_replicas]`` yields fewer indices than ``__len__`` reports
+    when ``rank >= num_replicas``. That rank then runs fewer optimizer steps than
+    its peers and the whole job hangs on the next collective until the NCCL
+    timeout -- hours into a multi-node run, with nothing in the logs explaining why.
+    """
+
+    def test_rank_at_or_above_num_replicas_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(10)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            with pytest.raises(ValueError, match="rank"):
+                ClusterWeightedDistributedSampler(
+                    data_list, cluster_path, num_replicas=4, rank=4, seed=42
+                )
+
+    def test_negative_rank_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(10)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            with pytest.raises(ValueError, match="rank"):
+                ClusterWeightedDistributedSampler(
+                    data_list, cluster_path, num_replicas=4, rank=-1, seed=42
+                )
+
+    def test_zero_num_replicas_raises(self):
+        """Without the guard this is a bare ZeroDivisionError from math.ceil."""
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(10)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            with pytest.raises(ValueError, match="num_replicas"):
+                ClusterWeightedDistributedSampler(
+                    data_list, cluster_path, num_replicas=0, rank=0, seed=42
+                )
+
+    def test_shard_length_matches_len_for_every_valid_rank(self):
+        """``__len__`` must not lie for any accepted rank -- DDP requires equal steps."""
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(103)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            for rank in range(4):
+                sampler = ClusterWeightedDistributedSampler(
+                    data_list, cluster_path, num_replicas=4, rank=rank, seed=42
+                )
+                assert len(list(sampler)) == len(sampler)
+
+
+class TestAlphaUpperBound:
+    """alpha > 1 inverts the weighting and silently collapses the epoch.
+
+    Draws per cluster scale as ``matched ** alpha * n_c ** (1 - alpha)``, so above
+    alpha=1 the largest cluster is starved. On an 18,000 + 10 split over 18,010
+    draws: alpha=1.0 -> 8,935/9,075 (6,991 distinct), alpha=2.0 -> 7/18,003
+    (17 distinct), alpha=5.0 -> 0/18,010 (10 distinct). Nothing raised before this
+    guard; loss falls because the model memorizes.
+    """
+
+    @pytest.mark.parametrize("alpha", [1.0001, 2.0, 5.0, 200.0])
+    def test_alpha_above_one_raises(self, alpha):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(1000)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            with pytest.raises(ValueError, match="alpha"):
+                ClusterWeightedDistributedSampler(
+                    data_list, cluster_path, num_replicas=1, rank=0, seed=42, alpha=alpha
+                )
+
+    @pytest.mark.parametrize("alpha", [0.0, 0.25, 0.5, 1.0])
+    def test_alpha_within_bounds_accepted(self, alpha):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(100)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            sampler = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42, alpha=alpha
+            )
+            assert sampler.alpha == alpha
+
+
+class TestDuplicateClusterAssignment:
+    def test_path_in_two_clusters_raises(self):
+        """Last-write-wins would silently decide the cluster by JSON iteration order,
+        while matched_count still reports a full match."""
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/train/loc/train/d/t/sample_{i}.npz" for i in range(10)]
+            clusters = {
+                "cluster_id0": data_list[:5],
+                "cluster_id1": data_list[4:],  # sample_4 claimed twice
+            }
+            cluster_path = str(Path(tmp) / "clusters.json")
+            with open(cluster_path, "w") as f:
+                json.dump(clusters, f)
+
+            with pytest.raises(ValueError, match="more than"):
+                ClusterWeightedDistributedSampler(
+                    data_list, cluster_path, num_replicas=1, rank=0, seed=42
+                )
+
+    def test_canonical_key_collision_across_roots_raises(self):
+        """``data_path_to_rel`` anchors on the first train/valid component, so two
+        NPZs under different dataset roots can collapse to one key."""
+        with tempfile.TemporaryDirectory() as tmp:
+            a = "/mnt/nvme1/dsA/loc/train/20240101/120000/0001.npz"
+            b = "/mnt/rdma/dsB/loc/train/20240101/120000/0001.npz"
+            clusters = {"cluster_id0": [a], "cluster_id1": [b]}
+            cluster_path = str(Path(tmp) / "clusters.json")
+            with open(cluster_path, "w") as f:
+                json.dump(clusters, f)
+
+            with pytest.raises(ValueError, match="more than"):
+                ClusterWeightedDistributedSampler(
+                    [a, b], cluster_path, num_replicas=1, rank=0, seed=42
+                )
+
+    def test_same_path_repeated_within_one_cluster_is_allowed(self):
+        """A duplicate inside a single cluster is not ambiguous -- do not reject it."""
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(10)]
+            clusters = {"cluster_id0": data_list[:2] + data_list[:2], "cluster_id1": data_list[2:]}
+            cluster_path = str(Path(tmp) / "clusters.json")
+            with open(cluster_path, "w") as f:
+                json.dump(clusters, f)
+
+            sampler = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42
+            )
+            assert sampler.matched_count == 10
+
+
+class TestRanksPartitionOneStream:
+    def test_interleaved_shards_reconstruct_single_rank_stream(self):
+        """Every rank must draw the SAME global sequence and slice it by stride.
+
+        ``__iter__`` seeds only on ``seed + epoch`` deliberately -- no rank term.
+        Without this test, adding a ``+ rank`` to the seed still passes every other
+        DDP test (shards still differ, lengths still match) while silently giving
+        each rank its own overlapping sample stream.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(20)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            reference = list(
+                ClusterWeightedDistributedSampler(
+                    data_list, cluster_path, num_replicas=1, rank=0, seed=42
+                )
+            )
+            shards = [
+                list(
+                    ClusterWeightedDistributedSampler(
+                        data_list, cluster_path, num_replicas=2, rank=r, seed=42
+                    )
+                )
+                for r in range(2)
+            ]
+            interleaved = [idx for pair in zip(*shards) for idx in pair]
+            assert interleaved == reference

--- a/diffusion_planner/tests/test_weighted_sampler.py
+++ b/diffusion_planner/tests/test_weighted_sampler.py
@@ -166,6 +166,21 @@ class TestDDP:
 
 
 class TestEdgeCases:
+    def test_multinomial_size_guard(self):
+        """Datasets exceeding torch.multinomial's 2^24 category limit are rejected early."""
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(5)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            class BigList(list):
+                def __len__(self):
+                    return 2**24 + 1
+
+            with pytest.raises(ValueError, match="2\\^24"):
+                ClusterWeightedDistributedSampler(
+                    BigList(data_list), cluster_path, num_replicas=1, rank=0
+                )
+
     def test_missing_paths_get_neutral_weight(self):
         """Paths not in any cluster get the mean of matched weights (neutral rate).
 

--- a/diffusion_planner/tests/test_weighted_sampler.py
+++ b/diffusion_planner/tests/test_weighted_sampler.py
@@ -690,3 +690,109 @@ class TestRanksPartitionOneStream:
             ]
             interleaved = [idx for pair in zip(*shards) for idx in pair]
             assert interleaved == reference
+
+
+class TestRepeatFlags:
+    def test_repeat_flags_none_when_not_tracking(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(20)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+            sampler = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42
+            )
+            list(iter(sampler))
+            assert sampler.repeat_flags is None
+            assert sampler.repeat_flags_epoch is None
+
+    def test_repeat_flags_length_matches_num_samples(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(20)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+            sampler = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42, track_repeats=True
+            )
+            list(iter(sampler))
+            assert len(sampler.repeat_flags) == sampler.num_samples
+            assert sampler.repeat_flags_epoch == 0
+
+    def test_first_occurrence_false_later_true(self):
+        """Flag i is True iff indices[i] appeared earlier in the same epoch."""
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(20)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+            sampler = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42, track_repeats=True
+            )
+            indices = list(iter(sampler))
+            seen = set()
+            expected = []
+            for idx in indices:
+                expected.append(idx in seen)
+                seen.add(idx)
+            assert sampler.repeat_flags == expected
+
+    def test_some_repeats_actually_occur(self):
+        """Guard against a vacuous test: with 2 rare of 20, replacement must repeat."""
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(20)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+            sampler = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42, track_repeats=True
+            )
+            list(iter(sampler))
+            assert any(sampler.repeat_flags), "expected at least one repeat draw"
+
+    def test_deterministic_for_same_seed_and_epoch(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(20)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+            kwargs = dict(num_replicas=1, rank=0, seed=42, track_repeats=True)
+            a = ClusterWeightedDistributedSampler(data_list, cluster_path, **kwargs)
+            b = ClusterWeightedDistributedSampler(data_list, cluster_path, **kwargs)
+            list(iter(a))
+            list(iter(b))
+            assert a.repeat_flags == b.repeat_flags
+
+    def test_flags_change_across_epochs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(20)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+            sampler = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42, track_repeats=True
+            )
+            list(iter(sampler))
+            epoch0 = list(sampler.repeat_flags)
+            sampler.set_epoch(1)
+            list(iter(sampler))
+            assert sampler.repeat_flags_epoch == 1
+            assert sampler.repeat_flags != epoch0
+
+    def test_dedup_is_global_across_ranks(self):
+        """A sample drawn on two ranks yields one first occurrence, not two.
+
+        Ordinals must be computed BEFORE sharding. Interleaving the two ranks'
+        flags must reconstruct the global first-occurrence pattern.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(20)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+            r0 = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=2, rank=0, seed=42, track_repeats=True
+            )
+            r1 = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=2, rank=1, seed=42, track_repeats=True
+            )
+            idx0, idx1 = list(iter(r0)), list(iter(r1))
+
+            global_indices, global_flags = [], []
+            for a, b in zip(idx0, idx1):
+                global_indices.extend([a, b])
+            for a, b in zip(r0.repeat_flags, r1.repeat_flags):
+                global_flags.extend([a, b])
+
+            seen = set()
+            expected = []
+            for idx in global_indices:
+                expected.append(idx in seen)
+                seen.add(idx)
+            assert global_flags == expected

--- a/diffusion_planner/tests/test_weighted_sampler.py
+++ b/diffusion_planner/tests/test_weighted_sampler.py
@@ -2,7 +2,6 @@ import json
 import tempfile
 from pathlib import Path
 
-import pytest
 from diffusion_planner.utils.weighted_sampler import ClusterWeightedDistributedSampler
 
 

--- a/diffusion_planner/tests/test_weighted_sampler.py
+++ b/diffusion_planner/tests/test_weighted_sampler.py
@@ -199,6 +199,20 @@ class TestEdgeCases:
             for i in range(6, 10):
                 assert sampler.weights[i].item() == unmatched_weight
 
+    def test_all_empty_clusters_raises_valueerror(self):
+        """All-empty cluster JSON should raise ValueError, not ZeroDivisionError."""
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(5)]
+            clusters = {"cluster_id0": [], "cluster_id1": []}
+            cluster_path = str(Path(tmp) / "clusters.json")
+            with open(cluster_path, "w") as f:
+                json.dump(clusters, f)
+
+            with pytest.raises(ValueError, match="Cluster JSON contains no paths"):
+                ClusterWeightedDistributedSampler(
+                    data_list, cluster_path, num_replicas=1, rank=0, seed=42
+                )
+
     def test_no_matching_paths_raises_error(self):
         with tempfile.TemporaryDirectory() as tmp:
             data_list = [f"/data/sample_{i}.npz" for i in range(5)]

--- a/diffusion_planner/tests/test_weighted_sampler.py
+++ b/diffusion_planner/tests/test_weighted_sampler.py
@@ -166,11 +166,10 @@ class TestDDP:
 
 
 class TestEdgeCases:
-    def test_missing_paths_get_default_weight(self):
-        """Paths not in any cluster get pre-normalization weight 1.0.
+    def test_missing_paths_get_neutral_weight(self):
+        """Paths not in any cluster get the mean of matched weights (neutral rate).
 
-        After normalization, clustered paths are upweighted relative to
-        unclustered ones, so unmatched paths end up with the lowest weight.
+        After normalization: rare > unmatched > common.
         """
         with tempfile.TemporaryDirectory() as tmp:
             data_list = [f"/data/sample_{i}.npz" for i in range(10)]
@@ -182,9 +181,16 @@ class TestEdgeCases:
             with open(cluster_path, "w") as f:
                 json.dump(clusters, f)
 
-            sampler = ClusterWeightedDistributedSampler(
-                data_list, cluster_path, num_replicas=1, rank=0, seed=42
-            )
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                sampler = ClusterWeightedDistributedSampler(
+                    data_list, cluster_path, num_replicas=1, rank=0, seed=42
+                )
+                matching_warnings = [
+                    x for x in w if "paths matched cluster JSON" in str(x.message)
+                ]
+                assert len(matching_warnings) == 1
+
             assert len(sampler.weights) == 10
             assert sampler.matched_count == 6
 
@@ -192,12 +198,12 @@ class TestEdgeCases:
             common_weight = sampler.weights[3].item()
             unmatched_weight = sampler.weights[7].item()
 
-            assert rare_weight > common_weight > unmatched_weight, (
-                f"Expected rare ({rare_weight:.3f}) > common ({common_weight:.3f}) "
-                f"> unmatched ({unmatched_weight:.3f})"
+            assert rare_weight > unmatched_weight > common_weight, (
+                f"Expected rare ({rare_weight:.3f}) > unmatched ({unmatched_weight:.3f}) "
+                f"> common ({common_weight:.3f})"
             )
             for i in range(6, 10):
-                assert sampler.weights[i].item() == unmatched_weight
+                assert sampler.weights[i].item() == pytest.approx(unmatched_weight)
 
     def test_all_empty_clusters_raises_valueerror(self):
         """All-empty cluster JSON should raise ValueError, not ZeroDivisionError."""

--- a/diffusion_planner/tests/test_weighted_sampler.py
+++ b/diffusion_planner/tests/test_weighted_sampler.py
@@ -1,0 +1,135 @@
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+from diffusion_planner.utils.weighted_sampler import ClusterWeightedDistributedSampler
+
+
+def _make_cluster_json(tmp_dir: str, data_list: list[str]) -> tuple[str, dict]:
+    """Create a cluster JSON where first 2 paths are 'rare' and rest are 'common'."""
+    clusters = {
+        "cluster_id0": data_list[:2],
+        "cluster_id1": data_list[2:],
+    }
+    path = str(Path(tmp_dir) / "clusters.json")
+    with open(path, "w") as f:
+        json.dump(clusters, f)
+    return path, clusters
+
+
+class TestWeightComputation:
+    def test_rare_cluster_gets_higher_weight(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(20)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            sampler = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42
+            )
+
+            rare_weight = sampler.weights[0].item()
+            common_weight = sampler.weights[2].item()
+            assert rare_weight > common_weight, (
+                f"Rare cluster weight {rare_weight} should be > common {common_weight}"
+            )
+
+    def test_weights_length_matches_dataset(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(10)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            sampler = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42
+            )
+            assert len(sampler.weights) == len(data_list)
+
+
+class TestIteration:
+    def test_yields_correct_count(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(20)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            sampler = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42
+            )
+            indices = list(sampler)
+            assert len(indices) == len(data_list)
+
+    def test_indices_in_range(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(20)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            sampler = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42
+            )
+            indices = list(sampler)
+            assert all(0 <= idx < len(data_list) for idx in indices)
+
+    def test_rare_cluster_sampled_more(self):
+        """Over many samples, rare cluster indices should appear more than their natural rate."""
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(100)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            sampler = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42
+            )
+            indices = list(sampler)
+            rare_count = sum(1 for idx in indices if idx < 2)
+            # Natural rate is 2/100 = 2%. With inverse-frequency weighting,
+            # rare cluster should be sampled at ~50% (2 clusters, equal weight).
+            assert rare_count > 10, (
+                f"Rare cluster appeared {rare_count} times in 100 samples, expected >> 2"
+            )
+
+
+class TestDDP:
+    def test_two_ranks_cover_full_dataset_size(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(20)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            s0 = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=2, rank=0, seed=42
+            )
+            s1 = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=2, rank=1, seed=42
+            )
+            i0, i1 = list(s0), list(s1)
+            assert len(i0) == 10
+            assert len(i1) == 10
+
+    def test_set_epoch_changes_order(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(50)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            sampler = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42
+            )
+            sampler.set_epoch(0)
+            indices_e0 = list(sampler)
+            sampler.set_epoch(1)
+            indices_e1 = list(sampler)
+            assert indices_e0 != indices_e1, "Different epochs should produce different orderings"
+
+
+class TestEdgeCases:
+    def test_missing_paths_get_default_weight(self):
+        """Paths not in cluster JSON get weight 1.0 (neutral)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(5)]
+            clusters = {"cluster_id0": data_list[:2]}
+            cluster_path = str(Path(tmp) / "clusters.json")
+            with open(cluster_path, "w") as f:
+                json.dump(clusters, f)
+
+            sampler = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42
+            )
+            assert len(sampler.weights) == 5
+            indices = list(sampler)
+            assert len(indices) == 5

--- a/diffusion_planner/tests/test_weighted_sampler.py
+++ b/diffusion_planner/tests/test_weighted_sampler.py
@@ -240,6 +240,27 @@ class TestEdgeCases:
             assert sampler.cluster_counts == {"cluster_id0": 2, "cluster_id1": 18}
             assert sampler.matched_count == 20
 
+    def test_cluster_counts_reflect_live_data_list(self):
+        """cluster_counts should reflect the live data_list, not raw JSON totals."""
+        with tempfile.TemporaryDirectory() as tmp:
+            all_paths = [f"/data/sample_{i}.npz" for i in range(20)]
+            clusters = {
+                "cluster_id0": all_paths[:10],
+                "cluster_id1": all_paths[10:],
+            }
+            cluster_path = str(Path(tmp) / "clusters.json")
+            with open(cluster_path, "w") as f:
+                json.dump(clusters, f)
+
+            # data_list only includes 2 from cluster_id0 and 8 from cluster_id1
+            data_list = all_paths[:2] + all_paths[10:18]
+
+            sampler = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42
+            )
+            assert sampler.cluster_counts == {"cluster_id0": 2, "cluster_id1": 8}
+            assert sampler.matched_count == 10
+
     def test_prefix_mismatched_paths_still_match(self):
         """Cluster JSON with different path prefix still matches via canonicalization."""
         with tempfile.TemporaryDirectory() as tmp:

--- a/diffusion_planner/tests/test_weighted_sampler.py
+++ b/diffusion_planner/tests/test_weighted_sampler.py
@@ -1,6 +1,9 @@
 import json
 import tempfile
+import warnings
 from pathlib import Path
+
+import pytest
 
 from diffusion_planner.utils.weighted_sampler import ClusterWeightedDistributedSampler
 
@@ -101,6 +104,34 @@ class TestDDP:
             assert len(i0) == 10
             assert len(i1) == 10
 
+    def test_two_ranks_get_different_shards(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(20)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            s0 = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=2, rank=0, seed=42
+            )
+            s1 = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=2, rank=1, seed=42
+            )
+            i0, i1 = list(s0), list(s1)
+            assert i0 != i1, "Different ranks should receive different index shards"
+
+    def test_padding_with_non_divisible_size(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(21)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            s0 = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=2, rank=0, seed=42
+            )
+            s1 = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=2, rank=1, seed=42
+            )
+            assert len(list(s0)) == 11
+            assert len(list(s1)) == 11
+
     def test_set_epoch_changes_order(self):
         with tempfile.TemporaryDirectory() as tmp:
             data_list = [f"/data/sample_{i}.npz" for i in range(50)]
@@ -118,10 +149,17 @@ class TestDDP:
 
 class TestEdgeCases:
     def test_missing_paths_get_default_weight(self):
-        """Paths not in cluster JSON get weight 1.0 (neutral)."""
+        """Paths not in any cluster get pre-normalization weight 1.0.
+
+        After normalization, clustered paths are upweighted relative to
+        unclustered ones, so unmatched paths end up with the lowest weight.
+        """
         with tempfile.TemporaryDirectory() as tmp:
-            data_list = [f"/data/sample_{i}.npz" for i in range(5)]
-            clusters = {"cluster_id0": data_list[:2]}
+            data_list = [f"/data/sample_{i}.npz" for i in range(10)]
+            clusters = {
+                "cluster_id0": data_list[:2],
+                "cluster_id1": data_list[2:6],
+            }
             cluster_path = str(Path(tmp) / "clusters.json")
             with open(cluster_path, "w") as f:
                 json.dump(clusters, f)
@@ -129,6 +167,57 @@ class TestEdgeCases:
             sampler = ClusterWeightedDistributedSampler(
                 data_list, cluster_path, num_replicas=1, rank=0, seed=42
             )
-            assert len(sampler.weights) == 5
-            indices = list(sampler)
-            assert len(indices) == 5
+            assert len(sampler.weights) == 10
+            assert sampler.matched_count == 6
+
+            rare_weight = sampler.weights[0].item()
+            common_weight = sampler.weights[3].item()
+            unmatched_weight = sampler.weights[7].item()
+
+            assert rare_weight > common_weight > unmatched_weight, (
+                f"Expected rare ({rare_weight:.3f}) > common ({common_weight:.3f}) "
+                f"> unmatched ({unmatched_weight:.3f})"
+            )
+            for i in range(6, 10):
+                assert sampler.weights[i].item() == unmatched_weight
+
+    def test_no_matching_paths_raises_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(5)]
+            clusters = {"cluster_id0": ["/other/path_0.npz", "/other/path_1.npz"]}
+            cluster_path = str(Path(tmp) / "clusters.json")
+            with open(cluster_path, "w") as f:
+                json.dump(clusters, f)
+
+            with pytest.raises(ValueError, match="No paths in data_list matched"):
+                ClusterWeightedDistributedSampler(
+                    data_list, cluster_path, num_replicas=1, rank=0, seed=42
+                )
+
+    def test_low_match_rate_warns(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(10)]
+            clusters = {"cluster_id0": data_list[:2]}
+            cluster_path = str(Path(tmp) / "clusters.json")
+            with open(cluster_path, "w") as f:
+                json.dump(clusters, f)
+
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                sampler = ClusterWeightedDistributedSampler(
+                    data_list, cluster_path, num_replicas=1, rank=0, seed=42
+                )
+                matching_warnings = [x for x in w if "paths matched cluster JSON" in str(x.message)]
+                assert len(matching_warnings) == 1
+                assert sampler.matched_count == 2
+
+    def test_cluster_counts_exposed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_list = [f"/data/sample_{i}.npz" for i in range(20)]
+            cluster_path, _ = _make_cluster_json(tmp, data_list)
+
+            sampler = ClusterWeightedDistributedSampler(
+                data_list, cluster_path, num_replicas=1, rank=0, seed=42
+            )
+            assert sampler.cluster_counts == {"cluster_id0": 2, "cluster_id1": 18}
+            assert sampler.matched_count == 20

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -30,6 +30,12 @@ def get_args(args_list=None):
     parser.add_argument("--train_set_list", type=str, required=True)
     parser.add_argument("--valid_set_list", type=str, required=True)
     parser.add_argument("--train_subsample_step", type=int, default=1)
+    parser.add_argument(
+        "--cluster_json",
+        type=str,
+        default="",
+        help="Path to cluster assignment JSON from cluster.py. Enables weighted sampling.",
+    )
 
     parser.add_argument("--future_len", type=int, default=OUTPUT_T)
     parser.add_argument("--time_len", type=int, default=INPUT_T + 1)

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -91,6 +91,52 @@ def get_args(args_list=None):
         "--augment_type", type=str, choices=["quintic", "bridge"], default="quintic"
     )
     parser.add_argument(
+        "--use_flip_augment",
+        default=_train_config_default("use_flip_augment"),
+        type=boolean,
+    )
+    parser.add_argument("--flip_prob", type=float, default=_train_config_default("flip_prob"))
+    parser.add_argument(
+        "--use_neighbor_dropout",
+        default=_train_config_default("use_neighbor_dropout"),
+        type=boolean,
+    )
+    parser.add_argument(
+        "--neighbor_dropout_prob",
+        type=float,
+        default=_train_config_default("neighbor_dropout_prob"),
+    )
+    parser.add_argument(
+        "--use_neighbor_noise",
+        default=_train_config_default("use_neighbor_noise"),
+        type=boolean,
+    )
+    parser.add_argument(
+        "--neighbor_noise_pos_std",
+        type=float,
+        default=_train_config_default("neighbor_noise_pos_std"),
+    )
+    parser.add_argument(
+        "--neighbor_noise_vel_std",
+        type=float,
+        default=_train_config_default("neighbor_noise_vel_std"),
+    )
+    parser.add_argument(
+        "--neighbor_noise_heading_std",
+        type=float,
+        default=_train_config_default("neighbor_noise_heading_std"),
+    )
+    parser.add_argument(
+        "--use_turn_indicator_dropout",
+        default=_train_config_default("use_turn_indicator_dropout"),
+        type=boolean,
+    )
+    parser.add_argument(
+        "--turn_indicator_dropout_prob",
+        type=float,
+        default=_train_config_default("turn_indicator_dropout_prob"),
+    )
+    parser.add_argument(
         "--num_refine", type=int, default=20, help="number of refinement steps for augmentation"
     )
     parser.add_argument(

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -44,6 +44,23 @@ def get_args(args_list=None):
         "weighting (every cluster gets an equal share of draws), 0.0 = uniform. "
         "Lower values soften oversampling. Ignored without --cluster_json.",
     )
+    parser.add_argument(
+        "--force_aug_on_repeat",
+        default=_train_config_default("force_aug_on_repeat"),
+        type=boolean,
+        help="Force one augmentation on any sample the cluster-weighted sampler draws "
+        "more than once in an epoch, so repeats vary instead of duplicating. "
+        "Requires --cluster_json.",
+    )
+    parser.add_argument(
+        "--repeat_aug_pool",
+        type=str,
+        default=_train_config_default("repeat_aug_pool"),
+        help="Comma-separated augmentation names eligible to be forced on a repeat "
+        "draw (flip, neighbor_dropout, neighbor_noise, turn_indicator, traffic_light, "
+        "state_perturbation). Empty means every enabled augmentation. Ignored without "
+        "--force_aug_on_repeat.",
+    )
 
     parser.add_argument("--future_len", type=int, default=OUTPUT_T)
     parser.add_argument("--time_len", type=int, default=INPUT_T + 1)

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -36,6 +36,14 @@ def get_args(args_list=None):
         default="",
         help="Path to cluster assignment JSON from cluster.py. Enables weighted sampling.",
     )
+    parser.add_argument(
+        "--cluster_weight_alpha",
+        type=float,
+        default=1.0,
+        help="Exponent on inverse-frequency cluster weights. 1.0 = full inverse "
+        "weighting (every cluster gets an equal share of draws), 0.0 = uniform. "
+        "Lower values soften oversampling. Ignored without --cluster_json.",
+    )
 
     parser.add_argument("--future_len", type=int, default=OUTPUT_T)
     parser.add_argument("--time_len", type=int, default=INPUT_T + 1)

--- a/diffusion_planner/train_run.py
+++ b/diffusion_planner/train_run.py
@@ -17,7 +17,17 @@ from pathlib import Path
 from run_utils import NCCL_ENV, gpu_count, tee_run
 
 
-def parse_args() -> argparse.Namespace:
+def boolean(value: str | bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value.lower() in ("yes", "true", "t", "y", "1"):
+        return True
+    if value.lower() in ("no", "false", "f", "n", "0"):
+        return False
+    raise argparse.ArgumentTypeError("Boolean value expected.")
+
+
+def parse_args(args_list: list[str] | None = None) -> argparse.Namespace:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--exp_name", required=True)
     p.add_argument("--train_set_list", required=True)
@@ -44,26 +54,21 @@ def parse_args() -> argparse.Namespace:
         help="optional: exponent on inverse-frequency cluster weights "
         "(1.0 = full inverse, 0.0 = uniform)",
     )
-    return p.parse_args()
-
-
-def main() -> None:
-    args = parse_args()
-
-    here = Path(__file__).resolve().parent
-    save_path = Path(args.output_root) / f"{datetime.now():%Y%m%d-%H%M%S}_{args.exp_name}"
-    save_path.mkdir(parents=True, exist_ok=True)
-
-    # Save git info next to the run.
-    def git_output(cmd: list[str]) -> str:
-        return subprocess.run(cmd, cwd=here, capture_output=True, text=True).stdout
-
-    branch = git_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip()
-    (save_path / "git_show.txt").write_text(
-        f"branch: {branch}\n\n" + git_output(["git", "show", "-s", "--decorate"])
+    p.add_argument(
+        "--force_aug_on_repeat",
+        type=boolean,
+        default=None,
+        help="optional: force one augmentation on repeated weighted-sampler draws",
     )
-    (save_path / "git_diff.txt").write_text(git_output(["git", "diff"]))
+    p.add_argument(
+        "--repeat_aug_pool",
+        default=None,
+        help="optional: comma-separated augmentations eligible for repeat-draw forcing",
+    )
+    return p.parse_args(args_list)
 
+
+def build_optional_args(args: argparse.Namespace) -> list[str]:
     optional: list[str] = []
     if args.resume_model_path:
         optional += ["--resume_model_path", str(Path(args.resume_model_path).resolve())]
@@ -87,6 +92,31 @@ def main() -> None:
                 file=sys.stderr,
             )
         optional += ["--cluster_weight_alpha", str(args.cluster_weight_alpha)]
+    if args.force_aug_on_repeat is not None:
+        optional += ["--force_aug_on_repeat", str(args.force_aug_on_repeat)]
+    if args.repeat_aug_pool is not None:
+        optional += ["--repeat_aug_pool", args.repeat_aug_pool]
+    return optional
+
+
+def main() -> None:
+    args = parse_args()
+
+    here = Path(__file__).resolve().parent
+    save_path = Path(args.output_root) / f"{datetime.now():%Y%m%d-%H%M%S}_{args.exp_name}"
+    save_path.mkdir(parents=True, exist_ok=True)
+
+    # Save git info next to the run.
+    def git_output(cmd: list[str]) -> str:
+        return subprocess.run(cmd, cwd=here, capture_output=True, text=True).stdout
+
+    branch = git_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip()
+    (save_path / "git_show.txt").write_text(
+        f"branch: {branch}\n\n" + git_output(["git", "show", "-s", "--decorate"])
+    )
+    (save_path / "git_diff.txt").write_text(git_output(["git", "diff"]))
+
+    optional = build_optional_args(args)
 
     Path("/tmp/tmp_dist_init").unlink(missing_ok=True)
 

--- a/diffusion_planner/train_run.py
+++ b/diffusion_planner/train_run.py
@@ -65,6 +65,10 @@ def parse_args(args_list: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="optional: comma-separated augmentations eligible for repeat-draw forcing",
     )
+    p.add_argument("--use_flip_augment", type=boolean, default=None)
+    p.add_argument("--use_neighbor_dropout", type=boolean, default=None)
+    p.add_argument("--use_neighbor_noise", type=boolean, default=None)
+    p.add_argument("--use_turn_indicator_dropout", type=boolean, default=None)
     return p.parse_args(args_list)
 
 
@@ -96,6 +100,15 @@ def build_optional_args(args: argparse.Namespace) -> list[str]:
         optional += ["--force_aug_on_repeat", str(args.force_aug_on_repeat)]
     if args.repeat_aug_pool is not None:
         optional += ["--repeat_aug_pool", args.repeat_aug_pool]
+    for name in (
+        "use_flip_augment",
+        "use_neighbor_dropout",
+        "use_neighbor_noise",
+        "use_turn_indicator_dropout",
+    ):
+        value = getattr(args, name, None)
+        if value is not None:
+            optional += [f"--{name}", str(value)]
     return optional
 
 

--- a/diffusion_planner/train_run.py
+++ b/diffusion_planner/train_run.py
@@ -37,6 +37,13 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="optional: path to cluster assignment JSON for weighted sampling",
     )
+    p.add_argument(
+        "--cluster_weight_alpha",
+        type=float,
+        default=None,
+        help="optional: exponent on inverse-frequency cluster weights "
+        "(1.0 = full inverse, 0.0 = uniform)",
+    )
     return p.parse_args()
 
 
@@ -66,6 +73,8 @@ def main() -> None:
         optional += ["--wandb_project_name", args.wandb_project_name]
     if args.cluster_json:
         optional += ["--cluster_json", str(Path(args.cluster_json).resolve())]
+    if args.cluster_weight_alpha is not None:
+        optional += ["--cluster_weight_alpha", str(args.cluster_weight_alpha)]
 
     Path("/tmp/tmp_dist_init").unlink(missing_ok=True)
 

--- a/diffusion_planner/train_run.py
+++ b/diffusion_planner/train_run.py
@@ -32,6 +32,11 @@ def parse_args() -> argparse.Namespace:
         help="optional: dir tree of route NPZ frames for closed-loop validation, OR a .json path "
         "list of such dirs (like --train_set_list). Empty = disabled.",
     )
+    p.add_argument(
+        "--cluster_json",
+        default=None,
+        help="optional: path to cluster assignment JSON for weighted sampling",
+    )
     return p.parse_args()
 
 
@@ -59,6 +64,8 @@ def main() -> None:
         optional += ["--wandb_run_id", args.wandb_run_id]
     if args.wandb_project_name:
         optional += ["--wandb_project_name", args.wandb_project_name]
+    if args.cluster_json:
+        optional += ["--cluster_json", str(Path(args.cluster_json).resolve())]
 
     Path("/tmp/tmp_dist_init").unlink(missing_ok=True)
 

--- a/diffusion_planner/train_run.py
+++ b/diffusion_planner/train_run.py
@@ -72,8 +72,20 @@ def main() -> None:
     if args.wandb_project_name:
         optional += ["--wandb_project_name", args.wandb_project_name]
     if args.cluster_json:
-        optional += ["--cluster_json", str(Path(args.cluster_json).resolve())]
+        # ``Path.resolve()`` is non-strict, so a typo would sail through and only
+        # surface after every rank has loaded the (large) train/valid path lists
+        # and built the model. Fail before launching torchrun.
+        cluster_json = Path(args.cluster_json).resolve()
+        if not cluster_json.is_file():
+            sys.exit(f"--cluster_json not found: {cluster_json}")
+        optional += ["--cluster_json", str(cluster_json)]
     if args.cluster_weight_alpha is not None:
+        if not args.cluster_json:
+            print(
+                f"WARNING: --cluster_weight_alpha {args.cluster_weight_alpha} has no effect "
+                "without --cluster_json; training will use the default DistributedSampler.",
+                file=sys.stderr,
+            )
         optional += ["--cluster_weight_alpha", str(args.cluster_weight_alpha)]
 
     Path("/tmp/tmp_dist_init").unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

- Add `ClusterWeightedDistributedSampler` that reads Fumiya's `cluster.py` output and oversamples rare trajectory clusters via inverse-frequency weighting. All data is retained (no undersampling).
- Integrate via `--cluster_json` CLI flag on `train_predictor.py` and `train_run.py`. Default behavior (no flag) is unchanged.
- Add `--cluster_weight_alpha` to tune how aggressive the reweighting is.
- Log cluster distribution and per-cluster oversampling multipliers at training start when weighted sampling is active.

Based on the FlowDrive paper (arXiv:2509.21961) approach which showed +4.94% improvement on Diffusion Planner with trajectory-cluster reweighting.

**Base branch:** rebased onto `tier4-main` (was previously targeting `dev`). The 15 dev-only model commits this branch used to carry — `turn_indicator.py`, lightweight lane encoder, self-attention K/V LayerNorm, masked scene pooling, lineencoder refactor — are **not** part of this PR. It contains sampler and cluster-tooling changes only.

## Usage

```bash
# Step 1: Generate cluster assignment JSON
python sampling/cluster.py \
    --data_list /path/to/train.json \
    --output /path/to/cluster_result.json

# Step 2: Train with weighted sampling
python train_run.py \
    --exp_name my_exp \
    --train_set_list /path/to/train.json \
    --valid_set_list /path/to/valid.json \
    --cluster_json /path/to/cluster_result.json \
    --cluster_weight_alpha 0.5

# Train without (unchanged default)
python train_run.py \
    --exp_name my_exp \
    --train_set_list /path/to/train.json \
    --valid_set_list /path/to/valid.json
```

**Note:** The cluster JSON must reference the same NPZ files as `--train_set_list`. Paths are canonicalized before matching, so differing prefixes (absolute vs relative, different mount points) are handled automatically.

## Weight strength

Each sample's weight is `(1 / cluster_frequency) ** alpha`, normalized to mean 1.0 — so a sample's weight *is* its oversampling multiplier.

`--cluster_weight_alpha` defaults to `1.0`, which is unchanged behavior: every cluster receives an equal share of draws regardless of size. That turned out to be too drastic in practice (the rarest cluster was oversampled ~2.33x), so lower values soften it. The multiplier ratio between any two clusters goes from `R` at `alpha=1.0` to `R ** alpha`:

| alpha | max/min ratio (from 2.33) |
| --- | --- |
| 1.0 | 2.33 (default, unchanged) |
| 0.5 | 1.53 |
| 0.25 | 1.24 |

Training prints the resulting multipliers at startup, so alpha can be tuned against real numbers rather than predicted:

```
Using cluster-weighted sampling from /path/to/cluster_result.json
Cluster distribution (matched 48231/48231 data paths, alpha=0.50):
  cluster_id0: 18402 samples  0.78x
  cluster_id7: 1204 samples  1.53x
```

`alpha=0.0` gives uniform weights. Note this is still sampling *with* replacement, so it is not equivalent to omitting `--cluster_json` (plain `DistributedSampler` samples without replacement).

`visualize_cluster_report.py` takes the same `--cluster_weight_alpha` flag, so the report's Weight column reflects what training actually applies. A test asserts the report's weights equal the sampler's `cluster_multipliers` at alpha 1.0, 0.5, and 0.0, so the two implementations of the formula cannot drift apart.

## Known gaps

- **Enriched clustering vs npz v3.** `--mode enriched` reads `neighbor_agents_future`, which tier4-main changed to 4-col `[x,y,cos,sin]` in npz version 3 (#292). The default `--mode trajectory` reads only `ego_agent_future` (still `(80, 3)`) and is unaffected. Enriched mode against v3 data, and mixed v2/v3 data lists, are untested.

## Test plan

- [x] Unit tests for sampler: weight computation, iteration count, index bounds, oversampling behavior, DDP sharding, epoch shuffling, unclustered paths
- [x] Alpha tests: default reproduces prior weights bit-for-bit, `alpha=0` is uniform, `alpha=0.5` satisfies the `R ** alpha` relation, invalid alpha (negative, NaN, infinite) rejected at construction in both the sampler and the report, multipliers predict observed `torch.multinomial` draw counts over 100 epochs
- [x] Report/sampler cross-check: report weights equal sampler multipliers at alpha 1.0 / 0.5 / 0.0
- [x] DDP shard padding verified for odd dataset sizes
- [x] Default (non-weighted) code path unchanged
- [x] Lint clean (ruff check + format) on changed files
- [ ] Integration test: short training run with and without `--cluster_json` on sakurab — **not yet done**
- [ ] Verify printed multipliers against the real cluster JSON — **not yet done**

> Note: the full test suite shows 32 failures on this base, all pre-existing on `tier4-main` and unrelated to this PR (verified against a clean `tier4-main` checkout). The cluster test files are fully green.
