### PR TITLE
Fix route-conditioned HDP RL and validation semantics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ ros_scripts/convert_all_v4.sh
 CLAUDE.md
 memory/
 wandb/
+/cache/
 
 .vscode/
 *.egg-info

--- a/diffusion_planner/README.md
+++ b/diffusion_planner/README.md
@@ -36,7 +36,7 @@ python3 -m torch.distributed.run --nproc_per_node=8 --master_port=<PORT> train_p
   --batch_size 512 \
   --learning_rate 2e-4 \
   --warm_up_epoch 5 \
-  --train_epochs 60 \
+  --train_epochs 20 \
   --save_utd 10 \
   --future_len 80 \
   --time_len 31 \
@@ -50,14 +50,15 @@ python3 -m torch.distributed.run --nproc_per_node=8 --master_port=<PORT> train_p
   --hybrid_loss_window 10 \
   --turn_indicator_generated_loss_weight 1.0 \
   --turn_indicator_expert_loss_weight 1.0 \
-  --diffusion_sample_steps 10 \
+  --diffusion_sample_steps 6 \
   --enable_epdms_eval True \
   --use_wandb True \
   --wandb_project_name Diffusion-Planner-Temporal \
   --tf32 True \
   --amp_dtype bf16 \
   --fused_optimizer True \
-  --ddp_static_graph True
+  --ddp_static_graph True \
+  --compile_model True
 ```
 
 ## HDP SFT
@@ -80,12 +81,13 @@ python3 -m torch.distributed.run --nproc_per_node=8 --master_port=<PORT> train_p
   --use_velocity_representation True \
   --planning_hybrid_loss 0.01 \
   --hybrid_loss_window 10 \
-  --diffusion_sample_steps 10 \
+  --diffusion_sample_steps 6 \
   --enable_epdms_eval True \
   --use_wandb True \
   --wandb_project_name Diffusion-Planner-Temporal \
   --tf32 True \
-  --amp_dtype bf16
+  --amp_dtype bf16 \
+  --compile_model True
 ```
 
 Use `--resume_model_path` only for continuing the same interrupted run. Do not use it for base-to-SFT or SFT-to-RL transfer.
@@ -124,7 +126,7 @@ python3 -m torch.distributed.run --nproc_per_node=8 --master_port=<PORT> train_h
   --use_velocity_representation True \
   --planning_hybrid_loss 0.01 \
   --hybrid_loss_window 10 \
-  --diffusion_sample_steps 10 \
+  --diffusion_sample_steps 6 \
   --multisample_eval_num_samples 6 \
   --multisample_eval_sample_steps 6 \
   --rl_full_eval_utd 5 \
@@ -132,10 +134,15 @@ python3 -m torch.distributed.run --nproc_per_node=8 --master_port=<PORT> train_h
   --use_wandb True \
   --wandb_project_name Diffusion-Planner-Temporal \
   --tf32 True \
