### PR TITLE
feat: Added TrafficLightDropoutAugmentation

### DIFF
--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -15,7 +15,10 @@ from diffusion_planner.model.diffusion_planner import Diffusion_Planner
 from diffusion_planner.train_config import TrainConfig
 from diffusion_planner.train_epoch import train_epoch
 from diffusion_planner.utils import ddp
-from diffusion_planner.utils.data_augmentation import StatePerturbation
+from diffusion_planner.utils.data_augmentation import (
+    StatePerturbation,
+    TrafficLightDropoutAugmentation,
+)
 from diffusion_planner.utils.data_augmentation_bridge import (
     StatePerturbation as BridgeStatePerturbation,
 )
@@ -234,6 +237,13 @@ def model_training(args: TrainConfig):
     else:
         aug = None
 
+    if args.use_traffic_light_dropout:
+        traffic_light_dropout = TrafficLightDropoutAugmentation(
+            dropout_prob=args.traffic_light_dropout_prob, device=args.device
+        )
+    else:
+        traffic_light_dropout = None
+
     # prepare dataset
     train_set = DiffusionPlannerData(args.train_set_list)
     valid_set = DiffusionPlannerData(args.valid_set_list)
@@ -432,7 +442,7 @@ def model_training(args: TrainConfig):
 
         # training step
         train_loss, train_total_loss = train_epoch(
-            train_loader, diffusion_planner, optimizer, args, model_ema, aug
+            train_loader, diffusion_planner, optimizer, args, model_ema, aug, traffic_light_dropout
         )
 
         valid_dict = validate_model(diffusion_planner, valid_loader, args)

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -58,6 +58,8 @@ class TrainConfig:
     use_data_augment: bool = True
     augment_prob: float = 0.5
     augment_type: Literal["quintic", "bridge"] = "quintic"
+    use_traffic_light_dropout: bool = False
+    traffic_light_dropout_prob: float = 0.1
     num_refine: int = 20
     ego_past_noise_std: float = 0.1
     use_smoothing_future_trajectory: bool = True

--- a/diffusion_planner/diffusion_planner/train_epoch.py
+++ b/diffusion_planner/diffusion_planner/train_epoch.py
@@ -4,7 +4,10 @@ from tqdm import tqdm
 
 from diffusion_planner.model.module.decoder import compute_training_loss
 from diffusion_planner.utils import ddp
-from diffusion_planner.utils.data_augmentation import StatePerturbation
+from diffusion_planner.utils.data_augmentation import (
+    StatePerturbation,
+    TrafficLightDropoutAugmentation,
+)
 from diffusion_planner.utils.train_utils import compute_grad_stats, get_epoch_mean_loss
 
 
@@ -32,7 +35,15 @@ def heading_to_cos_sin(x):
     )
 
 
-def train_epoch(data_loader, model, optimizer, args, ema, aug: StatePerturbation = None):
+def train_epoch(
+    data_loader,
+    model,
+    optimizer,
+    args,
+    ema,
+    aug: StatePerturbation = None,
+    traffic_light_dropout: TrafficLightDropoutAugmentation = None,
+):
     epoch_loss = []
 
     model.train()
