### PR TITLE
Fixed: SelfAttentionBlock to apply LayerNorm to key/value as well as query.

### DIFF
--- a/diffusion_planner/diffusion_planner/model/module/encoder.py
+++ b/diffusion_planner/diffusion_planner/model/module/encoder.py
@@ -328,9 +328,8 @@ class SelfAttentionBlock(nn.Module):
         )
 
     def forward(self, x, mask):
-        x = x + self.drop_path(
-            self.attn(self.norm1(x), x, x, key_padding_mask=mask, need_weights=False)[0]
-        )
+        y = self.norm1(x)
+        x = x + self.drop_path(self.attn(y, y, y, key_padding_mask=mask, need_weights=False)[0])
         x = x + self.drop_path(self.mlp(self.norm2(x)))
         return x
 

--- a/diffusion_planner/tests/test_self_attention_block.py
+++ b/diffusion_planner/tests/test_self_attention_block.py
@@ -1,0 +1,46 @@
+"""SelfAttentionBlock: pre-LN must be applied to query, key and value alike
+(regression test for the q-only LayerNorm inherited from upstream)."""
+
+import torch
+from diffusion_planner.model.module.encoder import SelfAttentionBlock
+
+
+def _block(dim=32, heads=4):
+    torch.manual_seed(0)
+    return SelfAttentionBlock(dim=dim, heads=heads, dropout=0.0).eval()
+
+
+def test_attn_receives_normalized_qkv():
+    blk = _block()
+    x = torch.randn(2, 7, 32) * 10.0  # large scale so norm1(x) != x
+    mask = torch.zeros(2, 7, dtype=torch.bool)
+
+    captured = {}
+    orig_forward = blk.attn.forward
+
+    def spy(query, key, value, **kwargs):
+        captured["q"], captured["k"], captured["v"] = query, key, value
+        return orig_forward(query, key, value, **kwargs)
+
+    blk.attn.forward = spy
+    blk(x, mask)
+
+    expected = blk.norm1(x)
+    assert torch.allclose(captured["q"], expected)
+    assert torch.allclose(captured["k"], expected)
+    assert torch.allclose(captured["v"], expected)
+
+
+def test_forward_shape_and_grad_with_padding_mask():
+    blk = _block()
+    x = torch.randn(2, 10, 32, requires_grad=True)
+    mask = torch.zeros(2, 10, dtype=torch.bool)
+    mask[:, 7:] = True  # padded tail
+
+    out = blk(x, mask)
+
+    assert out.shape == x.shape
+    assert torch.isfinite(out).all()
+
+    out.sum().backward()
+    assert torch.isfinite(x.grad).all()


### PR DESCRIPTION
 ## Summary
  - Fixed `SelfAttentionBlock` so that pre-LN is applied to key/value as well as query in self-attention (`self.attn(norm1(x), x, x)` → `self.attn(y, y,
  y)` with `y = norm1(x)`), aligning it with the standard pre-LN Transformer formulation
  - The DiT block in the same codebase (`dit.py`) already applies normalization to all of q/k/v; only the encoder side was asymmetric, suggesting an
  oversight rather than an intentional design
  - This was inherited from the upstream [ZhengYinan-AIR/Diffusion-Planner](https://github.com/ZhengYinan-AIR/Diffusion-Planner) implementation, where it
  remains unfixed and unreported.
  - Added a regression test verifying that q/k/v all receive the normalized input, plus a forward/backward sanity check with a padding mask

  ## Test plan
  - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest diffusion_planner/tests/test_self_attention_block.py` — 2 passed
  - Pre-existing failures in `test_data_augmentation.py` and the `test_cluster.py` collection error (missing sklearn) were confirmed to reproduce on clean
  `tier4-main` and are unrelated to this change

  ## ⚠️  Note
  - **This change is not compatible with existing checkpoints.** The model must be retrained for this fix to take effect. Merging should be timed with the
  next full training run.
