### PR TITLE
feat(ros_scripts): output npz under proj_id/map_id/{manual,auto}/date…

### DIFF
--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/io/frame_writer.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/io/frame_writer.cpp
@@ -156,14 +156,14 @@ void save_route_json(
 {
   namespace fs = std::filesystem;
 
-  const std::string routes_dir = output_path + "/routes";
-  fs::create_directories(routes_dir);
+  fs::create_directories(output_path);
 
   const nlohmann::json j = build_route_json(
     num_frames, traveled_distance_m, start_timestamp, end_timestamp, skipping_info,
     timestamp_stats_map, goal_pose_overwritten, bag_metadata);
 
-  const std::string json_filename = routes_dir + "/" + rosbag_dir_name + "_" + identifier + ".json";
+  const std::string json_filename =
+    output_path + "/" + rosbag_dir_name + "_" + identifier + ".json";
   std::ofstream json_file(json_filename);
   if (!json_file.is_open()) {
     std::cerr << "Failed to open route JSON file for writing: " << json_filename << std::endl;

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_processor.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_processor.cpp
@@ -72,6 +72,11 @@ void process_sequence(
   std::ostringstream seq_id_stream;
   seq_id_stream << "sequence_" << std::setfill('0') << std::setw(8) << seq_id;
   const std::string sequence_id_str = seq_id_stream.str();
+
+  // Per-route output subdirectory: <save_dir>/route_<seq_id (8 digits)>
+  std::ostringstream route_dir_stream;
+  route_dir_stream << "route_" << std::setfill('0') << std::setw(8) << seq_id;
+  const std::string route_save_dir = paths.save_dir + "/" + route_dir_stream.str();
   const int64_t start_ts = seq.data_list.empty() ? 0 : seq.data_list.front().timestamp;
   const int64_t end_ts = seq.data_list.empty() ? 0 : seq.data_list.back().timestamp;
 
@@ -89,7 +94,7 @@ void process_sequence(
     std::cout << "Skipping sequence with only " << n << " frames (min: " << options.min_frames
               << ")" << std::endl;
     save_route_json(
-      paths.save_dir, rosbag_dir_name, sequence_id_str, n, traveled_distance, start_ts, end_ts,
+      route_save_dir, rosbag_dir_name, sequence_id_str, n, traveled_distance, start_ts, end_ts,
       SkippingInfo::insufficient_frames(n, options.min_frames), timestamp_stats_map, false,
       bag_metadata);
     return;
@@ -100,7 +105,7 @@ void process_sequence(
     std::cout << "Skipping sequence with traveled distance " << traveled_distance
               << " meters (min: " << options.min_distance << " meters)" << std::endl;
     save_route_json(
-      paths.save_dir, rosbag_dir_name, sequence_id_str, n, traveled_distance, start_ts, end_ts,
+      route_save_dir, rosbag_dir_name, sequence_id_str, n, traveled_distance, start_ts, end_ts,
       SkippingInfo::insufficient_distance(traveled_distance, options.min_distance),
       timestamp_stats_map, false, bag_metadata);
     return;
@@ -117,7 +122,7 @@ void process_sequence(
   }
 
   save_route_json(
-    paths.save_dir, rosbag_dir_name, sequence_id_str, n, traveled_distance, start_ts, end_ts,
+    route_save_dir, rosbag_dir_name, sequence_id_str, n, traveled_distance, start_ts, end_ts,
     SkippingInfo::accepted(), timestamp_stats_map, goal_pose_overwritten, bag_metadata);
 
   // Pack-sequence accumulators: in pack mode every frame is collected here (gap-free) and
@@ -326,13 +331,13 @@ void process_sequence(
       // no npz is written at all (the sidecar below still carries the exact neighbor_ids/skip).
       if (!options.sidecar_only && (!is_skipped || options.write_skipped_npz)) {
         save_frame_data_npz(
-          paths.save_dir, rosbag_dir_name, token, ego_past, ego_current, ego_future, neighbor_past,
+          route_save_dir, rosbag_dir_name, token, ego_past, ego_current, ego_future, neighbor_past,
           neighbor_future, static_objects, lanes, lanes_speed_limit, lanes_has_speed_limit,
           route_lanes, route_lanes_speed_limit, route_lanes_has_speed_limit, polygons, line_strings,
           goal_pose_vec, turn_indicators, ego_shape);
       }
       save_frame_json(
-        paths.save_dir, rosbag_dir_name, token, seq.data_list[i].kinematic_state,
+        route_save_dir, rosbag_dir_name, token, seq.data_list[i].kinematic_state,
         seq.data_list[i].timestamp, skipping_info, neighbor_result.neighbor_ids, bag_metadata);
     }
 
@@ -343,8 +348,8 @@ void process_sequence(
 
   // Flush the packed sequence once all frames are collected.
   if (options.pack_sequence && sequence_npz.num_frames > 0) {
-    save_sequence_data_npz(paths.save_dir, rosbag_dir_name, sequence_id_str, sequence_npz);
+    save_sequence_data_npz(route_save_dir, rosbag_dir_name, sequence_id_str, sequence_npz);
     save_sequence_frames_json(
-      paths.save_dir, rosbag_dir_name, sequence_id_str, sequence_frames_json);
+      route_save_dir, rosbag_dir_name, sequence_id_str, sequence_frames_json);
   }
 }

--- a/ros_scripts/parse_rosbag_by_cpp.py
+++ b/ros_scripts/parse_rosbag_by_cpp.py
@@ -98,7 +98,7 @@ def main(
 
     print("C++ binary execution completed successfully.")
 
-    npz_files = list(save_dir.glob("*.npz"))
+    npz_files = list(save_dir.rglob("*.npz"))
     print(f"Generated {len(npz_files)} .npz files in {save_dir}")
 
 

--- a/ros_scripts/parse_rosbag_for_directory.py
+++ b/ros_scripts/parse_rosbag_for_directory.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import os
+import shutil
 import time
 from multiprocessing import Pool, cpu_count
 from pathlib import Path
@@ -67,8 +68,15 @@ def process_single_bag(args_tuple):
 
     logging.info(f"Processing bag: {bag_path}")
 
+    # bag_path layout: <proj_id>/<map_id>/<split>/<date>/<time>
     date = bag_path.parent.name
     time = bag_path.name
+    split = bag_path.parent.parent.name
+    map_id = bag_path.parent.parent.parent.name
+    proj_id = bag_path.parent.parent.parent.parent.name
+
+    # train/valid are human-driven -> manual, auto stays auto
+    mode = "auto" if split == "auto" else "manual"
 
     map_dir = bag_path.parent.parent.parent / "map" / date
     vector_map_path = map_dir / "lanelet2_map.osm"
@@ -77,12 +85,13 @@ def process_single_bag(args_tuple):
     if (map_dir / time).is_dir():
         vector_map_path = map_dir / time / "lanelet2_map.osm"
 
-    (save_root / date).mkdir(parents=True, exist_ok=True)
-    save_dir = (save_root / date / time).resolve()
+    save_dir = (save_root / proj_id / map_id / mode / date / time / "routes").resolve()
 
     if save_dir.is_dir():
         logging.info(f"Already exists: {save_dir}")
         return f"Skipped (already exists): {save_dir}"
+
+    save_dir.mkdir(parents=True, exist_ok=True)
 
     try:
         parse_rosbag_main_cpp(
@@ -109,6 +118,14 @@ def process_single_bag(args_tuple):
             offlane_time_stride=offlane_time_stride,
             write_skipped_npz=write_skipped_npz,
         )
+        # The C++ converter writes the per-frame npz/json directly under save_dir
+        # but emits the per-sequence route json into a nested "routes" subdir.
+        # Flatten it so save_dir does not end up with a redundant routes/routes level.
+        nested_routes = save_dir / "routes"
+        if nested_routes.is_dir():
+            for entry in nested_routes.iterdir():
+                shutil.move(str(entry), str(save_dir / entry.name))
+            nested_routes.rmdir()
         logging.info(f"Completed: {save_dir}")
     except Exception as e:
         error_msg = f"Error processing {bag_path}: {str(e)}"

--- a/ros_scripts/parse_rosbag_for_directory.py
+++ b/ros_scripts/parse_rosbag_for_directory.py
@@ -13,6 +13,9 @@ DEFAULT_CPP_BINARY = (
     PROJECT_ROOT / "cpp_tools" / "build" / "autoware_diffusion_planner_tools" / "data_converter"
 )
 
+# train/valid are human-driven -> manual, auto stays auto
+SPLIT_TO_MODE = {"train": "manual", "valid": "manual", "auto": "auto"}
+
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -75,8 +78,15 @@ def process_single_bag(args_tuple):
     map_id = bag_path.parent.parent.parent.name
     proj_id = bag_path.parent.parent.parent.parent.name
 
-    # train/valid are human-driven -> manual, auto stays auto
-    mode = "auto" if split == "auto" else "manual"
+    if split not in SPLIT_TO_MODE or not map_id or not proj_id:
+        logging.warning(
+            f"Unexpected bag path layout for {bag_path}: expected "
+            f"<proj_id>/<map_id>/<split>/<date>/<time> with split in "
+            f"{sorted(SPLIT_TO_MODE)}. Skipping."
+        )
+        return f"Skipped (unexpected layout): {bag_path}"
+
+    mode = SPLIT_TO_MODE[split]
 
     map_dir = bag_path.parent.parent.parent / "map" / date
     vector_map_path = map_dir / "lanelet2_map.osm"
@@ -118,18 +128,28 @@ def process_single_bag(args_tuple):
             offlane_time_stride=offlane_time_stride,
             write_skipped_npz=write_skipped_npz,
         )
-        # The C++ converter writes the per-frame npz/json directly under save_dir
-        # but emits the per-sequence route json into a nested "routes" subdir.
-        # Flatten it so save_dir does not end up with a redundant routes/routes level.
+    except Exception as e:
+        error_msg = f"Error processing {bag_path}: {str(e)}"
+        logging.error(error_msg)
+        return error_msg
+
+    # The C++ converter writes the per-frame npz/json directly under save_dir but
+    # emits the per-sequence route json into a nested "routes" subdir. Flatten it
+    # so save_dir does not end up with a redundant routes/routes level. This runs
+    # only after a successful conversion, and its own failures are reported
+    # separately so a completed conversion is not mislabeled as a failure.
+    try:
         nested_routes = save_dir / "routes"
         if nested_routes.is_dir():
             for entry in nested_routes.iterdir():
                 shutil.move(str(entry), str(save_dir / entry.name))
             nested_routes.rmdir()
-        logging.info(f"Completed: {save_dir}")
     except Exception as e:
-        error_msg = f"Error processing {bag_path}: {str(e)}"
+        error_msg = f"Error flattening routes for {save_dir}: {str(e)}"
         logging.error(error_msg)
+        return error_msg
+
+    logging.info(f"Completed: {save_dir}")
 
 
 if __name__ == "__main__":

--- a/ros_scripts/parse_rosbag_for_directory.py
+++ b/ros_scripts/parse_rosbag_for_directory.py
@@ -78,15 +78,15 @@ def process_single_bag(args_tuple):
     map_id = bag_path.parent.parent.parent.name
     proj_id = bag_path.parent.parent.parent.parent.name
 
-    if split not in SPLIT_TO_MODE or not map_id or not proj_id:
+    if not map_id or not proj_id:
         logging.warning(
             f"Unexpected bag path layout for {bag_path}: expected "
-            f"<proj_id>/<map_id>/<split>/<date>/<time> with split in "
-            f"{sorted(SPLIT_TO_MODE)}. Skipping."
+            f"<proj_id>/<map_id>/<split>/<date>/<time>. Skipping."
         )
         return f"Skipped (unexpected layout): {bag_path}"
 
-    mode = SPLIT_TO_MODE[split]
+    # split が train/valid/auto のいずれでもない場合 (例: psim) は manual にフォールバック
+    mode = SPLIT_TO_MODE.get(split, "manual")
 
     map_dir = bag_path.parent.parent.parent / "map" / date
     vector_map_path = map_dir / "lanelet2_map.osm"
@@ -95,7 +95,7 @@ def process_single_bag(args_tuple):
     if (map_dir / time).is_dir():
         vector_map_path = map_dir / time / "lanelet2_map.osm"
 
-    save_dir = (save_root / proj_id / map_id / mode / date / time / "routes").resolve()
+    save_dir = (save_root / proj_id / map_id / mode / date / time).resolve()
 
     if save_dir.is_dir():
         logging.info(f"Already exists: {save_dir}")

--- a/ros_scripts/parse_rosbag_for_directory_with_map_version.py
+++ b/ros_scripts/parse_rosbag_for_directory_with_map_version.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import logging
 import os
+import shutil
 import time
 from multiprocessing import Pool, cpu_count
 from pathlib import Path
@@ -126,14 +127,18 @@ def process_single_bag(args_tuple):
     date = bag_path.parent.name
     time = bag_path.name
 
+    # train/valid are human-driven -> manual, auto stays auto
+    mode = "auto" if train_or_val == "auto" else "manual"
+
     vector_map_path = _resolve_vector_map_path(bag_path)
 
-    save_dir = (save_root / project_name / map_name / train_or_val / date / time).resolve()
-    save_dir.parent.mkdir(parents=True, exist_ok=True)
+    save_dir = (save_root / project_name / map_name / mode / date / time).resolve()
 
     if save_dir.is_dir():
         logging.info(f"Already exists: {save_dir}")
         return f"Skipped (already exists): {save_dir}"
+
+    save_dir.mkdir(parents=True, exist_ok=True)
 
     try:
         parse_rosbag_main_cpp(
@@ -160,6 +165,13 @@ def process_single_bag(args_tuple):
             offlane_time_stride=offlane_time_stride,
             write_skipped_npz=write_skipped_npz,
         )
+        # Flatten the nested routes/ subdir emitted by the C++ converter so
+        # save_dir does not end up with a redundant routes/routes level.
+        nested_routes = save_dir / "routes"
+        if nested_routes.is_dir():
+            for entry in nested_routes.iterdir():
+                shutil.move(str(entry), str(save_dir / entry.name))
+            nested_routes.rmdir()
         logging.info(f"Completed: {save_dir}")
     except Exception as e:
         error_msg = f"Error processing {bag_path}: {str(e)}"


### PR DESCRIPTION
## Description
Reorganize `parse_rosbag_for_directory.py` output layout so converted npz/json are placed under `proj_id/map_id/{manual,auto}/date/time/routes/`, reconstructed from the input bag path. train/valid splits map to "manual" and auto maps to "auto". The per-sequence route json emitted by the C++ converter into a nested "routes" subdir is flattened into the same routes/ directory to avoid a redundant routes/routes level.

## How it was tested
It was tested on  a Server inside TIER IV.
