### PR TITLE
Feat: Add neighbor noise augmentation

### DIFF
--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -15,7 +15,10 @@ from diffusion_planner.model.diffusion_planner import Diffusion_Planner
 from diffusion_planner.train_config import TrainConfig
 from diffusion_planner.train_epoch import train_epoch
 from diffusion_planner.utils import ddp
-from diffusion_planner.utils.data_augmentation import StatePerturbation
+from diffusion_planner.utils.data_augmentation import (
+    NeighborNoiseAugmentation,
+    StatePerturbation,
+)
 from diffusion_planner.utils.data_augmentation_bridge import (
     StatePerturbation as BridgeStatePerturbation,
 )
@@ -234,6 +237,16 @@ def model_training(args: TrainConfig):
     else:
         aug = None
 
+    if args.use_neighbor_noise:
+        neighbor_noise = NeighborNoiseAugmentation(
+            pos_noise_std=args.neighbor_noise_pos_std,
+            vel_noise_std=args.neighbor_noise_vel_std,
+            heading_noise_std=args.neighbor_noise_heading_std,
+            device=args.device,
+        )
+    else:
+        neighbor_noise = None
+
     # prepare dataset
     train_set = DiffusionPlannerData(args.train_set_list)
     valid_set = DiffusionPlannerData(args.valid_set_list)
@@ -432,7 +445,7 @@ def model_training(args: TrainConfig):
 
         # training step
         train_loss, train_total_loss = train_epoch(
-            train_loader, diffusion_planner, optimizer, args, model_ema, aug
+            train_loader, diffusion_planner, optimizer, args, model_ema, aug, neighbor_noise
         )
 
         valid_dict = validate_model(diffusion_planner, valid_loader, args)

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -58,6 +58,10 @@ class TrainConfig:
     use_data_augment: bool = True
     augment_prob: float = 0.5
     augment_type: Literal["quintic", "bridge"] = "quintic"
+    use_neighbor_noise: bool = False
+    neighbor_noise_pos_std: float = 0.2
+    neighbor_noise_vel_std: float = 0.3
+    neighbor_noise_heading_std: float = 0.05
     num_refine: int = 20
     ego_past_noise_std: float = 0.1
     use_smoothing_future_trajectory: bool = True

--- a/diffusion_planner/diffusion_planner/train_epoch.py
+++ b/diffusion_planner/diffusion_planner/train_epoch.py
@@ -4,7 +4,10 @@ from tqdm import tqdm
 
 from diffusion_planner.model.module.decoder import compute_training_loss
 from diffusion_planner.utils import ddp
-from diffusion_planner.utils.data_augmentation import StatePerturbation
+from diffusion_planner.utils.data_augmentation import (
+    NeighborNoiseAugmentation,
+    StatePerturbation,
+)
 from diffusion_planner.utils.train_utils import compute_grad_stats, get_epoch_mean_loss
 
 
@@ -32,7 +35,15 @@ def heading_to_cos_sin(x):
     )
 
 
-def train_epoch(data_loader, model, optimizer, args, ema, aug: StatePerturbation = None):
+def train_epoch(
+    data_loader,
+    model,
+    optimizer,
+    args,
+    ema,
+    aug: StatePerturbation = None,
+    neighbor_noise: NeighborNoiseAugmentation = None,
+):
     epoch_loss = []
 
     model.train()
