### PR TITLE
Restore closed-loop seg_len segment rollouts

### DIFF
--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -127,6 +127,7 @@ def closed_loop_validate(model, args, epoch: int, out_dir: str) -> None:
             args,
             args.closed_loop_npz_root,
             out_dir,
+            seg_len=args.closed_loop_seg_len,
             device=args.device,
             near_miss_thresh=args.closed_loop_near_miss_thresh,
             search_radius=args.closed_loop_search_radius,

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -156,6 +156,7 @@ class TrainConfig:
     # one route).
     # ---------------------------------------------------------
     closed_loop_npz_root: str = ""
+    closed_loop_seg_len: int = 100000  # large -> one route = one segment = one trial
     # Re-plan every N steps: replan=1 is a model forward EVERY step (~minutes/epoch over a full
     # route); 40 keeps per-epoch cost to ~tens of seconds. Lower it for higher-fidelity validation.
     closed_loop_replan_interval: int = 4

--- a/diffusion_planner/train_grpo_predictor.py
+++ b/diffusion_planner/train_grpo_predictor.py
@@ -330,6 +330,12 @@ def get_args():
         "cadence (save_utd). Empty = disabled. One route per trial.",
     )
     parser.add_argument(
+        "--closed_loop_seg_len",
+        type=int,
+        default=100000,
+        help="frames per segment; large => one route = one segment = one trial",
+    )
+    parser.add_argument(
         "--closed_loop_replan_interval",
         type=int,
         default=4,

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -243,6 +243,12 @@ def get_args(args_list=None):
         "cadence (save_utd). Empty = disabled. One route per trial.",
     )
     parser.add_argument(
+        "--closed_loop_seg_len",
+        type=int,
+        default=100000,
+        help="frames per segment; large => one route = one segment = one trial",
+    )
+    parser.add_argument(
         "--closed_loop_replan_interval",
         type=int,
         default=4,

--- a/diffusion_planner/valid_predictor_closed_loop.py
+++ b/diffusion_planner/valid_predictor_closed_loop.py
@@ -9,10 +9,11 @@ realized ego footprint is scored against those neighbors with the canonical OBB
 (``score_step`` -> collision / near-miss / min clearance).
 
 A *route* = one bag-prefix group of consecutive 10 Hz NPZ frames (``RouteTimeline``);
-each route is rolled out whole with ``render_segment`` (one GPU forward per tick), which BOTH
-returns the route metrics AND writes a per-step PNG of the live-ego scene. Every run therefore
-always produces video: one MP4 per route (``<route>.mp4``). Per-route metrics are streamed to
-``segments.jsonl`` and aggregated into ``summary.json`` (both next to the checkpoint).
+each route is sliced into ``--seg_len`` segments and rolled out with ``render_segment``
+(one GPU forward per tick), which BOTH returns the segment metrics AND writes a per-step
+PNG of the live-ego scene. Every run therefore always produces video: one MP4 per segment
+(``<route>_<start>_<end>.mp4``). Per-segment metrics are streamed to ``segments.jsonl`` and
+aggregated into ``summary.json`` (both next to the checkpoint).
 
 Only ``--model_path`` and ``--npz_root`` are required; all outputs are written next to
 the checkpoint (``<model_path dir>/closed_loop/``) and the rollout knobs default to the
@@ -56,6 +57,7 @@ def parse_args() -> argparse.Namespace:
         "sidecars are read from next to each .npz, falling back to its own source tree.",
     )
     # --- tunable knobs (default to the closed-loop mining config) ---
