### PR TITLE
feat:  Add flip augmentation that mirrors training scenes across the ego axis

### DIFF
--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -15,7 +15,7 @@ from diffusion_planner.model.diffusion_planner import Diffusion_Planner
 from diffusion_planner.train_config import TrainConfig
 from diffusion_planner.train_epoch import train_epoch
 from diffusion_planner.utils import ddp
-from diffusion_planner.utils.data_augmentation import StatePerturbation
+from diffusion_planner.utils.data_augmentation import FlipAugmentation, StatePerturbation
 from diffusion_planner.utils.data_augmentation_bridge import (
     StatePerturbation as BridgeStatePerturbation,
 )
@@ -234,6 +234,11 @@ def model_training(args: TrainConfig):
     else:
         aug = None
 
+    if args.use_flip_augment:
+        flip_aug = FlipAugmentation(flip_prob=args.flip_prob, device=args.device)
+    else:
+        flip_aug = None
+
     # prepare dataset
     train_set = DiffusionPlannerData(args.train_set_list)
     valid_set = DiffusionPlannerData(args.valid_set_list)
@@ -432,7 +437,7 @@ def model_training(args: TrainConfig):
 
         # training step
         train_loss, train_total_loss = train_epoch(
-            train_loader, diffusion_planner, optimizer, args, model_ema, aug
+            train_loader, diffusion_planner, optimizer, args, model_ema, aug, flip_aug
         )
 
         valid_dict = validate_model(diffusion_planner, valid_loader, args)

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -58,6 +58,8 @@ class TrainConfig:
     use_data_augment: bool = True
     augment_prob: float = 0.5
     augment_type: Literal["quintic", "bridge"] = "quintic"
+    use_flip_augment: bool = False
+    flip_prob: float = 0.5
     num_refine: int = 20
     ego_past_noise_std: float = 0.1
     use_smoothing_future_trajectory: bool = True

--- a/diffusion_planner/diffusion_planner/train_epoch.py
+++ b/diffusion_planner/diffusion_planner/train_epoch.py
@@ -4,7 +4,7 @@ from tqdm import tqdm
 
 from diffusion_planner.model.module.decoder import compute_training_loss
 from diffusion_planner.utils import ddp
-from diffusion_planner.utils.data_augmentation import StatePerturbation
+from diffusion_planner.utils.data_augmentation import FlipAugmentation, StatePerturbation
 from diffusion_planner.utils.train_utils import compute_grad_stats, get_epoch_mean_loss
 
 
@@ -32,7 +32,15 @@ def heading_to_cos_sin(x):
     )
 
 
-def train_epoch(data_loader, model, optimizer, args, ema, aug: StatePerturbation = None):
+def train_epoch(
+    data_loader,
+    model,
+    optimizer,
+    args,
+    ema,
+    aug: StatePerturbation = None,
+    flip_aug: FlipAugmentation = None,
+):
     epoch_loss = []
 
     model.train()
