### PR TITLE
fix: sample state perturbation dimensions independently

### DIFF
--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -151,8 +151,11 @@ class StatePerturbation:
         self._device = torch.device(device)
         self._ego_past_noise_std = ego_past_noise_std
         self._use_smoothing_future_trajectory = use_smoothing_future_trajectory
-        lo = ([0.0, -0.75, -0.2, -1, -0.5, -0.2, -0.1, 0.0, 0.0],)
-        hi = ([0.0, +0.75, +0.2, +1, +0.5, +0.2, +0.1, 0.0, 0.0],)
+        lo = [0.0, -0.75, -0.2, -1, -0.5, -0.2, -0.1, 0.0, 0.0]
+        hi = [0.0, +0.75, +0.2, +1, +0.5, +0.2, +0.1, 0.0, 0.0]
+        # Shape (9,) so that len(self._low) is the number of perturbation dims;
+        # the previous (1, 9) shape made torch.rand(B, len(self._low)) sample a
+        # single scalar per sample, perfectly correlating all 9 perturbations.
         self._low = torch.tensor(lo).to(self._device)
         self._high = torch.tensor(hi).to(self._device)
 


### PR DESCRIPTION
## Description

In the quintic `StatePerturbation` augmentation, the perturbation bounds were stored as a `(1, 9)` tensor:

```python
lo = ([0.0, -0.75, -0.2, -1, -0.5, -0.2, -0.1, 0.0, 0.0],)  # tuple of one list -> shape (1, 9)
self._low = torch.tensor(lo)
...
random_tensor = torch.rand(B, len(self._low))  # len(self._low) == 1 -> shape (B, 1)!
```

`len()` on a tensor returns the size of dim 0, so only **one random scalar per sample** was drawn and broadcast across all 9 perturbation dimensions. As a result, the lateral offset, heading, velocity and acceleration perturbations were perfectly correlated — every augmented sample satisfied exactly `dvy = dy / 1.5` and `dθ ≈ 0.27 · dy`, i.e. the perturbations lived on a single 1-D line in the 9-D space instead of covering it.

### Why this matters

State perturbation exists to teach lateral recovery: displace the ego, label with a trajectory that returns to the GT path. With the collapsed sampling:

1. **Shortcut learning** — the perturbed `vy`/heading/`ay` channels of `ego_current_state` predict the lateral displacement exactly, so the model can learn the recovery correction from the kinematic channels alone, without consulting the lane geometry.
2. **Coverage hole** — the state that actually occurs in deployment ("laterally offset from the centerline, but heading parallel and `vy ≈ 0`") never appears in training. Following the learned shortcut, the model interprets `vy = 0` as "no offset, no correction needed" and keeps driving offset from the centerline.

This suppresses exactly the recovery behavior needed to correct the constant lateral offset observed in deployment.

## Changes

- Store the perturbation bounds as shape `(9,)` so `torch.rand(B, len(self._low))` samples each dimension independently (`diffusion_planner/utils/data_augmentation.py`).
- The bridge augmentation (`data_augmentation_bridge.py`) already samples each dimension independently and is unchanged.

## Verification

- With B=1000 samples: `corr(dy, dvy) ≈ -0.01` after the fix (exactly `1.0` before); fixed dimensions (x, steering, yaw-rate slots) remain 0; all values stay within their bounds.
- Full `StatePerturbation.__call__` smoke test (perturb → quintic interpolation → `centric_transform`) runs without errors with the default `num_refine=20`.
- `tests/test_data_augmentation.py`: 32 failed / 26 passed both **before and after** this change — the failures are pre-existing (the tests call `StatePerturbation()` with an outdated constructor signature); no new failures.
- `pre-commit` (ruff etc.): passed.

## Notes

- Training-time only; **retraining is required** for the fix to take effect.
- Related: #263 fixes `goal_pose` not being re-anchored by `centric_transform`. The two fixes are independent and target the same observed symptom (constant lateral offset / no lateral recovery).
