### PR TITLE
fix: call closed_loop_validate() from every rank, not just rank 0

### DIFF
--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -103,73 +103,82 @@ def wandb_epdms_metrics(epdms_means):
 
 
 def closed_loop_validate(model, args, epoch: int, out_dir: str) -> None:
-    """Closed-loop rendered rollout; logs metrics + the rollout video to wandb.
+    """Closed-loop rendered rollout; logs metrics + videos to wandb.
 
-    Drives the ego in CLOSED LOOP over the route NPZ frames under ``args.closed_loop_npz_root``
-    (one route = one trial), renders an MP4 into ``out_dir``, aggregates collision/clearance
-    metrics, and logs both to wandb at ``step=epoch+1``. Called on the checkpoint-save cadence.
-    No-op when ``closed_loop_npz_root`` is unset. Rank-0 only: pass the unwrapped model; it is
-    switched to eval for the rollout (so the diffusion sampler runs and produces ``prediction``)
-    and restored afterwards.
+    Discovery and workflow live in :class:`ResolvedClosedLoopEvaluation`.
     """
     if not args.closed_loop_npz_root:
         return
-    import math
 
-    from scenario_generation.closed_loop_eval import run_closed_loop_eval
+    from scenario_generation.closed_loop_ddp import ddp_device_for_rank
+    from scenario_generation.closed_loop_evaluation import RolloutParams
+    from scenario_generation.grouped_closed_loop_eval import ResolvedClosedLoopEvaluation
+    from scenario_generation.wandb_closed_loop import (
+        build_full_closed_loop_wandb_log,
+        build_grouped_closed_loop_wandb_log,
+    )
+
+    rank = ddp.get_rank()
+    world_size = ddp.get_world_size()
+    ddp_active = args.ddp and ddp.is_dist_avail_and_initialized() and world_size > 1
+    cl_device = ddp_device_for_rank(args.device) if ddp_active else args.device
 
     net = ddp.get_model(model, args.ddp)
     was_training = net.training
     net.eval()
+    log: dict = {}
     try:
-        summary = run_closed_loop_eval(
+        evaluator = ResolvedClosedLoopEvaluation.from_training(
             net,
             args,
-            args.closed_loop_npz_root,
             out_dir,
+            npz_root=args.closed_loop_npz_root,
+            params=RolloutParams(
+                device=cl_device,
+                near_miss_thresh=args.closed_loop_near_miss_thresh,
+                search_radius=args.closed_loop_search_radius,
+                warmup_steps=args.closed_loop_warmup_steps,
+                unstick_after=args.closed_loop_unstick_after,
+                unstick_advance_m=args.closed_loop_unstick_advance_m,
+                draw_every=args.closed_loop_draw_every,
+                replan_interval=args.closed_loop_replan_interval,
+                profile_sync_gpu=args.closed_loop_profile_sync_gpu,
+            ),
+            fps=float(args.closed_loop_fps),
             seg_len=args.closed_loop_seg_len,
-            device=args.device,
-            near_miss_thresh=args.closed_loop_near_miss_thresh,
-            search_radius=args.closed_loop_search_radius,
-            warmup_steps=args.closed_loop_warmup_steps,
-            unstick_after=args.closed_loop_unstick_after,
-            unstick_advance_m=args.closed_loop_unstick_advance_m,
-            fps=args.closed_loop_fps,
-            replan_interval=args.closed_loop_replan_interval,
-            draw_every=args.closed_loop_draw_every,
-            neighbor_history_mode="recorded",
-            verbose=False,
+            classification_json_root=args.closed_loop_classification_json_root or None,
+            classification_json=args.closed_loop_classification_json or None,
+            dataset_name=args.closed_loop_scenario_dataset_name or None,
+            verbose=args.closed_loop_profile and (rank == 0 or not ddp_active),
+            profile=args.closed_loop_profile,
+            ddp_rank=rank,
+            ddp_world_size=world_size if ddp_active else 1,
         )
+        summary = evaluator.run_distributed() if ddp_active else evaluator.run()
+        if rank == 0 and summary:
+            if summary.get("mode") == "grouped":
+                log = build_grouped_closed_loop_wandb_log(summary)
+                totals = (summary.get("grouped_summary") or {}).get("totals") or {}
+                print(
+                    f"grouped closed-loop @epoch {epoch + 1}: "
+                    f"{totals.get('n_steps_run', 0)} steps, "
+                    f"coll={totals.get('collision_steps', 0)}, "
+                    f"near_miss={totals.get('n_near_miss_steps', 0)} "
+                    f"in {summary['elapsed_sec']:.1f}s"
+                    + (f" (DDP x{world_size})" if ddp_active else "")
+                )
+            else:
+                log = build_full_closed_loop_wandb_log(summary)
+                print(
+                    f"closed-loop @epoch {epoch + 1}: {summary['n_segments']} seg in "
+                    f"{summary['elapsed_sec']:.1f}s  coll_seg_rate={summary['collision_segment_rate']:.3f}  "
+                    f"min_clr={summary['global_min_clearance']:.2f}  -> {len(summary['video_mp4s'])} video(s)"
+                )
     finally:
         net.train(was_training)
 
-    # Scalar metrics (drop non-finite clearances: a segment with no neighbor reports +inf).
-    scalar_keys = [
-        "collision_segment_rate",
-        "collision_step_rate",
-        "near_miss_segment_rate",
-        "near_miss_step_rate",
-        "global_min_clearance",
-        "mean_segment_min_clearance",
-        "mean_segment_mean_clearance",
-        "total_collision_steps",
-        "total_near_miss_steps",
-        "total_snaps",
-        "total_steps",
-    ]
-    log = {
-        f"closed_loop/{k}": summary[k]
-        for k in scalar_keys
-        if isinstance(summary[k], (int,)) or math.isfinite(summary[k])
-    }
-    for mp4 in summary["video_mp4s"]:
-        log[f"closed_loop/video/{Path(mp4).stem}"] = wandb.Video(str(mp4), format="mp4")
-    wandb.log(log, step=epoch + 1)
-    print(
-        f"closed-loop @epoch {epoch + 1}: {summary['n_segments']} seg in "
-        f"{summary['elapsed_sec']:.1f}s  coll_seg_rate={summary['collision_segment_rate']:.3f}  "
-        f"min_clr={summary['global_min_clearance']:.2f}  -> {len(summary['video_mp4s'])} video(s)"
-    )
+    if rank == 0 and log:
+        wandb.log(log, step=epoch + 1)
 
 
 def model_training(args: TrainConfig):

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -102,6 +102,13 @@ def wandb_epdms_metrics(epdms_means):
     }
 
 
+def _is_grouped_closed_loop_summary(summary: dict) -> bool:
+    """Grouped summaries use ``grouped_summary`` / ``n_episodes``, not ``n_segments``."""
+    if summary.get("mode") == "grouped":
+        return True
+    return summary.get("grouped_summary") is not None
+
+
 def closed_loop_validate(model, args, epoch: int, out_dir: str) -> None:
     """Closed-loop rendered rollout; logs metrics + videos to wandb.
 
@@ -156,7 +163,7 @@ def closed_loop_validate(model, args, epoch: int, out_dir: str) -> None:
         )
         summary = evaluator.run_distributed() if ddp_active else evaluator.run()
         if rank == 0 and summary:
-            if summary.get("mode") == "grouped":
+            if _is_grouped_closed_loop_summary(summary):
                 log = build_grouped_closed_loop_wandb_log(summary)
                 totals = (summary.get("grouped_summary") or {}).get("totals") or {}
                 print(

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -577,6 +577,11 @@ def model_training(args: TrainConfig):
                     external_data=False,
                 )
 
+        # Closed-loop validation runs on the same cadence as the checkpoint save; outputs
+        # (videos + metrics) land next to the saved weights they correspond to.
+        # Must run on every rank (not gated behind `if global_rank == 0`): it calls
+        # dist.barrier() internally under DDP, so if only rank 0 reached it, rank 0
+        # would hang forever waiting for ranks that never call the barrier.
         if (epoch + 1 - init_epoch) % save_utd == 0:
             closed_loop_validate(
                 diffusion_planner,

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -554,11 +554,6 @@ def model_training(args: TrainConfig):
                     opset_version=20,
                     external_data=False,
                 )
-                # Closed-loop validation runs on the same cadence as the checkpoint save; outputs
-                # (videos + metrics) land next to the saved weights they correspond to.
-                closed_loop_validate(
-                    diffusion_planner, args, epoch, os.path.join(curr_dir, "closed_loop")
-                )
 
             if valid_loss_ego_position_lat_loss < best_loss:
                 curr_dir = os.path.join(save_path, "best_model")
@@ -581,6 +576,14 @@ def model_training(args: TrainConfig):
                     opset_version=20,
                     external_data=False,
                 )
+
+        if (epoch + 1 - init_epoch) % save_utd == 0:
+            closed_loop_validate(
+                diffusion_planner,
+                args,
+                epoch,
+                os.path.join(save_path, f"epoch{epoch + 1:04d}", "closed_loop"),
+            )
 
         scheduler.step()
         train_sampler.set_epoch(epoch + 1)

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -154,16 +154,21 @@ class TrainConfig:
     # ---------------------------------------------------------
     closed_loop_npz_root: str = ""
     closed_loop_seg_len: int = 100000  # large -> one route = one segment = one trial
-    # Re-plan every N steps: replan=1 is a model forward EVERY step (~minutes/epoch over a full
-    # route); 40 keeps per-epoch cost to ~tens of seconds. Lower it for higher-fidelity validation.
-    closed_loop_replan_interval: int = 4
-    closed_loop_draw_every: int = 4  # render 1 of every N steps (matplotlib is the dominant cost)
+    closed_loop_draw_every: int = 4
     closed_loop_fps: int = 10
     closed_loop_near_miss_thresh: float = 0.5
     closed_loop_search_radius: float = 1.5
     closed_loop_warmup_steps: int = 0
     closed_loop_unstick_after: int = 300
     closed_loop_unstick_advance_m: float = 2.5
+    closed_loop_replan_interval: int = 10
+    # Grouped closed-loop (scenario_classification_json episodes). When a JSON is resolved,
+    # training logs per-area metrics + videos to wandb; otherwise falls back to full-route CL.
+    closed_loop_classification_json: str = ""
+    closed_loop_classification_json_root: str = ""
+    closed_loop_scenario_dataset_name: str = ""
+    closed_loop_profile: bool = False
+    closed_loop_profile_sync_gpu: bool = False
 
     # ---------------------------------------------------------
     # Normalizers (Placeholders to be initialized and set during training execution)

--- a/diffusion_planner/valid_predictor_closed_loop.py
+++ b/diffusion_planner/valid_predictor_closed_loop.py
@@ -1,135 +1,73 @@
-"""Closed-loop validation of a Diffusion-Planner checkpoint with the PerfectTracker.
+"""Closed-loop validation of a Diffusion-Planner checkpoint.
 
-Open-loop counterpart: ``valid_predictor.py``. Uses
-:class:`scenario_generation.closed_loop_evaluation.FullRouteClosedLoopEvaluation`.
+Two modes (``--mode``):
 
-A *route* = one bag-prefix group of consecutive 10 Hz NPZ frames (``RouteTimeline``);
-each route is sliced into ``--seg_len`` segments and rolled out with ``render_segment``.
-Per-segment metrics are streamed to ``segments.jsonl`` and aggregated into ``summary.json``.
+* **full** (default) — roll out every route under ``--npz_root`` in ``--seg_len`` chunks;
+  same behavior as the original mining validation CLI.
+* **grouped** — one full-route closed-loop rollout per sequence, then per-map-area
+  metrics and videos split by reproducer frame index (from ``scenario_classification_json``).
 
