### PR TITLE
Make LaneEncoder mixer dims configurable for lightweight reuse

### DIFF
--- a/diffusion_planner/diffusion_planner/model/module/encoder.py
+++ b/diffusion_planner/diffusion_planner/model/module/encoder.py
@@ -510,10 +510,17 @@ class StaticEncoder(nn.Module):
 
 
 class LaneEncoder(nn.Module):
-    def __init__(self, lane_len, class_type, drop_path_rate, hidden_dim, depth):
+    def __init__(
+        self,
+        lane_len,
+        class_type,
+        drop_path_rate,
+        hidden_dim,
+        depth,
+        tokens_mlp_dim=64,
+        channels_mlp_dim=128,
+    ):
         super().__init__()
-        tokens_mlp_dim = 64
-        channels_mlp_dim = 128
 
         self._lane_len = lane_len
         self._class_type = class_type

--- a/diffusion_planner/diffusion_planner/model/module/turn_indicator.py
+++ b/diffusion_planner/diffusion_planner/model/module/turn_indicator.py
@@ -243,6 +243,8 @@ class TurnIndicatorNetwork(nn.Module):
             drop_path_rate=drop_path_rate,
             hidden_dim=hidden_dim,
             depth=mixer_depth,
+            tokens_mlp_dim=32,
+            channels_mlp_dim=64,
         )
         self.route_encoder = LaneEncoder(
             POINTS_PER_LANELET,
@@ -250,6 +252,8 @@ class TurnIndicatorNetwork(nn.Module):
             drop_path_rate=drop_path_rate,
             hidden_dim=hidden_dim,
             depth=mixer_depth,
+            tokens_mlp_dim=32,
+            channels_mlp_dim=64,
         )
 
         # position embedding for key/value tokens encodes x, y, cos, sin, type


### PR DESCRIPTION
## Summary

Expose `LaneEncoder`'s `tokens_mlp_dim` / `channels_mlp_dim` as constructor arguments (defaulting to the existing `64` / `128`, so all current call sites are unchanged).

`TurnIndicatorNetwork` now passes smaller values (`32` / `64`) to its lane/route encoders, keeping the diffusion-independent turn-indicator predictor lightweight.

## Changes

- **`model/module/encoder.py`**: `LaneEncoder.__init__` accepts `tokens_mlp_dim` / `channels_mlp_dim` (backwards-compatible defaults).
- **`model/module/turn_indicator.py`**: lane/route encoders in `TurnIndicatorNetwork` use the reduced `32` / `64` mixer dims.

## Testing

- Verified `TurnIndicatorNetwork` forward + backward pass (output shape `(B, 5)`).
- Pre-commit hooks (ruff / ruff format) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)