### PR TITLE
fix: Use recent ego history in the encoder

### DIFF
--- a/diffusion_planner/diffusion_planner/model/module/encoder.py
+++ b/diffusion_planner/diffusion_planner/model/module/encoder.py
@@ -38,6 +38,17 @@ def add_class_type(x, class_type):
     return torch.cat([x, class_type_tensor], dim=-1)
 
 
+def _keep_recent_history(history, history_frames):
+    """Keep the newest temporal samples and preserve the input width."""
+    total_frames = history.shape[-2]
+    if history_frames < 1 or history_frames > total_frames:
+        raise ValueError(
+            f"history_frames must be in [1, {total_frames}], got {history_frames}"
+        )
+    recent = history[..., -history_frames:, :]
+    return F.pad(recent, (0, 0, total_frames - history_frames, 0))
+
+
 class Encoder(nn.Module):
     def __init__(self, config):
         super().__init__()
@@ -169,18 +180,11 @@ class Encoder(nn.Module):
         ego = inputs["ego_agent_past"].clone()  # (B, T=INPUT_T + 1, D=4)
         if not self.use_ego_history:
             ego = torch.zeros_like(ego)
-        ego = torch.cat(
-            # [torch.zeros_like(ego[:, :-6]), ego[:, -6:]],
-            [ego[:, :6], torch.zeros_like(ego[:, 6:])],
-            dim=1,
-        )  # Only keep the current + first 5 steps of ego history
+        ego = _keep_recent_history(ego, 6)  # Keep current + five preceding frames
 
         # agents
         neighbors = inputs["neighbor_agents_past"].clone()  # (B, N=32, T=21, D=11)
-        neighbors = torch.cat(
-            [torch.zeros_like(neighbors[:, :, :-6]), neighbors[:, :, -6:]],
-            dim=2,
-        )  # Only keep the current + first 5 steps of history
+        neighbors = _keep_recent_history(neighbors, 6)
 
         # static objects
         static = inputs["static_objects"]  # (B, P=5, D=10)

--- a/diffusion_planner/diffusion_planner/model/module/encoder.py
+++ b/diffusion_planner/diffusion_planner/model/module/encoder.py
@@ -42,9 +42,7 @@ def _keep_recent_history(history, history_frames):
     """Keep the newest temporal samples and preserve the input width."""
     total_frames = history.shape[-2]
     if history_frames < 1 or history_frames > total_frames:
-        raise ValueError(
-            f"history_frames must be in [1, {total_frames}], got {history_frames}"
-        )
+        raise ValueError(f"history_frames must be in [1, {total_frames}], got {history_frames}")
     recent = history[..., -history_frames:, :]
     return F.pad(recent, (0, 0, total_frames - history_frames, 0))
 

--- a/diffusion_planner/tests/test_encoder_history.py
+++ b/diffusion_planner/tests/test_encoder_history.py
@@ -1,0 +1,21 @@
+import pytest
+import torch
+
+from diffusion_planner.model.module.encoder import _keep_recent_history
+
+
+def test_keep_recent_history_uses_current_and_previous_frames():
+    history = torch.arange(21 * 4, dtype=torch.float32).reshape(1, 21, 4)
+
+    selected = _keep_recent_history(history, 6)
+
+    assert selected.shape == history.shape
+    torch.testing.assert_close(selected[:, :-6], torch.zeros(1, 15, 4))
+    torch.testing.assert_close(selected[:, -6:], history[:, -6:])
+
+
+def test_keep_recent_history_rejects_invalid_window():
+    history = torch.zeros(1, 6, 4)
+
+    with pytest.raises(ValueError, match="history_frames must be"):
+        _keep_recent_history(history, 7)

--- a/diffusion_planner/tests/test_encoder_history.py
+++ b/diffusion_planner/tests/test_encoder_history.py
@@ -1,6 +1,5 @@
 import pytest
 import torch
-
 from diffusion_planner.model.module.encoder import _keep_recent_history
 
 


### PR DESCRIPTION
## Summary

- keep the newest six ego-history frames
- preserve the existing tensor shape by left-padding the older slots
- share the temporal slicing helper with the neighbor-history path

## Why

The converter stores history from oldest to current, but the encoder selected
`ego[:, :6]` while selecting `neighbors[:, :, -6:]`. The ego encoder therefore
received stale history and zeroed the current portion of its temporal input.

## Validation

- added focused history-window tests: 2 passed
- `git diff --check`

The tensor shape and deployment interface are unchanged. This changes the
meaning of the six ego-history slots and requires retraining.