-Only ``--model_path`` and ``--npz_root`` are required; outputs land under
-``<model_path dir>/closed_loop/<timestamp>/``.
+Open-loop counterpart: ``valid_predictor.py``.
+
+Examples::
+
+    # Full-route validation
+    python diffusion_planner/valid_predictor_closed_loop.py \\
+        --model_path ./best_model.pth \\
+        --npz_root /path/to/valid/2026-01-15
+
+    # Grouped-by-area validation (after classify_scenario_corpus)
+    python diffusion_planner/valid_predictor_closed_loop.py \\
+        --mode grouped \\
+        --model_path ./best_model.pth \\
+        --npz_root /path/to/x2_dev/2231_odaiba.../valid/2026-01-15 \\
+        --classification_json_root ../Diffusion-Planner-Meta-Repository/dataset/scenario_classification_json \\
+        --out_dir ./odaiba_cl_results \\
+        --near_miss_thresh 0.3 \\
+        --replan_interval 10 \\
+        --draw_every 8
 """
 
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 
-from scenario_generation.closed_loop_evaluation import (
-    ClosedLoopEvalConfig,
-    FullRouteClosedLoopEvaluation,
-    RolloutParams,
-    resolve_default_out_dir,
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scenario_generation.closed_loop_cli import (  # noqa: E402
+    add_full_route_args,
+    add_grouped_args,
+    add_rollout_args,
+    create_evaluator_from_args,
 )
 
 
 def parse_args() -> argparse.Namespace:
-    # Only the checkpoint and the NPZ dir are required; everything else is a tunable
-    # knob with the closed-loop mining default. Outputs land next to the checkpoint.
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument(
-        "--model_path",
-        type=Path,
-        required=True,
-        help="checkpoint .pth; args.json must sit next to it (e.g. epoch0001/best_model.pth)",
+        "--mode",
+        choices=("full", "grouped"),
+        default="full",
+        help="full: segment-wise rollout over all routes; grouped: per-area metrics from classification JSON",
     )
-    p.add_argument(
-        "--npz_root",
-        type=Path,
-        required=True,
-        help="dir tree of route NPZ frames (recursively globbed, grouped into routes). "
-        "Pose JSON sidecars are read from next to each .npz, falling back to this same tree.",
-    )
-    # --- tunable knobs (default to the closed-loop mining config) ---
-    p.add_argument("--seg_len", type=int, default=6000, help="frames per segment (~60s @10Hz)")
-    p.add_argument("--device", type=str, default="cuda", help="'cuda' or 'cpu'")
-    p.add_argument("--near_miss_thresh", type=float, default=0.5, help="near-miss clearance (m)")
-    p.add_argument(
-        "--search_radius", type=float, default=1.5, help="PerceptionReproducer cursor search (m)"
-    )
-    p.add_argument(
-        "--warmup_steps",
-        type=int,
-        default=0,
-        help="steps driven by the recorded GT pose before handing control to the model",
-    )
-    p.add_argument(
-        "--unstick_after",
-        type=int,
-        default=300,
-        help="snap the ego to the GT pose ahead after this many no-progress steps (0=off)",
-    )
-    p.add_argument(
-        "--unstick_advance_m", type=float, default=2.5, help="how far ahead to snap when unsticking"
-    )
-    p.add_argument(
-        "--unstick_radius_mult",
-        type=float,
-        default=3.0,
-        help="when stuck, first widen the cursor search_radius to this x nominal so it reaches "
-        "frames further ahead (model proceeds on its own); restored to nominal once the ego moves. "
-        "<=1 disables this gentle stage (teleport straight away at --unstick_after)",
-    )
-    p.add_argument(
-        "--unstick_teleport_after",
-        type=int,
-        default=300,
-        help="if still stuck this many steps AFTER the radius was widened, fall back to the hard "
-        "teleport onto the GT pose ahead (last resort)",
-    )
-    p.add_argument("--fps", type=int, default=10, help="output video frame rate (10 = realtime)")
-    p.add_argument(
-        "--replan_interval",
-        type=int,
-        default=4,
-        help="re-run the model every N steps (1 = every step). Between inferences the cached plan "
-        "is executed, re-expressed in the current ego frame each step; the ego still steps at 10Hz",
-    )
-    p.add_argument(
-        "--draw_every",
-        type=int,
-        default=8,
-        help="render a PNG only every N steps (1 = every step). PNG rendering (matplotlib) is the "
-        "dominant cost; this throttles it without touching the rollout. Frames are encoded at --fps "
-        "regardless, so the video also plays N x faster (shorter). For real-time use --fps 10/N",
-    )
+    add_rollout_args(p)
+    add_full_route_args(p)
+    add_grouped_args(p)
     return p.parse_args()
 
 
-def main() -> None:
+def main() -> int:
     args = parse_args()
-    out_dir = resolve_default_out_dir(args.model_path)
-    print(f"device: {args.device} | model: {args.model_path} | out: {out_dir}")
-
-    config = ClosedLoopEvalConfig(
-        out_dir=out_dir,
-        params=RolloutParams(
-            device=args.device,
-            near_miss_thresh=args.near_miss_thresh,
-            search_radius=args.search_radius,
-            warmup_steps=args.warmup_steps,
-            unstick_after=args.unstick_after,
-            unstick_advance_m=args.unstick_advance_m,
-            unstick_radius_mult=args.unstick_radius_mult,
-            unstick_teleport_after=args.unstick_teleport_after,
-            draw_every=args.draw_every,
-            replan_interval=args.replan_interval,
-            tracker_mode="perfect",
-            neighbor_history_mode="recorded",
-        ),
-        fps=float(args.fps),
-        verbose=True,
-    )
-    evaluator = FullRouteClosedLoopEvaluation.from_checkpoint(
-        args.model_path,
-        args.npz_root,
-        config,
-        seg_len=args.seg_len,
-    )
+    evaluator = create_evaluator_from_args(args)
     summary = evaluator.run()
-    summary["model_path"] = str(args.model_path)
+    if summary:
+        summary["model_path"] = str(args.model_path)
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scenario_generation/closed_loop_cli.py
+++ b/scenario_generation/closed_loop_cli.py
@@ -1,0 +1,192 @@
+"""Shared CLI argument helpers and evaluator factory for closed-loop validation."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from scenario_generation.closed_loop_evaluation import (
+    ClosedLoopEvalConfig,
+    FullRouteClosedLoopEvaluation,
+    RolloutParams,
+    resolve_default_out_dir,
+)
+from scenario_generation.grouped_closed_loop_eval import (
+    GroupedClassificationParams,
+    GroupedMultiDateClosedLoopEvaluation,
+)
+
+
+def add_rollout_args(parser: argparse.ArgumentParser) -> None:
+    """Rollout knobs shared by full-route and grouped-by-area validation."""
+    parser.add_argument(
+        "--model_path",
+        type=Path,
+        required=True,
+        help="checkpoint .pth; args.json must sit next to it",
+    )
+    parser.add_argument(
+        "--npz_root",
+        type=Path,
+        required=True,
+        help="dir tree of route NPZ frames (recursively globbed into routes). "
+        "Pose JSON sidecars are read from next to each .npz, falling back to this same tree.",
+    )
+    parser.add_argument("--device", type=str, default="cuda", help="'cuda' or 'cpu'")
+    parser.add_argument(
+        "--near_miss_thresh",
+        "--margin_m",
+        type=float,
+        default=0.5,
+        help="clearance threshold (m) for near-miss / safety violation counting",
+    )
+    parser.add_argument(
+        "--search_radius",
+        type=float,
+        default=1.5,
+        help="PerceptionReproducer cursor search radius (m)",
+    )
+    parser.add_argument(
+        "--warmup_steps",
+        type=int,
+        default=0,
+        help="steps driven by recorded GT pose before model control",
+    )
+    parser.add_argument(
+        "--unstick_after",
+        type=int,
+        default=300,
+        help="snap ego to GT pose after this many no-progress steps (0=off)",
+    )
+    parser.add_argument(
+        "--unstick_advance_m",
+        type=float,
+        default=2.5,
+        help="how far ahead to snap when unsticking (m)",
+    )
+    parser.add_argument(
+        "--unstick_radius_mult",
+        type=float,
+        default=3.0,
+        help="widen cursor search radius by this factor before hard teleport",
+    )
+    parser.add_argument(
+        "--unstick_teleport_after",
+        type=int,
+        default=300,
+        help="steps after radius widen before hard teleport onto GT pose ahead",
+    )
+    parser.add_argument("--fps", type=int, default=10, help="output video frame rate")
+    parser.add_argument(
+        "--draw_every",
+        type=int,
+        default=8,
+        help="render PNG every N steps (matplotlib cost throttle)",
+    )
+    parser.add_argument(
+        "--replan_interval",
+        type=int,
+        default=10,
+        help="re-run the model every N closed-loop steps (1=every step)",
+    )
+    parser.add_argument(
+        "--tracker_mode",
+        choices=("mpc", "perfect"),
+        default="perfect",
+        help="ego advance: mpc=bicycle MPC tracker; perfect=place ego on predicted polyline",
+    )
+
+
+def add_output_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--out_dir",
+        "--output_dir",
+        type=Path,
+        default=None,
+        help="output directory (full: default <model_dir>/closed_loop/<ts>; grouped: required)",
+    )
+
+
+def add_full_route_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--seg_len",
+        type=int,
+        default=6000,
+        help="frames per route segment in full-route mode (~60s @10Hz)",
+    )
+    add_output_args(parser)
+
+
+def add_grouped_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--classification_json_root",
+        type=Path,
+        default=None,
+        help="Root of scenario_classification_json/ ({root}/{project}/{map}/{date}.json).",
+    )
+    parser.add_argument(
+        "--classification_json",
+        type=Path,
+        default=None,
+        help="Optional legacy single {date}.json override.",
+    )
+    parser.add_argument(
+        "--areas",
+        nargs="*",
+        default=None,
+        help="optional subset of area names in the classification JSON",
+    )
+
+
+def rollout_params_from_args(args: argparse.Namespace) -> RolloutParams:
+    return RolloutParams(
+        device=args.device,
+        near_miss_thresh=args.near_miss_thresh,
+        search_radius=args.search_radius,
+        warmup_steps=args.warmup_steps,
+        unstick_after=args.unstick_after,
+        unstick_advance_m=args.unstick_advance_m,
+        unstick_radius_mult=args.unstick_radius_mult,
+        unstick_teleport_after=args.unstick_teleport_after,
+        draw_every=args.draw_every,
+        replan_interval=args.replan_interval,
+        tracker_mode=args.tracker_mode,
+    )
+
+
+def create_evaluator_from_args(args: argparse.Namespace):
+    """Return the closed-loop evaluator for ``--mode`` (subclass selection only)."""
+    params = rollout_params_from_args(args)
+    if args.mode == "grouped":
+        if args.out_dir is None:
+            raise SystemExit("grouped mode requires --out_dir")
+        return GroupedMultiDateClosedLoopEvaluation.from_checkpoint(
+            args.model_path,
+            args.out_dir,
+            GroupedClassificationParams(
+                npz_root=Path(args.npz_root),
+                classification_json_root=args.classification_json_root,
+                classification_json=args.classification_json,
+                dataset_name=getattr(args, "scenario_dataset_name", None),
+                areas=args.areas,
+            ),
+            params=params,
+            fps=float(args.fps),
+            verbose=True,
+            require_jobs=True,
+        )
+
+    out_dir = resolve_default_out_dir(args.model_path, args.out_dir)
+    print(f"device: {args.device} | model: {args.model_path} | out: {out_dir}")
+    config = ClosedLoopEvalConfig(
+        out_dir=out_dir,
+        params=params,
+        fps=float(args.fps),
+        verbose=True,
+    )
+    return FullRouteClosedLoopEvaluation.from_checkpoint(
+        args.model_path,
+        args.npz_root,
+        config,
+        seg_len=args.seg_len,
+    )

