### PR TITLE
R2LPL patience repair: morph re-timing, replay quotas, anchor slice, patience benchmark tools

### DIFF
--- a/planner_metrics/subscores.py
+++ b/planner_metrics/subscores.py
@@ -493,10 +493,17 @@ def compute_kinematic_gate(
     abs_violated = yaw_rate > config.max_yaw_rate
 
     # Check 2: bicycle-model curvature cap. κ_max = margin * tan(max_steer) / wheelbase.
+    # Low-speed conditioning: as speed -> 0 the bound collapses to ~0 and the
+    # check compares SG heading noise against SG speed noise (observed firing at
+    # 0.002 rad/s = 0.11 deg/s — physically meaningless; recorded logs only pass
+    # because their standstill poses repeat bit-identically). Clamp the bound's
+    # speed at 0.1 m/s: at standstill the bound becomes kappa_max * 0.1
+    # (~2 deg/s for a car), which still catches genuine turning-in-place while
+    # being immune to numerical noise. Behavior above 0.1 m/s is unchanged.
     if ego_shape is not None:
         wheelbase = float(ego_shape[0])
         kappa_max = config.kinematic_margin * math.tan(config.max_steer) / max(wheelbase, 1e-3)
-        curv_violated = yaw_rate > kappa_max * speed_align
+        curv_violated = yaw_rate > kappa_max * speed_align.clamp_min(0.1)
     else:
         curv_violated = torch.zeros_like(abs_violated)
 

--- a/rlvr/README.md
+++ b/rlvr/README.md
@@ -393,7 +393,11 @@ vehicle's bicycle-model constraints:
 - **Absolute yaw rate** must stay below `max_yaw_rate` (default 1.0 rad/s)
 - **Bicycle-model curvature** must stay below `κ_max = kinematic_margin · tan(max_steer) / wheelbase`
   (defaults: `max_steer=0.64` rad, `kinematic_margin=2.5`). Yaw and speed are
-  Savitzky-Golay smoothed before curvature estimation
+  Savitzky-Golay smoothed before curvature estimation. The bound's speed is
+  clamped at 0.1 m/s: below that the check would compare SG heading noise
+  against SG speed noise and gate stopping trajectories on numerics; at
+  standstill the effective bound is `κ_max · 0.1` (genuine turning-in-place is
+  still caught), and behavior above 0.1 m/s is unchanged
 
 Returns a per-trajectory **binary** gate (0 = any timestep violated, 1 = all clean).
 Applied as a hard flooring multiplier on `totals` **after** survival/gate aggregation, so a

--- a/rlvr/autoresearch/README_r2lpl_lifelong.md
+++ b/rlvr/autoresearch/README_r2lpl_lifelong.md
@@ -90,8 +90,14 @@ Each round runs:
 
 The miner writes `credit_windows.jsonl` directly. Repair generation consumes that
 file and writes accepted repaired scenes. Replay memory merges current accepted
-scenes with prior replay scenes. Training uses the repaired current scenes plus
-the replay list.
+scenes with prior replay scenes, with optional per-label reserved capacity
+(`replay_memory.label_quotas`) so a dominant event label cannot evict a rarer
+behavior class across rounds. Training uses the repaired current scenes plus the
+replay list, plus — when `training.anchor` is configured — a seeded slice of
+real logged normal scenes at `ratio` : 1 (anchor : focus), optionally stratified
+with a waits/interaction list; training on repaired+replay only leaves the model
+unanchored off the failure distribution (base_sft backend only; the runner
+rejects the anchor with any other backend).
 
 At a high level:
 
@@ -267,15 +273,16 @@ schedules under an accel/jerk-limited tracker) and eases laterally toward the
 expert in the det path's Frenet frame. It goes through the same gates and
 selection as every other candidate — nothing is forced.
 
-When the expert is stopped at the horizon end, the morph brakes to a stop. WHERE
-it stops is controlled by `repair_generation.expert_stop_anchor`
-(CLI `--expert_stop_anchor`):
+When the expert ends stopped (including a log-truncated held tail that reads
+as stopped), the morph brakes to a stop. WHERE it stops is controlled by
+`repair_generation.expert_stop_anchor` (CLI `--expert_stop_anchor`):
 
 - **`recorded` (default)** — stop at the recorded expert's ACTUAL stop position,
   projected onto the det path. Position-fidelity semantics: the target stops
   where the human stopped. Requires `ego_recorded_future` in the mined scenes
-  (saved by the reproducer alongside `ego_expert_future`; re-mine older corpora
-  that lack it — the repair fails loudly rather than falling back). Because the
+  (saved by the reproducer alongside `ego_expert_future`). Older corpora that
+  lack the field fail loudly BEFORE any GPU work, with two remedies: re-mine,
+  or run with `expert_stop_anchor: "pseudo"`. Because the
   diverged-ahead ego must stop earlier and harder, some morphs become
   kinematically infeasible and their scenes fall back to model candidates or go
   unrepaired: fidelity costs coverage.
@@ -284,8 +291,8 @@ it stops is controlled by `repair_generation.expert_stop_anchor`
   expert's timing"). Maximum morph coverage, but the stop lands as far past the
   human's stop point as the ego had already diverged.
 
-Both anchors are floored at the tracker's shortest feasible stop from the ego's
-current speed, so neither can demand the impossible. Pick `recorded` when the
+Both anchors are floored at the tracker's shortest feasible stop from the det
+plan's initial speed, so neither can demand the impossible. Pick `recorded` when the
 campaign metric is stop-location fidelity (patience repair); pick `pseudo` when
 repair coverage matters more than where exactly the target stops.
 

--- a/rlvr/autoresearch/README_r2lpl_lifelong.md
+++ b/rlvr/autoresearch/README_r2lpl_lifelong.md
@@ -257,6 +257,38 @@ Default winner rule:
 - then lower deviation penalty
 - then stable first index
 
+### Expert-disagreement morph candidate and `expert_stop_anchor`
+
+For `expert_disagreement` scenes, one extra scripted candidate joins the K
+model-generated candidates: the **det-path re-timing morph**
+(`rlvr/autoresearch/tools/expert_morph.py`). It re-times the model's own
+deterministic plan to the logged expert's timing (blended cumulative-distance
+schedules under an accel/jerk-limited tracker) and eases laterally toward the
+expert in the det path's Frenet frame. It goes through the same gates and
+selection as every other candidate — nothing is forced.
+
+When the expert is stopped at the horizon end, the morph brakes to a stop. WHERE
+it stops is controlled by `repair_generation.expert_stop_anchor`
+(CLI `--expert_stop_anchor`):
+
+- **`recorded` (default)** — stop at the recorded expert's ACTUAL stop position,
+  projected onto the det path. Position-fidelity semantics: the target stops
+  where the human stopped. Requires `ego_recorded_future` in the mined scenes
+  (saved by the reproducer alongside `ego_expert_future`; re-mine older corpora
+  that lack it — the repair fails loudly rather than falling back). Because the
+  diverged-ahead ego must stop earlier and harder, some morphs become
+  kinematically infeasible and their scenes fall back to model candidates or go
+  unrepaired: fidelity costs coverage.
+- **`pseudo`** — stop after the expert's REMAINING travel distance, applied from
+  the ego's own pose (the paper's pseudo-target semantics: "brake with the
+  expert's timing"). Maximum morph coverage, but the stop lands as far past the
+  human's stop point as the ego had already diverged.
+
+Both anchors are floored at the tracker's shortest feasible stop from the ego's
+current speed, so neither can demand the impossible. Pick `recorded` when the
+campaign metric is stop-location fidelity (patience repair); pick `pseudo` when
+repair coverage matters more than where exactly the target stops.
+
 ## Outputs
 
 Per round, the workflow reports:

--- a/rlvr/autoresearch/tools/build_patience_benchmark.py
+++ b/rlvr/autoresearch/tools/build_patience_benchmark.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Build a frozen patience benchmark from an NPZ dataset list.
+
+Scans a scene list for *waits-during-interaction* scenes — the recorded ego is
+quasi-stationary for >= ``min_wait_s`` somewhere in its future while there is a
+plausible interaction reason in the observation (a pedestrian within
+``ped_near_m`` of the GT path, or a red traffic light on a route lane) — then
+event-deduplicates them (consecutive NPZs sample the same wait at multiple
+offsets) keeping ONE scene per event, preferring the wait-ONSET offset (ego
+still moving at t0, GT stops within the horizon): onset is the discriminative
+test of the braking DECISION, staying-stopped is trivially passed.
+
+Outputs:
+  --out       frozen benchmark list (deduped, onset-preferred, capped at --max_scenes)
+  --out_pool  optional: the FULL undeduped waits-interaction pool (anchor-slice
+              ``waits_scene_list`` input for the R2LPL lifelong runner)
+
+Channel conventions (see diffusion_planner_ros lanelet_converter): lane feature
+channels 8-12 are the traffic-light one-hot [green, yellow, red, unknown, none];
+neighbor one-hot [vehicle, pedestrian, bicycle] occupies columns 8-10 of
+``neighbor_agents_past``.
+
+Usage:
+    python -m rlvr.autoresearch.tools.build_patience_benchmark \
+        --scenes <dataset_list.json> --out <benchmark.json> [--out_pool <pool.json>]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+import numpy as np
+
+_DT = 0.1
+_LANE_TL_RED_CH = 10
+_NEIGHBOR_PED_COL = 9
+_FRAME_RE = re.compile(r"^(?P<bag>.+)_(?P<frame>\d+)$")
+
+
+def scan_scene(
+    path: str,
+    *,
+    wait_speed_mps: float,
+    min_wait_steps: int,
+    ped_near_m: float,
+) -> dict | None:
+    """Classify one NPZ. Returns per-scene flags or None on load failure."""
+    try:
+        with np.load(path) as d:
+            route = d["route_lanes"]
+            nb_now = d["neighbor_agents_past"][:, -1, :]
+            fut = d["ego_agent_future"][:, :2]
+    except Exception as exc:  # noqa: BLE001 - report, caller decides
+        return {"error": str(exc)}
+
+    red_route = bool((route[..., _LANE_TL_RED_CH] > 0.5).any())
+
+    valid = np.abs(nb_now[:, :4]).sum(axis=1) > 0
+    is_ped = (nb_now[:, _NEIGHBOR_PED_COL] > 0.5) & valid
+    ped_near = False
+    if is_ped.any():
+        dists = np.linalg.norm(nb_now[is_ped, :2][:, None, :] - fut[None, :, :], axis=-1)
+        ped_near = bool((dists.min(axis=1) < ped_near_m).any())
+
+    step_disp = np.linalg.norm(np.diff(fut, axis=0), axis=-1)
+    slow = step_disp < wait_speed_mps * _DT
+    run = best = 0
+    for s in slow:
+        run = run + 1 if s else 0
+        best = max(best, run)
+    gt_waits = best >= min_wait_steps
+
+    v0 = float(step_disp[0] / _DT) if step_disp.shape[0] else 0.0
+    # Onset: ego moving at t0, GT reaches a stop within the horizon.
+    is_onset = v0 > 2.0 and bool((step_disp / _DT < wait_speed_mps).any())
+
+    return {
+        "gt_waits_interact": gt_waits and (ped_near or red_route),
+        "is_onset": is_onset,
+        "v0": v0,
+        "ped_near": ped_near,
+        "red_route": red_route,
+    }
+
+
+def _event_key(path: str, frame_gap: int) -> tuple[str, int] | None:
+    """(bag_id, frame//gap) — scenes of one bag within ``frame_gap`` frames = one event."""
+    stem = Path(path).stem
+    m = _FRAME_RE.match(stem)
+    if m is None:
+        return None
+    return (str(Path(path).parent / m.group("bag")), int(m.group("frame")) // frame_gap)
+
+
+def build_benchmark(
+    scene_paths: list[str],
+    *,
+    wait_speed_mps: float,
+    min_wait_steps: int,
+    ped_near_m: float,
+    event_frame_gap: int,
+    max_scenes: int,
+) -> tuple[list[str], list[str], dict]:
+    pool: list[tuple[str, dict]] = []
+    n_err = 0
+    for p in scene_paths:
+        r = scan_scene(
+            p,
+            wait_speed_mps=wait_speed_mps,
+            min_wait_steps=min_wait_steps,
+            ped_near_m=ped_near_m,
+        )
+        if r is None or "error" in r:
+            n_err += 1
+            continue
+        if r["gt_waits_interact"]:
+            pool.append((p, r))
+
+    # Event dedup: one scene per (bag, frame-bin), onset-preferred, then highest v0
+    # (the offset where the braking decision is hardest).
+    events: dict[tuple[str, int], tuple[str, dict]] = {}
+    unkeyed: list[tuple[str, dict]] = []
+    for p, r in pool:
+        key = _event_key(p, event_frame_gap)
+        if key is None:
+            unkeyed.append((p, r))
+            continue
+        prev = events.get(key)
+        if prev is None or (r["is_onset"], r["v0"]) > (prev[1]["is_onset"], prev[1]["v0"]):
+            events[key] = (p, r)
+
+    deduped = [*events.values(), *unkeyed]
+    deduped.sort(key=lambda pr: (not pr[1]["is_onset"], -pr[1]["v0"], pr[0]))
+    benchmark = [p for p, _ in deduped[:max_scenes]]
+    stats = {
+        "scanned": len(scene_paths),
+        "errors": n_err,
+        "pool": len(pool),
+        "events": len(deduped),
+        "benchmark": len(benchmark),
+        "onset_in_benchmark": sum(1 for p, r in deduped[:max_scenes] if r["is_onset"]),
+    }
+    return benchmark, [p for p, _ in pool], stats
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--scenes", required=True, help="JSON list of NPZ paths to scan")
+    ap.add_argument("--out", required=True, help="frozen benchmark JSON (deduped)")
+    ap.add_argument("--out_pool", help="optional full waits-interaction pool JSON")
+    ap.add_argument("--max_scenes", type=int, default=150)
+    ap.add_argument("--wait_speed_mps", type=float, default=0.5)
+    ap.add_argument("--min_wait_s", type=float, default=1.0)
+    ap.add_argument("--ped_near_m", type=float, default=5.0)
+    ap.add_argument(
+        "--event_frame_gap",
+        type=int,
+        default=100,
+        help="frames (10 Hz) binning consecutive scenes into one wait event",
+    )
+    args = ap.parse_args()
+
+    scene_paths = [str(p) for p in json.load(open(args.scenes))]
+    benchmark, full_pool, stats = build_benchmark(
+        scene_paths,
+        wait_speed_mps=args.wait_speed_mps,
+        min_wait_steps=int(round(args.min_wait_s / _DT)),
+        ped_near_m=args.ped_near_m,
+        event_frame_gap=args.event_frame_gap,
+        max_scenes=args.max_scenes,
+    )
+    if not benchmark:
+        raise RuntimeError(
+            "no waits-interaction scenes found; refusing to write an empty benchmark"
+        )
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.out).write_text(json.dumps(benchmark, indent=2))
+    if args.out_pool:
+        Path(args.out_pool).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.out_pool).write_text(json.dumps(full_pool, indent=2))
+    print(json.dumps(stats, indent=2))
+    print(f"benchmark -> {args.out}" + (f"\npool -> {args.out_pool}" if args.out_pool else ""))
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/build_patience_benchmark.py
+++ b/rlvr/autoresearch/tools/build_patience_benchmark.py
@@ -46,8 +46,9 @@ def scan_scene(
     wait_speed_mps: float,
     min_wait_steps: int,
     ped_near_m: float,
+    onset_speed_mps: float = 2.0,
 ) -> dict | None:
-    """Classify one NPZ. Returns per-scene flags or None on load failure."""
+    """Classify one NPZ. Returns per-scene flags, or {"error": ...} on load failure."""
     try:
         with np.load(path) as d:
             route = d["route_lanes"]