@@ -50,6 +61,11 @@ def train_epoch(data_loader, model, optimizer, args, ema, aug: StatePerturbation
 
         ego_future = inputs["ego_agent_future"]
         neighbors_future = inputs["neighbor_agents_future"]
+        if neighbor_noise is not None:
+            inputs, ego_future, neighbors_future = neighbor_noise(
+                inputs, ego_future, neighbors_future
+            )
+
         # Normalize to ego-centric
         if aug is not None:
             inputs, ego_future, neighbors_future = aug(inputs, ego_future, neighbors_future)

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -595,3 +595,58 @@ class StatePerturbation:
             return torch.concatenate([interpolated, ego_future[:, P:, :]], axis=1)
         else:
             return interpolated
+
+
+class NeighborNoiseAugmentation:
+    """
+    Data augmentation that adds per-frame Gaussian noise to the observed
+    neighbor history to simulate tracking noise in the perception output.
+
+    Only `neighbor_agents_past` is perturbed: position (x, y), velocity
+    (vx, vy) and heading (the (cos, sin) pair is rotated by a small random
+    angle, so it stays a unit vector). The prediction target
+    `neighbors_future` and the ego inputs are left clean. Noise is applied
+    only to valid frames so padding rows stay all-zero.
+    """
+
+    def __init__(
+        self,
+        pos_noise_std: float,
+        vel_noise_std: float,
+        heading_noise_std: float,
+        device: torch.device | str,
+    ) -> None:
+        self._pos_noise_std = pos_noise_std
+        self._vel_noise_std = vel_noise_std
+        self._heading_noise_std = heading_noise_std
+        self._device = torch.device(device)
+
+    def __call__(self, inputs, ego_future, neighbors_future):
+        past = inputs["neighbor_agents_past"]  # (B, N, T, D)
+        B, N, T, _ = past.shape
+        device = past.device
+
+        # A frame is valid when any of its first 8 features is non-zero,
+        # matching the encoder's padding convention.
+        valid = torch.sum(torch.ne(past[..., :8], 0), dim=-1) > 0  # (B, N, T)
+        valid_f = valid.to(past.dtype).unsqueeze(-1)  # (B, N, T, 1)
+
+        noisy = past.clone()
+        noisy[..., 0:2] = (
+            past[..., 0:2] + torch.randn(B, N, T, 2, device=device) * self._pos_noise_std * valid_f
+        )
+        noisy[..., 4:6] = (
+            past[..., 4:6] + torch.randn(B, N, T, 2, device=device) * self._vel_noise_std * valid_f
+        )
+
+        # Rotate (cos, sin) by a small random angle. Padding rows have
+        # cos = sin = 0 and stay zero under rotation.
+        eps = torch.randn(B, N, T, device=device) * self._heading_noise_std
+        cos_e, sin_e = torch.cos(eps), torch.sin(eps)
+        cos_h, sin_h = past[..., 2], past[..., 3]
+        noisy[..., 2] = cos_h * cos_e - sin_h * sin_e
+        noisy[..., 3] = sin_h * cos_e + cos_h * sin_e
+
+        inputs["neighbor_agents_past"] = noisy
+
+        return inputs, ego_future, neighbors_future

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -628,25 +628,33 @@ class NeighborNoiseAugmentation:
 
         # A frame is valid when any of its first 8 features is non-zero,
         # matching the encoder's padding convention.
-        valid = torch.sum(torch.ne(past[..., :8], 0), dim=-1) > 0  # (B, N, T)
-        valid_f = valid.to(past.dtype).unsqueeze(-1)  # (B, N, T, 1)
+        # Build the mask one channel at a time. A single comparison against
+        # past[..., :8] would temporarily allocate a (B, N, T, 8) tensor.
+        valid = torch.ne(past[..., 0], 0)  # (B, N, T)
+        for feature_idx in range(1, 8):
+            valid.logical_or_(torch.ne(past[..., feature_idx], 0))
+        invalid = ~valid
 
-        noisy = past.clone()
-        noisy[..., 0:2] = (
-            past[..., 0:2] + torch.randn(B, N, T, 2, device=device) * self._pos_noise_std * valid_f
-        )
-        noisy[..., 4:6] = (
-            past[..., 4:6] + torch.randn(B, N, T, 2, device=device) * self._vel_noise_std * valid_f
-        )
+        # Training inputs are disposable batch tensors, so perturb only the relevant
+        # channels in place. Keeping a cloned (B, N, T, D) tensor here adds more than
+        # 200 MiB at the default B=512, N=320, T=31 configuration.
+        noise = torch.randn(B, N, T, 2, device=device, dtype=past.dtype)
+        noise.masked_fill_(invalid.unsqueeze(-1), 0.0)
+        past[..., 0:2].add_(noise, alpha=self._pos_noise_std)
+
+        noise.normal_()
+        noise.masked_fill_(invalid.unsqueeze(-1), 0.0)
+        past[..., 4:6].add_(noise, alpha=self._vel_noise_std)
+        del noise
 
         # Rotate (cos, sin) by a small random angle. Padding rows have
-        # cos = sin = 0 and stay zero under rotation.
-        eps = torch.randn(B, N, T, device=device) * self._heading_noise_std
-        cos_e, sin_e = torch.cos(eps), torch.sin(eps)
-        cos_h, sin_h = past[..., 2], past[..., 3]
-        noisy[..., 2] = cos_h * cos_e - sin_h * sin_e
-        noisy[..., 3] = sin_h * cos_e + cos_h * sin_e
-
-        inputs["neighbor_agents_past"] = noisy
+        # cos = sin = 0 and are restored to zero after converting through an angle.
+        heading = torch.atan2(past[..., 3], past[..., 2])
+        heading.add_(
+            torch.randn(B, N, T, device=device, dtype=past.dtype),
+            alpha=self._heading_noise_std,
+        )
+        past[..., 2].copy_(torch.cos(heading)).masked_fill_(invalid, 0.0)
+        past[..., 3].copy_(torch.sin(heading)).masked_fill_(invalid, 0.0)
 
         return inputs, ego_future, neighbors_future

--- a/diffusion_planner/tests/test_neighbor_noise_augmentation.py
+++ b/diffusion_planner/tests/test_neighbor_noise_augmentation.py
@@ -1,0 +1,105 @@
+"""NeighborNoiseAugmentation: add tracking-like Gaussian noise to the neighbor
+history only, keeping futures clean and padding rows all-zero."""
+
+import torch
+from diffusion_planner.utils.data_augmentation import NeighborNoiseAugmentation
+
+B, N, T, TF = 2, 5, 4, 6
+
+
+def _make_batch(seed=0):
+    g = torch.Generator().manual_seed(seed)
+    past = torch.randn(B, N, T, 11, generator=g)
+    # give valid frames a unit-norm (cos, sin) pair like real data
+    heading = torch.rand(B, N, T, generator=g) * 6.28
+    past[..., 2] = torch.cos(heading)
+    past[..., 3] = torch.sin(heading)
+    # last two neighbors are padding (all-zero)
+    past[:, -2:] = 0.0
+    inputs = {
+        "neighbor_agents_past": past,
+        "ego_current_state": torch.randn(B, 10, generator=g),
+        "ego_agent_past": torch.randn(B, T, 4, generator=g),
+    }
+    ego_future = torch.randn(B, TF, 3, generator=g)
+    neighbors_future = torch.randn(B, N, TF, 3, generator=g)
+    neighbors_future[:, -2:] = 0.0
+    return inputs, ego_future, neighbors_future
+
+
+def _aug(pos=0.2, vel=0.3, heading=0.05):
+    return NeighborNoiseAugmentation(
+        pos_noise_std=pos, vel_noise_std=vel, heading_noise_std=heading, device="cpu"
+    )
+
+
+def test_noise_perturbs_only_past_pose_and_velocity():
+    torch.manual_seed(0)
+    inputs, ego_future, neighbors_future = _make_batch()
+    orig = {k: v.clone() for k, v in inputs.items()}
+    orig_future = neighbors_future.clone()
+    orig_ego_future = ego_future.clone()
+
+    inputs, ego_future, neighbors_future = _aug()(inputs, ego_future, neighbors_future)
+
+    past, orig_past = inputs["neighbor_agents_past"], orig["neighbor_agents_past"]
+    valid = orig_past[:, :-2]
+    noisy = past[:, :-2]
+    # x, y, cos, sin, vx, vy all changed on valid frames
+    for i in range(6):
+        assert not torch.equal(noisy[..., i], valid[..., i])
+    # width, length and type one-hot untouched
+    assert torch.equal(past[..., 6:], orig_past[..., 6:])
+    # everything else in the batch is untouched
+    assert torch.equal(inputs["ego_current_state"], orig["ego_current_state"])
+    assert torch.equal(inputs["ego_agent_past"], orig["ego_agent_past"])
+    assert torch.equal(ego_future, orig_ego_future)
+    assert torch.equal(neighbors_future, orig_future)
+
+
+def test_heading_stays_unit_norm():
+    torch.manual_seed(0)
+    inputs, ego_future, neighbors_future = _make_batch()
+
+    inputs, _, _ = _aug()(inputs, ego_future, neighbors_future)
+
+    cos_sin = inputs["neighbor_agents_past"][:, :-2, :, 2:4]
+    norms = cos_sin.norm(dim=-1)
+    assert torch.allclose(norms, torch.ones_like(norms), atol=1e-5)
+
+
+def test_padding_rows_stay_zero():
+    torch.manual_seed(0)
+    inputs, ego_future, neighbors_future = _make_batch()
+
+    inputs, _, neighbors_future = _aug()(inputs, ego_future, neighbors_future)
+
+    pad = inputs["neighbor_agents_past"][:, -2:]
+    assert torch.equal(pad, torch.zeros_like(pad))
+    assert torch.equal(neighbors_future[:, -2:], torch.zeros_like(neighbors_future[:, -2:]))
+
+
+def test_zero_std_is_identity():
+    inputs, ego_future, neighbors_future = _make_batch()
+    orig_past = inputs["neighbor_agents_past"].clone()
+
+    inputs, _, _ = _aug(pos=0.0, vel=0.0, heading=0.0)(inputs, ego_future, neighbors_future)
+
+    assert torch.allclose(inputs["neighbor_agents_past"], orig_past, atol=1e-6)
+
+
+def test_noise_magnitude_matches_std():
+    torch.manual_seed(0)
+    inputs, ego_future, neighbors_future = _make_batch()
+    # larger batch of frames for a stable estimate
+    inputs["neighbor_agents_past"] = torch.randn(8, 16, 21, 11)
+    inputs["neighbor_agents_past"][..., 2] = 1.0  # cos
+    inputs["neighbor_agents_past"][..., 3] = 0.0  # sin
+    orig = inputs["neighbor_agents_past"].clone()
+    neighbors_future = torch.randn(8, 16, TF, 3)
+
+    inputs, _, _ = _aug(pos=0.2, vel=0.3)(inputs, ego_future, neighbors_future)
+
+    diff = inputs["neighbor_agents_past"] - orig
+    assert abs(diff[..., 0:2].std().item() - 0.2) < 0.02
+    assert abs(diff[..., 4:6].std().item() - 0.3) < 0.03

--- a/diffusion_planner/tests/test_neighbor_noise_augmentation.py
+++ b/diffusion_planner/tests/test_neighbor_noise_augmentation.py
@@ -36,12 +36,16 @@ def _aug(pos=0.2, vel=0.3, heading=0.05):
 def test_noise_perturbs_only_past_pose_and_velocity():
     torch.manual_seed(0)
     inputs, ego_future, neighbors_future = _make_batch()
+    past_input = inputs["neighbor_agents_past"]
     orig = {k: v.clone() for k, v in inputs.items()}
     orig_future = neighbors_future.clone()
     orig_ego_future = ego_future.clone()
 
     inputs, ego_future, neighbors_future = _aug()(inputs, ego_future, neighbors_future)
 
+    # The disposable training input is updated in place to avoid cloning the full
+    # (B, N, T, D) neighbor-history tensor.
+    assert inputs["neighbor_agents_past"] is past_input
     past, orig_past = inputs["neighbor_agents_past"], orig["neighbor_agents_past"]
     valid = orig_past[:, :-2]
     noisy = past[:, :-2]

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -60,6 +60,30 @@ def get_args(args_list=None):
         "--augment_type", type=str, choices=["quintic", "bridge"], default="quintic"
     )
     parser.add_argument(
+        "--use_neighbor_noise",
+        default=_train_config_default("use_neighbor_noise"),
+        type=boolean,
+        help="whether to add tracking-like Gaussian noise to the neighbor history",
+    )
+    parser.add_argument(
+        "--neighbor_noise_pos_std",
+        type=float,
+        default=_train_config_default("neighbor_noise_pos_std"),
+        help="std [m] of position noise added to neighbor past frames",
+    )
+    parser.add_argument(
+        "--neighbor_noise_vel_std",
+        type=float,
+        default=_train_config_default("neighbor_noise_vel_std"),
+        help="std [m/s] of velocity noise added to neighbor past frames",
+    )
+    parser.add_argument(
+        "--neighbor_noise_heading_std",
+        type=float,
+        default=_train_config_default("neighbor_noise_heading_std"),
+        help="std [rad] of heading noise added to neighbor past frames",
+    )
+    parser.add_argument(
         "--num_refine", type=int, default=20, help="number of refinement steps for augmentation"
     )
     parser.add_argument(


### PR DESCRIPTION
  ## Summary
  - Added `NeighborNoiseAugmentation`, which adds per-frame Gaussian noise to the observed neighbor history (`neighbor_agents_past`) to simulate tracking
  noise in the perception output
  - Position (x, y) and velocity (vx, vy) get additive noise; heading is perturbed by rotating the (cos, sin) pair by a small random angle, so it stays a
  unit vector
  - Only the past input is perturbed — the prediction target `neighbors_future` and all ego inputs stay clean, and noise is masked to valid frames so
  padding rows stay all-zero
  - This mirrors the existing ego-side past noise (`ego_past_noise_std`) which had no neighbor-side counterpart
  - Applied in `train_epoch` after neighbor dropout and before `StatePerturbation`; controlled by `use_neighbor_noise` (default: `False`) with
  `neighbor_noise_pos_std` (0.2 m), `neighbor_noise_vel_std` (0.3 m/s) and `neighbor_noise_heading_std` (0.05 rad). Disabled by default.
-   Known limitation: velocity noise is currently removed by NeighborEncoder, which replaces (vx, vy) with zeros before projection. The velocity-noise configuration is retained for future encoder changes, but currently has no effect on the encoded neighbor features.

 ## Test plan

  - Added `diffusion_planner/tests/test_neighbor_noise_augmentation.py` (5 tests):
    - only past pose and velocity channels are perturbed
    - heading remains unit-norm
    - padding rows remain zero
    - zero standard deviations preserve the input values
    - empirical noise standard deviations match the configuration
    - the neighbor-history tensor is updated in place

  - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest diffusion_planner/tests/test_neighbor_noise_augmentation.py -q`
    - `5 passed`

