### PR TITLE
feat: Added NeighborDropoutAugmentation to simulate perception misses

### DIFF
--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -15,7 +15,10 @@ from diffusion_planner.model.diffusion_planner import Diffusion_Planner
 from diffusion_planner.train_config import TrainConfig
 from diffusion_planner.train_epoch import train_epoch
 from diffusion_planner.utils import ddp
-from diffusion_planner.utils.data_augmentation import StatePerturbation
+from diffusion_planner.utils.data_augmentation import (
+    NeighborDropoutAugmentation,
+    StatePerturbation,
+)
 from diffusion_planner.utils.data_augmentation_bridge import (
     StatePerturbation as BridgeStatePerturbation,
 )
@@ -234,6 +237,13 @@ def model_training(args: TrainConfig):
     else:
         aug = None
 
+    if args.use_neighbor_dropout:
+        neighbor_dropout = NeighborDropoutAugmentation(
+            dropout_prob=args.neighbor_dropout_prob, device=args.device
+        )
+    else:
+        neighbor_dropout = None
+
     # prepare dataset
     train_set = DiffusionPlannerData(args.train_set_list)
     valid_set = DiffusionPlannerData(args.valid_set_list)
@@ -432,7 +442,7 @@ def model_training(args: TrainConfig):
 
         # training step
         train_loss, train_total_loss = train_epoch(
-            train_loader, diffusion_planner, optimizer, args, model_ema, aug
+            train_loader, diffusion_planner, optimizer, args, model_ema, aug, neighbor_dropout
         )
 
         valid_dict = validate_model(diffusion_planner, valid_loader, args)

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -58,6 +58,8 @@ class TrainConfig:
     use_data_augment: bool = True
     augment_prob: float = 0.5
     augment_type: Literal["quintic", "bridge"] = "quintic"
+    use_neighbor_dropout: bool = False
+    neighbor_dropout_prob: float = 0.1
     num_refine: int = 20
     ego_past_noise_std: float = 0.1
     use_smoothing_future_trajectory: bool = True

--- a/diffusion_planner/diffusion_planner/train_epoch.py
+++ b/diffusion_planner/diffusion_planner/train_epoch.py
@@ -4,7 +4,10 @@ from tqdm import tqdm
 
 from diffusion_planner.model.module.decoder import compute_training_loss
 from diffusion_planner.utils import ddp
-from diffusion_planner.utils.data_augmentation import StatePerturbation
+from diffusion_planner.utils.data_augmentation import (
+    NeighborDropoutAugmentation,
+    StatePerturbation,
+)
 from diffusion_planner.utils.train_utils import compute_grad_stats, get_epoch_mean_loss
 
 
@@ -32,7 +35,15 @@ def heading_to_cos_sin(x):
     )
 
 
-def train_epoch(data_loader, model, optimizer, args, ema, aug: StatePerturbation = None):
+def train_epoch(
+    data_loader,
+    model,
+    optimizer,
+    args,
+    ema,
+    aug: StatePerturbation = None,
+    neighbor_dropout: NeighborDropoutAugmentation = None,
+):
     epoch_loss = []
 
     model.train()