@@ -75,7 +76,7 @@ def scan_scene(
 
     v0 = float(step_disp[0] / _DT) if step_disp.shape[0] else 0.0
     # Onset: ego moving at t0, GT reaches a stop within the horizon.
-    is_onset = v0 > 2.0 and bool((step_disp / _DT < wait_speed_mps).any())
+    is_onset = v0 > onset_speed_mps and bool((step_disp / _DT < wait_speed_mps).any())
 
     return {
         "gt_waits_interact": gt_waits and (ped_near or red_route),
@@ -103,6 +104,7 @@ def build_benchmark(
     ped_near_m: float,
     event_frame_gap: int,
     max_scenes: int,
+    onset_speed_mps: float = 2.0,
 ) -> tuple[list[str], list[str], dict]:
     pool: list[tuple[str, dict]] = []
     n_err = 0
@@ -112,6 +114,7 @@ def build_benchmark(
             wait_speed_mps=wait_speed_mps,
             min_wait_steps=min_wait_steps,
             ped_near_m=ped_near_m,
+            onset_speed_mps=onset_speed_mps,
         )
         if r is None or "error" in r:
             n_err += 1
@@ -156,6 +159,12 @@ def main() -> None:
     ap.add_argument("--min_wait_s", type=float, default=1.0)
     ap.add_argument("--ped_near_m", type=float, default=5.0)
     ap.add_argument(
+        "--onset_speed_mps",
+        type=float,
+        default=2.0,
+        help="minimum t0 speed for a scene to count as a wait-ONSET offset",
+    )
+    ap.add_argument(
         "--event_frame_gap",
         type=int,
         default=100,
@@ -171,6 +180,7 @@ def main() -> None:
         ped_near_m=args.ped_near_m,
         event_frame_gap=args.event_frame_gap,
         max_scenes=args.max_scenes,
+        onset_speed_mps=args.onset_speed_mps,
     )
     if not benchmark:
         raise RuntimeError(

--- a/rlvr/autoresearch/tools/build_repaired_targets.py
+++ b/rlvr/autoresearch/tools/build_repaired_targets.py
@@ -646,7 +646,7 @@ def build_repaired_targets(
     expert_morph_w_max: float = 1.0,
     expert_morph_max_accel: float = 2.0,
     expert_morph_max_jerk: float = 4.0,
-    expert_stop_anchor: str = "pseudo",
+    expert_stop_anchor: str = "recorded",
 ) -> tuple[list[str], list[dict[str, Any]]]:
     rcfg = load_reward_config(reward_config_path)
     _apply_rear_end_collision_mode(
@@ -997,12 +997,14 @@ def main() -> None:
     ap.add_argument(
         "--expert_stop_anchor",
         choices=["pseudo", "recorded"],
-        default="pseudo",
+        default="recorded",
         help=(
-            "Where a stopped-expert morph stops: 'pseudo' (default) = the expert's "
-            "remaining travel distance applied from the ego pose; 'recorded' = the "
-            "recorded expert's actual stop position projected onto the det path "
-            "(requires ego_recorded_future in the mined scenes)."
+            "Where a stopped-expert morph stops. 'recorded' (default) = the recorded "
+            "expert's actual stop position projected onto the det path (position "
+            "fidelity; requires ego_recorded_future in the mined scenes; earlier, "
+            "harder stops cost some morph coverage). 'pseudo' = the expert's remaining "
+            "travel distance applied from the ego pose (paper pseudo-target; maximum "
+            "coverage, stops land later than the human's)."
         ),
     )
     ap.add_argument("--expert_morph_max_accel", type=float, default=2.0)

--- a/rlvr/autoresearch/tools/build_repaired_targets.py
+++ b/rlvr/autoresearch/tools/build_repaired_targets.py
@@ -130,31 +130,6 @@ def _row_is_expert_disagreement(row: dict[str, Any]) -> bool:
     return "expert_disagreement" in set(row.get("repair_labels") or [])
 
 
-def _route_xy_from_data(data: dict[str, torch.Tensor]) -> np.ndarray | None:
-    """Concatenate route_lanes (ego frame) into one xy polyline.
-
-    data["route_lanes"] is (1, L, P, C); channels 0:2 are xy. All-zero padding
-    points are dropped and the lanes are concatenated in order.
-    """
-    if "route_lanes" not in data:
-        return None
-    rl = data["route_lanes"].detach().cpu().numpy()
-    if rl.ndim == 4:
-        rl = rl[0]
-    if rl.ndim != 3 or rl.shape[-1] < 2:
-        return None
-    pts: list[np.ndarray] = []
-    for lane in rl:  # (P, C)
-        xy = lane[:, :2].astype(np.float64)
-        valid = np.abs(xy).sum(axis=1) > 1e-6
-        xy = xy[valid]
-        if xy.shape[0] > 0:
-            pts.append(xy)
-    if not pts:
-        return None
-    return np.concatenate(pts, axis=0)
-
-
 def _expert_reference_scoring_data(
     data: dict[str, torch.Tensor],
     *,
@@ -807,33 +782,16 @@ def build_repaired_targets(
             morph_index: int | None = None
             morph_diag: dict[str, Any] | None = None
             if repair_expert_gt_candidate and is_expert:
-                route_xy = _route_xy_from_data(data)
                 expert_traj = _future_to_4col(data["ego_expert_future"].detach().cpu().numpy())
                 det_traj = det_trajs[scene_idx].detach().cpu().numpy().astype(np.float32)
-                morph = None
-                if route_xy is None:
-                    morph_diag = {"stage": "no_route"}
-                else:
-                    # Yaw-rate bounds mirror the reward's compute_kinematic_gate so
-                    # the morph cannot be synthesized into a kinematically-gated
-                    # rejection (stopping morphs must not turn at standstill).
-                    scene_wheelbase = float(data["ego_shape"].reshape(-1)[0])
-                    scene_kappa_max = (
-                        rcfg.kinematic_margin
-                        * math.tan(rcfg.max_steer)
-                        / max(scene_wheelbase, 1e-3)
-                    )
-                    morph, morph_diag = build_expert_morph_candidate(
-                        det_traj,
-                        expert_traj,
-                        route_xy,
-                        w_max=expert_morph_w_max,
-                        max_accel=expert_morph_max_accel,
-                        max_jerk=expert_morph_max_jerk,
-                        max_yaw_rate=float(rcfg.max_yaw_rate),
-                        kappa_max=scene_kappa_max,
-                        return_diag=True,
-                    )
+                morph, morph_diag = build_expert_morph_candidate(
+                    det_traj,
+                    expert_traj,
+                    w_max=expert_morph_w_max,
+                    max_accel=expert_morph_max_accel,
+                    max_jerk=expert_morph_max_jerk,
+                    return_diag=True,
+                )
                 if morph is not None:
                     morph_tensor = torch.from_numpy(np.ascontiguousarray(morph)).to(
                         device=device, dtype=scene_trajs.dtype

--- a/rlvr/autoresearch/tools/build_repaired_targets.py
+++ b/rlvr/autoresearch/tools/build_repaired_targets.py
@@ -646,6 +646,7 @@ def build_repaired_targets(
     expert_morph_w_max: float = 1.0,
     expert_morph_max_accel: float = 2.0,
     expert_morph_max_jerk: float = 4.0,
+    expert_stop_anchor: str = "pseudo",
 ) -> tuple[list[str], list[dict[str, Any]]]:
     rcfg = load_reward_config(reward_config_path)
     _apply_rear_end_collision_mode(
@@ -784,12 +785,28 @@ def build_repaired_targets(
             if repair_expert_gt_candidate and is_expert:
                 expert_traj = _future_to_4col(data["ego_expert_future"].detach().cpu().numpy())
                 det_traj = det_trajs[scene_idx].detach().cpu().numpy().astype(np.float32)
+                stop_anchor_xy = None
+                if expert_stop_anchor == "recorded":
+                    if "ego_recorded_future" not in data:
+                        raise ValueError(
+                            f"{row['scene_path']}: --expert_stop_anchor recorded requires "
+                            "'ego_recorded_future' in the mined scene (re-mine with a "
+                            "reproducer that saves it; no silent fallback)."
+                        )
+                    recorded = _future_to_4col(data["ego_recorded_future"].detach().cpu().numpy())
+                    stop_anchor_xy = recorded[-1, :2]
+                elif expert_stop_anchor != "pseudo":
+                    raise ValueError(
+                        f"unknown expert_stop_anchor {expert_stop_anchor!r}; "
+                        "expected 'pseudo' or 'recorded'"
+                    )
                 morph, morph_diag = build_expert_morph_candidate(
                     det_traj,
                     expert_traj,
                     w_max=expert_morph_w_max,
                     max_accel=expert_morph_max_accel,
                     max_jerk=expert_morph_max_jerk,
+                    stop_anchor_xy=stop_anchor_xy,
                     return_diag=True,
                 )
                 if morph is not None:
@@ -977,6 +994,17 @@ def main() -> None:
         help="Score expert_disagreement scenes against the realized ego future instead.",
     )
     ap.add_argument("--expert_morph_w_max", type=float, default=1.0)
+    ap.add_argument(
+        "--expert_stop_anchor",
+        choices=["pseudo", "recorded"],
+        default="pseudo",
+        help=(
+            "Where a stopped-expert morph stops: 'pseudo' (default) = the expert's "
+            "remaining travel distance applied from the ego pose; 'recorded' = the "
+            "recorded expert's actual stop position projected onto the det path "
+            "(requires ego_recorded_future in the mined scenes)."
+        ),
+    )
     ap.add_argument("--expert_morph_max_accel", type=float, default=2.0)
     ap.add_argument("--expert_morph_max_jerk", type=float, default=4.0)
     args = ap.parse_args()
@@ -1041,6 +1069,7 @@ def main() -> None:
         expert_morph_w_max=float(args.expert_morph_w_max),
         expert_morph_max_accel=float(args.expert_morph_max_accel),
         expert_morph_max_jerk=float(args.expert_morph_max_jerk),
+        expert_stop_anchor=str(args.expert_stop_anchor),
     )
 
 

--- a/rlvr/autoresearch/tools/build_repaired_targets.py
+++ b/rlvr/autoresearch/tools/build_repaired_targets.py
@@ -743,7 +743,7 @@ def build_repaired_targets(
             args=cls_args,
         )
 
-        # Deterministic plan per scene — only needed to seed the Frenet det->GT
+        # Deterministic plan per scene — only needed to seed the det-path re-timing
         # morph candidate for expert_disagreement scenes.
         want_morph = repair_expert_gt_candidate and any(
             _row_is_expert_disagreement(row) for row in kept_rows
@@ -777,7 +777,7 @@ def build_repaired_targets(
 
             name = _output_name_for_scene(row["scene_path"])
 
-            # Extra Frenet det->GT morph candidate for expert_disagreement scenes.
+            # Extra det-path re-timing morph candidate for expert_disagreement scenes.
             morph_added = False
             morph_index: int | None = None
             morph_diag: dict[str, Any] | None = None
@@ -955,13 +955,13 @@ def main() -> None:
         dest="repair_expert_gt_candidate",
         action="store_true",
         default=True,
-        help="Add a Frenet det->GT morph candidate for expert_disagreement scenes (default on).",
+        help="Add a det-path re-timing morph candidate for expert_disagreement scenes (default on).",
     )
     ap.add_argument(
         "--no_repair_expert_gt_candidate",
         dest="repair_expert_gt_candidate",
         action="store_false",
-        help="Disable the Frenet det->GT morph candidate.",
+        help="Disable the det-path re-timing morph candidate.",
     )
     ap.add_argument(
         "--repair_expert_reference",

--- a/rlvr/autoresearch/tools/build_repaired_targets.py
+++ b/rlvr/autoresearch/tools/build_repaired_targets.py
@@ -616,6 +616,29 @@ def _best_safe_candidate(
 
 
 @torch.no_grad()
+def _preflight_recorded_anchor(rows: list[dict[str, Any]]) -> None:
+    """Fail BEFORE model load / GPU work when --expert_stop_anchor recorded is
+    unusable: every expert_disagreement scene must carry ego_recorded_future.
+
+    Old mined corpora predate the field; without this check the run burns
+    through generation until the first expert scene, hours into a round.
+    """
+    missing = []
+    for row in rows:
+        if not _row_is_expert_disagreement(row):
+            continue
+        with np.load(row["scene_path"]) as z:
+            if "ego_recorded_future" not in z.files:
+                missing.append(str(row["scene_path"]))
+    if missing:
+        raise ValueError(
+            f"--expert_stop_anchor recorded requires 'ego_recorded_future' in mined "
+            f"scenes, missing in {len(missing)} expert_disagreement scene(s), e.g. "
+            f"{missing[0]}. Either re-mine with a reproducer that saves it, or run "
+            f"with --expert_stop_anchor pseudo (no silent fallback)."
+        )
+
+
 def build_repaired_targets(
     *,
     model_path: str,
@@ -654,6 +677,12 @@ def build_repaired_targets(
         count_rear_end_collisions=count_rear_end_collisions,
     )
     _validate_static_collision_config(rows, rcfg)
+    if expert_stop_anchor == "recorded":
+        _preflight_recorded_anchor(rows)
+    elif expert_stop_anchor != "pseudo":
+        raise ValueError(
+            f"unknown expert_stop_anchor {expert_stop_anchor!r}; expected 'pseudo' or 'recorded'"
+        )
     thresholds = _load_scene_thresholds(threshold_config_path)
     model, model_args = load_model(model_path, device)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -791,7 +820,8 @@ def build_repaired_targets(
                         raise ValueError(
                             f"{row['scene_path']}: --expert_stop_anchor recorded requires "
                             "'ego_recorded_future' in the mined scene (re-mine with a "
-                            "reproducer that saves it; no silent fallback)."
+                            "reproducer that saves it, or run with --expert_stop_anchor "
+                            "pseudo; no silent fallback)."
                         )
                     recorded = _future_to_4col(data["ego_recorded_future"].detach().cpu().numpy())
                     stop_anchor_xy = recorded[-1, :2]

--- a/rlvr/autoresearch/tools/build_repaired_targets.py
+++ b/rlvr/autoresearch/tools/build_repaired_targets.py
@@ -485,6 +485,18 @@ def _passes_global_gates(label_row: dict[str, Any], reward_row) -> bool:
     )
 
 
+def _global_gate_flags(label_row: dict[str, Any], reward_row) -> dict[str, bool]:
+    """Which _passes_global_gates condition(s) failed — diagnosis mirror, keep in sync."""
+    return {
+        "collision": reward_row.collision_step is not None,
+        "rb_crossing": bool(reward_row.rb_crossing),
+        "lane_crossing": bool(reward_row.lane_crossing),
+        "static_crossing": bool(reward_row.static_crossing),
+        "kinematic_violated": bool(reward_row.kinematic_violated),
+        "moving_collision": label_row["moving_collision_step"] is not None,
+    }
+
+
 def _repairs_source_labels(
     source_labels: list[str],
     label_row: dict[str, Any],
@@ -524,6 +536,7 @@ def _best_safe_candidate(
     target_gt_disagreement_thresh: float,
     candidate_trajs: list[torch.Tensor] | torch.Tensor | np.ndarray | None = None,
     reference_traj: torch.Tensor | np.ndarray | None = None,
+    morph_index: int | None = None,
 ) -> tuple[int | None, dict[str, Any]]:
     accepted: list[tuple[float, float, float, int]] = []
     candidate_traj_list = None
@@ -543,18 +556,27 @@ def _best_safe_candidate(
             )
             accepted.append((violation_score, deviation_penalty, float(reward_row.total), idx))
 
+    accepted_indices = {item[3] for item in accepted}
     if not accepted:
         best_total = max(float(r.total) for r in reward_rows)
         best_sc = max(float(getattr(r, "sc_min_dist", -99.0)) for r in reward_rows)
-        return None, {
+        meta = {
             "reason": "no_safe_candidate",
             "best_total": best_total,
             "best_sc_min_dist": best_sc,
         }
+        if morph_index is not None:
+            meta["morph_outcome"] = "gate_rejected"
+            meta["morph_labels"] = list(candidate_rows[morph_index].get("labels", []))
+            meta["morph_gate_flags"] = _global_gate_flags(
+                candidate_rows[morph_index], reward_rows[morph_index]
+            )
+        return None, meta
 
     uses_r2lpl_conflict_selection = "expert_disagreement" in set(
         source_row.get("repair_labels", [])
     )
+    morph_r2lpl_score: float | None = None
     if uses_r2lpl_conflict_selection:
         rule_scores = _normalize_values([item[2] for item in accepted])
         state_class = _r2lpl_state_class(source_row)
@@ -564,6 +586,8 @@ def _best_safe_candidate(
             violation_score, deviation_penalty, _reward_total, idx = item
             expert_score = math.exp(-max(deviation_penalty, 0.0) / 4.0)
             r2lpl_score = rule_weight * rule_score + expert_weight * expert_score
+            if morph_index is not None and idx == morph_index:
+                morph_r2lpl_score = float(r2lpl_score)
             ranked.append((-r2lpl_score, violation_score, deviation_penalty, idx))
         ranked.sort()
         neg_r2lpl_score, violation_score, deviation_penalty, idx = ranked[0]
@@ -600,6 +624,19 @@ def _best_safe_candidate(
     if selected_r2lpl_score is not None:
         meta["selected_r2lpl_score"] = float(selected_r2lpl_score)
         meta["selected_r2lpl_state_class"] = selected_state_class
+    if morph_index is not None:
+        if idx == morph_index:
+            meta["morph_outcome"] = "selected"
+        elif morph_index in accepted_indices:
+            meta["morph_outcome"] = "lost_selection"
+            if morph_r2lpl_score is not None:
+                meta["morph_r2lpl_score"] = morph_r2lpl_score
+        else:
+            meta["morph_outcome"] = "gate_rejected"
+            meta["morph_labels"] = list(candidate_rows[morph_index].get("labels", []))
+            meta["morph_gate_flags"] = _global_gate_flags(
+                candidate_rows[morph_index], reward_rows[morph_index]
+            )
     return idx, meta
 
 
@@ -768,19 +805,34 @@ def build_repaired_targets(
             # Extra Frenet det->GT morph candidate for expert_disagreement scenes.
             morph_added = False
             morph_index: int | None = None
+            morph_diag: dict[str, Any] | None = None
             if repair_expert_gt_candidate and is_expert:
                 route_xy = _route_xy_from_data(data)
                 expert_traj = _future_to_4col(data["ego_expert_future"].detach().cpu().numpy())
                 det_traj = det_trajs[scene_idx].detach().cpu().numpy().astype(np.float32)
                 morph = None
-                if route_xy is not None:
-                    morph = build_expert_morph_candidate(
+                if route_xy is None:
+                    morph_diag = {"stage": "no_route"}
+                else:
+                    # Yaw-rate bounds mirror the reward's compute_kinematic_gate so
+                    # the morph cannot be synthesized into a kinematically-gated
+                    # rejection (stopping morphs must not turn at standstill).
+                    scene_wheelbase = float(data["ego_shape"].reshape(-1)[0])
+                    scene_kappa_max = (
+                        rcfg.kinematic_margin
+                        * math.tan(rcfg.max_steer)
+                        / max(scene_wheelbase, 1e-3)
+                    )
+                    morph, morph_diag = build_expert_morph_candidate(
                         det_traj,
                         expert_traj,
                         route_xy,
                         w_max=expert_morph_w_max,
                         max_accel=expert_morph_max_accel,
                         max_jerk=expert_morph_max_jerk,
+                        max_yaw_rate=float(rcfg.max_yaw_rate),
+                        kappa_max=scene_kappa_max,
+                        return_diag=True,
                     )
                 if morph is not None:
                     morph_tensor = torch.from_numpy(np.ascontiguousarray(morph)).to(
@@ -815,11 +867,20 @@ def build_repaired_targets(
                 target_gt_disagreement_thresh=target_gt_disagreement_thresh,
                 candidate_trajs=scene_trajs,
                 reference_traj=reference_traj,
+                morph_index=morph_index if morph_added else None,
             )
             morph_selected = bool(morph_added and best_idx == morph_index)
             if is_expert:
                 meta["expert_morph_added"] = bool(morph_added)
                 meta["expert_morph_selected"] = morph_selected
+                # Synthesis diagnostics: why the morph exists / was rejected before
+                # ever reaching the gates ("stage" == "ok" when synthesized). The
+                # gate/selection outcome ("morph_outcome") comes from
+                # _best_safe_candidate; merge the synthesis stage for the full story.
+                if morph_diag is not None:
+                    meta["expert_morph_diag"] = morph_diag
+                    if not morph_added:
+                        meta["morph_outcome"] = f"not_synthesized:{morph_diag['stage']}"
             if morph_added:
                 print(f"  morph candidate {name}: added=True selected={morph_selected}")
             if best_idx is None:

--- a/rlvr/autoresearch/tools/eval_patience_onset.py
+++ b/rlvr/autoresearch/tools/eval_patience_onset.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Patience-onset evaluation: does the det plan stop when/where the GT stops?
+
+Runs deterministic inference on a patience benchmark (see
+``build_patience_benchmark``) for one or two models and reports, per scene and
+aggregated, over the full 8 s horizon:
+
+  * fail_to_stop  — GT reaches < ``stop_speed`` m/s but the det plan never does
+  * stop_onset_delay_s — det stop-onset time minus GT stop-onset time
+  * over_distance_m — det 8 s path length minus GT's
+
+This is the OPEN-LOOP guard of the patience benchmark; pair it with a
+closed-loop probe (``valid_predictor_closed_loop`` on the same scenes) — a
+model can pass open-loop (conditioned on GT history) yet still creep in closed
+loop where per-step biases compound.
+
+Usage:
+    python -m rlvr.autoresearch.tools.eval_patience_onset \
+        --model <a.pth> [--model_b <b.pth>] --scenes <benchmark.json> --out <report.json>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from preference_optimization.utils import load_npz_data
+from rlvr.autoresearch.tools.eval_det_avoidance import det_inference_batched, load_model
+
+_DT = 0.1
+
+
+def _stop_metrics(xy: np.ndarray, stop_speed: float) -> dict:
+    v = np.linalg.norm(np.diff(xy, axis=0), axis=-1) / _DT
+    stopped = v < stop_speed
+    return {
+        "stops": bool(stopped.any()),
+        "stop_onset_s": float(np.argmax(stopped) * _DT) if stopped.any() else None,
+        "dist_m": float(v.sum() * _DT),
+        "min_v": float(v.min()),
+    }
+
+
+def _eval_model(model_path: str, datas: list[dict], device: torch.device, batch: int):
+    model, margs = load_model(model_path, device)
+    outs = []
+    for i in range(0, len(datas), batch):
+        ego = det_inference_batched(model, margs, datas[i : i + batch], device)
+        outs.append(ego[..., :2].cpu().numpy())
+    del model
+    return np.concatenate(outs)
+
+
+def evaluate(
+    model_paths: dict[str, str],
+    scene_paths: list[str],
+    *,
+    stop_speed: float,
+    device: torch.device,
+    batch: int,
+) -> dict:
+    datas = [load_npz_data(p, device) for p in scene_paths]
+    gt = {
+        p: d["ego_agent_future"][0, :, :2].detach().cpu().numpy()
+        for p, d in zip(scene_paths, datas)
+    }
+    preds = {label: _eval_model(mp, datas, device, batch) for label, mp in model_paths.items()}
+
+    rows = []
+    for i, p in enumerate(scene_paths):
+        g = _stop_metrics(gt[p], stop_speed)
+        row: dict = {"scene": p, "gt": g}
+        for label in model_paths:
+            m = _stop_metrics(preds[label][i], stop_speed)
+            m["fail_to_stop"] = bool(g["stops"] and not m["stops"])
+            m["stop_onset_delay_s"] = (
+                round(m["stop_onset_s"] - g["stop_onset_s"], 2)
+                if g["stops"] and m["stops"] and g["stop_onset_s"] is not None
+                else None
+            )
+            m["over_distance_m"] = round(m["dist_m"] - g["dist_m"], 2)
+            row[label] = m
+        rows.append(row)
+
+    summary: dict = {"n_scenes": len(rows), "stop_speed_mps": stop_speed}
+    for label in model_paths:
+        fails = sum(1 for r in rows if r[label]["fail_to_stop"])
+        delays = [
+            r[label]["stop_onset_delay_s"]
+            for r in rows
+            if r[label]["stop_onset_delay_s"] is not None
+        ]
+        overs = [r[label]["over_distance_m"] for r in rows]
+        summary[label] = {
+            "fail_to_stop": fails,
+            "stop_onset_delay_mean_s": round(float(np.mean(delays)), 3) if delays else None,
+            "stop_onset_delay_p95_s": round(float(np.percentile(delays, 95)), 3)
+            if delays
+            else None,
+            "over_distance_mean_m": round(float(np.mean(overs)), 3),
+            "over_distance_p95_m": round(float(np.percentile(overs, 95)), 3),
+        }
+    return {"summary": summary, "scenes": rows}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--model", required=True, help="checkpoint to evaluate")
+    ap.add_argument("--model_b", help="optional second checkpoint (e.g. the baseline)")
+    ap.add_argument("--scenes", required=True, help="patience benchmark JSON")
+    ap.add_argument("--out", required=True, help="report JSON")
+    ap.add_argument("--stop_speed", type=float, default=0.5)
+    ap.add_argument("--batch_size", type=int, default=8)
+    ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    args = ap.parse_args()
+
+    scene_paths = [str(p) for p in json.load(open(args.scenes))]
+    if not scene_paths:
+        raise ValueError(f"--scenes list is empty: {args.scenes}")
+    model_paths = {"model": args.model}
+    if args.model_b:
+        model_paths["model_b"] = args.model_b
+
+    report = evaluate(
+        model_paths,
+        scene_paths,
+        stop_speed=args.stop_speed,
+        device=torch.device(args.device),
+        batch=args.batch_size,
+    )
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.out).write_text(json.dumps(report, indent=2))
+    print(json.dumps(report["summary"], indent=2))
+    print(f"report -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/eval_patience_onset.py
+++ b/rlvr/autoresearch/tools/eval_patience_onset.py
@@ -86,7 +86,11 @@ def evaluate(
             row[label] = m
         rows.append(row)
 
-    summary: dict = {"n_scenes": len(rows), "stop_speed_mps": stop_speed}
+    summary: dict = {
+        "n_scenes": len(rows),
+        "stop_speed_mps": stop_speed,
+        "model_paths": dict(model_paths),
+    }
     for label in model_paths:
         fails = sum(1 for r in rows if r[label]["fail_to_stop"])
         delays = [

--- a/rlvr/autoresearch/tools/expert_morph.py
+++ b/rlvr/autoresearch/tools/expert_morph.py
@@ -143,6 +143,7 @@ def build_expert_morph_candidate(
     max_accel: float = 2.0,
     max_jerk: float = 4.0,
     dt: float = 0.1,
+    stop_anchor_xy: np.ndarray | None = None,
     return_diag: bool = False,
 ) -> np.ndarray | None | tuple[np.ndarray | None, dict]:
     """Re-time the det plan to the expert's speed profile + lateral merge.
@@ -154,6 +155,11 @@ def build_expert_morph_candidate(
         max_accel: longitudinal accel cap (m/s^2).
         max_jerk: longitudinal jerk cap (m/s^3).
         dt: timestep (s).
+        stop_anchor_xy: optional (2,) ego-frame point overriding WHERE a
+            stopped-expert morph stops: its projection onto the det path
+            becomes the stop arc (e.g. the recorded expert's actual stop
+            position). Default: the pseudo-target's final point, i.e. the
+            expert's remaining travel distance applied from the ego's pose.
         return_diag: when True, return ``(morph, diag)`` where ``diag`` records
             why synthesis failed (``stage``) plus the clamp statistics — the
             repair pipeline persists it so morph losses are diagnosable.
@@ -226,8 +232,15 @@ def build_expert_morph_candidate(
         keep0 = np.concatenate([[True], np.linalg.norm(np.diff(det_xy, axis=0), axis=1) > _EPS])
         stop_pts = det_xy[keep0]
         if stop_pts.shape[0] >= 2:
+            # Where should the morph stop? Default: the (re-anchored)
+            # pseudo-target's final point = the expert's REMAINING distance
+            # applied from the ego's own pose. With stop_anchor_xy: the
+            # caller-supplied point — e.g. the recorded expert's actual stop
+            # POSITION — for "stop where the driver stopped" semantics (a
+            # diverged-ahead ego then stops earlier, bounded by the floor).
+            stop_point = expert_xy[-1:] if stop_anchor_xy is None else stop_anchor_xy[None, :2]
             stop_proj = project_points_to_polyline(
-                expert_xy[-1:], stop_pts, _cumulative_arc(stop_pts)
+                np.asarray(stop_point, dtype=np.float64), stop_pts, _cumulative_arc(stop_pts)
             )
             a_stop = float(stop_proj[0, 0]) + _STOP_ARC_OVERSHOOT_M
             s_floor, _ = _feasible_longitudinal(

--- a/rlvr/autoresearch/tools/expert_morph.py
+++ b/rlvr/autoresearch/tools/expert_morph.py
@@ -187,7 +187,10 @@ def build_expert_morph_candidate(
     max_accel: float = 2.0,
     max_jerk: float = 4.0,
     dt: float = 0.1,
-) -> np.ndarray | None:
+    max_yaw_rate: float = 0.6,
+    kappa_max: float | None = None,
+    return_diag: bool = False,
+) -> np.ndarray | None | tuple[np.ndarray | None, dict]:
     """Blend a deterministic plan toward the logged expert in route Frenet frame.
 
     Args:
@@ -198,12 +201,29 @@ def build_expert_morph_candidate(
         max_accel: longitudinal accel cap (m/s^2).
         max_jerk: longitudinal jerk cap (m/s^3).
         dt: timestep (s).
+        max_yaw_rate: absolute per-step yaw-rate cap (rad/s).
+        kappa_max: optional bicycle-model curvature bound (1/m). When given,
+            the per-step yaw rate is ALSO capped to ``kappa_max * speed`` — a
+            stopping morph must not turn at standstill, or the reward's
+            ``compute_kinematic_gate`` (same bound) rejects the candidate.
+            Pass the same ``kinematic_margin * tan(max_steer) / wheelbase`` the
+            reward config uses.
+        return_diag: when True, return ``(morph, diag)`` where ``diag`` records
+            why synthesis failed (``stage``) plus the clamp statistics — the
+            repair pipeline persists it so morph losses are diagnosable.
 
     Returns:
         (T,4) [x,y,cos,sin] ego-frame morphed trajectory, or None when the
         route projection is unreliable or the feasibility clamps had to distort
-        the intended blend too much (see module-level thresholds).
+        the intended blend too much (see module-level thresholds). With
+        ``return_diag`` a ``(morph, diag)`` tuple instead.
     """
+
+    def _ret(morph: np.ndarray | None, stage: str, **extra):
+        if not return_diag:
+            return morph
+        return morph, {"stage": stage, **extra}
+
     det = np.asarray(det_traj, dtype=np.float64)
     expert = np.asarray(expert_traj, dtype=np.float64)
     route = np.asarray(route_xy, dtype=np.float64)
@@ -215,16 +235,16 @@ def build_expert_morph_candidate(
 
     # Route reliability: need at least a segment.
     if route.ndim != 2 or route.shape[1] < 2 or route.shape[0] < 2:
-        return None
+        return _ret(None, "route_unreliable")
     # Drop consecutive duplicate route points (zero-length segments break arc).
     keep = np.concatenate([[True], np.linalg.norm(np.diff(route, axis=0), axis=1) > _EPS])
     route = route[keep]
     if route.shape[0] < 2:
-        return None
+        return _ret(None, "route_unreliable")
 
     T = int(min(det.shape[0], expert.shape[0]))
     if T < 2:
-        return None
+        return _ret(None, "too_short_horizon")
     det = det[:T]
     expert = expert[:T]
 
@@ -247,12 +267,13 @@ def build_expert_morph_candidate(
 
     # Reject if the trajectory extends beyond the route arc by a margin.
     for pt in (det_xy[0], det_xy[-1], expert_xy[0], expert_xy[-1]):
-        if _endpoint_overshoot(pt, route) > _ROUTE_OVERSHOOT_MARGIN_M:
-            return None
+        overshoot = _endpoint_overshoot(pt, route)
+        if overshoot > _ROUTE_OVERSHOOT_MARGIN_M:
+            return _ret(None, "endpoint_overshoot", overshoot_m=float(overshoot))
 
     s_ref = _cumulative_arc(route)
     if s_ref[-1] < _EPS:
-        return None
+        return _ret(None, "route_unreliable")
 
     det_proj = project_points_to_polyline(det_xy, route, s_ref)
     gt_proj = project_points_to_polyline(expert_xy, route, s_ref)
@@ -281,7 +302,13 @@ def build_expert_morph_candidate(
     terminal_err = abs(float(s_feasible[-1] - s_blend[-1]))
     fired_fraction = n_fired / float(max(T - 1, 1))
     if terminal_err > _TERMINAL_PROGRESS_TOL_M or fired_fraction > _CLAMP_FIRE_FRACTION:
-        return None
+        return _ret(
+            None,
+            "infeasible_deceleration",
+            terminal_err_m=terminal_err,
+            clamp_fire_fraction=fired_fraction,
+            v0_mps=v0,
+        )
 
     d_feasible = _feasible_lateral(d_blend, rate_cap=_DEFAULT_LATERAL_RATE_CAP_MPS, dt=dt)
 
@@ -311,9 +338,31 @@ def build_expert_morph_candidate(
     heading = theta_q + beta
 
     # Hard guarantee: cap the per-step yaw rate so no residual spike survives
-    # (e.g. from a route-end tangent edge). max_yaw_rate ~ 0.6 rad/s.
-    max_yaw_step = 0.6 * dt
+    # (e.g. from a route-end tangent edge). Two bounds, matching the reward's
+    # compute_kinematic_gate: the absolute cap AND — when kappa_max is given —
+    # the bicycle-model bound kappa_max * speed (with a safety factor, since the
+    # gate evaluates SG-smoothed signals, not these raw steps). Without the
+    # speed-aware bound a decelerating/stopped morph turns faster than a real
+    # vehicle can at that speed and the gate rejects it (observed: 32/52
+    # expert-waits morphs kinematically gated, all at speed < ~1.3 m/s).
+    # t=0 continuity: start from the det plan's actual heading, not the route
+    # tangent (a tangent snap at t=0 is itself an infeasible yaw step).
+    # The reward gate evaluates SG-SMOOTHED heading vs SG-SMOOTHED speed, so the
+    # raw caps must be conservative: below _HEADING_FREEZE_SPEED_MPS the heading
+    # is frozen outright — SG smoothing bleeds pre-stop heading change into the
+    # stopped region, where the curvature bound collapses to ~0 and even
+    # milli-rad/s residuals fire the gate (observed at SG speeds of 0.06-0.11 m/s).
+    _KAPPA_SAFETY = 0.85
+    _HEADING_FREEZE_SPEED_MPS = 0.5
+    heading[0] = float(np.arctan2(det[0, 3], det[0, 2])) if det.shape[1] >= 4 else heading[0]
     for t in range(1, T):
+        yaw_rate_cap = max_yaw_rate
+        if kappa_max is not None:
+            if float(ds_dt[t]) < _HEADING_FREEZE_SPEED_MPS:
+                yaw_rate_cap = 0.0
+            else:
+                yaw_rate_cap = min(yaw_rate_cap, _KAPPA_SAFETY * kappa_max * float(ds_dt[t]))
+        max_yaw_step = yaw_rate_cap * dt
         dh = (heading[t] - heading[t - 1] + np.pi) % (2 * np.pi) - np.pi
         heading[t] = heading[t - 1] + float(np.clip(dh, -max_yaw_step, max_yaw_step))
 
@@ -322,4 +371,10 @@ def build_expert_morph_candidate(
     out[:, 1] = recon_xy[:, 1]
     out[:, 2] = np.cos(heading)
     out[:, 3] = np.sin(heading)
-    return out
+    return _ret(
+        out,
+        "ok",
+        terminal_err_m=terminal_err,
+        clamp_fire_fraction=fired_fraction,
+        v0_mps=v0,
+    )

--- a/rlvr/autoresearch/tools/expert_morph.py
+++ b/rlvr/autoresearch/tools/expert_morph.py
@@ -5,18 +5,26 @@ For ``expert_disagreement`` scenes the disagreement is a PROGRESS / timing
 mismatch between the model's deterministic plan and the logged human expert.
 The morph is deliberately simple:
 
-1. **Re-time the det plan to the expert's speed profile** — blend the two
-   per-step speed profiles under a quintic onset weight (zero speed-jump at
-   t=0), integrate to an arc schedule, and interpolate the det plan's own
-   positions AND headings at those arcs. The det plan is already a feasible,
-   kinematically valid trajectory; driving the same path slower (or stopping
-   on it) stays valid by construction — a stop is a fixed point on the path
-   with its fixed heading.
-2. **Lateral merge toward the expert** — the expert's lateral offset is
-   measured in the det path's own Frenet frame (projection reuses
-   ``_heatmap_common``; no hand-rolled geometry) and applied with an
-   arc-progress weight under a slope cap (|Δd| ≤ slope·Δs), so the offset can
-   only change while the vehicle moves: no lateral drift at standstill.
+1. **Re-time the det plan to the expert's timing** — blend the two cumulative
+   DISTANCE SCHEDULES (not instantaneous speeds) under a quintic onset weight
+   (zero speed-jump at t=0), track the result with an accel/jerk-limited
+   profile, and interpolate the det plan's own positions AND headings at the
+   resulting arcs. The det plan is already a feasible, kinematically valid
+   trajectory; driving the same path slower (or stopping on it) stays valid
+   by construction — a stop is a fixed point on the path with its fixed
+   heading.
+2. **Stopped expert => stop-arc cap** — when the expert ends stopped (or its
+   log-truncated held tail reads as stopped), the arc schedule is capped at a
+   stop point: by default the expert trajectory's final point, or the
+   caller-supplied ``stop_anchor_xy`` (e.g. the recorded expert's actual stop
+   position). The cap anticipates with a braking parabola and is floored at
+   the tracker's shortest feasible stop from the det plan's initial speed.
+3. **Lateral merge toward the expert** — the expert's lateral offset at the
+   morph's end arc, measured in the det path's own Frenet frame (projection
+   reuses ``_heatmap_common``; no hand-rolled geometry), applied as ONE
+   analytic quintic ease in arc space whose magnitude is pre-scaled so the
+   crab-angle slope bound holds without pointwise clipping; the offset only
+   changes while the vehicle moves — no lateral drift at standstill.
 
 Everything is ego-frame numpy in/out.
 """
@@ -338,7 +346,10 @@ def build_expert_morph_candidate(
             d_end = float(np.interp(s_feasible[-1], a_mono, d_int))
     arc_span = max(float(s_feasible[-1] - s_feasible[0]), _EPS)
     if abs(d_end) > _EPS:
-        scale = min(1.0, _DEFAULT_LATERAL_SLOPE_CAP * arc_span / (1.875 * abs(d_end)))
+        # Peak slope of d_end*scale*quintic(u, w_max) is 1.875*w_max*scale*|d_end|/span,
+        # so w_max belongs in the denominator — without it the crab-angle bound
+        # is violated for w_max > 1.
+        scale = min(1.0, _DEFAULT_LATERAL_SLOPE_CAP * arc_span / (1.875 * w_max * abs(d_end)))
     else:
         scale = 0.0
     u_arc = (s_feasible - s_feasible[0]) / arc_span

--- a/rlvr/autoresearch/tools/expert_morph.py
+++ b/rlvr/autoresearch/tools/expert_morph.py
@@ -1,17 +1,24 @@
 #!/usr/bin/env python3
-"""Frenet det->GT morph repair candidate for expert_disagreement scenes.
+"""det->GT morph repair candidate for expert_disagreement scenes.
 
 For ``expert_disagreement`` scenes the disagreement is a PROGRESS / timing
 mismatch between the model's deterministic plan and the logged human expert.
-This module builds a single extra repair candidate by blending the model
-deterministic plan (``det_traj``) toward the logged expert future
-(``expert_traj``) in the route Frenet frame, under a smooth quintic onset
-weight (zero deformation AND zero speed-jump at t=0) plus longitudinal
-acceleration / jerk feasibility clamps.
+The morph is deliberately simple:
 
-Everything is ego-frame numpy in/out. The route Frenet frame is built by
-REUSING ``scenario_generation.tools._heatmap_common`` (no hand-rolled
-projection geometry).
+1. **Re-time the det plan to the expert's speed profile** — blend the two
+   per-step speed profiles under a quintic onset weight (zero speed-jump at
+   t=0), integrate to an arc schedule, and interpolate the det plan's own
+   positions AND headings at those arcs. The det plan is already a feasible,
+   kinematically valid trajectory; driving the same path slower (or stopping
+   on it) stays valid by construction — a stop is a fixed point on the path
+   with its fixed heading.
+2. **Lateral merge toward the expert** — the expert's lateral offset is
+   measured in the det path's own Frenet frame (projection reuses
+   ``_heatmap_common``; no hand-rolled geometry) and applied with an
+   arc-progress weight under a slope cap (|Δd| ≤ slope·Δs), so the offset can
+   only change while the vehicle moves: no lateral drift at standstill.
+
+Everything is ego-frame numpy in/out.
 """
 
 from __future__ import annotations
@@ -28,12 +35,17 @@ _CLAMP_TOL = 1e-6
 _TERMINAL_PROGRESS_TOL_M = 2.0
 # ...or if the accel/jerk clamps had to fire on more than this fraction of steps.
 _CLAMP_FIRE_FRACTION = 0.5
-# Route reliability: reject if a det/expert endpoint overshoots the polyline end
-# (or precedes its start) by more than this many metres along the terminal tangent.
-_ROUTE_OVERSHOOT_MARGIN_M = 3.0
-# Lateral rate cap (m/s) — bounds |d[i]-d[i-1]|/dt so the morph cannot teleport
-# sideways.
-_DEFAULT_LATERAL_RATE_CAP_MPS = 2.0
+# Lateral slope cap (m of offset per m of arc) — |Δd| <= slope_cap * Δs, so the
+# lateral offset freezes when the vehicle stops (~30° max path-crab angle).
+_DEFAULT_LATERAL_SLOPE_CAP = 0.58
+# Reject when the expert strays this far laterally from the det path — the two
+# trajectories no longer describe the same maneuver corridor and a lateral
+# merge is meaningless.
+_PATHS_DIVERGED_M = 5.0
+# Expert counts as stopped at the horizon end below this speed (m/s); then the
+# morph's arc is capped at the expert's stop location plus this overshoot.
+_STOPPED_EXPERT_SPEED_MPS = 0.5
+_STOP_ARC_OVERSHOOT_M = 0.5
 _EPS = 1e-9
 
 
@@ -55,27 +67,6 @@ def _quintic_smoothstep(u: np.ndarray, w_max: float) -> np.ndarray:
     """
     u = np.clip(u, 0.0, 1.0)
     return w_max * (6.0 * u**5 - 15.0 * u**4 + 10.0 * u**3)
-
-
-def _endpoint_overshoot(pt: np.ndarray, pts: np.ndarray) -> float:
-    """Signed metres a point lies BEYOND the polyline (start or end).
-
-    Returns the larger of the start-side overshoot (point precedes the first
-    vertex along the initial tangent) and the end-side overshoot (point lies
-    past the last vertex along the terminal tangent). Non-positive when the
-    point projects onto the interior.
-    """
-    head_tan = pts[1] - pts[0]
-    head_len = float(np.linalg.norm(head_tan))
-    tail_tan = pts[-1] - pts[-2]
-    tail_len = float(np.linalg.norm(tail_tan))
-    over_start = 0.0
-    over_end = 0.0
-    if head_len > _EPS:
-        over_start = -float(np.dot(pt - pts[0], head_tan / head_len))
-    if tail_len > _EPS:
-        over_end = float(np.dot(pt - pts[-1], tail_tan / tail_len))
-    return max(over_start, over_end)
 
 
 def _feasible_longitudinal(
@@ -120,103 +111,57 @@ def _feasible_longitudinal(
     return s, n_fired
 
 
-def _feasible_lateral(d_target: np.ndarray, *, rate_cap: float, dt: float) -> np.ndarray:
-    """Bound the lateral signal's per-step rate to |d[i]-d[i-1]|/dt <= rate_cap."""
-    T = int(d_target.shape[0])
-    d = np.empty(T, dtype=np.float64)
-    d[0] = float(d_target[0])
-    max_step = rate_cap * dt
-    for i in range(1, T):
-        step = float(d_target[i] - d[i - 1])
-        step = float(np.clip(step, -max_step, max_step))
-        d[i] = d[i - 1] + step
-    return d
+def _det_headings(det: np.ndarray) -> np.ndarray:
+    """Unwrapped per-step heading of the det plan.
 
-
-def _moving_average(x: np.ndarray, w: int) -> np.ndarray:
-    """Odd-window moving average with edge padding (length preserved)."""
-    if w <= 1 or len(x) < w:
-        return np.asarray(x, dtype=np.float64)
-    k = np.ones(w) / w
-    padded = np.pad(np.asarray(x, dtype=np.float64), w // 2, mode="edge")
-    return np.convolve(padded, k, mode="valid")[: len(x)]
-
-
-def _smoothed_tangent_angles(pts: np.ndarray) -> np.ndarray:
-    """Unwrapped, smoothed per-vertex tangent angle of a polyline.
-
-    Central differences give a per-VERTEX tangent (continuous across segment
-    joins, unlike a per-SEGMENT tangent), unwrapped then lightly smoothed so the
-    route normal — and hence the reconstructed lateral offset + heading — does
-    not flip at route-segment boundaries.
+    Prefers the plan's own (cos, sin) channels — they are valid even where the
+    plan is stationary. Falls back to the path tangent for 2-column input.
     """
-    d = np.zeros_like(pts, dtype=np.float64)
-    d[1:-1] = pts[2:] - pts[:-2]
-    d[0] = pts[1] - pts[0]
-    d[-1] = pts[-1] - pts[-2]
-    ang = np.unwrap(np.arctan2(d[:, 1], d[:, 0]))
-    return _moving_average(ang, 5)
-
-
-def _arc_interp(
-    s_ref: np.ndarray, pts: np.ndarray, s_query: np.ndarray
-) -> tuple[np.ndarray, np.ndarray]:
-    """Interpolate polyline position + unit tangent at arc positions s_query.
-
-    Returns (base_xy (M,2), unit_tangent (M,2)).
-    """
-    s_max = float(s_ref[-1])
-    sq = np.clip(s_query, 0.0, s_max)
-    idx = np.searchsorted(s_ref, sq, side="right") - 1
-    idx = np.clip(idx, 0, len(s_ref) - 2)
-    seg_len = s_ref[idx + 1] - s_ref[idx]
-    frac = (sq - s_ref[idx]) / np.maximum(seg_len, _EPS)
-    seg_vec = pts[idx + 1] - pts[idx]
-    base = pts[idx] + frac[:, None] * seg_vec
-    tan_len = np.linalg.norm(seg_vec, axis=1, keepdims=True)
-    unit_tan = seg_vec / np.maximum(tan_len, _EPS)
-    return base, unit_tan
+    if det.shape[1] >= 4:
+        return np.unwrap(np.arctan2(det[:, 3], det[:, 2]))
+    d = np.zeros_like(det[:, :2])
+    d[1:-1] = det[2:, :2] - det[:-2, :2]
+    d[0] = det[1, :2] - det[0, :2]
+    d[-1] = det[-1, :2] - det[-2, :2]
+    ang = np.arctan2(d[:, 1], d[:, 0])
+    # Hold heading through stationary stretches (no tangent to read off).
+    moving = np.linalg.norm(d, axis=1) > _EPS
+    if moving.any():
+        first = int(np.argmax(moving))
+        ang[:first] = ang[first]
+        for i in range(first + 1, len(ang)):
+            if not moving[i]:
+                ang[i] = ang[i - 1]
+    return np.unwrap(ang)
 
 
 def build_expert_morph_candidate(
     det_traj: np.ndarray,
     expert_traj: np.ndarray,
-    route_xy: np.ndarray,
     *,
     w_max: float = 1.0,
     max_accel: float = 2.0,
     max_jerk: float = 4.0,
     dt: float = 0.1,
-    max_yaw_rate: float = 0.6,
-    kappa_max: float | None = None,
     return_diag: bool = False,
 ) -> np.ndarray | None | tuple[np.ndarray | None, dict]:
-    """Blend a deterministic plan toward the logged expert in route Frenet frame.
+    """Re-time the det plan to the expert's speed profile + lateral merge.
 
     Args:
         det_traj: (T,4) [x,y,cos,sin] ego-frame model deterministic plan.
         expert_traj: (T,4) [x,y,cos,sin] ego-frame logged expert future.
-        route_xy: (P,2) ego-frame route centerline polyline.
-        w_max: peak onset weight (1.0 -> reach the expert by the horizon end).
+        w_max: peak onset weight (1.0 -> fully adopt the expert by horizon end).
         max_accel: longitudinal accel cap (m/s^2).
         max_jerk: longitudinal jerk cap (m/s^3).
         dt: timestep (s).
-        max_yaw_rate: absolute per-step yaw-rate cap (rad/s).
-        kappa_max: optional bicycle-model curvature bound (1/m). When given,
-            the per-step yaw rate is ALSO capped to ``kappa_max * speed`` — a
-            stopping morph must not turn at standstill, or the reward's
-            ``compute_kinematic_gate`` (same bound) rejects the candidate.
-            Pass the same ``kinematic_margin * tan(max_steer) / wheelbase`` the
-            reward config uses.
         return_diag: when True, return ``(morph, diag)`` where ``diag`` records
             why synthesis failed (``stage``) plus the clamp statistics — the
             repair pipeline persists it so morph losses are diagnosable.
 
     Returns:
         (T,4) [x,y,cos,sin] ego-frame morphed trajectory, or None when the
-        route projection is unreliable or the feasibility clamps had to distort
-        the intended blend too much (see module-level thresholds). With
-        ``return_diag`` a ``(morph, diag)`` tuple instead.
+        blend is infeasible (see module-level thresholds). With ``return_diag``
+        a ``(morph, diag)`` tuple instead.
     """
 
     def _ret(morph: np.ndarray | None, stage: str, **extra):
@@ -226,36 +171,20 @@ def build_expert_morph_candidate(
 
     det = np.asarray(det_traj, dtype=np.float64)
     expert = np.asarray(expert_traj, dtype=np.float64)
-    route = np.asarray(route_xy, dtype=np.float64)
-
     if det.ndim != 2 or det.shape[1] < 2:
         raise ValueError(f"det_traj must be (T,>=2), got {det.shape}")
     if expert.ndim != 2 or expert.shape[1] < 2:
         raise ValueError(f"expert_traj must be (T,>=2), got {expert.shape}")
 
-    # Route reliability: need at least a segment.
-    if route.ndim != 2 or route.shape[1] < 2 or route.shape[0] < 2:
-        return _ret(None, "route_unreliable")
-    # Drop consecutive duplicate route points (zero-length segments break arc).
-    keep = np.concatenate([[True], np.linalg.norm(np.diff(route, axis=0), axis=1) > _EPS])
-    route = route[keep]
-    if route.shape[0] < 2:
-        return _ret(None, "route_unreliable")
-
     T = int(min(det.shape[0], expert.shape[0]))
     if T < 2:
         return _ret(None, "too_short_horizon")
     det = det[:T]
-    expert = expert[:T]
+    expert = expert[:T].copy()
 
-    # The logged expert future can be zero-padded past its valid length (recorded
-    # route ended before the horizon). Those trailing (0,0) pads would project to
-    # the route origin and collapse the expert arc/lateral at the tail (teleport +
-    # tail yaw), so hold the last valid pose for the remainder. NOTE: an all-zero
-    # expert is a genuinely STOPPED expert (relative motion ~0 everywhere), NOT
-    # padding — it must be kept (it drives the morph to a stop), so only the
-    # valid-prefix-then-trailing-zeros case is held, never rejected.
-    expert = expert.copy()
+    # The logged expert future can be zero-padded past its valid length. Those
+    # trailing (0,0) pads would read as teleports, so hold the last valid pose.
+    # NOTE: an all-zero expert is a genuinely STOPPED expert, not padding.
     expert_valid = np.abs(expert[:, :2]).sum(axis=1) > _EPS
     if expert_valid.any() and not expert_valid.all():
         last_valid = int(np.max(np.flatnonzero(expert_valid)))
@@ -265,41 +194,64 @@ def build_expert_morph_candidate(
     det_xy = det[:, :2]
     expert_xy = expert[:, :2]
 
-    # Reject if the trajectory extends beyond the route arc by a margin.
-    for pt in (det_xy[0], det_xy[-1], expert_xy[0], expert_xy[-1]):
-        overshoot = _endpoint_overshoot(pt, route)
-        if overshoot > _ROUTE_OVERSHOOT_MARGIN_M:
-            return _ret(None, "endpoint_overshoot", overshoot_m=float(overshoot))
-
-    s_ref = _cumulative_arc(route)
-    if s_ref[-1] < _EPS:
-        return _ret(None, "route_unreliable")
-
-    det_proj = project_points_to_polyline(det_xy, route, s_ref)
-    gt_proj = project_points_to_polyline(expert_xy, route, s_ref)
-    s_det, d_det = det_proj[:, 0], det_proj[:, 1]
-    s_gt, d_gt = gt_proj[:, 0], gt_proj[:, 1]
-
-    # Smooth quintic onset weight.
+    # --- 1. Re-time: blend the distance-traveled schedules. ---
+    # s_det_sched / s_gt_sched are each trajectory's own cumulative distance
+    # over time. Blending the SCHEDULES (not the instantaneous speeds) makes
+    # the morph's terminal arc converge to the expert's traveled distance —
+    # "drive the det path with the expert's timing".
+    v_det = np.linalg.norm(np.diff(det_xy, axis=0), axis=1) / dt  # (T-1,)
+    s_det_sched = np.concatenate([[0.0], np.cumsum(v_det * dt)])
+    v_gt = np.linalg.norm(np.diff(expert_xy, axis=0), axis=1) / dt  # (T-1,)
+    s_gt_sched = np.concatenate([[0.0], np.cumsum(v_gt * dt)])
     u = np.arange(T, dtype=np.float64) / float(T - 1)
     w = _quintic_smoothstep(u, w_max)
+    s_target = s_det_sched + w * (s_gt_sched - s_det_sched)
+    # Monotone non-decreasing (a time-varying blend of monotone schedules can
+    # locally reverse; the vehicle cannot).
+    s_target = np.maximum.accumulate(s_target)
 
-    # Blend in Frenet.
-    s_blend = s_det + w * (s_gt - s_det)
-    d_blend = d_det + w * (d_gt - d_det)
+    s_det = _cumulative_arc(det_xy)
+    th_det = _det_headings(det)
 
-    # Monotone non-decreasing longitudinal target (no reversing).
-    s_blend = np.maximum.accumulate(s_blend)
+    # --- 1b. Stopped expert => stop AT the expert's stop location (projected
+    # onto the det path), not merely after the expert's traveled DISTANCE: the
+    # (diverged, ahead) ego covering the same distance can land mid-curve or on
+    # a road border where the det plan was only passing through — and a target
+    # that PARKS there is unsafe. The cap anticipates with the braking parabola
+    # v <= sqrt(2 a_eff (s_cap - s)) so the demand stays trackable, and is
+    # floored at the tracker's own shortest feasible stop (the ego may already
+    # be past the expert's spot).
+    expert_speed_end = float(np.linalg.norm(expert_xy[-1] - expert_xy[-2]) / dt)
+    if expert_speed_end < _STOPPED_EXPERT_SPEED_MPS:
+        keep0 = np.concatenate([[True], np.linalg.norm(np.diff(det_xy, axis=0), axis=1) > _EPS])
+        stop_pts = det_xy[keep0]
+        if stop_pts.shape[0] >= 2:
+            stop_proj = project_points_to_polyline(
+                expert_xy[-1:], stop_pts, _cumulative_arc(stop_pts)
+            )
+            a_stop = float(stop_proj[0, 0]) + _STOP_ARC_OVERSHOOT_M
+            s_floor, _ = _feasible_longitudinal(
+                np.full(T, float(s_target[0])),
+                float(v_det[0]),
+                max_accel=max_accel,
+                max_jerk=max_jerk,
+                dt=dt,
+            )
+            s_cap = max(a_stop, float(s_floor[-1]) + 0.5)
+            a_eff = 0.7 * max_accel
+            s_capped = np.empty_like(s_target)
+            s_capped[0] = min(float(s_target[0]), s_cap)
+            for i in range(1, T):
+                ds_i = float(s_target[i] - s_target[i - 1])
+                v_allow = np.sqrt(max(2.0 * a_eff * (s_cap - s_capped[i - 1]), 0.0))
+                s_capped[i] = min(s_capped[i - 1] + min(ds_i, v_allow * dt), s_cap)
+            s_target = s_capped
 
-    # Initial ego speed from the det plan (keep v[0] continuous with the ego).
-    v0 = float(np.linalg.norm(det_xy[1] - det_xy[0]) / dt)
-
+    # --- 1c. Feasibility: accel/jerk-limited tracking of the demand. ---
     s_feasible, n_fired = _feasible_longitudinal(
-        s_blend, v0, max_accel=max_accel, max_jerk=max_jerk, dt=dt
+        s_target, float(v_det[0]), max_accel=max_accel, max_jerk=max_jerk, dt=dt
     )
-
-    # Feasibility failure: clamps distorted the intended progress too much.
-    terminal_err = abs(float(s_feasible[-1] - s_blend[-1]))
+    terminal_err = abs(float(s_feasible[-1] - s_target[-1]))
     fired_fraction = n_fired / float(max(T - 1, 1))
     if terminal_err > _TERMINAL_PROGRESS_TOL_M or fired_fraction > _CLAMP_FIRE_FRACTION:
         return _ret(
@@ -307,64 +259,74 @@ def build_expert_morph_candidate(
             "infeasible_deceleration",
             terminal_err_m=terminal_err,
             clamp_fire_fraction=fired_fraction,
-            v0_mps=v0,
+            v0_mps=float(v_det[0]),
         )
+    # Numerical standstill hygiene: the tracker's jerk-limited decay leaves a
+    # long tail of sub-centimetre steps. Positions/headings are interpolated
+    # from the arc, so crumb-sized arc motion becomes crumb-sized pose noise —
+    # snap steps below 1 cm to exactly zero so a stop is bit-exact (identical
+    # arcs -> identical interpolated poses -> exact zero yaw and speed, like
+    # logged data).
+    step_arc = np.diff(s_feasible)
+    step_arc[step_arc < 0.01] = 0.0
+    s_feasible = np.concatenate([[s_feasible[0]], s_feasible[0] + np.cumsum(step_arc)])
 
-    d_feasible = _feasible_lateral(d_blend, rate_cap=_DEFAULT_LATERAL_RATE_CAP_MPS, dt=dt)
+    # --- 2. Sample the det plan's own positions + headings at the new arcs. ---
+    # np.interp needs monotone x; s_det is non-decreasing (ties allowed).
+    base_x = np.interp(s_feasible, s_det, det_xy[:, 0])
+    base_y = np.interp(s_feasible, s_det, det_xy[:, 1])
+    th = np.interp(s_feasible, s_det, th_det)
+    # Beyond the det path's end (expert faster than det), continue along the
+    # det plan's terminal heading.
+    over = s_feasible > s_det[-1]
+    if over.any():
+        extra = s_feasible[over] - float(s_det[-1])
+        base_x[over] = det_xy[-1, 0] + extra * np.cos(th_det[-1])
+        base_y[over] = det_xy[-1, 1] + extra * np.sin(th_det[-1])
+        th[over] = th_det[-1]
+    base = np.stack([base_x, base_y], axis=1)
 
-    # Reconstruct ego-frame xy from (s,d): route point at arc s, offset by d
-    # along the SMOOTHED route left-normal. Using a per-vertex smoothed tangent
-    # (not the piecewise per-segment tangent) keeps the normal continuous across
-    # route-segment joins — a per-segment tangent flips there and teleports the
-    # lateral-offset point / spikes the heading.
-    base, _seg_tan = _arc_interp(s_ref, route, s_feasible)
-    theta_ref = _smoothed_tangent_angles(route)
-    theta_q = np.interp(np.clip(s_feasible, 0.0, float(s_ref[-1])), s_ref, theta_ref)
-    unit_tan = np.stack([np.cos(theta_q), np.sin(theta_q)], axis=1)
-    left_normal = np.stack([-unit_tan[:, 1], unit_tan[:, 0]], axis=1)
-    # Lightly smooth the lateral offset to avoid wiggle from noisy projections.
-    d_smooth = _moving_average(d_feasible, 5)
-    recon_xy = base + d_smooth[:, None] * left_normal
+    # --- 3. Lateral merge toward the expert, in the det path's Frenet frame. ---
+    # ONE smooth ease from the det path toward the expert's lateral offset at
+    # the morph's end arc: d(s) = d_end * quintic(arc fraction). The magnitude
+    # is limited analytically so the lateral slope never exceeds the crab-angle
+    # bound — no pointwise clipping, hence no slope discontinuities for the
+    # kinematic gate's SG-smoothed yaw to trip on. A quintic's peak slope is
+    # 1.875/span, so scale = slope_cap*span / (1.875*|d_end|), capped at 1.
+    d_end = 0.0
+    keep = np.concatenate([[True], np.linalg.norm(np.diff(det_xy, axis=0), axis=1) > _EPS])
+    ref_pts = det_xy[keep]
+    if ref_pts.shape[0] >= 2:
+        ref_arc = _cumulative_arc(ref_pts)
+        proj = project_points_to_polyline(expert_xy, ref_pts, ref_arc)
+        a_gt, d_gt = proj[:, 0], proj[:, 1]
+        # Only projections landing in the path INTERIOR are lateral offsets; an
+        # expert that overruns the det path's end projects onto the endpoint
+        # and its longitudinal overhang would masquerade as a lateral gap.
+        interior = (a_gt > _EPS) & (a_gt < float(ref_arc[-1]) - _EPS)
+        if interior.any():
+            a_int, d_int = a_gt[interior], d_gt[interior]
+            if float(np.max(np.abs(d_int))) > _PATHS_DIVERGED_M:
+                return _ret(None, "paths_diverged", max_lateral_gap_m=float(np.max(np.abs(d_int))))
+            # Expert lateral at the arc where the morph ends.
+            a_mono = np.maximum.accumulate(a_int)
+            d_end = float(np.interp(s_feasible[-1], a_mono, d_int))
+    arc_span = max(float(s_feasible[-1] - s_feasible[0]), _EPS)
+    if abs(d_end) > _EPS:
+        scale = min(1.0, _DEFAULT_LATERAL_SLOPE_CAP * arc_span / (1.875 * abs(d_end)))
+    else:
+        scale = 0.0
+    u_arc = (s_feasible - s_feasible[0]) / arc_span
+    d = d_end * scale * _quintic_smoothstep(u_arc, w_max)
 
-    # Heading = smooth route tangent + bounded lateral-rate correction. The
-    # correction is faded out with a SMOOTH speed ramp (not a hard threshold —
-    # a hard cutoff steps the heading as the ego decelerates through it, the
-    # residual end-of-clip yaw jump), so a near-stationary step cannot produce an
-    # atan2 spike (a stop holds the route tangent).
-    ds_dt = np.concatenate([[0.0], np.diff(s_feasible)]) / dt
-    dd_dt = np.concatenate([[0.0], np.diff(d_smooth)]) / dt
-    speed_ramp = np.clip((ds_dt - 0.2) / (0.8 - 0.2), 0.0, 1.0)  # 0 below 0.2 m/s, 1 above 0.8
-    beta = speed_ramp * np.clip(np.arctan2(dd_dt, np.maximum(ds_dt, _EPS)), -0.3, 0.3)
-    heading = theta_q + beta
-
-    # Hard guarantee: cap the per-step yaw rate so no residual spike survives
-    # (e.g. from a route-end tangent edge). Two bounds, matching the reward's
-    # compute_kinematic_gate: the absolute cap AND — when kappa_max is given —
-    # the bicycle-model bound kappa_max * speed (with a safety factor, since the
-    # gate evaluates SG-smoothed signals, not these raw steps). Without the
-    # speed-aware bound a decelerating/stopped morph turns faster than a real
-    # vehicle can at that speed and the gate rejects it (observed: 32/52
-    # expert-waits morphs kinematically gated, all at speed < ~1.3 m/s).
-    # t=0 continuity: start from the det plan's actual heading, not the route
-    # tangent (a tangent snap at t=0 is itself an infeasible yaw step).
-    # The reward gate evaluates SG-SMOOTHED heading vs SG-SMOOTHED speed, so the
-    # raw caps must be conservative: below _HEADING_FREEZE_SPEED_MPS the heading
-    # is frozen outright — SG smoothing bleeds pre-stop heading change into the
-    # stopped region, where the curvature bound collapses to ~0 and even
-    # milli-rad/s residuals fire the gate (observed at SG speeds of 0.06-0.11 m/s).
-    _KAPPA_SAFETY = 0.85
-    _HEADING_FREEZE_SPEED_MPS = 0.5
-    heading[0] = float(np.arctan2(det[0, 3], det[0, 2])) if det.shape[1] >= 4 else heading[0]
-    for t in range(1, T):
-        yaw_rate_cap = max_yaw_rate
-        if kappa_max is not None:
-            if float(ds_dt[t]) < _HEADING_FREEZE_SPEED_MPS:
-                yaw_rate_cap = 0.0
-            else:
-                yaw_rate_cap = min(yaw_rate_cap, _KAPPA_SAFETY * kappa_max * float(ds_dt[t]))
-        max_yaw_step = yaw_rate_cap * dt
-        dh = (heading[t] - heading[t - 1] + np.pi) % (2 * np.pi) - np.pi
-        heading[t] = heading[t - 1] + float(np.clip(dh, -max_yaw_step, max_yaw_step))
+    left_normal = np.stack([-np.sin(th), np.cos(th)], axis=1)
+    recon_xy = base + d[:, None] * left_normal
+    # Heading correction for the lateral slope; d is a smooth function of the
+    # arc, so beta is smooth and vanishes wherever the arc stops advancing.
+    ds = np.concatenate([[0.0], np.diff(s_feasible)])
+    dd = np.concatenate([[0.0], np.diff(d)])
+    beta = np.where(ds > _EPS, np.arctan2(dd, np.maximum(ds, _EPS)), 0.0)
+    heading = th + beta
 
     out = np.empty((T, 4), dtype=np.float32)
     out[:, 0] = recon_xy[:, 0]
@@ -376,5 +338,5 @@ def build_expert_morph_candidate(
         "ok",
         terminal_err_m=terminal_err,
         clamp_fire_fraction=fired_fraction,
-        v0_mps=v0,
+        v0_mps=float(v_det[0]),
     )

--- a/rlvr/autoresearch/tools/expert_morph.py
+++ b/rlvr/autoresearch/tools/expert_morph.py
@@ -262,28 +262,40 @@ def build_expert_morph_candidate(
             v0_mps=float(v_det[0]),
         )
     # Numerical standstill hygiene: the tracker's jerk-limited decay leaves a
-    # long tail of sub-centimetre steps. Positions/headings are interpolated
-    # from the arc, so crumb-sized arc motion becomes crumb-sized pose noise —
-    # snap steps below 1 cm to exactly zero so a stop is bit-exact (identical
-    # arcs -> identical interpolated poses -> exact zero yaw and speed, like
-    # logged data).
-    step_arc = np.diff(s_feasible)
-    step_arc[step_arc < 0.01] = 0.0
-    s_feasible = np.concatenate([[s_feasible[0]], s_feasible[0] + np.cumsum(step_arc)])
+    # long TAIL of crumb-sized steps after a stop. Positions/headings are
+    # interpolated from the arc, so crumb-sized arc motion becomes crumb-sized
+    # pose noise. Freeze the suffix with < 1 cm of REMAINING motion so a stop
+    # is bit-exact (identical arcs -> identical interpolated poses -> exact
+    # zero yaw and speed, like logged data). Defining the tail by remaining
+    # motion — not by per-step size — keeps slow-creep profiles intact (a
+    # 0.09 m/s queue creep is all sub-centimetre steps but must not park).
+    remaining = s_feasible[-1] - s_feasible
+    tail = remaining < 0.01
+    if tail.any():
+        tail_start = int(np.argmax(tail))
+        s_feasible[tail_start:] = s_feasible[tail_start]
 
     # --- 2. Sample the det plan's own positions + headings at the new arcs. ---
-    # np.interp needs monotone x; s_det is non-decreasing (ties allowed).
-    base_x = np.interp(s_feasible, s_det, det_xy[:, 0])
-    base_y = np.interp(s_feasible, s_det, det_xy[:, 1])
-    th = np.interp(s_feasible, s_det, th_det)
+    # np.interp needs an increasing grid; s_det has TIES where the det plan is
+    # stationary. Tied arcs share a position, but the det heading channel may
+    # rotate in place, so which tie np.interp lands on would be arbitrary —
+    # dedup to the FIRST sample of each tied arc group for a deterministic grid.
+    grid = np.concatenate([[True], np.diff(s_det) > _EPS])
+    s_grid = s_det[grid]
+    x_grid = det_xy[grid, 0]
+    y_grid = det_xy[grid, 1]
+    th_grid = th_det[grid]
+    base_x = np.interp(s_feasible, s_grid, x_grid)
+    base_y = np.interp(s_feasible, s_grid, y_grid)
+    th = np.interp(s_feasible, s_grid, th_grid)
     # Beyond the det path's end (expert faster than det), continue along the
     # det plan's terminal heading.
-    over = s_feasible > s_det[-1]
+    over = s_feasible > s_grid[-1]
     if over.any():
-        extra = s_feasible[over] - float(s_det[-1])
-        base_x[over] = det_xy[-1, 0] + extra * np.cos(th_det[-1])
-        base_y[over] = det_xy[-1, 1] + extra * np.sin(th_det[-1])
-        th[over] = th_det[-1]
+        extra = s_feasible[over] - float(s_grid[-1])
+        base_x[over] = x_grid[-1] + extra * np.cos(th_grid[-1])
+        base_y[over] = y_grid[-1] + extra * np.sin(th_grid[-1])
+        th[over] = th_grid[-1]
     base = np.stack([base_x, base_y], axis=1)
 
     # --- 3. Lateral merge toward the expert, in the det path's Frenet frame. ---

--- a/rlvr/autoresearch/tools/lifelong_replay_memory.py
+++ b/rlvr/autoresearch/tools/lifelong_replay_memory.py
@@ -61,10 +61,13 @@ def _parse_label_quotas(spec: str | None) -> dict[str, float]:
         if "=" not in part:
             raise ValueError(f"--label_quotas entry {part!r} must be label=fraction")
         label, frac_text = part.split("=", 1)
-        frac = float(frac_text)
+        label = label.strip()
+        if not label:
+            raise ValueError(f"--label_quotas entry {part!r} has an empty label")
+        frac = float(frac_text.strip())
         if not 0.0 < frac <= 1.0:
             raise ValueError(f"--label_quotas fraction for {label!r} must be in (0, 1]: {frac}")
-        quotas[label.strip()] = frac
+        quotas[label] = frac
     if sum(quotas.values()) > 1.0 + 1e-9:
         raise ValueError(f"--label_quotas fractions sum to > 1: {quotas}")
     return quotas
@@ -122,12 +125,14 @@ def build_memory(
 
     selected: list[dict[str, Any]] = []
     selected_paths: set[str] = set()
+    selected_buckets: set[str] = set()
 
     def _take(row: dict[str, Any]) -> None:
         path = str(row["scene_path"])
         if path in selected_paths:
             return
         selected_paths.add(path)
+        selected_buckets.add(str(row["bucket"]))
         selected.append(row)
 
     # Per-label quotas first: reserve floor(frac * capacity) top-priority slots
@@ -147,10 +152,15 @@ def build_memory(
             for row in pool[:reserve]:
                 _take(row)
 
-    # Preserve rare buckets next.
+    # Preserve rare buckets next — one representative per bucket. Buckets that
+    # already have a member via the quota pass are REPRESENTED and must be
+    # skipped, otherwise a quota label double-dips (its reserve + a second row
+    # per bucket) and squeezes the majority labels beyond the quota's promise.
     for key in sorted(buckets):
         if len(selected) >= capacity:
             break
+        if key in selected_buckets:
+            continue
         for row in buckets[key]:
             if str(row["scene_path"]) not in selected_paths:
                 _take(row)

--- a/rlvr/autoresearch/tools/lifelong_replay_memory.py
+++ b/rlvr/autoresearch/tools/lifelong_replay_memory.py
@@ -49,6 +49,31 @@ def _bucket(row: dict[str, Any], arc_bin_m: float) -> str:
     return f"arc{arc_bin:05d}|{label}|{variant}"
 
 
+def _parse_label_quotas(spec: str | None) -> dict[str, float]:
+    """Parse ``label=frac,label=frac`` into a dict. Fails loudly on bad input."""
+    if not spec:
+        return {}
+    quotas: dict[str, float] = {}
+    for part in spec.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "=" not in part:
+            raise ValueError(f"--label_quotas entry {part!r} must be label=fraction")
+        label, frac_text = part.split("=", 1)
+        frac = float(frac_text)
+        if not 0.0 < frac <= 1.0:
+            raise ValueError(f"--label_quotas fraction for {label!r} must be in (0, 1]: {frac}")
+        quotas[label.strip()] = frac
+    if sum(quotas.values()) > 1.0 + 1e-9:
+        raise ValueError(f"--label_quotas fractions sum to > 1: {quotas}")
+    return quotas
+
+
+def _row_label(row: dict[str, Any]) -> str:
+    return str(row.get("label") or row.get("failure_label") or "unknown")
+
+
 def build_memory(
     current_rows: list[dict[str, Any]],
     previous_memory: dict[str, Any],
@@ -58,6 +83,7 @@ def build_memory(
     alpha: float,
     beta: float,
     arc_bin_m: float,
+    label_quotas: dict[str, float] | None = None,
 ) -> dict[str, Any]:
     entries: dict[str, dict[str, Any]] = {}
     for row in previous_memory.get("entries", []):
@@ -95,20 +121,51 @@ def build_memory(
         rows.sort(key=lambda r: (-float(r["priority"]), str(r["scene_path"])))
 
     selected: list[dict[str, Any]] = []
-    # Preserve rare buckets first.
+    selected_paths: set[str] = set()
+
+    def _take(row: dict[str, Any]) -> None:
+        path = str(row["scene_path"])
+        if path in selected_paths:
+            return
+        selected_paths.add(path)
+        selected.append(row)
+
+    # Per-label quotas first: reserve floor(frac * capacity) top-priority slots
+    # per label so a dominant label (rb/collision) cannot evict a rarer behavior
+    # class (expert_disagreement) across rounds.
+    scored_rows = [row for rows in buckets.values() for row in rows]
+    if label_quotas:
+        by_label: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for row in scored_rows:
+            by_label[_row_label(row)].append(row)
+        for label, frac in sorted(label_quotas.items()):
+            reserve = int(frac * capacity)
+            pool = sorted(
+                by_label.get(label, []),
+                key=lambda r: (-float(r["priority"]), str(r["scene_path"])),
+            )
+            for row in pool[:reserve]:
+                _take(row)
+
+    # Preserve rare buckets next.
     for key in sorted(buckets):
         if len(selected) >= capacity:
             break
-        selected.append(buckets[key].pop(0))
-    remaining = [row for rows in buckets.values() for row in rows]
+        for row in buckets[key]:
+            if str(row["scene_path"]) not in selected_paths:
+                _take(row)
+                break
+    remaining = [row for row in scored_rows if str(row["scene_path"]) not in selected_paths]
     remaining.sort(key=lambda r: (-float(r["priority"]), str(r["scene_path"])))
-    selected.extend(remaining[: max(0, capacity - len(selected))])
+    for row in remaining[: max(0, capacity - len(selected))]:
+        _take(row)
     selected.sort(key=lambda r: (-float(r["priority"]), str(r["scene_path"])))
     return {
         "capacity": capacity,
         "alpha": alpha,
         "beta": beta,
         "arc_bin_m": arc_bin_m,
+        "label_quotas": dict(label_quotas or {}),
         "entries": selected[:capacity],
     }
 
@@ -124,9 +181,21 @@ def main() -> None:
     parser.add_argument("--alpha", type=float, default=0.5)
     parser.add_argument("--beta", type=float, default=0.5)
     parser.add_argument("--arc_bin_m", type=float, default=25.0)
+    parser.add_argument(
+        "--label_quotas",
+        type=str,
+        default=None,
+        help=(
+            "Reserved capacity fractions per event label, e.g. "
+            "'expert_disagreement=0.25,road_border_crossing=0.2'. Each listed label "
+            "keeps at least floor(frac*capacity) of its top-priority entries so a "
+            "dominant label cannot evict a rarer behavior class across rounds."
+        ),
+    )
     args = parser.parse_args()
     if args.capacity < 1:
         raise ValueError("--capacity must be >= 1")
+    label_quotas = _parse_label_quotas(args.label_quotas)
     rows = _load_jsonl(args.current_credit_jsonl)
     prev = (
         _load_json(args.previous_memory, {"entries": []})
@@ -142,6 +211,7 @@ def main() -> None:
         alpha=args.alpha,
         beta=args.beta,
         arc_bin_m=args.arc_bin_m,
+        label_quotas=label_quotas,
     )
     args.out_memory.parent.mkdir(parents=True, exist_ok=True)
     args.out_replay_scenes.parent.mkdir(parents=True, exist_ok=True)

--- a/rlvr/autoresearch/tools/lifelong_replay_memory.py
+++ b/rlvr/autoresearch/tools/lifelong_replay_memory.py
@@ -67,6 +67,8 @@ def _parse_label_quotas(spec: str | None) -> dict[str, float]:
         frac = float(frac_text.strip())
         if not 0.0 < frac <= 1.0:
             raise ValueError(f"--label_quotas fraction for {label!r} must be in (0, 1]: {frac}")
+        if label in quotas:
+            raise ValueError(f"--label_quotas has duplicate label {label!r}")
         quotas[label] = frac
     if sum(quotas.values()) > 1.0 + 1e-9:
         raise ValueError(f"--label_quotas fractions sum to > 1: {quotas}")

--- a/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
+++ b/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
@@ -1003,8 +1003,50 @@ def _anchor_slice_paths(
             raise ValueError(f"training.anchor.waits_scene_list is empty: {waits_list}")
         n_waits = int(round(frac * n_anchor))
         picked.extend(_sample(waits_pool, n_waits))
-    picked.extend(_sample([p for p in normal_pool if p not in set(picked)], n_anchor - len(picked)))
+    picked_set = set(picked)
+    picked.extend(_sample([p for p in normal_pool if p not in picked_set], n_anchor - len(picked)))
     return picked
+
+
+def _validate_anchor_config(cfg: dict[str, Any]) -> None:
+    """Fail at STARTUP on anchor misconfiguration, not hours into round 1.
+
+    Checks the required fields, the paired waits fields, that the referenced
+    scene lists exist and are non-empty, and that the anchor slice is actually
+    consumable: only the base_sft backend unions the anchor into training —
+    with any other backend the slice would be silently dropped, which this
+    rejects loudly instead.
+    """
+    anchor_cfg = cfg.get("anchor")
+    if not anchor_cfg:
+        # Legacy direct configs may carry the template's nested form; a nested
+        # training.anchor that is NOT lifted would be silently ignored.
+        training_section = cfg.get("training")
+        if isinstance(training_section, dict) and training_section.get("anchor"):
+            raise ValueError(
+                "config has training.anchor but the runner consumes the top-level "
+                "'anchor' key on this config path; move the section to the top level"
+            )
+        return
+    if str(cfg.get("training_backend", "base_sft")) != "base_sft":
+        raise ValueError(
+            "training.anchor is only wired into the base_sft training backend; "
+            "remove the anchor section or use backend 'base_sft'"
+        )
+    missing = [key for key in ("scene_list", "ratio") if not anchor_cfg.get(key)]
+    if missing:
+        raise ValueError(f"training.anchor is missing required fields: {missing}")
+    if (anchor_cfg.get("waits_scene_list") is None) != (anchor_cfg.get("waits_fraction") is None):
+        raise ValueError("training.anchor.waits_scene_list and waits_fraction must be set together")
+    for key in ("scene_list", "waits_scene_list"):
+        value = anchor_cfg.get(key)
+        if value is None:
+            continue
+        path = Path(value)
+        if not path.exists():
+            raise ValueError(f"training.anchor.{key} does not exist: {path}")
+        if not _read_json_list(path):
+            raise ValueError(f"training.anchor.{key} is empty: {path}")
 
 
 def _repair_cmd(
@@ -1845,6 +1887,17 @@ def _print_dry_run_plan(
                 f"CUDA_VISIBLE_DEVICES={gpu_id} {' '.join(repair_cmd)}"
             )
     print(f"[round {round_idx}] memory: {' '.join(memory_cmd)}")
+    anchor_cfg = cfg.get("anchor")
+    if anchor_cfg:
+        print(
+            f"[round {round_idx}] anchor slice: ratio {anchor_cfg['ratio']}:1 from "
+            f"{anchor_cfg['scene_list']}"
+            + (
+                f" (waits {anchor_cfg['waits_fraction']} from {anchor_cfg['waits_scene_list']})"
+                if anchor_cfg.get("waits_scene_list")
+                else ""
+            )
+        )
 
 
 def _derive_event_counts_from_credit_rows(rows: list[dict[str, Any]]) -> dict[str, int]:
@@ -1931,6 +1984,7 @@ def main() -> None:
     args = parser.parse_args()
 
     cfg = _load_config(args.config) if args.config else _config_from_cli_args(args)
+    _validate_anchor_config(cfg)
 
     out = Path(cfg["output_dir"]).resolve()
     out.mkdir(parents=True, exist_ok=True)
@@ -2003,7 +2057,7 @@ def main() -> None:
         repaired_paths = [str(p) for p in _read_json_list(repaired_list_json)]
         replay_paths = [str(p) for p in _read_json_list(replay_json)]
         anchor_paths = _anchor_slice_paths(
-            cfg.get("anchor"), len(repaired_paths) + len(replay_paths), round_idx
+            cfg.get("anchor"), len(set(repaired_paths) | set(replay_paths)), round_idx
         )
         if anchor_paths:
             print(

--- a/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
+++ b/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
@@ -405,7 +405,10 @@ def _config_from_workflow_contract(contract: dict[str, Any]) -> dict[str, Any]:
             "arc_bin_m": float(_first_non_null(replay.get("arc_bin_m"), 25.0)),
             "label_quotas": replay.get("label_quotas"),
         },
-        "anchor": dict(training_section.get("anchor") or {}),
+        # Set only when actually configured — an ever-present empty dict would
+        # make "anchor key present but empty" (a misconfiguration the validator
+        # rejects) indistinguishable from "no anchor".
+        **({"anchor": dict(training_section["anchor"])} if training_section.get("anchor") else {}),
         "training_config": str(training_source)
         if isinstance(training_source, (str, os.PathLike))
         else training_source,
@@ -1019,6 +1022,10 @@ def _validate_anchor_config(cfg: dict[str, Any]) -> None:
     rejects loudly instead.
     """
     anchor_cfg = cfg.get("anchor")
+    if "anchor" in cfg and not anchor_cfg:
+        raise ValueError(
+            "config has an empty 'anchor' section; remove it or fill in scene_list/ratio"
+        )
     if not anchor_cfg:
         # Legacy direct configs may carry the template's nested form; a nested
         # training.anchor that is NOT lifted would be silently ignored.

--- a/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
+++ b/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
@@ -222,6 +222,11 @@ def _config_from_workflow_contract(contract: dict[str, Any]) -> dict[str, Any]:
     rounds = dict(workflow.get("rounds") or {})
     refresh = dict(rounds.get("repair_refresh") or workflow.get("repair_refresh") or {})
     training_section = dict(workflow.get("training") or {})
+    if "anchor" in training_section and not training_section["anchor"]:
+        raise ValueError(
+            "workflow training.anchor is present but empty; remove the section or "
+            "fill in scene_list/ratio"
+        )
 
     scene_list = _contract_scene_list(contract)
     chunk_manifest = _first_non_null(
@@ -1044,8 +1049,13 @@ def _validate_anchor_config(cfg: dict[str, Any]) -> None:
     missing = [key for key in ("scene_list", "ratio") if not anchor_cfg.get(key)]
     if missing:
         raise ValueError(f"training.anchor is missing required fields: {missing}")
+    if float(anchor_cfg["ratio"]) <= 0.0:
+        raise ValueError(f"training.anchor.ratio must be > 0: {anchor_cfg['ratio']}")
     if (anchor_cfg.get("waits_scene_list") is None) != (anchor_cfg.get("waits_fraction") is None):
         raise ValueError("training.anchor.waits_scene_list and waits_fraction must be set together")
+    waits_fraction = anchor_cfg.get("waits_fraction")
+    if waits_fraction is not None and not 0.0 < float(waits_fraction) < 1.0:
+        raise ValueError(f"training.anchor.waits_fraction must be in (0, 1): {waits_fraction}")
     for key in ("scene_list", "waits_scene_list"):
         value = anchor_cfg.get(key)
         if value is None:
@@ -1686,7 +1696,7 @@ def _refresh_repair(
         unrepaired_rows = _read_json_list(unrepaired_path) if unrepaired_path.exists() else []
         if not unrepaired_rows:
             _write_jsonl(input_jsonl, [])
-            return []
+            return [], 0.0
         keep_keys = _credit_row_keys(credit_jsonl)
         stripped = [{k: v for k, v in row.items() if k in keep_keys} for row in unrepaired_rows]
         _write_jsonl(input_jsonl, stripped)

--- a/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
+++ b/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
@@ -402,7 +402,9 @@ def _config_from_workflow_contract(contract: dict[str, Any]) -> dict[str, Any]:
             "alpha": float(_first_non_null(replay.get("alpha"), 0.5)),
             "beta": float(_first_non_null(replay.get("beta"), 0.5)),
             "arc_bin_m": float(_first_non_null(replay.get("arc_bin_m"), 25.0)),
+            "label_quotas": replay.get("label_quotas"),
         },
+        "anchor": dict(training_section.get("anchor") or {}),
         "training_config": str(training_source)
         if isinstance(training_source, (str, os.PathLike))
         else training_source,
@@ -942,6 +944,67 @@ def _union_scene_lists(current_scenes: list[str], replay_scenes: list[str], out_
             seen.add(scene)
             merged.append(scene)
     _write_json(out_path, merged)
+
+
+def _anchor_slice_paths(
+    anchor_cfg: dict[str, Any] | None, n_focus: int, round_idx: int
+) -> list[str]:
+    """Real logged normal scenes unioned into a round's train list.
+
+    Training only on repaired+replay scenes leaves the regularizer with no reach
+    outside the failure distribution — competence drifts on everything the
+    rounds never see. The anchor slice counters this with real logged scenes at
+    ``ratio`` : 1 (anchor : focus), optionally stratified so ``waits_fraction``
+    of the anchors come from a waits/interaction list (scenes where the logged
+    ego stops — the slice most eroded by pro-motion post-training).
+
+    Config (``training.anchor`` in the workflow JSON): ``scene_list`` +
+    ``ratio`` are required when the section is present (fail loudly, no silent
+    defaults); ``waits_scene_list``/``waits_fraction`` must be given together;
+    ``seed`` (default 0) is offset by the round index so each round redraws
+    reproducibly.
+    """
+    if not anchor_cfg:
+        return []
+    missing = [key for key in ("scene_list", "ratio") if not anchor_cfg.get(key)]
+    if missing:
+        raise ValueError(f"training.anchor is missing required fields: {missing}")
+    ratio = float(anchor_cfg["ratio"])
+    if ratio <= 0.0:
+        raise ValueError(f"training.anchor.ratio must be > 0: {ratio}")
+    waits_list = anchor_cfg.get("waits_scene_list")
+    waits_fraction = anchor_cfg.get("waits_fraction")
+    if (waits_list is None) != (waits_fraction is None):
+        raise ValueError("training.anchor.waits_scene_list and waits_fraction must be set together")
+
+    import math as _math
+    import random as _random
+
+    n_anchor = int(_math.ceil(ratio * n_focus))
+    if n_anchor < 1:
+        return []
+    rng = _random.Random(int(anchor_cfg.get("seed", 0)) + round_idx)
+
+    def _sample(pool: list[str], n: int) -> list[str]:
+        if n >= len(pool):
+            return list(pool)
+        return rng.sample(pool, n)
+
+    normal_pool = [str(p) for p in _read_json_list(Path(anchor_cfg["scene_list"]))]
+    if not normal_pool:
+        raise ValueError(f"training.anchor.scene_list is empty: {anchor_cfg['scene_list']}")
+    picked: list[str] = []
+    if waits_list is not None:
+        frac = float(waits_fraction)
+        if not 0.0 < frac < 1.0:
+            raise ValueError(f"training.anchor.waits_fraction must be in (0, 1): {frac}")
+        waits_pool = [str(p) for p in _read_json_list(Path(waits_list))]
+        if not waits_pool:
+            raise ValueError(f"training.anchor.waits_scene_list is empty: {waits_list}")
+        n_waits = int(round(frac * n_anchor))
+        picked.extend(_sample(waits_pool, n_waits))
+    picked.extend(_sample([p for p in normal_pool if p not in set(picked)], n_anchor - len(picked)))
+    return picked
 
 
 def _repair_cmd(
@@ -1916,6 +1979,11 @@ def main() -> None:
             "--arc_bin_m",
             str(mem_cfg.get("arc_bin_m", 25.0)),
         ]
+        if mem_cfg.get("label_quotas"):
+            quotas = mem_cfg["label_quotas"]
+            if isinstance(quotas, dict):
+                quotas = ",".join(f"{k}={v}" for k, v in sorted(quotas.items()))
+            memory_cmd.extend(["--label_quotas", str(quotas)])
         if previous_memory is not None:
             memory_cmd.extend(["--previous_memory", str(previous_memory)])
 
@@ -1934,7 +2002,15 @@ def main() -> None:
 
         repaired_paths = [str(p) for p in _read_json_list(repaired_list_json)]
         replay_paths = [str(p) for p in _read_json_list(replay_json)]
-        _union_scene_lists(repaired_paths, replay_paths, train_input_list)
+        anchor_paths = _anchor_slice_paths(
+            cfg.get("anchor"), len(repaired_paths) + len(replay_paths), round_idx
+        )
+        if anchor_paths:
+            print(
+                f"[round {round_idx}] anchor slice: {len(anchor_paths)} real scenes "
+                f"({len(repaired_paths)} repaired + {len(replay_paths)} replay)"
+            )
+        _union_scene_lists(repaired_paths, [*replay_paths, *anchor_paths], train_input_list)
         if bool(cfg.get("validate_on_repaired_targets", False)):
             cfg["val_scenes"] = str(train_input_list)
 

--- a/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
+++ b/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
@@ -288,6 +288,7 @@ def _config_from_workflow_contract(contract: dict[str, Any]) -> dict[str, Any]:
             "rl_cl_col_sweep",
         ),
         "gt_max_speed": float(_first_non_null(repair.get("gt_max_speed"), 9.0)),
+        "expert_stop_anchor": str(_first_non_null(repair.get("expert_stop_anchor"), "recorded")),
         "scene_batch_size": int(
             _first_non_null(repair.get("generation_batch_size"), repair.get("scene_batch_size"), 8)
         ),
@@ -1122,6 +1123,8 @@ def _repair_cmd(
         cmd.extend(["--expert_morph_max_accel", str(repair_cfg["expert_morph_max_accel"])])
     if "expert_morph_max_jerk" in repair_cfg:
         cmd.extend(["--expert_morph_max_jerk", str(repair_cfg["expert_morph_max_jerk"])])
+    if "expert_stop_anchor" in repair_cfg:
+        cmd.extend(["--expert_stop_anchor", str(repair_cfg["expert_stop_anchor"])])
     if cfg.get("repair_labels"):
         cmd.extend(["--labels", ",".join(cfg["repair_labels"])])
     if bool(cfg.get("enable_conflict_detector", False)):

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -1219,6 +1219,100 @@ def test_replay_memory_preserves_rare_buckets_with_capacity():
     assert len(selected) == 2
 
 
+def test_replay_memory_label_quotas_reserve_capacity():
+    # 20 high-priority rb rows vs 4 low-priority expert rows at capacity 8:
+    # without quotas the expert rows are crowded out beyond the single
+    # rare-bucket pick; a 0.5 expert quota must retain floor(0.5*8)=4 of them.
+    rows = [
+        {
+            "scene_path": f"/tmp/rb_{i}.npz",
+            "label": "road_border_crossing",
+            "route_arc_m": float(i),  # spread over arc bins
+            "variant_kind": "credit",
+            "difficulty": 100.0 + i,
+        }
+        for i in range(20)
+    ]
+    rows += [
+        {
+            "scene_path": f"/tmp/expert_{i}.npz",
+            "label": "expert_disagreement",
+            "route_arc_m": 0.0,
+            "variant_kind": "credit",
+            "difficulty": float(i),
+        }
+        for i in range(4)
+    ]
+
+    baseline = build_memory(
+        rows, {"entries": []}, {}, capacity=8, alpha=1.0, beta=0.0, arc_bin_m=1000.0
+    )
+    n_expert_baseline = sum(1 for r in baseline["entries"] if r["label"] == "expert_disagreement")
+
+    memory = build_memory(
+        rows,
+        {"entries": []},
+        {},
+        capacity=8,
+        alpha=1.0,
+        beta=0.0,
+        arc_bin_m=1000.0,
+        label_quotas={"expert_disagreement": 0.5},
+    )
+    n_expert = sum(1 for r in memory["entries"] if r["label"] == "expert_disagreement")
+    assert len(memory["entries"]) == 8
+    assert n_expert == 4
+    assert n_expert > n_expert_baseline
+    assert memory["label_quotas"] == {"expert_disagreement": 0.5}
+
+
+def test_replay_memory_label_quotas_parse_rejects_bad_spec():
+    from rlvr.autoresearch.tools.lifelong_replay_memory import _parse_label_quotas
+
+    assert _parse_label_quotas(None) == {}
+    assert _parse_label_quotas("a=0.25,b=0.5") == {"a": 0.25, "b": 0.5}
+    with pytest.raises(ValueError):
+        _parse_label_quotas("nofraction")
+    with pytest.raises(ValueError):
+        _parse_label_quotas("a=1.5")
+    with pytest.raises(ValueError):
+        _parse_label_quotas("a=0.7,b=0.7")
+
+
+def test_anchor_slice_paths_ratio_and_waits_stratification(tmp_path):
+    normal = [f"/tmp/normal_{i}.npz" for i in range(100)]
+    waits = [f"/tmp/waits_{i}.npz" for i in range(50)]
+    normal_json = tmp_path / "normal.json"
+    waits_json = tmp_path / "waits.json"
+    normal_json.write_text(json.dumps(normal))
+    waits_json.write_text(json.dumps(waits))
+
+    cfg = {
+        "scene_list": str(normal_json),
+        "ratio": 1.6,
+        "waits_scene_list": str(waits_json),
+        "waits_fraction": 0.25,
+        "seed": 7,
+    }
+    picked = round_runner._anchor_slice_paths(cfg, n_focus=10, round_idx=1)
+    assert len(picked) == 16  # ceil(1.6 * 10)
+    n_waits = sum(1 for p in picked if "waits_" in p)
+    assert n_waits == 4  # round(0.25 * 16)
+    assert len(set(picked)) == len(picked)
+    # reproducible per round, redrawn across rounds
+    assert picked == round_runner._anchor_slice_paths(cfg, n_focus=10, round_idx=1)
+    assert picked != round_runner._anchor_slice_paths(cfg, n_focus=10, round_idx=2)
+
+    # disabled when absent; loud on partial config
+    assert round_runner._anchor_slice_paths(None, n_focus=10, round_idx=1) == []
+    with pytest.raises(ValueError):
+        round_runner._anchor_slice_paths({"scene_list": str(normal_json)}, 10, 1)
+    with pytest.raises(ValueError):
+        round_runner._anchor_slice_paths(
+            {"scene_list": str(normal_json), "ratio": 1.0, "waits_fraction": 0.2}, 10, 1
+        )
+
+
 def test_round_runner_checkpoint_policy_prefers_latest_lora(tmp_path):
     run_dir = tmp_path / "run"
     run_dir.mkdir()
@@ -3385,6 +3479,132 @@ def test_expert_morph_never_reverses():
     morph = build_expert_morph_candidate(det, expert, _straight_route())
     assert morph is not None
     assert np.all(np.diff(morph[:, 0]) >= -1e-4)
+
+
+def test_expert_morph_return_diag_reports_stage():
+    # ok: diag carries the clamp statistics.
+    det = _straight_traj(np.cumsum(np.full(_MORPH_T, 0.4)))
+    expert = _straight_traj(np.zeros(_MORPH_T))
+    morph, diag = build_expert_morph_candidate(det, expert, _straight_route(), return_diag=True)
+    assert morph is not None
+    assert diag["stage"] == "ok"
+    assert "terminal_err_m" in diag and "clamp_fire_fraction" in diag and "v0_mps" in diag
+
+    # infeasible deceleration: rejection reason + statistics.
+    Ts = 20
+    det_fast = _straight_traj(np.cumsum(np.full(Ts, 2.0)))  # 20 m/s
+    expert_stop = _straight_traj(np.zeros(Ts))
+    morph, diag = build_expert_morph_candidate(
+        det_fast, expert_stop, _straight_route(length_m=200.0, n=400), return_diag=True
+    )
+    assert morph is None
+    assert diag["stage"] == "infeasible_deceleration"
+    assert diag["terminal_err_m"] > 0.0
+
+    # unreliable route.
+    morph, diag = build_expert_morph_candidate(
+        det, expert, np.array([[0.0, 0.0], [1.0, 0.0]]), return_diag=True
+    )
+    assert morph is None
+    assert diag["stage"] in {"route_unreliable", "endpoint_overshoot"}
+
+    # default (no return_diag) keeps the plain return type.
+    assert build_expert_morph_candidate(det, expert, _straight_route()) is not None
+
+
+def _morph_outcome_reward_row(total: float, *, rb_crossing: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(
+        total=total,
+        collision_step=None,
+        rb_crossing=rb_crossing,
+        lane_crossing=False,
+        static_crossing=False,
+        kinematic_violated=False,
+        sc_min_dist=1.0,
+        rb_min_dist=1.0,
+    )
+
+
+def _morph_outcome_candidate_row(labels: list[str]) -> dict:
+    return {"moving_collision_step": None, "expert_disagreement": False, "labels": labels}
+
+
+def test_best_safe_candidate_reports_morph_outcome():
+    source_row = {"repair_labels": ["expert_disagreement"], "expert_disagreement_max_dev": 0.5}
+    T = 20
+    expert = np.zeros((T, 4), dtype=np.float32)
+    mover = np.zeros((T, 4), dtype=np.float32)
+    mover[:, 0] = np.arange(T, dtype=np.float32)  # far from the waiting expert
+    morph = np.zeros((T, 4), dtype=np.float32)  # matches the waiting expert
+
+    # morph accepted + wins (near_log -> expert-closeness dominates).
+    idx, meta = _best_safe_candidate(
+        source_row,
+        [_morph_outcome_candidate_row(["clean"]), _morph_outcome_candidate_row(["clean"])],
+        [_morph_outcome_reward_row(5.0), _morph_outcome_reward_row(0.0)],
+        min_static_margin=0.3,
+        target_gt_disagreement_thresh=2.0,
+        candidate_trajs=[mover, morph],
+        reference_traj=expert,
+        morph_index=1,
+    )
+    assert idx == 1
+    assert meta["morph_outcome"] == "selected"
+
+    # morph accepted but loses -> lost_selection + its r2lpl score recorded.
+    far_off = {"repair_labels": ["expert_disagreement"], "expert_disagreement_max_dev": 9.0}
+    idx, meta = _best_safe_candidate(
+        far_off,  # far_offpolicy -> rule-score weight 1.0, expert weight 0.0
+        [_morph_outcome_candidate_row(["clean"]), _morph_outcome_candidate_row(["clean"])],
+        [_morph_outcome_reward_row(5.0), _morph_outcome_reward_row(0.0)],
+        min_static_margin=0.3,
+        target_gt_disagreement_thresh=2.0,
+        candidate_trajs=[mover, morph],
+        reference_traj=expert,
+        morph_index=1,
+    )
+    assert idx == 0
+    assert meta["morph_outcome"] == "lost_selection"
+    assert "morph_r2lpl_score" in meta
+
+    # morph gate-rejected (rb crossing) while a model candidate is safe.
+    idx, meta = _best_safe_candidate(
+        source_row,
+        [
+            _morph_outcome_candidate_row(["clean"]),
+            _morph_outcome_candidate_row(["road_border_crossing"]),
+        ],
+        [_morph_outcome_reward_row(5.0), _morph_outcome_reward_row(0.0, rb_crossing=True)],
+        min_static_margin=0.3,
+        target_gt_disagreement_thresh=2.0,
+        candidate_trajs=[mover, morph],
+        reference_traj=expert,
+        morph_index=1,
+    )
+    assert idx == 0
+    assert meta["morph_outcome"] == "gate_rejected"
+    assert meta["morph_labels"] == ["road_border_crossing"]
+
+    # every candidate gate-rejected -> no_safe_candidate still reports the morph gate.
+    idx, meta = _best_safe_candidate(
+        source_row,
+        [
+            _morph_outcome_candidate_row(["road_border_crossing"]),
+            _morph_outcome_candidate_row(["road_border_crossing"]),
+        ],
+        [
+            _morph_outcome_reward_row(-5.0, rb_crossing=True),
+            _morph_outcome_reward_row(-9.0, rb_crossing=True),
+        ],
+        min_static_margin=0.3,
+        target_gt_disagreement_thresh=2.0,
+        candidate_trajs=[mover, morph],
+        reference_traj=expert,
+        morph_index=1,
+    )
+    assert idx is None
+    assert meta["reason"] == "no_safe_candidate"
+    assert meta["morph_outcome"] == "gate_rejected"
 
 
 # ---------------------------------------------------------------------------

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -3414,10 +3414,6 @@ _MORPH_T = 80
 _MORPH_DT = 0.1
 
 
-def _straight_route(length_m: float = 60.0, n: int = 200) -> np.ndarray:
-    return np.stack([np.linspace(0.0, length_m, n), np.zeros(n)], axis=1)
-
-
 def _straight_traj(xs: np.ndarray) -> np.ndarray:
     xy = np.stack([xs, np.zeros(len(xs))], axis=1)
     return np.concatenate([xy, np.ones((len(xs), 1)), np.zeros((len(xs), 1))], axis=1)
@@ -3427,7 +3423,7 @@ def test_expert_morph_takeoff_advances_toward_expert():
     # det ~stationary, expert ramps forward -> morph must advance to ~expert terminal.
     det = _straight_traj(np.zeros(_MORPH_T))
     expert = _straight_traj(np.cumsum(np.full(_MORPH_T, 0.4)))  # ~4 m/s
-    morph = build_expert_morph_candidate(det, expert, _straight_route())
+    morph = build_expert_morph_candidate(det, expert)
     assert morph is not None
     assert morph.shape == (_MORPH_T, 4)
     # Monotone non-decreasing longitudinal progress (no backward step).
@@ -3443,7 +3439,7 @@ def test_expert_morph_stop_holds_position():
     # the stationary expert (terminal progress well below det's) and stays monotone.
     det = _straight_traj(np.cumsum(np.full(_MORPH_T, 0.4)))  # ~4 m/s
     expert = _straight_traj(np.zeros(_MORPH_T))
-    morph = build_expert_morph_candidate(det, expert, _straight_route())
+    morph = build_expert_morph_candidate(det, expert)
     assert morph is not None
     assert np.all(np.diff(morph[:, 0]) >= -1e-4)
     # Pulled back well short of the det terminal progress ("holds position").
@@ -3461,31 +3457,101 @@ def test_expert_morph_rejects_impossible_deceleration():
     Ts = 20
     det = _straight_traj(np.cumsum(np.full(Ts, 2.0)))  # 20 m/s
     expert = _straight_traj(np.zeros(Ts))
-    route = _straight_route(length_m=200.0, n=400)
-    assert build_expert_morph_candidate(det, expert, route) is None
+    assert build_expert_morph_candidate(det, expert) is None
 
 
-def test_expert_morph_rejects_route_too_short():
-    det = _straight_traj(np.zeros(_MORPH_T))
+def test_expert_morph_rejects_diverged_paths():
+    # Expert far off the det path laterally -> no meaningful merge corridor.
+    det = _straight_traj(np.cumsum(np.full(_MORPH_T, 0.4)))
     expert = _straight_traj(np.cumsum(np.full(_MORPH_T, 0.4)))
-    short_route = np.array([[0.0, 0.0], [1.0, 0.0]])
-    assert build_expert_morph_candidate(det, expert, short_route) is None
+    expert[:, 1] = 12.0
+    morph, diag = build_expert_morph_candidate(det, expert, return_diag=True)
+    assert morph is None
+    assert diag["stage"] == "paths_diverged"
 
 
 def test_expert_morph_never_reverses():
     # A wiggly blend must still yield a monotone longitudinal signal.
     det = _straight_traj(np.cumsum(np.full(_MORPH_T, 0.3)))
     expert = _straight_traj(np.cumsum(np.full(_MORPH_T, 0.5)))
-    morph = build_expert_morph_candidate(det, expert, _straight_route())
+    morph = build_expert_morph_candidate(det, expert)
     assert morph is not None
     assert np.all(np.diff(morph[:, 0]) >= -1e-4)
+
+
+def test_expert_morph_no_lateral_motion_at_standstill():
+    # det moves forward on a laterally-offset line, expert is stopped on the
+    # centerline: after the morph brakes to a stop, the position must FREEZE —
+    # lateral blending must not keep sliding the point sideways (the
+    # "curls onto itself" artifact: crab-walk at standstill).
+    det_xy_x = np.cumsum(np.full(_MORPH_T, 0.4))  # ~4 m/s
+    det = _straight_traj(det_xy_x)
+    det[:, 1] = 1.5  # det path laterally offset from the expert's stop point
+    expert = _straight_traj(np.zeros(_MORPH_T))  # stopped at origin (d=0)
+    morph = build_expert_morph_candidate(det, expert)
+    assert morph is not None
+    step = np.linalg.norm(np.diff(morph[:, :2], axis=0), axis=-1)
+    stopped = step / _MORPH_DT < 0.1
+    assert stopped.any()
+    t_stop = int(np.argmax(stopped))
+    # once stopped, every subsequent step must stay stopped (no curl / drift)
+    assert np.all(step[t_stop:] / _MORPH_DT < 0.1)
+    tail_drift = np.linalg.norm(morph[-1, :2] - morph[t_stop, :2])
+    assert tail_drift < 0.15
+
+
+def test_expert_morph_passes_reward_kinematic_gate():
+    # The acceptance criterion that used to reject 32/52 real expert-waits
+    # morphs: the reward's own kinematic gate (SG-smoothed yaw-rate vs absolute
+    # cap AND bicycle-model curvature bound). Motion-derived heading must pass
+    # it without scenario tuning — including the hard case: braking to a stop
+    # while the route curves.
+    import torch as _torch
+
+    from planner_metrics.config import RewardConfig
+    from planner_metrics.subscores import compute_kinematic_gate
+
+    # Curved route: straight 20 m then a gentle 90-degree bend.
+    a = np.stack([np.linspace(0.0, 20.0, 80), np.zeros(80)], axis=1)
+    ang = np.linspace(-np.pi / 2, 0.0, 120)
+    b = np.stack([20.0 + 15.0 * np.cos(ang), 15.0 + 15.0 * np.sin(ang)], axis=1)
+    route = np.concatenate([a, b[1:]], axis=0)
+
+    # det: constant 4 m/s along the route; expert: stops early (at ~6 m).
+    s_det = np.cumsum(np.full(_MORPH_T, 0.4))
+    det = _traj_along_polyline(route, s_det)
+    s_exp = np.minimum(np.cumsum(np.full(_MORPH_T, 0.2)), 6.0)
+    expert = _traj_along_polyline(route, s_exp)
+
+    morph = build_expert_morph_candidate(det, expert)
+    assert morph is not None
+    cfg = RewardConfig()
+    gate = compute_kinematic_gate(
+        _torch.from_numpy(morph)[None],
+        cfg,
+        _torch.tensor([3.0, 4.5, 1.9]),
+    )
+    assert float(gate[0]) == 1.0
+
+
+def _traj_along_polyline(route: np.ndarray, s_query: np.ndarray) -> np.ndarray:
+    seg = np.diff(route, axis=0)
+    seg_len = np.linalg.norm(seg, axis=1)
+    s_ref = np.concatenate([[0.0], np.cumsum(seg_len)])
+    xs = np.interp(s_query, s_ref, route[:, 0])
+    ys = np.interp(s_query, s_ref, route[:, 1])
+    th = np.arctan2(
+        np.gradient(ys),
+        np.maximum(np.abs(np.gradient(xs)), 1e-9) * np.sign(np.gradient(xs) + 1e-12),
+    )
+    return np.stack([xs, ys, np.cos(th), np.sin(th)], axis=1).astype(np.float32)
 
 
 def test_expert_morph_return_diag_reports_stage():
     # ok: diag carries the clamp statistics.
     det = _straight_traj(np.cumsum(np.full(_MORPH_T, 0.4)))
     expert = _straight_traj(np.zeros(_MORPH_T))
-    morph, diag = build_expert_morph_candidate(det, expert, _straight_route(), return_diag=True)
+    morph, diag = build_expert_morph_candidate(det, expert, return_diag=True)
     assert morph is not None
     assert diag["stage"] == "ok"
     assert "terminal_err_m" in diag and "clamp_fire_fraction" in diag and "v0_mps" in diag
@@ -3494,22 +3560,18 @@ def test_expert_morph_return_diag_reports_stage():
     Ts = 20
     det_fast = _straight_traj(np.cumsum(np.full(Ts, 2.0)))  # 20 m/s
     expert_stop = _straight_traj(np.zeros(Ts))
-    morph, diag = build_expert_morph_candidate(
-        det_fast, expert_stop, _straight_route(length_m=200.0, n=400), return_diag=True
-    )
+    morph, diag = build_expert_morph_candidate(det_fast, expert_stop, return_diag=True)
     assert morph is None
     assert diag["stage"] == "infeasible_deceleration"
     assert diag["terminal_err_m"] > 0.0
 
-    # unreliable route.
-    morph, diag = build_expert_morph_candidate(
-        det, expert, np.array([[0.0, 0.0], [1.0, 0.0]]), return_diag=True
-    )
+    # too short horizon.
+    morph, diag = build_expert_morph_candidate(det[:1], expert[:1], return_diag=True)
     assert morph is None
-    assert diag["stage"] in {"route_unreliable", "endpoint_overshoot"}
+    assert diag["stage"] == "too_short_horizon"
 
     # default (no return_diag) keeps the plain return type.
-    assert build_expert_morph_candidate(det, expert, _straight_route()) is not None
+    assert build_expert_morph_candidate(det, expert) is not None
 
 
 def _morph_outcome_reward_row(total: float, *, rb_crossing: bool = False) -> SimpleNamespace:

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -1277,6 +1277,15 @@ def test_replay_memory_label_quotas_parse_rejects_bad_spec():
         _parse_label_quotas("a=1.5")
     with pytest.raises(ValueError):
         _parse_label_quotas("a=0.7,b=0.7")
+    with pytest.raises(ValueError):
+        _parse_label_quotas("a=0.2,a=0.3")  # duplicate label
+
+
+def test_validate_anchor_config_rejects_empty_section():
+    with pytest.raises(ValueError):
+        round_runner._validate_anchor_config({"anchor": {}})
+    # absent anchor is fine
+    round_runner._validate_anchor_config({})
 
 
 def test_anchor_slice_paths_ratio_and_waits_stratification(tmp_path):

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -3407,7 +3407,7 @@ def test_refresh_repair_returns_empty_when_no_unrepaired_rows(monkeypatch, tmp_p
 
 
 # ---------------------------------------------------------------------------
-# Frenet det->GT morph candidate (expert_morph.build_expert_morph_candidate)
+# det-path re-timing morph candidate (expert_morph.build_expert_morph_candidate)
 # ---------------------------------------------------------------------------
 
 _MORPH_T = 80
@@ -3589,6 +3589,160 @@ def _morph_outcome_reward_row(total: float, *, rb_crossing: bool = False) -> Sim
 
 def _morph_outcome_candidate_row(labels: list[str]) -> dict:
     return {"moving_collision_step": None, "expert_disagreement": False, "labels": labels}
+
+
+def test_replay_memory_quota_does_not_double_dip_rare_buckets():
+    # A quota label whose reserved rows already cover its bucket must NOT get a
+    # second row from the rare-bucket pass (that would squeeze the majority
+    # label beyond the quota's promise).
+    rows = [
+        {
+            "scene_path": f"/tmp/rb_{i}.npz",
+            "label": "road_border_crossing",
+            "route_arc_m": 0.0,
+            "variant_kind": "credit",
+            "difficulty": 100.0 + i,
+        }
+        for i in range(6)
+    ]
+    rows += [
+        {
+            "scene_path": f"/tmp/expert_{i}.npz",
+            "label": "expert_disagreement",
+            "route_arc_m": 0.0,
+            "variant_kind": "credit",
+            "difficulty": float(i),
+        }
+        for i in range(3)
+    ]
+    memory = build_memory(
+        rows,
+        {"entries": []},
+        {},
+        capacity=4,
+        alpha=1.0,
+        beta=0.0,
+        arc_bin_m=1000.0,
+        label_quotas={"expert_disagreement": 0.5},
+    )
+    n_expert = sum(1 for r in memory["entries"] if r["label"] == "expert_disagreement")
+    n_rb = sum(1 for r in memory["entries"] if r["label"] == "road_border_crossing")
+    assert n_expert == 2  # exactly the reserve, not reserve + bucket pick
+    assert n_rb == 2
+
+
+def test_replay_memory_label_quotas_rejects_empty_label():
+    from rlvr.autoresearch.tools.lifelong_replay_memory import _parse_label_quotas
+
+    with pytest.raises(ValueError):
+        _parse_label_quotas("=0.5")
+
+
+def test_kinematic_gate_standstill_noise_passes_turn_in_place_fails():
+    # Pins the low-speed conditioning of compute_kinematic_gate: sub-noise yaw
+    # at standstill must PASS (the fixed false positive), while genuine
+    # turning-in-place above the clamped bound must still FAIL.
+    from planner_metrics.config import RewardConfig
+    from planner_metrics.subscores import compute_kinematic_gate
+
+    cfg = RewardConfig()
+    ego_shape = torch.tensor([3.0, 4.5, 1.9])
+    T = 80
+    # Standstill with tiny heading noise (0.002 rad/s scale) on a fixed point.
+    h = np.cumsum(np.full(T, 0.0002))
+    still = np.stack([np.zeros(T), np.zeros(T), np.cos(h), np.sin(h)], axis=1).astype(np.float32)
+    gate = compute_kinematic_gate(torch.from_numpy(still)[None], cfg, ego_shape)
+    assert float(gate[0]) == 1.0
+    # Standstill turning in place well above kappa_max * 0.1 (but below the
+    # absolute max_yaw_rate cap) must still be caught by the curvature check.
+    kappa_max = cfg.kinematic_margin * np.tan(cfg.max_steer) / 3.0
+    yaw_rate = min(3.0 * kappa_max * 0.1, 0.9 * cfg.max_yaw_rate)
+    h2 = np.cumsum(np.full(T, yaw_rate * 0.1))
+    spin = np.stack([np.zeros(T), np.zeros(T), np.cos(h2), np.sin(h2)], axis=1).astype(np.float32)
+    gate2 = compute_kinematic_gate(torch.from_numpy(spin)[None], cfg, ego_shape)
+    assert float(gate2[0]) == 0.0
+
+
+def test_expert_morph_stops_at_expert_location():
+    # The stop-arc cap must stop the morph AT the expert's stop location
+    # (projected onto the det path), not merely after the expert's traveled
+    # distance. Expert stops at x=20 m, well beyond the braking floor from
+    # 4 m/s, so the projection-based cap is the binding constraint.
+    det = _straight_traj(np.cumsum(np.full(_MORPH_T, 0.4)))  # 4 m/s, 32 m
+    s_exp = np.minimum(np.cumsum(np.full(_MORPH_T, 0.4)), 20.0)
+    expert = _straight_traj(s_exp)
+    morph = build_expert_morph_candidate(det, expert)
+    assert morph is not None
+    assert abs(morph[-1, 0] - 20.5) < 1.0  # expert stop arc + overshoot margin
+
+
+def test_expert_morph_preserves_slow_creep():
+    # Sub-centimetre-step snapping must only affect the standstill TAIL —
+    # a slow queue creep (~0.09 m/s) must not be converted into a full park.
+    det = _straight_traj(np.cumsum(np.full(_MORPH_T, 0.009)))
+    expert = _straight_traj(np.cumsum(np.full(_MORPH_T, 0.009)))
+    morph = build_expert_morph_candidate(det, expert)
+    assert morph is not None
+    assert morph[-1, 0] > 0.5  # creep distance preserved (~0.7 m), not 0
+
+
+def _patience_npz(path, *, red_route: bool, v_profile: np.ndarray) -> None:
+    T = len(v_profile) + 1
+    x = np.concatenate([[0.0], np.cumsum(v_profile * 0.1)])
+    fut = np.stack([x, np.zeros(T), np.zeros(T)], axis=1).astype(np.float32)
+    route = np.zeros((2, 20, 33), dtype=np.float32)
+    route[..., 0] = 1.0  # non-zero xy so lanes read as valid
+    if red_route:
+        route[0, :, 10] = 1.0
+    np.savez(
+        path,
+        route_lanes=route,
+        neighbor_agents_past=np.zeros((4, 31, 11), dtype=np.float32),
+        ego_agent_future=fut,
+    )
+
+
+def test_build_patience_benchmark_synthetic(tmp_path):
+    from rlvr.autoresearch.tools.build_patience_benchmark import build_benchmark
+
+    T = 79
+    # Onset offset: moving at t0, stops mid-horizon (red light on route).
+    onset = np.concatenate([np.full(30, 5.0), np.zeros(T - 30)])
+    _patience_npz(tmp_path / "bag_0000000100.npz", red_route=True, v_profile=onset)
+    # Same event 2 s later: already stopped (same bag, same frame bin).
+    _patience_npz(tmp_path / "bag_0000000120.npz", red_route=True, v_profile=np.zeros(T))
+    # No wait: cruises through (never below the wait speed).
+    _patience_npz(tmp_path / "bag_0000005000.npz", red_route=True, v_profile=np.full(T, 5.0))
+
+    scenes = [
+        str(tmp_path / n)
+        for n in ("bag_0000000100.npz", "bag_0000000120.npz", "bag_0000005000.npz")
+    ]
+    benchmark, pool, stats = build_benchmark(
+        scenes,
+        wait_speed_mps=0.5,
+        min_wait_steps=10,
+        ped_near_m=5.0,
+        event_frame_gap=100,
+        max_scenes=10,
+    )
+    assert stats["pool"] == 2  # the two waiting offsets
+    assert stats["events"] == 1  # deduped to one event
+    assert benchmark == [str(tmp_path / "bag_0000000100.npz")]  # onset preferred
+    assert stats["onset_in_benchmark"] == 1
+
+
+def test_eval_patience_onset_stop_metrics():
+    from rlvr.autoresearch.tools.eval_patience_onset import _stop_metrics
+
+    T = 80
+    stop_at_3s = np.concatenate([np.full(30, 0.5), np.zeros(T - 1 - 30)])
+    xy = np.stack([np.concatenate([[0.0], np.cumsum(stop_at_3s)]), np.zeros(T)], axis=1)
+    m = _stop_metrics(xy, stop_speed=0.5)
+    assert m["stops"] and abs(m["stop_onset_s"] - 3.0) < 0.11
+    never = np.stack([np.arange(T, dtype=float), np.zeros(T)], axis=1)
+    m2 = _stop_metrics(never, stop_speed=0.5)
+    assert not m2["stops"] and m2["stop_onset_s"] is None
 
 
 def test_best_safe_candidate_reports_morph_outcome():

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -3409,10 +3409,11 @@ def test_refresh_repair_returns_empty_when_no_unrepaired_rows(monkeypatch, tmp_p
         raise AssertionError("_run should not be called when there is nothing to re-attempt")
 
     monkeypatch.setattr(round_runner, "_run", _boom)
-    assert (
-        _refresh_repair(cfg, tmp_path / "m.pth", rdir, scope="unrepaired", cycle=0, gpu_ids=[])
-        == []
-    )
+    # Returns the (paths, elapsed) tuple the caller unpacks — a bare [] here
+    # crashed the round loop the first time a refresh found nothing to do.
+    assert _refresh_repair(
+        cfg, tmp_path / "m.pth", rdir, scope="unrepaired", cycle=0, gpu_ids=[]
+    ) == ([], 0.0)
 
 
 # ---------------------------------------------------------------------------
@@ -3554,6 +3555,99 @@ def _traj_along_polyline(route: np.ndarray, s_query: np.ndarray) -> np.ndarray:
         np.maximum(np.abs(np.gradient(xs)), 1e-9) * np.sign(np.gradient(xs) + 1e-12),
     )
     return np.stack([xs, ys, np.cos(th), np.sin(th)], axis=1).astype(np.float32)
+
+
+def test_expert_morph_stop_anchor_overrides_stop_location():
+    # recorded-anchor semantics: the caller-supplied stop point wins over the
+    # expert's traveled distance. Expert travels to 20 m; anchor at 12 m must
+    # pull the stop to ~12.5 (anchor + overshoot margin).
+    det = _straight_traj(np.cumsum(np.full(_MORPH_T, 0.4)))  # 4 m/s
+    s_exp = np.minimum(np.cumsum(np.full(_MORPH_T, 0.4)), 20.0)
+    expert = _straight_traj(s_exp)
+    morph = build_expert_morph_candidate(det, expert, stop_anchor_xy=np.array([12.0, 0.0]))
+    assert morph is not None
+    assert abs(morph[-1, 0] - 12.5) < 1.0
+    # without the anchor the stop lands at the expert's terminal (~20.5 bound)
+    default = build_expert_morph_candidate(det, expert)
+    assert default is not None
+    assert default[-1, 0] > 15.0
+
+
+def test_expert_morph_stop_anchor_floored_by_feasible_stop():
+    # An anchor the ego cannot reach (1 m ahead at 5 m/s) must be floored at
+    # the tracker's shortest feasible stop, not demanded.
+    det = _straight_traj(np.cumsum(np.full(_MORPH_T, 0.5)))  # 5 m/s
+    expert = _straight_traj(np.zeros(_MORPH_T))
+    morph = build_expert_morph_candidate(det, expert, stop_anchor_xy=np.array([1.0, 0.0]))
+    assert morph is not None
+    step = np.linalg.norm(np.diff(morph[:, :2], axis=0), axis=-1)
+    assert (step / _MORPH_DT < 0.5).any()  # it does stop
+    assert morph[-1, 0] > 1.5  # but beyond the infeasible 1 m anchor
+
+
+def test_expert_morph_lateral_slope_cap_honors_w_max():
+    # The analytic lateral magnitude limit must include w_max: at w_max=2 the
+    # quintic's peak slope doubles, and without the factor the crab-angle
+    # bound is violated.
+    from rlvr.autoresearch.tools.expert_morph import _DEFAULT_LATERAL_SLOPE_CAP
+
+    det = _straight_traj(np.cumsum(np.full(_MORPH_T, 0.4)))
+    det[:, 1] = 0.0
+    expert = _straight_traj(np.minimum(np.cumsum(np.full(_MORPH_T, 0.4)), 4.0))
+    expert[:, 1] = 4.0  # large lateral gap, short stop arc
+    morph = build_expert_morph_candidate(det, expert, w_max=2.0)
+    if morph is None:
+        return  # rejected outright is acceptable; the cap claim is about accepted output
+    dd = np.abs(np.diff(morph[:, 1]))
+    ds = (
+        np.linalg.norm(np.diff(morph[:, :2], axis=1), axis=-1)
+        if False
+        else np.abs(np.diff(morph[:, 0]))
+    )
+    moving = ds > 1e-3
+    assert (dd[moving] / ds[moving]).max() <= _DEFAULT_LATERAL_SLOPE_CAP * 1.2 + 1e-6
+
+
+def test_preflight_recorded_anchor_raises_on_missing_field(tmp_path):
+    from rlvr.autoresearch.tools.build_repaired_targets import _preflight_recorded_anchor
+
+    T = 80
+    base = dict(
+        ego_agent_future=np.zeros((T, 3), dtype=np.float32),
+        ego_expert_future=np.zeros((T, 4), dtype=np.float32),
+    )
+    old = tmp_path / "old.npz"
+    np.savez(old, **base)
+    new = tmp_path / "new.npz"
+    np.savez(new, **base, ego_recorded_future=np.zeros((T, 4), dtype=np.float32))
+
+    rows_old = [{"scene_path": str(old), "repair_labels": ["expert_disagreement"]}]
+    rows_new = [{"scene_path": str(new), "repair_labels": ["expert_disagreement"]}]
+    rows_nonexpert = [{"scene_path": str(old), "repair_labels": ["road_border_crossing"]}]
+
+    with pytest.raises(ValueError, match="ego_recorded_future"):
+        _preflight_recorded_anchor(rows_old)
+    _preflight_recorded_anchor(rows_new)  # passes
+    _preflight_recorded_anchor(rows_nonexpert)  # non-expert rows are exempt
+
+
+def test_repair_cmd_forwards_expert_stop_anchor(tmp_path):
+    cfg = {
+        "reward_config": "r.json",
+        "threshold_config": "t.json",
+        "repair_config": {
+            "ego_shape": "4.76,7.24,2.29",
+            "min_margin": 0.3,
+            "expert_stop_anchor": "pseudo",
+        },
+    }
+    cmd = round_runner._repair_cmd(cfg, tmp_path / "m.pth", tmp_path / "c.jsonl", tmp_path)
+    idx = cmd.index("--expert_stop_anchor")
+    assert cmd[idx + 1] == "pseudo"
+    # without the key the flag is omitted (CLI default 'recorded' applies)
+    del cfg["repair_config"]["expert_stop_anchor"]
+    cmd2 = round_runner._repair_cmd(cfg, tmp_path / "m.pth", tmp_path / "c.jsonl", tmp_path)
+    assert "--expert_stop_anchor" not in cmd2
 
 
 def test_expert_morph_return_diag_reports_stage():

--- a/rlvr/configs/r2lpl_workflow_template.json
+++ b/rlvr/configs/r2lpl_workflow_template.json
@@ -46,10 +46,15 @@
     "use_route_cl_guidance": true
   },
   "replay_memory": {
-    "capacity": 16,
+    "capacity": 200,
     "alpha": 0.5,
     "beta": 0.5,
-    "arc_bin_m": 25
+    "arc_bin_m": 25,
+    "label_quotas": {
+      "expert_disagreement": 0.25,
+      "road_border_crossing": 0.2,
+      "moving_collision": 0.2
+    }
   },
   "rounds": {
     "rounds": 1,
@@ -58,6 +63,14 @@
   },
   "training": {
     "backend": "base_sft",
-    "val_scenes": "REPLACE_ME/val_scenes.json"
+    "val_scenes": "REPLACE_ME/val_scenes.json",
+    "anchor": {
+      "_comment": "Real logged normal scenes unioned into every round's train list (ratio : 1 anchor:focus). waits_scene_list = scenes where the logged ego waits (patience anchor); build it with rlvr.autoresearch.tools.build_patience_benchmark --out_pool. Remove this section to train on repaired+replay only (NOT recommended: competence drifts off the failure distribution).",
+      "scene_list": "REPLACE_ME/real_normal_scenes.json",
+      "ratio": 1.6,
+      "waits_scene_list": "REPLACE_ME/waits_interaction_scenes.json",
+      "waits_fraction": 0.25,
+      "seed": 0
+    }
   }
 }

--- a/rlvr/configs/r2lpl_workflow_template.json
+++ b/rlvr/configs/r2lpl_workflow_template.json
@@ -43,7 +43,9 @@
     "variant": "rl_cl_soft_sweep_stretch",
     "noise_low": 0.5,
     "noise_high": 2,
-    "use_route_cl_guidance": true
+    "use_route_cl_guidance": true,
+    "expert_stop_anchor": "recorded",
+    "_comment_expert_stop_anchor": "Where a stopped-expert morph stops: 'recorded' (default; the recorded expert's actual stop position, needs ego_recorded_future in mined scenes) or 'pseudo' (the expert's remaining travel distance from the ego pose; max coverage)."
   },
   "replay_memory": {
     "capacity": 200,

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -2622,6 +2622,22 @@ def _dump_precollision_window(
         if 0 < n_expert < fut_len:
             expert_eaf[n_expert:] = expert_eaf[n_expert - 1]
         scene["ego_expert_future"] = expert_eaf
+        # Recorded expert at its ACTUAL positions, in the live-ego frame (for
+        # overlays/analysis — NOT the repair pseudo-target above). Index 0 is
+        # the recorded ego's CURRENT pose, so the live-vs-recorded divergence
+        # offset is visible; the tail holds the last valid pose like above.
+        recorded_eaf = np.zeros((fut_len, 4), dtype=np.float32)
+        n_recorded = 0
+        for j in range(fut_len):
+            ridx = idx + j
+            if ridx >= len(tl.poses):
+                break
+            rx, ry, rh = _world_pose_to_ego(tl.poses[ridx], live_pose)
+            recorded_eaf[j] = (rx, ry, math.cos(rh), math.sin(rh))
+            n_recorded = j + 1
+        if 0 < n_recorded < fut_len:
+            recorded_eaf[n_recorded:] = recorded_eaf[n_recorded - 1]
+        scene["ego_recorded_future"] = recorded_eaf
         scene["origin"] = np.array("live")
         token = f"{step_k - t_c:+06d}"
         np.savez_compressed(out_dir / f"collision{token}.npz", **scene)


### PR DESCRIPTION
## Summary

Improves the R2LPL lifelong-replay workflow's ability to repair `expert_disagreement` (expert-waits/model-goes) events — the class where the model proceeds while the logged expert yields — and adds the data-distribution and evaluation tooling around it.

### Expert-morph repair candidate (rewritten)

- `expert_morph.build_expert_morph_candidate` is now a **det-path re-timing**: blend the det plan's and the expert's cumulative distance schedules (quintic onset, accel/jerk-limited tracking), then interpolate the det plan's **own positions and headings** at the resulting arcs. Slowing a feasible path preserves kinematic feasibility; a stop is a fixed point with a fixed heading.
- Stopped expert ⇒ the arc is capped at the **expert's stop location projected onto the det path** (braking-parabola anticipation, floored at the tracker's shortest feasible stop) — capping by traveled distance could park the target mid-curve or on a road border.
- Lateral merge toward the expert is one smooth arc-space ease, magnitude-limited analytically (no pointwise clipping), so the offset freezes exactly at standstill (fixes targets that curled onto themselves near the stop point).
- Sub-centimetre arc steps snap to zero so standstill poses are bit-exact.
- The previous route-Frenet construction (independent heading channel + stacked yaw caps / freeze thresholds) is removed.

### Kinematic gate numerical conditioning (`planner_metrics/subscores.py`)

The bicycle-model check `yaw_rate > kappa_max * speed` collapses to a noise-vs-noise comparison as speed → 0 (observed firing at 0.002 rad/s against a bound of kappa_max × mm/s). The bound's speed is now clamped at 0.1 m/s: standstill bound ≈ 2°/s (still catches genuine turning-in-place), behavior above 0.1 m/s unchanged, reward golden tests unaffected.

### Repair pipeline instrumentation

`build_repaired_targets` records per-scene `morph_outcome` (`selected` / `lost_selection` / `gate_rejected` + which global gate) and the synthesis diagnostics in repaired and unrepaired rows, so morph losses are diagnosable from the run artifacts.

### Replay memory + round data distribution

- `lifelong_replay_memory --label_quotas 'label=frac,...'`: reserved per-label capacity so a dominant event label cannot evict a rarer behavior class across rounds.
- `run_lifelong_r2lpl_rounds` `training.anchor` config: unions a seeded sample of real logged normal scenes into every round's train list at a configurable anchor:focus ratio, optionally stratified with a waits/interaction list — training on repaired+replay scenes only leaves the model unanchored off the failure distribution.
- Workflow template: replay capacity set explicitly, default label quotas, anchor section.

### Patience evaluation tools

- `build_patience_benchmark`: scans an NPZ list for waits-during-interaction scenes (ego stationary ≥1 s with a pedestrian near the GT path or a red light on the route), event-deduplicates, prefers wait-onset offsets; also emits the full pool for the anchor slice.
- `eval_patience_onset`: dual-model deterministic eval reporting fail-to-stop, stop-onset delay vs GT, and over-distance.

## Testing

- 219 tests pass (R2LPL lifelong suite + reward golden/gates/parity + planner_metrics), including new tests: gate-acceptance of the morph on a curved route, standstill freeze (no lateral drift after stopping), diverged-paths rejection, label-quota reservation, anchor-slice ratio/stratification/reproducibility.
- Repair validated end-to-end on a mined expert-disagreement event set: all events repaired; remaining morph rejections are semantically justified (stop location near a road border → model-generated candidates repair those scenes instead) and fully attributed in the row metadata.
<img width="827" height="846" alt="g000000000480_6ab618b021_13-05-58_00000000_0_56_danger_expert_disagreement__credit-00024" src="https://github.com/user-attachments/assets/5cd59e92-4d61-4643-8e28-7ead0965c023" />
<img width="827" height="846" alt="g000000000480_6ab618b021_13-05-58_00000000_0_56_danger_expert_disagreement__credit-00026" src="https://github.com/user-attachments/assets/830df298-f991-4328-81d2-fa2896f1f221" />


<img width="827" height="846" alt="g000000000640_6ab618b021_13-05-58_00000000_0_17_danger_expert_disagreement__credit-00017" src="https://github.com/user-attachments/assets/1fd33e2c-852d-4387-b3bd-2e4afc46110a" />


