### PR TITLE
feat: Added TurnIndicatorDropoutAugmentation with GT-preserving loss

### DIFF
--- a/diffusion_planner/diffusion_planner/model/module/decoder.py
+++ b/diffusion_planner/diffusion_planner/model/module/decoder.py
@@ -254,11 +254,14 @@ def compute_training_loss(
     assert not torch.isnan(dpm_loss).sum(), f"loss cannot be nan, z={z}"
 
     turn_indicator_logit = decoder_output["turn_indicator_logit"]  # [B, TURN_INDICATOR_OUTPUT_KEEP]
-    turn_indicator_gt = make_turn_indicator_gt(inputs["turn_indicators"])  # [B,]
+    # TurnIndicatorDropoutAugmentation zeroes the encoder input but stashes the
+    # original sequence under turn_indicators_gt_source so the GT stays intact.
+    turn_indicators_for_gt = inputs.get("turn_indicators_gt_source", inputs["turn_indicators"])
+    turn_indicator_gt = make_turn_indicator_gt(turn_indicators_for_gt)  # [B,]
     turn_indicator_loss = nn.functional.cross_entropy(
         turn_indicator_logit, turn_indicator_gt, reduction="none"
     )
-    turn_indicator_change = inputs["turn_indicators"][:, -2] != inputs["turn_indicators"][:, -1]
+    turn_indicator_change = turn_indicators_for_gt[:, -2] != turn_indicators_for_gt[:, -1]
     turn_indicator_coeff = torch.where(turn_indicator_change, 1.0, 0.05)
     turn_indicator_loss = (turn_indicator_loss * turn_indicator_coeff).mean()
     loss["turn_indicator_loss"] = turn_indicator_loss

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -15,7 +15,10 @@ from diffusion_planner.model.diffusion_planner import Diffusion_Planner
 from diffusion_planner.train_config import TrainConfig
 from diffusion_planner.train_epoch import train_epoch
 from diffusion_planner.utils import ddp
-from diffusion_planner.utils.data_augmentation import StatePerturbation
+from diffusion_planner.utils.data_augmentation import (
+    StatePerturbation,
+    TurnIndicatorDropoutAugmentation,
+)
 from diffusion_planner.utils.data_augmentation_bridge import (
     StatePerturbation as BridgeStatePerturbation,
 )
@@ -234,6 +237,13 @@ def model_training(args: TrainConfig):
     else:
         aug = None
 
+    if args.use_turn_indicator_dropout:
+        turn_indicator_dropout = TurnIndicatorDropoutAugmentation(
+            dropout_prob=args.turn_indicator_dropout_prob, device=args.device
+        )
+    else:
+        turn_indicator_dropout = None
+
     # prepare dataset
     train_set = DiffusionPlannerData(args.train_set_list)
     valid_set = DiffusionPlannerData(args.valid_set_list)
@@ -432,7 +442,7 @@ def model_training(args: TrainConfig):
 
         # training step
         train_loss, train_total_loss = train_epoch(
-            train_loader, diffusion_planner, optimizer, args, model_ema, aug
+            train_loader, diffusion_planner, optimizer, args, model_ema, aug, turn_indicator_dropout
         )
 
         valid_dict = validate_model(diffusion_planner, valid_loader, args)

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -58,6 +58,8 @@ class TrainConfig:
     use_data_augment: bool = True
     augment_prob: float = 0.5
     augment_type: Literal["quintic", "bridge"] = "quintic"
+    use_turn_indicator_dropout: bool = False
+    turn_indicator_dropout_prob: float = 0.1
     num_refine: int = 20
     ego_past_noise_std: float = 0.1
     use_smoothing_future_trajectory: bool = True

--- a/diffusion_planner/diffusion_planner/train_epoch.py
+++ b/diffusion_planner/diffusion_planner/train_epoch.py
@@ -4,7 +4,10 @@ from tqdm import tqdm
 
 from diffusion_planner.model.module.decoder import compute_training_loss
 from diffusion_planner.utils import ddp
-from diffusion_planner.utils.data_augmentation import StatePerturbation
+from diffusion_planner.utils.data_augmentation import (
+    StatePerturbation,
+    TurnIndicatorDropoutAugmentation,
+)
 from diffusion_planner.utils.train_utils import compute_grad_stats, get_epoch_mean_loss
 
 
@@ -32,7 +35,15 @@ def heading_to_cos_sin(x):
     )
 
 