+    p.add_argument("--seg_len", type=int, default=6000, help="frames per segment (~60s @10Hz)")
     p.add_argument("--device", type=str, default="cuda", help="'cuda' or 'cpu'")
     p.add_argument("--near_miss_thresh", type=float, default=0.5, help="near-miss clearance (m)")
     p.add_argument(
@@ -124,6 +126,7 @@ def _eval_knobs(args: argparse.Namespace) -> dict:
     """The rollout tunables forwarded to run_closed_loop_eval (everything except model/npz/out/
     device/shard), gathered once so the sequential and per-worker calls stay in lockstep."""
     return dict(
+        seg_len=args.seg_len,
         near_miss_thresh=args.near_miss_thresh,
         search_radius=args.search_radius,
         warmup_steps=args.warmup_steps,
@@ -243,7 +246,7 @@ def main() -> None:
         f"mean_segment_mean_clearance={summary['mean_segment_mean_clearance']:.3f} m"
     )
     print(f"total_snaps={summary['total_snaps']}  terminated={summary['terminated_counts']}")
-    print(f"videos: one <route>.mp4 per route in {out_dir}")
+    print(f"videos: per-segment <route>_<start>_<end>.mp4 in {out_dir}")
 
 
 if __name__ == "__main__":

--- a/scenario_generation/closed_loop_eval.py
+++ b/scenario_generation/closed_loop_eval.py
@@ -153,6 +153,7 @@ def run_closed_loop_eval(
     npz_root,
     out_dir,
     *,
+    seg_len: int,
     device: str,
     near_miss_thresh: float,
     search_radius: float,
@@ -175,20 +176,20 @@ def run_closed_loop_eval(
     list (``route_keys[rank::world_size]``) and writes its rows to ``segments_{rank}.jsonl`` instead
     of the merged ``segments.jsonl``/``summary.json`` -- the route-level multi-GPU parallel driver in
     ``valid_predictor_closed_loop.py`` spawns one such call per worker (route keys are globally
-    unique, so all shards share ``out_dir`` for the per-route PNG dirs and MP4s without collision).
+    unique, so all shards share ``out_dir`` for the per-segment PNG dirs and MP4s without collision).
     The returned summary is then per-shard; the parent merges the ``segments_*.jsonl`` rows.
 
     ``model`` must be an eval-mode Diffusion-Planner (callable ``model(data) -> (_, outputs)`` with
     ``outputs["prediction"]``); ``model_args`` provides ``observation_normalizer`` /
-    ``predicted_neighbor_num`` / ``future_len`` (a ``Config`` or ``TrainConfig``). Each route is
-    rolled out whole (no sub-segmenting) into one PNG dir + one MP4 (``<route>.mp4``).
-    ``segments.jsonl`` (one row per route) and ``summary.json`` are written into ``out_dir``.
+    ``predicted_neighbor_num`` / ``future_len`` (a ``Config`` or ``TrainConfig``). Per segment a PNG
+    dir + an MP4 (``<route>_<start>_<end>.mp4``) are written. ``segments.jsonl`` and
+    ``summary.json`` are written into ``out_dir``.
 
     Turn indicators are CLOSED-LOOP: the model's own predicted turn indicator is fed back into
     the input history each step, held across cached-plan steps when ``replan_interval`` > 1
     (see ``render_segment``).
 
-    Returns the summary dict with extra keys ``video_mp4s`` (list[Path] of every per-route MP4),
+    Returns the summary dict with extra keys ``video_mp4s`` (list[Path] of every per-segment MP4),
     ``segments`` (list[row]), and ``elapsed_sec``.
     """
     out_dir = Path(out_dir)
@@ -225,50 +226,55 @@ def run_closed_loop_eval(
     try:
         for ri, key in enumerate(route_keys):
             tl = RouteTimeline(routes[key], sidecar_dir=route_sidecar_dir[key], timers=timers)
-            # One route = one whole-route rollout = one <key>.mp4 (no sub-segmenting).
-            png_dir = out_dir / key
-            metrics = render_segment(
-                model,
-                model_args,
-                tl,
-                0,
-                len(tl),
-                png_dir,
-                device=device,
-                near_miss_thresh=near_miss_thresh,
-                search_radius=search_radius,
-                warmup_steps=warmup_steps,
-                unstick_after=unstick_after,
-                unstick_advance_m=unstick_advance_m,
-                unstick_radius_mult=unstick_radius_mult,
-                unstick_teleport_after=unstick_teleport_after,
-                replan_interval=replan_interval,
-                draw_every=draw_every,
-                neighbor_history_mode=neighbor_history_mode,
-                tracker_mode=tracker_mode,
-            )
-            row = {"route": key, **metrics}
-            fout.write(json.dumps(row, default=float) + "\n")
-            fout.flush()
-            rows.append(row)
-
-            # A route that terminates at step 0 (e.g. ego starts within goal_reach_m) draws no PNG;
-            # skip the empty ffmpeg call (its glob would error on an empty dir).
-            if not any(png_dir.glob("*.png")):
-                if verbose:
-                    print(f"[{ri + 1}/{len(route_keys)}] {key} -> 0 frames, no video")
-                continue
-            seg_mp4 = out_dir / f"{key}.mp4"
-            # Raw fps: with only every draw_every-th frame drawn, the video plays
-            # draw_every x faster than real time. For real time use fps = 10 / draw_every.
-            build_mp4(png_dir, seg_mp4, fps)
-            video_mp4s.append(seg_mp4)
-            if verbose:
-                print(
-                    f"[{ri + 1}/{len(route_keys)}] {key} -> {seg_mp4.name}  "
-                    f"coll={metrics['n_collision_steps']} near={metrics['n_near_miss_steps']} "
-                    f"min_clr={metrics['min_clearance']:.3f}"
+            n_seg_videos = 0
+            for start, end in tl.iter_segments(seg_len):
+                png_dir = out_dir / f"{key}_{start}_{end}"
+                metrics = render_segment(
+                    model,
+                    model_args,
+                    tl,
+                    start,
+                    end,
+                    png_dir,
+                    device=device,
+                    near_miss_thresh=near_miss_thresh,
+                    search_radius=search_radius,
+                    warmup_steps=warmup_steps,
+                    unstick_after=unstick_after,
+                    unstick_advance_m=unstick_advance_m,
+                    unstick_radius_mult=unstick_radius_mult,
+                    unstick_teleport_after=unstick_teleport_after,
+                    replan_interval=replan_interval,
+                    draw_every=draw_every,
+                    neighbor_history_mode=neighbor_history_mode,
+                    tracker_mode=tracker_mode,
                 )
+                row = {"route": key, **metrics}
+                fout.write(json.dumps(row, default=float) + "\n")
+                fout.flush()
+                rows.append(row)
+
+                # A segment that terminates at step 0 (e.g. ego starts within goal_reach_m) draws
+                # no PNG; skip the empty ffmpeg call (its glob would error on an empty dir).
+                if not any(png_dir.glob("*.png")):
+                    if verbose:
+                        print(f"  [{key}] segment [{start},{end}] -> 0 frames, no video")
+                    continue
+                seg_mp4 = out_dir / f"{key}_{start}_{end}.mp4"
+                # Raw fps: with only every draw_every-th frame drawn, the video plays
+                # draw_every x faster than real time. For real time use fps = 10 / draw_every.
+                build_mp4(png_dir, seg_mp4, fps)
+                video_mp4s.append(seg_mp4)
+                n_seg_videos += 1
+                if verbose:
+                    print(
+                        f"  [{key}] segment [{start},{end}] -> {seg_mp4.name}  "
+                        f"coll={metrics['n_collision_steps']} near={metrics['n_near_miss_steps']} "
+                        f"min_clr={metrics['min_clearance']:.3f}"
+                    )
+
+            if verbose:
+                print(f"[{ri + 1}/{len(route_keys)}] {key}: {n_seg_videos} segment video(s)")
     finally:
         fout.close()
 


### PR DESCRIPTION
## Summary
- Restores the closed-loop `seg_len` / `closed_loop_seg_len` segmented rollout path removed in `dd73e460` ("Fixed save name and removed seg_len").
- Each segment reseeds ego from the recorded pose at segment start via `iter_segments(seg_len)`, and writes per-segment videos as `<route>_<start>_<end>.mp4`.
- Training `closed_loop_seg_len` default remains `100000` (effectively whole-route); offline CLI `--seg_len` default is `6000` (~60s @10Hz).
- Kept later tier4-main features (path_list roots, sharding, route labels, etc.); only the segmenting behavior is restored.

## Test plan
- [x] `python diffusion_planner/valid_predictor_closed_loop.py --help` shows `--seg_len`
- [x] `run_closed_loop_eval` signature includes required `seg_len`
- [ ] Smoke a short closed-loop eval with `--seg_len 100` and confirm `<route>_<start>_<end>.mp4` outputs and multiple `segments.jsonl` rows per long route


Made with [Cursor](https://cursor.com)