### PR TITLE
fix: Avoid aliasing in pose conversion

### DIFF
--- a/diffusion_planner/diffusion_planner/train_epoch.py
+++ b/diffusion_planner/diffusion_planner/train_epoch.py
@@ -20,8 +20,12 @@ def heading_to_cos_sin(x):
     unchanged. This guards against double-conversion (cos(cos)) now that scene-gen
     emits 4-col futures — callers can hand it either layout safely.
     """
+    if x.shape[-1] not in (3, 4):
+        raise ValueError(f"Expected pose features with last dimension 3 or 4, got {x.shape}")
     if x.shape[-1] == 4:
-        return x
+        # Callers mask padded neighbor futures in place after conversion. Do
+        # not let that mutate a batch-owned tensor when it is already 4-column.
+        return x.clone()
     return torch.cat(
         [
             x[..., :2],

--- a/diffusion_planner/tests/test_heading_conversion.py
+++ b/diffusion_planner/tests/test_heading_conversion.py
@@ -1,6 +1,5 @@
 import pytest
 import torch
-
 from diffusion_planner.train_epoch import heading_to_cos_sin
 
 

--- a/diffusion_planner/tests/test_heading_conversion.py
+++ b/diffusion_planner/tests/test_heading_conversion.py
@@ -1,0 +1,29 @@
+import pytest
+import torch
+
+from diffusion_planner.train_epoch import heading_to_cos_sin
+
+
+def test_heading_conversion_preserves_a_valid_origin_pose():
+    raw = torch.zeros(1, 2, 3)
+
+    converted = heading_to_cos_sin(raw)
+
+    torch.testing.assert_close(converted[..., :2], torch.zeros(1, 2, 2))
+    torch.testing.assert_close(converted[..., 2], torch.ones(1, 2))
+    torch.testing.assert_close(converted[..., 3], torch.zeros(1, 2))
+
+
+def test_heading_conversion_clones_four_column_inputs():
+    raw = torch.zeros(1, 2, 4)
+
+    converted = heading_to_cos_sin(raw)
+    converted[..., 0] = 1.0
+
+    assert converted.data_ptr() != raw.data_ptr()
+    assert torch.count_nonzero(raw) == 0
+
+
+def test_heading_conversion_rejects_invalid_feature_width():
+    with pytest.raises(ValueError, match="last dimension 3 or 4"):
+        heading_to_cos_sin(torch.zeros(1, 2, 5))


### PR DESCRIPTION
## Summary

- validate pose feature widths explicitly
- clone already-converted four-column tensors before callers mask them in place
- preserve the ordinary conversion of a valid raw `(0, 0, 0)` origin pose

## Why

Some callers mask converted neighbor futures in place. Returning an already
four-column batch tensor by alias can mutate the original batch. The conversion
must also keep the official ego-frame origin semantics rather than treating
every all-zero raw pose as padding.

## Validation

- added conversion tests: 3 passed
- `git diff --check`

This is a correctness and input-ownership fix; it does not change tensor shapes
or the model architecture.
