### PR TITLE
perf: Improve Diffusion Planner training throughput

### DIFF
--- a/diffusion_planner/diffusion_planner/model/diffusion_utils/dpm_solver_pytorch.py
+++ b/diffusion_planner/diffusion_planner/model/diffusion_utils/dpm_solver_pytorch.py
@@ -325,22 +325,21 @@ class DPM_Solver:
             A pytorch tensor of the time steps, with the shape (N + 1,).
         """
         if skip_type == "logSNR":
-            lambda_T = self.noise_schedule.marginal_lambda(torch.tensor(t_T).to(device))
-            lambda_0 = self.noise_schedule.marginal_lambda(torch.tensor(t_0).to(device))
-            logSNR_steps = torch.linspace(lambda_T.cpu().item(), lambda_0.cpu().item(), N + 1).to(
-                device
-            )
+            lambda_T = self.noise_schedule.marginal_lambda(torch.as_tensor(t_T, device=device))
+            lambda_0 = self.noise_schedule.marginal_lambda(torch.as_tensor(t_0, device=device))
+            unit_steps = torch.linspace(0.0, 1.0, N + 1, device=device, dtype=lambda_T.dtype)
+            logSNR_steps = lambda_T + (lambda_0 - lambda_T) * unit_steps
             return self.noise_schedule.inverse_lambda(logSNR_steps)
         elif skip_type == "time_uniform":
-            return torch.linspace(t_T, t_0, N + 1).to(device)
+            return torch.linspace(t_T, t_0, N + 1, device=device)
         elif skip_type == "time_quadratic":
             t_order = 2
-            t = (
-                torch.linspace(t_T ** (1.0 / t_order), t_0 ** (1.0 / t_order), N + 1)
-                .pow(t_order)
-                .to(device)
-            )
-            return t
+            return torch.linspace(
+                t_T ** (1.0 / t_order),
+                t_0 ** (1.0 / t_order),
+                N + 1,
+                device=device,
+            ).pow(t_order)
         else:
             raise ValueError(
                 "Unsupported skip_type {}, need to be 'logSNR' or 'time_uniform' or 'time_quadratic'".format(

--- a/diffusion_planner/diffusion_planner/model/diffusion_utils/sde.py
+++ b/diffusion_planner/diffusion_planner/model/diffusion_utils/sde.py
@@ -96,6 +96,11 @@ class VPSDE_linear(SDE):
         std = torch.sqrt(1 - torch.exp(2.0 * mean_log_coeff))
         return mean, std
 
+    def marginal_alpha(self, t):
+        """Return the scalar mean coefficient without materializing ``alpha * x``."""
+        mean_log_coeff = -0.25 * t**2 * (self._beta_max - self._beta_min) - 0.5 * self._beta_min * t
+        return torch.exp(mean_log_coeff)
+
     def diffusion_coeff(self, t):
         beta_t = (self._beta_max - self._beta_min) * t + self._beta_min
         diffusion = torch.sqrt(beta_t)

--- a/diffusion_planner/diffusion_planner/model/module/decoder.py
+++ b/diffusion_planner/diffusion_planner/model/module/decoder.py
@@ -117,9 +117,12 @@ def compute_training_loss(
     all_gt[:, 1:][neighbor_mask] = 0.0
 
     if model_type == "x_start":
-        mean, std = VPSDE_linear().marginal_prob(all_gt[..., 1:, :], t[..., 1:, :])
+        sde = VPSDE_linear()
+        future_t = t[..., 1:, :]
+        alpha = sde.marginal_alpha(future_t)
+        std = sde.marginal_prob_std(future_t)
         # mean([B, P, T, D]), std([B, 1, T, 1]), z([B, P, T, D])
-        xT = mean + std * z
+        xT = alpha * all_gt[..., 1:, :] + std * z
 
         xT = torch.cat([all_gt[:, :, :1, :], xT], dim=2)
         xT = torch.where(prefix_mask, all_gt, xT)  # [B, P, 1 + T, 4]

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -250,6 +250,8 @@ def model_training(args: TrainConfig):
         num_workers=args.num_workers,
         pin_memory=args.pin_mem,
         drop_last=True,
+        persistent_workers=args.num_workers > 0,
+        prefetch_factor=4 if args.num_workers > 0 else None,
     )
 
     # Validation is sharded across all ranks (DistributedSampler); each rank computes
@@ -264,6 +266,8 @@ def model_training(args: TrainConfig):
         num_workers=args.num_workers,
         pin_memory=args.pin_mem,
         drop_last=False,
+        persistent_workers=args.num_workers > 0,
+        prefetch_factor=4 if args.num_workers > 0 else None,
     )
 
     valid_pair_loader = None
@@ -284,6 +288,8 @@ def model_training(args: TrainConfig):
                 num_workers=args.num_workers,
                 pin_memory=args.pin_mem,
                 drop_last=False,
+                persistent_workers=args.num_workers > 0,
+                prefetch_factor=4 if args.num_workers > 0 else None,
             )
 
     if global_rank == 0:

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -64,6 +64,9 @@ class TrainConfig:
     normalization_file_path: str = "normalization.json"
     num_workers: int = 8
     pin_mem: bool = True
+    # Gradient diagnostics are expensive (they reduce every parameter gradient to
+    # host scalars). Sample them periodically instead of every training step.
+    grad_stats_interval: int = 100
 
     # ---------------------------------------------------------
     # Training Parameters

--- a/diffusion_planner/diffusion_planner/train_epoch.py
+++ b/diffusion_planner/diffusion_planner/train_epoch.py
@@ -36,15 +36,18 @@ def train_epoch(data_loader, model, optimizer, args, ema, aug: StatePerturbation
     epoch_loss = []
 
     model.train()
-
-    if args.ddp:
-        torch.cuda.synchronize()
+    grad_stats_interval = getattr(args, "grad_stats_interval", 100)
+    if grad_stats_interval < 0:
+        raise ValueError("grad_stats_interval must be >= 0")
+    num_batches = len(data_loader)
 
     if ddp.get_rank() == 0:
         data_loader = tqdm(data_loader, desc="Training", unit="batch")
 
-    for inputs in data_loader:
-        inputs = {key: value.to(args.device) for key, value in inputs.items()}
+    for batch_idx, inputs in enumerate(data_loader, start=1):
+        # DataLoader uses pinned host memory in the default training setup.  Let
+        # the copy overlap with the previous GPU step instead of synchronizing it.
+        inputs = {key: value.to(args.device, non_blocking=True) for key, value in inputs.items()}
         inputs["ego_agent_past"] = heading_to_cos_sin(inputs["ego_agent_past"])
         inputs["goal_pose"] = heading_to_cos_sin(inputs["goal_pose"])
 
@@ -79,18 +82,26 @@ def train_epoch(data_loader, model, optimizer, args, ema, aug: StatePerturbation
         # loss backward
         loss["loss"].backward()
 
-        # Gradient statistics (computed before clipping so that exploding
-        # gradients are not masked by clip_grad_norm_).
-        loss.update(compute_grad_stats(model.parameters()))
+        # Gradient statistics are diagnostics only.  Computing them every step
+        # reduces every parameter gradient to host scalars and stalls the GPU.
+        # Sample at a fixed interval, plus the final batch, consistently on all
+        # DDP ranks.
+        if grad_stats_interval > 0 and (
+            batch_idx % grad_stats_interval == 0 or batch_idx == num_batches
+        ):
+            loss.update(compute_grad_stats(model.parameters()))
 
         nn.utils.clip_grad_norm_(model.parameters(), 5)
         optimizer.step()
 
         ema.update(model)
 
-        if args.ddp:
-            torch.cuda.synchronize()
-        epoch_loss.append(loss)
+        epoch_loss.append(
+            {
+                key: value.detach() if torch.is_tensor(value) else value
+                for key, value in loss.items()
+            }
+        )
 
     epoch_mean_loss = get_epoch_mean_loss(epoch_loss)
 

--- a/diffusion_planner/diffusion_planner/utils/normalizer.py
+++ b/diffusion_planner/diffusion_planner/utils/normalizer.py
@@ -10,6 +10,18 @@ class StateNormalizer:
         self.mean = torch.as_tensor(mean)
         self.std = torch.as_tensor(std)
 
+    def _mean_std_on(self, device):
+        # Avoid repeating host-to-device copies for every batch.  Lazy creation
+        # keeps old serialized normalizers compatible.
+        cache = getattr(self, "_device_cache", None)
+        if cache is None:
+            cache = {}
+            self._device_cache = cache
+        key = str(device)
+        if key not in cache:
+            cache[key] = (self.mean.to(device), self.std.to(device))
+        return cache[key]
+
     @classmethod
     def from_json(cls, args):
         data = openjson(args.normalization_file_path)
@@ -18,10 +30,12 @@ class StateNormalizer:
         return cls(mean, std)
 
     def __call__(self, data):
-        return (data - self.mean.to(data.device)) / self.std.to(data.device)
+        mean, std = self._mean_std_on(data.device)
+        return (data - mean) / std
 
     def inverse(self, data):
-        return data * self.std.to(data.device) + self.mean.to(data.device)
+        mean, std = self._mean_std_on(data.device)
+        return data * std + mean
 
     def to_dict(self):
         return {
@@ -53,23 +67,38 @@ class ObservationNormalizer:
 
     def __call__(self, data):
         norm_data = copy(data)
-        for k, v in self._normalization_dict.items():
+        for k in self._normalization_dict:
             if k not in data:  # Check if key `k` exists in `data`
                 continue
+            mean, std = self._stats_on(k, data[k].device)
             mask = torch.sum(torch.ne(data[k], 0), dim=-1) == 0
-            norm_data[k] = (data[k] - v["mean"].to(data[k].device)) / v["std"].to(data[k].device)
+            norm_data[k] = (data[k] - mean) / std
             norm_data[k][mask] = 0
         return norm_data
 
     def inverse(self, data):
         norm_data = copy(data)
-        for k, v in self._normalization_dict.items():
+        for k in self._normalization_dict:
             if k not in data:  # Check if key `k` exists in `data`
                 continue
+            mean, std = self._stats_on(k, data[k].device)
             mask = torch.sum(torch.ne(data[k], 0), dim=-1) == 0
-            norm_data[k] = data[k] * v["std"].to(data[k].device) + v["mean"].to(data[k].device)
+            norm_data[k] = data[k] * std + mean
             norm_data[k][mask] = 0
         return norm_data
+
+    def _stats_on(self, key, device):
+        # Lazy per-device cache; this object is serialized through to_dict(), so
+        # cached tensors never enter args.json or checkpoints.
+        cache = getattr(self, "_device_cache", None)
+        if cache is None:
+            cache = {}
+            self._device_cache = cache
+        cache_key = (key, str(device))
+        if cache_key not in cache:
+            entry = self._normalization_dict[key]
+            cache[cache_key] = (entry["mean"].to(device), entry["std"].to(device))
+        return cache[cache_key]
 
     def to_dict(self):
         return {

--- a/diffusion_planner/diffusion_planner/validate_model.py
+++ b/diffusion_planner/diffusion_planner/validate_model.py
@@ -47,7 +47,9 @@ class _PreparedValidationBatch:
 
 
 def _prepare_validation_inputs(inputs, args, device, delay=0) -> _PreparedValidationBatch:
-    inputs = {key: value.to(device) for key, value in inputs.items()}
+    # Validation loaders use pinned host memory when enabled; keep H2D copies
+    # asynchronous so metric-side CPU work can overlap with the next batch.
+    inputs = {key: value.to(device, non_blocking=True) for key, value in inputs.items()}
     batch_size = inputs["ego_current_state"].shape[0]
     turn_indicator_seq = inputs["turn_indicators"]
     inputs["sampled_trajectories"] = torch.zeros(
@@ -483,7 +485,7 @@ def validate_replan_consistency(model, pair_loader, args) -> dict[str, float]:
     for step, batch in enumerate(pair_loader):
         pred_a, future_a = _predict_ego_for_temporal_metrics(model, batch["current"], args, device)
         pred_b, _ = _predict_ego_for_temporal_metrics(model, batch["next"], args, device)
-        frame_gap = batch["frame_gap"].to(device=device, dtype=torch.long)
+        frame_gap = batch["frame_gap"].to(device=device, dtype=torch.long, non_blocking=True)
         valid_gap = (
             (frame_gap > 0) & (frame_gap < pred_a.shape[1]) & (frame_gap <= future_a.shape[1])
         )

--- a/diffusion_planner/tests/test_diffusion_schedule.py
+++ b/diffusion_planner/tests/test_diffusion_schedule.py
@@ -1,0 +1,34 @@
+import torch
+
+from diffusion_planner.model.diffusion_utils.dpm_solver_pytorch import DPM_Solver, NoiseScheduleVP
+from diffusion_planner.model.diffusion_utils.sde import VPSDE_linear
+
+
+def test_vpsde_alpha_matches_marginal_mean():
+    sde = VPSDE_linear()
+    t = torch.linspace(1e-3, 1.0, 6).reshape(2, 1, 3, 1)
+    x = torch.randn(2, 4, 3, 4)
+
+    mean, std = sde.marginal_prob(x, t)
+
+    torch.testing.assert_close(mean, sde.marginal_alpha(t) * x)
+    torch.testing.assert_close(std, sde.marginal_prob_std(t), rtol=1e-6, atol=1e-7)
+
+
+def test_dpm_timesteps_match_the_previous_cpu_construction():
+    schedule = NoiseScheduleVP()
+    solver = DPM_Solver(lambda x, t: x, schedule)
+    t_T, t_0, steps = 1.0, 1e-3, 6
+
+    for skip_type in ("logSNR", "time_uniform", "time_quadratic"):
+        actual = solver.get_time_steps(skip_type, t_T, t_0, steps, torch.device("cpu"))
+        if skip_type == "logSNR":
+            lambda_T = schedule.marginal_lambda(torch.tensor(t_T))
+            lambda_0 = schedule.marginal_lambda(torch.tensor(t_0))
+            log_snr = torch.linspace(lambda_T.item(), lambda_0.item(), steps + 1)
+            expected = schedule.inverse_lambda(log_snr)
+        elif skip_type == "time_uniform":
+            expected = torch.linspace(t_T, t_0, steps + 1)
+        else:
+            expected = torch.linspace(t_T**0.5, t_0**0.5, steps + 1).pow(2)
+        torch.testing.assert_close(actual, expected, rtol=1e-6, atol=1e-7)

--- a/diffusion_planner/tests/test_diffusion_schedule.py
+++ b/diffusion_planner/tests/test_diffusion_schedule.py
@@ -1,5 +1,4 @@
 import torch
-
 from diffusion_planner.model.diffusion_utils.dpm_solver_pytorch import DPM_Solver, NoiseScheduleVP
 from diffusion_planner.model.diffusion_utils.sde import VPSDE_linear
 

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -79,6 +79,12 @@ def get_args(args_list=None):
     parser.add_argument("--pin-mem", action="store_true", help="Pin CPU memory in DataLoader")
     parser.add_argument("--no-pin-mem", action="store_false", dest="pin_mem")
     parser.set_defaults(pin_mem=True)
+    parser.add_argument(
+        "--grad_stats_interval",
+        type=int,
+        default=_train_config_default("grad_stats_interval"),
+        help="Collect gradient diagnostics every N batches; 0 disables them.",
+    )
 
     # Training
     parser.add_argument("--seed", type=int, default=3407)

--- a/diffusion_planner/valid_predictor.py
+++ b/diffusion_planner/valid_predictor.py
@@ -140,6 +140,8 @@ def run_validation(valid_cfg: ValidConfig):
         num_workers=valid_cfg.num_workers,
         pin_memory=valid_cfg.pin_mem,
         drop_last=False,
+        persistent_workers=valid_cfg.num_workers > 0,
+        prefetch_factor=4 if valid_cfg.num_workers > 0 else None,
     )
     valid_pair_loader = None
     if valid_cfg.enable_replan_consistency_eval:
@@ -161,6 +163,8 @@ def run_validation(valid_cfg: ValidConfig):
                 num_workers=valid_cfg.num_workers,
                 pin_memory=valid_cfg.pin_mem,
                 drop_last=False,
+                persistent_workers=valid_cfg.num_workers > 0,
+                prefetch_factor=4 if valid_cfg.num_workers > 0 else None,
             )
 
     if global_rank == 0:


### PR DESCRIPTION
## Summary

Improve upstream Diffusion Planner training and validation throughput without changing model, data, or deployment tensor contracts.

## Changes

- Remove per-step CUDA synchronizations from the training loop; CUDA stream ordering and DDP synchronization remain intact.
- Use non-blocking host-to-device copies with pinned DataLoader memory.
- Keep DataLoader workers alive across epochs and increase prefetching for train/validation loaders.
- Cache normalizer statistics per device instead of repeating host-to-device transfers for every batch.
- Sample expensive gradient diagnostics every 100 batches by default (configurable; 0 disables them), while retaining the final-batch diagnostic.
- Detach stored epoch metrics so the loss history cannot retain autograd graphs.
- Use non-blocking copies for validation and replan frame-gap tensors.

No model architecture, loss, data-list, output shape, or deployment behavior is changed.

## Verification

- pre-commit run --all-files (all hooks passed)
- git diff --check
- python -m compileall -q diffusion_planner
- 39 focused upstream tests passed
- DataLoader, normalizer, CLI, and train_epoch smoke checks passed

The repository-wide test run still has the existing stale test_data_augmentation.py constructor failures on this dev baseline; those failures are unrelated to this performance-only change.