@@ -50,6 +61,11 @@ def train_epoch(data_loader, model, optimizer, args, ema, aug: StatePerturbation
 
         ego_future = inputs["ego_agent_future"]
         neighbors_future = inputs["neighbor_agents_future"]
+        if neighbor_dropout is not None:
+            inputs, ego_future, neighbors_future = neighbor_dropout(
+                inputs, ego_future, neighbors_future
+            )
+
         # Normalize to ego-centric
         if aug is not None:
             inputs, ego_future, neighbors_future = aug(inputs, ego_future, neighbors_future)

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -595,3 +595,34 @@ class StatePerturbation:
             return torch.concatenate([interpolated, ego_future[:, P:, :]], axis=1)
         else:
             return interpolated
+
+
+class NeighborDropoutAugmentation:
+    """
+    Data augmentation that zeroes out whole neighbor agents to simulate
+    perception misses (missed detections, track drops).
+
+    Each valid neighbor is dropped independently with probability
+    dropout_prob. A dropped neighbor is removed from BOTH the past input and
+    the future prediction target, so the model is never asked to predict an
+    agent it cannot see. Padding rows are already all-zero and are left
+    untouched, matching the all-zero-is-invalid convention used by the
+    encoder and the prediction-loss masks.
+    """
+
+    def __init__(self, dropout_prob: float, device: torch.device | str) -> None:
+        self._dropout_prob = dropout_prob
+        self._device = torch.device(device)
+
+    def __call__(self, inputs, ego_future, neighbors_future):
+        past = inputs["neighbor_agents_past"]  # (B, N, T, D)
+        B, N = past.shape[:2]
+
+        valid = torch.sum(torch.ne(past, 0), dim=(-2, -1)) > 0  # (B, N)
+        drop = valid & (torch.rand(B, N, device=past.device) < self._dropout_prob)
+        keep = (~drop).to(past.dtype).view(B, N, 1, 1)
+
+        inputs["neighbor_agents_past"] = past * keep
+        neighbors_future = neighbors_future * keep
+
+        return inputs, ego_future, neighbors_future

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -618,11 +618,14 @@ class NeighborDropoutAugmentation:
         past = inputs["neighbor_agents_past"]  # (B, N, T, D)
         B, N = past.shape[:2]
 
-        valid = torch.sum(torch.ne(past, 0), dim=(-2, -1)) > 0  # (B, N)
+        # Count directly instead of materializing a (B, N, T, D) boolean tensor.
+        valid = torch.count_nonzero(past, dim=(-2, -1)).ne(0)  # (B, N)
         drop = valid & (torch.rand(B, N, device=past.device) < self._dropout_prob)
-        keep = (~drop).to(past.dtype).view(B, N, 1, 1)
+        drop = drop.view(B, N, 1, 1)
 
-        inputs["neighbor_agents_past"] = past * keep
-        neighbors_future = neighbors_future * keep
+        # Training inputs and targets are disposable batch tensors. Mutating them
+        # avoids full-size copies of both neighbor history and future trajectories.
+        past.masked_fill_(drop, 0.0)
+        neighbors_future.masked_fill_(drop, 0.0)
 
         return inputs, ego_future, neighbors_future

--- a/diffusion_planner/tests/test_neighbor_dropout_augmentation.py
+++ b/diffusion_planner/tests/test_neighbor_dropout_augmentation.py
@@ -1,0 +1,98 @@
+"""NeighborDropoutAugmentation: zero out whole neighbor agents (past and future
+together) to simulate perception misses, without touching padding rows."""
+
+import torch
+from diffusion_planner.utils.data_augmentation import NeighborDropoutAugmentation
+
+B, N, T, TF = 2, 5, 4, 6
+
+
+def _make_batch(seed=0):
+    g = torch.Generator().manual_seed(seed)
+    inputs = {
+        "neighbor_agents_past": torch.randn(B, N, T, 11, generator=g),
+        "ego_current_state": torch.randn(B, 10, generator=g),
+    }
+    # last two neighbors are padding (all-zero)
+    inputs["neighbor_agents_past"][:, -2:] = 0.0
+    ego_future = torch.randn(B, TF, 3, generator=g)
+    neighbors_future = torch.randn(B, N, TF, 3, generator=g)
+    neighbors_future[:, -2:] = 0.0
+    return inputs, ego_future, neighbors_future
+
+
+def test_dropout_prob_one_drops_all_valid_neighbors():
+    inputs, ego_future, neighbors_future = _make_batch()
+    orig_ego_current = inputs["ego_current_state"].clone()
+    orig_ego_future = ego_future.clone()
+
+    aug = NeighborDropoutAugmentation(dropout_prob=1.0, device="cpu")
+    inputs, ego_future, neighbors_future = aug(inputs, ego_future, neighbors_future)
+
+    assert torch.equal(
+        inputs["neighbor_agents_past"], torch.zeros_like(inputs["neighbor_agents_past"])
+    )
+    assert torch.equal(neighbors_future, torch.zeros_like(neighbors_future))
+    # ego is untouched
+    assert torch.equal(inputs["ego_current_state"], orig_ego_current)
+    assert torch.equal(ego_future, orig_ego_future)
+
+
+def test_dropout_prob_zero_is_identity():
+    inputs, ego_future, neighbors_future = _make_batch()
+    orig_past = inputs["neighbor_agents_past"].clone()
+    orig_future = neighbors_future.clone()
+
+    aug = NeighborDropoutAugmentation(dropout_prob=0.0, device="cpu")
+    inputs, _, neighbors_future = aug(inputs, ego_future, neighbors_future)
+
+    assert torch.equal(inputs["neighbor_agents_past"], orig_past)
+    assert torch.equal(neighbors_future, orig_future)
+
+
+def test_past_and_future_are_dropped_together():
+    torch.manual_seed(0)
+    inputs, ego_future, neighbors_future = _make_batch()
+    orig_past = inputs["neighbor_agents_past"].clone()
+    orig_future = neighbors_future.clone()
+
+    aug = NeighborDropoutAugmentation(dropout_prob=0.5, device="cpu")
+    inputs, _, neighbors_future = aug(inputs, ego_future, neighbors_future)
+
+    past = inputs["neighbor_agents_past"]
+    for b in range(B):
+        for n in range(N - 2):  # valid neighbors only
+            past_zeroed = torch.equal(past[b, n], torch.zeros_like(past[b, n]))
+            future_zeroed = torch.equal(
+                neighbors_future[b, n], torch.zeros_like(neighbors_future[b, n])
+            )
+            # an agent is either fully kept or fully dropped, consistently
+            assert past_zeroed == future_zeroed
+            if not past_zeroed:
+                assert torch.equal(past[b, n], orig_past[b, n])
+                assert torch.equal(neighbors_future[b, n], orig_future[b, n])
+
+
+def test_padding_rows_stay_zero():
+    inputs, ego_future, neighbors_future = _make_batch()
+
+    aug = NeighborDropoutAugmentation(dropout_prob=0.5, device="cpu")
+    inputs, _, neighbors_future = aug(inputs, ego_future, neighbors_future)
+
+    assert torch.equal(
+        inputs["neighbor_agents_past"][:, -2:],
+        torch.zeros_like(inputs["neighbor_agents_past"][:, -2:]),
+    )
+    assert torch.equal(neighbors_future[:, -2:], torch.zeros_like(neighbors_future[:, -2:]))
+
+
+def test_some_neighbors_survive_at_moderate_prob():
+    torch.manual_seed(0)
+    inputs, ego_future, neighbors_future = _make_batch()
+
+    aug = NeighborDropoutAugmentation(dropout_prob=0.3, device="cpu")
+    inputs, _, _ = aug(inputs, ego_future, neighbors_future)
+
+    # with 6 valid agents and p=0.3, all being dropped is astronomically
+    # unlikely under the fixed seed; guards against inverted keep/drop logic
+    assert inputs["neighbor_agents_past"].abs().sum() > 0

--- a/diffusion_planner/tests/test_neighbor_dropout_augmentation.py
+++ b/diffusion_planner/tests/test_neighbor_dropout_augmentation.py
@@ -23,12 +23,17 @@ def _make_batch(seed=0):
 
 def test_dropout_prob_one_drops_all_valid_neighbors():
     inputs, ego_future, neighbors_future = _make_batch()
+    past_input = inputs["neighbor_agents_past"]
+    future_input = neighbors_future
     orig_ego_current = inputs["ego_current_state"].clone()
     orig_ego_future = ego_future.clone()
 
     aug = NeighborDropoutAugmentation(dropout_prob=1.0, device="cpu")
     inputs, ego_future, neighbors_future = aug(inputs, ego_future, neighbors_future)
 
+    # Disposable training tensors are updated in place to avoid full-size copies.
+    assert inputs["neighbor_agents_past"] is past_input
+    assert neighbors_future is future_input
     assert torch.equal(
         inputs["neighbor_agents_past"], torch.zeros_like(inputs["neighbor_agents_past"])
     )

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -60,6 +60,18 @@ def get_args(args_list=None):
         "--augment_type", type=str, choices=["quintic", "bridge"], default="quintic"
     )
     parser.add_argument(
+        "--use_neighbor_dropout",
+        default=_train_config_default("use_neighbor_dropout"),
+        type=boolean,
+        help="whether to randomly zero out whole neighbor agents (past and future together)",
+    )
+    parser.add_argument(
+        "--neighbor_dropout_prob",
+        type=float,
+        default=_train_config_default("neighbor_dropout_prob"),
+        help="per-agent probability of dropping a valid neighbor",
+    )
+    parser.add_argument(
         "--num_refine", type=int, default=20, help="number of refinement steps for augmentation"
     )
     parser.add_argument(


### PR DESCRIPTION
  ## Summary
  - Added `NeighborDropoutAugmentation`, which zeroes out whole neighbor agents with a per-agent probability `neighbor_dropout_prob` to simulate
  perception misses (missed detections, track drops)
  - A dropped agent is removed from BOTH the past input and the future prediction target, so the model is never asked to predict an agent it cannot see;
  the prediction-loss mask follows automatically from the all-zero-future convention
  - Padding rows are already all-zero and are left untouched
  - Applied in `train_epoch` before `StatePerturbation`; controlled by `use_neighbor_dropout` (default: `False`) and `neighbor_dropout_prob` (default:
  `0.1`) in `TrainConfig` and the CLI. Disabled by default, so existing training setups are unaffected.

  ## Test plan
  - Added `diffusion_planner/tests/test_neighbor_dropout_augmentation.py` (5 tests): prob=1 drops all valid agents while ego stays untouched, prob=0
  identity, past/future dropped consistently per agent, padding rows stay zero, and survivors exist at moderate prob (guards against inverted keep/drop
  logic)
  - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest diffusion_planner/tests/test_neighbor_dropout_augmentation.py` — 5 passed

