### PR TITLE
[WIP]Feat: Run checkpoint ONNX export in a detached subprocess and dedupe save_utd/best exports

### DIFF
--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -22,7 +22,7 @@ from diffusion_planner.utils.data_augmentation_bridge import (
 from diffusion_planner.utils.dataset import DiffusionPlannerData, DiffusionPlannerPairData
 from diffusion_planner.utils.lr_schedule import CosineAnnealingWarmUpRestarts
 from diffusion_planner.utils.normalizer import ObservationNormalizer, StateNormalizer
-from diffusion_planner.utils.onnx_export import export_checkpoint_onnx_guarded
+from diffusion_planner.utils.onnx_export import launch_checkpoint_onnx_export
 from diffusion_planner.utils.train_utils import resume_model, set_seed
 from diffusion_planner.validate_model import (
     aggregate_replan_consistency_metrics,
@@ -370,6 +370,7 @@ def model_training(args: TrainConfig):
 
     data_list = []
     best_loss = float("inf")
+    onnx_export_procs = []
 
     valid_dict = validate_model(diffusion_planner, valid_loader, args)
     agg = aggregate_valid_metrics(valid_dict, args.device)
@@ -519,6 +520,8 @@ def model_training(args: TrainConfig):
             }
             torch.save(model_dict, f"{save_path}/latest.pth")
 
+            onnx_export_dirs = []
+
             if (epoch + 1 - init_epoch) % save_utd == 0:
                 curr_dir = os.path.join(save_path, f"epoch{epoch + 1:04d}")
                 os.makedirs(curr_dir, exist_ok=True)
@@ -527,17 +530,7 @@ def model_training(args: TrainConfig):
                     json.dump(curr_data, f, indent=4)
                 with open(os.path.join(curr_dir, "args.json"), "w", encoding="utf-8") as f:
                     json.dump(args_dict, f, indent=4)
-                # Export ONNX next to the checkpoint (regular weights, ORT validation skipped).
-                export_checkpoint_onnx_guarded(
-                    config_json_path=os.path.join(curr_dir, "args.json"),
-                    ckpt_path=f"{curr_dir}/best_model.pth",
-                    output_dir=Path(curr_dir),
-                    output_prefix="diffusion_planner",
-                    use_ema=False,
-                    use_simplify=False,
-                    opset_version=20,
-                    external_data=False,
-                )
+                onnx_export_dirs.append(curr_dir)
                 # Closed-loop validation runs on the same cadence as the checkpoint save; outputs
                 # (videos + metrics) land next to the saved weights they correspond to.
                 closed_loop_validate(
@@ -554,20 +547,37 @@ def model_training(args: TrainConfig):
                     json.dump(curr_data, f, indent=4)
                 with open(os.path.join(curr_dir, "args.json"), "w", encoding="utf-8") as f:
                     json.dump(args_dict, f, indent=4)
+                onnx_export_dirs.append(curr_dir)
+
+            if onnx_export_dirs:
                 # Export ONNX next to the checkpoint (regular weights, ORT validation skipped).
-                export_checkpoint_onnx_guarded(
-                    config_json_path=os.path.join(curr_dir, "args.json"),
-                    ckpt_path=f"{curr_dir}/best_model.pth",
-                    output_dir=Path(curr_dir),
+                # The export runs in a detached CPU-only subprocess so the (multi-rank) training
+                # loop never stalls behind the trace; when the epoch is both a save_utd snapshot
+                # and the new best model, the checkpoint is traced once and copied.
+                proc = launch_checkpoint_onnx_export(
+                    config_json_path=os.path.join(onnx_export_dirs[0], "args.json"),
+                    ckpt_path=os.path.join(onnx_export_dirs[0], "best_model.pth"),
+                    output_dirs=[Path(d) for d in onnx_export_dirs],
                     output_prefix="diffusion_planner",
                     use_ema=False,
                     use_simplify=False,
                     opset_version=20,
                     external_data=False,
                 )
+                # Reap finished exports and keep handles so the artifacts are complete
+                # before the run exits.
+                onnx_export_procs = [p for p in onnx_export_procs if p.poll() is None]
+                if proc is not None:
+                    onnx_export_procs.append(proc)
 
         scheduler.step()
         train_sampler.set_epoch(epoch + 1)
+
+    if global_rank == 0:
+        for proc in onnx_export_procs:
+            if proc.poll() is None:
+                print("Waiting for a background ONNX export to finish...")
+            proc.wait()
 
     if global_rank == 0 and wandb.run is not None:
         wandb.finish()

--- a/diffusion_planner/diffusion_planner/utils/onnx_export.py
+++ b/diffusion_planner/diffusion_planner/utils/onnx_export.py
@@ -9,8 +9,13 @@ The backends are only forced (and restored) inside :func:`onnx_export_backends`,
 the export itself, so importing this module from a training process never slows training down.
 """
 
+import argparse
 import contextlib
+import os
 import random
+import shutil
+import subprocess
+import sys
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
@@ -577,3 +582,139 @@ def export_checkpoint_onnx_guarded(
         )
     except Exception as exc:
         print(f"WARNING: ONNX export failed for {ckpt_path}: {exc}")
+
+
+def copy_exported_artifacts(src_dir: Path, dst_dirs: list[Path], output_prefix: str) -> None:
+    """Copy every exported ONNX artifact (including external-data files) to ``dst_dirs``."""
+    artifacts = sorted(Path(src_dir).glob(f"{output_prefix}*.onnx*"))
+    for dst in dst_dirs:
+        dst = Path(dst)
+        dst.mkdir(parents=True, exist_ok=True)
+        for artifact in artifacts:
+            shutil.copy2(artifact, dst / artifact.name)
+
+
+def build_export_command(
+    config_json_path: str,
+    ckpt_path: str,
+    output_dirs: list[Path],
+    output_prefix: str,
+    use_ema: bool,
+    use_simplify: bool,
+    opset_version: int,
+    external_data: bool,
+) -> list[str]:
+    cmd = [
+        sys.executable,
+        "-m",
+        "diffusion_planner.utils.onnx_export",
+        "--config-json",
+        str(config_json_path),
+        "--ckpt",
+        str(ckpt_path),
+        "--output-prefix",
+        output_prefix,
+        "--opset-version",
+        str(opset_version),
+    ]
+    for output_dir in output_dirs:
+        cmd += ["--output-dir", str(output_dir)]
+    if use_ema:
+        cmd.append("--use-ema")
+    if use_simplify:
+        cmd.append("--use-simplify")
+    if external_data:
+        cmd.append("--external-data")
+    return cmd
+
+
+def launch_checkpoint_onnx_export(
+    config_json_path: str,
+    ckpt_path: str,
+    output_dirs: list[Path],
+    output_prefix: str,
+    use_ema: bool,
+    use_simplify: bool,
+    opset_version: int,
+    external_data: bool,
+) -> subprocess.Popen | None:
+    """Launch :func:`export_checkpoint_onnx` in a detached CPU-only subprocess.
+
+    The export re-builds the model from the on-disk checkpoint, so it needs nothing from the
+    training process: running it in a child process keeps the (multi-rank) training loop from
+    stalling behind the CPU trace, and keeps the export's global RNG seeding out of the
+    training process. The child exports once into ``output_dirs[0]`` and copies the artifacts
+    to the remaining dirs, so a checkpoint that is both a ``save_utd`` snapshot and the new
+    best model is only traced once.
+
+    Never raises; returns the ``Popen`` handle (poll/wait it to reap the child), or ``None``
+    when the launch itself failed. Child output goes to ``<output_dirs[0]>/onnx_export.log``.
+    """
+    cmd = build_export_command(
+        config_json_path,
+        ckpt_path,
+        output_dirs,
+        output_prefix,
+        use_ema,
+        use_simplify,
+        opset_version,
+        external_data,
+    )
+    # The export runs on CPU; hide the GPUs so the child never allocates CUDA memory
+    # next to the training process.
+    env = {**os.environ, "CUDA_VISIBLE_DEVICES": ""}
+    log_path = Path(output_dirs[0]) / "onnx_export.log"
+    try:
+        with open(log_path, "w") as log_file:
+            return subprocess.Popen(
+                cmd,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                env=env,
+                start_new_session=True,
+            )
+    except Exception as exc:
+        print(f"WARNING: failed to launch ONNX export subprocess for {ckpt_path}: {exc}")
+        return None
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Export the ONNX graphs for a Diffusion-Planner checkpoint."
+    )
+    parser.add_argument("--config-json", required=True)
+    parser.add_argument("--ckpt", required=True)
+    parser.add_argument(
+        "--output-dir",
+        action="append",
+        required=True,
+        dest="output_dirs",
+        help="Repeatable. The export runs into the first dir; artifacts are copied to the rest.",
+    )
+    parser.add_argument("--output-prefix", default="diffusion_planner")
+    parser.add_argument("--opset-version", type=int, default=20)
+    parser.add_argument("--use-ema", action="store_true")
+    parser.add_argument("--use-simplify", action="store_true")
+    parser.add_argument("--external-data", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _build_arg_parser().parse_args(argv)
+    output_dirs = [Path(d) for d in args.output_dirs]
+    export_checkpoint_onnx(
+        config_json_path=args.config_json,
+        ckpt_path=args.ckpt,
+        output_dir=output_dirs[0],
+        output_prefix=args.output_prefix,
+        use_ema=args.use_ema,
+        use_simplify=args.use_simplify,
+        opset_version=args.opset_version,
+        external_data=args.external_data,
+    )
+    if len(output_dirs) > 1:
+        copy_exported_artifacts(output_dirs[0], output_dirs[1:], args.output_prefix)
+
+
+if __name__ == "__main__":
+    main()

--- a/diffusion_planner/tests/test_onnx_export_launch.py
+++ b/diffusion_planner/tests/test_onnx_export_launch.py
@@ -1,0 +1,140 @@
+"""Subprocess-based ONNX export: command building, artifact copying and the
+detached launch, so the training loop never stalls behind the CPU trace and a
+save_utd + best checkpoint is only traced once."""
+
+from pathlib import Path
+
+from diffusion_planner.utils import onnx_export as oe
+
+
+def test_build_export_command_round_trips_through_parser():
+    cmd = oe.build_export_command(
+        config_json_path="/tmp/args.json",
+        ckpt_path="/tmp/best_model.pth",
+        output_dirs=[Path("/tmp/epoch0010"), Path("/tmp/best_model")],
+        output_prefix="diffusion_planner",
+        use_ema=False,
+        use_simplify=False,
+        opset_version=20,
+        external_data=False,
+    )
+    # sys.executable -m diffusion_planner.utils.onnx_export <args...>
+    assert cmd[1:3] == ["-m", "diffusion_planner.utils.onnx_export"]
+
+    args = oe._build_arg_parser().parse_args(cmd[3:])
+    assert args.config_json == "/tmp/args.json"
+    assert args.ckpt == "/tmp/best_model.pth"
+    assert args.output_dirs == ["/tmp/epoch0010", "/tmp/best_model"]
+    assert args.output_prefix == "diffusion_planner"
+    assert args.opset_version == 20
+    assert args.use_ema is False
+    assert args.use_simplify is False
+    assert args.external_data is False
+
+
+def test_copy_exported_artifacts_copies_all_graphs(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    names = [
+        "diffusion_planner.onnx",
+        "diffusion_planner_encoder.onnx",
+        "diffusion_planner_decoder.onnx",
+        "diffusion_planner_turn_indicator.onnx",
+        "diffusion_planner.onnx.data",  # external-data sidecar
+    ]
+    for name in names:
+        (src / name).write_bytes(b"onnx")
+    (src / "unrelated.txt").write_text("keep out")
+
+    dst1 = tmp_path / "dst1"
+    dst2 = tmp_path / "dst2"  # not pre-created on purpose
+    oe.copy_exported_artifacts(src, [dst1, dst2], "diffusion_planner")
+
+    for dst in [dst1, dst2]:
+        assert sorted(p.name for p in dst.iterdir()) == sorted(names)
+
+
+def test_main_exports_once_then_copies(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_export(**kwargs):
+        calls.append(kwargs)
+        (Path(kwargs["output_dir"]) / "diffusion_planner.onnx").write_bytes(b"onnx")
+
+    monkeypatch.setattr(oe, "export_checkpoint_onnx", lambda **kw: fake_export(**kw))
+
+    primary = tmp_path / "epoch0010"
+    secondary = tmp_path / "best_model"
+    primary.mkdir()
+    oe.main(
+        [
+            "--config-json",
+            str(tmp_path / "args.json"),
+            "--ckpt",
+            str(tmp_path / "best_model.pth"),
+            "--output-dir",
+            str(primary),
+            "--output-dir",
+            str(secondary),
+        ]
+    )
+
+    # exported exactly once, into the first dir
+    assert len(calls) == 1
+    assert calls[0]["output_dir"] == primary
+    # copied to the second dir
+    assert (secondary / "diffusion_planner.onnx").read_bytes() == b"onnx"
+
+
+def test_launch_is_detached_and_cpu_only(tmp_path, monkeypatch):
+    captured = {}
+
+    class FakeProc:
+        def poll(self):
+            return None
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return FakeProc()
+
+    monkeypatch.setattr(oe.subprocess, "Popen", fake_popen)
+
+    out_dir = tmp_path / "epoch0010"
+    out_dir.mkdir()
+    proc = oe.launch_checkpoint_onnx_export(
+        config_json_path=str(out_dir / "args.json"),
+        ckpt_path=str(out_dir / "best_model.pth"),
+        output_dirs=[out_dir],
+        output_prefix="diffusion_planner",
+        use_ema=False,
+        use_simplify=False,
+        opset_version=20,
+        external_data=False,
+    )
+
+    assert isinstance(proc, FakeProc)
+    assert captured["kwargs"]["start_new_session"] is True
+    assert captured["kwargs"]["env"]["CUDA_VISIBLE_DEVICES"] == ""
+    assert (out_dir / "onnx_export.log").exists()
+
+
+def test_launch_failure_returns_none(tmp_path, monkeypatch):
+    def fake_popen(cmd, **kwargs):
+        raise OSError("spawn failed")
+
+    monkeypatch.setattr(oe.subprocess, "Popen", fake_popen)
+
+    out_dir = tmp_path / "epoch0010"
+    out_dir.mkdir()
+    proc = oe.launch_checkpoint_onnx_export(
+        config_json_path="c",
+        ckpt_path="k",
+        output_dirs=[out_dir],
+        output_prefix="diffusion_planner",
+        use_ema=False,
+        use_simplify=False,
+        opset_version=20,
+        external_data=False,
+    )
+    assert proc is None


### PR DESCRIPTION
 ## Summary
  - Moved the per-checkpoint ONNX export out of the training process into a detached, CPU-only
  subprocess (`launch_checkpoint_onnx_export` + a new `python -m diffusion_planner.utils.onnx_export`
  CLI). The export already rebuilds the model from the on-disk `.pth` + `args.json`, so it needs
  nothing from the training process — rank 0 no longer stalls all ranks behind the CPU trace of 4
  graphs (the full graph contains 10 unrolled DiT evaluations)
  - Deduplicated the double export: when an epoch is both a `save_utd` snapshot and the new best model,
  the checkpoint is now traced once and the artifacts are copied to the second directory (previously 8
  traced graphs, now 4)
  - The child runs with `CUDA_VISIBLE_DEVICES=""` (never touches GPU memory), logs to
  `<output_dir>/onnx_export.log`, and is detached via `start_new_session`; the training loop reaps
  finished exports each launch and waits for stragglers before exiting so artifacts are always complete
  - Side effect: the export's global RNG seeding (`random/np/torch.manual_seed(42)` in
  `export_checkpoint_onnx`) no longer runs inside the training process, so it can no longer reset rank
  0's augmentation RNG mid-training (O-B1 in `docs/onnx_export_analysis.md`)
  - `export_checkpoint_onnx_guarded` is kept unchanged for existing callers (e.g.
  `train_grpo_predictor.py`); migrating GRPO can follow up separately

  ## Test plan
  - Added `diffusion_planner/tests/test_onnx_export_launch.py` (5 tests): command/parser round-trip,
  artifact copying (creates missing dirs, includes external-data sidecars, excludes unrelated files),
  `main()` exports once then copies, launch is detached and CPU-only with a log file, launch failure
  returns `None` without raising
  - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest diffusion_planner/tests/test_onnx_export_launch.py`
  — 5 passed
  - Verified `python -m diffusion_planner.utils.onnx_export --help` works and `diffusion_planner.train`
  imports cleanly
