### PR TITLE
fix(cpp_tools): align turn_indicators_command with autoware_universe …

### DIFF
--- a/cpp_tools/cpp_tools.repos
+++ b/cpp_tools/cpp_tools.repos
@@ -11,7 +11,7 @@ repositories:
   core/autoware_internal_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_internal_msgs.git
-    version: 1.12.1
+    version: 1.14.0
   core/autoware_cmake:
     type: git
     url: https://github.com/autowarefoundation/autoware_cmake.git

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/inference_tool.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/inference_tool.cpp
@@ -731,7 +731,7 @@ int main(int argc, char ** argv)
     writer_parser.write_topic(
       planner_output.predicted_objects, frame_time, TOPIC_OUT_PREDICTED_OBJECTS);
     writer_parser.write_topic(
-      planner_output.turn_indicator_command, frame_time, TOPIC_OUT_TURN_INDICATORS);
+      planner_output.turn_indicators_command, frame_time, TOPIC_OUT_TURN_INDICATORS);
 
     // Build ground truth trajectory from future odometry with interpolation
     autoware_planning_msgs::msg::Trajectory gt_trajectory;


### PR DESCRIPTION
The tool builds against autoware_universe @ main, which moved turn-indicator output to the plural turn_indicators_command names.

- inference_tool.cpp: write PlannerOutput.turn_indicators_command (was the stale singular turn_indicator_command, which no longer exists on the struct).
- cpp_tools.repos: bump autoware_internal_msgs 1.12.1 -> 1.14.0. The turn_indicators_command field was added to CandidateTrajectory.msg in 1.14.0; the old pin made autoware_diffusion_planner fail to compile.