--- a/scenario_generation/closed_loop_types.py
+++ b/scenario_generation/closed_loop_types.py
@@ -1,0 +1,48 @@
+"""Shared types for instrumented closed-loop rollouts and grouped eval plugins."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from scenario_generation.perf_timer import Timers
+from scenario_generation.reproducer_rollout import SegmentResult
+
+
+@dataclass
+class StepRecord:
+    """One closed-loop sim step with optional per-area metric fields."""
+
+    k: int
+    rec_idx: int
+    area: str | None
+    centerline_m: float | None = None
+    turn_match: bool | None = None
+    clearance_m: float = float("inf")
+    collision: bool = False
+    neighbor_violation: bool = False
+    rb_violation: bool = False
+    png_path: Path | None = None
+
+
+@dataclass
+class BagRolloutResult:
+    """One full-route closed-loop pass over a bag (sequence directory)."""
+
+    route_key: str
+    bag_name: str
+    segment: SegmentResult
+    png_dir: Path | None = None
+    timers: Timers | None = None
+
+    @property
+    def steps(self) -> list[StepRecord]:
+        return self.segment.steps
+
+    @property
+    def n_steps_run(self) -> int:
+        return int(self.segment.metrics.get("n_steps_run", 0))
+
+    @property
+    def terminated(self) -> str:
+        return str(self.segment.metrics.get("terminated", ""))

--- a/scenario_generation/grouped_closed_loop_eval.py
+++ b/scenario_generation/grouped_closed_loop_eval.py
@@ -1,0 +1,873 @@
+"""Grouped-by-area closed-loop evaluation.
+
+:class:`GroupedByAreaClosedLoopEvaluation` — one classification JSON, bags in
+``discover_jobs``, instrumented rollout inlined in ``run_job``.
+
+:class:`GroupedMultiDateClosedLoopEvaluation` — discovers classification dates
+then bags (flattened jobs for DDP sharding).
+
+:class:`ResolvedClosedLoopEvaluation` — training/CLI auto: grouped when JSON
+resolves, else full-route (discovery only in ``discover_jobs``).
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import nullcontext
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from scenario_generation.closed_loop_evaluation import (
+    ClosedLoopEvalConfig,
+    ClosedLoopEvaluation,
+    ClosedLoopJob,
+    FullRouteClosedLoopEvaluation,
+    JobRunResult,
+    RolloutParams,
+)
+from scenario_generation.closed_loop_types import BagRolloutResult
+from scenario_generation.metrics.grouped_by_area import (
+    aggregate_episode_metrics,
+    build_episode_video,
+)
+from scenario_generation.metrics.group_report import (
+    aggregate_segment_rows,
+    write_metrics_summary,
+    write_results_table,
+)
+from scenario_generation.perf_timer import Timers
+from scenario_generation.reproducer_rollout import SegmentResult, render_segment
+from scenario_generation.route_timeline import RouteTimeline, _frame_index
+from scenario_generation.scenario_classification import (
+    ClassificationEvalJob,
+    discover_classification_eval_jobs,
+    episodes_from_entry,
+    load_area_metric_groups,
+    load_classification_json,
+    merge_grouped_eval_summaries,
+    time_series_from_doc,
+    validate_classification_npz_root,
+)
+
+
+@dataclass
+class GroupedBagJob(ClosedLoopJob):
+    """One sequence (bag directory) listed in classification ``time_series``."""
+
+    bag_name: str = ""
+    entry: dict = field(default_factory=dict)
+    npz_root: Path = field(default_factory=Path)
+    classification_json: Path = field(default_factory=Path)
+    date: str = ""
+    dataset_key: str = ""
+    job_out_dir: Path = field(default_factory=Path)
+
+
+@dataclass
+class GroupedClassificationParams:
+    """Grouped discovery inputs (shared by multi-date and resolved evaluators)."""
+
+    npz_root: Path
+    classification_json_root: Path | None = None
+    classification_json: Path | None = None
+    dataset_name: str | None = None
+    areas: list[str] | None = None
+
+    def resolve_classification_jobs(self) -> list[ClassificationEvalJob]:
+        cl_root = self.classification_json_root
+        cl_explicit = self.classification_json
+        if cl_explicit is not None and cl_explicit.is_dir():
+            cl_root = cl_root or cl_explicit
+            cl_explicit = None
+        return discover_classification_eval_jobs(
+            self.npz_root,
+            classification_root=cl_root,
+            explicit_path=cl_explicit,
+            dataset_name=self.dataset_name,
+        )
+
+
+class GroupedByAreaClosedLoopEvaluation(ClosedLoopEvaluation):
+    """Closed-loop eval over one classification JSON (bags = jobs)."""
+
+    mode = "grouped"
+
+    def __init__(
+        self,
+        model,
+        model_args,
+        config: ClosedLoopEvalConfig,
+        npz_root: Path | str,
+        classification_json: Path | str,
+        *,
+        areas: list[str] | None = None,
+        ddp_rank: int = 0,
+        ddp_world_size: int = 1,
+    ) -> None:
+        super().__init__(
+            model,
+            model_args,
+            config,
+            ddp_rank=ddp_rank,
+            ddp_world_size=ddp_world_size,
+        )
+        self.npz_root = Path(npz_root).expanduser().resolve()
+        self.classification_json = Path(classification_json).expanduser().resolve()
+        self.allowed_areas: set[str] | None = set(areas) if areas else None
+        self._doc: dict | None = None
+        self._area_to_metric: dict[str, str] | None = None
+
+    @classmethod
+    def from_checkpoint(
+        cls,
+        model_path: Path | str,
+        npz_root: Path | str,
+        classification_json: Path | str,
+        config: ClosedLoopEvalConfig,
+        *,
+        areas: list[str] | None = None,
+        ddp_rank: int = 0,
+        ddp_world_size: int = 1,
+    ) -> GroupedByAreaClosedLoopEvaluation:
+        model, model_args = cls.load_model_pair(model_path, config.params.device)
+        return cls(
+            model,
+            model_args,
+            config,
+            npz_root,
+            classification_json,
+            areas=areas,
+            ddp_rank=ddp_rank,
+            ddp_world_size=ddp_world_size,
+        )
+
+    def _classification_doc(self) -> dict:
+        if self._doc is None:
+            self._doc = load_classification_json(self.classification_json)
+        return self._doc
+
+    def _area_to_metric(self) -> dict[str, str]:
+        if self._area_to_metric is None:
+            self._area_to_metric = load_area_metric_groups(self._classification_doc())
+        return self._area_to_metric
+
+    def discover_jobs(self) -> list[GroupedBagJob]:
+        doc = self._classification_doc()
+        time_series = time_series_from_doc(doc)
+        if not time_series:
+            raise ValueError(
+                "classification JSON has no 'time_series' — re-run classify_scenario_corpus"
+            )
+        for warning in validate_classification_npz_root(doc, self.npz_root):
+            if self.config.verbose:
+                print(f"Warning: {warning}")
+        return [
+            GroupedBagJob(
+                job_id=bag_name,
+                bag_name=bag_name,
+                entry=entry,
+                npz_root=self.npz_root,
+                classification_json=self.classification_json,
+                job_out_dir=self.out_dir,
+            )
+            for bag_name, entry in sorted(time_series.items())
+        ]
+
+    def initial_job_extras(self) -> dict[str, Any]:
+        return {"rollouts": {}, "per_bag_timing": [], "total_steps": 0}
+
+    def _rollout_bag(
+        self,
+        tl: RouteTimeline,
+        *,
+        route_key: str,
+        bag_name: str,
+        episodes: list[dict],
+        png_dir: Path,
+    ) -> BagRolloutResult:
+        """One instrumented full-route pass via :func:`render_segment` (no wrapper module)."""
+        n = len(tl)
+        if n < 2:
+            empty = SegmentResult(
+                metrics={"n_steps_run": 0, "terminated": "empty"},
+                clearances=np.zeros(0),
+                collisions=np.zeros(0, dtype=bool),
+            )
+            return BagRolloutResult(
+                route_key=route_key, bag_name=bag_name, segment=empty, png_dir=png_dir
+            )
+
+        draw_dir = png_dir if png_dir is not None else Path("/tmp") / "_cl_rollout_no_png"
+        if png_dir is not None:
+            draw_dir.mkdir(parents=True, exist_ok=True)
+
+        segment = render_segment(
+            self.model,
+            self.model_args,
+            tl,
+            0,
+            n,
+            draw_dir,
+            instrument=True,
+            area_episodes=episodes,
+            area_to_metric_group=self._area_to_metric(),
+            **self.config.params.render_kwargs(),
+        )
+        return BagRolloutResult(
+            route_key=route_key,
+            bag_name=bag_name,
+            segment=segment,
+            png_dir=png_dir,
+            timers=segment.timers,
+        )
+
+    def run_job(self, job: ClosedLoopJob) -> JobRunResult:
+        assert isinstance(job, GroupedBagJob)
+        seq_dir = job.npz_root / job.bag_name
+        if not seq_dir.is_dir():
+            if self.config.verbose:
+                print(f"Skip bag {job.bag_name}: not under {job.npz_root}")
+            return JobRunResult()
+
+        paths = sorted(seq_dir.glob("*.npz"), key=_frame_index)
+        if len(paths) < 2:
+            if self.config.verbose:
+                print(f"Skip bag {job.bag_name}: fewer than 2 NPZ frames")
+            return JobRunResult()
+
+        route_key = str(job.entry["route_key"])
+        episodes = episodes_from_entry(job.entry)
+        bag_timers = Timers() if self.config.profile else None
+        tl = RouteTimeline(paths, sidecar_dir=job.npz_root, timers=bag_timers)
+        png_dir = job.job_out_dir / "rollouts" / job.bag_name
+        if self.config.verbose:
+            print(
+                f"Full-route rollout: {job.bag_name} ({route_key}), "
+                f"{len(paths)} frames, {len(episodes)} episodes..."
+            )
+
+        with bag_timers("rollout") if bag_timers else nullcontext():
+            rollout = self._rollout_bag(
+                tl,
+                route_key=route_key,
+                bag_name=job.bag_name,
+                episodes=episodes,
+                png_dir=png_dir,
+            )
+        if bag_timers is not None and rollout.timers is not None:
+            bag_timers.merge(rollout.timers)
+
+        rows, video_mp4s = self._postprocess_bag(
+            job.bag_name,
+            episodes,
+            rollout,
+            tl,
+            out_dir=job.job_out_dir,
+            timers=bag_timers,
+        )
+        extras: dict[str, Any] = {
+            "rollouts": {job.bag_name: rollout},
+            "total_steps": rollout.n_steps_run,
+        }
+        if bag_timers is not None:
+            extras["per_bag_timing"] = [
+                {
+                    "bag": job.bag_name,
+                    "n_steps_run": rollout.n_steps_run,
+                    "stages": bag_timers.as_dict(),
+                }
+            ]
+        return JobRunResult(rows=rows, video_mp4s=video_mp4s, extras=extras)
+
+    def _postprocess_bag(
+        self,
+        bag_name: str,
+        episodes: list[dict],
+        rollout: BagRolloutResult,
+        tl: RouteTimeline,
+        *,
+        out_dir: Path,
+        timers: Timers | None,
+    ) -> tuple[list[dict], list[Path]]:
+        rows: list[dict] = []
+        video_mp4s: list[Path] = []
+        span_counts: dict[str, int] = {}
+        area_to_metric = self._area_to_metric()
+        near_miss = self.config.params.near_miss_thresh
+
+        for ep in episodes:
+            area_name = str(ep["area"])
+            if self.allowed_areas is not None and area_name not in self.allowed_areas:
+                continue
+            metric_group = area_to_metric.get(area_name)
+            if metric_group is None:
+                continue
+            span_key = f"{bag_name}:{area_name}"
+            span_index = span_counts.get(span_key, 0)
+            span_counts[span_key] = span_index + 1
+
+            ctx = timers("aggregate_metrics") if timers else nullcontext()
+            with ctx:
+                row = aggregate_episode_metrics(
+                    rollout.steps,
+                    area_name,
+                    metric_group,
+                    rollout.route_key,
+                    bag_name,
+                    tl,
+                    labeled_ranges=ep["labeled_ranges"],
+                    video_start_idx=int(ep["video_start_idx"]),
+                    video_end_idx=int(ep["video_end_idx"]),
+                    span_index=span_index,
+                    near_miss_thresh=near_miss,
+                )
+            if row is None:
+                continue
+
+            video_root = out_dir / "videos" / metric_group / area_name
+            video_root.mkdir(parents=True, exist_ok=True)
+            seg_tag = row["segment"].strip("[]").replace(",", "_").replace(" ", "")
+            mp4 = video_root / f"{bag_name}_{span_index}_{seg_tag}.mp4"
+            ctx = timers("build_videos") if timers else nullcontext()
+            with ctx:
+                built = build_episode_video(
+                    rollout,
+                    mp4,
+                    self.config.fps,
+                    video_start_idx=int(ep["video_start_idx"]),
+                    video_end_idx=int(ep["video_end_idx"]),
+                )
+            if built:
+                row["video_path"] = str(mp4.relative_to(out_dir))
+                video_mp4s.append(mp4)
+            rows.append(row)
+            if self.config.verbose:
+                print(
+                    f"  [{area_name}] {bag_name} span#{span_index} {row['segment']} "
+                    f"steps={row['n_steps_run']} coll={row.get('collision_steps', 0)}"
+                )
+        return rows, video_mp4s
+
+    def on_job_complete(
+        self,
+        job: ClosedLoopJob,
+        partial: JobRunResult,
+        index: int,
+        total: int,
+    ) -> None:
+        assert isinstance(job, GroupedBagJob)
+        if not partial.rows and not partial.extras.get("rollouts"):
+            return
+        rollout = (partial.extras.get("rollouts") or {}).get(job.bag_name)
+        if self.config.verbose and rollout is not None:
+            print(
+                f"[{index + 1}/{total}] {job.bag_name}: "
+                f"{len(partial.rows)} episode row(s), "
+                f"steps={rollout.n_steps_run} terminated={rollout.terminated}"
+            )
+
+    def ddp_shard_extras(self, result: JobRunResult) -> dict[str, Any]:
+        return {
+            "rollout_bags": sorted((result.extras.get("rollouts") or {}).keys()),
+            "total_steps": int(result.extras.get("total_steps", 0)),
+            "per_bag_timing": (result.extras.get("per_bag_timing") or [])
+            if self.config.profile
+            else [],
+        }
+
+    def ddp_partial_summary(self, result: JobRunResult, *, elapsed_sec: float) -> dict:
+        return {
+            "mode": "grouped",
+            "ddp_shard": True,
+            "ddp_rank": self.ddp_rank,
+            "ddp_world_size": self.ddp_world_size,
+            "n_bags": len(result.extras.get("rollouts") or {}),
+            "n_episodes": len(result.rows),
+            "elapsed_sec": elapsed_sec,
+            "classification_json": str(self.classification_json),
+            "npz_root": str(self.npz_root),
+            "near_miss_thresh": self.config.params.near_miss_thresh,
+        }
+
+    def build_summary(self, result: JobRunResult, *, elapsed_sec: float) -> dict:
+        rollouts = result.extras.get("rollouts") or {}
+        rollout_bags = result.extras.get("rollout_bags") or sorted(rollouts.keys())
+        grouped_summary = aggregate_segment_rows(result.rows)
+        timing = None
+        if self.config.profile:
+            timing = build_grouped_timing_summary(
+                result.extras.get("per_bag_timing") or [],
+                int(result.extras.get("total_steps", 0)),
+                elapsed_sec,
+            )
+        return {
+            "mode": "grouped",
+            "classification_json": str(self.classification_json),
+            "npz_root": str(self.npz_root),
+            "near_miss_thresh": self.config.params.near_miss_thresh,
+            "n_episodes": len(result.rows),
+            "n_bags": len(rollout_bags) if rollout_bags else len(rollouts),
+            "elapsed_sec": elapsed_sec,
+            "grouped_summary": grouped_summary,
+            "segments": result.rows,
+            "video_mp4s": result.video_mp4s,
+            "timing": timing,
+        }
+
+    def write_artifacts(self, summary: dict, result: JobRunResult) -> None:
+        all_rows = result.rows
+        grouped_summary = summary["grouped_summary"]
+        for area_name in sorted({r["area_name"] for r in all_rows}):
+            area_rows = [r for r in all_rows if r["area_name"] == area_name]
+            write_metrics_summary(
+                aggregate_segment_rows(area_rows),
+                self.out_dir / "by_area" / f"{area_name}_metrics_summary.json",
+            )
+        write_results_table(all_rows, self.out_dir / "results_table.csv")
+        write_metrics_summary(grouped_summary, self.out_dir / "metrics_summary.json")
+
+        timing = summary.get("timing")
+        with open(self.out_dir / "summary.json", "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    k: v
+                    for k, v in summary.items()
+                    if k not in ("segments", "video_mp4s", "grouped_summary", "timing")
+                }
+                | {"grouped_summary": grouped_summary}
+                | ({"timing": timing} if timing else {}),
+                f,
+                indent=2,
+                default=str,
+            )
+        if timing is not None:
+            with open(self.out_dir / "timing.json", "w", encoding="utf-8") as f:
+                json.dump(timing, f, indent=2)
+
+    def print_summary(self, summary: dict) -> None:
+        print(
+            f"\n=== grouped closed-loop: {summary['n_episodes']} episodes, "
+            f"{summary['n_bags']} bag(s) in {summary['elapsed_sec']:.1f}s ==="
+        )
+        totals = (summary.get("grouped_summary") or {}).get("totals") or {}
+        print(
+            f"steps={totals.get('n_steps_run', 0)} "
+            f"coll={totals.get('collision_steps', 0)} "
+            f"near_miss={totals.get('n_near_miss_steps', 0)}"
+        )
+        if summary.get("timing"):
+            print("\n" + summary["timing"]["report"])
+        print(f"results -> {self.out_dir / 'results_table.csv'}")
+
+
+class GroupedMultiDateClosedLoopEvaluation(ClosedLoopEvaluation):
+    """Grouped eval across all classification dates under ``npz_root``."""
+
+    mode = "grouped"
+
+    def __init__(
+        self,
+        model,
+        model_args,
+        config: ClosedLoopEvalConfig,
+        grouped_params: GroupedClassificationParams,
+        *,
+        require_jobs: bool = False,
+        ddp_rank: int = 0,
+        ddp_world_size: int = 1,
+    ) -> None:
+        super().__init__(
+            model,
+            model_args,
+            config,
+            ddp_rank=ddp_rank,
+            ddp_world_size=ddp_world_size,
+        )
+        self.grouped_params = grouped_params
+        self.require_jobs = require_jobs
+        self._date_jobs: list[ClassificationEvalJob] = []
+        self._cached_jobs: list[GroupedBagJob] | None = None
+
+    @classmethod
+    def from_checkpoint(
+        cls,
+        model_path: Path | str,
+        out_dir: Path | str,
+        grouped_params: GroupedClassificationParams,
+        *,
+        params: RolloutParams | None = None,
+        fps: float = 10.0,
+        verbose: bool = True,
+        profile: bool = False,
+        require_jobs: bool = True,
+        ddp_rank: int = 0,
+        ddp_world_size: int = 1,
+    ) -> GroupedMultiDateClosedLoopEvaluation:
+        params = params or RolloutParams()
+        model, model_args = cls.load_model_pair(model_path, params.device)
+        return cls(
+            model,
+            model_args,
+            ClosedLoopEvalConfig(
+                out_dir=Path(out_dir),
+                params=params,
+                fps=fps,
+                verbose=verbose,
+                profile=profile,
+            ),
+            grouped_params,
+            require_jobs=require_jobs,
+            ddp_rank=ddp_rank,
+            ddp_world_size=ddp_world_size,
+        )
+
+    def _single_json_evaluator(
+        self, date_job: ClassificationEvalJob, job_out: Path
+    ) -> GroupedByAreaClosedLoopEvaluation:
+        return GroupedByAreaClosedLoopEvaluation(
+            self.model,
+            self.model_args,
+            ClosedLoopEvalConfig(
+                out_dir=job_out,
+                params=self.config.params,
+                fps=self.config.fps,
+                verbose=self.config.verbose,
+                profile=self.config.profile,
+            ),
+            date_job.npz_root,
+            date_job.classification_json,
+            areas=self.grouped_params.areas,
+            ddp_rank=self.ddp_rank,
+            ddp_world_size=self.ddp_world_size,
+        )
+
+    def discover_jobs(self) -> list[GroupedBagJob]:
+        if self._cached_jobs is not None:
+            return self._cached_jobs
+
+        self._date_jobs = self.grouped_params.resolve_classification_jobs()
+        if not self._date_jobs and self.require_jobs:
+            raise SystemExit(
+                "grouped mode: no classification JSON matched npz_root. Set "
+                "--classification_json_root and ensure npz path follows valid/{date}/ layout."
+            )
+
+        all_bags: list[GroupedBagJob] = []
+        for date_job in self._date_jobs:
+            job_out = (
+                self.out_dir if len(self._date_jobs) == 1 else self.out_dir / date_job.date
+            )
+            if self.config.verbose:
+                print(
+                    f"Grouped job: {date_job.dataset_key} {date_job.date} "
+                    f"npz={date_job.npz_root} json={date_job.classification_json}"
+                )
+            single = self._single_json_evaluator(date_job, job_out)
+            for bag in single.discover_jobs():
+                bag.job_id = f"{date_job.date}:{bag.bag_name}"
+                bag.classification_json = date_job.classification_json
+                bag.date = date_job.date
+                bag.dataset_key = date_job.dataset_key
+                bag.job_out_dir = job_out
+                all_bags.append(bag)
+        self._cached_jobs = all_bags
+        return all_bags
+
+    def initial_job_extras(self) -> dict[str, Any]:
+        return {"rollouts": {}, "per_bag_timing": [], "total_steps": 0}
+
+    def run_job(self, job: ClosedLoopJob) -> JobRunResult:
+        assert isinstance(job, GroupedBagJob)
+        single = self._single_json_evaluator(
+            ClassificationEvalJob(
+                npz_root=job.npz_root,
+                classification_json=job.classification_json,
+                dataset_key=job.dataset_key,
+                date=job.date,
+            ),
+            job.job_out_dir,
+        )
+        return single.run_job(job)
+
+    def merge_job_result(self, merged: JobRunResult, partial: JobRunResult) -> None:
+        super().merge_job_result(merged, partial)
+
+    def ddp_shard_extras(self, result: JobRunResult) -> dict[str, Any]:
+        return {
+            "rollout_bags": sorted((result.extras.get("rollouts") or {}).keys()),
+            "total_steps": int(result.extras.get("total_steps", 0)),
+            "per_bag_timing": (result.extras.get("per_bag_timing") or [])
+            if self.config.profile
+            else [],
+        }
+
+    def build_summary(self, result: JobRunResult, *, elapsed_sec: float) -> dict:
+        if len(self._date_jobs) <= 1:
+            single = self._single_json_evaluator(
+                self._date_jobs[0],
+                self.out_dir,
+            )
+            return single.build_summary(result, elapsed_sec=elapsed_sec)
+
+        bags_by_date: dict[str, set[str]] = {}
+        for bag in self._cached_jobs or []:
+            bags_by_date.setdefault(bag.date, set()).add(bag.bag_name)
+
+        summaries: list[dict] = []
+        for date_job in self._date_jobs:
+            bag_names = bags_by_date.get(date_job.date, set())
+            date_rows = [r for r in result.rows if r.get("bag_name") in bag_names]
+            summaries.append(
+                {
+                    "mode": "grouped",
+                    "classification_json": str(date_job.classification_json),
+                    "npz_root": str(date_job.npz_root),
+                    "near_miss_thresh": self.config.params.near_miss_thresh,
+                    "n_episodes": len(date_rows),
+                    "n_bags": len(bag_names),
+                    "elapsed_sec": elapsed_sec,
+                    "grouped_summary": aggregate_segment_rows(date_rows),
+                    "segments": date_rows,
+                    "video_mp4s": [p for p in result.video_mp4s if date_job.date in str(p)],
+                    "date": date_job.date,
+                    "dataset_key": date_job.dataset_key,
+                }
+            )
+        return merge_grouped_eval_summaries(summaries)
+
+    def write_artifacts(self, summary: dict, result: JobRunResult) -> None:
+        if len(self._date_jobs) <= 1:
+            self._single_json_evaluator(self._date_jobs[0], self.out_dir).write_artifacts(
+                summary, result
+            )
+            return
+
+        write_results_table(
+            summary.get("segments") or [], self.out_dir / "results_table.csv"
+        )
+        write_metrics_summary(
+            summary.get("grouped_summary") or {},
+            self.out_dir / "metrics_summary.json",
+        )
+        with open(self.out_dir / "summary.json", "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    k: v
+                    for k, v in summary.items()
+                    if k not in ("segments", "video_mp4s", "grouped_summary")
+                }
+                | {"grouped_summary": summary.get("grouped_summary")},
+                f,
+                indent=2,
+                default=str,
+            )
+
+    def print_summary(self, summary: dict) -> None:
+        if len(self._date_jobs) <= 1:
+            self._single_json_evaluator(self._date_jobs[0], self.out_dir).print_summary(
+                summary
+            )
+            return
+        print(
+            f"\n=== grouped closed-loop: {summary['n_episodes']} episodes "
+            f"({len(self._date_jobs)} date(s)) in {summary['elapsed_sec']:.1f}s ==="
+        )
+        print(f"results -> {self.out_dir / 'results_table.csv'}")
+
+
+class ResolvedClosedLoopEvaluation(ClosedLoopEvaluation):
+    """Training entry: ``discover_jobs`` picks grouped multi-date or full-route."""
+
+    mode = "auto"
+
+    def __init__(
+        self,
+        model,
+        model_args,
+        config: ClosedLoopEvalConfig,
+        *,
+        npz_root: Path | str,
+        grouped_params: GroupedClassificationParams,
+        seg_len: int = 100_000,
+        fallback_full_route: bool = True,
+        warn_on_fallback: bool = True,
+        ddp_rank: int = 0,
+        ddp_world_size: int = 1,
+    ) -> None:
+        super().__init__(
+            model,
+            model_args,
+            config,
+            ddp_rank=ddp_rank,
+            ddp_world_size=ddp_world_size,
+        )
+        self._npz_root = Path(npz_root)
+        self._grouped_params = grouped_params
+        self._seg_len = seg_len
+        self._fallback_full_route = fallback_full_route
+        self._warn_on_fallback = warn_on_fallback
+        self._delegate: ClosedLoopEvaluation | None = None
+
+    @classmethod
+    def from_training(
+        cls,
+        model,
+        model_args,
+        out_dir: Path | str,
+        *,
+        npz_root: str,
+        params: RolloutParams,
+        fps: float,
+        seg_len: int,
+        classification_json_root: str | None,
+        classification_json: str | None,
+        dataset_name: str | None,
+        verbose: bool,
+        profile: bool,
+        ddp_rank: int = 0,
+        ddp_world_size: int = 1,
+    ) -> ResolvedClosedLoopEvaluation:
+        cl_root = Path(classification_json_root) if classification_json_root else None
+        cl_explicit = Path(classification_json) if classification_json else None
+        return cls(
+            model,
+            model_args,
+            ClosedLoopEvalConfig(
+                out_dir=Path(out_dir),
+                params=params,
+                fps=fps,
+                verbose=verbose,
+                profile=profile,
+            ),
+            npz_root=npz_root,
+            grouped_params=GroupedClassificationParams(
+                npz_root=Path(npz_root),
+                classification_json_root=cl_root,
+                classification_json=cl_explicit,
+                dataset_name=dataset_name,
+            ),
+            seg_len=seg_len,
+            ddp_rank=ddp_rank,
+            ddp_world_size=ddp_world_size,
+        )
+
+    def _ensure_delegate(self) -> ClosedLoopEvaluation:
+        if self._delegate is not None:
+            return self._delegate
+
+        grouped_config = ClosedLoopEvalConfig(
+            out_dir=self.config.out_dir / "grouped",
+            params=self.config.params,
+            fps=self.config.fps,
+            verbose=self.config.verbose,
+            profile=self.config.profile,
+        )
+        grouped = GroupedMultiDateClosedLoopEvaluation(
+            self.model,
+            self.model_args,
+            grouped_config,
+            self._grouped_params,
+            require_jobs=False,
+            ddp_rank=self.ddp_rank,
+            ddp_world_size=self.ddp_world_size,
+        )
+        if grouped.discover_jobs():
+            self._delegate = grouped
+            return grouped
+
+        if self._warn_on_fallback and self.config.verbose and self.ddp_rank == 0:
+            print(
+                "Warning: no classification JSON matched "
+                f"npz_root={self._npz_root!r}; using full-route closed-loop"
+            )
+
+        if not self._fallback_full_route:
+            self._delegate = grouped
+            return grouped
+
+        self._delegate = FullRouteClosedLoopEvaluation(
+            self.model,
+            self.model_args,
+            self.config,
+            self._npz_root,
+            seg_len=self._seg_len,
+            ddp_rank=self.ddp_rank,
+            ddp_world_size=self.ddp_world_size,
+        )
+        return self._delegate
+
+    def discover_jobs(self) -> list[ClosedLoopJob]:
+        return self._ensure_delegate().discover_jobs()
+
+    def run_job(self, job: ClosedLoopJob) -> JobRunResult:
+        return self._ensure_delegate().run_job(job)
+
+    def shard_jobs(self, jobs: list[ClosedLoopJob]) -> list[ClosedLoopJob]:
+        return self._ensure_delegate().shard_jobs(jobs)
+
+    def initial_job_extras(self) -> dict[str, Any]:
+        return self._ensure_delegate().initial_job_extras()
+
+    def merge_job_result(self, merged: JobRunResult, partial: JobRunResult) -> None:
+        self._ensure_delegate().merge_job_result(merged, partial)
+
+    def on_job_complete(
+        self,
+        job: ClosedLoopJob,
+        partial: JobRunResult,
+        index: int,
+        total: int,
+    ) -> None:
+        self._ensure_delegate().on_job_complete(job, partial, index, total)
+
+    def execute_jobs(self, jobs: list[ClosedLoopJob]) -> JobRunResult:
+        return self._ensure_delegate().execute_jobs(jobs)
+
+    def ddp_shard_extras(self, result: JobRunResult) -> dict[str, Any]:
+        return self._ensure_delegate().ddp_shard_extras(result)
+
+    def ddp_partial_summary(self, result: JobRunResult, *, elapsed_sec: float) -> dict:
+        return self._ensure_delegate().ddp_partial_summary(result, elapsed_sec=elapsed_sec)
+
+    def prepare_ddp_merge_artifacts(self, result: JobRunResult) -> None:
+        self._ensure_delegate().prepare_ddp_merge_artifacts(result)
+
+    def merge_ddp_shards(self, world_size: int) -> dict:
+        return self._ensure_delegate().merge_ddp_shards(world_size)
+
+    def build_summary(self, result: JobRunResult, *, elapsed_sec: float) -> dict:
+        return self._ensure_delegate().build_summary(result, elapsed_sec=elapsed_sec)
+
+    def write_artifacts(self, summary: dict, result: JobRunResult) -> None:
+        self._ensure_delegate().write_artifacts(summary, result)
+
+    def print_summary(self, summary: dict) -> None:
+        self._ensure_delegate().print_summary(summary)
+
+
+def build_grouped_timing_summary(
+    per_bag_timing: list[dict],
+    total_steps: int,
+    elapsed_sec: float,
+) -> dict[str, Any]:
+    global_timers = Timers()
+    for bag_info in per_bag_timing:
+        for stage, info in bag_info.get("stages", {}).items():
+            global_timers.add(stage, float(info["total_s"]), int(info["calls"]))
+    stages = global_timers.as_dict()
+    model_calls = stages.get("model_forward", {}).get("calls", 0)
+    cached_calls = stages.get("model_forward_cached", {}).get("calls", 0)
+    total_sim_steps = total_steps + cached_calls
+    return {
+        "elapsed_sec": elapsed_sec,
+        "total_sim_steps": total_sim_steps,
+        "model_forward_calls": model_calls,
+        "model_forward_cached_calls": cached_calls,
+        "model_forward_rate": model_calls / max(1, total_sim_steps),
+        "stages": stages,
+        "per_bag": per_bag_timing,
+        "report": global_timers.report(total_sim_steps),
+    }

