### PR TITLE
fix: centric transform goal pose

### DIFF
--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -425,6 +425,16 @@ class StatePerturbation:
         )
         inputs["ego_agent_future"] = ego_future
 
+        # goal pose (x, y, cos, sin)
+        mask = torch.sum(torch.ne(inputs["goal_pose"], 0), dim=-1) == 0
+        inputs["goal_pose"][..., :2] = vector_transform(
+            inputs["goal_pose"][..., :2], transform_matrix, center_xy
+        )
+        inputs["goal_pose"][..., 2:4] = vector_transform(
+            inputs["goal_pose"][..., 2:4], transform_matrix
+        )
+        inputs["goal_pose"][mask] = 0.0
+
         # neighbor past xy
         mask = torch.sum(torch.ne(inputs["neighbor_agents_past"][..., :6], 0), dim=-1) == 0
         inputs["neighbor_agents_past"][..., :2] = vector_transform(

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_bridge.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_bridge.py
@@ -1414,6 +1414,16 @@ class StatePerturbation:
         ego_future[..., 2] = heading_transform(ego_future[..., 2], transform_matrix)
         inputs["ego_agent_future"] = ego_future
 
+        # goal pose (x, y, cos, sin)
+        mask = torch.sum(torch.ne(inputs["goal_pose"], 0), dim=-1) == 0
+        inputs["goal_pose"][..., :2] = vector_transform(
+            inputs["goal_pose"][..., :2], transform_matrix, center_xy
+        )
+        inputs["goal_pose"][..., 2:4] = vector_transform(
+            inputs["goal_pose"][..., 2:4], transform_matrix
+        )
+        inputs["goal_pose"][mask] = 0.0
+
         # neighbor past xy
         mask = torch.sum(torch.ne(inputs["neighbor_agents_past"][..., :6], 0), dim=-1) == 0
         inputs["neighbor_agents_past"][..., :2] = vector_transform(


### PR DESCRIPTION
## Description

During state-perturbation data augmentation, `centric_transform` re-anchors all model inputs and labels (`lanes`, `route_lanes`, ego future, neighbors, polygons, line strings, static objects) into the perturbed ego frame — but `goal_pose` was left in the un-perturbed frame.

With a lateral perturbation of ±0.75 m and a heading perturbation of ±0.2 rad applied to ~50% of training samples, the goal's **lateral** position becomes zero-mean noise with respect to the label endpoint (a 0.2 rad frame rotation displaces a goal 100 m ahead by up to ~20 m laterally), while its **longitudinal** position stays almost intact. Training therefore teaches the model to ignore the lateral component of `goal_pose`.

This matches the behavior observed in deployment: the ego reaches the goal longitudinally but with a consistent lateral offset, and rides laterally offset from the lane centerline.

## Changes

- Transform `goal_pose` (x, y, cos, sin) into the perturbed ego frame in `centric_transform`, for both augmentation paths:
  - quintic: `diffusion_planner/utils/data_augmentation.py`
  - bridge: `diffusion_planner/utils/data_augmentation_bridge.py`
- All-zero rows are kept zero, following the same masking convention as the other inputs (consistent with `ObservationNormalizer`).

All callers (`train_epoch.py`, `grpo_epoch.py`) convert `goal_pose` to the (x, y, cos, sin) format before invoking the augmentation, so the `[..., 2:4]` slice is always valid.

## Verification

- Numerical check: a goal placed at the same coordinates as a lane point maps to the identical position after the transform; the goal heading rotates by −δθ; the transform is the identity for non-augmented samples (ego current state = (0, 0, 1, 0)). Verified for both quintic and bridge paths.
- `tests/test_data_augmentation.py`: 32 failed / 26 passed both **before and after** this change — the failures are pre-existing (the tests call `StatePerturbation()` with an outdated constructor signature) and no new failures are introduced.
- `pre-commit` (ruff etc.): passed.

## Notes

- This is a training-time fix only; **retraining is required** for it to take effect.
- `centric_transform` runs unconditionally inside `StatePerturbation.__call__`; the only gate is `use_data_augment` (default `True`, `augment_type="quintic"`).
