### PR TITLE
refactor(encoder): feed line/polygon type via embedding, fix pos heading

### DIFF
--- a/diffusion_planner/diffusion_planner/model/module/encoder.py
+++ b/diffusion_planner/diffusion_planner/model/module/encoder.py
@@ -102,7 +102,7 @@ class Encoder(nn.Module):
             drop_path_rate=config.encoder_drop_path_rate,
             hidden_dim=config.hidden_dim,
             depth=config.encoder_mixer_depth,
-            point_dim=2 + POLYGON_TYPE_NUM,
+            num_types=POLYGON_TYPE_NUM,
         )
         self.line_string_encoder = LineEncoder(
             config.line_string_len,
@@ -110,7 +110,7 @@ class Encoder(nn.Module):
             drop_path_rate=config.encoder_drop_path_rate,
             hidden_dim=config.hidden_dim,
             depth=config.encoder_mixer_depth,
-            point_dim=2 + LINE_STRING_TYPE_NUM,
+            num_types=LINE_STRING_TYPE_NUM,
         )
         self.goal_pose_encoder = GoalPoseEncoder(
             drop_path_rate=config.encoder_drop_path_rate,
@@ -570,8 +570,7 @@ class LaneEncoder(nn.Module):
         pos = add_class_type(pos, self._class_type)
 
         B, P, V, _ = x.shape
-        mask_v = torch.sum(torch.ne(x[..., :8], 0), dim=-1).to(x.device) == 0
-        mask_p = torch.sum(~mask_v, dim=-1) == 0
+        mask_p = torch.sum(torch.ne(x[..., :8], 0), dim=(-2, -1)) == 0
         valid_indices = ~mask_p.view(-1)
 
         x = x.view(B * P, V, -1)
@@ -613,7 +612,7 @@ class LaneEncoder(nn.Module):
 
 
 class LineEncoder(nn.Module):
-    def __init__(self, line_len, class_type, drop_path_rate, hidden_dim, depth, point_dim=2):
+    def __init__(self, line_len, class_type, drop_path_rate, hidden_dim, depth, num_types):
         super().__init__()
         self._class_type = class_type
         tokens_mlp_dim = 64
@@ -621,8 +620,11 @@ class LineEncoder(nn.Module):
 
         self._line_len = line_len
 
+        # type one-hot is fed via an embedding, not through the Mlp/Mixer
+        self.type_emb = nn.Linear(num_types, channels_mlp_dim)
+
         self.channel_pre_project = Mlp(
-            in_features=point_dim + 2,  # point_dim (x, y, type_one_hot...) + dx + dy
+            in_features=4,  # x, y, dx, dy
             hidden_features=channels_mlp_dim,
             out_features=channels_mlp_dim,
             act_layer=nn.GELU,
@@ -651,50 +653,54 @@ class LineEncoder(nn.Module):
 
     def forward(self, x):
         """
-        x: B, P, V, D(x, y)
+        x: B, P, V, D (x, y, type_one_hot...)
         """
         B, P, V, D = x.shape
-        # diffを取る
-        diff_x = x[:, :, 1:, 0] - x[:, :, :-1, 0]  # (B, P, V-1)
-        diff_y = x[:, :, 1:, 1] - x[:, :, :-1, 1]  # (B, P, V-1)
+
+        # Mask before splitting: an element is empty only if every coord/type is 0.
+        mask_p = torch.sum(torch.ne(x, 0), dim=(-2, -1)) == 0
+        valid_indices = ~mask_p.view(-1)
+
+        # Split coordinates and type one-hot. The type is constant within an element,
+        # so a single representative point is enough.
+        coords = x[..., :2]  # (B, P, V, 2)
+        type_one_hot = x[:, :, 0, 2:]  # (B, P, num_types)
+
+        diff_x = coords[:, :, 1:, 0] - coords[:, :, :-1, 0]  # (B, P, V-1)
+        diff_y = coords[:, :, 1:, 1] - coords[:, :, :-1, 1]  # (B, P, V-1)
         diff_x = torch.cat([diff_x, torch.zeros_like(diff_x[:, :, :1])], dim=2)  # (B, P, V)
         diff_x = diff_x.view(B, P, V, 1)
         diff_y = torch.cat([diff_y, torch.zeros_like(diff_y[:, :, :1])], dim=2)  # (B, P, V)
         diff_y = diff_y.view(B, P, V, 1)
-        x = torch.concat([x, diff_x, diff_y], dim=-1)  # (B, P, V, D+2)
+        feat = torch.concat([coords, diff_x, diff_y], dim=-1)  # (B, P, V, 4): x, y, dx, dy
 
-        pos = x[:, :, int(self._line_len / 2), :4].clone()  # x, y, x'-x, y'-y
+        pos = feat[:, :, int(self._line_len / 2), :4].clone()  # x, y, x'-x, y'-y
         heading = torch.atan2(pos[..., 3], pos[..., 2])
         pos = torch.stack(
             [pos[..., 0], pos[..., 1], torch.cos(heading), torch.sin(heading)], dim=-1
         )
         pos = add_class_type(pos, self._class_type)
 
-        B, P, V, _ = x.shape
-        mask_v = torch.sum(torch.ne(x[..., :4], 0), dim=-1).to(x.device) == 0
-        mask_p = torch.sum(~mask_v, dim=-1) == 0
-        valid_indices = ~mask_p.view(-1)
+        feat = feat.view(B * P, V, -1)
 
-        x = x.view(B * P, V, -1)
-
-        # Use torch.where instead of indexing to maintain fixed size
-        x = torch.where(valid_indices.view(-1, 1, 1), x, torch.zeros_like(x))
-
-        x = self.channel_pre_project(x)
-        x = x.permute(0, 2, 1)
-        x = self.token_pre_project(x)
-        x = x.permute(0, 2, 1)
+        feat = self.channel_pre_project(feat)
+        feat = feat.permute(0, 2, 1)
+        feat = self.token_pre_project(feat)
+        feat = feat.permute(0, 2, 1)
         for block in self.blocks:
-            x = block(x)
+            feat = block(feat)
 
-        x = torch.mean(x, dim=1)
+        feat = torch.mean(feat, dim=1)
 
-        x = self.emb_project(self.norm(x))
+        # Inject type information via embedding instead of through the Mlp/Mixer.
+        feat = feat + self.type_emb(type_one_hot.view(B * P, -1))
+
+        feat = self.emb_project(self.norm(feat))
 
         # Apply mask to zero out invalid positions
-        x = x * valid_indices.float().unsqueeze(-1)
+        feat = feat * valid_indices.float().unsqueeze(-1)
 
-        return x.view(B, P, -1), mask_p.reshape(B, -1), pos.view(B, P, -1)
+        return feat.view(B, P, -1), mask_p.reshape(B, -1), pos.view(B, P, -1)
 
 
 class GoalPoseEncoder(nn.Module):


### PR DESCRIPTION
## Summary

Refactors LineEncoder (used for polygons and line strings) to inject the class type through a dedicated embedding instead of passing it through the Mlp/Mixer. Also simplifies the mask computation and fixes a latent bug in the position heading.

## Changes

- Inject type via embedding: Instead of feeding the type one-hot through the Mlp/Mixer, it is now added after pooling via type_emb (nn.Linear(num_types, channels_mlp_dim)). The Mlp input is reduced to just (x, y, dx, dy) (4 dims).
- Argument rename: LineEncoder's point_dim → num_types. Callers now pass POLYGON_TYPE_NUM / LINE_STRING_TYPE_NUM instead of 2 + *_TYPE_NUM.
- Fix pos heading: Previously the type one-hot leaked into pos[:4] due to the concat ordering, so heading was computed from the type channels. By building feat = [x, y, dx, dy] from coords and diffs, heading = atan2(dy, dx) is now computed correctly.
- Simplify mask computation: Removed the intermediate mask_v in LineEncoder and LaneEncoder; mask_p is now computed directly.
- Remove redundant op: Dropped the torch.where zeroing of invalid elements before the Mlp input — invalid elements are already all-zero and get masked at the output.