--- a/scenario_generation/grouped_closed_loop_eval.py
+++ b/scenario_generation/grouped_closed_loop_eval.py
@@ -118,7 +118,7 @@ class GroupedByAreaClosedLoopEvaluation(ClosedLoopEvaluation):
         self.classification_json = Path(classification_json).expanduser().resolve()
         self.allowed_areas: set[str] | None = set(areas) if areas else None
         self._doc: dict | None = None
-        self._area_to_metric: dict[str, str] | None = None
+        self._area_to_metric_map: dict[str, str] | None = None
 
     @classmethod
     def from_checkpoint(
@@ -150,9 +150,9 @@ class GroupedByAreaClosedLoopEvaluation(ClosedLoopEvaluation):
         return self._doc
 
     def _area_to_metric(self) -> dict[str, str]:
-        if self._area_to_metric is None:
-            self._area_to_metric = load_area_metric_groups(self._classification_doc())
-        return self._area_to_metric
+        if self._area_to_metric_map is None:
+            self._area_to_metric_map = load_area_metric_groups(self._classification_doc())
+        return self._area_to_metric_map
 
     def discover_jobs(self) -> list[GroupedBagJob]:
         doc = self._classification_doc()

--- a/scenario_generation/grouped_closed_loop_eval.py
+++ b/scenario_generation/grouped_closed_loop_eval.py
@@ -799,6 +799,14 @@ class ResolvedClosedLoopEvaluation(ClosedLoopEvaluation):
         )
         return self._delegate
 