@@ -50,6 +61,11 @@ def train_epoch(data_loader, model, optimizer, args, ema, aug: StatePerturbation
 
         ego_future = inputs["ego_agent_future"]
         neighbors_future = inputs["neighbor_agents_future"]
+        if traffic_light_dropout is not None:
+            inputs, ego_future, neighbors_future = traffic_light_dropout(
+                inputs, ego_future, neighbors_future
+            )
+
         # Normalize to ego-centric
         if aug is not None:
             inputs, ego_future, neighbors_future = aug(inputs, ego_future, neighbors_future)

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -1,6 +1,11 @@
 import numpy as np
 import torch
 
+from diffusion_planner.dimensions import (
+    TRAFFIC_LIGHT_GREEN,
+    TRAFFIC_LIGHT_RED,
+    TRAFFIC_LIGHT_WHITE,
+)
 from diffusion_planner.utils.unicycle_accel_curvature import smoothing_future_trajectory
 
 TIME_INTERVAL = 0.1
@@ -595,3 +600,43 @@ class StatePerturbation:
             return torch.concatenate([interpolated, ego_future[:, P:, :]], axis=1)
         else:
             return interpolated
+
+
+class TrafficLightDropoutAugmentation:
+    """
+    Data augmentation that replaces a known traffic light color
+    (green / yellow / red) with the unknown state to simulate traffic light
+    misdetection in the perception output.
+
+    Each lane with a known color is dropped independently with probability
+    dropout_prob, consistently across its whole polyline. The unknown one-hot
+    (`TRAFFIC_LIGHT_WHITE`) is the same encoding the converter emits when
+    traffic light recognition fails, so the augmented input matches a real
+    failure mode exactly. Lanes without a traffic light and lanes already
+    unknown are left untouched, and padding rows stay all-zero.
+    """
+
+    def __init__(self, dropout_prob: float, device: torch.device | str) -> None:
+        self._dropout_prob = dropout_prob
+        self._device = torch.device(device)
+
+    def _drop_known_colors(self, lanes):
+        """lanes: (B, P, V, D) with the traffic light one-hot at 8..12."""
+        B, P, V, _ = lanes.shape
+
+        valid_pt = torch.sum(torch.ne(lanes[..., :8], 0), dim=-1) > 0  # (B, P, V)
+        color = lanes[..., TRAFFIC_LIGHT_GREEN : TRAFFIC_LIGHT_RED + 1]
+        has_color = torch.sum(torch.ne(color, 0), dim=(-2, -1)) > 0  # (B, P)
+
+        drop = has_color & (torch.rand(B, P, device=lanes.device) < self._dropout_prob)
+
+        dropped = lanes.clone()
+        dropped[..., TRAFFIC_LIGHT_GREEN : TRAFFIC_LIGHT_RED + 1] = 0.0
+        dropped[..., TRAFFIC_LIGHT_WHITE] = valid_pt.to(lanes.dtype)
+
+        return torch.where(drop.view(B, P, 1, 1), dropped, lanes)
+
+    def __call__(self, inputs, ego_future, neighbors_future):
+        inputs["lanes"] = self._drop_known_colors(inputs["lanes"])
+        inputs["route_lanes"] = self._drop_known_colors(inputs["route_lanes"])
+        return inputs, ego_future, neighbors_future

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -606,21 +606,31 @@ class TrafficLightDropoutAugmentation:
     """
     Data augmentation that replaces a known traffic light color
     (green / yellow / red) with the unknown state to simulate traffic light
-    misdetection in the perception output.
+    recognition timeout in the perception output.
 
-    Each lane with a known color is dropped independently with probability
-    dropout_prob, consistently across its whole polyline. The unknown one-hot
-    (`TRAFFIC_LIGHT_WHITE`) is the same encoding the converter emits when
-    traffic light recognition fails, so the augmented input matches a real
-    failure mode exactly. Lanes without a traffic light and lanes already
-    unknown are left untouched, and padding rows stay all-zero.
+    A single dropout decision is sampled per training sample (one NPZ frame at
+    one timestamp) and shared by `lanes` and `route_lanes`. When selected,
+    every known traffic light in that sample is changed to unknown. This keeps
+    duplicate lanelets consistent and approximates a whole traffic-light
+    recognition message being unavailable for that frame.
+
+    Decisions are independent between samples, including NPZ frames that are
+    consecutive in the source rosbag, so this does not reproduce the duration
+    of a multi-frame recognition timeout. It also does not model an individual
+    traffic-light group disappearing while other groups remain visible; doing
+    that consistently would require the converter to preserve traffic-light
+    group IDs in both tensors.
+
+    The unknown one-hot (`TRAFFIC_LIGHT_WHITE`) is the same encoding the
+    converter emits when recognition fails. Lanes without a traffic light and
+    lanes already unknown are left untouched, and padding rows stay all-zero.
     """
 
     def __init__(self, dropout_prob: float, device: torch.device | str) -> None:
         self._dropout_prob = dropout_prob
         self._device = torch.device(device)
 
-    def _drop_known_colors(self, lanes):
+    def _drop_known_colors(self, lanes, drop_sample):
         """lanes: (B, P, V, D) with the traffic light one-hot at 8..12."""
         B, P, V, _ = lanes.shape
 
@@ -628,15 +638,28 @@ class TrafficLightDropoutAugmentation:
         color = lanes[..., TRAFFIC_LIGHT_GREEN : TRAFFIC_LIGHT_RED + 1]
         has_color = torch.sum(torch.ne(color, 0), dim=(-2, -1)) > 0  # (B, P)
 
-        drop = has_color & (torch.rand(B, P, device=lanes.device) < self._dropout_prob)
+        drop = has_color & drop_sample.view(B, 1)
 
-        dropped = lanes.clone()
-        dropped[..., TRAFFIC_LIGHT_GREEN : TRAFFIC_LIGHT_RED + 1] = 0.0
-        dropped[..., TRAFFIC_LIGHT_WHITE] = valid_pt.to(lanes.dtype)
+        # Training inputs are disposable batch tensors, so update only the traffic-light
+        # channels in place. Cloning/selecting the full lane tensor here would temporarily
+        # require two additional tensors of shape (B, P, V, D).
+        drop_pt = drop.view(B, P, 1)
+        lanes[..., TRAFFIC_LIGHT_GREEN : TRAFFIC_LIGHT_RED + 1].masked_fill_(
+            drop_pt.unsqueeze(-1), 0.0
+        )
+        white = lanes[..., TRAFFIC_LIGHT_WHITE]
+        white.masked_fill_(drop_pt, 0.0)
+        white.masked_fill_(drop_pt & valid_pt, 1.0)
 
-        return torch.where(drop.view(B, P, 1, 1), dropped, lanes)
+        return lanes
 
     def __call__(self, inputs, ego_future, neighbors_future):
-        inputs["lanes"] = self._drop_known_colors(inputs["lanes"])
-        inputs["route_lanes"] = self._drop_known_colors(inputs["route_lanes"])
+        lanes = inputs["lanes"]
+        # One batch element is one NPZ frame. Sharing this per-sample mask keeps
+        # lanes/route_lanes consistent, but consecutive frames are still sampled
+        # independently. Per-group dropout would require traffic-light group IDs,
+        # which the current NPZ format discards.
+        drop_sample = torch.rand(lanes.shape[0], device=lanes.device) < self._dropout_prob
+        inputs["lanes"] = self._drop_known_colors(lanes, drop_sample)
+        inputs["route_lanes"] = self._drop_known_colors(inputs["route_lanes"], drop_sample)
         return inputs, ego_future, neighbors_future

--- a/diffusion_planner/tests/test_traffic_light_dropout_augmentation.py
+++ b/diffusion_planner/tests/test_traffic_light_dropout_augmentation.py
@@ -1,0 +1,107 @@
+"""TrafficLightDropoutAugmentation: replace known traffic light colors with the
+unknown state to simulate misdetection, per lane, across the whole polyline."""
+
+import torch
+from diffusion_planner.dimensions import (
+    SEGMENT_POINT_DIM,
+    TRAFFIC_LIGHT_GREEN,
+    TRAFFIC_LIGHT_NO_TRAFFIC_LIGHT,
+    TRAFFIC_LIGHT_RED,
+    TRAFFIC_LIGHT_WHITE,
+    TRAFFIC_LIGHT_YELLOW,
+)
+from diffusion_planner.utils.data_augmentation import TrafficLightDropoutAugmentation
+
+B, P, V = 2, 4, 6
+
+
+def _make_lanes(seed=0):
+    """4 lanes per sample: green, red, no-traffic-light, padding."""
+    g = torch.Generator().manual_seed(seed)
+    lanes = torch.randn(B, P, V, SEGMENT_POINT_DIM, generator=g)
+    lanes[..., TRAFFIC_LIGHT_GREEN : TRAFFIC_LIGHT_NO_TRAFFIC_LIGHT + 1] = 0.0
+    lanes[:, 0, :, TRAFFIC_LIGHT_GREEN] = 1.0
+    lanes[:, 1, :, TRAFFIC_LIGHT_RED] = 1.0
+    lanes[:, 2, :, TRAFFIC_LIGHT_NO_TRAFFIC_LIGHT] = 1.0
+    lanes[:, 3] = 0.0  # padding lane
+    # last point of lane 0 is padding within a valid lane
+    lanes[:, 0, -1] = 0.0
+    return lanes
+
+
+def _make_batch(seed=0):
+    inputs = {"lanes": _make_lanes(seed), "route_lanes": _make_lanes(seed + 1)}
+    ego_future = torch.randn(B, 5, 3)
+    neighbors_future = torch.randn(B, 3, 5, 3)
+    return inputs, ego_future, neighbors_future
+
+
+def test_known_colors_become_unknown():
+    inputs, ego_future, neighbors_future = _make_batch()
+    orig = {k: v.clone() for k, v in inputs.items()}
+
+    aug = TrafficLightDropoutAugmentation(dropout_prob=1.0, device="cpu")
+    inputs, _, _ = aug(inputs, ego_future, neighbors_future)
+
+    for key in ["lanes", "route_lanes"]:
+        new = inputs[key]
+        for lane in [0, 1]:  # green and red lanes
+            valid = torch.sum(torch.ne(orig[key][:, lane, :, :8], 0), dim=-1) > 0
+            assert torch.equal(
+                new[:, lane, :, TRAFFIC_LIGHT_GREEN : TRAFFIC_LIGHT_RED + 1],
+                torch.zeros_like(new[:, lane, :, TRAFFIC_LIGHT_GREEN : TRAFFIC_LIGHT_RED + 1]),
+            )
+            assert torch.equal(new[:, lane, :, TRAFFIC_LIGHT_WHITE], valid.to(new.dtype))
+            # geometry and line types untouched
+            assert torch.equal(new[:, lane, :, :8], orig[key][:, lane, :, :8])
+            assert torch.equal(
+                new[:, lane, :, TRAFFIC_LIGHT_NO_TRAFFIC_LIGHT + 1 :],
+                orig[key][:, lane, :, TRAFFIC_LIGHT_NO_TRAFFIC_LIGHT + 1 :],
+            )
+
+
+def test_no_traffic_light_and_padding_lanes_untouched():
+    inputs, ego_future, neighbors_future = _make_batch()
+    orig = {k: v.clone() for k, v in inputs.items()}
+
+    aug = TrafficLightDropoutAugmentation(dropout_prob=1.0, device="cpu")
+    inputs, _, _ = aug(inputs, ego_future, neighbors_future)
+
+    for key in ["lanes", "route_lanes"]:
+        assert torch.equal(inputs[key][:, 2], orig[key][:, 2])  # no traffic light
+        assert torch.equal(inputs[key][:, 3], torch.zeros_like(inputs[key][:, 3]))  # padding
+
+
+def test_padding_points_stay_zero_in_dropped_lane():
+    inputs, ego_future, neighbors_future = _make_batch()
+
+    aug = TrafficLightDropoutAugmentation(dropout_prob=1.0, device="cpu")
+    inputs, _, _ = aug(inputs, ego_future, neighbors_future)
+
+    # last point of lane 0 is a padding row; the unknown flag must not be set there
+    pad_point = inputs["lanes"][:, 0, -1]
+    assert torch.equal(pad_point, torch.zeros_like(pad_point))
+
+
+def test_dropout_prob_zero_is_identity():
+    inputs, ego_future, neighbors_future = _make_batch()
+    orig = {k: v.clone() for k, v in inputs.items()}
+
+    aug = TrafficLightDropoutAugmentation(dropout_prob=0.0, device="cpu")
+    inputs, _, _ = aug(inputs, ego_future, neighbors_future)
+
+    for key, val in orig.items():
+        assert torch.equal(inputs[key], val), key
+
+
+def test_yellow_is_also_dropped():
+    inputs, ego_future, neighbors_future = _make_batch()
+    inputs["lanes"][:, 0, :, TRAFFIC_LIGHT_GREEN] = 0.0
+    inputs["lanes"][:, 0, :-1, TRAFFIC_LIGHT_YELLOW] = 1.0
+
+    aug = TrafficLightDropoutAugmentation(dropout_prob=1.0, device="cpu")
+    inputs, _, _ = aug(inputs, ego_future, neighbors_future)
+
+    yellow = inputs["lanes"][:, 0, :, TRAFFIC_LIGHT_YELLOW]
+    assert torch.equal(yellow, torch.zeros_like(yellow))
+    assert (inputs["lanes"][:, 0, 0, TRAFFIC_LIGHT_WHITE] == 1.0).all()

--- a/diffusion_planner/tests/test_traffic_light_dropout_augmentation.py
+++ b/diffusion_planner/tests/test_traffic_light_dropout_augmentation.py
@@ -105,3 +105,40 @@ def test_yellow_is_also_dropped():
     yellow = inputs["lanes"][:, 0, :, TRAFFIC_LIGHT_YELLOW]
     assert torch.equal(yellow, torch.zeros_like(yellow))
     assert (inputs["lanes"][:, 0, 0, TRAFFIC_LIGHT_WHITE] == 1.0).all()
+
+
+def test_sample_dropout_is_shared_by_lanes_and_route_lanes(monkeypatch):
+    """One per-NPZ-sample decision must apply consistently to both lane tensors."""
+    inputs, ego_future, neighbors_future = _make_batch()
+
+    # The same physical lane can appear at different indices in the surrounding-lane
+    # and route-lane tensors. Make route lane 1 an exact copy of surrounding lane 0.
+    inputs["route_lanes"][:, 1] = inputs["lanes"][:, 0].clone()
+    orig = {key: value.clone() for key, value in inputs.items()}
+
+    def fake_rand(*size, **kwargs):
+        assert size == (B,)
+        # Drop every known light in sample 0 and keep every light in sample 1.
+        return torch.tensor([0.1, 0.9], device=kwargs.get("device"))
+
+    monkeypatch.setattr(torch, "rand", fake_rand)
+
+    aug = TrafficLightDropoutAugmentation(dropout_prob=0.5, device="cpu")
+    inputs, _, _ = aug(inputs, ego_future, neighbors_future)
+
+    traffic_light = slice(TRAFFIC_LIGHT_GREEN, TRAFFIC_LIGHT_NO_TRAFFIC_LIGHT + 1)
+    lane_traffic_light = inputs["lanes"][:, 0, :, traffic_light]
+    route_traffic_light = inputs["route_lanes"][:, 1, :, traffic_light]
+    assert torch.equal(lane_traffic_light, route_traffic_light)
+    assert (lane_traffic_light[0, :-1, TRAFFIC_LIGHT_WHITE - TRAFFIC_LIGHT_GREEN] == 1).all()
+    assert (lane_traffic_light[1, :-1, TRAFFIC_LIGHT_GREEN - TRAFFIC_LIGHT_GREEN] == 1).all()
+
+    # The mask is sample-wide, not limited to the duplicated lane: every other known
+    # green/red lane in sample 0 is unknown, while sample 1 remains unchanged.
+    for key in ["lanes", "route_lanes"]:
+        for lane in [0, 1]:
+            valid = torch.sum(torch.ne(orig[key][0, lane, :, :8], 0), dim=-1) > 0
+            assert torch.equal(
+                inputs[key][0, lane, :, TRAFFIC_LIGHT_WHITE], valid.to(inputs[key].dtype)
+            )
+            assert torch.equal(inputs[key][1, lane], orig[key][1, lane])

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -60,6 +60,18 @@ def get_args(args_list=None):
         "--augment_type", type=str, choices=["quintic", "bridge"], default="quintic"
     )
     parser.add_argument(
+        "--use_traffic_light_dropout",
+        default=_train_config_default("use_traffic_light_dropout"),
+        type=boolean,
+        help="whether to replace known traffic light colors with unknown to simulate misdetection",
+    )
+    parser.add_argument(
+        "--traffic_light_dropout_prob",
+        type=float,
+        default=_train_config_default("traffic_light_dropout_prob"),
+        help="per-lane probability of dropping a known traffic light color to unknown",
+    )
+    parser.add_argument(
         "--num_refine", type=int, default=20, help="number of refinement steps for augmentation"
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary

  - Added `TrafficLightDropoutAugmentation`, which replaces known traffic-light colors (`GREEN`, `YELLOW`, and `RED`) with `TRAFFIC_LIGHT_WHITE`
  (unknown).
  - The augmentation is disabled by default and controlled by:
    - `use_traffic_light_dropout` (default: `False`)
    - `traffic_light_dropout_prob` (default: `0.1`)
  - It is applied in `train_epoch` before `StatePerturbation`.

  ## Dropout behavior

  A single dropout decision is sampled per training sample, where one sample corresponds to one NPZ frame at one timestamp.

  The same decision is shared by `lanes` and `route_lanes`. When a sample is selected, every known traffic-light color in both tensors is changed to
  unknown.

  This prevents contradictory states when the same lanelet appears in both tensors, such as:

  - `lanes`: `GREEN`
  - `route_lanes`: `UNKNOWN`

  Lanes without traffic lights, lanes already marked unknown, and padding rows remain unchanged.

  ## Motivation

  `TRAFFIC_LIGHT_WHITE` is the same representation emitted by the converter when traffic-light recognition is unavailable. Only known colors are
  changed to unknown; colors are never changed to another known color because doing so could contradict the ground-truth trajectory.

  The shared per-sample mask approximates the entire traffic-light recognition message being unavailable for one frame.

  ## Scope and limitations

  - Dropout decisions are independent between training samples, including consecutive NPZ frames. Therefore, this augmentation does not reproduce the
  duration of a multi-frame recognition timeout.
  - It does not simulate an individual traffic-light group disappearing while other groups remain visible.
  - Faithful per-group dropout would require preserving `traffic_light_group_id` in both `lanes` and `route_lanes` during NPZ conversion.
  - The augmentation models unavailable recognition results, not incorrect color classification.

  ## Test plan

  Added and updated tests covering:

  - Green, yellow, and red becoming unknown
  - A shared dropout decision across `lanes` and `route_lanes`
  - Consistent states for lanelets duplicated between both tensors
  - Sample-wide dropout of all known traffic lights
  - Unchanged samples when dropout is not selected
  - No-traffic-light lanes remaining unchanged
  - Already-unknown lanes remaining unchanged
  - Padding lanes and padding points remaining zero
  - `dropout_prob=0.0` preserving the input
  - Geometry and line-type attributes remaining unchanged

  Verification results:

  - Traffic-light dropout tests: `6 passed`
  - Relevant Diffusion Planner regression tests: `12 passed`
  - Ruff: passed
  - Pre-commit hooks: passed
  - GitHub `pre-commit` check: passed