-def train_epoch(data_loader, model, optimizer, args, ema, aug: StatePerturbation = None):
+def train_epoch(
+    data_loader,
+    model,
+    optimizer,
+    args,
+    ema,
+    aug: StatePerturbation = None,
+    turn_indicator_dropout: TurnIndicatorDropoutAugmentation = None,
+):
     epoch_loss = []
 
     model.train()
@@ -50,6 +61,11 @@ def train_epoch(data_loader, model, optimizer, args, ema, aug: StatePerturbation
 
         ego_future = inputs["ego_agent_future"]
         neighbors_future = inputs["neighbor_agents_future"]
+        if turn_indicator_dropout is not None:
+            inputs, ego_future, neighbors_future = turn_indicator_dropout(
+                inputs, ego_future, neighbors_future
+            )
+
         # Normalize to ego-centric
         if aug is not None:
             inputs, ego_future, neighbors_future = aug(inputs, ego_future, neighbors_future)

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -595,3 +595,39 @@ class StatePerturbation:
             return torch.concatenate([interpolated, ego_future[:, P:, :]], axis=1)
         else:
             return interpolated
+
+
+class TurnIndicatorDropoutAugmentation:
+    """
+    Data augmentation that zeroes out the turn indicator input sequence for a
+    whole sample with probability dropout_prob, so the model cannot rely
+    exclusively on the indicator and learns to infer the intent from the scene
+    context as well. Zeroing matches the `use_turn_indicators=False` encoder
+    semantics.
+
+    The turn-indicator classification GT is derived from `turn_indicators` in
+    the loss, so the ORIGINAL sequence is stashed under
+    `turn_indicators_gt_source` before zeroing and the loss prefers that key
+    when present. Dropped samples therefore keep their true label and become
+    "predict the indicator from context" training signal instead of getting a
+    corrupted label.
+    """
+
+    def __init__(self, dropout_prob: float, device: torch.device | str) -> None:
+        self._dropout_prob = dropout_prob
+        self._device = torch.device(device)
+
+    def __call__(self, inputs, ego_future, neighbors_future):
+        turn_indicators = inputs["turn_indicators"]  # (B, T)
+        B = turn_indicators.shape[0]
+
+        # Preserve the original sequence for the loss GT before zeroing the
+        # encoder input.
+        inputs["turn_indicators_gt_source"] = turn_indicators.clone()
+
+        drop = torch.rand(B, device=turn_indicators.device) < self._dropout_prob
+        inputs["turn_indicators"] = torch.where(
+            drop.view(B, 1), torch.zeros_like(turn_indicators), turn_indicators
+        )
+
+        return inputs, ego_future, neighbors_future

--- a/diffusion_planner/tests/test_turn_indicator_dropout_augmentation.py
+++ b/diffusion_planner/tests/test_turn_indicator_dropout_augmentation.py
@@ -1,0 +1,79 @@
+"""TurnIndicatorDropoutAugmentation: zero the turn indicator input per sample
+while preserving the original sequence for the loss GT."""
+
+import torch
+from diffusion_planner.loss import make_turn_indicator_gt
+from diffusion_planner.utils.data_augmentation import TurnIndicatorDropoutAugmentation
+
+B, T = 4, 6
+
+
+def _make_batch():
+    inputs = {
+        "turn_indicators": torch.tensor(
+            [
+                [1, 1, 2, 2, 2, 2],  # keeps LEFT -> gt KEEP
+                [1, 1, 1, 1, 1, 2],  # changes to LEFT -> gt LEFT
+                [1, 1, 1, 3, 3, 3],  # keeps RIGHT -> gt KEEP
+                [3, 3, 3, 3, 3, 1],  # changes to DISABLE -> gt DISABLE
+            ]
+        ),
+    }
+    ego_future = torch.randn(B, 5, 3)
+    neighbors_future = torch.randn(B, 3, 5, 3)
+    return inputs, ego_future, neighbors_future
+
+
+def test_dropout_zeroes_input_but_preserves_gt_source():
+    inputs, ego_future, neighbors_future = _make_batch()
+    orig = inputs["turn_indicators"].clone()
+
+    aug = TurnIndicatorDropoutAugmentation(dropout_prob=1.0, device="cpu")
+    inputs, _, _ = aug(inputs, ego_future, neighbors_future)
+
+    assert torch.equal(inputs["turn_indicators"], torch.zeros_like(orig))
+    assert torch.equal(inputs["turn_indicators_gt_source"], orig)
+
+
+def test_gt_from_source_matches_original_gt():
+    inputs, ego_future, neighbors_future = _make_batch()
+    gt_before = make_turn_indicator_gt(inputs["turn_indicators"])
+
+    aug = TurnIndicatorDropoutAugmentation(dropout_prob=1.0, device="cpu")
+    inputs, _, _ = aug(inputs, ego_future, neighbors_future)
+
+    # the loss reads turn_indicators_gt_source when present
+    source = inputs.get("turn_indicators_gt_source", inputs["turn_indicators"])
+    assert torch.equal(make_turn_indicator_gt(source), gt_before)
+    # zeroed input alone would corrupt the GT — that is exactly what the
+    # gt_source key guards against
+    assert not torch.equal(make_turn_indicator_gt(inputs["turn_indicators"]), gt_before)
+
+
+def test_dropout_prob_zero_keeps_input():
+    inputs, ego_future, neighbors_future = _make_batch()
+    orig = inputs["turn_indicators"].clone()
+
+    aug = TurnIndicatorDropoutAugmentation(dropout_prob=0.0, device="cpu")
+    inputs, _, _ = aug(inputs, ego_future, neighbors_future)
+
+    assert torch.equal(inputs["turn_indicators"], orig)
+    assert torch.equal(inputs["turn_indicators_gt_source"], orig)
+
+
+def test_dropout_is_per_sample():
+    torch.manual_seed(0)
+    inputs, ego_future, neighbors_future = _make_batch()
+    orig = inputs["turn_indicators"].clone()
+
+    aug = TurnIndicatorDropoutAugmentation(dropout_prob=0.5, device="cpu")
+    inputs, _, _ = aug(inputs, ego_future, neighbors_future)
+
+    for b in range(B):
+        row = inputs["turn_indicators"][b]
+        zeroed = torch.equal(row, torch.zeros_like(row))
+        kept = torch.equal(row, orig[b])
+        # each sample is either fully zeroed or fully kept
+        assert zeroed or kept
+    # gt source is always the original, regardless of the drop decision
+    assert torch.equal(inputs["turn_indicators_gt_source"], orig)

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -60,6 +60,18 @@ def get_args(args_list=None):
         "--augment_type", type=str, choices=["quintic", "bridge"], default="quintic"
     )
     parser.add_argument(
+        "--use_turn_indicator_dropout",
+        default=_train_config_default("use_turn_indicator_dropout"),
+        type=boolean,
+        help="whether to zero out the turn indicator input per sample while keeping its GT label",
+    )
+    parser.add_argument(
+        "--turn_indicator_dropout_prob",
+        type=float,
+        default=_train_config_default("turn_indicator_dropout_prob"),
+        help="per-sample probability of zeroing the turn indicator input sequence",
+    )
+    parser.add_argument(
         "--num_refine", type=int, default=20, help="number of refinement steps for augmentation"
     )
     parser.add_argument(


### PR DESCRIPTION
  ## Summary
  - Added `TurnIndicatorDropoutAugmentation`, which zeroes the turn indicator input sequence for a whole sample with probability
  `turn_indicator_dropout_prob`, so the model cannot rely exclusively on the indicator and learns to infer intent from scene context; zeroing matches the
  existing `use_turn_indicators=False` encoder semantics
  - The turn-indicator classification GT is derived from the input sequence itself (`make_turn_indicator_gt`), so the original sequence is stashed under
  `turn_indicators_gt_source` before zeroing and `compute_training_loss` now prefers that key when present — dropped samples keep their true label instead
  of degenerating to a corrupted KEEP label
  - `ObservationNormalizer` iterates only over its own configured keys, so the extra dict entry passes through training untouched; inference paths never
  see it
  - Controlled by `use_turn_indicator_dropout` (default: `False`) and `turn_indicator_dropout_prob` (default: `0.1`). Disabled by default.

  ## Test plan
  - Added `diffusion_planner/tests/test_turn_indicator_dropout_augmentation.py` (4 tests): input zeroed while gt_source preserves the original, GT 
  computed from gt_source equals the pre-dropout GT (and the zeroed input alone would corrupt it), prob=0 keeps the input, and dropout is all-or-nothing
  per sample
  - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest diffusion_planner/tests/test_turn_indicator_dropout_augmentation.py` — 4 passed