+    def run(self) -> dict:
+        """Run delegate workflow; preserve delegate ``mode`` (not ``auto``)."""
+        delegate = self._ensure_delegate()
+        summary = super().run()
+        if self.mode == "auto":
+            summary["mode"] = delegate.mode
+        return summary
+
     def discover_jobs(self) -> list[ClosedLoopJob]:
         return self._ensure_delegate().discover_jobs()
 

--- a/scenario_generation/metrics/__init__.py
+++ b/scenario_generation/metrics/__init__.py
@@ -1,0 +1,18 @@
+"""Closed-loop validation metrics for scenario-group evaluation."""
+
+from scenario_generation.metrics.centerline_deviation import lateral_offset_from_route_lanes
+from scenario_generation.metrics.group_report import aggregate_segment_rows, write_results_table
+from scenario_generation.metrics.safety_clearance import score_safety_step
+from scenario_generation.metrics.turn_indicator import (
+    expected_turn_class,
+    score_turn_indicator_step,
+)
+
+__all__ = [
+    "lateral_offset_from_route_lanes",
+    "score_safety_step",
+    "score_turn_indicator_step",
+    "expected_turn_class",
+    "aggregate_segment_rows",
+    "write_results_table",
+]

--- a/scenario_generation/metrics/centerline_deviation.py
+++ b/scenario_generation/metrics/centerline_deviation.py
@@ -1,0 +1,31 @@
+"""Centerline lateral offset from route_lanes in the current ego frame."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def _valid_centerline_points(route_lanes: np.ndarray) -> np.ndarray:
+    valid = np.abs(route_lanes[..., :2]).sum(axis=-1) > 1e-6
+    pts = route_lanes[..., :2][valid]
+    if pts.size == 0:
+        return np.zeros((0, 2), dtype=np.float32)
+    return pts.reshape(-1, 2).astype(np.float32)
+
+
+def lateral_offset_from_route_lanes(route_lanes: np.ndarray) -> float:
+    """Min distance from ego origin (0,0) to any route_lanes centerline point (m).
+
+      At each closed-loop step the observation is re-centered so the live ego sits
+    at the origin; this matches the training centerline reward geometry.
+    """
+    pts = _valid_centerline_points(np.asarray(route_lanes))
+    if pts.shape[0] == 0:
+        return float("inf")
+    return float(np.linalg.norm(pts, axis=-1).min())
+
+
+def lateral_offset_series(route_lanes_list: list[np.ndarray]) -> np.ndarray:
+    return np.array(
+        [lateral_offset_from_route_lanes(rl) for rl in route_lanes_list], dtype=np.float32
+    )

--- a/scenario_generation/metrics/group_report.py
+++ b/scenario_generation/metrics/group_report.py
@@ -1,0 +1,120 @@
+"""Aggregate per-segment metric rows into summary tables."""
+
+from __future__ import annotations
+
+import csv
+import json
+from collections import defaultdict
+from pathlib import Path
+
+# Keys rolled up with sum() across segment rows (validation / per-area totals).
+_SUM_KEYS = (
+    "n_steps_run",
+    "neighbor_violation_steps",
+    "rb_violation_steps",
+    "collision_steps",
+    "n_collision_steps",
+    "n_near_miss_steps",
+    "n_snaps",
+)
+
+# Keys excluded from wandb scalar comparison (episode/video counts vary by dataset).
+WANDB_EXCLUDED_SCALAR_KEYS = frozenset({"n_segments", "n_segments_total", "n_episodes", "n_videos"})
+
+
+def aggregate_segment_rows(rows: list[dict]) -> dict:
+    """Build per-area and validation-wide totals from segment rows."""
+    by_area: dict[str, list[dict]] = defaultdict(list)
+    for row in rows:
+        by_area[row["area_name"]].append(row)
+
+    return {
+        "by_area_name": {k: _agg_segment_stats(v) for k, v in sorted(by_area.items())},
+        "totals": _agg_segment_stats(rows),
+    }
+
+
+def _agg_segment_stats(items: list[dict]) -> dict:
+    if not items:
+        return {}
+
+    def _sum(key: str) -> int:
+        return int(sum(r.get(key, 0) or 0 for r in items))
+
+    def _weighted_mean(rate_key: str, weight_key: str = "n_steps_run") -> float | None:
+        num = 0.0
+        den = 0.0
+        for row in items:
+            rate = row.get(rate_key)
+            if rate is None or rate != rate:
+                continue
+            weight = float(row.get(weight_key) or 0)
+            if weight <= 0:
+                continue
+            num += float(rate) * weight
+            den += weight
+        return float(num / den) if den > 0 else None
+
+    def _mean(key: str) -> float | None:
+        vals = [r[key] for r in items if r.get(key) is not None and r[key] == r[key]]
+        return float(sum(vals) / len(vals)) if vals else None
+
+    finite_min_cl = [
+        r["min_clearance_m"]
+        for r in items
+        if r.get("min_clearance_m") is not None and r["min_clearance_m"] == r["min_clearance_m"]
+    ]
+
+    out: dict = {key: _sum(key) for key in _SUM_KEYS}
+    out["centerline_mean_m"] = _weighted_mean("centerline_mean_m")
+    out["centerline_p95_m"] = _mean("centerline_p95_m")
+    out["turn_match_rate"] = _weighted_mean("turn_match_rate")
+    out["min_clearance_m"] = float(min(finite_min_cl)) if finite_min_cl else None
+    return out
+
+
+RESULTS_TABLE_COLUMNS = [
+    "metric_group",
+    "area_name",
+    "sequence",
+    "bag",
+    "span_index",
+    "list_start_idx",
+    "list_end_idx",
+    "segment",
+    "n_steps_run",
+    "terminated",
+    "centerline_mean_m",
+    "centerline_p95_m",
+    "centerline_max_m",
+    "turn_match_rate",
+    "neighbor_violation_steps",
+    "rb_violation_steps",
+    "collision_steps",
+    "n_collision_steps",
+    "n_near_miss_steps",
+    "min_clearance",
+    "min_clearance_m",
+    "mean_clearance",
+    "min_rb_dist_m",
+    "n_snaps",
+    "video_path",
+]
+
+
+def write_results_table(rows: list[dict], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    extra = {k for row in rows for k in row} - set(RESULTS_TABLE_COLUMNS)
+    fieldnames = RESULTS_TABLE_COLUMNS + sorted(extra)
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_metrics_summary(summary: dict, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")

--- a/scenario_generation/metrics/grouped_by_area.py
+++ b/scenario_generation/metrics/grouped_by_area.py
@@ -1,0 +1,137 @@
+"""Grouped-by-area post-processing plugin (no rollout logic).
+
+Consumes per-step records from an instrumented bag rollout and produces
+episode-level metrics and videos using scenario classification JSON spans.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import numpy as np
+from diffusion_planner.utils.scene_skip import is_skipped
+
+from scenario_generation.closed_loop_eval import build_mp4
+from scenario_generation.closed_loop_types import BagRolloutResult, StepRecord
+from scenario_generation.route_timeline import RouteTimeline
+from scenario_generation.scenario_classification import idx_in_labeled_ranges
+
+
+def _percentile(arr: np.ndarray, q: float) -> float:
+    finite = arr[np.isfinite(arr)]
+    if finite.size == 0:
+        return float("inf")
+    return float(np.percentile(finite, q))
+
+
+def aggregate_episode_metrics(
+    steps: list[StepRecord],
+    area_name: str,
+    metric_group: str,
+    route_key: str,
+    bag_name: str,
+    tl: RouteTimeline,
+    *,
+    labeled_ranges: list[list[int]],
+    video_start_idx: int,
+    video_end_idx: int,
+    span_index: int,
+    near_miss_thresh: float = 0.3,
+) -> dict | None:
+    """Aggregate metrics on labeled, non-skipped frames only."""
+    area_steps = [
+        st
+        for st in steps
+        if st.area == area_name
+        and idx_in_labeled_ranges(st.rec_idx, labeled_ranges)
+        and not is_skipped(tl.npz_paths[st.rec_idx])
+    ]
+    if not area_steps:
+        return None
+
+    f_start = int(tl.frame_indices[video_start_idx])
+    f_end = int(tl.frame_indices[min(video_end_idx - 1, len(tl.frame_indices) - 1)])
+
+    cl = np.array(
+        [st.centerline_m for st in area_steps if st.centerline_m is not None],
+        dtype=np.float32,
+    )
+    tm = np.array(
+        [st.turn_match for st in area_steps if st.turn_match is not None],
+        dtype=bool,
+    )
+    clearances = np.array([st.clearance_m for st in area_steps], dtype=np.float32)
+    collisions = [st.collision for st in area_steps]
+
+    return {
+        "metric_group": metric_group,
+        "area_name": area_name,
+        "sequence": route_key,
+        "bag": bag_name,
+        "span_index": span_index,
+        "list_start_idx": video_start_idx,
+        "list_end_idx": video_end_idx,
+        "labeled_ranges": labeled_ranges,
+        "segment": f"[{f_start},{f_end}]",
+        "n_steps_run": len(area_steps),
+        "terminated": "area_span",
+        "min_clearance": float(clearances[np.isfinite(clearances)].min())
+        if clearances.size
+        else float("inf"),
+        "mean_clearance": float(clearances[np.isfinite(clearances)].mean())
+        if clearances.size
+        else float("inf"),
+        "n_collision_steps": int(sum(collisions)),
+        "n_near_miss_steps": int(np.sum(clearances <= near_miss_thresh)),
+        "n_snaps": 0,
+        "centerline_mean_m": float(cl[np.isfinite(cl)].mean()) if cl.size else None,
+        "centerline_p95_m": _percentile(cl, 95) if cl.size else None,
+        "centerline_max_m": float(cl[np.isfinite(cl)].max()) if cl.size else None,
+        "turn_match_rate": float(tm.mean()) if tm.size else None,
+        "neighbor_violation_steps": int(sum(st.neighbor_violation for st in area_steps)),
+        "rb_violation_steps": int(sum(st.rb_violation for st in area_steps)),
+        "collision_steps": int(sum(collisions)),
+        "min_clearance_m": float(clearances[np.isfinite(clearances)].min())
+        if clearances.size
+        else float("inf"),
+        "min_rb_dist_m": None,
+        "video_path": "",
+    }
+
+
+def build_episode_video(
+    rollout: BagRolloutResult,
+    out_mp4: Path,
+    fps: float,
+    *,
+    video_start_idx: int,
+    video_end_idx: int,
+) -> bool:
+    """Copy PNGs for a continuous video span (includes unlabeled stopping gaps)."""
+    if rollout.png_dir is None:
+        return False
+    video_steps = [
+        st
+        for st in rollout.steps
+        if st.png_path is not None and video_start_idx <= st.rec_idx < video_end_idx
+    ]
+    if not video_steps:
+        return False
+
+    staging = out_mp4.parent / f"_staging_{out_mp4.stem}"
+    if staging.exists():
+        shutil.rmtree(staging)
+    staging.mkdir(parents=True)
+
+    for st in sorted(video_steps, key=lambda x: x.k):
+        if st.png_path and st.png_path.is_file():
+            shutil.copy2(st.png_path, staging / f"{st.png_path.name}")
+
+    if not any(staging.glob("*.png")):
+        shutil.rmtree(staging, ignore_errors=True)
+        return False
+
+    build_mp4(staging, out_mp4, fps)
+    shutil.rmtree(staging, ignore_errors=True)
+    return True

