### PR TITLE
fix: strip DDP module prefix for non-DDP checkpoint load (PR 1/6)

### DIFF
--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -334,7 +334,13 @@ def model_training(args: TrainConfig):
         print(f"Model loaded from {args.resume_model_path}")
         # We always use new wandb run for each training session, so we don't need to load the wandb_id from the model_dict.
         diffusion_planner, optimizer, scheduler, init_epoch, _, model_ema = resume_model(
-            args.resume_model_path, diffusion_planner, optimizer, scheduler, model_ema, args.device
+            args.resume_model_path,
+            diffusion_planner,
+            optimizer,
+            scheduler,
+            model_ema,
+            args.device,
+            use_ddp=args.ddp,
         )
 
         # Override learning rate with the new value

--- a/diffusion_planner/diffusion_planner/utils/train_utils.py
+++ b/diffusion_planner/diffusion_planner/utils/train_utils.py
@@ -1,5 +1,6 @@
 import json
 import random
+from typing import Any
 
 import numpy as np
 import torch
@@ -81,17 +82,31 @@ def get_epoch_mean_loss(epoch_loss):
     return epoch_mean_loss
 
 
-def resume_model(path: str, model, optimizer, scheduler, ema, device):
+def strip_module_prefix(state_dict: dict[str, Any]) -> dict[str, Any]:
+    """Remove DDP ``module.`` prefix from checkpoint keys."""
+    return {
+        k.replace("module.", "", 1) if k.startswith("module.") else k: v
+        for k, v in state_dict.items()
+    }
+
+
+def resume_model(path: str, model, optimizer, scheduler, ema, device, use_ddp: bool = False):
     """
     load ckpt from path
     """
     ckpt = torch.load(path, map_location=device)
 
     # load model
-    try:
-        model.load_state_dict(ckpt["model"])
-    except:
-        model.load_state_dict(ckpt)
+    if use_ddp:
+        try:
+            model.load_state_dict(ckpt["model"])
+        except:
+            model.load_state_dict(ckpt)
+    else:
+        try:
+            model.load_state_dict(strip_module_prefix(ckpt["model"]))
+        except:
+            model.load_state_dict(strip_module_prefix(ckpt))
     print("Model load done")
 
     # load optimizer
@@ -123,7 +138,10 @@ def resume_model(path: str, model, optimizer, scheduler, ema, device):
         wandb_id = None
 
     try:
-        ema.ema.load_state_dict(ckpt["ema_state_dict"])
+        ema_state = ckpt["ema_state_dict"]
+        if not use_ddp:
+            ema_state = strip_module_prefix(ema_state)
+        ema.ema.load_state_dict(ema_state)
         ema.ema.eval()
         for p in ema.ema.parameters():
             p.requires_grad_(False)

--- a/diffusion_planner/train_grpo_predictor.py
+++ b/diffusion_planner/train_grpo_predictor.py
@@ -521,7 +521,13 @@ def model_training(args):
     if args.resume_model_path is not None:
         print(f"Model loaded from {args.resume_model_path}")
         diffusion_planner, optimizer, scheduler, init_epoch, wandb_id, model_ema = resume_model(
-            args.resume_model_path, diffusion_planner, optimizer, scheduler, model_ema, args.device
+            args.resume_model_path,
+            diffusion_planner,
+            optimizer,
+            scheduler,
+            model_ema,
+            args.device,
+            use_ddp=args.ddp,
         )
         # GRPO restarts the LR schedule from the configured base rate.
         for param_group in optimizer.param_groups:

--- a/diffusion_planner/valid_predictor.py
+++ b/diffusion_planner/valid_predictor.py
@@ -206,6 +206,7 @@ def run_validation(valid_cfg: ValidConfig):
         None,  # scheduler is not needed
         model_ema,
         valid_cfg.device,
+        use_ddp=valid_cfg.ddp,
     )
 
     if valid_cfg.ddp:


### PR DESCRIPTION
## Summary

Split stack **1/6** for [tier4/Diffusion-Planner#205](https://github.com/tier4/Diffusion-Planner/pull/205) (Odaiba grouped closed-loop eval).

DDP training saves `state_dict` keys with a `module.` prefix. Single-GPU smoke, `valid_predictor.py`, and GRPO resume need bare keys. Adds `strip_module_prefix()` and threads `use_ddp=args.ddp` through `resume_model()`.

## Files

- `diffusion_planner/diffusion_planner/utils/train_utils.py` — `strip_module_prefix`, `resume_model(..., use_ddp=False)`
- `diffusion_planner/diffusion_planner/train.py` — pass `use_ddp=args.ddp` on resume
- `diffusion_planner/valid_predictor.py` — pass `use_ddp=valid_cfg.ddp`
- `diffusion_planner/train_grpo_predictor.py` — pass `use_ddp=args.ddp`

## Test plan

- [ ] `python diffusion_planner/valid_predictor.py --ddp false ...` loads a DDP-saved `best_model.pth`
- [ ] `torchrun` training with `--ddp true` still resumes correctly

## Notes for reviewers

- [ ] `use_ddp=True` path unchanged from `tier4-main`
- [ ] EMA weights get the same strip treatment as model weights when `use_ddp=False`

## Stack

`PR-01` → `PR-02` → `PR-03` → `PR-04` → `PR-05` → `PR-06`


Made with [Cursor](https://cursor.com)