@@ -50,6 +58,9 @@ def train_epoch(data_loader, model, optimizer, args, ema, aug: StatePerturbation
 
         ego_future = inputs["ego_agent_future"]
         neighbors_future = inputs["neighbor_agents_future"]
+        if flip_aug is not None:
+            inputs, ego_future, neighbors_future = flip_aug(inputs, ego_future, neighbors_future)
+
         # Normalize to ego-centric
         if aug is not None:
             inputs, ego_future, neighbors_future = aug(inputs, ego_future, neighbors_future)

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -1,6 +1,19 @@
 import numpy as np
 import torch
 
+from diffusion_planner.dimensions import (
+    LB_X,
+    LB_Y,
+    LINE_TYPE_LEFT_START,
+    LINE_TYPE_NUM,
+    LINE_TYPE_RIGHT_START,
+    RB_X,
+    RB_Y,
+    TURN_INDICATOR_OUTPUT_ENABLE_LEFT,
+    TURN_INDICATOR_OUTPUT_ENABLE_RIGHT,
+    Y,
+    dY,
+)
 from diffusion_planner.utils.unicycle_accel_curvature import smoothing_future_trajectory
 
 TIME_INTERVAL = 0.1
@@ -595,3 +608,97 @@ class StatePerturbation:
             return torch.concatenate([interpolated, ego_future[:, P:, :]], axis=1)
         else:
             return interpolated
+
+
+class FlipAugmentation:
+    """
+    Data augmentation that mirrors the whole scene across the ego longitudinal
+    axis (y -> -y) with probability flip_prob per sample.
+
+    Expects ego-centric inputs with `ego_agent_past` / `goal_pose` already in
+    (x, y, cos, sin) form and futures in (x, y, heading) form, i.e. the state
+    they are in right before StatePerturbation in train_epoch. Padding rows are
+    all-zero and stay all-zero under negation and left/right swaps, so no
+    validity masks are needed.
+    """
+
+    def __init__(self, flip_prob: float, device: torch.device | str) -> None:
+        self._flip_prob = flip_prob
+        self._device = torch.device(device)
+
+    @staticmethod
+    def _negate(x, channels, flip):
+        """Negate the given channels of x for flipped samples. flip: (B,) bool."""
+        flipped = x.clone()
+        flipped[..., channels] = -flipped[..., channels]
+        cond = flip.reshape(-1, *([1] * (x.ndim - 1)))
+        return torch.where(cond, flipped, x)
+
+    def _flip_lanes(self, lanes, flip):
+        """
+        Mirror lane segments: negate y components and swap the left/right
+        boundaries and line types. Traffic light one-hot is side-agnostic.
+        """
+        flipped = lanes.clone()
+        flipped[..., Y] = -lanes[..., Y]
+        flipped[..., dY] = -lanes[..., dY]
+        flipped[..., LB_X] = lanes[..., RB_X]
+        flipped[..., LB_Y] = -lanes[..., RB_Y]
+        flipped[..., RB_X] = lanes[..., LB_X]
+        flipped[..., RB_Y] = -lanes[..., LB_Y]
+        left = slice(LINE_TYPE_LEFT_START, LINE_TYPE_LEFT_START + LINE_TYPE_NUM)
+        right = slice(LINE_TYPE_RIGHT_START, LINE_TYPE_RIGHT_START + LINE_TYPE_NUM)
+        flipped[..., left] = lanes[..., right]
+        flipped[..., right] = lanes[..., left]
+        cond = flip.reshape(-1, *([1] * (lanes.ndim - 1)))
+        return torch.where(cond, flipped, lanes)
+
+    def _flip_turn_indicators(self, turn_indicators, flip):
+        left = TURN_INDICATOR_OUTPUT_ENABLE_LEFT
+        right = TURN_INDICATOR_OUTPUT_ENABLE_RIGHT
+        swapped = torch.where(
+            turn_indicators == left,
+            torch.full_like(turn_indicators, right),
+            torch.where(
+                turn_indicators == right,
+                torch.full_like(turn_indicators, left),
+                turn_indicators,
+            ),
+        )
+        return torch.where(flip.reshape(-1, 1), swapped, turn_indicators)
+
+    def __call__(self, inputs, ego_future, neighbors_future):
+        B = ego_future.shape[0]
+        flip = torch.rand(B, device=ego_future.device) < self._flip_prob
+        if not flip.any():
+            return inputs, ego_future, neighbors_future
+
+        # ego_current_state: x, y, cos, sin, vx, vy, ax, ay, steering, yaw_rate
+        inputs["ego_current_state"] = self._negate(
+            inputs["ego_current_state"], [1, 3, 5, 7, 8, 9], flip
+        )
+        # ego_agent_past: x, y, cos, sin
+        inputs["ego_agent_past"] = self._negate(inputs["ego_agent_past"], [1, 3], flip)
+        # goal_pose: x, y, cos, sin
+        inputs["goal_pose"] = self._negate(inputs["goal_pose"], [1, 3], flip)
+        # neighbor_agents_past: x, y, cos, sin, vx, vy, w, l, type(3)
+        inputs["neighbor_agents_past"] = self._negate(
+            inputs["neighbor_agents_past"], [1, 3, 5], flip
+        )
+        # static_objects: x, y, cos, sin, w, l, type(4)
+        inputs["static_objects"] = self._negate(inputs["static_objects"], [1, 3], flip)
+        # polygons / line_strings: x, y, type one-hot...
+        inputs["polygons"] = self._negate(inputs["polygons"], [1], flip)
+        inputs["line_strings"] = self._negate(inputs["line_strings"], [1], flip)
+        # lanes / route_lanes: swap left/right boundaries and line types too
+        inputs["lanes"] = self._flip_lanes(inputs["lanes"], flip)
+        inputs["route_lanes"] = self._flip_lanes(inputs["route_lanes"], flip)
+        # turn indicators: swap ENABLE_LEFT <-> ENABLE_RIGHT
+        inputs["turn_indicators"] = self._flip_turn_indicators(inputs["turn_indicators"], flip)
+
+        # futures: x, y, heading
+        ego_future = self._negate(ego_future, [1, 2], flip)
+        neighbors_future = self._negate(neighbors_future, [1, 2], flip)
+        inputs["ego_agent_future"] = ego_future
+
+        return inputs, ego_future, neighbors_future

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -623,35 +623,41 @@ class FlipAugmentation:
     """
 
     def __init__(self, flip_prob: float, device: torch.device | str) -> None:
+        if not 0.0 <= flip_prob <= 1.0:
+            raise ValueError(f"flip_prob must be in [0, 1], got {flip_prob}")
         self._flip_prob = flip_prob
         self._device = torch.device(device)
 
     @staticmethod
-    def _negate(x, channels, flip):
-        """Negate the given channels of x for flipped samples. flip: (B,) bool."""
-        flipped = x.clone()
-        flipped[..., channels] = -flipped[..., channels]
+    def _negate_(x, channels, flip):
+        """Negate channels in-place for flipped samples without cloning ``x``."""
+        signs = torch.ones((x.shape[0], x.shape[-1]), dtype=x.dtype, device=x.device)
+        sample_sign = 1 - 2 * flip.to(dtype=x.dtype)
+        signs[:, channels] = sample_sign[:, None]
+        x.mul_(signs.reshape(x.shape[0], *([1] * (x.ndim - 2)), x.shape[-1]))
+        return x
+
+    @staticmethod
+    def _swap_slices_(x, left, right, flip):
+        """Conditionally swap equal-width feature slices using bounded temporaries."""
+        left_values = x[..., left]
+        right_values = x[..., right]
+        saved_left = left_values.clone()
         cond = flip.reshape(-1, *([1] * (x.ndim - 1)))
-        return torch.where(cond, flipped, x)
+        left_values.copy_(torch.where(cond, right_values, left_values))
+        right_values.copy_(torch.where(cond, saved_left, right_values))
 
     def _flip_lanes(self, lanes, flip):
         """
         Mirror lane segments: negate y components and swap the left/right
         boundaries and line types. Traffic light one-hot is side-agnostic.
         """
-        flipped = lanes.clone()
-        flipped[..., Y] = -lanes[..., Y]
-        flipped[..., dY] = -lanes[..., dY]
-        flipped[..., LB_X] = lanes[..., RB_X]
-        flipped[..., LB_Y] = -lanes[..., RB_Y]
-        flipped[..., RB_X] = lanes[..., LB_X]
-        flipped[..., RB_Y] = -lanes[..., LB_Y]
+        self._negate_(lanes, [Y, dY, LB_Y, RB_Y], flip)
+        self._swap_slices_(lanes, slice(LB_X, LB_Y + 1), slice(RB_X, RB_Y + 1), flip)
         left = slice(LINE_TYPE_LEFT_START, LINE_TYPE_LEFT_START + LINE_TYPE_NUM)
         right = slice(LINE_TYPE_RIGHT_START, LINE_TYPE_RIGHT_START + LINE_TYPE_NUM)
-        flipped[..., left] = lanes[..., right]
-        flipped[..., right] = lanes[..., left]
-        cond = flip.reshape(-1, *([1] * (lanes.ndim - 1)))
-        return torch.where(cond, flipped, lanes)
+        self._swap_slices_(lanes, left, right, flip)
+        return lanes
 
     def _flip_turn_indicators(self, turn_indicators, flip):
         left = TURN_INDICATOR_OUTPUT_ENABLE_LEFT
@@ -665,40 +671,50 @@ class FlipAugmentation:
                 turn_indicators,
             ),
         )
-        return torch.where(flip.reshape(-1, 1), swapped, turn_indicators)
+        turn_indicators.copy_(torch.where(flip.reshape(-1, 1), swapped, turn_indicators))
+        return turn_indicators
+
+    @staticmethod
+    def _future_flip_channels(future):
+        if future.shape[-1] == 3:  # x, y, heading
+            return [1, 2]
+        if future.shape[-1] == 4:  # x, y, cos, sin
+            return [1, 3]
+        raise ValueError(
+            "future trajectory must end in (x, y, heading) or (x, y, cos, sin), "
+            f"got shape {tuple(future.shape)}"
+        )
 
     def __call__(self, inputs, ego_future, neighbors_future):
-        B = ego_future.shape[0]
-        flip = torch.rand(B, device=ego_future.device) < self._flip_prob
-        if not flip.any():
+        if self._flip_prob == 0.0:
             return inputs, ego_future, neighbors_future
 
+        B = ego_future.shape[0]
+        flip = torch.rand(B, device=ego_future.device) < self._flip_prob
+
         # ego_current_state: x, y, cos, sin, vx, vy, ax, ay, steering, yaw_rate
-        inputs["ego_current_state"] = self._negate(
-            inputs["ego_current_state"], [1, 3, 5, 7, 8, 9], flip
-        )
+        self._negate_(inputs["ego_current_state"], [1, 3, 5, 7, 8, 9], flip)
         # ego_agent_past: x, y, cos, sin
-        inputs["ego_agent_past"] = self._negate(inputs["ego_agent_past"], [1, 3], flip)
+        self._negate_(inputs["ego_agent_past"], [1, 3], flip)
         # goal_pose: x, y, cos, sin
-        inputs["goal_pose"] = self._negate(inputs["goal_pose"], [1, 3], flip)
+        self._negate_(inputs["goal_pose"], [1, 3], flip)
         # neighbor_agents_past: x, y, cos, sin, vx, vy, w, l, type(3)
-        inputs["neighbor_agents_past"] = self._negate(
-            inputs["neighbor_agents_past"], [1, 3, 5], flip
-        )
+        self._negate_(inputs["neighbor_agents_past"], [1, 3, 5], flip)
         # static_objects: x, y, cos, sin, w, l, type(4)
-        inputs["static_objects"] = self._negate(inputs["static_objects"], [1, 3], flip)
+        self._negate_(inputs["static_objects"], [1, 3], flip)
         # polygons / line_strings: x, y, type one-hot...
-        inputs["polygons"] = self._negate(inputs["polygons"], [1], flip)
-        inputs["line_strings"] = self._negate(inputs["line_strings"], [1], flip)
+        self._negate_(inputs["polygons"], [1], flip)
+        self._negate_(inputs["line_strings"], [1], flip)
         # lanes / route_lanes: swap left/right boundaries and line types too
         inputs["lanes"] = self._flip_lanes(inputs["lanes"], flip)
         inputs["route_lanes"] = self._flip_lanes(inputs["route_lanes"], flip)
         # turn indicators: swap ENABLE_LEFT <-> ENABLE_RIGHT
         inputs["turn_indicators"] = self._flip_turn_indicators(inputs["turn_indicators"], flip)
 
-        # futures: x, y, heading
-        ego_future = self._negate(ego_future, [1, 2], flip)
-        neighbors_future = self._negate(neighbors_future, [1, 2], flip)
+        # futures may use either heading or cos/sin representation.
+        self._negate_(ego_future, self._future_flip_channels(ego_future), flip)
+        self._negate_(neighbors_future, self._future_flip_channels(neighbors_future), flip)
         inputs["ego_agent_future"] = ego_future
+        inputs["neighbor_agents_future"] = neighbors_future
 
         return inputs, ego_future, neighbors_future

--- a/diffusion_planner/tests/test_flip_augmentation.py
+++ b/diffusion_planner/tests/test_flip_augmentation.py
@@ -1,0 +1,182 @@
+"""FlipAugmentation: mirror the scene across the ego longitudinal axis (y -> -y),
+swapping left/right lane boundaries, line types and turn indicators."""
+
+import torch
+from diffusion_planner.dimensions import (
+    LB_X,
+    LB_Y,
+    LINE_TYPE_LEFT_START,
+    LINE_TYPE_NUM,
+    LINE_TYPE_RIGHT_START,
+    RB_X,
+    RB_Y,
+    SEGMENT_POINT_DIM,
+    TRAFFIC_LIGHT,
+    Y,
+    dY,
+)
+from diffusion_planner.utils.data_augmentation import FlipAugmentation
+
+B, N, T, P, V = 2, 3, 5, 4, 6
+
+
+def _make_batch(seed=0):
+    g = torch.Generator().manual_seed(seed)
+
+    def r(*shape):
+        return torch.randn(*shape, generator=g)
+
+    inputs = {
+        "ego_current_state": r(B, 10),
+        "ego_agent_past": r(B, T, 4),
+        "goal_pose": r(B, 4),
+        "neighbor_agents_past": r(B, N, T, 11),
+        "static_objects": r(B, P, 10),
+        "polygons": r(B, P, V, 3),
+        "line_strings": r(B, P, V, 4),
+        "lanes": r(B, P, V, SEGMENT_POINT_DIM),
+        "route_lanes": r(B, P, V, SEGMENT_POINT_DIM),
+        "turn_indicators": torch.tensor([[0, 1, 2, 3, 2, 1], [1, 1, 3, 3, 0, 2]]),
+    }
+    # zero padding rows to verify they stay zero
+    inputs["neighbor_agents_past"][:, -1] = 0.0
+    inputs["lanes"][:, -1] = 0.0
+    ego_future = r(B, T, 3)
+    neighbors_future = r(B, N, T, 3)
+    neighbors_future[:, -1] = 0.0
+    return inputs, ego_future, neighbors_future
+
+
+def _clone_batch(inputs, ego_future, neighbors_future):
+    return (
+        {k: v.clone() for k, v in inputs.items()},
+        ego_future.clone(),
+        neighbors_future.clone(),
+    )
+
+
+def test_flip_negates_lateral_components():
+    inputs, ego_future, neighbors_future = _make_batch()
+    orig = _clone_batch(inputs, ego_future, neighbors_future)[0]
+    orig_ego_future = ego_future.clone()
+    orig_neighbors_future = neighbors_future.clone()
+
+    aug = FlipAugmentation(flip_prob=1.0, device="cpu")
+    inputs, ego_future, neighbors_future = aug(inputs, ego_future, neighbors_future)
+
+    # ego_current_state: y, sin, vy, ay, steering, yaw_rate negated; x, cos, vx, ax kept
+    for i in [1, 3, 5, 7, 8, 9]:
+        assert torch.equal(inputs["ego_current_state"][:, i], -orig["ego_current_state"][:, i])
+    for i in [0, 2, 4, 6]:
+        assert torch.equal(inputs["ego_current_state"][:, i], orig["ego_current_state"][:, i])
+
+    # (x, y, cos, sin) tensors: y and sin negated
+    for key in ["ego_agent_past", "goal_pose", "neighbor_agents_past", "static_objects"]:
+        assert torch.equal(inputs[key][..., 1], -orig[key][..., 1])
+        assert torch.equal(inputs[key][..., 3], -orig[key][..., 3])
+        assert torch.equal(inputs[key][..., 0], orig[key][..., 0])
+        assert torch.equal(inputs[key][..., 2], orig[key][..., 2])
+
+    # neighbor vy negated, vx kept
+    assert torch.equal(
+        inputs["neighbor_agents_past"][..., 5], -orig["neighbor_agents_past"][..., 5]
+    )
+    assert torch.equal(inputs["neighbor_agents_past"][..., 4], orig["neighbor_agents_past"][..., 4])
+
+    # polygons / line_strings: y negated, types kept
+    for key in ["polygons", "line_strings"]:
+        assert torch.equal(inputs[key][..., 1], -orig[key][..., 1])
+        assert torch.equal(inputs[key][..., 0], orig[key][..., 0])
+        assert torch.equal(inputs[key][..., 2:], orig[key][..., 2:])
+
+    # futures: y and heading negated
+    assert torch.equal(ego_future[..., 1], -orig_ego_future[..., 1])
+    assert torch.equal(ego_future[..., 2], -orig_ego_future[..., 2])
+    assert torch.equal(ego_future[..., 0], orig_ego_future[..., 0])
+    assert torch.equal(neighbors_future[..., 1], -orig_neighbors_future[..., 1])
+    assert torch.equal(neighbors_future[..., 2], -orig_neighbors_future[..., 2])
+    assert torch.equal(inputs["ego_agent_future"], ego_future)
+
+
+def test_flip_swaps_lane_boundaries_and_line_types():
+    inputs, ego_future, neighbors_future = _make_batch()
+    orig = {k: v.clone() for k, v in inputs.items()}
+
+    aug = FlipAugmentation(flip_prob=1.0, device="cpu")
+    inputs, _, _ = aug(inputs, ego_future, neighbors_future)
+
+    for key in ["lanes", "route_lanes"]:
+        new, old = inputs[key], orig[key]
+        assert torch.equal(new[..., Y], -old[..., Y])
+        assert torch.equal(new[..., dY], -old[..., dY])
+        # left boundary becomes mirrored right boundary and vice versa
+        assert torch.equal(new[..., LB_X], old[..., RB_X])
+        assert torch.equal(new[..., LB_Y], -old[..., RB_Y])
+        assert torch.equal(new[..., RB_X], old[..., LB_X])
+        assert torch.equal(new[..., RB_Y], -old[..., LB_Y])
+        # line type one-hots swap sides
+        left = slice(LINE_TYPE_LEFT_START, LINE_TYPE_LEFT_START + LINE_TYPE_NUM)
+        right = slice(LINE_TYPE_RIGHT_START, LINE_TYPE_RIGHT_START + LINE_TYPE_NUM)
+        assert torch.equal(new[..., left], old[..., right])
+        assert torch.equal(new[..., right], old[..., left])
+        # traffic light one-hot is side-agnostic
+        assert torch.equal(
+            new[..., TRAFFIC_LIGHT:LINE_TYPE_LEFT_START],
+            old[..., TRAFFIC_LIGHT:LINE_TYPE_LEFT_START],
+        )
+
+
+def test_flip_swaps_turn_indicators():
+    inputs, ego_future, neighbors_future = _make_batch()
+
+    aug = FlipAugmentation(flip_prob=1.0, device="cpu")
+    inputs, _, _ = aug(inputs, ego_future, neighbors_future)
+
+    # 2 (ENABLE_LEFT) <-> 3 (ENABLE_RIGHT); 0 / 1 untouched
+    expected = torch.tensor([[0, 1, 3, 2, 3, 1], [1, 1, 2, 2, 0, 3]])
+    assert torch.equal(inputs["turn_indicators"], expected)
+
+
+def test_flip_keeps_padding_rows_zero():
+    inputs, ego_future, neighbors_future = _make_batch()
+
+    aug = FlipAugmentation(flip_prob=1.0, device="cpu")
+    inputs, _, neighbors_future = aug(inputs, ego_future, neighbors_future)
+
+    assert torch.equal(
+        inputs["neighbor_agents_past"][:, -1],
+        torch.zeros_like(inputs["neighbor_agents_past"][:, -1]),
+    )
+    assert torch.equal(inputs["lanes"][:, -1], torch.zeros_like(inputs["lanes"][:, -1]))
+    assert torch.equal(neighbors_future[:, -1], torch.zeros_like(neighbors_future[:, -1]))
+
+
+def test_flip_prob_zero_is_identity():
+    inputs, ego_future, neighbors_future = _make_batch()
+    orig_inputs, orig_ego_future, orig_neighbors_future = _clone_batch(
+        inputs, ego_future, neighbors_future
+    )
+
+    aug = FlipAugmentation(flip_prob=0.0, device="cpu")
+    inputs, ego_future, neighbors_future = aug(inputs, ego_future, neighbors_future)
+
+    for key, val in orig_inputs.items():
+        assert torch.equal(inputs[key], val), key
+    assert torch.equal(ego_future, orig_ego_future)
+    assert torch.equal(neighbors_future, orig_neighbors_future)
+
+
+def test_double_flip_is_identity():
+    inputs, ego_future, neighbors_future = _make_batch()
+    orig_inputs, orig_ego_future, orig_neighbors_future = _clone_batch(
+        inputs, ego_future, neighbors_future
+    )
+
+    aug = FlipAugmentation(flip_prob=1.0, device="cpu")
+    inputs, ego_future, neighbors_future = aug(inputs, ego_future, neighbors_future)
+    inputs, ego_future, neighbors_future = aug(inputs, ego_future, neighbors_future)
+
+    for key, val in orig_inputs.items():
+        assert torch.equal(inputs[key], val), key
+    assert torch.equal(ego_future, orig_ego_future)
+    assert torch.equal(neighbors_future, orig_neighbors_future)

--- a/diffusion_planner/tests/test_flip_augmentation.py
+++ b/diffusion_planner/tests/test_flip_augmentation.py
@@ -1,6 +1,8 @@
 """FlipAugmentation: mirror the scene across the ego longitudinal axis (y -> -y),
 swapping left/right lane boundaries, line types and turn indicators."""
 
+from unittest.mock import patch
+
 import torch
 from diffusion_planner.dimensions import (
     LB_X,
@@ -164,6 +166,78 @@ def test_flip_prob_zero_is_identity():
         assert torch.equal(inputs[key], val), key
     assert torch.equal(ego_future, orig_ego_future)
     assert torch.equal(neighbors_future, orig_neighbors_future)
+
+
+def test_flip_is_in_place_and_updates_future_entries():
+    inputs, ego_future, neighbors_future = _make_batch()
+    input_refs = {key: value for key, value in inputs.items()}
+
+    aug = FlipAugmentation(flip_prob=1.0, device="cpu")
+    inputs, returned_ego, returned_neighbors = aug(inputs, ego_future, neighbors_future)
+
+    for key, ref in input_refs.items():
+        assert inputs[key] is ref, key
+    assert returned_ego is ego_future
+    assert returned_neighbors is neighbors_future
+    assert inputs["ego_agent_future"] is ego_future
+    assert inputs["neighbor_agents_future"] is neighbors_future
+
+
+def test_mixed_batch_only_flips_selected_samples():
+    inputs, ego_future, neighbors_future = _make_batch()
+    orig_inputs, orig_ego_future, orig_neighbors_future = _clone_batch(
+        inputs, ego_future, neighbors_future
+    )
+
+    aug = FlipAugmentation(flip_prob=0.5, device="cpu")
+    with patch(
+        "diffusion_planner.utils.data_augmentation.torch.rand",
+        return_value=torch.tensor([0.1, 0.9]),
+    ):
+        inputs, ego_future, neighbors_future = aug(inputs, ego_future, neighbors_future)
+
+    assert torch.equal(ego_future[0, :, 1:], -orig_ego_future[0, :, 1:])
+    assert torch.equal(ego_future[1], orig_ego_future[1])
+    assert torch.equal(neighbors_future[0, ..., 1:], -orig_neighbors_future[0, ..., 1:])
+    assert torch.equal(neighbors_future[1], orig_neighbors_future[1])
+    assert torch.equal(inputs["ego_current_state"][1], orig_inputs["ego_current_state"][1])
+
+
+def test_four_component_futures_negate_sin_not_cos():
+    inputs, ego_future, neighbors_future = _make_batch()
+    ego_future = torch.cat(
+        [ego_future[..., :2], ego_future[..., 2:].cos(), ego_future[..., 2:].sin()], dim=-1
+    )
+    neighbors_future = torch.cat(
+        [
+            neighbors_future[..., :2],
+            neighbors_future[..., 2:].cos(),
+            neighbors_future[..., 2:].sin(),
+        ],
+        dim=-1,
+    )
+    orig_ego_future = ego_future.clone()
+    orig_neighbors_future = neighbors_future.clone()
+
+    aug = FlipAugmentation(flip_prob=1.0, device="cpu")
+    inputs, ego_future, neighbors_future = aug(inputs, ego_future, neighbors_future)
+
+    assert torch.equal(ego_future[..., 0], orig_ego_future[..., 0])
+    assert torch.equal(ego_future[..., 1], -orig_ego_future[..., 1])
+    assert torch.equal(ego_future[..., 2], orig_ego_future[..., 2])
+    assert torch.equal(ego_future[..., 3], -orig_ego_future[..., 3])
+    assert torch.equal(neighbors_future[..., 2], orig_neighbors_future[..., 2])
+    assert torch.equal(neighbors_future[..., 3], -orig_neighbors_future[..., 3])
+
+
+def test_invalid_flip_probability_is_rejected():
+    for flip_prob in (-0.1, 1.1):
+        try:
+            FlipAugmentation(flip_prob=flip_prob, device="cpu")
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"flip_prob={flip_prob} was accepted")
 
 
 def test_double_flip_is_identity():

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -60,6 +60,18 @@ def get_args(args_list=None):
         "--augment_type", type=str, choices=["quintic", "bridge"], default="quintic"
     )
     parser.add_argument(
+        "--use_flip_augment",
+        default=_train_config_default("use_flip_augment"),
+        type=boolean,
+        help="whether to mirror scenes across the ego longitudinal axis",
+    )
+    parser.add_argument(
+        "--flip_prob",
+        type=float,
+        default=_train_config_default("flip_prob"),
+        help="per-sample probability of applying the flip augmentation",
+    )
+    parser.add_argument(
         "--num_refine", type=int, default=20, help="number of refinement steps for augmentation"
     )
     parser.add_argument(

--- a/diffusion_planner/util_scripts/visualize_flip_augmentation.py
+++ b/diffusion_planner/util_scripts/visualize_flip_augmentation.py
@@ -1,0 +1,156 @@
+"""Verify FlipAugmentation visually and numerically.
+
+Loads npz samples, applies the flip with flip_prob=1.0, renders original vs
+flipped side by side with visualize_inputs, and runs numeric invariant checks
+(double-flip identity, y-negation of futures, left/right boundary mirror,
+padding preservation, turn indicator swap). Exits non-zero if any check fails.
+
+Usage (from the diffusion_planner directory):
+    uv run python util_scripts/visualize_flip_augmentation.py <npz> [<npz> ...] --out_dir <dir>
+"""
+
+import argparse
+import copy
+import sys
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from diffusion_planner.train_epoch import heading_to_cos_sin
+from diffusion_planner.utils.data_augmentation import FlipAugmentation
+from diffusion_planner.utils.visualize_input import visualize_inputs
+
+
+def load_inputs(npz_path: Path) -> dict:
+    """Build the batch dict exactly like train_epoch right before flip_aug is applied."""
+    loaded = np.load(npz_path)
+    data = {}
+    for key, value in loaded.items():
+        if key in ("map_name", "token", "version"):
+            continue
+        t = torch.tensor(np.expand_dims(value, axis=0))
+        if t.dtype == torch.float64:
+            t = t.float()
+        data[key] = t
+    # train_epoch applies these before flip_aug; futures stay (x, y, heading).
+    data["ego_agent_past"] = heading_to_cos_sin(data["ego_agent_past"])
+    data["goal_pose"] = heading_to_cos_sin(data["goal_pose"])
+    return data
+
+
+def apply_flip(flip_aug: FlipAugmentation, inputs: dict) -> dict:
+    """Apply the flip and return a dict with the flipped futures written back in.
+
+    FlipAugmentation returns the flipped futures but only writes ego_agent_future
+    back into the dict, so mirror the returned tensors in for checks/visualization.
+    """
+    work = copy.deepcopy(inputs)
+    ego_f = work["ego_agent_future"].clone()
+    nei_f = work["neighbor_agents_future"].clone()
+    work, ego_f, nei_f = flip_aug(work, ego_f, nei_f)
+    work["ego_agent_future"] = ego_f
+    work["neighbor_agents_future"] = nei_f
+    return work
+
+
+def run_checks(orig: dict, flipped: dict, flip_aug: FlipAugmentation) -> list[str]:
+    failures = []
+
+    def check(name, cond):
+        if not cond:
+            failures.append(name)
+
+    # 1. Double flip == identity (up to float error).
+    twice = apply_flip(flip_aug, flipped)
+    for key in orig:
+        if not torch.is_floating_point(orig[key]):
+            check(f"double-flip identity ({key})", torch.equal(twice[key], orig[key]))
+        else:
+            check(
+                f"double-flip identity ({key})",
+                torch.allclose(twice[key], orig[key], atol=1e-6),
+            )
+
+    # 2. Futures: y and heading negated.
+    check(
+        "ego_future y negated",
+        torch.allclose(
+            flipped["ego_agent_future"][..., 1], -orig["ego_agent_future"][..., 1], atol=1e-6
+        ),
+    )
+    check(
+        "neighbor_future y negated",
+        torch.allclose(
+            flipped["neighbor_agents_future"][..., 1],
+            -orig["neighbor_agents_future"][..., 1],
+            atol=1e-6,
+        ),
+    )
+
+    # 3. Lanes: flipped left boundary == mirrored original right boundary (absolute coords).
+    o, f = orig["lanes"], flipped["lanes"]
+    o_rb = o[..., 0:2] + o[..., 6:8]
+    f_lb = f[..., 0:2] + f[..., 4:6]
+    mirror_o_rb = o_rb.clone()
+    mirror_o_rb[..., 1] = -mirror_o_rb[..., 1]
+    check("lanes L<-R boundary mirror", torch.allclose(f_lb, mirror_o_rb, atol=1e-5))
+
+    # 4. Padding rows stay all-zero.
+    pad_mask = orig["lanes"].abs().sum(dim=(-1, -2)) == 0
+    check("lane padding stays zero", bool(flipped["lanes"][pad_mask].abs().sum() == 0))
+    pad_n = orig["neighbor_agents_past"].abs().sum(dim=(-1, -2)) == 0
+    check(
+        "neighbor padding stays zero",
+        bool(flipped["neighbor_agents_past"][pad_n].abs().sum() == 0),
+    )
+
+    # 5. Turn indicators: 2<->3 swapped, others unchanged.
+    ti_o, ti_f = orig["turn_indicators"], flipped["turn_indicators"]
+    check("turn indicator L->R", torch.equal(ti_f == 3, ti_o == 2))
+    check("turn indicator R->L", torch.equal(ti_f == 2, ti_o == 3))
+    check("turn indicator others", torch.equal((ti_f < 2) | (ti_f > 3), (ti_o < 2) | (ti_o > 3)))
+
+    return failures
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("npz_paths", type=Path, nargs="+")
+    parser.add_argument("--out_dir", type=Path, required=True)
+    args = parser.parse_args()
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    flip_aug = FlipAugmentation(flip_prob=1.0, device="cpu")
+
+    any_fail = False
+    for npz_path in args.npz_paths:
+        orig = load_inputs(npz_path)
+        flipped = apply_flip(flip_aug, orig)
+
+        failures = run_checks(orig, flipped, flip_aug)
+        status = "OK" if not failures else "NG: " + ", ".join(failures)
+        print(f"{npz_path.name}: {status}")
+        any_fail |= bool(failures)
+
+        # Side-by-side render. visualize_inputs mutates its dict -> pass copies.
+        fig, axes = plt.subplots(1, 2, figsize=(20, 9))
+        visualize_inputs(copy.deepcopy(orig), ax=axes[0])
+        axes[0].set_title("original")
+        visualize_inputs(copy.deepcopy(flipped), ax=axes[1])
+        axes[1].set_title("flipped (y -> -y)")
+        fig.suptitle(f"{npz_path.name}   [{status}]", color="red" if failures else "green")
+        out = args.out_dir / f"{npz_path.stem}_flip_check.png"
+        plt.tight_layout()
+        plt.savefig(out, dpi=90, bbox_inches="tight")
+        plt.close(fig)
+        print(f"  -> {out}")
+
+    sys.exit(1 if any_fail else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
  ## Summary
  - Added `FlipAugmentation`, a data augmentation that mirrors the whole scene across the ego longitudinal axis (y → -y) with a per-sample probability
  `flip_prob`
  - Sign flips: y / sin / vy / ay / steering angle / yaw rate of `ego_current_state`; y / sin of `ego_agent_past`, `goal_pose`, `neighbor_agents_past`
  (plus vy), and `static_objects`; y of `polygons` / `line_strings`; y / heading of ego and neighbor futures
  - Side swaps: left/right lane boundaries (`LB_*` ↔ `RB_*` with y negated) and left/right line-type one-hots of `lanes` / `route_lanes` (using the index
  constants from `dimensions.py`); the traffic-light one-hot (green/yellow/red/white/none) is side-agnostic and left untouched
  - `turn_indicators`: `ENABLE_LEFT (2)` ↔ `ENABLE_RIGHT (3)` are swapped, so the turn-indicator GT derived from them stays consistent with the mirrored
  scene
  - Padding rows are all-zero and remain all-zero under both negation and left/right swaps, so no validity masks are needed
  - Wired into `train_epoch` **before** `StatePerturbation` (the flip is a rigid transform, so the downstream perturbation and its collision checks stay
  consistent), with new config fields `use_flip_augment` (default: `False`) and `flip_prob` (default: `0.5`) exposed in `TrainConfig` and the
  `train_predictor.py` CLI. Disabled by default, so existing training setups are unaffected.

  ## Test plan
  - Added `diffusion_planner/tests/test_flip_augmentation.py` (6 tests): per-feature sign flips, boundary/line-type side swaps, turn-indicator swap,
  padding-row preservation, identity at `flip_prob=0`, and double-flip identity
  - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest diffusion_planner/tests/test_flip_augmentation.py` — 6 passed
  - Verified `train.py` / `train_epoch.py` import cleanly and the new CLI flags parse into `TrainConfig`

## Visual verification

  `util_scripts/visualize_flip_augmentation.py` verifies that `FlipAugmentation` mirrors scenes correctly, both
  visually and numerically.

  ### Usage

  Run from the `diffusion_planner` directory:

  ```bash
  uv run python util_scripts/visualize_flip_augmentation.py <npz> [<npz> ...] --out_dir <dir>
  ```

  Example with the mini dataset:

  ```bash
  uv run python util_scripts/visualize_flip_augmentation.py \
    ../../mini_datasets/j6_2231_fullseq_mini_20260707/data/**/valid/**/*.npz \
    --out_dir /tmp/flip_check
  ```

### What it does

  For each npz sample, the script reproduces the exact tensor state right before `flip_aug` is applied in
  `train_epoch` (`heading_to_cos_sin` applied to `ego_agent_past` / `goal_pose`, futures kept as `(x, y, heading)`,
  no normalization), applies `FlipAugmentation` with `flip_prob=1.0`, and then:

  1. **Renders a side-by-side PNG** (`<name>_flip_check.png`) of the original and flipped scenes using the existing
  `visualize_inputs`, so lane boundaries, route, goal, neighbors, static objects, and the ego future can be
  inspected at a glance.
  2. **Runs numeric invariant checks**:
     - double flip == identity for every input tensor
     - `y` / heading of ego and neighbor futures are negated
     - flipped left lane boundary == mirrored original right boundary (absolute coordinates)
     - all-zero padding rows stay all-zero
     - turn indicators are swapped `ENABLE_LEFT <-> ENABLE_RIGHT`, other values unchanged

  Each sample is reported as `OK` or `NG: <failed checks>`, and the check result is also stamped on the figure
  title. The script exits with a non-zero code if any check fails, so it can be used as a regression gate in CI or
  after future changes.


## ⚠️  Notes
  - Japan drives on the left; mirrored scenes follow right-hand-traffic conventions (keep-right, mirrored turn geometry). A high `flip_prob` may distort
  the traffic-side prior, so starting with a low value (0.1–0.3) is recommended.
  - The GRPO training path (`train_grpo_predictor.py`) is not wired up in this PR; it can be added the same way if needed.