--- a/scenario_generation/metrics/safety_clearance.py
+++ b/scenario_generation/metrics/safety_clearance.py
@@ -1,0 +1,54 @@
+"""Neighbor clearance and road-border distance for closed-loop steps."""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+from planner_metrics.config import RewardConfig
+from planner_metrics.subscores import compute_road_border_penalty
+from scenario_generation.reproducer_rollout import score_step
+
+
+def score_safety_step(
+    neighbors_live: np.ndarray,
+    ego_shape: np.ndarray,
+    np_dict: dict,
+    device: str,
+    *,
+    margin_m: float = 0.3,
+) -> dict:
+    """Per-step neighbor clearance + road-border distance and violation flags."""
+    clearance_m, collision, _n_valid = score_step(
+        neighbors_live, ego_shape, ego_speed=0.0, device=device
+    )
+
+    rb_dist_m = float("inf")
+    if "line_strings" in np_dict and "ego_shape" in np_dict:
+        ego_shape_t = torch.tensor(
+            np.asarray(np_dict["ego_shape"]).reshape(-1)[:3],
+            dtype=torch.float32,
+            device=device,
+        )
+        traj = torch.zeros(1, 1, 4, dtype=torch.float32, device=device)
+        traj[0, 0, 2] = 1.0  # heading +x in ego frame
+        data = {
+            "line_strings": torch.tensor(
+                np_dict["line_strings"][None], dtype=torch.float32, device=device
+            )
+        }
+        _gate, _near, _wide, _steps, _cont, per_ts_min = compute_road_border_penalty(
+            traj, ego_shape_t, data, config=RewardConfig()
+        )
+        rb_dist_m = float(per_ts_min[0, 0].item())
+
+    neighbor_violation = clearance_m < margin_m
+    rb_violation = rb_dist_m < margin_m
+    return {
+        "clearance_m": clearance_m,
+        "collision": collision,
+        "rb_dist_m": rb_dist_m,
+        "neighbor_violation": neighbor_violation,
+        "rb_violation": rb_violation,
+        "safety_violation": neighbor_violation or rb_violation or collision,
+    }

--- a/scenario_generation/metrics/turn_indicator.py
+++ b/scenario_generation/metrics/turn_indicator.py
@@ -1,0 +1,47 @@
+"""Turn-indicator scoring for left/right turn scenario groups."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from scenario_generation.simulate import decode_turn_indicator
+
+# Class ids aligned with C++ TurnIndicatorManager / decode_turn_indicator.
+TI_NONE = 0
+TI_LEFT = 2
+TI_RIGHT = 3
+TI_KEEP = 4
+
+
+def expected_turn_class(metric_group: str) -> int | None:
+    if metric_group == "left_turn":
+        return TI_LEFT
+    if metric_group == "right_turn":
+        return TI_RIGHT
+    return None
+
+
+def score_turn_indicator_step(
+    outputs: dict,
+    metric_group: str,
+    *,
+    keep_bias: float = 0.25,
+) -> dict:
+    """Compare model-predicted turn indicator to expected side for turn groups."""
+    expected = expected_turn_class(metric_group)
+    if expected is None:
+        return {"turn_pred": None, "turn_expected": None, "turn_match": None}
+
+    if "turn_indicator_logit" not in outputs:
+        return {"turn_pred": None, "turn_expected": expected, "turn_match": False}
+
+    pred = int(
+        np.asarray(decode_turn_indicator(outputs["turn_indicator_logit"], keep_bias)).reshape(-1)[0]
+    )
+    # LEFT/RIGHT match; KEEP also acceptable when actively turning.
+    match = pred == expected or (pred == TI_KEEP and expected in (TI_LEFT, TI_RIGHT))
+    return {
+        "turn_pred": pred,
+        "turn_expected": expected,
+        "turn_match": bool(match),
+    }

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -565,6 +565,8 @@ class SegmentResult:
     clearances: np.ndarray
     collisions: np.ndarray
     timers: Timers = field(default_factory=Timers)
+    steps: list = field(default_factory=list)
+    png_dir: Path | None = None
 
 
 @dataclass
@@ -971,7 +973,10 @@ def _finalize(s: _SegState, timers: Timers) -> SegmentResult:
         "n_snaps": int(s.n_snaps),
     }
     return SegmentResult(
-        metrics=metrics, clearances=s.clearances, collisions=s.collisions, timers=timers
+        metrics=metrics,
+        clearances=s.clearances,
+        collisions=s.collisions,
+        timers=timers,
     )
 
 
@@ -1372,7 +1377,11 @@ def render_segment(
     *,
     replan_interval: int = 1,
     draw_every: int = 1,
-) -> dict:
+    instrument: bool = False,
+    area_episodes: list | None = None,
+    area_to_metric_group: dict[str, str] | None = None,
+    profile_sync_gpu: bool = False,
+) -> dict | SegmentResult:
     """Re-run one segment with per-step PNG rendering (live-ego frame).
 
     Turn indicators are CLOSED-LOOP: the model's own predicted turn indicator is fed back