-  --amp_dtype bf16
+  --amp_dtype bf16 \
+  --compile_model True
 ```
 
 Important semantics:
+
+- `--compile_model True` compiles the encoder and decoder in place. Checkpoint keys and ONNX
+  export remain unchanged. Set `TORCHINDUCTOR_CACHE_DIR` to persistent local storage so restarts
+  reuse compiled artifacts.
 
 - `--init_weights_path`: fresh RL run initialized from SFT weights only; by default it selects the SFT EMA shadow.
 - `--resume_model_path`: strict resume of an interrupted RL run, including optimizer/scheduler state.

--- a/diffusion_planner/diffusion_planner/hdp_rl_epoch.py
+++ b/diffusion_planner/diffusion_planner/hdp_rl_epoch.py
@@ -43,6 +43,15 @@ def _neighbor_future_world(neighbor_future_raw: torch.Tensor):
     return neighbors_future
 
 
+def _policy_observation_inputs(norm_inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    """Drop supervision-only futures before candidate batch expansion."""
+    return {
+        key: value
+        for key, value in norm_inputs.items()
+        if key not in {"ego_agent_future", "neighbor_agents_future"}
+    }
+
+
 def _hdp_rl_step(raw_inputs, model, optimizer, trainable_params, args, ema, aug, profile=False):
     n = args.num_generations
     timing_events = None
@@ -69,7 +78,7 @@ def _hdp_rl_step(raw_inputs, model, optimizer, trainable_params, args, ema, aug,
     if getattr(args, "rl_train_scope", "decoder") == "decoder":
         decoder_inputs = {"ego_current_state": norm_inputs["ego_current_state"]}
     else:
-        decoder_inputs = norm_inputs
+        decoder_inputs = _policy_observation_inputs(norm_inputs)
     norm_exp = expand_batch(decoder_inputs, n)
     if getattr(args, "rl_train_scope", "decoder") == "decoder":
         # Keep one route tensor per scene. Decoder compresses it inside the DDP forward,

--- a/diffusion_planner/diffusion_planner/hdp_rl_epoch.py
+++ b/diffusion_planner/diffusion_planner/hdp_rl_epoch.py
@@ -39,7 +39,7 @@ def _set_hdp_rl_train_mode(model, args):
 def _neighbor_future_world(neighbor_future_raw: torch.Tensor):
     mask = neighbor_future_padding_mask(neighbor_future_raw)
     neighbors_future = heading_to_cos_sin(neighbor_future_raw)
-    neighbors_future[mask] = 0.0
+    neighbors_future.masked_fill_(mask.unsqueeze(-1), 0.0)
     return neighbors_future
 
 
@@ -163,9 +163,10 @@ def _hdp_rl_step(raw_inputs, model, optimizer, trainable_params, args, ema, aug,
 
     grouped_reward = reward.reshape(num_scenes, n)
     endpoints = ego_world[:, -1, :2].reshape(num_scenes, n, 2)
-    endpoint_diversity = torch.stack(
-        [torch.pdist(scene_endpoints).mean() for scene_endpoints in endpoints]
-    ).mean()
+    endpoint_distances = torch.linalg.vector_norm(
+        endpoints[:, :, None] - endpoints[:, None, :], dim=-1
+    )
+    endpoint_diversity = endpoint_distances.sum() / max(num_scenes * n * (n - 1), 1)
     result = {
         "loss": loss_dict["loss"].detach(),
         "rl_loss": loss_dict["loss"].detach(),

--- a/diffusion_planner/diffusion_planner/hdp_rl_utils.py
+++ b/diffusion_planner/diffusion_planner/hdp_rl_utils.py
@@ -29,13 +29,15 @@ from diffusion_planner.loss import (
 )
 from diffusion_planner.model.diffusion_utils.sde import VPSDE_linear
 from planner_metrics.config import RewardConfig
-from planner_metrics.geometry import _point_to_segments_min_dist
+from planner_metrics.geometry import _point_to_segments_dist
 from planner_metrics.subscores import (
     compute_ego_neighbor_signed_clearance,
     compute_road_border_penalty,
 )
 
 _RL_REWARD_CONFIG = RewardConfig()
+_COMPILED_COLLISION_AND_LEADER_TERMS = None
+_COMPILED_POINT_TO_SEGMENTS_DIST = None
 
 
 @dataclass(frozen=True)
@@ -116,8 +118,9 @@ def _scene_neighbors(
     # (cos, sin) vector even when its center crosses the ego origin.
     pose_valid = neighbors_future[..., 2:4].norm(dim=-1) > 0.5
     slot_valid = pose_valid.any(dim=1)
-    future = neighbors_future[slot_valid, :T, :4]
-    past = neighbor_past[slot_valid]
+    valid_indices = slot_valid.nonzero(as_tuple=True)[0]
+    future = neighbors_future.index_select(0, valid_indices)[:, :T, :4]
+    past = neighbor_past.index_select(0, valid_indices)
     valid = future[..., 2:4].norm(dim=-1) > 0.5
     if future.shape[0] == 0:
         return (
@@ -252,10 +255,8 @@ def _collision_and_leader_terms(
         & (neighbor_speed[:, 1] < _RL_REWARD_CONFIG.sc_neighbor_vel_thresh)
         & (max_displacement < _RL_REWARD_CONFIG.sc_neighbor_disp_thresh)
     )
-    stopped_clearance = (
-        clearance[:, stopped_mask].min(dim=1).values
-        if stopped_mask.any()
-        else torch.full((C, T), float("inf"), device=device)
+    stopped_clearance = clearance.masked_fill(~stopped_mask[None, :, None], float("inf")).amin(
+        dim=1
     )
     selected_leader_speed = torch.gather(
         neighbor_speed[None].expand(C, -1, -1),
@@ -297,6 +298,20 @@ def _collision_and_leader_terms(
     }
 
 
+def _run_collision_and_leader_terms(*args, compile_kernel: bool):
+    if not compile_kernel or args[0].device.type != "cuda":
+        return _collision_and_leader_terms(*args)
+    global _COMPILED_COLLISION_AND_LEADER_TERMS
+    if _COMPILED_COLLISION_AND_LEADER_TERMS is None:
+        _COMPILED_COLLISION_AND_LEADER_TERMS = torch.compile(
+            _collision_and_leader_terms,
+            mode="default",
+            dynamic=True,
+            fullgraph=True,
+        )
+    return _COMPILED_COLLISION_AND_LEADER_TERMS(*args)
+
+
 def _occupancy_score(
     ego_trajs: torch.Tensor,
     ego_shape: torch.Tensor,
@@ -316,8 +331,8 @@ def _occupancy_score(
         valid = (static_objects[..., :2].abs().sum(dim=-1) > 1e-6) | (
             static_objects[..., 4:6].abs().sum(dim=-1) > 1e-6
         )
-        objects = static_objects[valid]
-        if objects.shape[0] > 0:
+        if valid.any():
+            objects = static_objects[valid]
             poses = objects[:, None, :4].expand(-1, T, -1).clone()
             heading_norm = poses[..., 2:4].norm(dim=-1, keepdim=True)
             poses[..., 2:4] = torch.where(
@@ -372,19 +387,50 @@ def _occupancy_score(
     return _linear_safe_score(clearance, critical_distance, safe_distance), sources
 
 
-def _nearest_lane_distance(points: torch.Tensor, lanes: torch.Tensor) -> torch.Tensor:
+def _run_point_to_segments_dist(
+    points: torch.Tensor,
+    seg_start: torch.Tensor,
+    seg_end: torch.Tensor,
+    *,
+    compile_kernel: bool,
+) -> torch.Tensor:
+    if not compile_kernel or points.device.type != "cuda":
+        return _point_to_segments_dist(points, seg_start, seg_end)
+    global _COMPILED_POINT_TO_SEGMENTS_DIST
+    if _COMPILED_POINT_TO_SEGMENTS_DIST is None:
+        _COMPILED_POINT_TO_SEGMENTS_DIST = torch.compile(
+            _point_to_segments_dist,
+            mode="default",
+            dynamic=True,
+            fullgraph=True,
+        )
+    return _COMPILED_POINT_TO_SEGMENTS_DIST(points, seg_start, seg_end)
+
+
+def _nearest_lane_distance(
+    points: torch.Tensor,
+    lanes: torch.Tensor,
+    *,
+    compile_kernel: bool = False,
+) -> torch.Tensor:
     center = lanes[..., :2]
     valid = center.abs().sum(dim=-1) > 1e-6
-    valid_pair = valid[..., :-1] & valid[..., 1:]
-    seg_start = center[..., :-1, :][valid_pair]
-    seg_end = center[..., 1:, :][valid_pair]
-    if seg_start.shape[0] == 0:
-        lane_points = center[valid]
-        if lane_points.shape[0] == 0:
-            raise RuntimeError("HDP lane reward requires valid lane centerline points.")
-        distance = torch.cdist(points.reshape(-1, 2), lane_points).min(dim=-1).values
-    else:
-        distance = _point_to_segments_min_dist(points.reshape(-1, 2), seg_start, seg_end)
+    valid_pair = (valid[..., :-1] & valid[..., 1:]).reshape(-1)
+    seg_start = center[..., :-1, :].reshape(-1, 2)
+    seg_end = center[..., 1:, :].reshape(-1, 2)
+    flat_points = points.reshape(-1, 2)
+    max_distance_elements = 10_000_000
+    chunk_size = max(1, max_distance_elements // seg_start.shape[0])
+    chunks = []
+    for start in range(0, flat_points.shape[0], chunk_size):
+        distance = _run_point_to_segments_dist(
+            flat_points[start : start + chunk_size],
+            seg_start,
+            seg_end,
+            compile_kernel=compile_kernel,
+        )
+        chunks.append(distance.masked_fill(~valid_pair[None], float("inf")).amin(dim=-1))
+    distance = torch.cat(chunks)
     return distance.reshape(points.shape[:-1])
 
 
@@ -393,15 +439,19 @@ def _lane_reward_centerlines(
     lanes: torch.Tensor,
     route_lanes: torch.Tensor | None,
     config: HDPRewardConfig,
+    *,
+    compile_kernel: bool = False,
 ) -> tuple[torch.Tensor, bool]:
     """Prefer the navigation route when it agrees with the logged expert trajectory."""
-    if route_lanes is None or not (route_lanes[..., :2].abs().sum(dim=-1) > 1e-6).any():
+    if route_lanes is None:
+        return lanes, False
+    route_valid = route_lanes[..., :2].abs().sum(dim=-1) > 1e-6
+    if not (route_valid[..., :-1] & route_valid[..., 1:]).any():
         return lanes, False
 
-    expert_valid = expert_future[..., 2:4].norm(dim=-1) > 0.5
-    if not expert_valid.any():
-        return lanes, False
-    route_distance = _nearest_lane_distance(expert_future[expert_valid, :2], route_lanes)
+    route_distance = _nearest_lane_distance(
+        expert_future[..., :2], route_lanes, compile_kernel=compile_kernel
+    )
     route_aligned = (route_distance.mean() <= config.lane_half_width_m) & (
         route_distance.max() <= 2.0 * config.lane_half_width_m
     )
@@ -414,29 +464,25 @@ def _hdp_lane_score(
     lanes: torch.Tensor,
     turn_indicators: torch.Tensor | None,
     config: HDPRewardConfig,
-) -> tuple[torch.Tensor, bool, bool]:
-    if not (lanes[..., :2].abs().sum(dim=-1) > 1e-6).any():
-        return torch.zeros(ego_trajs.shape[0], device=ego_trajs.device), True, False
-    pred_distance = _nearest_lane_distance(ego_trajs[..., :2], lanes)
+    *,
+    compile_kernel: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    lane_valid = lanes[..., :2].abs().sum(dim=-1) > 1e-6
+    if not (lane_valid[..., :-1] & lane_valid[..., 1:]).any():
+        zero = torch.zeros((), dtype=torch.bool, device=ego_trajs.device)
+        return torch.zeros(ego_trajs.shape[0], device=ego_trajs.device), ~zero, zero
+    pred_distance = _nearest_lane_distance(ego_trajs[..., :2], lanes, compile_kernel=compile_kernel)
     center_score = (1.0 - pred_distance / config.lane_half_width_m).clamp(0.0, 1.0)
 
     expert_xy = expert_future[..., :2]
-    expert_valid = expert_future[..., 2:4].norm(dim=-1) > 0.5
-    if not expert_valid.any():
-        return torch.zeros(ego_trajs.shape[0], device=ego_trajs.device), True, False
-    expert_distance = _nearest_lane_distance(expert_xy[expert_valid], lanes)
-    expert_off_lane = bool(
-        (
-            (expert_distance.mean() > config.lane_half_width_m)
-            | (expert_distance.max() > 2.0 * config.lane_half_width_m)
-        ).item()
+    expert_distance = _nearest_lane_distance(expert_xy, lanes, compile_kernel=compile_kernel)
+    expert_off_lane = (expert_distance.mean() > config.lane_half_width_m) | (
+        expert_distance.max() > 2.0 * config.lane_half_width_m
     )
 
-    indicator_active = bool(
-        turn_indicators is not None
-        and turn_indicators.numel() > 0
-        and int(turn_indicators[-1].item()) in (2, 3)
-    )
+    indicator_active = torch.zeros((), dtype=torch.bool, device=ego_trajs.device)
+    if turn_indicators is not None and turn_indicators.numel() > 0:
+        indicator_active = (turn_indicators[-1] == 2) | (turn_indicators[-1] == 3)
     # Measure lateral motion in the road frame. Ego-frame endpoint y is not a lateral offset on a
     # curve and used to classify ordinary bends as lane changes. A centerline-to-centerline change
     # has a pronounced distance peak while both ends remain close to some lane centerline. When a
@@ -455,15 +501,10 @@ def _hdp_lane_score(
     indicated_departure = starts_on_lane & (
         peak_distance - start_distance > 0.5 * config.lane_half_width_m
     )
-    expert_lane_change = bool((centerline_change | (indicator_active & indicated_departure)).item())
-    masked = expert_off_lane or expert_lane_change
-    if masked:
-        return (
-            torch.zeros(ego_trajs.shape[0], device=ego_trajs.device),
-            expert_off_lane,
-            expert_lane_change,
-        )
-    return center_score.mean(dim=-1), False, False
+    expert_lane_change = centerline_change | (indicator_active & indicated_departure)
+    masked = expert_off_lane | expert_lane_change
+    lane_score = torch.where(masked, torch.zeros_like(center_score), center_score).mean(dim=-1)
+    return lane_score, expert_off_lane, expert_lane_change
 
 
 @torch.no_grad()
@@ -508,6 +549,7 @@ def compute_hdp_reward(
         )
     }
     rewards = []
+    compile_kernels = bool(getattr(args, "compile_model", False))
 
     required = ("ego_shape", "neighbor_agents_past", "ego_agent_future", "lanes")
     missing = [key for key in required if key not in scene_inputs]
@@ -519,7 +561,7 @@ def compute_hdp_reward(
         nf, neighbor_shapes, neighbor_valid, neighbor_initial, neighbor_is_vehicle = (
             _scene_neighbors(neighbor_group[scene], scene_inputs["neighbor_agents_past"][scene])
         )
-        terms = _collision_and_leader_terms(
+        terms = _run_collision_and_leader_terms(
             ego_group[scene],
             ego_shape,
             nf,
@@ -528,6 +570,7 @@ def compute_hdp_reward(
             neighbor_initial,
             neighbor_is_vehicle,
             config,
+            compile_kernel=compile_kernels,
         )
         occupancy, occupancy_sources = _occupancy_score(
             ego_group[scene],
@@ -555,6 +598,7 @@ def compute_hdp_reward(
             scene_inputs["lanes"][scene],
             scene_inputs.get("route_lanes", None)[scene] if "route_lanes" in scene_inputs else None,
             config,
+            compile_kernel=compile_kernels,
         )
         lane, expert_off_lane, expert_lane_change = _hdp_lane_score(
             ego_group[scene],
@@ -564,6 +608,7 @@ def compute_hdp_reward(
             if "turn_indicators" in scene_inputs
             else None,
             config,
+            compile_kernel=compile_kernels,
         )
         reward = (
             args.rl_reward_w_risk * risk
@@ -581,8 +626,8 @@ def compute_hdp_reward(
         metric_lists["leader_fraction"].append(terms["leader_fraction"])
         metric_lists["collision_active"].append(terms["collision_active"])
         metric_lists["collision_rear"].append(terms["collision_rear"])
-        metric_lists["lane_masked"].append(lane.new_full((n,), float(expert_off_lane)))
-        metric_lists["lane_change_masked"].append(lane.new_full((n,), float(expert_lane_change)))
+        metric_lists["lane_masked"].append(expert_off_lane.to(lane.dtype).expand(n))
+        metric_lists["lane_change_masked"].append(expert_lane_change.to(lane.dtype).expand(n))
         metric_lists["lane_route_source"].append(lane.new_full((n,), float(lane_route_source)))
         metric_lists["occupancy_any_source"].append(
             lane.new_full((n,), float(any(occupancy_sources.values())))
@@ -606,11 +651,9 @@ def heading_to_cos_sin_if_needed(trajectory: torch.Tensor) -> torch.Tensor:
         return trajectory[..., :4]
     if trajectory.shape[-1] != 3:
         raise ValueError(f"Expected trajectory last dimension 3 or >=4, got {trajectory.shape}")
-    padding = trajectory[..., :3].abs().sum(dim=-1) == 0
-    converted = torch.cat(
+    return torch.cat(
         [trajectory[..., :2], trajectory[..., 2:3].cos(), trajectory[..., 2:3].sin()], dim=-1
     )
-    return converted.masked_fill(padding.unsqueeze(-1), 0.0)
 
 
 def expand_batch(inputs: dict[str, torch.Tensor], n: int) -> dict[str, torch.Tensor]:

--- a/diffusion_planner/diffusion_planner/hdp_rl_utils.py
+++ b/diffusion_planner/diffusion_planner/hdp_rl_utils.py
@@ -388,6 +388,26 @@ def _nearest_lane_distance(points: torch.Tensor, lanes: torch.Tensor) -> torch.T
     return distance.reshape(points.shape[:-1])
 
 
+def _lane_reward_centerlines(
+    expert_future: torch.Tensor,
+    lanes: torch.Tensor,
+    route_lanes: torch.Tensor | None,
+    config: HDPRewardConfig,
+) -> tuple[torch.Tensor, bool]:
+    """Prefer the navigation route when it agrees with the logged expert trajectory."""
+    if route_lanes is None or not (route_lanes[..., :2].abs().sum(dim=-1) > 1e-6).any():
+        return lanes, False
+
+    expert_valid = expert_future[..., 2:4].norm(dim=-1) > 0.5
+    if not expert_valid.any():
+        return lanes, False
+    route_distance = _nearest_lane_distance(expert_future[expert_valid, :2], route_lanes)
+    route_aligned = (route_distance.mean() <= config.lane_half_width_m) & (
+        route_distance.max() <= 2.0 * config.lane_half_width_m
+    )
+    return (route_lanes, True) if bool(route_aligned.item()) else (lanes, False)
+
+
 def _hdp_lane_score(
     ego_trajs: torch.Tensor,
     expert_future: torch.Tensor,
@@ -480,6 +500,7 @@ def compute_hdp_reward(
             "collision_rear",
             "lane_masked",
             "lane_change_masked",
+            "lane_route_source",
             "occupancy_any_source",
             "occupancy_static_source",
             "occupancy_stopped_source",
@@ -528,10 +549,17 @@ def compute_hdp_reward(
             terms["collision_active"],
             config.rear_end_penalty,
         )
+        expert_future = heading_to_cos_sin_if_needed(scene_inputs["ego_agent_future"][scene])
+        lane_centerlines, lane_route_source = _lane_reward_centerlines(
+            expert_future,
+            scene_inputs["lanes"][scene],
+            scene_inputs.get("route_lanes", None)[scene] if "route_lanes" in scene_inputs else None,
+            config,
+        )
         lane, expert_off_lane, expert_lane_change = _hdp_lane_score(
             ego_group[scene],
-            heading_to_cos_sin_if_needed(scene_inputs["ego_agent_future"][scene]),
-            scene_inputs["lanes"][scene],
+            expert_future,
+            lane_centerlines,
             scene_inputs.get("turn_indicators", None)[scene]
             if "turn_indicators" in scene_inputs
             else None,
@@ -555,6 +583,7 @@ def compute_hdp_reward(
         metric_lists["collision_rear"].append(terms["collision_rear"])
         metric_lists["lane_masked"].append(lane.new_full((n,), float(expert_off_lane)))
         metric_lists["lane_change_masked"].append(lane.new_full((n,), float(expert_lane_change)))
+        metric_lists["lane_route_source"].append(lane.new_full((n,), float(lane_route_source)))
         metric_lists["occupancy_any_source"].append(
             lane.new_full((n,), float(any(occupancy_sources.values())))
         )
@@ -652,9 +681,7 @@ def sample_group(
                 cached_global_route_condition = net.decoder.global_route_encoder(
                     scene_norm_inputs["route_lanes"]
                 ).repeat_interleave(group_size, dim=0)
-                inference_inputs["_cached_global_route_condition"] = (
-                    cached_global_route_condition
-                )
+                inference_inputs["_cached_global_route_condition"] = cached_global_route_condition
                 outputs = net.decoder(cached_encoding, inference_inputs)
             else:
                 _, outputs = model(inference_inputs)

--- a/diffusion_planner/diffusion_planner/loss.py
+++ b/diffusion_planner/diffusion_planner/loss.py
@@ -34,28 +34,25 @@ def velocity_to_waypoints(velocity: torch.Tensor) -> torch.Tensor:
 
 
 def normalize_ego_state(data: torch.Tensor, normalizer) -> torch.Tensor:
-    mean = normalizer.mean[0].to(device=data.device, dtype=data.dtype).reshape(-1)[: data.shape[-1]]
-    std = normalizer.std[0].to(device=data.device, dtype=data.dtype).reshape(-1)[: data.shape[-1]]
+    mean, std = normalizer._mean_std_on(data.device, data.dtype)
+    mean = mean[0].reshape(-1)[: data.shape[-1]]
+    std = std[0].reshape(-1)[: data.shape[-1]]
     shape = (1,) * (data.ndim - 1) + (data.shape[-1],)
     return (data - mean.reshape(shape)) / std.reshape(shape)
 
 
 def inverse_normalize_ego_state(data: torch.Tensor, normalizer) -> torch.Tensor:
-    mean = normalizer.mean[0].to(device=data.device, dtype=data.dtype).reshape(-1)[: data.shape[-1]]
-    std = normalizer.std[0].to(device=data.device, dtype=data.dtype).reshape(-1)[: data.shape[-1]]
+    mean, std = normalizer._mean_std_on(data.device, data.dtype)
+    mean = mean[0].reshape(-1)[: data.shape[-1]]
+    std = std[0].reshape(-1)[: data.shape[-1]]
     shape = (1,) * (data.ndim - 1) + (data.shape[-1],)
     return data * std.reshape(shape) + mean.reshape(shape)
 
 
 def _ego_velocity_stats(data: torch.Tensor, normalizer) -> tuple[torch.Tensor, torch.Tensor]:
-    if normalizer.ego_velocity_mean is None or normalizer.ego_velocity_std is None:
-        raise RuntimeError("ego_velocity normalization stats are required for HDP velocity mode")
-    mean = normalizer.ego_velocity_mean.to(device=data.device, dtype=data.dtype).reshape(-1)[
-        : data.shape[-1]
-    ]
-    std = normalizer.ego_velocity_std.to(device=data.device, dtype=data.dtype).reshape(-1)[
-        : data.shape[-1]
-    ]
+    mean, std = normalizer.ego_velocity_stats_on(data.device, data.dtype)
+    mean = mean.reshape(-1)[: data.shape[-1]]
+    std = std.reshape(-1)[: data.shape[-1]]
     shape = (1,) * (data.ndim - 1) + (data.shape[-1],)
     return mean.reshape(shape), std.reshape(shape)
 

--- a/diffusion_planner/diffusion_planner/model/module/decoder.py
+++ b/diffusion_planner/diffusion_planner/model/module/decoder.py
@@ -71,7 +71,9 @@ class GlobalRouteEncoder(nn.Module):
                 f"got {tuple(route_lanes.shape)}"
             )
         if route_lanes.shape[-1] < 4:
-            raise ValueError(f"Route lanes need at least four geometry channels, got {route_lanes.shape[-1]}")
+            raise ValueError(
+                f"Route lanes need at least four geometry channels, got {route_lanes.shape[-1]}"
+            )
 
         # Match the official NuPlan HDP route conditioner: ordered x/y geometry and
         # direction vectors are mixed across the complete route, then pooled once.
@@ -114,9 +116,7 @@ def compute_training_loss(
     gt_future = ego_future[:, None]  # [B, 1, T, 4]
     # bf16 autocast is scoped to the model forward ONLY: noising, SDE schedule math and
     # every loss below stay fp32 (the diffusion-sensitive parts). Off on CPU.
-    use_bf16 = (
-        getattr(args, "amp_dtype", "off") == "bf16" and gt_future.device.type == "cuda"
-    )
+    use_bf16 = getattr(args, "amp_dtype", "off") == "bf16" and gt_future.device.type == "cuda"
 
     eps = 1e-3
     t = sample_diffusion_time(
@@ -561,9 +561,5 @@ class Decoder(nn.Module):
 
         # Dispatch to training or inference
         if self.training:
-            return self._forward_training(
-                encoding, inputs, encoding_pooled, global_route_condition
-            )
-        return self._forward_inference(
-            encoding, inputs, encoding_pooled, global_route_condition
-        )
+            return self._forward_training(encoding, inputs, encoding_pooled, global_route_condition)
+        return self._forward_inference(encoding, inputs, encoding_pooled, global_route_condition)

--- a/diffusion_planner/diffusion_planner/model/module/encoder.py
+++ b/diffusion_planner/diffusion_planner/model/module/encoder.py
@@ -173,20 +173,22 @@ class Encoder(nn.Module):
 
     def forward(self, inputs):
         # ego agent
-        ego = inputs["ego_agent_past"].clone()  # (B, T=INPUT_T + 1, D=4)
+        ego = inputs["ego_agent_past"]  # (B, T=INPUT_T + 1, D=4)
         if not self.use_ego_history:
             ego = torch.zeros_like(ego)
-        ego = torch.cat(
-            [torch.zeros_like(ego[:, :-6]), ego[:, -6:]],
-            dim=1,
-        )  # Only keep the current + nearest 5 steps of ego history
+        else:
+            recent_ego = ego[:, -6:]
+            ego = F.pad(recent_ego, (0, 0, ego.shape[1] - recent_ego.shape[1], 0))
+        # Only keep the current + nearest 5 steps of ego history.
 
         # agents
-        neighbors = inputs["neighbor_agents_past"].clone()  # (B, N=32, T=21, D=11)
-        neighbors = torch.cat(
-            [torch.zeros_like(neighbors[:, :, :-6]), neighbors[:, :, -6:]],
-            dim=2,
-        )  # Only keep the current + first 5 steps of history
+        neighbors = inputs["neighbor_agents_past"]  # (B, N=32, T=21, D=11)
+        recent_neighbors = neighbors[:, :, -6:]
+        neighbors = F.pad(
+            recent_neighbors,
+            (0, 0, neighbors.shape[2] - recent_neighbors.shape[2], 0),
+        )
+        # Only keep the current + nearest 5 steps of neighbor history.
 
         # static objects
         static = inputs["static_objects"]  # (B, P=5, D=10)

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -431,74 +431,96 @@ def mean_epdms_metric(loss_dict):
 
 
 def closed_loop_validate(model, args, epoch: int, out_dir: str) -> None:
-    """Closed-loop rendered rollout; logs metrics + the rollout video to wandb.
-
-    Drives the ego in CLOSED LOOP over the route NPZ frames under ``args.closed_loop_npz_root``
-    (one route = one trial), renders an MP4 into ``out_dir``, aggregates collision/clearance
-    metrics, and logs both to wandb at ``step=epoch+1``. Called on the checkpoint-save cadence.
-    No-op when ``closed_loop_npz_root`` is unset. Rank-0 only: pass the unwrapped model; it is
-    switched to eval for the rollout (so the diffusion sampler runs and produces ``prediction``)
-    and restored afterwards.
-    """
+    """Run grouped or full-route closed-loop evaluation on checkpoint-save cadence."""
     if not args.closed_loop_npz_root:
         return
-    import math
 
-    from scenario_generation.closed_loop_eval import run_closed_loop_eval
+    from scenario_generation.scenario_classification import resolve_classification_json
+    from scenario_generation.wandb_closed_loop import (
+        build_full_closed_loop_wandb_log,
+        build_grouped_closed_loop_wandb_log,
+    )
+
+    explicit_classification = getattr(args, "closed_loop_classification_json", "")
+    classification_json = resolve_classification_json(
+        args.closed_loop_npz_root,
+        explicit_classification or None,
+        dataset_name=getattr(args, "closed_loop_scenario_dataset_name", "") or None,
+    )
+    if explicit_classification and classification_json is None:
+        raise FileNotFoundError(
+            f"closed-loop classification JSON does not exist: {explicit_classification}"
+        )
 
     net = ddp.get_model(model, args.ddp)
     was_training = net.training
     net.eval()
     try:
-        summary = run_closed_loop_eval(
-            net,
-            args,
-            args.closed_loop_npz_root,
-            out_dir,
-            seg_len=args.closed_loop_seg_len,
-            device=args.device,
-            near_miss_thresh=args.closed_loop_near_miss_thresh,
-            search_radius=args.closed_loop_search_radius,
-            warmup_steps=args.closed_loop_warmup_steps,
-            unstick_after=args.closed_loop_unstick_after,
-            unstick_advance_m=args.closed_loop_unstick_advance_m,
-            fps=args.closed_loop_fps,
-            replan_interval=args.closed_loop_replan_interval,
-            draw_every=args.closed_loop_draw_every,
-            neighbor_history_mode="recorded",
-            verbose=False,
-        )
+        if classification_json is not None:
+            from scenario_generation.grouped_closed_loop_eval import run_grouped_closed_loop_eval
+
+            summary = run_grouped_closed_loop_eval(
+                net,
+                args,
+                args.closed_loop_npz_root,
+                classification_json,
+                os.path.join(out_dir, "grouped"),
+                device=args.device,
+                near_miss_thresh=args.closed_loop_near_miss_thresh,
+                search_radius=args.closed_loop_search_radius,
+                warmup_steps=args.closed_loop_warmup_steps,
+                unstick_after=args.closed_loop_unstick_after,
+                unstick_advance_m=args.closed_loop_unstick_advance_m,
+                draw_every=args.closed_loop_draw_every,
+                fps=float(args.closed_loop_fps),
+                verbose=False,
+            )
+            log = build_grouped_closed_loop_wandb_log(
+                summary,
+                max_videos=getattr(args, "closed_loop_grouped_wandb_max_videos", 24),
+            )
+        else:
+            from scenario_generation.closed_loop_eval import run_closed_loop_eval
+
+            summary = run_closed_loop_eval(
+                net,
+                args,
+                args.closed_loop_npz_root,
+                out_dir,
+                seg_len=args.closed_loop_seg_len,
+                device=args.device,
+                near_miss_thresh=args.closed_loop_near_miss_thresh,
+                search_radius=args.closed_loop_search_radius,
+                warmup_steps=args.closed_loop_warmup_steps,
+                unstick_after=args.closed_loop_unstick_after,
+                unstick_advance_m=args.closed_loop_unstick_advance_m,
+                fps=args.closed_loop_fps,
+                replan_interval=args.closed_loop_replan_interval,
+                draw_every=args.closed_loop_draw_every,
+                neighbor_history_mode="recorded",
+                verbose=False,
+            )
+            log = build_full_closed_loop_wandb_log(summary)
     finally:
         net.train(was_training)
 
-    # Scalar metrics (drop non-finite clearances: a segment with no neighbor reports +inf).
-    scalar_keys = [
-        "collision_segment_rate",
-        "collision_step_rate",
-        "near_miss_segment_rate",
-        "near_miss_step_rate",
-        "global_min_clearance",
-        "mean_segment_min_clearance",
-        "mean_segment_mean_clearance",
-        "total_collision_steps",
-        "total_near_miss_steps",
-        "total_snaps",
-        "total_steps",
-    ]
-    log = {
-        f"closed_loop/{k}": summary[k]
-        for k in scalar_keys
-        if isinstance(summary[k], (int,)) or math.isfinite(summary[k])
-    }
     if getattr(args, "use_wandb", False):
-        for mp4 in summary["video_mp4s"]:
-            log[f"closed_loop/video/{Path(mp4).stem}"] = wandb.Video(str(mp4), format="mp4")
         wandb.log(log)
-    print(
-        f"closed-loop @epoch {epoch + 1}: {summary['n_segments']} seg in "
-        f"{summary['elapsed_sec']:.1f}s  coll_seg_rate={summary['collision_segment_rate']:.3f}  "
-        f"min_clr={summary['global_min_clearance']:.2f}  -> {len(summary['video_mp4s'])} video(s)"
-    )
+    if classification_json is not None:
+        grouped = summary["grouped_summary"]
+        print(
+            f"grouped closed-loop @epoch {epoch + 1}: "
+            f"{summary['n_episodes']}/{summary['n_episodes_expected']} episodes, "
+            f"{summary['n_bags']}/{summary['n_bags_expected']} bags in "
+            f"{summary['elapsed_sec']:.1f}s, "
+            f"reported={grouped['n_segments_total']}"
+        )
+    else:
+        print(
+            f"closed-loop @epoch {epoch + 1}: {summary['n_segments']} seg in "
+            f"{summary['elapsed_sec']:.1f}s  coll_seg_rate={summary['collision_segment_rate']:.3f}  "
+            f"min_clr={summary['global_min_clearance']:.2f}"
+        )
 
 
 def model_training(args: TrainConfig):

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -982,7 +982,9 @@ def model_training(args: TrainConfig):
             }
             atomic_torch_save(model_dict, f"{save_path}/latest.pth")
 
-            if (epoch + 1 - init_epoch) % save_utd == 0:
+            # Keep checkpoint and closed-loop cadence anchored to the absolute epoch.
+            # A resume from (for example) epoch 7 must still save at epochs 10 and 20.
+            if (epoch + 1) % save_utd == 0:
                 curr_dir = os.path.join(save_path, f"epoch{epoch + 1:04d}")
                 os.makedirs(curr_dir, exist_ok=True)
                 atomic_torch_save(model_dict, f"{curr_dir}/best_model.pth")

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -28,6 +28,7 @@ from diffusion_planner.utils.onnx_export import export_checkpoint_onnx_guarded
 from diffusion_planner.utils.train_utils import (
     ModelEma,
     atomic_torch_save,
+    compile_model_components,
     gather_rng_states,
     resume_model,
     set_seed,
@@ -564,6 +565,7 @@ def model_training(args: TrainConfig):
         print("Weight decay: {}".format(args.weight_decay))
         print("Use device: {}".format(args.device))
         print("TF32: {}".format(args.tf32))
+        print("TorchInductor model compile: {}".format(args.compile_model))
 
         save_path = args.save_dir
         os.makedirs(save_path, exist_ok=True)
@@ -746,6 +748,10 @@ def model_training(args: TrainConfig):
     args._wandb_global_step = int(
         getattr(diffusion_planner, "_resume_global_step", init_epoch * len(train_loader))
     )
+    if args.compile_model:
+        compile_model_components(diffusion_planner)
+        if model_ema is not None:
+            compile_model_components(model_ema.ema)
     requested_wandb_id = args.wandb_run_id or checkpoint_wandb_id
     active_wandb_id = requested_wandb_id
     # logger

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import numpy as np
 import torch
 import wandb
-from timm.utils import ModelEma
 from torch import optim
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data import DataLoader, DistributedSampler
@@ -27,6 +26,7 @@ from diffusion_planner.utils.lr_schedule import LinearWarmupConstantLR
 from diffusion_planner.utils.normalizer import ObservationNormalizer, StateNormalizer
 from diffusion_planner.utils.onnx_export import export_checkpoint_onnx_guarded
 from diffusion_planner.utils.train_utils import (
+    ModelEma,
     atomic_torch_save,
     gather_rng_states,
     resume_model,

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -164,6 +164,7 @@ class TrainConfig:
     amp_dtype: Literal["off", "bf16"] = "bf16"
     fused_optimizer: bool = True
     ddp_static_graph: bool = True
+    compile_model: bool = True
     export_onnx_on_save: bool = False
 
     device: str = "cuda"

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -214,6 +214,9 @@ class TrainConfig:
     closed_loop_warmup_steps: int = 0
     closed_loop_unstick_after: int = 300
     closed_loop_unstick_advance_m: float = 2.5
+    closed_loop_classification_json: str = ""
+    closed_loop_scenario_dataset_name: str = ""
+    closed_loop_grouped_wandb_max_videos: int = 24
 
     # ---------------------------------------------------------
     # Normalizers (Placeholders to be initialized and set during training execution)

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -9,7 +9,10 @@ from diffusion_planner.utils.masks import (
     static_object_padding_mask,
     zero_padding_mask,
 )
-from diffusion_planner.utils.unicycle_accel_curvature import smoothing_future_trajectory
+from diffusion_planner.utils.unicycle_accel_curvature import (
+    UnicycleAccelCurvatureActionSpace,
+    smoothing_future_trajectory,
+)
 
 TIME_INTERVAL = 0.1
 
@@ -111,6 +114,11 @@ class StatePerturbation:
         self._device = torch.device(device)
         self._ego_past_noise_std = ego_past_noise_std
         self._use_smoothing_future_trajectory = use_smoothing_future_trajectory
+        self._smoothing_action_space = (
+            UnicycleAccelCurvatureActionSpace(n_waypoints=80).to(self._device)
+            if use_smoothing_future_trajectory
+            else None
+        )
         # Production samples carry per-vehicle wheelbase in ego_shape. Keep the historical
         # constructor value as a fallback for lightweight callers and unit tests.
         self._wheel_base = wheel_base
@@ -158,24 +166,28 @@ class StatePerturbation:
         ).clamp(1.0 - 2 * W, 1.0 + 2 * W)
         ego_past_aug = inputs["ego_agent_past"].clone()
         ego_past_aug[..., :2] *= scale
-        inputs["ego_agent_past"][aug_flag] = ego_past_aug[aug_flag]
+        inputs["ego_agent_past"] = torch.where(
+            aug_flag[:, None, None], ego_past_aug, inputs["ego_agent_past"]
+        )
 
         scale_1d = scale.squeeze(-1)
-        aug_ego_current_state[aug_flag, 4:6] *= scale_1d[aug_flag]
-        aug_ego_current_state[aug_flag, 6:8] *= scale_1d[aug_flag]
+        aug_ego_current_state[:, 4:6] *= scale_1d
+        aug_ego_current_state[:, 6:8] *= scale_1d
         wheel_base = inputs["ego_shape"][:, 0]
         speed = aug_ego_current_state[:, 4].abs()
         steering = torch.atan(
             aug_ego_current_state[:, 9] * wheel_base / speed.clamp_min(0.2)
         ).clamp(-2 / 3 * np.pi, 2 / 3 * np.pi)
         steering = torch.where(speed >= 0.2, steering, torch.zeros_like(steering))
-        aug_ego_current_state[aug_flag, 8] = steering[aug_flag]
+        aug_ego_current_state[:, 8] = steering
 
         interpolated_ego_future = self.interpolation_future_trajectory(
             aug_ego_current_state, ego_future
         )
-        inputs["ego_current_state"][aug_flag] = aug_ego_current_state[aug_flag]
-        ego_future[aug_flag] = interpolated_ego_future[aug_flag]
+        inputs["ego_current_state"] = torch.where(
+            aug_flag[:, None], aug_ego_current_state, inputs["ego_current_state"]
+        )
+        ego_future = torch.where(aug_flag[:, None, None], interpolated_ego_future, ego_future)
 
         return self.centric_transform(inputs, ego_future, neighbors_future)
 
@@ -199,7 +211,7 @@ class StatePerturbation:
             :, 4:10
         ]  # x, y, h is 0 because of ego-centric, update vx, vy, ax, ay, steering angle, yaw rate
         new_state = new_state + scaled_random_tensor
-        new_state[:, 3] = torch.max(new_state[:, 3], torch.tensor(0.0, device=new_state.device))
+        new_state[:, 3].clamp_min_(0.0)
         new_state[:, -1] = torch.clip(new_state[:, -1], -0.85, 0.85)
 
         ego_current_state[:, :2] = new_state[:, :2]
@@ -212,18 +224,15 @@ class StatePerturbation:
         cur_velocity = ego_current_state[:, 4]
         yaw_rate = ego_current_state[:, 9]
 
-        steering_angle = torch.zeros_like(cur_velocity)
-        new_yaw_rate = torch.zeros_like(yaw_rate)
-
         mask = torch.abs(cur_velocity) < 0.2
         not_mask = ~mask
-        steering_angle[not_mask] = torch.atan(
-            yaw_rate[not_mask] * wheel_base[not_mask] / torch.abs(cur_velocity[not_mask])
+        steering_angle = torch.atan(yaw_rate * wheel_base / torch.abs(cur_velocity).clamp_min(0.2))
+        steering_angle = torch.where(
+            not_mask,
+            torch.clamp(steering_angle, -2 / 3 * np.pi, 2 / 3 * np.pi),
+            torch.zeros_like(steering_angle),
         )
-        steering_angle[not_mask] = torch.clamp(
-            steering_angle[not_mask], -2 / 3 * np.pi, 2 / 3 * np.pi
-        )
-        new_yaw_rate[not_mask] = yaw_rate[not_mask]
+        new_yaw_rate = torch.where(not_mask, yaw_rate, torch.zeros_like(yaw_rate))
 
         ego_current_state[:, 8] = steering_angle
         ego_current_state[:, 9] = new_yaw_rate
@@ -265,17 +274,16 @@ class StatePerturbation:
         if "neighbor_agents_past" in inputs:
             nbr = inputs["neighbor_agents_past"][:, :, -1, :]  # [B, N, 11]
             N = nbr.shape[1]
-            valid = torch.sum(torch.ne(nbr[:, :, :4], 0), dim=-1) > 0  # [B, N]
-            if valid.any():
-                # neighbor_agents_past layout: x,y,cos,sin (0:4), width (6), length (7)
-                nbr_rect = torch.cat(
-                    [nbr[:, :, :4], nbr[:, :, 7:8], nbr[:, :, 6:7]], dim=-1
-                )  # [B, N, 6]  — (x,y,cos,sin,length,width)
-                dists = _sat_signed_distance(
-                    _rect_corners(ego_rect.unsqueeze(1).expand(-1, N, -1).reshape(B * N, 6)),
-                    _rect_corners(nbr_rect.reshape(B * N, 6)),
-                ).reshape(B, N)
-                collision = collision | ((dists < 0) & valid).any(dim=1)
+            valid = torch.any(nbr[:, :, :4] != 0, dim=-1)  # [B, N]
+            # neighbor_agents_past layout: x,y,cos,sin (0:4), width (6), length (7)
+            nbr_rect = torch.cat(
+                [nbr[:, :, :4], nbr[:, :, 7:8], nbr[:, :, 6:7]], dim=-1
+            )  # [B, N, 6]  — (x,y,cos,sin,length,width)
+            dists = _sat_signed_distance(
+                _rect_corners(ego_rect.unsqueeze(1).expand(-1, N, -1).reshape(B * N, 6)),
+                _rect_corners(nbr_rect.reshape(B * N, 6)),
+            ).reshape(B, N)
+            collision = collision | ((dists < 0) & valid).any(dim=1)
 
         return collision
 
@@ -357,7 +365,7 @@ class StatePerturbation:
             inputs["ego_agent_past"][..., 2:4] = vector_transform(
                 inputs["ego_agent_past"][..., 2:4], transform_matrix
             )
-        inputs["ego_agent_past"][ego_past_mask] = 0.0
+        inputs["ego_agent_past"].masked_fill_(ego_past_mask.unsqueeze(-1), 0.0)
 
         if self._use_smoothing_future_trajectory:
             smoothing_ego_past = inputs["ego_agent_past"]
@@ -370,9 +378,12 @@ class StatePerturbation:
                     ],
                     dim=-1,
                 )
-                smoothing_ego_past[ego_past_mask] = 0.0
+                smoothing_ego_past.masked_fill_(ego_past_mask.unsqueeze(-1), 0.0)
             ego_future4d = smoothing_future_trajectory(
-                smoothing_ego_past, inputs["ego_current_state"], ego_future4d
+                smoothing_ego_past,
+                inputs["ego_current_state"],
+                ego_future4d,
+                action_space=self._smoothing_action_space,
             )
 
         if ego_future_is_heading:
@@ -400,7 +411,7 @@ class StatePerturbation:
         inputs["neighbor_agents_past"][..., 4:6] = vector_transform(
             inputs["neighbor_agents_past"][..., 4:6], transform_matrix
         )
-        inputs["neighbor_agents_past"][mask] = 0.0
+        inputs["neighbor_agents_past"].masked_fill_(mask.unsqueeze(-1), 0.0)
 
         # neighbor future
         mask = neighbor_future_padding_mask(neighbors_future)
@@ -413,7 +424,7 @@ class StatePerturbation:
             neighbors_future[..., 2:4] = vector_transform(
                 neighbors_future[..., 2:4], transform_matrix
             )
-        neighbors_future[mask] = 0.0
+        neighbors_future.masked_fill_(mask.unsqueeze(-1), 0.0)
 
         # lanes
         mask = lane_point_padding_mask(inputs["lanes"])
@@ -423,7 +434,7 @@ class StatePerturbation:
         inputs["lanes"][..., 2:4] = vector_transform(inputs["lanes"][..., 2:4], transform_matrix)
         inputs["lanes"][..., 4:6] = vector_transform(inputs["lanes"][..., 4:6], transform_matrix)
         inputs["lanes"][..., 6:8] = vector_transform(inputs["lanes"][..., 6:8], transform_matrix)
-        inputs["lanes"][mask] = 0.0
+        inputs["lanes"].masked_fill_(mask.unsqueeze(-1), 0.0)
 
         # route_lanes
         mask = lane_point_padding_mask(inputs["route_lanes"])
@@ -439,21 +450,21 @@ class StatePerturbation:
         inputs["route_lanes"][..., 6:8] = vector_transform(
             inputs["route_lanes"][..., 6:8], transform_matrix
         )
-        inputs["route_lanes"][mask] = 0.0
+        inputs["route_lanes"].masked_fill_(mask.unsqueeze(-1), 0.0)
 
         # polygons
         mask = zero_padding_mask(inputs["polygons"])
         inputs["polygons"][..., :2] = vector_transform(
             inputs["polygons"][..., :2], transform_matrix, center_xy
         )
-        inputs["polygons"][mask] = 0.0
+        inputs["polygons"].masked_fill_(mask.unsqueeze(-1), 0.0)
 
         # line_strings
         mask = zero_padding_mask(inputs["line_strings"])
         inputs["line_strings"][..., :2] = vector_transform(
             inputs["line_strings"][..., :2], transform_matrix, center_xy
         )
-        inputs["line_strings"][mask] = 0.0
+        inputs["line_strings"].masked_fill_(mask.unsqueeze(-1), 0.0)
 
         # static objects xy
         mask = static_object_padding_mask(inputs["static_objects"])
@@ -464,10 +475,10 @@ class StatePerturbation:
         inputs["static_objects"][..., 2:4] = vector_transform(
             inputs["static_objects"][..., 2:4], transform_matrix
         )
-        inputs["static_objects"][mask] = 0.0
+        inputs["static_objects"].masked_fill_(mask.unsqueeze(-1), 0.0)
 
         if "goal_pose" in inputs:
-            goal_mask = torch.sum(torch.ne(inputs["goal_pose"], 0), dim=-1) == 0
+            goal_mask = torch.all(inputs["goal_pose"] == 0, dim=-1)
             inputs["goal_pose"][..., :2] = vector_transform(
                 inputs["goal_pose"][..., :2], transform_matrix, center_xy
             )
@@ -479,7 +490,7 @@ class StatePerturbation:
                 inputs["goal_pose"][..., 2:4] = vector_transform(
                     inputs["goal_pose"][..., 2:4], transform_matrix
                 )
-            inputs["goal_pose"][goal_mask] = 0.0
+            inputs["goal_pose"].masked_fill_(goal_mask.unsqueeze(-1), 0.0)
 
         return inputs, ego_future, neighbors_future
 

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -165,10 +165,10 @@ class StatePerturbation:
         # Production samples carry per-vehicle wheelbase in ego_shape. Keep the historical
         # constructor value as a fallback for lightweight callers and unit tests.
         self._wheel_base = wheel_base
-        lo = ([0.0, -0.75, -0.2, -1, -0.5, -0.2, -0.1, 0.0, 0.0],)
-        hi = ([0.0, +0.75, +0.2, +1, +0.5, +0.2, +0.1, 0.0, 0.0],)
-        self._low = torch.tensor(lo).to(self._device)
-        self._high = torch.tensor(hi).to(self._device)
+        low = [0.0, -0.75, -0.2, -1, -0.5, -0.2, -0.1, 0.0, 0.0]
+        high = [0.0, +0.75, +0.2, +1, +0.5, +0.2, +0.1, 0.0, 0.0]
+        self._low = torch.tensor(low, dtype=torch.float32, device=self._device)
+        self._high = torch.tensor(high, dtype=torch.float32, device=self._device)
 
         self.num_refine = num_refine
         self.time_interval = TIME_INTERVAL

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -46,11 +46,6 @@ def heading_transform(heading, transform_mat):
     ).reshape(*shape)
 
 
-def _cross2d(u: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
-    """2D cross product along the last dimension: u × v = u.x*v.y - u.y*v.x"""
-    return u[..., 0] * v[..., 1] - u[..., 1] * v[..., 0]
-
-
 def _rect_corners(rect: torch.Tensor) -> torch.Tensor:
     """
     rect: [B, 6] — (x, y, cos_h, sin_h, length, width)
@@ -85,52 +80,6 @@ def _sat_signed_distance(c1: torch.Tensor, c2: torch.Tensor) -> torch.Tensor:
     is_overlap = (overlap < 0).all(dim=1)
     pos = torch.where(overlap < 0, torch.full_like(overlap, 1e5), overlap)
     return torch.where(is_overlap, overlap.max(1).values, pos.min(1).values)
-
-
-def _segments_intersect_rect(
-    seg_start: torch.Tensor,
-    seg_end: torch.Tensor,
-    rect_corners: torch.Tensor,
-    valid: torch.Tensor | None = None,
-) -> torch.Tensor:
-    """
-    Returns [B] bool — True if any valid segment touches the rectangle.
-
-    seg_start, seg_end: [B, N, 2]
-    rect_corners:       [B, 4, 2]
-    valid:              [B, N] bool — True for valid segments
-    """
-    hit = torch.zeros(seg_start.shape[:2], dtype=torch.bool, device=seg_start.device)
-    edges = [(0, 1), (1, 2), (2, 3), (3, 0)]
-
-    # Proper segment–edge crossing: both pairs straddle each other's line
-    for i, j in edges:
-        C = rect_corners[:, i, :].unsqueeze(1)  # [B, 1, 2]
-        D = rect_corners[:, j, :].unsqueeze(1)  # [B, 1, 2]
-        AB = seg_end - seg_start  # [B, N, 2]
-        CD = D - C  # [B, 1, 2]
-        hit = hit | (
-            (_cross2d(AB, C - seg_start) * _cross2d(AB, D - seg_start) < 0)
-            & (_cross2d(CD, seg_start - C) * _cross2d(CD, seg_end - C) < 0)
-        )
-
-    # Endpoint inside polygon: all edge cross products share the same sign
-    for pt in (seg_start, seg_end):
-        crosses = torch.stack(
-            [
-                _cross2d(
-                    (rect_corners[:, j, :] - rect_corners[:, i, :]).unsqueeze(1),
-                    pt - rect_corners[:, i, :].unsqueeze(1),
-                )
-                for i, j in edges
-            ],
-            dim=-1,
-        )  # [B, N, 4]
-        hit = hit | (crosses > 0).all(-1) | (crosses < 0).all(-1)
-
-    if valid is not None:
-        hit = hit & valid
-    return hit.any(dim=1)  # [B]
 
 
 class StatePerturbation:
@@ -289,9 +238,11 @@ class StatePerturbation:
         """
         Returns [B] bool — True where the augmented ego position is invalid.
 
-        Invalid conditions:
-          1. Ego polygon overlaps with a neighbour agent polygon.
-          2. Ego polygon intersects a lane left or right boundary segment.
+        An augmented pose is invalid when its ego polygon overlaps a neighbour polygon.
+
+        Lane boundaries are deliberately not treated as solid obstacles. ``lanes`` contains
+        every nearby lane, including internal markings and overlapping intersection geometry;
+        rejecting against all of them suppresses even centimetre-scale recovery perturbations.
         """
         B = aug_ego_state.shape[0]
         device = aug_ego_state.device
@@ -308,8 +259,6 @@ class StatePerturbation:
         # Match the convention used by training penalties and planner metrics.
         ego_center = aug_ego_state[:, :2] + heading * (ego_shape[:, 0:1] * 0.5)
         ego_rect = torch.cat([ego_center, heading, ego_length, ego_width], dim=-1)
-        ego_corners = _rect_corners(ego_rect)  # [B, 4, 2]
-
         collision = torch.zeros(B, dtype=torch.bool, device=device)
 
         # ── 1. Neighbour agent polygon collision ──────────────────────────────
@@ -327,39 +276,6 @@ class StatePerturbation:
                     _rect_corners(nbr_rect.reshape(B * N, 6)),
                 ).reshape(B, N)
                 collision = collision | ((dists < 0) & valid).any(dim=1)
-
-        # ── 2. Lane boundary segment collision ───────────────────────────────
-        if "lanes" in inputs:
-            lanes = inputs["lanes"]  # [B, L, P, 33]
-            left_offset = lanes[..., 4:6]  # [B, L, P, 2]
-            right_offset = lanes[..., 6:8]  # [B, L, P, 2]
-
-            # Absolute boundary positions
-            left_pts = lanes[..., :2] + left_offset  # [B, L, P, 2]
-            right_pts = lanes[..., :2] + right_offset  # [B, L, P, 2]
-
-            # A waypoint is valid when its first 8 features are not all zero.
-            # Additionally, only include a boundary side when its offset is
-            # non-trivial; a near-zero offset means no boundary data.
-            lane_valid = torch.sum(torch.ne(lanes[..., :8], 0), dim=-1) > 0  # [B, L, P]
-            left_bound_valid = (torch.norm(left_offset, dim=-1) > 0.01) & lane_valid
-            right_bound_valid = (torch.norm(right_offset, dim=-1) > 0.01) & lane_valid
-
-            def _boundary_segs(pts, point_valid):
-                s = pts[:, :, :-1, :].reshape(B, -1, 2)
-                e = pts[:, :, 1:, :].reshape(B, -1, 2)
-                v = (point_valid[:, :, :-1] & point_valid[:, :, 1:]).reshape(B, -1)
-                return s, e, v
-
-            ls, le, lv = _boundary_segs(left_pts, left_bound_valid)
-            rs, re, rv = _boundary_segs(right_pts, right_bound_valid)
-
-            collision = collision | _segments_intersect_rect(
-                torch.cat([ls, rs], dim=1),
-                torch.cat([le, re], dim=1),
-                ego_corners,
-                torch.cat([lv, rv], dim=1),
-            )
 
         return collision
 

--- a/diffusion_planner/diffusion_planner/utils/dataset.py
+++ b/diffusion_planner/diffusion_planner/utils/dataset.py
@@ -73,11 +73,12 @@ class DiffusionPlannerData(Dataset):
 
     def __getitem__(self, idx):
         path = self.data_list[idx]
-        with np.load(path, allow_pickle=True) as archive:
+        with np.load(path, allow_pickle=False) as archive:
             data = {
                 key: archive[key]
                 for key in archive.files
-                if self.include_neighbor_futures or key != "neighbor_agents_future"
+                if key != "version"
+                and (self.include_neighbor_futures or key != "neighbor_agents_future")
             }
         normalized_idx = idx if idx >= 0 else len(self.data_list) + idx
         source_idx = normalized_idx * self._source_index_stride

--- a/diffusion_planner/diffusion_planner/utils/ddp.py
+++ b/diffusion_planner/diffusion_planner/utils/ddp.py
@@ -9,8 +9,12 @@ from torch.distributed import init_process_group
 
 def ddp_setup_universal(verbose=False, args=None):
     if args.ddp == False:
-        print(f"do not use ddp, train on GPU 0")
+        print(f"DDP disabled; using {args.device}")
         return 0, 0, 1
+
+    requested_device = torch.device(args.device)
+    if requested_device.type != "cuda":
+        raise ValueError("DDP training/validation requires a CUDA device")
 
     if "RANK" in os.environ and "WORLD_SIZE" in os.environ:
         rank = int(os.environ["RANK"])
@@ -29,6 +33,10 @@ def ddp_setup_universal(verbose=False, args=None):
         os.environ["MASTER_ADDR"] = addr
     else:
         print("Not using DDP mode")
+        # The caller may be launched directly with the default --ddp=True. Keep the
+        # advertised single-process fallback internally consistent so it does not later
+        # wrap DDP or call collectives without an initialized process group.
+        args.ddp = False
         return 0, 0, 1
 
     os.environ["WORLD_SIZE"] = str(world_size)
@@ -36,6 +44,8 @@ def ddp_setup_universal(verbose=False, args=None):
     os.environ["RANK"] = str(rank)
 
     torch.cuda.set_device(gpu)
+    # Explicit inputs such as --device cuda:0 must still follow LOCAL_RANK under DDP.
+    args.device = str(torch.device("cuda", gpu))
     dist_backend = "nccl"
     dist_url = "env://"
     print("| distributed init (rank {}): {}, gpu {}".format(rank, dist_url, gpu), flush=True)

--- a/diffusion_planner/diffusion_planner/utils/masks.py
+++ b/diffusion_planner/diffusion_planner/utils/masks.py
@@ -3,7 +3,7 @@ import torch
 
 def zero_padding_mask(x: torch.Tensor, feature_dim: int | None = None) -> torch.Tensor:
     features = x if feature_dim is None else x[..., :feature_dim]
-    return torch.sum(torch.ne(features, 0), dim=-1) == 0
+    return torch.all(features == 0, dim=-1)
 
 
 def pose_padding_mask(x: torch.Tensor) -> torch.Tensor:

--- a/diffusion_planner/diffusion_planner/utils/normalizer.py
+++ b/diffusion_planner/diffusion_planner/utils/normalizer.py
@@ -38,24 +38,43 @@ class StateNormalizer:
             ego_velocity["std"] if ego_velocity is not None else None,
         )
 
-    def _mean_std_on(self, device):
+    def _cached_stats(self, name, mean, std, device, dtype=None):
         # Per-device cache: without it every call issues two host->device copies in the
         # training hot loop. getattr-lazy so unpickled instances from old checkpoints work.
         cache = getattr(self, "_device_cache", None)
         if cache is None:
             cache = {}
             self._device_cache = cache
-        key = str(device)
+        key = (name, str(device), dtype)
         if key not in cache:
-            cache[key] = (self.mean.to(device), self.std.to(device))
+            cache[key] = (
+                mean.to(device=device, dtype=dtype),
+                std.to(device=device, dtype=dtype),
+            )
         return cache[key]
 
+    def _mean_std_on(self, device, dtype=None):
+        return self._cached_stats("state", self.mean, self.std, device, dtype)
+
+    def ego_velocity_stats_on(self, device, dtype=None):
+        if self.ego_velocity_mean is None or self.ego_velocity_std is None:
+            raise RuntimeError(
+                "ego_velocity normalization stats are required for HDP velocity mode"
+            )
+        return self._cached_stats(
+            "ego_velocity",
+            self.ego_velocity_mean,
+            self.ego_velocity_std,
+            device,
+            dtype,
+        )
+
     def __call__(self, data):
-        mean, std = self._mean_std_on(data.device)
+        mean, std = self._mean_std_on(data.device, data.dtype)
         return (data - mean) / std
 
     def inverse(self, data):
-        mean, std = self._mean_std_on(data.device)
+        mean, std = self._mean_std_on(data.device, data.dtype)
         return data * std + mean
 
     def to_dict(self):

--- a/diffusion_planner/diffusion_planner/utils/normalizer.py
+++ b/diffusion_planner/diffusion_planner/utils/normalizer.py
@@ -133,9 +133,9 @@ class ObservationNormalizer:
             if k not in data:  # Check if key `k` exists in `data`
                 continue
             mean, std = self._stats_on(k, data[k].device)
-            mask = torch.sum(torch.ne(data[k], 0), dim=-1) == 0
+            mask = torch.all(data[k] == 0, dim=-1, keepdim=True)
             norm_data[k] = (data[k] - mean) / std
-            norm_data[k][mask] = 0
+            norm_data[k].masked_fill_(mask, 0)
         return norm_data
 
     def inverse(self, data):
@@ -144,9 +144,9 @@ class ObservationNormalizer:
             if k not in data:  # Check if key `k` exists in `data`
                 continue
             mean, std = self._stats_on(k, data[k].device)
-            mask = torch.sum(torch.ne(data[k], 0), dim=-1) == 0
+            mask = torch.all(data[k] == 0, dim=-1, keepdim=True)
             norm_data[k] = data[k] * std + mean
-            norm_data[k][mask] = 0
+            norm_data[k].masked_fill_(mask, 0)
         return norm_data
 
     def to_dict(self):

--- a/diffusion_planner/diffusion_planner/utils/onnx_export.py
+++ b/diffusion_planner/diffusion_planner/utils/onnx_export.py
@@ -302,7 +302,7 @@ def load_model(config_json_path: str, ckpt_path: str, use_ema: bool) -> Diffusio
     else:
         state_dict = ckpt["model"]
         print("Loading regular model weights")
-    model.load_state_dict({k.replace("module.", ""): v for k, v in state_dict.items()})
+    model.load_state_dict({k.removeprefix("module."): v for k, v in state_dict.items()})
     return model
 
 

--- a/diffusion_planner/diffusion_planner/utils/train_utils.py
+++ b/diffusion_planner/diffusion_planner/utils/train_utils.py
@@ -1,6 +1,7 @@
 import json
 import os
 import random
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -52,6 +53,25 @@ class ModelEma(ModelEmaV3):
     @property
     def ema(self):
         return self.module
+
+
+def compile_model_components(model) -> None:
+    """Compile the HDP encoder and decoder in place without changing state-dict keys."""
+    net = getattr(model, "module", model)
+    with warnings.catch_warnings():
+        # PyTorch 2.11 imports torch.utils.mkldnn while initializing Inductor; that upstream
+        # module still defines ScriptModule helpers and emits this warning even for CUDA compile.
+        warnings.filterwarnings(
+            "ignore",
+            message=r"`torch\.jit\.script_method` is deprecated\..*",
+            category=DeprecationWarning,
+            module=r"torch\.jit\._script",
+        )
+        for name in ("encoder", "decoder"):
+            component = getattr(net, name)
+            if not hasattr(component, "compile"):
+                raise RuntimeError("--compile_model requires torch.nn.Module.compile support")
+            component.compile(mode="default", dynamic=False, fullgraph=False)
 
 
 def capture_rng_state() -> dict:

--- a/diffusion_planner/diffusion_planner/utils/train_utils.py
+++ b/diffusion_planner/diffusion_planner/utils/train_utils.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import numpy as np
 import torch
+from timm.utils import ModelEmaV3
 
 
 def atomic_torch_save(obj, path) -> None:
@@ -30,6 +31,27 @@ def set_seed(CUR_SEED):
     torch.manual_seed(CUR_SEED)
     torch.backends.cudnn.deterministic = True
     torch.backends.cudnn.benchmark = False
+
+
+class ModelEma(ModelEmaV3):
+    """Foreach EMA with the legacy ``.ema`` attribute used by our checkpoints."""
+
+    def __init__(self, model, decay=0.9999, device=None):
+        model_device = next(model.parameters()).device
+        requested_device = torch.device(device) if device not in (None, "") else None
+        if requested_device is not None and requested_device.type == model_device.type:
+            if requested_device.index is None or requested_device.index == model_device.index:
+                requested_device = None
+        super().__init__(
+            model,
+            decay=decay,
+            device=requested_device,
+            foreach=requested_device is None,
+        )
+
+    @property
+    def ema(self):
+        return self.module
 
 
 def capture_rng_state() -> dict:
@@ -78,9 +100,7 @@ def restore_rng_state(state: dict) -> None:
     )
     torch.set_rng_state(torch.as_tensor(state["torch"], dtype=torch.uint8, device="cpu"))
     if "cuda" in state and torch.cuda.is_available():
-        torch.cuda.set_rng_state(
-            torch.as_tensor(state["cuda"], dtype=torch.uint8, device="cpu")
-        )
+        torch.cuda.set_rng_state(torch.as_tensor(state["cuda"], dtype=torch.uint8, device="cpu"))
 
 
 def compute_grad_stats(parameters, prefix="grad"):

--- a/diffusion_planner/diffusion_planner/utils/train_utils.py
+++ b/diffusion_planner/diffusion_planner/utils/train_utils.py
@@ -58,6 +58,16 @@ class ModelEma(ModelEmaV3):
 def compile_model_components(model) -> None:
     """Compile the HDP encoder and decoder in place without changing state-dict keys."""
     net = getattr(model, "module", model)
+    # Dynamo's tensor wrapper probes ``.grad`` on the non-leaf encoder output passed into the
+    # separately compiled decoder. PyTorch emits a false-positive warning even though neither
+    # our model nor autograd requests that intermediate gradient buffer. Keep this filter scoped
+    # to Dynamo's probe; genuine non-leaf ``.grad`` access elsewhere must remain visible.
+    warnings.filterwarnings(
+        "ignore",
+        message=r"The \.grad attribute of a Tensor that is not a leaf Tensor is being accessed\..*",
+        category=UserWarning,
+        module=r"torch\.(?:_dynamo\.variables\.builder|_subclasses\.meta_utils)",
+    )
     with warnings.catch_warnings():
         # PyTorch 2.11 imports torch.utils.mkldnn while initializing Inductor; that upstream
         # module still defines ScriptModule helpers and emits this warning even for CUDA compile.

--- a/diffusion_planner/diffusion_planner/utils/unicycle_accel_curvature.py
+++ b/diffusion_planner/diffusion_planner/utils/unicycle_accel_curvature.py
@@ -15,6 +15,7 @@
 
 import logging
 from abc import ABC, abstractmethod
+from functools import lru_cache
 from typing import Any, Optional, TypeVar, Union
 
 import einops
@@ -383,6 +384,32 @@ def third_order_D(
     return D
 
 
+@lru_cache(maxsize=64)
+def _cached_scalar_dtd(
+    N: int,
+    order: int,
+    lead: tuple[int, ...],
+    device: torch.device,
+    dtype: torch.dtype,
+    weight: float,
+    coefficient: float,
+) -> torch.Tensor:
+    if order == 1:
+        difference = first_order_D(N, lead, device=device, dtype=dtype)
+    elif order == 2:
+        difference = second_order_D(N, lead, device=device, dtype=dtype)
+    elif order == 3:
+        difference = third_order_D(N, lead, device=device, dtype=dtype)
+    else:
+        raise ValueError(f"Unsupported finite-difference order: {order}")
+    weight_tensor = torch.full((*lead, max(N - order, 0)), weight, dtype=dtype, device=device)
+    return coefficient * einops.einsum(
+        difference * weight_tensor.unsqueeze(-1),
+        difference,
+        "... i j, ... i k -> ... j k",
+    )
+
+
 @torch.amp.autocast(device_type="cuda", enabled=False)
 @torch.no_grad()
 @_disable_dynamo_if_available()
@@ -423,48 +450,45 @@ def construct_DTD(
     Returns:
         DTD: torch.Tensor, the dense matrix D^T s D for multiple orders of smoothing.
     """
-    DTD = torch.zeros(*lead, N, N, dtype=dtype, device=device)
-    if w_smooth1 is not None:
-        lam_1 = lam / dt**2
-        if isinstance(w_smooth1, float):
-            w_smooth1_tensor = torch.full(
-                (*lead, max(N - 1, 0)), w_smooth1, dtype=dtype, device=device
+    terms = []
+    for order, weight in ((1, w_smooth1), (2, w_smooth2), (3, w_smooth3)):
+        if weight is None:
+            continue
+        coefficient = lam / dt ** (2 * order)
+        if isinstance(weight, float):
+            terms.append(
+                _cached_scalar_dtd(
+                    N,
+                    order,
+                    tuple(lead),
+                    device,
+                    dtype,
+                    weight,
+                    coefficient,
+                ).clone()
             )
+            continue
+        if order == 1:
+            difference = first_order_D(N, lead, device=device, dtype=dtype)
+        elif order == 2:
+            difference = second_order_D(N, lead, device=device, dtype=dtype)
         else:
-            w_smooth1_tensor = w_smooth1
-        D1 = first_order_D(N, lead, device=device, dtype=dtype)
-        DTD += lam_1 * einops.einsum(
-            D1 * w_smooth1_tensor.unsqueeze(-1), D1, "... i j, ... i k -> ... j k"
+            difference = third_order_D(N, lead, device=device, dtype=dtype)
+        terms.append(
+            coefficient
+            * einops.einsum(
+                difference * weight.unsqueeze(-1),
+                difference,
+                "... i j, ... i k -> ... j k",
+            )
         )
 
-    if w_smooth2 is not None:
-        lam_2 = lam / dt**4
-        if isinstance(w_smooth2, float):
-            w_smooth2_tensor = torch.full(
-                (*lead, max(N - 2, 0)), w_smooth2, dtype=dtype, device=device
-            )
-        else:
-            w_smooth2_tensor = w_smooth2
-        D2 = second_order_D(N, lead, device=device, dtype=dtype)
-        DTD += lam_2 * einops.einsum(
-            D2 * w_smooth2_tensor.unsqueeze(-1), D2, "... i j, ... i k -> ... j k"
-        )
-
-    if w_smooth3 is not None:
-        lam_3 = lam / dt**6
-        if isinstance(w_smooth3, float):
-            w_smooth3_tensor = torch.full(
-                (*lead, max(N - 3, 0)), w_smooth3, dtype=dtype, device=device
-            )
-        else:
-            w_smooth3_tensor = w_smooth3
-        D3 = third_order_D(N, lead, device=device, dtype=dtype)
-
-        DTD += lam_3 * einops.einsum(
-            D3 * w_smooth3_tensor.unsqueeze(-1), D3, "... i j, ... i k -> ... j k"
-        )
-
-    return DTD
+    if not terms:
+        return torch.zeros(*lead, N, N, dtype=dtype, device=device)
+    result = terms[0]
+    for term in terms[1:]:
+        result = result + term
+    return result
 
 
 @torch.amp.autocast(device_type="cuda", enabled=False)
@@ -512,11 +536,8 @@ def solve_single_constraint(
 
     # Solve the normal equation
     # (A^TA + D^TD + ridge * I) x = A^T b
-    A_data = torch.eye(N, dtype=dtype, device=device).expand(*lead, N, N)
-    Aw_data = A_data * w_data.unsqueeze(-1)
-    with torch.amp.autocast(device_type="cuda", enabled=False):
-        ATA = einops.einsum(Aw_data, A_data, "... i j, ... i k -> ... j k")
-        rhs = einops.einsum(Aw_data, x_target, "... i j, ... i -> ... j")
+    ATA = torch.diag_embed(w_data)
+    rhs = w_data * x_target
 
     # The dim is N + 1 because we have x_init as the first element
     DTD = construct_DTD(
@@ -584,11 +605,9 @@ def solve_xs_eq_y(
 
     # Solve the normal equation
     # (A^TA + D^TD + ridge * I) x = A^T b
-    A_data = torch.diag_embed(s)
-    Aw_data = A_data * w_data.unsqueeze(-1)
-    with torch.amp.autocast(device_type="cuda", enabled=False):
-        ATA = einops.einsum(Aw_data, A_data, "... i j, ... i k -> ... j k")
-        rhs = einops.einsum(Aw_data, y, "... i j, ... i -> ... j")
+    weighted_s = s * w_data
+    ATA = torch.diag_embed(weighted_s * s)
+    rhs = weighted_s * y
 
     DTD = construct_DTD(
         N,
@@ -1246,9 +1265,13 @@ class UnicycleAccelCurvatureActionSpace(ActionSpace):
 
 
 def smoothing_future_trajectory(
-    ego_agent_past: torch.Tensor, ego_current_state: torch.Tensor, ego_future: torch.Tensor
+    ego_agent_past: torch.Tensor,
+    ego_current_state: torch.Tensor,
+    ego_future: torch.Tensor,
+    action_space: UnicycleAccelCurvatureActionSpace | None = None,
 ) -> torch.Tensor:
-    action_space = UnicycleAccelCurvatureActionSpace(n_waypoints=80)
+    if action_space is None:
+        action_space = UnicycleAccelCurvatureActionSpace(n_waypoints=80).to(ego_future.device)
     t0_states = {"v": ego_current_state[:, 4]}
     ego_actions = traj4d_to_action(
         action_space,

--- a/diffusion_planner/diffusion_planner/valid_config.py
+++ b/diffusion_planner/diffusion_planner/valid_config.py
@@ -22,6 +22,7 @@ class ValidConfig:
     agent_num: int = 32
     predicted_neighbor_num: int = 0
     ddp: bool = True
+    compile_model: bool = True
     port: str = "22323"
 
     enable_epdms_eval: bool = True

--- a/diffusion_planner/diffusion_planner/validate_model.py
+++ b/diffusion_planner/diffusion_planner/validate_model.py
@@ -205,9 +205,7 @@ def _multisample_metrics(
         with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=use_bf16):
             global_route_condition = decoder.global_route_encoder(norm_inputs["route_lanes"])
         repeated_global_route_condition = (
-            global_route_condition[:, None]
-            .expand(B, num_samples, -1)
-            .reshape(B * num_samples, -1)
+            global_route_condition[:, None].expand(B, num_samples, -1).reshape(B * num_samples, -1)
         )
         inference_inputs = {
             "sampled_trajectories": sampled,
@@ -227,36 +225,26 @@ def _multisample_metrics(
     sampled_xy = sampled_xy[:, :, :T]
     gt_xy = gt_xy[:, :T]
 
-    valid = gt_xy.abs().sum(dim=-1) > 1e-6
-    has_valid = valid.any(dim=-1)
     distance = torch.linalg.norm(sampled_xy - gt_xy[:, None], dim=-1)
-    ade = (distance * valid[:, None]).sum(dim=-1) / valid.sum(dim=-1, keepdim=True).clamp_min(1)
-    last_valid = (
-        valid.long() * torch.arange(1, T + 1, device=device, dtype=torch.long)[None]
-    ).argmax(dim=-1)
-    fde = torch.gather(
-        distance,
-        2,
-        last_valid[:, None, None].expand(-1, num_samples, 1),
-    ).squeeze(-1)
+    # Ego futures have a fixed full-horizon contract and no padding mask. A stopped vehicle can
+    # legitimately have x=y=yaw=0, so inferring validity from non-zero xy would drop precisely the
+    # stationary scenes whose behavior the planner must preserve.
+    ade = distance.mean(dim=-1)
+    fde = distance[..., -1]
 
     min_ade = ade.min(dim=1).values
     min_fde = fde.min(dim=1).values
-    endpoints = torch.gather(
-        sampled_xy,
-        2,
-        last_valid[:, None, None, None].expand(-1, num_samples, 1, 2),
-    ).squeeze(2)
+    endpoints = sampled_xy[..., -1, :]
     endpoint_center = endpoints.mean(dim=1, keepdim=True)
     endpoint_divergence = torch.linalg.norm(endpoints - endpoint_center, dim=-1).mean(dim=1)
     return {
-        "multisample_minADE": min_ade[has_valid],
-        "multisample_minFDE": min_fde[has_valid],
+        "multisample_minADE": min_ade,
+        "multisample_minFDE": min_fde,
         "multisample_ADE_score": 100.0
-        * (1.0 - min_ade[has_valid] / MULTISAMPLE_ADE_THRESHOLD_M).clamp(0.0, 1.0),
+        * (1.0 - min_ade / MULTISAMPLE_ADE_THRESHOLD_M).clamp(0.0, 1.0),
         "multisample_FDE_score": 100.0
-        * (1.0 - min_fde[has_valid] / MULTISAMPLE_FDE_THRESHOLD_M).clamp(0.0, 1.0),
-        "multisample_endpoint_divergence": endpoint_divergence[has_valid],
+        * (1.0 - min_fde / MULTISAMPLE_FDE_THRESHOLD_M).clamp(0.0, 1.0),
+        "multisample_endpoint_divergence": endpoint_divergence,
     }
 
 

--- a/diffusion_planner/diffusion_planner/validate_model.py
+++ b/diffusion_planner/diffusion_planner/validate_model.py
@@ -581,9 +581,12 @@ def aggregate_valid_metrics(valid_dict, device):
 
         available = valid_dict.get(f"{key}_available")
         if available is None:
-            local_sum = ddp.all_reduce_sum(torch.nan_to_num(tensor).sum().item(), device)
-            local_cnt = ddp.all_reduce_sum(tensor.numel(), device)
-            epdms_means[metric] = local_sum / max(local_cnt, 1)
+            finite = torch.isfinite(tensor)
+            local_sum = ddp.all_reduce_sum(
+                tensor[finite].sum().item() if finite.any() else 0.0, device
+            )
+            local_cnt = ddp.all_reduce_sum(finite.sum().item(), device)
+            epdms_means[metric] = local_sum / local_cnt if local_cnt > 0 else float("nan")
             continue
 
         mask = available.float() > 0.5

--- a/diffusion_planner/sampling/build_prototypes.py
+++ b/diffusion_planner/sampling/build_prototypes.py
@@ -174,7 +174,8 @@ def load_xy_futures(paths, max_samples, seed):
     feats, T = [], None
     for path in tqdm(paths, desc="Loading ego futures", unit="file"):
         try:
-            ego_future = np.load(path, allow_pickle=True)["ego_agent_future"].astype(np.float32)
+            with np.load(path, allow_pickle=False) as archive:
+                ego_future = archive["ego_agent_future"].astype(np.float32)
         except Exception as e:  # noqa: BLE001 - skip unreadable / malformed files
             tqdm.write(f"  [warn] skipping {path}: {e}")
             continue

--- a/diffusion_planner/slurm/run_hdp_ego_only_base_node01.sbatch
+++ b/diffusion_planner/slurm/run_hdp_ego_only_base_node01.sbatch
@@ -9,13 +9,13 @@
 #SBATCH --gres=gpu:h100:8
 #SBATCH --exclusive
 #SBATCH --requeue
-#SBATCH --output=/mnt/nvme/Diffusion-Planner-hyper-diffusion-planner/outputs/hdp_ego_only_route_adaln_base20_filtered_afterentry_tlsmask_3veh_x10_node01_8gpu_bf16_bs512/slurm-%j.out
-#SBATCH --error=/mnt/nvme/Diffusion-Planner-hyper-diffusion-planner/outputs/hdp_ego_only_route_adaln_base20_filtered_afterentry_tlsmask_3veh_x10_node01_8gpu_bf16_bs512/slurm-%j.err
+#SBATCH --output=/mnt/nvme/Diffusion-Planner-hyper-diffusion-planner/outputs/hdp_ego_only_route_adaln_base20_filtered_afterentry_tlsmask_3veh_x10_recoveryaug_node01_8gpu_bf16_bs512/slurm-%j.out
+#SBATCH --error=/mnt/nvme/Diffusion-Planner-hyper-diffusion-planner/outputs/hdp_ego_only_route_adaln_base20_filtered_afterentry_tlsmask_3veh_x10_recoveryaug_node01_8gpu_bf16_bs512/slurm-%j.err
 
 set -euo pipefail
 
 REPO=/mnt/nvme/Diffusion-Planner-hyper-diffusion-planner
-RUN_NAME=hdp_ego_only_route_adaln_base20_filtered_afterentry_tlsmask_3veh_x10_node01_8gpu_bf16_bs512
+RUN_NAME=hdp_ego_only_route_adaln_base20_filtered_afterentry_tlsmask_3veh_x10_recoveryaug_node01_8gpu_bf16_bs512
 SAVE_DIR=${REPO}/outputs/${RUN_NAME}
 WAIT_FOR_RUN=hdp_velocity_hybrid_omega001_sft20_fullseq_plus_unprotected_right_turn_x10_node01_8gpu_bf16_bs512_from_base_ep25
 EXPECTED_COMMIT=${HDP_EXPECTED_COMMIT:?submit with --export=ALL,HDP_EXPECTED_COMMIT=<commit>}

--- a/diffusion_planner/slurm/run_hdp_ego_only_base_node01.sbatch
+++ b/diffusion_planner/slurm/run_hdp_ego_only_base_node01.sbatch
@@ -30,7 +30,11 @@ PORT=22631
 MAX_ATTEMPTS=3
 FRESH_WANDB_RUN_ID=${HDP_WANDB_RUN_ID:-hdp-route-base-${SLURM_JOB_ID}}
 
-mkdir -p "${SAVE_DIR}" "${REPO}/tmp" "${REPO}/cache" "${REPO}/wandb_cache"
+mkdir -p \
+  "${SAVE_DIR}" \
+  "${REPO}/tmp" \
+  "${REPO}/cache/torchinductor" \
+  "${REPO}/wandb_cache"
 HEALTH_LOG=${SAVE_DIR}/health_monitor.log
 TRAIN_LOG=${SAVE_DIR}/train_stdout.log
 
@@ -82,6 +86,7 @@ sleep 30
 export HOME=/home/ubuntu
 export TMPDIR=${REPO}/tmp
 export XDG_CACHE_HOME=${REPO}/cache
+export TORCHINDUCTOR_CACHE_DIR=${REPO}/cache/torchinductor
 export WANDB_DIR=${SAVE_DIR}
 export WANDB_CACHE_DIR=${REPO}/wandb_cache
 export WANDB_ENTITY=advanced-technology-department
@@ -129,6 +134,7 @@ BASE_ARGS=(
   --amp_dtype bf16
   --fused_optimizer True
   --ddp_static_graph True
+  --compile_model True
   --use_data_augment True
   --augment_prob 0.5
   --num_refine 20

--- a/diffusion_planner/tests/test_data_augmentation.py
+++ b/diffusion_planner/tests/test_data_augmentation.py
@@ -56,6 +56,11 @@ from diffusion_planner.utils.data_augmentation import (
     heading_transform,
     vector_transform,
 )
+from diffusion_planner.utils.unicycle_accel_curvature import (
+    UnicycleAccelCurvatureActionSpace,
+    construct_DTD,
+    smoothing_future_trajectory,
+)
 
 # Standard ego vehicle shape used across tests: (wheelbase, length, width) in metres.
 _EGO_SHAPE_DEFAULT = torch.tensor([[2.75, 5.0, 2.0]])
@@ -222,6 +227,42 @@ def test_state_perturbation_init():
     assert aug.coeff_matrix.shape == (6, 6), f"coeff_matrix shape: {aug.coeff_matrix.shape}"
     assert aug.t_matrix.shape == (20, 6), f"t_matrix shape: {aug.t_matrix.shape}"
     print("  [PASS] StatePerturbation init")
+
+
+def test_smoothing_action_space_cache_preserves_output():
+    B, past_steps, future_steps = 1, 31, 80
+    past = torch.zeros(B, past_steps, 4)
+    past[..., 0] = torch.linspace(-3.0, 0.0, past_steps)
+    past[..., 2] = 1.0
+    current = torch.zeros(B, 10)
+    current[:, 2] = 1.0
+    current[:, 4] = 1.0
+    future = torch.zeros(B, future_steps, 4)
+    future[..., 0] = torch.linspace(0.1, 8.0, future_steps)
+    future[..., 2] = 1.0
+    cached_space = UnicycleAccelCurvatureActionSpace(n_waypoints=future_steps)
+
+    uncached = smoothing_future_trajectory(past, current, future)
+    cached = smoothing_future_trajectory(past, current, future, action_space=cached_space)
+
+    torch.testing.assert_close(cached, uncached, rtol=0, atol=0)
+
+
+def test_cached_smoothing_matrix_is_not_exposed_to_caller_mutation():
+    kwargs = {
+        "N": 8,
+        "lead": (2,),
+        "w_smooth2": 1.0,
+        "lam": 0.01,
+        "dt": 0.1,
+    }
+    first = construct_DTD(**kwargs)
+    expected = first.clone()
+    first.zero_()
+
+    second = construct_DTD(**kwargs)
+
+    torch.testing.assert_close(second, expected, rtol=0, atol=0)
 
 
 def test_state_perturbation_rejects_too_short_refinement_window():

--- a/diffusion_planner/tests/test_data_augmentation.py
+++ b/diffusion_planner/tests/test_data_augmentation.py
@@ -25,13 +25,10 @@ Covers:
   end-point proximity
 - StatePerturbation.centric_transform: identity ego (positions unchanged),
   zero-mask preserved, translation, ego xy zeroed
-- _cross2d: basic values, parallel vectors, batched
 - _rect_corners: heading=0 corner positions, heading=90° rotation
 - _sat_signed_distance: overlapping (negative), separated (positive), touching (~0)
-- _segments_intersect_rect: crossing, endpoint inside, outside, fully inside,
-  valid mask filtering, batch
 - StatePerturbation._check_aug_validity: no keys, neighbor overlap/clear,
-  left/right boundary cross/clear, zero offset ignored, batch mixed
+  internal lane boundaries ignored, batch mixed
 - StatePerturbation.augment (integration): collision suppresses aug_flag,
   no-collision preserves aug_flag
 
@@ -54,10 +51,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from diffusion_planner.utils.data_augmentation import (
     StatePerturbation,
-    _cross2d,
     _rect_corners,
     _sat_signed_distance,
-    _segments_intersect_rect,
     heading_transform,
     vector_transform,
 )
@@ -599,39 +594,6 @@ def _check_inputs(
     }
 
 
-# ──────────────────────────────── _cross2d ──────────────────────────────────
-
-
-def test_cross2d_ccw_positive():
-    """(1,0) × (0,1) = +1 (CCW orientation)."""
-    u = torch.tensor([[1.0, 0.0]])
-    v = torch.tensor([[0.0, 1.0]])
-    assert abs(_cross2d(u, v).item() - 1.0) < ATOL, f"Expected 1.0, got {_cross2d(u, v).item()}"
-    assert abs(_cross2d(v, u).item() + 1.0) < ATOL, f"Expected -1.0, got {_cross2d(v, u).item()}"
-    print("  [PASS] _cross2d CCW positive / CW negative")
-
-
-def test_cross2d_parallel_zero():
-    """Parallel vectors have zero cross product."""
-    u = torch.tensor([[2.0, 3.0]])
-    v = torch.tensor([[4.0, 6.0]])  # v = 2*u
-    assert abs(_cross2d(u, v).item()) < ATOL, (
-        f"Parallel vectors: expected 0, got {_cross2d(u, v).item()}"
-    )
-    print("  [PASS] _cross2d parallel zero")
-
-
-def test_cross2d_batched():
-    """Batched input produces per-element cross products."""
-    u = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
-    v = torch.tensor([[0.0, 1.0], [1.0, 0.0]])
-    out = _cross2d(u, v)
-    assert out.shape == (2,)
-    assert abs(out[0].item() - 1.0) < ATOL  # (1,0)×(0,1) = +1
-    assert abs(out[1].item() + 1.0) < ATOL  # (0,1)×(1,0) = -1
-    print("  [PASS] _cross2d batched")
-
-
 # ────────────────────────────── _rect_corners ───────────────────────────────
 
 
@@ -737,114 +699,6 @@ def test_sat_signed_distance_batch():
     print("  [PASS] _sat_signed_distance batch")
 
 
-# ─────────────────────────── _segments_intersect_rect ───────────────────────
-# Reference rect for these tests:
-# center=(0,0), heading=0, l=4, w=2 → x∈[-2,2], y∈[-1,1]
-
-_UNIT_RECT = None  # lazy-initialised once below
-
-
-def _get_unit_rect(B: int = 1) -> torch.Tensor:
-    spec = torch.tensor([[0.0, 0.0, 1.0, 0.0, 4.0, 2.0]]).expand(B, -1)
-    return _rect_corners(spec)
-
-
-def test_segments_intersect_rect_crossing():
-    """Segment crossing both sides of the rectangle → True."""
-    rect = _get_unit_rect()
-    s = torch.tensor([[[-5.0, 0.0]]])  # [1, 1, 2]
-    e = torch.tensor([[[5.0, 0.0]]])
-    assert _segments_intersect_rect(s, e, rect).item(), "Through-crossing segment should intersect"
-    print("  [PASS] _segments_intersect_rect crossing")
-
-
-def test_segments_intersect_rect_endpoint_inside():
-    """Segment with one endpoint inside the rectangle → True."""
-    rect = _get_unit_rect()
-    s = torch.tensor([[[0.0, 0.0]]])  # inside rect (x∈[-2,2], y∈[-1,1])
-    e = torch.tensor([[[10.0, 0.0]]])  # outside
-    assert _segments_intersect_rect(s, e, rect).item(), (
-        "Segment with inside endpoint should intersect"
-    )
-    print("  [PASS] _segments_intersect_rect endpoint inside")
-
-
-def test_segments_intersect_rect_fully_inside():
-    """Segment fully inside the rectangle → True (both endpoints inside)."""
-    rect = _get_unit_rect()
-    s = torch.tensor([[[-0.5, 0.0]]])
-    e = torch.tensor([[[0.5, 0.0]]])
-    assert _segments_intersect_rect(s, e, rect).item(), "Fully-inside segment should be detected"
-    print("  [PASS] _segments_intersect_rect fully inside")
-
-
-def test_segments_intersect_rect_outside():
-    """Segment entirely outside the rectangle → False."""
-    rect = _get_unit_rect()
-    s = torch.tensor([[[-5.0, 5.0]]])  # y=5 is well above rect (y∈[-1,1])
-    e = torch.tensor([[[5.0, 5.0]]])
-    assert not _segments_intersect_rect(s, e, rect).item(), "Outside segment should not intersect"
-    print("  [PASS] _segments_intersect_rect outside")
-
-
-def test_segments_intersect_rect_parallel_outside():
-    """Segment parallel to a rect edge but just outside → False."""
-    rect = _get_unit_rect()
-    # Rect top edge at y=1; segment at y=1.5 (above)
-    s = torch.tensor([[[-5.0, 1.5]]])
-    e = torch.tensor([[[5.0, 1.5]]])
-    assert not _segments_intersect_rect(s, e, rect).item(), (
-        "Parallel segment above rect should not intersect"
-    )
-    print("  [PASS] _segments_intersect_rect parallel outside")
-
-
-def test_segments_intersect_rect_valid_mask_excludes_crossing():
-    """valid=False for an otherwise-crossing segment → no intersection reported."""
-    rect = _get_unit_rect()
-    s = torch.tensor([[[-5.0, 0.0], [10.0, 5.0]]])  # seg0 crosses, seg1 doesn't
-    e = torch.tensor([[[5.0, 0.0], [20.0, 5.0]]])
-    # All invalid
-    assert not _segments_intersect_rect(s, e, rect, torch.tensor([[False, False]])).item(), (
-        "All-invalid mask: no intersection"
-    )
-    # Only the non-crossing segment is valid
-    assert not _segments_intersect_rect(s, e, rect, torch.tensor([[False, True]])).item(), (
-        "Only non-crossing segment valid: no intersection"
-    )
-    # Only the crossing segment is valid
-    assert _segments_intersect_rect(s, e, rect, torch.tensor([[True, False]])).item(), (
-        "Only crossing segment valid: intersection"
-    )
-    print("  [PASS] _segments_intersect_rect valid mask")
-
-
-def test_segments_intersect_rect_batch():
-    """Batch B=2: b=0 has crossing segment, b=1 has outside segment."""
-    rect = _get_unit_rect(B=2)  # [2, 4, 2]
-    # b=0: (-5,0)→(5,0) crosses; b=1: (-5,5)→(5,5) is above
-    s = torch.tensor([[[-5.0, 0.0]], [[-5.0, 5.0]]])  # [2, 1, 2]
-    e = torch.tensor([[[5.0, 0.0]], [[5.0, 5.0]]])
-    result = _segments_intersect_rect(s, e, rect)
-    assert result.shape == (2,)
-    assert result[0].item() and not result[1].item(), (
-        f"Expected [True, False], got {result.tolist()}"
-    )
-    print("  [PASS] _segments_intersect_rect batch")
-
-
-def test_segments_intersect_rect_multiple_segments_any():
-    """With N segments: True if ANY valid segment intersects."""
-    rect = _get_unit_rect()
-    # Two segments: one outside, one crossing; no mask
-    s = torch.tensor([[[-5.0, 5.0], [-5.0, 0.0]]])  # [1, 2, 2]
-    e = torch.tensor([[[5.0, 5.0], [5.0, 0.0]]])
-    assert _segments_intersect_rect(s, e, rect).item(), (
-        "Should return True when any segment crosses"
-    )
-    print("  [PASS] _segments_intersect_rect multiple (any)")
-
-
 # ────────────────────────── _check_aug_validity ─────────────────────────────
 
 
@@ -910,70 +764,17 @@ def test_check_aug_validity_all_zero_neighbors_ignored():
     print("  [PASS] _check_aug_validity all-zero neighbors ignored")
 
 
-def test_check_aug_validity_lane_left_boundary_cross():
-    """Ego shifted left until it straddles the left lane boundary → collision."""
+def test_check_aug_validity_ignores_internal_lane_boundaries():
+    """Nearby lane markings are scene context, not solid collision obstacles."""
     aug = StatePerturbation()
     B = 1
-    # Ego at y=0.8, width=2 → spans y∈[-0.2, 1.8].
-    # Left boundary at absolute y=1.0 (center y=0, left_off=+1.0) → inside ego.
     ego = _ego_state(B, y=0.8, vx=5.0)
     inputs = _check_inputs(
         B,
         torch.zeros(B, 5, 31, 11),
         _lanes(B, list(range(-10, 10)), left_y_off=1.0, right_y_off=-3.0),
     )
-    collision = aug._check_aug_validity(ego, inputs)
-    assert collision.item(), "Left boundary inside ego must trigger collision"
-    print("  [PASS] _check_aug_validity left boundary cross")
-
-
-def test_check_aug_validity_lane_right_boundary_cross():
-    """Ego shifted left until it straddles the right lane boundary → collision."""
-    aug = StatePerturbation()
-    B = 1
-    # Ego at y=0.8 → spans y∈[-0.2, 1.8].
-    # Right boundary at absolute y=-0.1 (right_off=-0.1) → inside ego.
-    ego = _ego_state(B, y=0.8, vx=5.0)
-    inputs = _check_inputs(
-        B,
-        torch.zeros(B, 5, 31, 11),
-        _lanes(B, list(range(-10, 10)), left_y_off=3.0, right_y_off=-0.1),
-    )
-    collision = aug._check_aug_validity(ego, inputs)
-    assert collision.item(), "Right boundary inside ego must trigger collision"
-    print("  [PASS] _check_aug_validity right boundary cross")
-
-
-def test_check_aug_validity_lane_both_boundaries_clear():
-    """Ego centered in lane with boundaries at ±2 m: no collision."""
-    aug = StatePerturbation()
-    B = 1
-    # Ego at (0, 0), width=2 → spans y∈[-1, 1].
-    # Left boundary at y=+2.0, right at y=-2.0: both well outside.
-    ego = _ego_state(B, vx=5.0)
-    inputs = _check_inputs(
-        B,
-        torch.zeros(B, 5, 31, 11),
-        _lanes(B, list(range(-10, 10)), left_y_off=2.0, right_y_off=-2.0),
-    )
-    collision = aug._check_aug_validity(ego, inputs)
-    assert not collision.item(), "Ego centered in lane should not collide"
-    print("  [PASS] _check_aug_validity lane both boundaries clear")
-
-
-def test_check_aug_validity_zero_boundary_offset_ignored():
-    """Boundary offset ≤ 0.01 m is treated as 'no data' and ignored."""
-    aug = StatePerturbation()
-    B = 1
-    # Ego at (0, 0). If zero right_off were honoured, abs right boundary = center = (cx, 0)
-    # which would be inside ego.  It must be skipped.
-    ego = _ego_state(B, vx=5.0)
-    inputs = _check_inputs(
-        B, torch.zeros(B, 5, 31, 11), _lanes(B, list(range(-3, 4)), left_y_off=2.0, right_y_off=0.0)
-    )
-    collision = aug._check_aug_validity(ego, inputs)
-    assert not collision.item(), "Zero boundary offset must not trigger collision"
-    print("  [PASS] _check_aug_validity zero boundary offset ignored")
+    assert not aug._check_aug_validity(ego, inputs).item()
 
 
 def test_check_aug_validity_batch_mixed():
@@ -1144,10 +945,6 @@ ALL_TESTS = [
     test_centric_transform_zero_mask_preserved,
     test_centric_transform_translation,
     test_centric_transform_ego_xy_zeroed,
-    # ── _cross2d ──
-    test_cross2d_ccw_positive,
-    test_cross2d_parallel_zero,
-    test_cross2d_batched,
     # ── _rect_corners ──
     test_rect_corners_shape,
     test_rect_corners_heading_zero,
@@ -1158,24 +955,13 @@ ALL_TESTS = [
     test_sat_signed_distance_separated_positive,
     test_sat_signed_distance_touching_zero,
     test_sat_signed_distance_batch,
-    # ── _segments_intersect_rect ──
-    test_segments_intersect_rect_crossing,
-    test_segments_intersect_rect_endpoint_inside,
-    test_segments_intersect_rect_fully_inside,
-    test_segments_intersect_rect_outside,
-    test_segments_intersect_rect_parallel_outside,
-    test_segments_intersect_rect_valid_mask_excludes_crossing,
-    test_segments_intersect_rect_batch,
-    test_segments_intersect_rect_multiple_segments_any,
     # ── _check_aug_validity ──
     test_check_aug_validity_no_collision_sources,
     test_check_aug_validity_neighbor_at_ego_position,
     test_check_aug_validity_neighbor_far,
+    test_check_aug_validity_uses_rear_axle_pose_for_ego_box,
     test_check_aug_validity_all_zero_neighbors_ignored,
-    test_check_aug_validity_lane_left_boundary_cross,
-    test_check_aug_validity_lane_right_boundary_cross,
-    test_check_aug_validity_lane_both_boundaries_clear,
-    test_check_aug_validity_zero_boundary_offset_ignored,
+    test_check_aug_validity_ignores_internal_lane_boundaries,
     test_check_aug_validity_batch_mixed,
     test_check_aug_validity_ego_shape_controls_size,
     # ── augment + collision filter (integration) ──

--- a/diffusion_planner/tests/test_data_augmentation.py
+++ b/diffusion_planner/tests/test_data_augmentation.py
@@ -373,6 +373,20 @@ def test_augment_cos_sin_unit_norm():
     print("  [PASS] augment cos/sin unit norm")
 
 
+def test_augment_state_components_use_independent_noise():
+    """Each state dimension must receive its own uniform perturbation draw."""
+    torch.manual_seed(42)
+    aug = StatePerturbation(augment_prob=1.0)
+    _, new_state = aug.augment(_augment_inputs(32, vx=5.0))
+
+    normalized_y = new_state[:, 1] / 0.75
+    yaw = torch.atan2(new_state[:, 3], new_state[:, 2])
+    normalized_yaw = yaw / 0.2
+    assert not torch.allclose(normalized_y, normalized_yaw), (
+        "lateral and yaw perturbations reused the same random draw"
+    )
+
+
 # ──────────────────── interpolation_future_trajectory ───────────────────────
 
 

--- a/diffusion_planner/tests/test_ddp_setup.py
+++ b/diffusion_planner/tests/test_ddp_setup.py
@@ -1,0 +1,25 @@
+from types import SimpleNamespace
+
+from diffusion_planner.utils import ddp
+
+
+def test_direct_launch_disables_uninitialized_ddp(monkeypatch):
+    for name in ("RANK", "WORLD_SIZE", "LOCAL_RANK", "SLURM_PROCID"):
+        monkeypatch.delenv(name, raising=False)
+    args = SimpleNamespace(ddp=True, device="cuda", port="22323")
+
+    rank, gpu, world_size = ddp.ddp_setup_universal(args=args)
+
+    assert (rank, gpu, world_size) == (0, 0, 1)
+    assert args.ddp is False
+
+
+def test_ddp_rejects_cpu_before_process_group_initialization():
+    args = SimpleNamespace(ddp=True, device="cpu", port="22323")
+
+    try:
+        ddp.ddp_setup_universal(args=args)
+    except ValueError as exc:
+        assert "CUDA" in str(exc)
+    else:
+        raise AssertionError("CPU DDP must be rejected explicitly")

--- a/diffusion_planner/tests/test_hdp_core.py
+++ b/diffusion_planner/tests/test_hdp_core.py
@@ -55,6 +55,7 @@ from diffusion_planner.utils.onnx_export import (
     build_dynamic_axes,
 )
 from diffusion_planner.utils.train_utils import (
+    ModelEma,
     atomic_torch_save,
     capture_rng_state,
     compute_grad_stats,
@@ -63,7 +64,6 @@ from diffusion_planner.utils.train_utils import (
     update_epoch_loss_sums,
 )
 from diffusion_planner.validate_model import _multisample_metrics, aggregate_valid_metrics
-from timm.utils import ModelEma
 
 
 def test_hdp_representation_and_normalization_round_trip():
@@ -923,6 +923,8 @@ def test_rl_ema_rate_005_maps_to_timm_decay_095():
     with torch.no_grad():
         model.weight.zero_()
     ema = ModelEma(model, decay=0.95, device="cpu")
+    assert ema.foreach
+    assert ema.ema is ema.module
     with torch.no_grad():
         model.weight.fill_(1.0)
     ema.update(model)

--- a/diffusion_planner/tests/test_hdp_core.py
+++ b/diffusion_planner/tests/test_hdp_core.py
@@ -879,6 +879,27 @@ def test_empty_multisample_metrics_aggregate_to_nan_not_false_zero():
     assert math.isnan(metrics["multisample_means"]["minADE"])
 
 
+def test_epdms_metric_without_availability_excludes_nonfinite_values():
+    metrics = aggregate_valid_metrics(
+        {
+            "_loss_ego_sum": 0.0,
+            "_samples_ego": 1,
+            "_loss_neighbor_sum": 0.0,
+            "_samples_neighbor": 0,
+            "_turn_correct": 0,
+            "_turn_total": 0,
+            "_turn_change_correct": 0,
+            "turn_indicator_change_total": 0,
+            "_turn_class_correct": [0, 0, 0, 0, 0],
+            "_turn_class_total": [0, 0, 0, 0, 0],
+            "epdms_unmasked_metric": torch.tensor([0.25, float("nan"), 0.75]),
+        },
+        "cpu",
+    )
+
+    assert metrics["epdms_means"]["unmasked_metric"] == pytest.approx(0.5)
+
+
 def test_ego_only_supervised_loss_and_onnx_shapes():
     class FakeObservationNormalizer:
         @staticmethod

--- a/diffusion_planner/tests/test_hdp_core.py
+++ b/diffusion_planner/tests/test_hdp_core.py
@@ -719,7 +719,7 @@ def test_seeded_multisample_metrics_compute_minade_and_minfde():
     torch.testing.assert_close(metrics["multisample_minFDE"], torch.tensor([1.0]))
 
 
-def test_multisample_metrics_exclude_scenes_without_valid_ground_truth():
+def test_multisample_metrics_include_valid_stationary_scenes():
     class FakeModel(torch.nn.Module):
         def __init__(self):
             super().__init__()
@@ -760,8 +760,9 @@ def test_multisample_metrics_exclude_scenes_without_valid_ground_truth():
         0,
     )
 
-    assert all(value.shape == (1,) for value in metrics.values())
-    torch.testing.assert_close(metrics["multisample_minADE"], torch.tensor([1.0]))
+    assert all(value.shape == (2,) for value in metrics.values())
+    torch.testing.assert_close(metrics["multisample_minADE"], torch.tensor([0.0, 1.0]))
+    torch.testing.assert_close(metrics["multisample_minFDE"], torch.tensor([0.0, 1.0]))
 
 
 def test_turn_indicator_class_metrics_keep_counts_visible():

--- a/diffusion_planner/tests/test_hdp_core.py
+++ b/diffusion_planner/tests/test_hdp_core.py
@@ -58,6 +58,7 @@ from diffusion_planner.utils.train_utils import (
     ModelEma,
     atomic_torch_save,
     capture_rng_state,
+    compile_model_components,
     compute_grad_stats,
     finalize_epoch_loss_sums,
     resume_model,
@@ -107,10 +108,40 @@ def test_state_normalizer_caches_stats_by_kind_device_and_dtype():
     assert state_fp32[0] is not velocity_fp32[0]
     assert state_fp32[0].dtype == torch.float32
     assert state_bf16[0].dtype == torch.bfloat16
-
     data = torch.tensor([[[[0.5, -0.25, 1.0, 0.0]]]], dtype=torch.float32)
     expected = (data - torch.tensor([0.0, 0.0, 0.0, 0.0])) / torch.tensor([0.5, 0.5, 1.0, 1.0])
     torch.testing.assert_close(normalize_ego_velocity(data, normalizer), expected)
+
+
+def test_observation_normalizer_preserves_zero_padding_in_both_directions():
+    normalizer = ObservationNormalizer(
+        {"feature": {"mean": torch.tensor([2.0, -3.0]), "std": torch.tensor([2.0, 4.0])}}
+    )
+    data = {"feature": torch.tensor([[[0.0, 0.0], [4.0, 5.0]]])}
+
+    normalized = normalizer(data)
+    restored = normalizer.inverse(normalized)
+
+    torch.testing.assert_close(normalized["feature"][0, 0], torch.zeros(2))
+    torch.testing.assert_close(normalized["feature"][0, 1], torch.tensor([1.0, 2.0]))
+    torch.testing.assert_close(restored["feature"], data["feature"])
+
+
+def test_compile_model_components_preserves_checkpoint_keys():
+    class TinyPlanner(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.encoder = torch.nn.Linear(2, 2)
+            self.decoder = torch.nn.Linear(2, 2)
+
+    model = TinyPlanner()
+    keys_before = tuple(model.state_dict())
+
+    compile_model_components(model)
+
+    assert tuple(model.state_dict()) == keys_before
+    assert model.encoder._compiled_call_impl is not None
+    assert model.decoder._compiled_call_impl is not None
 
 
 def test_hdp_dit_self_attention_runs_over_future_timesteps():
@@ -566,7 +597,16 @@ def test_hdp_neighbor_at_ego_origin_remains_valid():
     raw = torch.zeros(1, 3, 3)
     raw[:, 0, 0] = 1.0
     converted = heading_to_cos_sin_if_needed(raw)
-    torch.testing.assert_close(converted[:, 1:], torch.zeros_like(converted[:, 1:]))
+    torch.testing.assert_close(converted[..., :2], raw[..., :2])
+    torch.testing.assert_close(converted[..., 2], torch.ones_like(converted[..., 2]))
+    torch.testing.assert_close(converted[..., 3], torch.zeros_like(converted[..., 3]))
+
+
+def test_hdp_stationary_ego_future_is_not_treated_as_padding():
+    converted = heading_to_cos_sin_if_needed(torch.zeros(2, 80, 3))
+
+    assert converted[..., 2].eq(1.0).all()
+    assert converted[..., 3].eq(0.0).all()
 
 
 def test_neighbor_future_mask_preserves_internal_zero_pose():

--- a/diffusion_planner/tests/test_hdp_core.py
+++ b/diffusion_planner/tests/test_hdp_core.py
@@ -16,6 +16,7 @@ from diffusion_planner.hdp_rl_utils import (
     _attenuate_rear_only_risk,
     _collision_and_leader_terms,
     _hdp_lane_score,
+    _lane_reward_centerlines,
     _occupancy_score,
     _scene_neighbors,
     compute_reward_weights,
@@ -197,7 +198,9 @@ def test_hdp_decoder_repeats_only_global_route_condition_for_rl_groups():
     output = decoder(encoding, inputs)["model_output"]
     assert output.shape == (candidate_batch, 1, 80, 4)
     output.square().mean().backward()
-    assert all(parameter.grad is not None for parameter in decoder.global_route_encoder.parameters())
+    assert all(
+        parameter.grad is not None for parameter in decoder.global_route_encoder.parameters()
+    )
 
 
 def test_hdp_temporal_position_initialization_matches_navsim_frequency_base():
@@ -650,6 +653,26 @@ def test_hdp_lane_reward_masks_centerline_to_centerline_change_without_indicator
 
     assert lane_change
     torch.testing.assert_close(lane_score, torch.zeros(1))
+
+
+def test_hdp_lane_reward_prefers_aligned_route_and_falls_back_when_route_is_wrong():
+    x = torch.linspace(0.1, 20.0, 20)
+    lanes = torch.zeros(2, 20, 8)
+    lanes[:, :, 0] = x
+    lanes[1, :, 1] = 3.5
+    lanes[..., 2] = 1.0
+    expert = lanes[0, :, :4].clone()
+
+    aligned_route = lanes[:1].clone()
+    selected, route_used = _lane_reward_centerlines(expert, lanes, aligned_route, HDPRewardConfig())
+    assert route_used
+    torch.testing.assert_close(selected, aligned_route)
+
+    wrong_route = aligned_route.clone()
+    wrong_route[..., 1] = 20.0
+    selected, route_used = _lane_reward_centerlines(expert, lanes, wrong_route, HDPRewardConfig())
+    assert not route_used
+    torch.testing.assert_close(selected, lanes)
 
 
 def test_seeded_multisample_metrics_compute_minade_and_minfde():

--- a/diffusion_planner/tests/test_hdp_core.py
+++ b/diffusion_planner/tests/test_hdp_core.py
@@ -88,6 +88,31 @@ def test_hdp_representation_and_normalization_round_trip():
     )
 
 
+def test_state_normalizer_caches_stats_by_kind_device_and_dtype():
+    normalizer = StateNormalizer(
+        [[[10, 0, 0, 0]]],
+        [[[20, 20, 1, 1]]],
+        [0, 0, 0, 0],
+        [0.5, 0.5, 1, 1],
+    )
+
+    state_fp32 = normalizer._mean_std_on(torch.device("cpu"), torch.float32)
+    velocity_fp32 = normalizer.ego_velocity_stats_on(torch.device("cpu"), torch.float32)
+    state_bf16 = normalizer._mean_std_on(torch.device("cpu"), torch.bfloat16)
+
+    assert state_fp32[0] is normalizer._mean_std_on(torch.device("cpu"), torch.float32)[0]
+    assert (
+        velocity_fp32[0] is normalizer.ego_velocity_stats_on(torch.device("cpu"), torch.float32)[0]
+    )
+    assert state_fp32[0] is not velocity_fp32[0]
+    assert state_fp32[0].dtype == torch.float32
+    assert state_bf16[0].dtype == torch.bfloat16
+
+    data = torch.tensor([[[[0.5, -0.25, 1.0, 0.0]]]], dtype=torch.float32)
+    expected = (data - torch.tensor([0.0, 0.0, 0.0, 0.0])) / torch.tensor([0.5, 0.5, 1.0, 1.0])
+    torch.testing.assert_close(normalize_ego_velocity(data, normalizer), expected)
+
+
 def test_hdp_dit_self_attention_runs_over_future_timesteps():
     model = DiT(depth=1, output_dim=4, hidden_dim=32, heads=4, future_len=80).eval()
     observed = []

--- a/diffusion_planner/tests/test_rl_trainer_helpers.py
+++ b/diffusion_planner/tests/test_rl_trainer_helpers.py
@@ -11,6 +11,7 @@ class _TinyPlanner(torch.nn.Module):
         self.encoder = torch.nn.Linear(1, 1)
         self.decoder = torch.nn.Module()
         self.decoder.dit = torch.nn.Linear(1, 1)
+        self.decoder.global_route_encoder = torch.nn.Linear(1, 1)
         self.decoder.turn_indicator_predictor = torch.nn.Linear(1, 1)
 
 
@@ -21,6 +22,9 @@ def test_all_scope_freezes_only_the_unused_turn_head():
 
     assert all(value for name, value in state.items() if name.startswith("encoder."))
     assert all(value for name, value in state.items() if name.startswith("decoder.dit."))
+    assert all(
+        value for name, value in state.items() if name.startswith("decoder.global_route_encoder.")
+    )
     assert not any(
         value
         for name, value in state.items()
@@ -35,6 +39,9 @@ def test_decoder_scope_freezes_encoder_and_turn_head():
 
     assert not any(value for name, value in state.items() if name.startswith("encoder."))
     assert all(value for name, value in state.items() if name.startswith("decoder.dit."))
+    assert all(
+        value for name, value in state.items() if name.startswith("decoder.global_route_encoder.")
+    )
     assert not any(
         value
         for name, value in state.items()

--- a/diffusion_planner/tests/test_rl_trainer_helpers.py
+++ b/diffusion_planner/tests/test_rl_trainer_helpers.py
@@ -1,8 +1,22 @@
 import torch
+from diffusion_planner.hdp_rl_epoch import _policy_observation_inputs
 from train_hdp_rl_predictor import (
     best_valid_score_from_rows,
     configure_rl_trainable_parameters,
 )
+
+
+def test_all_scope_does_not_expand_reward_only_futures():
+    observations = {
+        "ego_current_state": torch.zeros(2, 10),
+        "lanes": torch.zeros(2, 4, 3),
+        "ego_agent_future": torch.zeros(2, 80, 4),
+        "neighbor_agents_future": torch.zeros(2, 320, 80, 3),
+    }
+
+    policy_inputs = _policy_observation_inputs(observations)
+
+    assert set(policy_inputs) == {"ego_current_state", "lanes"}
 
 
 class _TinyPlanner(torch.nn.Module):

--- a/diffusion_planner/train_hdp_rl_predictor.py
+++ b/diffusion_planner/train_hdp_rl_predictor.py
@@ -32,12 +32,12 @@ from diffusion_planner.utils.lr_schedule import LinearWarmupConstantLR
 from diffusion_planner.utils.normalizer import ObservationNormalizer, StateNormalizer
 from diffusion_planner.utils.onnx_export import export_checkpoint_onnx_guarded
 from diffusion_planner.utils.train_utils import (
+    ModelEma,
     atomic_torch_save,
     gather_rng_states,
     resume_model,
     set_seed,
 )
-from timm.utils import ModelEma
 from torch import optim
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data import DataLoader, DistributedSampler

--- a/diffusion_planner/train_hdp_rl_predictor.py
+++ b/diffusion_planner/train_hdp_rl_predictor.py
@@ -34,6 +34,7 @@ from diffusion_planner.utils.onnx_export import export_checkpoint_onnx_guarded
 from diffusion_planner.utils.train_utils import (
     ModelEma,
     atomic_torch_save,
+    compile_model_components,
     gather_rng_states,
     resume_model,
     set_seed,
@@ -470,6 +471,12 @@ def get_args():
         type=boolean,
         help="enable DDP static_graph for lower reducer overhead",
     )
+    parser.add_argument(
+        "--compile_model",
+        type=boolean,
+        default=_train_config_default("compile_model"),
+        help="compile the encoder and decoder with TorchInductor",
+    )
     parser.add_argument("--port", default="22323", type=str)
     parser.add_argument(
         "--amp_dtype",
@@ -641,6 +648,7 @@ def model_training(args):
         print("TF32: {}".format(args.tf32))
         print("Fused optimizer: {}".format(args.fused_optimizer))
         print("DDP static graph: {}".format(args.ddp_static_graph))
+        print("TorchInductor model compile: {}".format(args.compile_model))
         if not args.use_ema:
             print(
                 "WARNING: --use_ema false removes the stable previous-policy rollout used by "
@@ -840,6 +848,11 @@ def model_training(args):
         )
         init_epoch = 0
         wandb_id = None
+
+    if args.compile_model:
+        compile_model_components(diffusion_planner)
+        if model_ema is not None:
+            compile_model_components(model_ema.ema)
 
     requested_wandb_id = args.wandb_run_id or wandb_id
     if global_rank == 0 and args.use_wandb:

--- a/diffusion_planner/train_hdp_rl_predictor.py
+++ b/diffusion_planner/train_hdp_rl_predictor.py
@@ -569,20 +569,45 @@ def get_args():
         )
     if args.rl_noise_scale < 0.0:
         raise ValueError("--rl_noise_scale must be >= 0")
+    if args.advantage_eps <= 0.0:
+        raise ValueError("--advantage_eps must be > 0")
     if args.rl_reward_beta <= 0.0:
         raise ValueError("--rl_reward_beta must be > 0")
+    reward_weights = (
+        args.rl_reward_w_risk,
+        args.rl_reward_w_follow,
+        args.rl_reward_w_lane,
+    )
+    if any(weight < 0.0 for weight in reward_weights):
+        raise ValueError("RL reward weights must be non-negative")
+    if sum(reward_weights) <= 0.0:
+        raise ValueError("At least one RL reward weight must be positive")
     if args.predicted_neighbor_num != 0:
         raise ValueError("HDP-RL is ego-only; --predicted_neighbor_num must be 0")
     if args.rl_full_eval_utd < 1:
         raise ValueError("--rl_full_eval_utd must be >= 1")
     if not 0.0 < args.rl_ema_update_rate <= 1.0:
         raise ValueError("--rl_ema_update_rate must be in (0, 1]")
+    if args.rl_ttc_critical_s < 0.0:
+        raise ValueError("--rl_ttc_critical_s must be >= 0")
     if args.rl_ttc_safe_s <= args.rl_ttc_critical_s:
         raise ValueError("--rl_ttc_safe_s must be greater than --rl_ttc_critical_s")
+    if args.rl_thw_critical_s < 0.0:
+        raise ValueError("--rl_thw_critical_s must be >= 0")
     if args.rl_thw_safe_s <= args.rl_thw_critical_s:
         raise ValueError("--rl_thw_safe_s must be greater than --rl_thw_critical_s")
+    if args.rl_occupancy_critical_m < 0.0:
+        raise ValueError("--rl_occupancy_critical_m must be >= 0")
     if args.rl_occupancy_safe_m <= args.rl_occupancy_critical_m:
         raise ValueError("--rl_occupancy_safe_m must be greater than --rl_occupancy_critical_m")
+    if args.rl_reward_dt <= 0.0:
+        raise ValueError("--rl_reward_dt must be > 0")
+    if args.rl_occupancy_speed_gain_s < 0.0:
+        raise ValueError("--rl_occupancy_speed_gain_s must be >= 0")
+    if args.rl_lane_half_width_m <= 0.0:
+        raise ValueError("--rl_lane_half_width_m must be > 0")
+    if args.rl_leader_lateral_margin_m < 0.0:
+        raise ValueError("--rl_leader_lateral_margin_m must be >= 0")
     if not args.use_velocity_representation:
         raise ValueError("HDP-RL requires --use_velocity_representation true")
     if args.diffusion_model_type != "x_start" or args.diffusion_supervision_type != "x_start":
@@ -767,6 +792,7 @@ def model_training(args):
             diffusion_planner,
             device_ids=[rank],
             find_unused_parameters=False,
+            gradient_as_bucket_view=True,
             static_graph=args.ddp_static_graph,
         )
 
@@ -783,7 +809,7 @@ def model_training(args):
     if not trainable_params:
         raise RuntimeError("No trainable parameters found for RL training")
     params = [{"params": trainable_params, "lr": args.learning_rate}]
-    if args.fused_optimizer and args.device == "cuda":
+    if args.fused_optimizer and torch.device(args.device).type == "cuda":
         try:
             optimizer = optim.AdamW(params, fused=True, weight_decay=args.weight_decay)
         except TypeError:
@@ -1008,7 +1034,8 @@ def model_training(args):
             }
             atomic_torch_save(model_dict, f"{save_path}/latest.pth")
 
-            if (epoch + 1 - init_epoch) % save_utd == 0:
+            # Resume must not shift the configured checkpoint/closed-loop cadence.
+            if (epoch + 1) % save_utd == 0:
                 curr_dir = os.path.join(save_path, f"epoch{epoch + 1:04d}")
                 os.makedirs(curr_dir, exist_ok=True)
                 atomic_torch_save(model_dict, f"{curr_dir}/best_model.pth")

--- a/diffusion_planner/train_hdp_rl_predictor.py
+++ b/diffusion_planner/train_hdp_rl_predictor.py
@@ -64,7 +64,7 @@ def configure_rl_trainable_parameters(model: torch.nn.Module, scope: str) -> Non
         raise ValueError(f"Unsupported RL train scope: {scope!r}")
     for name, param in model.named_parameters():
         if scope == "decoder":
-            trainable = name.startswith("decoder.dit.")
+            trainable = name.startswith(("decoder.dit.", "decoder.global_route_encoder."))
         else:
             trainable = not name.startswith("decoder.turn_indicator_predictor.")
         param.requires_grad_(trainable)
@@ -436,6 +436,12 @@ def get_args():
     )
 
     parser.add_argument("--use_wandb", default=True, type=boolean)
+    parser.add_argument(
+        "--wandb_run_id",
+        type=str,
+        default=None,
+        help="existing W&B run ID to resume, or a stable ID for a fresh RL run",
+    )
     parser.add_argument(
         "--wandb_project_name",
         type=str,
@@ -835,13 +841,14 @@ def model_training(args):
         init_epoch = 0
         wandb_id = None
 
+    requested_wandb_id = args.wandb_run_id or wandb_id
     if global_rank == 0 and args.use_wandb:
         wandb.init(
             project=args.wandb_project_name,
             name=args.exp_name,
             notes=args.notes,
             resume="allow",
-            id=wandb_id,
+            id=requested_wandb_id,
             dir=f"{save_path}",
         )
         # Strict checkpoint compatibility runs before W&B initialization. An in-place

--- a/diffusion_planner/train_hdp_rl_predictor.py
+++ b/diffusion_planner/train_hdp_rl_predictor.py
@@ -552,13 +552,13 @@ def get_args():
         raise ValueError("--wandb_step_log_interval must be >= 0")
     if args.num_generations < 2:
         raise ValueError("--num_generations must be >= 2 for HDP-RL group reward normalization")
-    if args.rl_rollout_steps < 3:
-        raise ValueError("--rl_rollout_steps must be >= 3 for the third-order DPM solver")
+    if args.rl_rollout_steps < 2:
+        raise ValueError("--rl_rollout_steps must be >= 2 for the second-order DPM solver")
     if args.diffusion_sample_steps < 2:
         raise ValueError("--diffusion_sample_steps must be >= 2 for the second-order DPM solver")
-    if args.multisample_eval_num_samples > 0 and args.multisample_eval_sample_steps < 3:
+    if args.multisample_eval_num_samples > 0 and args.multisample_eval_sample_steps < 2:
         raise ValueError(
-            "--multisample_eval_sample_steps must be >= 3 for the third-order DPM solver"
+            "--multisample_eval_sample_steps must be >= 2 for the second-order DPM solver"
         )
     if args.rl_noise_scale < 0.0:
         raise ValueError("--rl_noise_scale must be >= 0")

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -332,6 +332,12 @@ def get_args(args_list=None):
         help="enable DDP static_graph optimizations (graph must stay identical every step)",
     )
     parser.add_argument(
+        "--compile_model",
+        type=boolean,
+        default=_train_config_default("compile_model"),
+        help="compile the encoder and decoder with TorchInductor",
+    )
+    parser.add_argument(
         "--export_onnx_on_save",
         type=boolean,
         default=_train_config_default("export_onnx_on_save"),

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -375,6 +375,24 @@ def get_args(args_list=None):
         type=float,
         default=_train_config_default("closed_loop_unstick_advance_m"),
     )
+    parser.add_argument(
+        "--closed_loop_classification_json",
+        type=str,
+        default="",
+        help="scenario classification JSON for grouped closed-loop evaluation",
+    )
+    parser.add_argument(
+        "--closed_loop_scenario_dataset_name",
+        type=str,
+        default="",
+        help="dataset-relative name used to auto-resolve a scenario classification JSON",
+    )
+    parser.add_argument(
+        "--closed_loop_grouped_wandb_max_videos",
+        type=int,
+        default=_train_config_default("closed_loop_grouped_wandb_max_videos"),
+        help="maximum grouped episode videos uploaded to W&B per evaluation",
+    )
 
     args = parser.parse_args(args_list)
     if args.train_subsample_step < 1:
@@ -383,6 +401,8 @@ def get_args(args_list=None):
         raise ValueError("--batch_size must be >= 1")
     if args.save_utd < 1:
         raise ValueError("--save_utd must be >= 1")
+    if args.closed_loop_grouped_wandb_max_videos < 0:
+        raise ValueError("--closed_loop_grouped_wandb_max_videos must be >= 0")
     if args.train_epochs < 1:
         raise ValueError("--train_epochs must be >= 1")
     if not 0 <= args.warm_up_epoch <= args.train_epochs:

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -417,9 +417,9 @@ def get_args(args_list=None):
         raise ValueError("--planning_hybrid_loss must be >= 0")
     if args.diffusion_sample_steps < 2:
         raise ValueError("--diffusion_sample_steps must be >= 2 for the second-order DPM solver")
-    if args.multisample_eval_num_samples > 0 and args.multisample_eval_sample_steps < 3:
+    if args.multisample_eval_num_samples > 0 and args.multisample_eval_sample_steps < 2:
         raise ValueError(
-            "--multisample_eval_sample_steps must be >= 3 for the third-order DPM solver"
+            "--multisample_eval_sample_steps must be >= 2 for the second-order DPM solver"
         )
     if args.learning_rate <= 0.0:
         raise ValueError("--learning_rate must be > 0")

--- a/diffusion_planner/valid_predictor.py
+++ b/diffusion_planner/valid_predictor.py
@@ -9,10 +9,9 @@ from diffusion_planner.utils import ddp
 from diffusion_planner.utils.config import Config
 from diffusion_planner.utils.dataset import DiffusionPlannerData, DistributedEvalSampler
 from diffusion_planner.utils.path_key import data_path_to_rel
-from diffusion_planner.utils.train_utils import resume_model, set_seed
+from diffusion_planner.utils.train_utils import ModelEma, resume_model, set_seed
 from diffusion_planner.valid_config import ValidConfig
 from diffusion_planner.validate_model import aggregate_valid_metrics, validate_model
-from timm.utils import ModelEma
 from torch import optim
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data import DataLoader

--- a/diffusion_planner/valid_predictor.py
+++ b/diffusion_planner/valid_predictor.py
@@ -9,7 +9,12 @@ from diffusion_planner.utils import ddp
 from diffusion_planner.utils.config import Config
 from diffusion_planner.utils.dataset import DiffusionPlannerData, DistributedEvalSampler
 from diffusion_planner.utils.path_key import data_path_to_rel
-from diffusion_planner.utils.train_utils import ModelEma, resume_model, set_seed
+from diffusion_planner.utils.train_utils import (
+    ModelEma,
+    compile_model_components,
+    resume_model,
+    set_seed,
+)
 from diffusion_planner.valid_config import ValidConfig
 from diffusion_planner.validate_model import aggregate_valid_metrics, validate_model
 from torch import optim
@@ -58,6 +63,11 @@ def get_args(args_list=None):
     parser.add_argument("--args_json_path", type=str, required=True)
     parser.add_argument("--save_predictions_dir", type=str, default=None)
     parser.add_argument("--ddp", default=True, type=boolean)
+    parser.add_argument(
+        "--compile_model",
+        default=_valid_config_default("compile_model"),
+        type=boolean,
+    )
     parser.add_argument("--port", default="22323", type=str)
     parser.add_argument(
         "--enable_epdms_eval",
@@ -120,6 +130,10 @@ def run_validation(valid_cfg: ValidConfig):
     config_obj.multisample_eval_noise_scale = valid_cfg.multisample_eval_noise_scale
     config_obj.multisample_eval_sample_steps = valid_cfg.multisample_eval_sample_steps
     config_obj.multisample_eval_seed = valid_cfg.multisample_eval_seed
+    if valid_cfg.device == "cuda" and bool(getattr(config_obj, "tf32", False)):
+        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.cudnn.allow_tf32 = True
+        torch.set_float32_matmul_precision("high")
     if valid_cfg.align_legacy_neighbor_futures is not None:
         config_obj.align_legacy_neighbor_futures = valid_cfg.align_legacy_neighbor_futures
     align_legacy_neighbor_futures = bool(
@@ -205,6 +219,8 @@ def run_validation(valid_cfg: ValidConfig):
         model_ema,
         valid_cfg.device,
     )
+    if valid_cfg.compile_model:
+        compile_model_components(model_ema.ema)
 
     if valid_cfg.ddp:
         torch.distributed.barrier()

--- a/diffusion_planner/valid_predictor.py
+++ b/diffusion_planner/valid_predictor.py
@@ -5,19 +5,14 @@ from pathlib import Path
 import numpy as np
 import torch
 from diffusion_planner.model.diffusion_planner import Diffusion_Planner
+from diffusion_planner.train import load_weights_only
 from diffusion_planner.utils import ddp
 from diffusion_planner.utils.config import Config
 from diffusion_planner.utils.dataset import DiffusionPlannerData, DistributedEvalSampler
 from diffusion_planner.utils.path_key import data_path_to_rel
-from diffusion_planner.utils.train_utils import (
-    ModelEma,
-    compile_model_components,
-    resume_model,
-    set_seed,
-)
+from diffusion_planner.utils.train_utils import compile_model_components, set_seed
 from diffusion_planner.valid_config import ValidConfig
 from diffusion_planner.validate_model import aggregate_valid_metrics, validate_model
-from torch import optim
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data import DataLoader
 from tqdm import tqdm
@@ -130,7 +125,8 @@ def run_validation(valid_cfg: ValidConfig):
     config_obj.multisample_eval_noise_scale = valid_cfg.multisample_eval_noise_scale
     config_obj.multisample_eval_sample_steps = valid_cfg.multisample_eval_sample_steps
     config_obj.multisample_eval_seed = valid_cfg.multisample_eval_seed
-    if valid_cfg.device == "cuda" and bool(getattr(config_obj, "tf32", False)):
+    device_type = torch.device(valid_cfg.device).type
+    if device_type == "cuda" and bool(getattr(config_obj, "tf32", False)):
         torch.backends.cuda.matmul.allow_tf32 = True
         torch.backends.cudnn.allow_tf32 = True
         torch.set_float32_matmul_precision("high")
@@ -145,6 +141,8 @@ def run_validation(valid_cfg: ValidConfig):
 
     # init ddp
     global_rank, rank, _ = ddp.ddp_setup_universal(True, valid_cfg)
+    config_obj.device = valid_cfg.device
+    config_obj.ddp = valid_cfg.ddp
     print(f"{global_rank=}, {rank=}")
     world_size = ddp.get_world_size()
     if valid_cfg.batch_size < world_size or valid_cfg.batch_size % world_size != 0:
@@ -189,9 +187,7 @@ def run_validation(valid_cfg: ValidConfig):
 
     # set up model (restore structure using training config_obj)
     diffusion_planner = Diffusion_Planner(config_obj)
-    diffusion_planner = diffusion_planner.to(
-        rank if valid_cfg.device == "cuda" else valid_cfg.device
-    )
+    diffusion_planner = diffusion_planner.to(valid_cfg.device)
 
     if valid_cfg.ddp:
         diffusion_planner = DDP(diffusion_planner, device_ids=[rank], find_unused_parameters=True)
@@ -203,29 +199,22 @@ def run_validation(valid_cfg: ValidConfig):
             )
         )
 
-    # optimizer (dummy)
-    params = [{"params": ddp.get_model(diffusion_planner, valid_cfg.ddp).parameters(), "lr": 0.0}]
-    optimizer = optim.AdamW(params)
-
-    # load weights
+    # Validation needs weights only. Loading optimizer/scheduler/RNG state here used to allocate
+    # the complete AdamW state on the GPU and overwrite the validation RNG for no benefit.
     print(f"Model loaded from {valid_cfg.resume_model_path}")
-    model_ema = ModelEma(diffusion_planner, decay=0.999, device=valid_cfg.device)
-
-    diffusion_planner, _, _, _, _, model_ema = resume_model(
+    load_weights_only(
         valid_cfg.resume_model_path,
         diffusion_planner,
-        optimizer,
-        None,  # scheduler is not needed
-        model_ema,
         valid_cfg.device,
+        prefer_ema=True,
     )
     if valid_cfg.compile_model:
-        compile_model_components(model_ema.ema)
+        compile_model_components(diffusion_planner)
 
     if valid_cfg.ddp:
         torch.distributed.barrier()
 
-    valid_dict = validate_model(model_ema.ema, valid_loader, config_obj, return_pred=True)
+    valid_dict = validate_model(diffusion_planner, valid_loader, config_obj, return_pred=True)
 
     # Per-rank tensors (this rank's disjoint eval shard, in loader order).
     loss_ego = valid_dict["loss_ego"]

--- a/diffusion_planner/valid_predictor.py
+++ b/diffusion_planner/valid_predictor.py
@@ -96,9 +96,9 @@ def get_args(args_list=None):
     )
 
     args = parser.parse_args(args_list)
-    if args.multisample_eval_num_samples > 0 and args.multisample_eval_sample_steps < 3:
+    if args.multisample_eval_num_samples > 0 and args.multisample_eval_sample_steps < 2:
         raise ValueError(
-            "--multisample_eval_sample_steps must be >= 3 for the third-order DPM solver"
+            "--multisample_eval_sample_steps must be >= 2 for the second-order DPM solver"
         )
     return args
 

--- a/diffusion_planner/valid_predictor_closed_loop.py
+++ b/diffusion_planner/valid_predictor_closed_loop.py
@@ -1,4 +1,4 @@
-"""Closed-loop validation of a Diffusion-Planner checkpoint with the PerfectTracker.
+"""Closed-loop validation of a Diffusion-Planner checkpoint.
 
 Open-loop counterpart: ``valid_predictor.py`` runs ONE forward per sample and scores
 the prediction against the recorded GT future. This script instead drives the ego in
@@ -15,9 +15,10 @@ PNG of the live-ego scene. Every run therefore always produces video: one MP4 pe
 (``<route>_<start>_<end>.mp4``). Per-segment metrics are streamed to ``segments.jsonl`` and
 aggregated into ``summary.json`` (both next to the checkpoint).
 
-Only ``--model_path`` and ``--npz_root`` are required; all outputs are written next to
-the checkpoint (``<model_path dir>/closed_loop/``) and the rollout knobs default to the
-closed-loop mining config. Example (1st epoch of an HDP-RL run)::
+Use ``--mode full`` (default) to evaluate complete routes or ``--mode grouped`` to
+evaluate the labeled Odaiba scenario groups from a classification JSON. Only
+``--model_path`` and ``--npz_root`` are required for full-route evaluation; outputs
+default to ``<model_path dir>/closed_loop/``. Example::
 
     NPZ=/path/to/closed_loop_npz_dir
 
@@ -29,134 +30,51 @@ closed-loop mining config. Example (1st epoch of an HDP-RL run)::
 from __future__ import annotations
 
 import argparse
-from datetime import datetime
+import sys
 from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scenario_generation.closed_loop_cli import (  # noqa: E402
+    add_full_route_args,
+    add_grouped_args,
+    add_rollout_args,
+    print_full_summary,
+    run_full_route_eval,
+    run_grouped_eval,
+)
 
 
 def parse_args() -> argparse.Namespace:
-    # Only the checkpoint and the NPZ dir are required; everything else is a tunable
-    # knob with the closed-loop mining default. Outputs land next to the checkpoint.
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument(
-        "--model_path",
-        type=Path,
-        required=True,
-        help="checkpoint .pth; args.json must sit next to it (e.g. epoch0001/best_model.pth)",
+        "--mode",
+        choices=("full", "grouped"),
+        default="full",
+        help="full: entire routes; grouped: labeled scenario areas",
     )
-    p.add_argument(
-        "--npz_root",
-        type=Path,
-        required=True,
-        help="dir tree of route NPZ frames (recursively globbed, grouped into routes). "
-        "Pose JSON sidecars are read from next to each .npz, falling back to this same tree.",
-    )
-    # --- tunable knobs (default to the closed-loop mining config) ---
-    p.add_argument("--seg_len", type=int, default=6000, help="frames per segment (~60s @10Hz)")
-    p.add_argument("--device", type=str, default="cuda", help="'cuda' or 'cpu'")
-    p.add_argument("--near_miss_thresh", type=float, default=0.5, help="near-miss clearance (m)")
-    p.add_argument(
-        "--search_radius", type=float, default=1.5, help="PerceptionReproducer cursor search (m)"
-    )
-    p.add_argument(
-        "--warmup_steps",
-        type=int,
-        default=0,
-        help="steps driven by the recorded GT pose before handing control to the model",
-    )
-    p.add_argument(
-        "--unstick_after",
-        type=int,
-        default=300,
-        help="snap the ego to the GT pose ahead after this many no-progress steps (0=off)",
-    )
-    p.add_argument(
-        "--unstick_advance_m", type=float, default=2.5, help="how far ahead to snap when unsticking"
-    )
-    p.add_argument(
-        "--unstick_radius_mult",
-        type=float,
-        default=3.0,
-        help="when stuck, first widen the cursor search_radius to this x nominal so it reaches "
-        "frames further ahead (model proceeds on its own); restored to nominal once the ego moves. "
-        "<=1 disables this gentle stage (teleport straight away at --unstick_after)",
-    )
-    p.add_argument(
-        "--unstick_teleport_after",
-        type=int,
-        default=300,
-        help="if still stuck this many steps AFTER the radius was widened, fall back to the hard "
-        "teleport onto the GT pose ahead (last resort)",
-    )
-    p.add_argument("--fps", type=int, default=10, help="output video frame rate (10 = realtime)")
-    p.add_argument(
-        "--replan_interval",
-        type=int,
-        default=40,
-        help="re-run the model every N steps (1 = every step). Between inferences the cached plan "
-        "is executed, re-expressed in the current ego frame each step; the ego still steps at 10Hz",
-    )
-    p.add_argument(
-        "--draw_every",
-        type=int,
-        default=8,
-        help="render a PNG only every N steps (1 = every step). PNG rendering (matplotlib) is the "
-        "dominant cost; this throttles it without touching the rollout. Frames are encoded at --fps "
-        "regardless, so the video also plays N x faster (shorter). For real-time use --fps 10/N",
-    )
+    add_rollout_args(p)
+    add_full_route_args(p)
+    add_grouped_args(p)
     return p.parse_args()
 
 
-def main() -> None:
+def main() -> int:
     args = parse_args()
+    if args.mode == "grouped":
+        return run_grouped_eval(args)
 
-    from scenario_generation.closed_loop_eval import run_closed_loop_eval
-    from scenario_generation.simulate import load_model
+    summary = run_full_route_eval(args)
+    out_dir = args.out_dir
+    if out_dir is None:
+        from datetime import datetime
 
-    model, model_args = load_model(args.model_path, args.device)
-    out_dir = args.model_path.parent / "closed_loop" / datetime.now().strftime("%Y%m%d_%H%M%S")
-    print(f"device: {args.device} | model: {args.model_path} | out: {out_dir}")
-
-    summary = run_closed_loop_eval(
-        model,
-        model_args,
-        args.npz_root,
-        out_dir,
-        seg_len=args.seg_len,
-        device=args.device,
-        near_miss_thresh=args.near_miss_thresh,
-        search_radius=args.search_radius,
-        warmup_steps=args.warmup_steps,
-        unstick_after=args.unstick_after,
-        unstick_advance_m=args.unstick_advance_m,
-        unstick_radius_mult=args.unstick_radius_mult,
-        unstick_teleport_after=args.unstick_teleport_after,
-        fps=args.fps,
-        replan_interval=args.replan_interval,
-        draw_every=args.draw_every,
-        neighbor_history_mode="recorded",
-    )
-    summary["model_path"] = str(args.model_path)
-
-    n_seg = summary["n_segments"]
-    print(f"\n=== closed-loop validation: {n_seg} segments in {summary['elapsed_sec']:.1f}s ===")
-    print(
-        f"collision: {summary['n_segments_with_collision']}/{n_seg} segments "
-        f"(rate {summary['collision_segment_rate']:.4f}), "
-        f"{summary['total_collision_steps']} steps (rate {summary['collision_step_rate']:.6f})"
-    )
-    print(
-        f"near-miss (<= {args.near_miss_thresh} m): "
-        f"{summary['n_segments_with_near_miss']}/{n_seg} segments "
-        f"(rate {summary['near_miss_segment_rate']:.4f}), {summary['total_near_miss_steps']} steps"
-    )
-    print(
-        f"global_min_clearance={summary['global_min_clearance']:.3f} m  "
-        f"mean_segment_min_clearance={summary['mean_segment_min_clearance']:.3f} m  "
-        f"mean_segment_mean_clearance={summary['mean_segment_mean_clearance']:.3f} m"
-    )
-    print(f"total_snaps={summary['total_snaps']}  terminated={summary['terminated_counts']}")
-    print(f"videos: per-segment <route>_<start>_<end>.mp4 in {out_dir}")
+        out_dir = args.model_path.parent / "closed_loop" / datetime.now().strftime("%Y%m%d_%H%M%S")
+    print_full_summary(summary, args.near_miss_thresh, Path(out_dir))
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/docs/code_review_findings_20260711.md
+++ b/docs/code_review_findings_20260711.md
@@ -221,3 +221,25 @@
 - Ruff import lint、format check、`git diff --check`：通过。
 - 当前 BaseTrain epoch-1 EMA checkpoint：成功加载到精简后的 Decoder，state dict 无缺失/多余 key。
 - ONNX：full/encoder/turn checker 通过；PyTorch/ORT parity 通过；full graph 动态 batch 1/2 通过；真实 validation NPZ 输出 `[1,1,80,4]`，最大差约 `7.6e-6`。
+
+## 第三轮独立全仓复核（同日追加）
+
+在上述 25 项全部完成后，又对训练恢复、DDP、RL all-scope、独立验证、场景闭环和
+ONNX 实机路径做了一轮独立复核，新增并修复：
+
+27. 独立 validation 不再构造 dummy AdamW/EMA 或恢复 optimizer、scheduler、RNG；直接优先加载 EMA 权重，避免额外 GPU 状态和验证随机数被 checkpoint 覆盖。
+28. `scenario_generation.load_model` 原先总是加载 live policy，现默认优先 checkpoint EMA，与训练验证和 ONNX 保持一致；真实 epoch-1 checkpoint 已逐参数确认。
+29. 没有 availability tensor 的 EPDMS 子指标不再把 NaN/Inf 当作分母中的零分样本，而是从分子和分母同时排除。
+30. grouped closed-loop 的两阶段 unstick 参数原先在 CLI 调用链中静默丢失，现完整传至 rollout state。
+31. grouped episode 完成度原先使用整条 route 的全局最大 index，可能把完全跳过的早期 episode 标成完成；现只使用 episode 视频区间内实际访问的 index。near-miss 也不再重复计入负 clearance 的 collision steps。
+32. 直接启动且没有 torchrun/Slurm 环境时，DDP fallback 原先仍保留 `ddp=True` 并在后续 collective 崩溃；现一致回退单进程。显式 `cuda:0` 在多卡 DDP 下也会按 `LOCAL_RANK` 绑定，非 DDP 的 `cuda:N` 仍被保留。
+33. resume 后周期 checkpoint/closed-loop 原先相对 `init_epoch` 重新计数，可能把 epoch 10/20 漂移到 17；SFT/RL 均改为绝对 epoch cadence。
+34. RL `all` scope 原先把 320x80 的 reward-only neighbor future 复制到每个候选，默认 32 generations 时可能 OOM；policy batch 现剔除 ego/neighbor supervision futures，reward 保留每场景原张量。
+35. RL 启动参数新增数学有效性检查（reward 权重、normalization epsilon、时间步长和 shaping 阈值）；仍允许 occupancy source 缺失并通过 source coverage 指标显式记录，不增加用户已拒绝的严格报错模式。
+36. ONNX CLI 不再在 import 时永久关闭 Flash-SDP/MHA fastpath，只在已有的可恢复导出上下文中切换；真实 NPZ 的 full/encoder/turn ORT parity 重新通过，full graph 动态 batch=2 最大差约 `1.9e-5`。
+37. 训练和场景主路径的 NPZ 读取关闭 pickle，并只解压实际消费字段；正式 JT 样本已通过 SceneContext、RouteTimeline 和 ONNX 输入实读。
+38. PyTorch 2.11 在分组件编译边界探测非叶子 encoder 输出时会产生上游 `.grad` 假阳性 warning；过滤范围限定在 Dynamo 内部模块。保留分组件方案，因为 H100 B64 稳态约 185 ms，而整图编译实测约 206 ms（慢约 12%）。
+
+追加验证：根目录 `368 passed, 15 skipped`（`PYTHONWARNINGS=error`）；pre-commit 全通过；
+2xH100 compiled DDP 真实 checkpoint forward/backward 后两 rank 参数 checksum 完全一致；
+EMA 场景推理输出有限且形状为 `[1,1,80,4]`。

--- a/docs/code_review_findings_20260711.md
+++ b/docs/code_review_findings_20260711.md
@@ -112,10 +112,10 @@
 - 问题：`extra_train_set_mask_traffic_lights` 按路径字符串成员（`path in traffic_light_mask_paths`）判定；同一路径若同时在 base 与 extra 列表中，其 **base 侧样本也被掩码**，违反"仅对 extra 样本掩码"的文档承诺。审计文档记录 node01 base∩extra = 33,913 条重叠（当前 sbatch 用过滤后列表规避了，但 API 陷阱仍在）。
 - 修复方向：按索引区间（extra 段起始下标）而非路径成员判定。
 
-### 18. 多样本评测中无效 GT 样本污染 minADE/minFDE
+### 18. 多样本评测曾错误地从 xy 非零值推断 ego GT 有效性
 - 位置：`diffusion_planner/diffusion_planner/validate_model.py:229`（`valid[no_valid] = True`）
-- 问题：ego future 全无效的样本被伪造为有效，其"minADE"是相对零填充原点的伪距离，直接混入均值。
-- 修复方向：将此类样本从均值中剔除（分子分母都不计）。
+- 最终复核：原发现不成立。ego future 没有 padding mask，数据契约固定为完整 80 帧；合法停车可以表现为全零 `(x,y,yaw)`。从 xy 是否非零推断有效性会系统性漏掉停车场景。
+- 最终修复：严格按论文定义，对全部 80 个 waypoints 计算 ADE，并在第 80 帧计算 FDE。
 
 ### 19. `rl_reward_normalize=batch` 不丢弃同奖励组
 - 位置：`diffusion_planner/diffusion_planner/hdp_rl_utils.py:697`
@@ -200,7 +200,7 @@
 | 15 | 成立 | HDP-only 分支完整删除永远不可达的 split decoder 导出/验证路径，只保留 full/encoder/turn 图。 |
 | 16 | 成立 | supervised/RL 两个循环都在每个 epoch 开始前调用 `sampler.set_epoch(epoch)`，严格 resume 不再复用 epoch-0 shuffle。 |
 | 17 | 成立 | Dataset 用 extra 起始索引和 subsample stride 按 occurrence 判定，不再按路径集合命中，也不分配 958 万项来源列表。base list/NPZ 未修改。 |
-| 18 | 成立 | 无任何有效 GT timestep 的 scene 从所有 multisample 均值分子和分母中排除；新增混合有效/无效 batch 测试；全空集合报告 NaN 而非伪装成 0。 |
+| 18 | 原报告不成立，已纠正 | ego future 是固定 80 帧且无 padding mask；合法停车可为全零。multisample ADE/FDE 现按论文定义覆盖全部 80 帧，并新增静止场景测试。 |
 | 19 | 成立 | “同场景候选奖励全相同则丢弃”现在独立于 normalization mode，group/batch/none 都执行；默认仍是论文的 group normalization。 |
 | 20 | 成立 | `valid_group_fraction` 改为每组 `.any(dim=1)`，不再只读 candidate 0。 |
 | 21 | 成立，但最佳修复不是移动 clamp | endpoint heading/acos 判据随错误的 ego-y lane-change proxy 一起删除，因此 NaN 路径不存在。 |

--- a/docs/hdp_deep_audit_20260710.md
+++ b/docs/hdp_deep_audit_20260710.md
@@ -247,17 +247,19 @@ same DDP world size so diffusion noise and augmentation continue from the same s
 - bf16 autocast covers model forward only; SDE/noising/loss math remains fp32.
 - Fused AdamW, TF32, DDP static graph, persistent workers, pinned memory, and prefetch are
   enabled where supported.
+- EMA uses timm's foreach implementation while retaining the existing `.ema` checkpoint API;
+  an 18.1M-parameter CPU benchmark reduced update time from 42.1 ms to 12.8 ms with exact
+  one-step numerical parity.
 - Extra-list weighting appends path references in memory instead of writing the previous
   roughly 798 MB combined manifest; giant W&B list artifacts are opt-in.
 - SFT/RL checkpoint ONNX export defaults off because synchronous export makes every other
   rank idle at the next barrier. Strict standalone export remains available.
 - Reward and update timing is sampled on the W&B logging cadence rather than synchronizing
   CUDA every step.
-- RL marks only `decoder.dit` trainable and skips the unused turn-head forward, avoiding
-  unsupervised DDP parameters and unnecessary classifier work.
+- RL marks `decoder.dit` and `decoder.global_route_encoder` trainable and skips the unused
+  turn-head forward, avoiding unsupervised DDP parameters and unnecessary classifier work.
 
-Joint-action RL is supported but group-32 memory scales with 321 action rows. Use it as a
-smaller-batch ablation; ego-only is the intended high-throughput real-vehicle arm.
+The branch has one ego-only action contract; the old joint-action decoder and RL mode are removed.
 
 ## Checkpoint and runtime safety
 

--- a/docs/hdp_deep_audit_20260710.md
+++ b/docs/hdp_deep_audit_20260710.md
@@ -188,23 +188,26 @@ List counts from the audit:
 | Clean Base source | 9,081,354 | not recomputed | preserved |
 | Filtered Base | 9,054,475 | not recomputed | preserved |
 | Three-source right-turn extra | 52,870 | 52,870 | 0 |
-| Validation | 53,008 | 53,008 | 0 |
+| Validation | 53,382 | 53,382 | 0 |
 
 Train/validation overlap is zero. Node01 base intersects its extra list in 33,913 paths;
 with `extra*10`, those paths receive 11 total exposures while extra-only paths receive 10.
 This is acceptable only if that slight extra emphasis is intended. The new clean Base
-uses the supplied filtered list instead: 26,879 matching right-turn samples were removed,
-then the complete, unique 53,185-sample three-source extra set is appended ten times.
-The JT extra manifest originally contained 315 validation paths; those entries were removed
-from the extra manifest without changing the Base list or any NPZ. The resulting 9,583,175
-path exposures contain no train/validation overlap and do not retain an accidental eleventh copy.
+uses the supplied filtered list instead: 26,879 matching right-turn samples were removed.
+The three source manifests initially contributed 53,185 unique right-turn samples. The JT
+manifest contained 315 validation paths; those entries were removed from the extra manifest
+without changing the Base list or any NPZ, leaving 52,870 samples that are appended ten times.
+The resulting 9,583,175 path exposures contain no train/validation overlap and do not retain
+an accidental eleventh copy.
 
 ## Validation and logging
 
 The deterministic zero-noise trajectory is retained as a stable checkpoint proxy. The
-paper Appendix explicitly generates six trajectories and reports minADE/minFDE; this
-branch separately implements a seeded six-sample metric and does not call the
-deterministic proxy the paper protocol. Six-sample evaluation reuses one scene encoding.
+paper Appendix explicitly generates six trajectories and reports minADE/minFDE over all
+future waypoints; this branch separately implements a seeded six-sample metric and does not
+call the deterministic proxy the paper protocol. Ego futures have a fixed 80-frame contract,
+so stationary all-zero xy trajectories remain valid metric samples. Six-sample evaluation
+reuses one scene encoding.
 Evaluation shards no longer use duplicate padding, so non-divisible validation-set sizes
 produce exact global metrics and prediction files are never written by two ranks.
 

--- a/docs/hyper_diffusion_planner.md
+++ b/docs/hyper_diffusion_planner.md
@@ -156,6 +156,7 @@ Implementation notes:
 - `rl_train_scope=decoder` updates only the DiT trajectory policy and freezes the encoder plus the separate turn-indicator classifier. This matches the released decoder-policy intent without leaving an unsupervised Tier IV-only head in DDP.
 - Encoder modules are kept in eval mode during decoder-only RL so frozen dropout/drop-path does not inject noise.
 - The EMA shadow is the previous rollout policy. The live decoder is updated first and EMA is refreshed afterward with update rate `0.05` (`timm` decay `0.95`).
+- EMA updates use timm's foreach implementation to fuse the per-tensor interpolation kernels while preserving the existing `.ema` checkpoint state.
 - The single reward path contains SAT collision, continuous TTC, THW, occupancy clearance, leader-conditioned following, lane-center scoring, lane-change/off-lane masking, and rear-end attenuation, using risk/follow/lane weights 1.0/3.0/2.5. Lane scoring uses the navigation route when it agrees with the logged expert trajectory and otherwise falls back to all visible lane centerlines.
 - Occupancy automatically uses real static boxes, stopped-agent clearance, then road-border clearance as a corpus fallback. Missing sources are neutral and their coverage is logged.
 - Scene encoding is computed once per candidate group. Decoder-only RL repeats only current action-state tensors, not the full 31-frame observation history.

--- a/docs/hyper_diffusion_planner.md
+++ b/docs/hyper_diffusion_planner.md
@@ -156,7 +156,7 @@ Implementation notes:
 - `rl_train_scope=decoder` updates only the DiT trajectory policy and freezes the encoder plus the separate turn-indicator classifier. This matches the released decoder-policy intent without leaving an unsupervised Tier IV-only head in DDP.
 - Encoder modules are kept in eval mode during decoder-only RL so frozen dropout/drop-path does not inject noise.
 - The EMA shadow is the previous rollout policy. The live decoder is updated first and EMA is refreshed afterward with update rate `0.05` (`timm` decay `0.95`).
-- The single reward path contains SAT collision, continuous TTC, THW, occupancy clearance, leader-conditioned following, lane-center scoring, lane-change/off-lane masking, and rear-end attenuation, using risk/follow/lane weights 1.0/3.0/2.5.
+- The single reward path contains SAT collision, continuous TTC, THW, occupancy clearance, leader-conditioned following, lane-center scoring, lane-change/off-lane masking, and rear-end attenuation, using risk/follow/lane weights 1.0/3.0/2.5. Lane scoring uses the navigation route when it agrees with the logged expert trajectory and otherwise falls back to all visible lane centerlines.
 - Occupancy automatically uses real static boxes, stopped-agent clearance, then road-border clearance as a corpus fallback. Missing sources are neutral and their coverage is logged.
 - Scene encoding is computed once per candidate group. Decoder-only RL repeats only current action-state tensors, not the full 31-frame observation history.
 - Full stochastic/EPDMS validation runs on `rl_full_eval_utd`; the deterministic proxy remains available each epoch.

--- a/docs/hyper_diffusion_planner.md
+++ b/docs/hyper_diffusion_planner.md
@@ -157,6 +157,9 @@ Implementation notes:
 - Encoder modules are kept in eval mode during decoder-only RL so frozen dropout/drop-path does not inject noise.
 - The EMA shadow is the previous rollout policy. The live decoder is updated first and EMA is refreshed afterward with update rate `0.05` (`timm` decay `0.95`).
 - EMA updates use timm's foreach implementation to fuse the per-tensor interpolation kernels while preserving the existing `.ema` checkpoint state.
+- SFT, RL, and standalone validation compile the encoder and decoder in place by default. The
+  state dict stays unchanged, while RL's direct component calls and DPM validation use the same
+  compiled modules. Use a persistent `TORCHINDUCTOR_CACHE_DIR` across restarts.
 - The single reward path contains SAT collision, continuous TTC, THW, occupancy clearance, leader-conditioned following, lane-center scoring, lane-change/off-lane masking, and rear-end attenuation, using risk/follow/lane weights 1.0/3.0/2.5. Lane scoring uses the navigation route when it agrees with the logged expert trajectory and otherwise falls back to all visible lane centerlines.
 - Occupancy automatically uses real static boxes, stopped-agent clearance, then road-border clearance as a corpus fallback. Missing sources are neutral and their coverage is logged.
 - Scene encoding is computed once per candidate group. Decoder-only RL repeats only current action-state tensors, not the full 31-frame observation history.

--- a/ros_scripts/torch2onnx.py
+++ b/ros_scripts/torch2onnx.py
@@ -22,11 +22,6 @@ from diffusion_planner.utils.onnx_export import (
     load_model,
 )
 
-torch.backends.cuda.enable_flash_sdp(False)
-torch.backends.cuda.enable_mem_efficient_sdp(False)
-torch.backends.cuda.enable_math_sdp(True)
-torch.backends.mha.set_fastpath_enabled(False)
-
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
@@ -66,7 +61,9 @@ def parse_args() -> argparse.Namespace:
 
 
 def build_inputs_from_npz(npz_path: Path, action_agent_num: int = 1) -> TensorDict:
-    data = np.load(npz_path, allow_pickle=True)
+    required_keys = set(FULL_INPUT_NAMES) - {"sampled_trajectories"}
+    with np.load(npz_path, allow_pickle=False) as archive:
+        data = {key: archive[key] for key in required_keys if key in archive.files}
     inputs = {}
     inputs["sampled_trajectories"] = 0.5 * torch.randn(
         1, action_agent_num, OUTPUT_T, POSE_DIM, dtype=torch.float32
@@ -126,8 +123,8 @@ def run_ort_in_subprocess(model_path: Path, np_inputs: NumpyDict) -> list[np.nda
         script = f"""
 import numpy as np
 import onnxruntime as ort
-data = np.load("{input_path}", allow_pickle=True)
-inputs = {{k: data[k] for k in data.files}}
+with np.load("{input_path}", allow_pickle=False) as data:
+    inputs = {{k: data[k] for k in data.files}}
 sess_options = ort.SessionOptions()
 sess_options.log_severity_level = 3
 sess = ort.InferenceSession(
@@ -146,8 +143,8 @@ np.savez("{output_path}", **{{f"out_{{i}}": o for i, o in enumerate(outputs)}})
         if result.returncode != 0:
             raise RuntimeError(f"ORT subprocess failed:\n{result.stderr[-1000:]}")
         print(result.stdout.strip())
-        data = np.load(output_path, allow_pickle=True)
-        return [data[f"out_{i}"] for i in range(len(data.files))]
+        with np.load(output_path, allow_pickle=False) as data:
+            return [data[f"out_{i}"] for i in range(len(data.files))]
 
 
 def compare(name: str, torch_output: np.ndarray, onnx_output: np.ndarray) -> None:

--- a/scenario_generation/closed_loop_cli.py
+++ b/scenario_generation/closed_loop_cli.py
@@ -1,0 +1,222 @@
+"""Shared CLI arguments and runners for closed-loop validation.
+
+Used by:
+  - ``diffusion_planner/valid_predictor_closed_loop.py`` (full-route mode)
+  - ``scenario_generation/tools/eval_scenario_groups_closed_loop.py`` (grouped-by-area mode)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+
+from scenario_generation.closed_loop_eval import run_closed_loop_eval
+from scenario_generation.grouped_closed_loop_eval import run_grouped_closed_loop_eval
+from scenario_generation.simulate import load_model
+
+
+def add_rollout_args(parser: argparse.ArgumentParser) -> None:
+    """Rollout knobs shared by full-route and grouped-by-area validation."""
+    parser.add_argument(
+        "--model_path",
+        type=Path,
+        required=True,
+        help="checkpoint .pth; args.json must sit next to it",
+    )
+    parser.add_argument(
+        "--npz_root",
+        type=Path,
+        required=True,
+        help="dir tree of route NPZ frames (recursively globbed into routes)",
+    )
+    parser.add_argument("--device", type=str, default="cuda", help="'cuda' or 'cpu'")
+    parser.add_argument(
+        "--near_miss_thresh",
+        "--margin_m",
+        type=float,
+        default=0.5,
+        help="clearance threshold (m) for near-miss / safety violation counting",
+    )
+    parser.add_argument(
+        "--search_radius",
+        type=float,
+        default=1.5,
+        help="PerceptionReproducer cursor search radius (m)",
+    )
+    parser.add_argument(
+        "--warmup_steps",
+        type=int,
+        default=0,
+        help="steps driven by recorded GT pose before model control",
+    )
+    parser.add_argument(
+        "--unstick_after",
+        type=int,
+        default=300,
+        help="snap ego to GT pose after this many no-progress steps (0=off)",
+    )
+    parser.add_argument(
+        "--unstick_advance_m",
+        type=float,
+        default=2.5,
+        help="how far ahead to snap when unsticking (m)",
+    )
+    parser.add_argument(
+        "--unstick_radius_mult",
+        type=float,
+        default=3.0,
+        help="widen cursor search radius by this factor before hard teleport",
+    )
+    parser.add_argument(
+        "--unstick_teleport_after",
+        type=int,
+        default=300,
+        help="steps after radius widen before hard teleport",
+    )
+    parser.add_argument("--fps", type=int, default=10, help="output video frame rate")
+    parser.add_argument(
+        "--draw_every",
+        type=int,
+        default=8,
+        help="render PNG every N steps (matplotlib cost throttle)",
+    )
+
+
+def add_output_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--out_dir",
+        "--output_dir",
+        type=Path,
+        default=None,
+        help="output directory (full: default <model_dir>/closed_loop/<ts>; grouped: required)",
+    )
+
+
+def add_full_route_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--seg_len",
+        type=int,
+        default=6000,
+        help="frames per route segment in full-route mode (~60s @10Hz)",
+    )
+    parser.add_argument(
+        "--replan_interval",
+        type=int,
+        default=40,
+        help="run the model every N ticks and execute the cached plan between replans",
+    )
+    add_output_args(parser)
+
+
+def add_grouped_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--classification_json",
+        type=Path,
+        default=None,
+        help="scenario_classification_json/.../<date>.json from classify_scenario_corpus (grouped mode)",
+    )
+    parser.add_argument(
+        "--areas",
+        nargs="*",
+        default=None,
+        help="optional subset of area names in the classification JSON",
+    )
+
+
+def _load_area_mapping(path: Path) -> dict[str, str]:
+    """Legacy helper for group->list mapping files (classify-time config only)."""
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if "areas" in raw:
+        return {str(k): str(v["metric_group"]) for k, v in raw["areas"].items()}
+    out: dict[str, str] = {}
+    for group, areas in raw.items():
+        if group == "version" or not isinstance(areas, list):
+            continue
+        for area in areas:
+            out[str(area)] = str(group)
+    return out
+
+
+def run_full_route_eval(args: argparse.Namespace) -> dict:
+    model, model_args = load_model(args.model_path, args.device)
+    out_dir = args.out_dir
+    if out_dir is None:
+        out_dir = args.model_path.parent / "closed_loop" / datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_dir = Path(out_dir)
+    print(f"device: {args.device} | model: {args.model_path} | out: {out_dir}")
+
+    summary = run_closed_loop_eval(
+        model,
+        model_args,
+        args.npz_root,
+        out_dir,
+        seg_len=args.seg_len,
+        device=args.device,
+        near_miss_thresh=args.near_miss_thresh,
+        search_radius=args.search_radius,
+        warmup_steps=args.warmup_steps,
+        unstick_after=args.unstick_after,
+        unstick_advance_m=args.unstick_advance_m,
+        unstick_radius_mult=args.unstick_radius_mult,
+        unstick_teleport_after=args.unstick_teleport_after,
+        fps=args.fps,
+        replan_interval=args.replan_interval,
+        draw_every=args.draw_every,
+        neighbor_history_mode="recorded",
+        verbose=True,
+    )
+    summary["model_path"] = str(args.model_path)
+    return summary
+
+
+def run_grouped_eval(args: argparse.Namespace) -> int:
+    if args.classification_json is None or args.out_dir is None:
+        raise SystemExit("grouped mode requires --classification_json and --out_dir")
+
+    model, model_args = load_model(args.model_path, args.device)
+    summary = run_grouped_closed_loop_eval(
+        model,
+        model_args,
+        args.npz_root,
+        args.classification_json,
+        args.out_dir,
+        device=args.device,
+        near_miss_thresh=args.near_miss_thresh,
+        search_radius=args.search_radius,
+        warmup_steps=args.warmup_steps,
+        unstick_after=args.unstick_after,
+        unstick_advance_m=args.unstick_advance_m,
+        draw_every=args.draw_every,
+        fps=args.fps,
+        areas=args.areas,
+        verbose=True,
+    )
+    print(
+        f"Wrote {summary['n_episodes']}/{summary['n_episodes_expected']} episode rows -> "
+        f"{Path(args.out_dir) / 'results_table.csv'}"
+    )
+    return 0
+
+
+def print_full_summary(summary: dict, near_miss_thresh: float, out_dir: Path) -> None:
+    n_seg = summary["n_segments"]
+    print(f"\n=== closed-loop validation: {n_seg} segments in {summary['elapsed_sec']:.1f}s ===")
+    print(
+        f"collision: {summary['n_segments_with_collision']}/{n_seg} segments "
+        f"(rate {summary['collision_segment_rate']:.4f}), "
+        f"{summary['total_collision_steps']} steps (rate {summary['collision_step_rate']:.6f})"
+    )
+    print(
+        f"near-miss (<= {near_miss_thresh} m): "
+        f"{summary['n_segments_with_near_miss']}/{n_seg} segments "
+        f"(rate {summary['near_miss_segment_rate']:.4f}), {summary['total_near_miss_steps']} steps"
+    )
+    print(
+        f"global_min_clearance={summary['global_min_clearance']:.3f} m  "
+        f"mean_segment_min_clearance={summary['mean_segment_min_clearance']:.3f} m  "
+        f"mean_segment_mean_clearance={summary['mean_segment_mean_clearance']:.3f} m"
+    )
+    print(f"total_snaps={summary['total_snaps']}  terminated={summary['terminated_counts']}")
+    print(f"videos: per-segment <route>_<start>_<end>.mp4 in {out_dir}")

--- a/scenario_generation/closed_loop_cli.py
+++ b/scenario_generation/closed_loop_cli.py
@@ -188,6 +188,8 @@ def run_grouped_eval(args: argparse.Namespace) -> int:
         warmup_steps=args.warmup_steps,
         unstick_after=args.unstick_after,
         unstick_advance_m=args.unstick_advance_m,
+        unstick_radius_mult=args.unstick_radius_mult,
+        unstick_teleport_after=args.unstick_teleport_after,
         draw_every=args.draw_every,
         fps=args.fps,
         areas=args.areas,

--- a/scenario_generation/grouped_closed_loop_eval.py
+++ b/scenario_generation/grouped_closed_loop_eval.py
@@ -46,6 +46,8 @@ def run_grouped_closed_loop_eval(
     warmup_steps: int = 0,
     unstick_after: int = 300,
     unstick_advance_m: float = 2.5,
+    unstick_radius_mult: float = 3.0,
+    unstick_teleport_after: int = 300,
     draw_every: int = 8,
     fps: float = 10.0,
     areas: list[str] | None = None,
@@ -126,6 +128,8 @@ def run_grouped_closed_loop_eval(
             warmup_steps=warmup_steps,
             unstick_after=unstick_after,
             unstick_advance_m=unstick_advance_m,
+            unstick_radius_mult=unstick_radius_mult,
+            unstick_teleport_after=unstick_teleport_after,
             draw_every=draw_every,
         )
         rollouts[bag_name] = rollout

--- a/scenario_generation/grouped_closed_loop_eval.py
+++ b/scenario_generation/grouped_closed_loop_eval.py
@@ -1,0 +1,239 @@
+"""Grouped closed-loop validation (scenario_classification_json episodes).
+
+Shared by the standalone CLI and per-epoch training validation in ``train.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import torch
+
+from scenario_generation.metrics.cl_route_by_area import (
+    RouteRolloutResult,
+    aggregate_area_metrics,
+    build_area_video,
+    run_full_route_rollout,
+)
+from scenario_generation.metrics.group_report import (
+    aggregate_segment_rows,
+    write_metrics_summary,
+    write_results_table,
+)
+from scenario_generation.route_timeline import RouteTimeline, _frame_index
+from scenario_generation.scenario_classification import (
+    episodes_from_entry,
+    load_area_metric_groups,
+    load_classification_json,
+    time_series_from_doc,
+    validate_classification_npz_root,
+)
+
+
+@torch.no_grad()
+def run_grouped_closed_loop_eval(
+    model,
+    model_args,
+    npz_root: Path | str,
+    classification_json: Path | str,
+    out_dir: Path | str,
+    *,
+    device: str = "cuda",
+    near_miss_thresh: float = 0.3,
+    search_radius: float = 1.5,
+    warmup_steps: int = 0,
+    unstick_after: int = 300,
+    unstick_advance_m: float = 2.5,
+    draw_every: int = 8,
+    fps: float = 10.0,
+    areas: list[str] | None = None,
+    verbose: bool = True,
+) -> dict:
+    """Run grouped-by-area closed-loop eval; return summary for disk + wandb.
+
+    One full-route rollout per bag in the classification JSON, then per-episode
+    metrics (non-``is_skipped`` labeled frames) and continuous-span videos.
+    """
+    npz_root = Path(npz_root).expanduser().resolve()
+    out_dir = Path(out_dir).expanduser().resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    doc = load_classification_json(Path(classification_json))
+    time_series = time_series_from_doc(doc)
+    if not time_series:
+        raise ValueError(
+            "classification JSON has no 'time_series' — re-run classify_scenario_corpus"
+        )
+
+    area_to_metric = load_area_metric_groups(doc)
+    allowed_areas: set[str] | None = set(areas) if areas else None
+    expected_episodes = sum(
+        1
+        for entry in time_series.values()
+        for episode in episodes_from_entry(entry)
+        if (allowed_areas is None or str(episode["area"]) in allowed_areas)
+        and area_to_metric.get(str(episode["area"])) is not None
+    )
+
+    rollouts: dict[str, RouteRolloutResult] = {}
+    timelines: dict[str, RouteTimeline] = {}
+    episodes_by_bag: dict[str, list[dict]] = {}
+    missing_bags: list[str] = []
+
+    t0 = time.perf_counter()
+
+    for warning in validate_classification_npz_root(doc, npz_root):
+        if verbose:
+            print(f"Warning: {warning}")
+
+    for bag_name, entry in sorted(time_series.items()):
+        seq_dir = npz_root / bag_name
+        if not seq_dir.is_dir():
+            missing_bags.append(bag_name)
+            if verbose:
+                print(f"Skip bag {bag_name}: not under {npz_root}")
+            continue
+        paths = sorted(seq_dir.glob("*.npz"), key=_frame_index)
+        if len(paths) < 2:
+            if verbose:
+                print(f"Skip bag {bag_name}: fewer than 2 NPZ frames")
+            continue
+
+        route_key = str(entry["route_key"])
+        episodes = episodes_from_entry(entry)
+        episodes_by_bag[bag_name] = episodes
+        tl = RouteTimeline(paths, sidecar_dir=npz_root)
+        png_dir = out_dir / "rollouts" / bag_name
+        if verbose:
+            print(
+                f"Full-route rollout: {bag_name} ({route_key}), "
+                f"{len(paths)} frames, {len(episodes)} episodes..."
+            )
+        rollout = run_full_route_rollout(
+            model,
+            model_args,
+            tl,
+            route_key,
+            bag_name,
+            episodes,
+            area_to_metric,
+            png_dir,
+            device=device,
+            near_miss_thresh=near_miss_thresh,
+            search_radius=search_radius,
+            warmup_steps=warmup_steps,
+            unstick_after=unstick_after,
+            unstick_advance_m=unstick_advance_m,
+            draw_every=draw_every,
+        )
+        rollouts[bag_name] = rollout
+        timelines[bag_name] = tl
+        if verbose:
+            print(
+                f"  done: steps={rollout.n_steps_run} terminated={rollout.terminated} "
+                f"episodes={len(episodes)}"
+            )
+
+    all_rows: list[dict] = []
+    span_counts: dict[str, int] = {}
+    video_mp4s: list[Path] = []
+
+    for bag_name, episodes in episodes_by_bag.items():
+        rollout = rollouts.get(bag_name)
+        if rollout is None:
+            continue
+        tl = timelines[bag_name]
+        route_key = rollout.route_key
+
+        for ep in episodes:
+            area_name = str(ep["area"])
+            if allowed_areas is not None and area_name not in allowed_areas:
+                continue
+            metric_group = area_to_metric.get(area_name)
+            if metric_group is None:
+                continue
+            span_key = f"{bag_name}:{area_name}"
+            span_index = span_counts.get(span_key, 0)
+            span_counts[span_key] = span_index + 1
+
+            row = aggregate_area_metrics(
+                rollout.steps,
+                area_name,
+                metric_group,
+                route_key,
+                bag_name,
+                tl,
+                labeled_ranges=ep["labeled_ranges"],
+                video_start_idx=int(ep["video_start_idx"]),
+                video_end_idx=int(ep["video_end_idx"]),
+                span_index=span_index,
+                near_miss_thresh=near_miss_thresh,
+            )
+            if row is None:
+                continue
+
+            video_root = out_dir / "videos" / metric_group / area_name
+            video_root.mkdir(parents=True, exist_ok=True)
+            seg_tag = row["segment"].strip("[]").replace(",", "_").replace(" ", "")
+            mp4 = video_root / f"{bag_name}_{span_index}_{seg_tag}.mp4"
+            if build_area_video(
+                rollout,
+                mp4,
+                fps,
+                video_start_idx=int(ep["video_start_idx"]),
+                video_end_idx=int(ep["video_end_idx"]),
+            ):
+                row["video_path"] = str(mp4.relative_to(out_dir))
+                video_mp4s.append(mp4)
+            all_rows.append(row)
+            if verbose:
+                print(
+                    f"  [{area_name}] {bag_name} span#{span_index} {row['segment']} "
+                    f"steps={row['n_steps_run']} coll={row.get('collision_steps', 0)}"
+                )
+
+    grouped_summary = aggregate_segment_rows(all_rows)
+    area_names = sorted({r["area_name"] for r in all_rows})
+    for area_name in area_names:
+        area_rows = [r for r in all_rows if r["area_name"] == area_name]
+        write_metrics_summary(
+            aggregate_segment_rows(area_rows),
+            out_dir / "by_area" / f"{area_name}_metrics_summary.json",
+        )
+
+    write_results_table(all_rows, out_dir / "results_table.csv")
+    write_metrics_summary(grouped_summary, out_dir / "metrics_summary.json")
+
+    elapsed_sec = time.perf_counter() - t0
+    summary = {
+        "mode": "grouped",
+        "classification_json": str(Path(classification_json).resolve()),
+        "npz_root": str(npz_root),
+        "near_miss_thresh": near_miss_thresh,
+        "n_episodes": len(all_rows),
+        "n_episodes_expected": expected_episodes,
+        "episode_report_fraction": len(all_rows) / max(expected_episodes, 1),
+        "n_bags": len(rollouts),
+        "n_bags_expected": len(time_series),
+        "bag_report_fraction": len(rollouts) / max(len(time_series), 1),
+        "missing_bags": missing_bags,
+        "elapsed_sec": elapsed_sec,
+        "grouped_summary": grouped_summary,
+        "segments": all_rows,
+        "video_mp4s": video_mp4s,
+    }
+    with open(out_dir / "summary.json", "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                k: v
+                for k, v in summary.items()
+                if k not in ("segments", "video_mp4s", "grouped_summary")
+            }
+            | {"grouped_summary": grouped_summary},
+            f,
+            indent=2,
+            default=str,
+        )
+    return summary

--- a/scenario_generation/metrics/__init__.py
+++ b/scenario_generation/metrics/__init__.py
@@ -1,0 +1,18 @@
+"""Closed-loop validation metrics for scenario-group evaluation."""
+
+from scenario_generation.metrics.centerline_deviation import lateral_offset_from_route_lanes
+from scenario_generation.metrics.group_report import aggregate_segment_rows, write_results_table
+from scenario_generation.metrics.safety_clearance import score_safety_step
+from scenario_generation.metrics.turn_indicator import (
+    expected_turn_class,
+    score_turn_indicator_step,
+)
+
+__all__ = [
+    "lateral_offset_from_route_lanes",
+    "score_safety_step",
+    "score_turn_indicator_step",
+    "expected_turn_class",
+    "aggregate_segment_rows",
+    "write_results_table",
+]

--- a/scenario_generation/metrics/centerline_deviation.py
+++ b/scenario_generation/metrics/centerline_deviation.py
@@ -1,0 +1,47 @@
+"""Centerline lateral offset from route_lanes in the current ego frame."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def lateral_offset_from_route_lanes(route_lanes: np.ndarray) -> float:
+    """Min distance from ego origin to valid route centerline segments (m).
+
+      At each closed-loop step the observation is re-centered so the live ego sits
+    at the origin. Segment distance avoids a sampling-density-dependent positive bias.
+    """
+    lanes = np.asarray(route_lanes, dtype=np.float32)
+    if lanes.ndim < 3 or lanes.shape[-1] < 2:
+        return float("inf")
+    xy = lanes[..., :2]
+    feature_width = min(lanes.shape[-1], 8)
+    valid = np.any(np.abs(lanes[..., :feature_width]) > 1e-6, axis=-1)
+    seg_valid = valid[..., :-1] & valid[..., 1:]
+    start = xy[..., :-1, :][seg_valid]
+    end = xy[..., 1:, :][seg_valid]
+    distances: list[np.ndarray] = []
+    if start.size:
+        delta = end - start
+        denom = np.sum(delta * delta, axis=-1)
+        projection = np.divide(
+            -np.sum(start * delta, axis=-1),
+            denom,
+            out=np.zeros_like(denom),
+            where=denom > 1e-12,
+        )
+        closest = start + np.clip(projection, 0.0, 1.0)[:, None] * delta
+        distances.append(np.linalg.norm(closest, axis=-1))
+
+    isolated = xy[valid]
+    if isolated.size:
+        distances.append(np.linalg.norm(isolated, axis=-1))
+    if not distances:
+        return float("inf")
+    return float(min(float(distance.min()) for distance in distances if distance.size))
+
+
+def lateral_offset_series(route_lanes_list: list[np.ndarray]) -> np.ndarray:
+    return np.array(
+        [lateral_offset_from_route_lanes(rl) for rl in route_lanes_list], dtype=np.float32
+    )

--- a/scenario_generation/metrics/cl_route_by_area.py
+++ b/scenario_generation/metrics/cl_route_by_area.py
@@ -75,6 +75,8 @@ def run_full_route_rollout(
     warmup_steps: int = 0,
     unstick_after: int = 300,
     unstick_advance_m: float = 2.5,
+    unstick_radius_mult: float = 3.0,
+    unstick_teleport_after: int = 300,
     draw_every: int = 8,
 ) -> RouteRolloutResult:
     """One closed-loop pass over the entire route; tag each step by reproducer ``rec_idx`` area."""
@@ -100,6 +102,8 @@ def run_full_route_rollout(
         max_steps=cap,
         unstick_after=unstick_after,
         unstick_advance_m=unstick_advance_m,
+        unstick_radius_mult=unstick_radius_mult,
+        unstick_teleport_after=unstick_teleport_after,
         neighbor_history_mode="recorded",
         goal_mode="route",
     )
@@ -202,7 +206,6 @@ def aggregate_area_metrics(
         and idx_in_labeled_ranges(st.rec_idx, labeled_ranges)
         and not is_skipped(tl.npz_paths[st.rec_idx])
     ]
-    idxs = [st.rec_idx for st in area_steps]
     f_start = int(tl.frame_indices[video_start_idx])
     f_end = int(tl.frame_indices[min(video_end_idx - 1, len(tl.frame_indices) - 1)])
 
@@ -221,12 +224,15 @@ def aggregate_area_metrics(
     finite_rb = rb_distances[np.isfinite(rb_distances)]
     finite_centerline = cl[np.isfinite(cl)]
     final_labeled_idx = max(int(end) for _, end in labeled_ranges) - 1
-    route_max_idx = max((step.rec_idx for step in steps), default=-1)
-    episode_reached = route_max_idx >= video_start_idx
-    reached_end = route_max_idx >= final_labeled_idx
+    episode_indices = [
+        step.rec_idx for step in steps if video_start_idx <= step.rec_idx < video_end_idx
+    ]
+    episode_max_idx = max(episode_indices, default=video_start_idx - 1)
+    episode_reached = bool(episode_indices)
+    reached_end = episode_max_idx >= final_labeled_idx
     span_length = max(video_end_idx - video_start_idx, 1)
     span_progress = min(
-        max((route_max_idx - video_start_idx + 1) / span_length, 0.0),
+        max((episode_max_idx - video_start_idx + 1) / span_length, 0.0),
         1.0,
     )
 
@@ -248,7 +254,7 @@ def aggregate_area_metrics(
         "min_clearance": float(finite_clearance.min()) if finite_clearance.size else None,
         "mean_clearance": float(finite_clearance.mean()) if finite_clearance.size else None,
         "n_collision_steps": int(sum(collisions)),
-        "n_near_miss_steps": int(np.sum(clearances <= near_miss_thresh)),
+        "n_near_miss_steps": int(np.sum((clearances >= 0.0) & (clearances <= near_miss_thresh))),
         "n_snaps": 0,
         "centerline_mean_m": float(finite_centerline.mean()) if finite_centerline.size else None,
         "centerline_p95_m": _percentile(finite_centerline, 95) if finite_centerline.size else None,

--- a/scenario_generation/metrics/cl_route_by_area.py
+++ b/scenario_generation/metrics/cl_route_by_area.py
@@ -1,0 +1,301 @@
+"""Full-route closed-loop rollout with per-step map-area tagging for grouped eval."""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+import torch
+from diffusion_planner.utils.scene_skip import is_skipped
+
+from scenario_generation.closed_loop_eval import build_mp4
+from scenario_generation.metrics.centerline_deviation import lateral_offset_from_route_lanes
+from scenario_generation.metrics.safety_clearance import score_safety_step
+from scenario_generation.metrics.turn_indicator import score_turn_indicator_step
+from scenario_generation.perf_timer import Timers
+from scenario_generation.reproducer_rollout import (
+    _advance_step,
+    _draw_step,
+    _pre_step,
+    _seed_state,
+    _to_torch_batch,
+)
+from scenario_generation.route_timeline import RouteTimeline
+from scenario_generation.scenario_classification import AreaEpisode, area_at_idx
+
+
+@dataclass
+class StepRecord:
+    k: int
+    rec_idx: int
+    area: str | None
+    centerline_m: float | None = None
+    turn_match: bool | None = None
+    clearance_m: float = float("inf")
+    rb_dist_m: float = float("inf")
+    collision: bool = False
+    neighbor_violation: bool = False
+    rb_violation: bool = False
+    png_path: Path | None = None
+
+
+@dataclass
+class RouteRolloutResult:
+    route_key: str
+    sequence: str
+    steps: list[StepRecord] = field(default_factory=list)
+    png_dir: Path | None = None
+    n_steps_run: int = 0
+    terminated: str = ""
+
+
+def _percentile(arr: np.ndarray, q: float) -> float:
+    finite = arr[np.isfinite(arr)]
+    if finite.size == 0:
+        return float("inf")
+    return float(np.percentile(finite, q))
+
+
+@torch.no_grad()
+def run_full_route_rollout(
+    model,
+    model_args,
+    tl: RouteTimeline,
+    route_key: str,
+    sequence: str,
+    segments: list[AreaEpisode],
+    area_to_metric_group: dict[str, str],
+    png_dir: Path | None,
+    *,
+    device: str = "cuda",
+    near_miss_thresh: float = 0.3,
+    search_radius: float = 1.5,
+    warmup_steps: int = 0,
+    unstick_after: int = 300,
+    unstick_advance_m: float = 2.5,
+    draw_every: int = 8,
+) -> RouteRolloutResult:
+    """One closed-loop pass over the entire route; tag each step by reproducer ``rec_idx`` area."""
+    n = len(tl)
+    if n < 2:
+        return RouteRolloutResult(route_key=route_key, sequence=sequence)
+
+    if png_dir is not None:
+        png_dir.mkdir(parents=True, exist_ok=True)
+
+    cap = max(3 * n, n)
+    timers = Timers()
+    s = _seed_state(
+        tl,
+        0,
+        n,
+        search_radius,
+        warmup_steps,
+        near_miss_thresh,
+        goal_reach_m=5.0,
+        max_stuck_steps=0,
+        timers=timers,
+        max_steps=cap,
+        unstick_after=unstick_after,
+        unstick_advance_m=unstick_advance_m,
+        neighbor_history_mode="recorded",
+        goal_mode="route",
+    )
+
+    steps: list[StepRecord] = []
+
+    while not s.done:
+        pre = _pre_step(s)
+        if pre is None:
+            break
+        np_dict, neighbors_live, idx, slot_uuids, _wbu = pre
+        area = area_at_idx(segments, int(idx))
+        metric_group = area_to_metric_group.get(area) if area else None
+
+        turn_match = None
+        data = _to_torch_batch([np_dict], model_args, device)
+        _, outputs = model(data)
+        pred_cur = outputs["prediction"][0, 0].cpu().numpy()
+        if metric_group is not None:
+            ti = score_turn_indicator_step(outputs, metric_group)
+            if ti["turn_match"] is not None:
+                turn_match = bool(ti["turn_match"])
+
+        centerline_m = None
+        if metric_group in ("straight", "curve"):
+            centerline_m = lateral_offset_from_route_lanes(np_dict["route_lanes"])
+
+        safety = score_safety_step(
+            neighbors_live,
+            s.ego_shape,
+            np_dict,
+            device,
+            margin_m=near_miss_thresh,
+        )
+
+        png_path = None
+        if png_dir is not None and s.k % draw_every == 0:
+            out_path = png_dir / f"{s.k:05d}.png"
+            nids = tl.neighbor_ids(idx) if slot_uuids is None else slot_uuids
+            _draw_step(
+                np_dict,
+                pred_cur,
+                s.ego_shape,
+                out_path,
+                neighbor_ids=nids,
+                step=s.k,
+                total=cap,
+            )
+            png_path = out_path
+
+        steps.append(
+            StepRecord(
+                k=int(s.k),
+                rec_idx=int(idx),
+                area=area,
+                centerline_m=centerline_m,
+                turn_match=turn_match,
+                clearance_m=float(safety["clearance_m"]),
+                rb_dist_m=float(safety["rb_dist_m"]),
+                collision=bool(safety["collision"]),
+                neighbor_violation=bool(safety["neighbor_violation"]),
+                rb_violation=bool(safety["rb_violation"]),
+                png_path=png_path,
+            )
+        )
+
+        _advance_step(s, pred_cur, idx, device, timers)
+
+    return RouteRolloutResult(
+        route_key=route_key,
+        sequence=sequence,
+        steps=steps,
+        png_dir=png_dir,
+        n_steps_run=int(s.k),
+        terminated=s.terminated,
+    )
+
+
+def aggregate_area_metrics(
+    steps: list[StepRecord],
+    area_name: str,
+    metric_group: str,
+    route_key: str,
+    bag_name: str,
+    tl: RouteTimeline,
+    *,
+    labeled_ranges: list[list[int]],
+    video_start_idx: int,
+    video_end_idx: int,
+    span_index: int,
+    near_miss_thresh: float = 0.3,
+) -> dict | None:
+    """Aggregate metrics on labeled, non-skipped frames only."""
+    from scenario_generation.scenario_classification import idx_in_labeled_ranges
+
+    area_steps = [
+        st
+        for st in steps
+        if st.area == area_name
+        and idx_in_labeled_ranges(st.rec_idx, labeled_ranges)
+        and not is_skipped(tl.npz_paths[st.rec_idx])
+    ]
+    idxs = [st.rec_idx for st in area_steps]
+    f_start = int(tl.frame_indices[video_start_idx])
+    f_end = int(tl.frame_indices[min(video_end_idx - 1, len(tl.frame_indices) - 1)])
+
+    cl = np.array(
+        [st.centerline_m for st in area_steps if st.centerline_m is not None],
+        dtype=np.float32,
+    )
+    tm = np.array(
+        [st.turn_match for st in area_steps if st.turn_match is not None],
+        dtype=bool,
+    )
+    clearances = np.array([st.clearance_m for st in area_steps], dtype=np.float32)
+    rb_distances = np.array([st.rb_dist_m for st in area_steps], dtype=np.float32)
+    collisions = [st.collision for st in area_steps]
+    finite_clearance = clearances[np.isfinite(clearances)]
+    finite_rb = rb_distances[np.isfinite(rb_distances)]
+    finite_centerline = cl[np.isfinite(cl)]
+    final_labeled_idx = max(int(end) for _, end in labeled_ranges) - 1
+    route_max_idx = max((step.rec_idx for step in steps), default=-1)
+    episode_reached = route_max_idx >= video_start_idx
+    reached_end = route_max_idx >= final_labeled_idx
+    span_length = max(video_end_idx - video_start_idx, 1)
+    span_progress = min(
+        max((route_max_idx - video_start_idx + 1) / span_length, 0.0),
+        1.0,
+    )
+
+    base = {
+        "metric_group": metric_group,
+        "area_name": area_name,
+        "sequence": route_key,
+        "bag": bag_name,
+        "span_index": span_index,
+        "list_start_idx": video_start_idx,
+        "list_end_idx": video_end_idx,
+        "labeled_ranges": labeled_ranges,
+        "segment": f"[{f_start},{f_end}]",
+        "n_steps_run": len(area_steps),
+        "terminated": "area_span" if area_steps else "unreached",
+        "episode_reached": episode_reached,
+        "episode_completed": reached_end,
+        "episode_progress_fraction": span_progress,
+        "min_clearance": float(finite_clearance.min()) if finite_clearance.size else None,
+        "mean_clearance": float(finite_clearance.mean()) if finite_clearance.size else None,
+        "n_collision_steps": int(sum(collisions)),
+        "n_near_miss_steps": int(np.sum(clearances <= near_miss_thresh)),
+        "n_snaps": 0,
+        "centerline_mean_m": float(finite_centerline.mean()) if finite_centerline.size else None,
+        "centerline_p95_m": _percentile(finite_centerline, 95) if finite_centerline.size else None,
+        "centerline_max_m": float(finite_centerline.max()) if finite_centerline.size else None,
+        "turn_match_rate": float(tm.mean()) if tm.size else None,
+        "neighbor_violation_steps": int(sum(st.neighbor_violation for st in area_steps)),
+        "rb_violation_steps": int(sum(st.rb_violation for st in area_steps)),
+        "collision_steps": int(sum(collisions)),
+        "min_clearance_m": float(finite_clearance.min()) if finite_clearance.size else None,
+        "min_rb_dist_m": float(finite_rb.min()) if finite_rb.size else None,
+        "video_path": "",
+    }
+    return base
+
+
+def build_area_video(
+    rollout: RouteRolloutResult,
+    out_mp4: Path,
+    fps: float,
+    *,
+    video_start_idx: int,
+    video_end_idx: int,
+) -> bool:
+    """Copy PNGs for a continuous video span (includes unlabeled stopping gaps)."""
+    if rollout.png_dir is None:
+        return False
+    video_steps = [
+        st
+        for st in rollout.steps
+        if st.png_path is not None and video_start_idx <= st.rec_idx < video_end_idx
+    ]
+    if not video_steps:
+        return False
+
+    staging = out_mp4.parent / f"_staging_{out_mp4.stem}"
+    if staging.exists():
+        shutil.rmtree(staging)
+    staging.mkdir(parents=True)
+
+    for st in sorted(video_steps, key=lambda x: x.k):
+        if st.png_path and st.png_path.is_file():
+            shutil.copy2(st.png_path, staging / f"{st.png_path.name}")
+
+    if not any(staging.glob("*.png")):
+        shutil.rmtree(staging, ignore_errors=True)
+        return False
+
+    build_mp4(staging, out_mp4, fps)
+    shutil.rmtree(staging, ignore_errors=True)
+    return True

--- a/scenario_generation/metrics/group_report.py
+++ b/scenario_generation/metrics/group_report.py
@@ -1,0 +1,112 @@
+"""Aggregate per-segment metric rows into summary tables."""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+from collections import defaultdict
+from pathlib import Path
+
+
+def aggregate_segment_rows(rows: list[dict]) -> dict:
+    """Build per metric_group and per area_name summaries from segment rows."""
+    by_group: dict[str, list[dict]] = defaultdict(list)
+    by_area: dict[str, list[dict]] = defaultdict(list)
+    for row in rows:
+        by_group[row["metric_group"]].append(row)
+        by_area[row["area_name"]].append(row)
+
+    def _agg(items: list[dict]) -> dict:
+        if not items:
+            return {"n_segments": 0}
+        n = len(items)
+
+        def _mean(key: str) -> float | None:
+            vals = [
+                r[key]
+                for r in items
+                if isinstance(r.get(key), (int, float)) and math.isfinite(float(r[key]))
+            ]
+            return float(sum(vals) / len(vals)) if vals else None
+
+        def _sum(key: str) -> int:
+            return int(sum(r.get(key, 0) or 0 for r in items))
+
+        return {
+            "n_segments": n,
+            "centerline_mean_m": _mean("centerline_mean_m"),
+            "centerline_p95_m": _mean("centerline_p95_m"),
+            "turn_match_rate": _mean("turn_match_rate"),
+            "episode_reach_rate": _mean("episode_reached"),
+            "episode_completion_rate": _mean("episode_completed"),
+            "episode_progress_fraction": _mean("episode_progress_fraction"),
+            "neighbor_violation_steps": _sum("neighbor_violation_steps"),
+            "rb_violation_steps": _sum("rb_violation_steps"),
+            "collision_steps": _sum("collision_steps"),
+            "min_clearance_m": min(
+                (
+                    r["min_clearance_m"]
+                    for r in items
+                    if isinstance(r.get("min_clearance_m"), (int, float))
+                    and math.isfinite(float(r["min_clearance_m"]))
+                ),
+                default=None,
+            ),
+        }
+
+    return {
+        "by_metric_group": {k: _agg(v) for k, v in sorted(by_group.items())},
+        "by_area_name": {k: _agg(v) for k, v in sorted(by_area.items())},
+        "n_segments_total": len(rows),
+    }
+
+
+RESULTS_TABLE_COLUMNS = [
+    "metric_group",
+    "area_name",
+    "sequence",
+    "bag",
+    "span_index",
+    "list_start_idx",
+    "list_end_idx",
+    "segment",
+    "n_steps_run",
+    "terminated",
+    "episode_reached",
+    "episode_completed",
+    "episode_progress_fraction",
+    "centerline_mean_m",
+    "centerline_p95_m",
+    "centerline_max_m",
+    "turn_match_rate",
+    "neighbor_violation_steps",
+    "rb_violation_steps",
+    "collision_steps",
+    "n_collision_steps",
+    "n_near_miss_steps",
+    "min_clearance",
+    "min_clearance_m",
+    "mean_clearance",
+    "min_rb_dist_m",
+    "n_snaps",
+    "video_path",
+]
+
+
+def write_results_table(rows: list[dict], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    extra = {k for row in rows for k in row} - set(RESULTS_TABLE_COLUMNS)
+    fieldnames = RESULTS_TABLE_COLUMNS + sorted(extra)
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_metrics_summary(summary: dict, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(summary, indent=2, allow_nan=False) + "\n", encoding="utf-8")

--- a/scenario_generation/metrics/safety_clearance.py
+++ b/scenario_generation/metrics/safety_clearance.py
@@ -1,0 +1,55 @@
+"""Neighbor clearance and road-border distance for closed-loop steps."""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+from planner_metrics.config import RewardConfig
+from planner_metrics.subscores import compute_road_border_penalty
+from scenario_generation.reproducer_rollout import score_step
+
+
+def score_safety_step(
+    neighbors_live: np.ndarray,
+    ego_shape: np.ndarray,
+    np_dict: dict,
+    device: str,
+    *,
+    margin_m: float = 0.3,
+) -> dict:
+    """Per-step neighbor clearance + road-border distance and violation flags."""
+    clearance_m, collision, _n_valid = score_step(
+        neighbors_live, ego_shape, ego_speed=0.0, device=device
+    )
+
+    rb_dist_m = float("inf")
+    if "line_strings" in np_dict and "ego_shape" in np_dict:
+        ego_shape_t = torch.tensor(
+            np.asarray(np_dict["ego_shape"]).reshape(-1)[:3],
+            dtype=torch.float32,
+            device=device,
+        )
+        traj = torch.zeros(1, 1, 4, dtype=torch.float32, device=device)
+        traj[0, 0, 2] = 1.0  # heading +x in ego frame
+        line_strings = np.asarray(np_dict["line_strings"])
+        if line_strings.ndim == 3:
+            line_strings = line_strings[None]
+        if line_strings.ndim != 4:
+            raise ValueError(f"line_strings must be [N,P,D] or [B,N,P,D], got {line_strings.shape}")
+        data = {"line_strings": torch.as_tensor(line_strings, dtype=torch.float32, device=device)}
+        _gate, _near, _wide, _steps, _cont, per_ts_min = compute_road_border_penalty(
+            traj, ego_shape_t, data, config=RewardConfig()
+        )
+        rb_dist_m = float(per_ts_min[0, 0].item())
+
+    neighbor_violation = clearance_m < margin_m
+    rb_violation = rb_dist_m < margin_m
+    return {
+        "clearance_m": clearance_m,
+        "collision": collision,
+        "rb_dist_m": rb_dist_m,
+        "neighbor_violation": neighbor_violation,
+        "rb_violation": rb_violation,
+        "safety_violation": neighbor_violation or rb_violation or collision,
+    }

--- a/scenario_generation/metrics/turn_indicator.py
+++ b/scenario_generation/metrics/turn_indicator.py
@@ -1,0 +1,47 @@
+"""Turn-indicator scoring for left/right turn scenario groups."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from scenario_generation.simulate import decode_turn_indicator
+
+# Class ids aligned with C++ TurnIndicatorManager / decode_turn_indicator.
+TI_NONE = 0
+TI_LEFT = 2
+TI_RIGHT = 3
+TI_KEEP = 4
+
+
+def expected_turn_class(metric_group: str) -> int | None:
+    if metric_group == "left_turn":
+        return TI_LEFT
+    if metric_group == "right_turn":
+        return TI_RIGHT
+    return None
+
+
+def score_turn_indicator_step(
+    outputs: dict,
+    metric_group: str,
+    *,
+    keep_bias: float = 0.25,
+) -> dict:
+    """Compare model-predicted turn indicator to expected side for turn groups."""
+    expected = expected_turn_class(metric_group)
+    if expected is None:
+        return {"turn_pred": None, "turn_expected": None, "turn_match": None}
+
+    if "turn_indicator_logit" not in outputs:
+        return {"turn_pred": None, "turn_expected": expected, "turn_match": False}
+
+    pred = int(
+        np.asarray(decode_turn_indicator(outputs["turn_indicator_logit"], keep_bias)).reshape(-1)[0]
+    )
+    # LEFT/RIGHT match; KEEP also acceptable when actively turning.
+    match = pred == expected or (pred == TI_KEEP and expected in (TI_LEFT, TI_RIGHT))
+    return {
+        "turn_pred": pred,
+        "turn_expected": expected,
+        "turn_match": bool(match),
+    }

--- a/scenario_generation/npz_loader.py
+++ b/scenario_generation/npz_loader.py
@@ -20,6 +20,26 @@ _DEFAULT_WIDTH = 1.70
 # Wheelbase-to-length ratio for deriving wheelbase from neighbor shape
 _WHEELBASE_LENGTH_RATIO = 0.65
 
+_SCENE_KEYS = {
+    "ego_agent_past",
+    "ego_current_state",
+    "ego_agent_future",
+    "ego_shape",
+    "goal_pose",
+    "neighbor_agents_past",
+    "neighbor_agents_future",
+    "route_lanes",
+    "route_lanes_speed_limit",
+    "route_lanes_has_speed_limit",
+    "turn_indicators",
+    "lanes",
+    "lanes_speed_limit",
+    "lanes_has_speed_limit",
+    "polygons",
+    "line_strings",
+    "static_objects",
+}
+
 
 def _correct_heading_flip(
     past_traj: np.ndarray,
@@ -321,8 +341,8 @@ def from_npz(path: str | Path) -> SceneContext:
     Returns:
         SceneContext with ego + neighbors + map data.
     """
-    with np.load(str(path), allow_pickle=True) as loaded:
-        data = {k: v for k, v in loaded.items() if k not in {"map_name", "token"}}
+    with np.load(str(path), allow_pickle=False) as loaded:
+        data = {key: loaded[key] for key in _SCENE_KEYS if key in loaded.files}
 
     # Ego shape: [wheelbase, length, width]
     ego_shape = data.get("ego_shape")

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -2084,7 +2084,7 @@ def _dump_precollision_window(
                     traj[: present[0]] = traj[present[0]]
             scene["neighbor_agents_future"] = naf_sim
         else:
-            with np.load(tl.npz_paths[idx], allow_pickle=True) as z:
+            with np.load(tl.npz_paths[idx], allow_pickle=False) as z:
                 naf = z["neighbor_agents_future"] if "neighbor_agents_future" in z.files else None
             if naf is not None:
                 dx, dy, dyaw = _rel_pose(tl.poses[idx], live_pose)

--- a/scenario_generation/route_timeline.py
+++ b/scenario_generation/route_timeline.py
@@ -221,7 +221,7 @@ class RouteTimeline:
         # Decompress OUTSIDE the lock (the expensive part) so concurrent build threads
         # don't serialize on np.load; a rare double-decompress of the same idx is benign.
         with self.timers("timeline_load_npz"):
-            with np.load(self.npz_paths[idx], allow_pickle=True) as z:
+            with np.load(self.npz_paths[idx], allow_pickle=False) as z:
                 # Only decompress the keys we need (skip GT futures) — lazy npz access.
                 data = {k: z[k] for k in _NEEDED_KEYS if k in z.files}
         with self._cache_lock:
@@ -239,7 +239,7 @@ class RouteTimeline:
         so reading just this one key is ~10x cheaper per frame (it dominated timeline_load_npz).
         Not cached: the track-build touches each frame once."""
         with self.timers("timeline_load_npz"):
-            with np.load(self.npz_paths[idx], allow_pickle=True) as z:
+            with np.load(self.npz_paths[idx], allow_pickle=False) as z:
                 return z["neighbor_agents_past"][:, -1]
 
     def prefetch(self, indices) -> None:

--- a/scenario_generation/scenario_classification.py
+++ b/scenario_generation/scenario_classification.py
@@ -1,0 +1,216 @@
+"""Load and resolve portable scenario classification JSON (Meta-Repository format)."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+AreaEpisode = dict
+# keys: area, metric_group, video_start_idx, video_end_idx, labeled_ranges
+
+
+def load_classification_json(path: Path) -> dict:
+    """Load scenario_classification_json document."""
+    return json.loads(path.expanduser().resolve().read_text(encoding="utf-8"))
+
+
+def time_series_from_doc(doc: dict) -> dict[str, dict]:
+    """Per-bag ``time_series`` entries.
+
+    Legacy docs may use top-level ``sequences``; they are normalized to the same shape.
+    """
+    if "time_series" in doc:
+        return dict(doc["time_series"])
+    legacy = doc.get("sequences", {})
+    return {k: {"name": k, **v} for k, v in legacy.items()}
+
+
+def load_area_metric_groups(doc: dict) -> dict[str, str]:
+    """area_name -> metric_group."""
+    if "area_catalog" in doc:
+        return {str(k): str(v["metric_group"]) for k, v in doc["area_catalog"].items()}
+    if "areas" in doc:
+        return {str(k): str(v["metric_group"]) for k, v in doc["areas"].items()}
+    out: dict[str, str] = {}
+    for entry in time_series_from_doc(doc).values():
+        for ep in episodes_from_entry(entry):
+            out[str(ep["area"])] = str(ep["metric_group"])
+    return out
+
+
+def _normalize_labeled_ranges(seg: dict) -> list[list[int]]:
+    if "labeled_ranges" in seg:
+        return [[int(r[0]), int(r[1])] for r in seg["labeled_ranges"]]
+    return [[int(seg["start_idx"]), int(seg["end_idx"])]]
+
+
+def episodes_from_entry(entry: dict) -> list[AreaEpisode]:
+    """Return normalized episode list for one bag entry.
+
+    v2.2 episodes bridge unlabeled gaps via ``video_*``; metrics use ``labeled_ranges``.
+    v2.1 ``start_idx``/``end_idx`` and legacy ``area_by_idx`` are upgraded on read.
+    """
+    if "segments" in entry:
+        episodes: list[AreaEpisode] = []
+        for seg in entry["segments"]:
+            if "labeled_ranges" in seg:
+                episodes.append(
+                    {
+                        "area": str(seg["area"]),
+                        "metric_group": str(seg["metric_group"]),
+                        "video_start_idx": int(seg["video_start_idx"]),
+                        "video_end_idx": int(seg["video_end_idx"]),
+                        "labeled_ranges": _normalize_labeled_ranges(seg),
+                    }
+                )
+            else:
+                start = int(seg["start_idx"])
+                end = int(seg["end_idx"])
+                episodes.append(
+                    {
+                        "area": str(seg["area"]),
+                        "metric_group": str(seg["metric_group"]),
+                        "video_start_idx": start,
+                        "video_end_idx": end,
+                        "labeled_ranges": [[start, end]],
+                    }
+                )
+        return _merge_v21_episodes(episodes)
+
+    area_by_idx = entry.get("area_by_idx") or []
+    groups = entry.get("metric_group_by_idx") or [None] * len(area_by_idx)
+    chunks: list[AreaEpisode] = []
+    for area, start_idx, end_idx in iter_area_spans(area_by_idx):
+        mg = groups[start_idx] if start_idx < len(groups) else None
+        chunks.append(
+            {
+                "area": area,
+                "metric_group": str(mg) if mg else "",
+                "video_start_idx": start_idx,
+                "video_end_idx": end_idx,
+                "labeled_ranges": [[start_idx, end_idx]],
+            }
+        )
+    return _merge_v21_episodes(chunks)
+
+
+def _merge_v21_episodes(episodes: list[AreaEpisode]) -> list[AreaEpisode]:
+    """Merge consecutive same-area v2.1-style episodes (bridge unlabeled gaps)."""
+    merged: list[AreaEpisode] = []
+    for ep in episodes:
+        if merged and merged[-1]["area"] == ep["area"]:
+            merged[-1]["video_end_idx"] = int(ep["video_end_idx"])
+            merged[-1]["labeled_ranges"].extend(ep["labeled_ranges"])
+        else:
+            merged.append(
+                {
+                    "area": ep["area"],
+                    "metric_group": ep["metric_group"],
+                    "video_start_idx": int(ep["video_start_idx"]),
+                    "video_end_idx": int(ep["video_end_idx"]),
+                    "labeled_ranges": [list(r) for r in ep["labeled_ranges"]],
+                }
+            )
+    return merged
+
+
+def segments_from_entry(entry: dict) -> list[AreaEpisode]:
+    """Alias for :func:`episodes_from_entry` (kept for older call sites)."""
+    return episodes_from_entry(entry)
+
+
+def iter_episodes(entry: dict) -> Iterator[AreaEpisode]:
+    """Yield normalized episodes for one bag."""
+    yield from episodes_from_entry(entry)
+
+
+def iter_segments(entry: dict) -> Iterator[tuple[str, int, int]]:
+    """Yield ``(area_name, start_idx, end_idx)`` per labeled range (legacy helper)."""
+    for ep in episodes_from_entry(entry):
+        for start, end in ep["labeled_ranges"]:
+            yield str(ep["area"]), int(start), int(end)
+
+
+def idx_in_labeled_ranges(idx: int, labeled_ranges: list[list[int]]) -> bool:
+    return any(int(start) <= idx < int(end) for start, end in labeled_ranges)
+
+
+def area_at_idx(episodes: list[AreaEpisode], idx: int) -> str | None:
+    """Map reproducer frame index to area name on labeled frames only."""
+    for ep in episodes:
+        if idx_in_labeled_ranges(idx, ep["labeled_ranges"]):
+            return str(ep["area"])
+    return None
+
+
+def iter_area_spans(area_by_idx: list[str | None]) -> Iterator[tuple[str, int, int]]:
+    """Yield ``(area_name, start_idx, end_idx)`` for each contiguous labeled span (legacy)."""
+    i, n = 0, len(area_by_idx)
+    while i < n:
+        area = area_by_idx[i]
+        if area is None:
+            i += 1
+            continue
+        start = i
+        i += 1
+        while i < n and area_by_idx[i] == area:
+            i += 1
+        yield str(area), start, i
+
+
+def validate_classification_npz_root(doc: dict, npz_root: Path) -> list[str]:
+    """Return warning strings if JSON date disagrees with ``npz_root`` basename."""
+    warnings: list[str] = []
+    date = doc.get("date")
+    if date and npz_root.name != date:
+        warnings.append(f"npz_root basename {npz_root.name!r} != classification date {date!r}")
+    return warnings
+
+
+def classification_json_search_roots() -> list[Path]:
+    """Candidate roots for auto-resolving ``scenario_classification_json/<dataset>/<date>.json``."""
+    roots: list[Path] = []
+    env = os.environ.get("SCENARIO_CLASSIFICATION_JSON_ROOT")
+    if env:
+        roots.append(Path(env).expanduser())
+    repo_root = Path(__file__).resolve().parents[1]
+    roots.append(
+        repo_root.parent
+        / "Diffusion-Planner-Meta-Repository"
+        / "dataset"
+        / "scenario_classification_json"
+    )
+    return roots
+
+
+def resolve_classification_json(
+    npz_root: Path | str,
+    explicit: str | Path | None = None,
+    *,
+    dataset_name: str | None = None,
+    search_roots: list[Path] | None = None,
+) -> Path | None:
+    """Resolve classification JSON path for grouped closed-loop eval.
+
+    Resolution order:
+    1. ``explicit`` path when the file exists.
+    2. ``<search_root>/<dataset_name>/<npz_date>.json`` for each search root.
+    """
+    npz_root = Path(npz_root).expanduser().resolve()
+    if explicit:
+        path = Path(explicit).expanduser()
+        if path.is_file():
+            return path.resolve()
+        return None
+
+    if not dataset_name:
+        return None
+
+    date = npz_root.name
+    for root in search_roots or classification_json_search_roots():
+        candidate = root.expanduser() / dataset_name / f"{date}.json"
+        if candidate.is_file():
+            return candidate.resolve()
+    return None

--- a/scenario_generation/simulate.py
+++ b/scenario_generation/simulate.py
@@ -36,20 +36,30 @@ from scenario_generation.tensor_converter import MapTensorCache, dump_step_npz, 
 from scenario_generation.visualize import draw_scene, draw_trajectory
 
 
-def load_model(model_path: str | Path, device: str = "cuda"):
-    """Load Diffusion-Planner model and args."""
+def _checkpoint_model_state(checkpoint, *, prefer_ema: bool = True):
+    if not isinstance(checkpoint, dict):
+        return checkpoint, "live"
+    ema_state = checkpoint.get("ema_state_dict")
+    if prefer_ema and ema_state is not None:
+        return ema_state, "EMA"
+    return checkpoint.get("model", checkpoint), "live"
+
+
+def load_model(model_path: str | Path, device: str = "cuda", *, prefer_ema: bool = True):
+    """Load Diffusion-Planner model and args, preferring its validated EMA policy."""
     from diffusion_planner.model.diffusion_planner import Diffusion_Planner
     from diffusion_planner.utils.config import Config
 
     args_file = str(Path(model_path).parent / "args.json")
     args = Config(args_file)
     model = Diffusion_Planner(args)
-    ckpt = torch.load(str(model_path), map_location=device)
-    state = ckpt.get("model", ckpt)
-    state = {k.replace("module.", ""): v for k, v in state.items()}
+    ckpt = torch.load(str(model_path), map_location="cpu", weights_only=True)
+    state, weight_kind = _checkpoint_model_state(ckpt, prefer_ema=prefer_ema)
+    state = {k.removeprefix("module."): v for k, v in state.items()}
     model.load_state_dict(state)
     model.to(device)
     model.eval()
+    print(f"Loaded {weight_kind} policy weights from {model_path}")
     return model, args
 
 

--- a/scenario_generation/tests/test_closed_loop_cli.py
+++ b/scenario_generation/tests/test_closed_loop_cli.py
@@ -56,3 +56,48 @@ def test_grouped_runner_requires_classification_and_output(tmp_path):
         assert "classification_json" in str(exc)
     else:
         raise AssertionError("missing classification JSON must be rejected")
+
+
+def test_grouped_runner_forwards_unstick_stages(monkeypatch, tmp_path):
+    model = object()
+    model_args = object()
+    captured = {}
+
+    monkeypatch.setattr(
+        closed_loop_cli,
+        "load_model",
+        lambda model_path, device: (model, model_args),
+    )
+
+    def fake_run_grouped_closed_loop_eval(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return {"n_episodes": 0, "n_episodes_expected": 0}
+
+    monkeypatch.setattr(
+        closed_loop_cli,
+        "run_grouped_closed_loop_eval",
+        fake_run_grouped_closed_loop_eval,
+    )
+    args = Namespace(
+        model_path=tmp_path / "model.pth",
+        npz_root=tmp_path / "npz",
+        classification_json=tmp_path / "classification.json",
+        out_dir=tmp_path / "out",
+        device="cpu",
+        near_miss_thresh=0.4,
+        search_radius=1.7,
+        warmup_steps=2,
+        unstick_after=30,
+        unstick_advance_m=2.0,
+        unstick_radius_mult=4.0,
+        unstick_teleport_after=50,
+        draw_every=3,
+        fps=10,
+        areas=None,
+    )
+
+    assert closed_loop_cli.run_grouped_eval(args) == 0
+    assert captured["args"][:2] == (model, model_args)
+    assert captured["kwargs"]["unstick_radius_mult"] == 4.0
+    assert captured["kwargs"]["unstick_teleport_after"] == 50

--- a/scenario_generation/tests/test_closed_loop_cli.py
+++ b/scenario_generation/tests/test_closed_loop_cli.py
@@ -1,0 +1,58 @@
+from argparse import Namespace
+from pathlib import Path
+
+from scenario_generation import closed_loop_cli
+
+
+def test_full_route_runner_forwards_replan_interval(monkeypatch, tmp_path):
+    model = object()
+    model_args = object()
+    captured = {}
+
+    monkeypatch.setattr(
+        closed_loop_cli,
+        "load_model",
+        lambda model_path, device: (model, model_args),
+    )
+
+    def fake_run_closed_loop_eval(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return {"n_segments": 0}
+
+    monkeypatch.setattr(closed_loop_cli, "run_closed_loop_eval", fake_run_closed_loop_eval)
+    args = Namespace(
+        model_path=tmp_path / "model.pth",
+        npz_root=tmp_path / "npz",
+        out_dir=tmp_path / "out",
+        device="cpu",
+        seg_len=123,
+        near_miss_thresh=0.4,
+        search_radius=1.7,
+        warmup_steps=2,
+        unstick_after=30,
+        unstick_advance_m=2.0,
+        unstick_radius_mult=4.0,
+        unstick_teleport_after=50,
+        fps=10,
+        replan_interval=7,
+        draw_every=3,
+    )
+
+    result = closed_loop_cli.run_full_route_eval(args)
+
+    assert result["model_path"] == str(args.model_path)
+    assert captured["args"][:2] == (model, model_args)
+    assert captured["kwargs"]["replan_interval"] == 7
+    assert captured["kwargs"]["neighbor_history_mode"] == "recorded"
+
+
+def test_grouped_runner_requires_classification_and_output(tmp_path):
+    args = Namespace(classification_json=None, out_dir=Path(tmp_path))
+
+    try:
+        closed_loop_cli.run_grouped_eval(args)
+    except SystemExit as exc:
+        assert "classification_json" in str(exc)
+    else:
+        raise AssertionError("missing classification JSON must be rejected")

--- a/scenario_generation/tests/test_grouped_metrics.py
+++ b/scenario_generation/tests/test_grouped_metrics.py
@@ -1,0 +1,112 @@
+import json
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+
+from scenario_generation.metrics import cl_route_by_area, safety_clearance
+from scenario_generation.metrics.centerline_deviation import lateral_offset_from_route_lanes
+from scenario_generation.metrics.group_report import aggregate_segment_rows, write_metrics_summary
+
+
+def test_centerline_offset_uses_segments_not_only_sampled_points():
+    route = np.zeros((1, 2, 8), dtype=np.float32)
+    route[0, :, :2] = [[-1.0, 0.0], [1.0, 0.0]]
+    route[0, :, 2] = 1.0
+
+    assert lateral_offset_from_route_lanes(route) == 0.0
+    assert np.isinf(lateral_offset_from_route_lanes(np.zeros_like(route)))
+
+
+def _timeline(tmp_path):
+    paths = [tmp_path / f"{index}.npz" for index in range(10)]
+    return SimpleNamespace(npz_paths=paths, frame_indices=np.arange(100, 110))
+
+
+def test_unreached_episode_is_retained_in_group_metrics(tmp_path):
+    row = cl_route_by_area.aggregate_area_metrics(
+        [],
+        "hard_turn",
+        "right_turn",
+        "route",
+        "bag",
+        _timeline(tmp_path),
+        labeled_ranges=[[2, 5]],
+        video_start_idx=2,
+        video_end_idx=5,
+        span_index=0,
+    )
+
+    assert row["episode_reached"] is False
+    assert row["episode_completed"] is False
+    assert row["episode_progress_fraction"] == 0.0
+    assert row["min_clearance_m"] is None
+    summary = aggregate_segment_rows([row])
+    assert summary["by_metric_group"]["right_turn"]["episode_reach_rate"] == 0.0
+
+
+def test_missing_geometry_is_json_safe(monkeypatch, tmp_path):
+    monkeypatch.setattr(cl_route_by_area, "is_skipped", lambda _: False)
+    step = cl_route_by_area.StepRecord(
+        k=0,
+        rec_idx=2,
+        area="straight_area",
+        centerline_m=float("inf"),
+        clearance_m=float("inf"),
+        rb_dist_m=float("inf"),
+    )
+    row = cl_route_by_area.aggregate_area_metrics(
+        [step],
+        "straight_area",
+        "straight",
+        "route",
+        "bag",
+        _timeline(tmp_path),
+        labeled_ranges=[[2, 3]],
+        video_start_idx=2,
+        video_end_idx=3,
+        span_index=0,
+    )
+
+    assert row["episode_completed"] is True
+    assert row["centerline_mean_m"] is None
+    assert row["min_clearance_m"] is None
+    assert row["min_rb_dist_m"] is None
+    path = tmp_path / "summary.json"
+    write_metrics_summary(aggregate_segment_rows([row]), path)
+    assert "Infinity" not in path.read_text(encoding="utf-8")
+    json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_safety_metric_does_not_double_batch_line_strings(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        safety_clearance,
+        "score_step",
+        lambda *args, **kwargs: (float("inf"), False, 0),
+    )
+
+    def fake_road_border(trajectory, ego_shape, data, config):
+        captured["shape"] = tuple(data["line_strings"].shape)
+        return (
+            torch.ones(1),
+            torch.zeros(1),
+            torch.zeros(1),
+            [None],
+            torch.zeros(1),
+            torch.full((1, 1), 2.0),
+        )
+
+    monkeypatch.setattr(safety_clearance, "compute_road_border_penalty", fake_road_border)
+    result = safety_clearance.score_safety_step(
+        np.zeros((2, 11), dtype=np.float32),
+        np.array([2.7, 4.8, 1.8], dtype=np.float32),
+        {
+            "ego_shape": np.array([[2.7, 4.8, 1.8]], dtype=np.float32),
+            "line_strings": np.zeros((1, 60, 20, 4), dtype=np.float32),
+        },
+        "cpu",
+    )
+
+    assert captured["shape"] == (1, 60, 20, 4)
+    assert result["rb_dist_m"] == 2.0

--- a/scenario_generation/tests/test_grouped_metrics.py
+++ b/scenario_generation/tests/test_grouped_metrics.py
@@ -78,6 +78,54 @@ def test_missing_geometry_is_json_safe(monkeypatch, tmp_path):
     json.loads(path.read_text(encoding="utf-8"))
 
 
+def test_later_route_progress_does_not_mark_a_skipped_episode_complete(monkeypatch, tmp_path):
+    monkeypatch.setattr(cl_route_by_area, "is_skipped", lambda _: False)
+    steps = [cl_route_by_area.StepRecord(k=0, rec_idx=8, area="later_area")]
+    row = cl_route_by_area.aggregate_area_metrics(
+        steps,
+        "target_area",
+        "right_turn",
+        "route",
+        "bag",
+        _timeline(tmp_path),
+        labeled_ranges=[[2, 5]],
+        video_start_idx=2,
+        video_end_idx=5,
+        span_index=0,
+    )
+
+    assert row["episode_reached"] is False
+    assert row["episode_completed"] is False
+    assert row["episode_progress_fraction"] == 0.0
+
+
+def test_near_miss_count_excludes_collision_steps(monkeypatch, tmp_path):
+    monkeypatch.setattr(cl_route_by_area, "is_skipped", lambda _: False)
+    steps = [
+        cl_route_by_area.StepRecord(
+            k=0, rec_idx=2, area="target_area", clearance_m=-0.1, collision=True
+        ),
+        cl_route_by_area.StepRecord(k=1, rec_idx=3, area="target_area", clearance_m=0.2),
+        cl_route_by_area.StepRecord(k=2, rec_idx=4, area="target_area", clearance_m=0.5),
+    ]
+    row = cl_route_by_area.aggregate_area_metrics(
+        steps,
+        "target_area",
+        "straight",
+        "route",
+        "bag",
+        _timeline(tmp_path),
+        labeled_ranges=[[2, 5]],
+        video_start_idx=2,
+        video_end_idx=5,
+        span_index=0,
+        near_miss_thresh=0.3,
+    )
+
+    assert row["n_collision_steps"] == 1
+    assert row["n_near_miss_steps"] == 1
+
+
 def test_safety_metric_does_not_double_batch_line_strings(monkeypatch):
     captured = {}
     monkeypatch.setattr(

--- a/scenario_generation/tests/test_hdp_integration_contracts.py
+++ b/scenario_generation/tests/test_hdp_integration_contracts.py
@@ -8,6 +8,7 @@ import torch
 import scenario_generation.replay as replay
 from planner_metrics.config import RewardConfig
 from scenario_generation.reproducer_rollout import _add_static_inputs
+from scenario_generation.simulate import _checkpoint_model_state
 
 
 def test_reproducer_static_inputs_match_temporal_hdp_shape():
@@ -18,6 +19,23 @@ def test_reproducer_static_inputs_match_temporal_hdp_shape():
 
     assert set(data) == {"sampled_trajectories"}
     assert data["sampled_trajectories"].shape == (3, 1, 80, 4)
+
+
+def test_scenario_model_loading_prefers_ema_with_live_fallback():
+    live = {"weight": torch.tensor(1.0)}
+    ema = {"weight": torch.tensor(2.0)}
+
+    selected, kind = _checkpoint_model_state(
+        {"model": live, "ema_state_dict": ema}, prefer_ema=True
+    )
+    assert selected is ema
+    assert kind == "EMA"
+
+    selected, kind = _checkpoint_model_state(
+        {"model": live, "ema_state_dict": None}, prefer_ema=True
+    )
+    assert selected is live
+    assert kind == "live"
 
 
 def test_replay_reward_serializes_scalar_and_per_timestep_subscores(monkeypatch):

--- a/scenario_generation/tests/test_scenario_classification.py
+++ b/scenario_generation/tests/test_scenario_classification.py
@@ -1,0 +1,148 @@
+"""Tests for portable scenario classification JSON resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scenario_generation.scenario_classification import (
+    area_at_idx,
+    episodes_from_entry,
+    idx_in_labeled_ranges,
+    iter_area_spans,
+    iter_segments,
+    load_area_metric_groups,
+    load_classification_json,
+    resolve_classification_json,
+    time_series_from_doc,
+    validate_classification_npz_root,
+)
+
+
+def test_iter_area_spans_legacy_dense() -> None:
+    area_by_idx = ["a", "a", None, "b", "b", "a", "a"]
+    spans = list(iter_area_spans(area_by_idx))
+    assert spans == [("a", 0, 2), ("b", 3, 5), ("a", 5, 7)]
+
+
+def test_episodes_bridge_unlabeled_gap() -> None:
+    entry = {
+        "segments": [
+            {
+                "area": "a",
+                "metric_group": "g1",
+                "video_start_idx": 0,
+                "video_end_idx": 10,
+                "labeled_ranges": [[0, 2], [5, 10]],
+            }
+        ]
+    }
+    eps = episodes_from_entry(entry)
+    assert len(eps) == 1
+    assert eps[0]["video_start_idx"] == 0
+    assert eps[0]["video_end_idx"] == 10
+    assert eps[0]["labeled_ranges"] == [[0, 2], [5, 10]]
+    assert area_at_idx(eps, 1) == "a"
+    assert area_at_idx(eps, 3) is None
+    assert idx_in_labeled_ranges(3, eps[0]["labeled_ranges"]) is False
+
+
+def test_episodes_from_v21_segments() -> None:
+    entry = {
+        "segments": [
+            {"area": "a", "metric_group": "g1", "start_idx": 0, "end_idx": 2},
+            {"area": "a", "metric_group": "g1", "start_idx": 5, "end_idx": 7},
+            {"area": "b", "metric_group": "g2", "start_idx": 10, "end_idx": 12},
+        ]
+    }
+    eps = episodes_from_entry(entry)
+    assert len(eps) == 2
+    assert eps[0]["area"] == "a"
+    assert eps[0]["video_start_idx"] == 0
+    assert eps[0]["video_end_idx"] == 7
+    assert eps[0]["labeled_ranges"] == [[0, 2], [5, 7]]
+    assert list(iter_segments(entry)) == [("a", 0, 2), ("a", 5, 7), ("b", 10, 12)]
+
+
+def test_episodes_from_legacy_area_by_idx() -> None:
+    entry = {
+        "area_by_idx": ["a", "a", None, "b"],
+        "metric_group_by_idx": ["g1", "g1", None, "g2"],
+    }
+    eps = episodes_from_entry(entry)
+    assert len(eps) == 2
+    assert eps[0]["labeled_ranges"] == [[0, 2]]
+
+
+def test_load_area_metric_groups_from_catalog() -> None:
+    doc = {
+        "area_catalog": {"zeikan_curve": {"metric_group": "curve"}},
+        "time_series": {},
+    }
+    assert load_area_metric_groups(doc) == {"zeikan_curve": "curve"}
+
+
+def test_time_series_from_legacy_sequences() -> None:
+    doc = {
+        "sequences": {
+            "13-42-45": {
+                "route_key": "r",
+                "segments": [
+                    {
+                        "area": "a",
+                        "metric_group": "g",
+                        "video_start_idx": 0,
+                        "video_end_idx": 1,
+                        "labeled_ranges": [[0, 1]],
+                    }
+                ],
+            }
+        }
+    }
+    ts = time_series_from_doc(doc)
+    assert "13-42-45" in ts
+    assert ts["13-42-45"]["name"] == "13-42-45"
+
+
+def test_validate_classification_npz_root_date_mismatch(tmp_path: Path) -> None:
+    doc = {"date": "2026-01-15", "time_series": {}}
+    warnings = validate_classification_npz_root(doc, tmp_path / "2026-01-16")
+    assert len(warnings) == 1
+
+
+def test_resolve_classification_json_explicit(tmp_path: Path) -> None:
+    json_path = tmp_path / "2026-01-15.json"
+    json_path.write_text("{}", encoding="utf-8")
+    resolved = resolve_classification_json(
+        tmp_path / "2026-01-15",
+        json_path,
+    )
+    assert resolved == json_path.resolve()
+
+
+def test_resolve_classification_json_auto(tmp_path: Path) -> None:
+    root = tmp_path / "scenario_classification_json"
+    dataset = "x2_dev/foo"
+    (root / dataset).mkdir(parents=True)
+    json_path = root / dataset / "2026-01-15.json"
+    json_path.write_text("{}", encoding="utf-8")
+    resolved = resolve_classification_json(
+        tmp_path / "2026-01-15",
+        None,
+        dataset_name=dataset,
+        search_roots=[root],
+    )
+    assert resolved == json_path.resolve()
+
+
+def test_resolve_classification_json_missing_returns_none(tmp_path: Path) -> None:
+    assert resolve_classification_json(tmp_path, None) is None
+
+
+def test_load_classification_json(tmp_path: Path) -> None:
+    path = tmp_path / "2026-01-15.json"
+    path.write_text(
+        '{"date": "2026-01-15", "time_series": {}, "area_catalog": {}}',
+        encoding="utf-8",
+    )
+    doc = load_classification_json(path)
+    assert doc["date"] == "2026-01-15"

--- a/scenario_generation/tools/eval_scenario_groups_closed_loop.py
+++ b/scenario_generation/tools/eval_scenario_groups_closed_loop.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Grouped closed-loop validation — thin wrapper around ``valid_predictor_closed_loop --mode grouped``.
+
+Prefer the unified entry point::
+
+    python diffusion_planner/valid_predictor_closed_loop.py --mode grouped ...
+
+This module remains for backward-compatible ``python -m scenario_generation.tools...`` usage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scenario_generation.closed_loop_cli import (  # noqa: E402
+    add_grouped_args,
+    add_output_args,
+    add_rollout_args,
+    run_grouped_eval,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        epilog="Rollout knobs match valid_predictor_closed_loop.py (--near_miss_thresh, etc.).",
+    )
+    add_rollout_args(p)
+    add_output_args(p)
+    add_grouped_args(p)
+    return p.parse_args()
+
+
+def main() -> int:
+    return run_grouped_eval(parse_args())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scenario_generation/wandb_closed_loop.py
+++ b/scenario_generation/wandb_closed_loop.py
@@ -1,0 +1,119 @@
+"""Build wandb log payloads for grouped closed-loop validation."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pandas as pd
+import wandb
+
+RESULTS_TABLE_COLUMNS = [
+    "metric_group",
+    "area_name",
+    "bag",
+    "span_index",
+    "segment",
+    "n_steps_run",
+    "episode_reached",
+    "episode_completed",
+    "episode_progress_fraction",
+    "centerline_mean_m",
+    "centerline_p95_m",
+    "turn_match_rate",
+    "collision_steps",
+    "n_collision_steps",
+    "n_near_miss_steps",
+    "min_clearance_m",
+    "mean_clearance",
+    "video_path",
+]
+
+
+def build_grouped_closed_loop_wandb_log(summary: dict, *, max_videos: int = 24) -> dict:
+    """Scalars, per-area/per-group aggregates, results table, and episode videos."""
+    log: dict = {"closed_loop/mode": "grouped"}
+    log["closed_loop/grouped/n_episodes"] = int(summary.get("n_episodes", 0))
+    log["closed_loop/grouped/n_episodes_expected"] = int(summary.get("n_episodes_expected", 0))
+    log["closed_loop/grouped/episode_report_fraction"] = float(
+        summary.get("episode_report_fraction", 0.0)
+    )
+    log["closed_loop/grouped/n_bags"] = int(summary.get("n_bags", 0))
+    log["closed_loop/grouped/n_bags_expected"] = int(summary.get("n_bags_expected", 0))
+    log["closed_loop/grouped/bag_report_fraction"] = float(summary.get("bag_report_fraction", 0.0))
+    log["closed_loop/grouped/elapsed_sec"] = float(summary.get("elapsed_sec", 0.0))
+
+    agg = summary.get("grouped_summary") or {}
+    for group, stats in (agg.get("by_metric_group") or {}).items():
+        for key, val in stats.items():
+            if not _wandb_scalar(val):
+                continue
+            log[f"closed_loop/grouped/metric_group/{group}/{key}"] = val
+
+    for area, stats in (agg.get("by_area_name") or {}).items():
+        safe_area = area.replace("/", "_")
+        for key, val in stats.items():
+            if not _wandb_scalar(val):
+                continue
+            log[f"closed_loop/grouped/area/{safe_area}/{key}"] = val
+
+    rows = summary.get("segments") or []
+    if rows:
+        df = pd.DataFrame(rows)
+        cols = [c for c in RESULTS_TABLE_COLUMNS if c in df.columns]
+        extra = [c for c in df.columns if c not in cols and c != "labeled_ranges"]
+        log["closed_loop/grouped/results_table"] = wandb.Table(dataframe=df[cols + extra])
+
+    video_mp4s = summary.get("video_mp4s") or []
+    log["closed_loop/grouped/n_videos"] = len(video_mp4s)
+    log["closed_loop/grouped/n_videos_logged"] = min(len(video_mp4s), max_videos)
+    for mp4 in video_mp4s[:max_videos]:
+        mp4_path = Path(mp4)
+        key = _video_wandb_key(mp4_path)
+        log[key] = wandb.Video(str(mp4_path), format="mp4")
+
+    return log
+
+
+def build_full_closed_loop_wandb_log(summary: dict) -> dict:
+    """Legacy full-route closed-loop wandb payload."""
+    scalar_keys = [
+        "collision_segment_rate",
+        "collision_step_rate",
+        "near_miss_segment_rate",
+        "near_miss_step_rate",
+        "global_min_clearance",
+        "mean_segment_min_clearance",
+        "mean_segment_mean_clearance",
+        "total_collision_steps",
+        "total_near_miss_steps",
+        "total_snaps",
+        "total_steps",
+    ]
+    log = {"closed_loop/mode": "full"}
+    for key in scalar_keys:
+        val = summary.get(key)
+        if _wandb_scalar(val):
+            log[f"closed_loop/{key}"] = val
+    for mp4 in summary.get("video_mp4s") or []:
+        log[f"closed_loop/video/{Path(mp4).stem}"] = wandb.Video(str(mp4), format="mp4")
+    return log
+
+
+def _wandb_scalar(val) -> bool:
+    if val is None:
+        return False
+    if isinstance(val, (int, bool)):
+        return True
+    if isinstance(val, float):
+        return math.isfinite(val)
+    return False
+
+
+def _video_wandb_key(mp4_path: Path) -> str:
+    parts = mp4_path.parts
+    if "videos" in parts:
+        idx = parts.index("videos")
+        rel = "/".join(parts[idx + 1 :])
+        return f"closed_loop/grouped/video/{rel.replace('/', '_')}"
+    return f"closed_loop/grouped/video/{mp4_path.stem}"

--- a/test_scripts/augmentation_smoke.py
+++ b/test_scripts/augmentation_smoke.py
@@ -62,9 +62,11 @@ fig, ax = plt.subplots(figsize=(10, 10))
 view_range = 30
 visualize_inputs(deepcopy(data), save_path=None, ax=ax, view_ranges=[view_range])
 
-# Get augmentation ranges from the aug object
-lo = aug._low.cpu().numpy()[0]  # Extract from tuple
-hi = aug._high.cpu().numpy()[0]  # Extract from tuple
+# Quintic stores flat bounds while the bridge augmentor keeps a singleton batch axis.
+lo = aug._low.detach().cpu().numpy().reshape(-1)
+hi = aug._high.detach().cpu().numpy().reshape(-1)
+if lo.size != 9 or hi.size != 9:
+    raise ValueError(f"Expected 9-state augmentation bounds, got {lo.shape} and {hi.shape}")
 x_min, y_min = lo[0], lo[1]
 x_max, y_max = hi[0], hi[1]
 


### PR DESCRIPTION
## Summary

- fine-tune the global route conditioner together with the DiT in decoder-scope HDP RL
- allow stable explicit W&B run IDs for RL
- prefer an expert-aligned navigation route for lane reward, with visible-lane fallback
- count legitimate stationary ego futures in the fixed 80-frame multisample metric
- replace deprecated per-tensor EMA updates with checkpoint-compatible foreach EMA
- correct the associated audit/data documentation

## Validation

- `350 passed, 15 skipped`
- Ruff check/format and `git diff --check` pass
- 18.1M-parameter CPU EMA microbenchmark: 42.1 ms -> 12.8 ms per update; one-step max absolute difference 0
- route coverage sample: X2 right-turn 100%, JT 96.7%, PSim 100%; fallback remains active for misaligned routes

## Runtime scope

These changes are isolated from the currently running BaseTrain job 691 at `ec02db0`. They affect future RL/evaluation or a later resumed process only and must not be merged into the BaseTrain worktree while its automatic retry guard is active.
