### PR TITLE
Hide EPDMS coverage metrics from training logs

### DIFF
--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -89,6 +89,14 @@ def mean_epdms_metric(loss_dict):
     return result
 
 
+def wandb_epdms_metrics(epdms_means):
+    return {
+        f"valid_epdms/{key}": value
+        for key, value in epdms_means.items()
+        if not key.endswith("_coverage")
+    }
+
+
 def closed_loop_validate(model, args, epoch: int, out_dir: str) -> None:
     """Closed-loop rendered rollout; logs metrics + the rollout video to wandb.
 
@@ -338,7 +346,7 @@ def model_training(args: TrainConfig):
         valid_loss_ego = agg["avg_loss_ego"]
         valid_loss_neighbor = agg["avg_loss_neighbor"]
         mean_ego_loss_dict = {f"valid_loss/{k}": v for k, v in agg["ego_means"].items()}
-        mean_epdms_dict = {f"valid_epdms/{k}": v for k, v in agg["epdms_means"].items()}
+        mean_epdms_dict = wandb_epdms_metrics(agg["epdms_means"])
         valid_loss_ego_position_lat_loss = mean_ego_loss_dict.get(
             "valid_loss/ego_position_lat_loss", 0.0
         )
@@ -388,7 +396,7 @@ def model_training(args: TrainConfig):
             valid_loss_ego = agg["avg_loss_ego"]
             valid_loss_neighbor = agg["avg_loss_neighbor"]
             mean_ego_loss_dict = {f"valid_loss/{k}": v for k, v in agg["ego_means"].items()}
-            mean_epdms_dict = {f"valid_epdms/{k}": v for k, v in agg["epdms_means"].items()}
+            mean_epdms_dict = wandb_epdms_metrics(agg["epdms_means"])
             valid_loss_ego_position_lat_loss = mean_ego_loss_dict.get(
                 "valid_loss/ego_position_lat_loss", 0.0
             )


### PR DESCRIPTION
## Summary

This PR removes per-metric EPDMS coverage entries from supervised training logs and W&B dashboards.

The coverage values are still computed in `aggregate_valid_metrics()` and remain available to validation/debug callers. The training logger now filters out keys ending with `_coverage` before writing `valid_epdms/*` metrics to W&B / `train_log.tsv`.

## Motivation

EPDMS coverage indicates metric availability for the fixed validation dataset, not model quality. In normal training runs these values are effectively constant, so logging every `*_coverage` key makes W&B panels harder to read without adding useful model-comparison signal.

## Impact

- Keeps EPDMS score metrics such as `valid_epdms/total` and sub-scores unchanged.
- Hides constant `valid_epdms/*_coverage` series from training dashboards.
- Does not change validation metric computation or availability masking.
- Does not change `valid_predictor.py` saved debug JSON.

## Validation

Not run; logging-only change.