@@ -1407,9 +1416,16 @@ def render_segment(
     tracking: every step (replan ticks included) places the ego DIRECTLY on the model's predicted
     world pose, so the realized trajectory exactly follows the predicted polyline — no Euler /
     heading-snap drift and no MPC physical smoothing.
-    Returns the SegmentResult metrics.
+    Returns segment metrics dict, or a full :class:`SegmentResult` when ``instrument=True``.
     """
     from pathlib import Path
+
+    if instrument:
+        from scenario_generation.closed_loop_types import StepRecord
+        from scenario_generation.metrics.centerline_deviation import lateral_offset_from_route_lanes
+        from scenario_generation.metrics.safety_clearance import score_safety_step
+        from scenario_generation.metrics.turn_indicator import score_turn_indicator_step
+        from scenario_generation.scenario_classification import area_at_idx
 
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -1444,6 +1460,7 @@ def render_segment(
         else {}
     )
     plan_world = None  # cached (world_xy(T,2), world_h(T,)) from the most recent inference
+    step_records: list = []
     # Per-step termination diagnostics: lets you see WHY a segment keeps running (e.g. the ego
     # looks near the goal in the PNG but `dist_goal` never drops below `goal_reach_m` because the
     # goal is the recorded GT end pose `poses[end-1]`, which a diverging closed-loop ego may never
@@ -1517,6 +1534,8 @@ def render_segment(
             model,
             model_args,
             device,
+            timers=timers if instrument else None,
+            profile_sync_gpu=profile_sync_gpu,
         )
         if outputs is not None:
             _feed_turn_indicator(s, outputs)
@@ -1541,18 +1560,52 @@ def render_segment(
         nids = slot_uuids or (tl.neighbor_ids(idx) if (color_by_uuid or interpolate) else None)
         if interpolate and nids and interp:
             _apply_neighbor_interp(np_dict, nids, s.live_pose, idx, interp)
+        png_path = None
         if (window is None or (window[0] <= k <= window[1])) and k % draw_every == 0:
+            png_path = out_dir / f"{k:05d}.png"
             _draw_step(
                 np_dict,
                 pred_cur,
                 s.ego_shape,
-                out_dir / f"{k:05d}.png",
+                png_path,
                 neighbor_ids=nids if color_by_uuid else None,
                 step=k,
                 total=cap,
                 title_prefix=title_prefix,
                 distance_label_offset_m=distance_label_offset_m,
                 view_half_m=view_half_m,
+            )
+        if instrument:
+            area = area_at_idx(area_episodes or [], int(idx))
+            metric_group = area_to_metric_group.get(area) if area and area_to_metric_group else None
+            turn_match = None
+            centerline_m = None
+            if outputs is not None and metric_group is not None:
+                ti = score_turn_indicator_step(outputs, metric_group)
+                if ti["turn_match"] is not None:
+                    turn_match = bool(ti["turn_match"])
+            if metric_group in ("straight", "curve"):
+                centerline_m = lateral_offset_from_route_lanes(np_dict["route_lanes"])
+            safety = score_safety_step(
+                neighbors_live,
+                s.ego_shape,
+                np_dict,
+                device,
+                margin_m=near_miss_thresh,
+            )
+            step_records.append(
+                StepRecord(
+                    k=int(k),
+                    rec_idx=int(idx),
+                    area=area,
+                    centerline_m=centerline_m,
+                    turn_match=turn_match,
+                    clearance_m=float(safety["clearance_m"]),
+                    collision=bool(safety["collision"]),
+                    neighbor_violation=bool(safety["neighbor_violation"]),
+                    rb_violation=bool(safety["rb_violation"]),
+                    png_path=png_path,
+                )
             )
         _score_into(s, neighbors_live, device, timers)
         snaps_before = s.n_snaps
@@ -1561,7 +1614,12 @@ def render_segment(
             # Unstick teleport: cached plan is pinned pre-snap — force a fresh inference.
             plan_world = None
     dbg.close()
-    return _finalize(s, timers).metrics
+    result = _finalize(s, timers)
+    if instrument:
+        result.steps = step_records
+        result.png_dir = out_dir
+        return result
+    return result.metrics
 
 
 @torch.no_grad()

--- a/scenario_generation/scenario_classification.py
+++ b/scenario_generation/scenario_classification.py
@@ -1,0 +1,470 @@
+"""Load and resolve portable scenario classification JSON (Meta-Repository format).
+
+Layout convention (mirrors on-disk NPZ valid trees)::
+
+    NPZ valid:   {corpus}/{project}/{map}/valid/{date}/{bag}/
+    Class JSON:  {root}/{project}/{map}/{date}.json
+
+Example::
+
+    .../x2_dev/2231_odaiba_shinagawa_copied_from_xx1/valid/2026-01-15/13-42-45/
+    .../scenario_classification_json/x2_dev/2231_odaiba_shinagawa_copied_from_xx1/2026-01-15.json
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+AreaEpisode = dict
+# keys: area, metric_group, video_start_idx, video_end_idx, labeled_ranges
+
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+BAG_RE = re.compile(r"^\d{2}-\d{2}-\d{2}$")
+
+
+@dataclass(frozen=True)
+class NpzValidLayout:
+    """Parsed NPZ path under ``.../{project}/{map}/valid/...``."""
+
+    dataset_key: str
+    valid_root: Path
+    dates: tuple[str, ...]
+    npz_roots_by_date: dict[str, Path]
+
+
+@dataclass(frozen=True)
+class ClassificationEvalJob:
+    """One grouped closed-loop eval: one valid date folder + one classification JSON."""
+
+    npz_root: Path
+    classification_json: Path
+    dataset_key: str
+    date: str
+
+
+def load_classification_json(path: Path) -> dict:
+    """Load scenario_classification_json document."""
+    return json.loads(path.expanduser().resolve().read_text(encoding="utf-8"))
+
+
+def time_series_from_doc(doc: dict) -> dict[str, dict]:
+    """Per-bag ``time_series`` entries.
+
+    Legacy docs may use top-level ``sequences``; they are normalized to the same shape.
+    """
+    if "time_series" in doc:
+        return dict(doc["time_series"])
+    legacy = doc.get("sequences", {})
+    return {k: {"name": k, **v} for k, v in legacy.items()}
+
+
+def load_area_metric_groups(doc: dict) -> dict[str, str]:
+    """area_name -> metric_group."""
+    if "area_catalog" in doc:
+        return {str(k): str(v["metric_group"]) for k, v in doc["area_catalog"].items()}
+    if "areas" in doc:
+        return {str(k): str(v["metric_group"]) for k, v in doc["areas"].items()}
+    out: dict[str, str] = {}
+    for entry in time_series_from_doc(doc).values():
+        for ep in episodes_from_entry(entry):
+            out[str(ep["area"])] = str(ep["metric_group"])
+    return out
+
+
+def _normalize_labeled_ranges(seg: dict) -> list[list[int]]:
+    if "labeled_ranges" in seg:
+        return [[int(r[0]), int(r[1])] for r in seg["labeled_ranges"]]
+    return [[int(seg["start_idx"]), int(seg["end_idx"])]]
+
+
+def episodes_from_entry(entry: dict) -> list[AreaEpisode]:
+    """Return normalized episode list for one bag entry.
+
+    v2.2 episodes bridge unlabeled gaps via ``video_*``; metrics use ``labeled_ranges``.
+    v2.1 ``start_idx``/``end_idx`` and legacy ``area_by_idx`` are upgraded on read.
+    """
+    if "segments" in entry:
+        episodes: list[AreaEpisode] = []
+        for seg in entry["segments"]:
+            if "labeled_ranges" in seg:
+                episodes.append(
+                    {
+                        "area": str(seg["area"]),
+                        "metric_group": str(seg["metric_group"]),
+                        "video_start_idx": int(seg["video_start_idx"]),
+                        "video_end_idx": int(seg["video_end_idx"]),
+                        "labeled_ranges": _normalize_labeled_ranges(seg),
+                    }
+                )
+            else:
+                start = int(seg["start_idx"])
+                end = int(seg["end_idx"])
+                episodes.append(
+                    {
+                        "area": str(seg["area"]),
+                        "metric_group": str(seg["metric_group"]),
+                        "video_start_idx": start,
+                        "video_end_idx": end,
+                        "labeled_ranges": [[start, end]],
+                    }
+                )
+        return _merge_v21_episodes(episodes)
+
+    area_by_idx = entry.get("area_by_idx") or []
+    groups = entry.get("metric_group_by_idx") or [None] * len(area_by_idx)
+    chunks: list[AreaEpisode] = []
+    for area, start_idx, end_idx in iter_area_spans(area_by_idx):
+        mg = groups[start_idx] if start_idx < len(groups) else None
+        chunks.append(
+            {
+                "area": area,
+                "metric_group": str(mg) if mg else "",
+                "video_start_idx": start_idx,
+                "video_end_idx": end_idx,
+                "labeled_ranges": [[start_idx, end_idx]],
+            }
+        )
+    return _merge_v21_episodes(chunks)
+
+
+def _merge_v21_episodes(episodes: list[AreaEpisode]) -> list[AreaEpisode]:
+    """Merge consecutive same-area v2.1-style episodes (bridge unlabeled gaps)."""
+    merged: list[AreaEpisode] = []
+    for ep in episodes:
+        if merged and merged[-1]["area"] == ep["area"]:
+            merged[-1]["video_end_idx"] = int(ep["video_end_idx"])
+            merged[-1]["labeled_ranges"].extend(ep["labeled_ranges"])
+        else:
+            merged.append(
+                {
+                    "area": ep["area"],
+                    "metric_group": ep["metric_group"],
+                    "video_start_idx": int(ep["video_start_idx"]),
+                    "video_end_idx": int(ep["video_end_idx"]),
+                    "labeled_ranges": [list(r) for r in ep["labeled_ranges"]],
+                }
+            )
+    return merged
+
+
+def segments_from_entry(entry: dict) -> list[AreaEpisode]:
+    """Alias for :func:`episodes_from_entry` (kept for older call sites)."""
+    return episodes_from_entry(entry)
+
+
+def iter_episodes(entry: dict) -> Iterator[AreaEpisode]:
+    """Yield normalized episodes for one bag."""
+    yield from episodes_from_entry(entry)
+
+
+def iter_segments(entry: dict) -> Iterator[tuple[str, int, int]]:
+    """Yield ``(area_name, start_idx, end_idx)`` per labeled range (legacy helper)."""
+    for ep in episodes_from_entry(entry):
+        for start, end in ep["labeled_ranges"]:
+            yield str(ep["area"]), int(start), int(end)
+
+
+def idx_in_labeled_ranges(idx: int, labeled_ranges: list[list[int]]) -> bool:
+    return any(int(start) <= idx < int(end) for start, end in labeled_ranges)
+
+
+def area_at_idx(episodes: list[AreaEpisode], idx: int) -> str | None:
+    """Map reproducer frame index to area name on labeled frames only."""
+    for ep in episodes:
+        if idx_in_labeled_ranges(idx, ep["labeled_ranges"]):
+            return str(ep["area"])
+    return None
+
+
+def iter_area_spans(area_by_idx: list[str | None]) -> Iterator[tuple[str, int, int]]:
+    """Yield ``(area_name, start_idx, end_idx)`` for each contiguous labeled span (legacy)."""
+    i, n = 0, len(area_by_idx)
+    while i < n:
+        area = area_by_idx[i]
+        if area is None:
+            i += 1
+            continue
+        start = i
+        i += 1
+        while i < n and area_by_idx[i] == area:
+            i += 1
+        yield str(area), start, i
+
+
+def validate_classification_npz_root(doc: dict, npz_root: Path) -> list[str]:
+    """Return warning strings if JSON date disagrees with ``npz_root`` basename."""
+    warnings: list[str] = []
+    date = doc.get("date")
+    if date and npz_root.name != date:
+        warnings.append(f"npz_root basename {npz_root.name!r} != classification date {date!r}")
+    return warnings
+
+
+def classification_json_search_roots() -> list[Path]:
+    """Default roots for ``scenario_classification_json/{dataset_key}/{date}.json``."""
+    roots: list[Path] = []
+    env = os.environ.get("SCENARIO_CLASSIFICATION_JSON_ROOT")
+    if env:
+        roots.append(Path(env).expanduser())
+    repo_root = Path(__file__).resolve().parents[1]
+    roots.append(
+        repo_root.parent
+        / "Diffusion-Planner-Meta-Repository"
+        / "dataset"
+        / "scenario_classification_json"
+    )
+    return roots
+
+
+def parse_npz_valid_layout(
+    npz_root: Path | str,
+    *,
+    dataset_name: str | None = None,
+) -> NpzValidLayout | None:
+    """Infer ``{project}/{map}``, valid root, and date(s) from an NPZ path.
+
+    Supported ``npz_root`` shapes::
+
+        .../{project}/{map}/valid
+        .../{project}/{map}/valid/{date}
+        .../{project}/{map}/valid/{date}/{bag}
+    """
+    path = Path(npz_root).expanduser()
+    if not path.is_absolute():
+        path = Path.cwd() / path
+    # Keep symlink components (e.g. .../diffusion_planner_local_dataset/x2_dev/.../valid)
+    # so dataset_key inference matches classification JSON layout; do not .resolve().
+    parts = path.parts
+    if "valid" not in parts:
+        return None
+
+    valid_idx = parts.index("valid")
+    if valid_idx < 2:
+        return None
+
+    inferred_key = "/".join(parts[valid_idx - 2 : valid_idx])
+    dataset_key = (dataset_name or inferred_key).strip("/")
+    valid_root = Path(*parts[: valid_idx + 1])
+
+    def _npz_date_dir(date: str) -> Path:
+        logical = valid_root / date
+        if logical.is_dir():
+            return logical
+        return (valid_root / date).resolve()
+
+    after_valid = parts[valid_idx + 1 :]
+    if not after_valid:
+        dates = sorted(d.name for d in valid_root.iterdir() if d.is_dir() and DATE_RE.match(d.name))
+        return NpzValidLayout(
+            dataset_key=dataset_key,
+            valid_root=valid_root,
+            dates=tuple(dates),
+            npz_roots_by_date={d: _npz_date_dir(d) for d in dates},
+        )
+
+    if not DATE_RE.match(after_valid[0]):
+        return None
+
+    date = after_valid[0]
+    return NpzValidLayout(
+        dataset_key=dataset_key,
+        valid_root=valid_root,
+        dates=(date,),
+        npz_roots_by_date={date: _npz_date_dir(date)},
+    )
+
+
+def _classification_search_roots(
+    classification_root: Path | str | None,
+    search_roots: list[Path] | None,
+) -> list[Path]:
+    roots: list[Path] = []
+    if classification_root:
+        root = Path(classification_root).expanduser()
+        if root.is_dir():
+            roots.append(root.resolve())
+    for root in search_roots or classification_json_search_roots():
+        resolved = root.expanduser().resolve()
+        if resolved.is_dir() and resolved not in roots:
+            roots.append(resolved)
+    return roots
+
+
+def _npz_date_has_bags(npz_date_root: Path) -> bool:
+    """True when the date folder exists and has at least one bag subdir or NPZ files."""
+    if not npz_date_root.is_dir():
+        return False
+    for child in npz_date_root.iterdir():
+        if child.is_dir() and BAG_RE.match(child.name):
+            return True
+        if child.suffix == ".npz":
+            return True
+    return False
+
+
+def discover_classification_eval_jobs(
+    npz_root: Path | str,
+    classification_root: Path | str | None = None,
+    *,
+    explicit_path: str | Path | None = None,
+    dataset_name: str | None = None,
+    search_roots: list[Path] | None = None,
+) -> list[ClassificationEvalJob]:
+    """Match classification JSON files under ``classification_root`` to NPZ valid dates.
+
+    Resolution order:
+    1. ``explicit_path`` when it is an existing ``.json`` file (legacy single-file override).
+    2. ``{root}/{dataset_key}/{date}.json`` for each valid date under ``npz_root``.
+    """
+    layout = parse_npz_valid_layout(npz_root, dataset_name=dataset_name)
+    if layout is None:
+        return []
+
+    if explicit_path:
+        path = Path(explicit_path).expanduser()
+        if path.is_file():
+            date = path.stem
+            npz_date_root = layout.npz_roots_by_date.get(date)
+            if npz_date_root is None:
+                # Legacy: npz_root may already be the date folder while JSON path is explicit.
+                npz_date_root = Path(npz_root).expanduser().resolve()
+                if DATE_RE.match(npz_date_root.name):
+                    date = npz_date_root.name
+                else:
+                    return []
+            return [
+                ClassificationEvalJob(
+                    npz_root=npz_date_root,
+                    classification_json=path.resolve(),
+                    dataset_key=layout.dataset_key,
+                    date=date,
+                )
+            ]
+        if path.is_dir():
+            classification_root = path
+
+    roots = _classification_search_roots(classification_root, search_roots)
+    if not roots:
+        return []
+
+    jobs: list[ClassificationEvalJob] = []
+    for date in layout.dates:
+        npz_date_root = layout.npz_roots_by_date[date]
+        if not _npz_date_has_bags(npz_date_root):
+            continue
+        json_path: Path | None = None
+        for root in roots:
+            candidate = root / layout.dataset_key / f"{date}.json"
+            if candidate.is_file():
+                json_path = candidate.resolve()
+                break
+        if json_path is None:
+            continue
+        jobs.append(
+            ClassificationEvalJob(
+                npz_root=npz_date_root,
+                classification_json=json_path,
+                dataset_key=layout.dataset_key,
+                date=date,
+            )
+        )
+    return jobs
+
+
+def resolve_classification_json(
+    npz_root: Path | str,
+    explicit: str | Path | None = None,
+    *,
+    dataset_name: str | None = None,
+    classification_root: str | Path | None = None,
+    search_roots: list[Path] | None = None,
+) -> Path | None:
+    """Resolve a single classification JSON for grouped closed-loop eval.
+
+    When multiple dates match, returns the JSON for the first matched date (sorted).
+    Prefer :func:`discover_classification_eval_jobs` for multi-date validation.
+    """
+    root = classification_root
+    explicit_path = explicit
+    if explicit:
+        path = Path(explicit).expanduser()
+        if path.is_dir():
+            root = path
+            explicit_path = None
+
+    jobs = discover_classification_eval_jobs(
+        npz_root,
+        classification_root=root,
+        explicit_path=explicit_path,
+        dataset_name=dataset_name,
+        search_roots=search_roots,
+    )
+    if not jobs:
+        return None
+    return jobs[0].classification_json
+
+
+def merge_grouped_eval_summaries(summaries: list[dict]) -> dict:
+    """Merge multiple grouped closed-loop summaries (e.g. several valid dates)."""
+    from scenario_generation.metrics.group_report import aggregate_segment_rows
+
+    if not summaries:
+        return {"mode": "grouped", "grouped_summary": {"by_area_name": {}, "totals": {}}}
+    if len(summaries) == 1:
+        return summaries[0]
+
+    all_segments: list[dict] = []
+    video_mp4s: list = []
+    elapsed_sec = 0.0
+    n_bags = 0
+    jobs_meta: list[dict] = []
+
+    for summary in summaries:
+        all_segments.extend(summary.get("segments") or [])
+        video_mp4s.extend(summary.get("video_mp4s") or [])
+        elapsed_sec += float(summary.get("elapsed_sec", 0.0))
+        n_bags += int(summary.get("n_bags", 0))
+        jobs_meta.append(
+            {
+                "date": summary.get("date"),
+                "dataset_key": summary.get("dataset_key"),
+                "classification_json": summary.get("classification_json"),
+                "npz_root": summary.get("npz_root"),
+            }
+        )
+
+    grouped_summary = aggregate_segment_rows(all_segments)
+    base = summaries[0]
+    timing = None
+    if any(s.get("timing") for s in summaries):
+        per_bag: list[dict] = []
+        total_steps = 0
+        for summary in summaries:
+            t = summary.get("timing") or {}
+            total_steps += int(t.get("total_sim_steps", 0))
+            per_bag.extend(t.get("per_bag") or [])
+        from scenario_generation.grouped_closed_loop_eval import build_grouped_timing_summary
+
+        timing = build_grouped_timing_summary(per_bag, total_steps, elapsed_sec)
+
+    merged = {
+        "mode": "grouped",
+        "classification_json": [m["classification_json"] for m in jobs_meta],
+        "classification_jobs": jobs_meta,
+        "npz_root": base.get("npz_root"),
+        "near_miss_thresh": base.get("near_miss_thresh"),
+        "n_episodes": len(all_segments),
+        "n_bags": n_bags,
+        "elapsed_sec": elapsed_sec,
+        "grouped_summary": grouped_summary,
+        "segments": all_segments,
+        "video_mp4s": video_mp4s,
+    }
+    if timing is not None:
+        merged["timing"] = timing
+    return merged

--- a/scenario_generation/wandb_closed_loop.py
+++ b/scenario_generation/wandb_closed_loop.py
@@ -1,0 +1,131 @@
+"""Build wandb log payloads for grouped closed-loop validation."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pandas as pd
+import wandb
+
+from scenario_generation.metrics.group_report import WANDB_EXCLUDED_SCALAR_KEYS
+
+RESULTS_TABLE_COLUMNS = [
+    "area_name",
+    "bag",
+    "span_index",
+    "segment",
+    "n_steps_run",
+    "centerline_mean_m",
+    "centerline_p95_m",
+    "turn_match_rate",
+    "neighbor_violation_steps",
+    "rb_violation_steps",
+    "collision_steps",
+    "n_collision_steps",
+    "n_near_miss_steps",
+    "min_clearance_m",
+    "mean_clearance",
+    "video_path",
+]
+
+
+def build_grouped_closed_loop_wandb_log(summary: dict) -> dict:
+    """Per-area scalars, validation totals, results table, and episode videos."""
+    log: dict = {"closed_loop/mode": "grouped"}
+    log["closed_loop/grouped/elapsed_sec"] = float(summary.get("elapsed_sec", 0.0))
+
+    timing = summary.get("timing")
+    if timing:
+        stages = timing.get("stages") or {}
+        for key, wandb_key in (
+            ("model_forward", "model_forward_total_s"),
+            ("draw", "draw_total_s"),
+            ("timeline_load_npz", "timeline_load_npz_total_s"),
+        ):
+            stage = stages.get(key)
+            if stage:
+                log[f"closed_loop/profile/{wandb_key}"] = float(stage["total_s"])
+        log["closed_loop/profile/model_forward_calls"] = int(timing.get("model_forward_calls", 0))
+        log["closed_loop/profile/total_sim_steps"] = int(timing.get("total_sim_steps", 0))
+        log["closed_loop/profile/model_forward_rate"] = float(timing.get("model_forward_rate", 0.0))
+
+    agg = summary.get("grouped_summary") or {}
+    _log_scalar_group(log, "closed_loop/grouped/total", agg.get("totals") or {})
+
+    for area, stats in (agg.get("by_area_name") or {}).items():
+        safe_area = area.replace("/", "_")
+        _log_scalar_group(log, f"closed_loop/grouped/area/{safe_area}", stats)
+
+    rows = summary.get("segments") or []
+    if rows:
+        df = pd.DataFrame(rows)
+        cols = [c for c in RESULTS_TABLE_COLUMNS if c in df.columns]
+        extra = [
+            c for c in df.columns if c not in cols and c not in ("labeled_ranges", "metric_group")
+        ]
+        log["closed_loop/grouped/results_table"] = wandb.Table(dataframe=df[cols + extra])
+
+    for mp4 in summary.get("video_mp4s") or []:
+        mp4_path = Path(mp4)
+        key = _video_wandb_key(mp4_path)
+        log[key] = wandb.Video(str(mp4_path), format="mp4")
+
+    return log
+
+
+def _log_scalar_group(log: dict, prefix: str, stats: dict) -> None:
+    for key, val in stats.items():
+        if key in WANDB_EXCLUDED_SCALAR_KEYS:
+            continue
+        if not _wandb_scalar(val):
+            continue
+        log[f"{prefix}/{key}"] = val
+
+
+def build_full_closed_loop_wandb_log(summary: dict) -> dict:
+    """Legacy full-route closed-loop wandb payload."""
+    scalar_keys = [
+        "collision_segment_rate",
+        "collision_step_rate",
+        "near_miss_segment_rate",
+        "near_miss_step_rate",
+        "global_min_clearance",
+        "mean_segment_min_clearance",
+        "mean_segment_mean_clearance",
+        "total_collision_steps",
+        "total_near_miss_steps",
+        "total_snaps",
+        "total_steps",
+    ]
+    log = {"closed_loop/mode": "full"}
+    for key in scalar_keys:
+        val = summary.get(key)
+        if _wandb_scalar(val):
+            log[f"closed_loop/{key}"] = val
+    for mp4 in summary.get("video_mp4s") or []:
+        log[f"closed_loop/video/{Path(mp4).stem}"] = wandb.Video(str(mp4), format="mp4")
+    return log
+
+
+def _wandb_scalar(val) -> bool:
+    if val is None:
+        return False
+    if isinstance(val, (int, bool)):
+        return True
+    if isinstance(val, float):
+        return math.isfinite(val)
+    return False
+
+
+def _video_wandb_key(mp4_path: Path) -> str:
+    parts = mp4_path.parts
+    if "videos" in parts:
+        idx = parts.index("videos")
+        rel_parts = list(parts[idx + 1 :])
+        # videos/<metric_group>/<area>/file.mp4 -> area/file for stable area-level keys
+        if len(rel_parts) >= 2:
+            rel_parts = rel_parts[1:]
+        rel = "/".join(rel_parts)
+        return f"closed_loop/grouped/video/{rel.replace('/', '_')}"
+    return f"closed_loop/grouped/video/{mp4_path.stem}"


### PR DESCRIPTION
## Summary
- `closed_loop_validate()` (introduced in #235) calls `ResolvedClosedLoopEvaluation.run_distributed()`, which internally calls `dist.barrier()` when DDP is active.
- The call site in `train.py` was nested inside `if global_rank == 0:`, so under real multi-GPU DDP training only rank 0 would ever reach the barrier; every other rank never does, deadlocking training the first time the `save_utd` cadence fires.
- This PR moves the `save_utd` cadence check and the `closed_loop_validate()` call outside the rank-0 guard so every rank participates in the collective. The rank-0-only checkpoint/ONNX export writes are unaffected.

## Why this wasn't caught by the diff
The buggy call site predates #235 (it called the old, non-DDP `run_closed_loop_eval()` before, with `ddp_world_size` always defaulting to 1, so `run_distributed()`'s barrier path was never exercised). #235 correctly started passing the real `ddp_rank`/`ddp_world_size`, which is what makes the pre-existing rank-0-only placement newly dangerous.

## Test plan
- [x] Static trace of indentation confirms `closed_loop_validate(...)` was reachable only when `global_rank == 0` before this change, and is reachable from every rank after.
- [x] `python3 -m ast` parse check on the modified file.
- [ ] Live multi-GPU DDP smoke test (`NPROC_PER_NODE>1 bash diffusion_planner/run_closed_loop_wandb_smoke.sh`) — not run here (single-GPU dev machine); recommend running before merge.