### PR TITLE
[WIP] Feat/route input augmentation

### DIFF
--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -23,6 +23,7 @@ from diffusion_planner.utils.dataset import DiffusionPlannerData, DiffusionPlann
 from diffusion_planner.utils.lr_schedule import CosineAnnealingWarmUpRestarts
 from diffusion_planner.utils.normalizer import ObservationNormalizer, StateNormalizer
 from diffusion_planner.utils.onnx_export import export_checkpoint_onnx_guarded
+from diffusion_planner.utils.route_augmentation import RouteAugmentation
 from diffusion_planner.utils.train_utils import resume_model, set_seed
 from diffusion_planner.validate_model import (
     aggregate_replan_consistency_metrics,
@@ -234,6 +235,17 @@ def model_training(args: TrainConfig):
     else:
         aug = None
 
+    if args.use_route_augment:
+        route_aug = RouteAugmentation(
+            device=args.device,
+            truncation_prob=args.route_truncation_prob,
+            truncation_min_m=args.route_truncation_min_m,
+            truncation_max_m=args.route_truncation_max_m,
+            speed_limit_unknown_prob=args.speed_limit_unknown_prob,
+        )
+    else:
+        route_aug = None
+
     # prepare dataset
     train_set = DiffusionPlannerData(args.train_set_list)
     valid_set = DiffusionPlannerData(args.valid_set_list)
@@ -432,7 +444,7 @@ def model_training(args: TrainConfig):
 
         # training step
         train_loss, train_total_loss = train_epoch(
-            train_loader, diffusion_planner, optimizer, args, model_ema, aug
+            train_loader, diffusion_planner, optimizer, args, model_ema, aug, route_aug
         )
 
         valid_dict = validate_model(diffusion_planner, valid_loader, args)

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -242,6 +242,9 @@ def model_training(args: TrainConfig):
             truncation_min_m=args.route_truncation_min_m,
             truncation_max_m=args.route_truncation_max_m,
             speed_limit_unknown_prob=args.speed_limit_unknown_prob,
+            geometry_noise_prob=args.route_geometry_noise_prob,
+            geometry_noise_std_m=args.route_geometry_noise_std_m,
+            head_trim_prob=args.route_head_trim_prob,
         )
     else:
         route_aug = None

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -67,6 +67,9 @@ class TrainConfig:
     route_truncation_min_m: float = 60.0
     route_truncation_max_m: float = 200.0
     speed_limit_unknown_prob: float = 0.1
+    route_geometry_noise_prob: float = 0.5
+    route_geometry_noise_std_m: float = 0.15
+    route_head_trim_prob: float = 0.1
     normalization_file_path: str = "normalization.json"
     num_workers: int = 8
     pin_mem: bool = True

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -61,6 +61,12 @@ class TrainConfig:
     num_refine: int = 20
     ego_past_noise_std: float = 0.1
     use_smoothing_future_trajectory: bool = True
+    # Route / speed-limit dropout augmentation (docs/route_augmentation_proposals.md)
+    use_route_augment: bool = False
+    route_truncation_prob: float = 0.5
+    route_truncation_min_m: float = 60.0
+    route_truncation_max_m: float = 200.0
+    speed_limit_unknown_prob: float = 0.1
     normalization_file_path: str = "normalization.json"
     num_workers: int = 8
     pin_mem: bool = True

--- a/diffusion_planner/diffusion_planner/train_epoch.py
+++ b/diffusion_planner/diffusion_planner/train_epoch.py
@@ -5,6 +5,7 @@ from tqdm import tqdm
 from diffusion_planner.model.module.decoder import compute_training_loss
 from diffusion_planner.utils import ddp
 from diffusion_planner.utils.data_augmentation import StatePerturbation
+from diffusion_planner.utils.route_augmentation import RouteAugmentation
 from diffusion_planner.utils.train_utils import compute_grad_stats, get_epoch_mean_loss
 
 
@@ -32,7 +33,15 @@ def heading_to_cos_sin(x):
     )
 
 
-def train_epoch(data_loader, model, optimizer, args, ema, aug: StatePerturbation = None):
+def train_epoch(
+    data_loader,
+    model,
+    optimizer,
+    args,
+    ema,
+    aug: StatePerturbation = None,
+    route_aug: RouteAugmentation = None,
+):
     epoch_loss = []
 
     model.train()
@@ -50,6 +59,10 @@ def train_epoch(data_loader, model, optimizer, args, ema, aug: StatePerturbation
 
         ego_future = inputs["ego_agent_future"]
         neighbors_future = inputs["neighbor_agents_future"]
+        # Route / speed-limit dropout runs before the state perturbation so the
+        # perturbation's collision checks see the augmented map.
+        if route_aug is not None:
+            inputs = route_aug(inputs)
         # Normalize to ego-centric
         if aug is not None:
             inputs, ego_future, neighbors_future = aug(inputs, ego_future, neighbors_future)

--- a/diffusion_planner/diffusion_planner/utils/route_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/route_augmentation.py
@@ -90,13 +90,14 @@ class RouteAugmentation:
         seg_valid = route[..., :_GEOM_DIM].abs().sum(dim=(2, 3)) > 0  # [B, P]
         n_valid = seg_valid.sum(dim=1)  # [B]
         apply = (torch.rand(B, device=route.device) < self._head_trim_prob) & (n_valid >= 3)
-        if not bool(apply.any()):
-            return
         for key in _ROUTE_KEYS:
             t = inputs[key]
-            shifted = torch.cat([t[:, 1:], torch.zeros_like(t[:, :1])], dim=1)
-            view = apply.view(B, *([1] * (t.dim() - 1)))
-            inputs[key] = torch.where(view, shifted, t)
+            # In-place masked shift: the advanced-indexing gather materializes
+            # only the selected rows, so the transient allocation scales with
+            # the applied subset instead of the whole batch, and an all-False
+            # mask degenerates to an empty copy (no host sync needed to skip).
+            t[apply, :-1] = t[apply, 1:]
+            t[apply, -1] = 0
 
     def _truncate_route_tail(self, inputs: dict[str, torch.Tensor]) -> None:
         """Zero out route segments starting beyond a sampled arc-length budget.
@@ -161,10 +162,10 @@ class RouteAugmentation:
         Scene-wide (not per-segment) so the same lanelet never carries a limit
         in ``lanes`` while missing it in ``route_lanes``.
         """
-        B = inputs["route_lanes"].shape[0]
-        scene = torch.rand(B, device=self._device) < self._speed_limit_unknown_prob  # [B]
-        if not bool(scene.any()):
-            return
+        route = inputs["route_lanes"]
+        # Mask on the tensors' own device: an all-False mask makes the fills
+        # no-ops, so no host-device sync is spent on an early-out check.
+        scene = torch.rand(route.shape[0], device=route.device) < self._speed_limit_unknown_prob
         for prefix in ("lanes", "route_lanes"):
             inputs[f"{prefix}_speed_limit"][scene] = 0.0
             inputs[f"{prefix}_has_speed_limit"][scene] = False

--- a/diffusion_planner/diffusion_planner/utils/route_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/route_augmentation.py
@@ -1,0 +1,102 @@
+"""Input-side augmentations for the route.
+
+Implements two of the high-priority proposals from
+docs/route_augmentation_proposals.md:
+
+- Route tail truncation: randomly shorten the forward extent of ``route_lanes``
+  so the model sees the short routes that occur near the goal / map edge at
+  deployment time.
+- Speed-limit unknown dropout: drop ``*_has_speed_limit`` to False (scene-wide,
+  lanes and route together) so the encoder's ``unknown_speed_emb`` path is
+  actually trained.
+
+(Traffic-light unknown dropout and scene flip live on separate branches.)
+
+Both transforms preserve the all-zero padding convention and only ever remove
+information (never fabricate a state that contradicts the ground truth
+trajectory). Applied in train_epoch before StatePerturbation, on raw
+(un-normalized) ego-centric inputs.
+"""
+
+import torch
+
+# Geometry channels used for validity checks (x, y, dx, dy, LB, RB), matching
+# the masks in data_augmentation.StatePerturbation.
+_GEOM_DIM = 8
+
+
+class RouteAugmentation:
+    """Randomized route / speed-limit dropout augmentation.
+
+    Each component is applied independently per sample with its own
+    probability. Probabilities of 0 disable a component.
+    """
+
+    def __init__(
+        self,
+        device,
+        truncation_prob: float = 0.0,
+        truncation_min_m: float = 60.0,
+        truncation_max_m: float = 200.0,
+        speed_limit_unknown_prob: float = 0.0,
+    ):
+        assert 0.0 < truncation_min_m <= truncation_max_m
+        self._device = device
+        self._truncation_prob = truncation_prob
+        self._truncation_min_m = truncation_min_m
+        self._truncation_max_m = truncation_max_m
+        self._speed_limit_unknown_prob = speed_limit_unknown_prob
+
+    @torch.no_grad()
+    def __call__(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        if self._truncation_prob > 0.0:
+            self._truncate_route_tail(inputs)
+        if self._speed_limit_unknown_prob > 0.0:
+            self._drop_speed_limit(inputs)
+        return inputs
+
+    def _truncate_route_tail(self, inputs: dict[str, torch.Tensor]) -> None:
+        """Zero out route segments starting beyond a sampled arc-length budget.
+
+        Distance is accumulated along the route polyline from the first route
+        segment (the ego's current lanelet), which approximates distance from
+        ego. The first segment is always kept so the immediate intent is never
+        destroyed.
+        """
+        route = inputs["route_lanes"]  # [B, P, V, D]
+        B = route.shape[0]
+
+        valid_pt = route[..., :_GEOM_DIM].abs().sum(-1) > 0  # [B, P, V]
+        xy = route[..., :2]
+        step = (xy[:, :, 1:] - xy[:, :, :-1]).norm(dim=-1)  # [B, P, V-1]
+        pair_valid = (valid_pt[:, :, 1:] & valid_pt[:, :, :-1]).to(step.dtype)
+        seg_len = (step * pair_valid).sum(-1)  # [B, P]
+
+        # Arc length from the route start to each segment's start.
+        cum_before = torch.cumsum(seg_len, dim=1) - seg_len  # [B, P]
+
+        budget = self._truncation_min_m + (
+            self._truncation_max_m - self._truncation_min_m
+        ) * torch.rand(B, 1, device=route.device)
+        apply = torch.rand(B, 1, device=route.device) < self._truncation_prob
+
+        drop = (cum_before >= budget) & apply  # [B, P]
+        drop[:, 0] = False
+
+        inputs["route_lanes"][drop] = 0.0
+        inputs["route_lanes_speed_limit"][drop] = 0.0
+        inputs["route_lanes_has_speed_limit"][drop] = False
+
+    def _drop_speed_limit(self, inputs: dict[str, torch.Tensor]) -> None:
+        """Scene-wide speed-limit unknown dropout on lanes and route together.
+
+        Scene-wide (not per-segment) so the same lanelet never carries a limit
+        in ``lanes`` while missing it in ``route_lanes``.
+        """
+        B = inputs["route_lanes"].shape[0]
+        scene = torch.rand(B, device=self._device) < self._speed_limit_unknown_prob  # [B]
+        if not bool(scene.any()):
+            return
+        for prefix in ("lanes", "route_lanes"):
+            inputs[f"{prefix}_speed_limit"][scene] = 0.0
+            inputs[f"{prefix}_has_speed_limit"][scene] = False

--- a/diffusion_planner/diffusion_planner/utils/route_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/route_augmentation.py
@@ -1,21 +1,25 @@
 """Input-side augmentations for the route.
 
-Implements two of the high-priority proposals from
+Implements the high- and medium-priority proposals from
 docs/route_augmentation_proposals.md:
 
-- Route tail truncation: randomly shorten the forward extent of ``route_lanes``
-  so the model sees the short routes that occur near the goal / map edge at
-  deployment time.
-- Speed-limit unknown dropout: drop ``*_has_speed_limit`` to False (scene-wide,
-  lanes and route together) so the encoder's ``unknown_speed_emb`` path is
-  actually trained.
+- Route tail truncation (high): randomly shorten the forward extent of
+  ``route_lanes`` so the model sees the short routes that occur near the goal /
+  map edge at deployment time.
+- Speed-limit unknown dropout (high): drop ``*_has_speed_limit`` to False
+  (scene-wide, lanes and route together) so the encoder's ``unknown_speed_emb``
+  path is actually trained.
+- Route geometry noise (medium): per-segment constant lateral offset of the
+  route centerline, simulating map survey error / map version drift and
+  loosening centerline snapping.
+- Route head trim (medium): drop the first route segment and shift the rest
+  forward, simulating nearest-lanelet selection jitter at the route start.
 
 (Traffic-light unknown dropout and scene flip live on separate branches.)
 
-Both transforms preserve the all-zero padding convention and only ever remove
-information (never fabricate a state that contradicts the ground truth
-trajectory). Applied in train_epoch before StatePerturbation, on raw
-(un-normalized) ego-centric inputs.
+All transforms preserve the all-zero padding convention and never fabricate a
+state that contradicts the ground truth trajectory. Applied in train_epoch
+before StatePerturbation, on raw (un-normalized) ego-centric inputs.
 """
 
 import torch
@@ -24,9 +28,11 @@ import torch
 # the masks in data_augmentation.StatePerturbation.
 _GEOM_DIM = 8
 
+_ROUTE_KEYS = ("route_lanes", "route_lanes_speed_limit", "route_lanes_has_speed_limit")
+
 
 class RouteAugmentation:
-    """Randomized route / speed-limit dropout augmentation.
+    """Randomized route / speed-limit augmentation.
 
     Each component is applied independently per sample with its own
     probability. Probabilities of 0 disable a component.
@@ -39,21 +45,58 @@ class RouteAugmentation:
         truncation_min_m: float = 60.0,
         truncation_max_m: float = 200.0,
         speed_limit_unknown_prob: float = 0.0,
+        geometry_noise_prob: float = 0.0,
+        geometry_noise_std_m: float = 0.15,
+        head_trim_prob: float = 0.0,
     ):
         assert 0.0 < truncation_min_m <= truncation_max_m
+        assert geometry_noise_std_m >= 0.0
         self._device = device
         self._truncation_prob = truncation_prob
         self._truncation_min_m = truncation_min_m
         self._truncation_max_m = truncation_max_m
         self._speed_limit_unknown_prob = speed_limit_unknown_prob
+        self._geometry_noise_prob = geometry_noise_prob
+        self._geometry_noise_std_m = geometry_noise_std_m
+        self._head_trim_prob = head_trim_prob
 
     @torch.no_grad()
     def __call__(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        # Head trim first (it moves the route start), then the tail truncation
+        # measures its arc-length budget from the new start, matching how a
+        # shifted nearest-lanelet pick would look at deployment time.
+        if self._head_trim_prob > 0.0:
+            self._trim_route_head(inputs)
         if self._truncation_prob > 0.0:
             self._truncate_route_tail(inputs)
+        if self._geometry_noise_prob > 0.0:
+            self._jitter_route_geometry(inputs)
         if self._speed_limit_unknown_prob > 0.0:
             self._drop_speed_limit(inputs)
         return inputs
+
+    def _trim_route_head(self, inputs: dict[str, torch.Tensor]) -> None:
+        """Drop the first route segment and shift the rest one slot forward.
+
+        Simulates the nearest-lanelet selection jitter at the route start
+        (replan timing, lane changes, inside intersections). Shifting keeps the
+        "slot 0 = current lanelet" convention of the ordered positional
+        embedding; leaving a zero row at slot 0 would be a pattern that never
+        occurs at deployment time. Only applied when at least 3 segments are
+        valid, so at least 2 segments of forward intent always survive.
+        """
+        route = inputs["route_lanes"]  # [B, P, V, D]
+        B = route.shape[0]
+        seg_valid = route[..., :_GEOM_DIM].abs().sum(dim=(2, 3)) > 0  # [B, P]
+        n_valid = seg_valid.sum(dim=1)  # [B]
+        apply = (torch.rand(B, device=route.device) < self._head_trim_prob) & (n_valid >= 3)
+        if not bool(apply.any()):
+            return
+        for key in _ROUTE_KEYS:
+            t = inputs[key]
+            shifted = torch.cat([t[:, 1:], torch.zeros_like(t[:, :1])], dim=1)
+            view = apply.view(B, *([1] * (t.dim() - 1)))
+            inputs[key] = torch.where(view, shifted, t)
 
     def _truncate_route_tail(self, inputs: dict[str, torch.Tensor]) -> None:
         """Zero out route segments starting beyond a sampled arc-length budget.
@@ -86,6 +129,31 @@ class RouteAugmentation:
         inputs["route_lanes"][drop] = 0.0
         inputs["route_lanes_speed_limit"][drop] = 0.0
         inputs["route_lanes_has_speed_limit"][drop] = False
+
+    def _jitter_route_geometry(self, inputs: dict[str, torch.Tensor]) -> None:
+        """Shift each route segment laterally by a constant per-segment offset.
+
+        The offset is constant within a segment, so the per-point direction
+        channels (dx, dy) and the relative boundary offsets stay exactly
+        consistent -- only the absolute placement moves, like a map survey
+        error. Point-wise independent noise would corrupt the direction
+        channels and is deliberately not done (see the proposal doc).
+        """
+        route = inputs["route_lanes"]  # [B, P, V, D]
+        B, P, _, _ = route.shape
+
+        valid_pt = route[..., :_GEOM_DIM].abs().sum(-1) > 0  # [B, P, V]
+        mean_dir = (route[..., 2:4] * valid_pt.unsqueeze(-1)).sum(dim=2)  # [B, P, 2]
+        unit = mean_dir / mean_dir.norm(dim=-1, keepdim=True).clamp_min(1e-6)
+        normal = torch.stack([-unit[..., 1], unit[..., 0]], dim=-1)  # [B, P, 2]
+
+        offset = torch.randn(B, P, 1, device=route.device) * self._geometry_noise_std_m
+        apply = (torch.rand(B, 1, 1, device=route.device) < self._geometry_noise_prob).to(
+            route.dtype
+        )
+        shift = normal * offset * apply  # [B, P, 2]
+
+        route[..., :2] += shift.unsqueeze(2) * valid_pt.unsqueeze(-1)
 
     def _drop_speed_limit(self, inputs: dict[str, torch.Tensor]) -> None:
         """Scene-wide speed-limit unknown dropout on lanes and route together.

--- a/diffusion_planner/tests/test_route_augmentation.py
+++ b/diffusion_planner/tests/test_route_augmentation.py
@@ -122,3 +122,61 @@ def test_speed_limit_unknown_prob_zero_is_identity():
     out = aug(inputs)
     for k in expected:
         assert torch.equal(out[k], expected[k]), k
+
+
+def test_head_trim_shifts_segments_forward():
+    inputs = _make_route_inputs(num_valid=4, seg_len_m=50.0)
+    expected_seg1 = inputs["route_lanes"][0, 1].clone()
+    aug = RouteAugmentation(device="cpu", head_trim_prob=1.0)
+    out = aug(inputs)
+
+    # Old segment 1 is now at slot 0; one fewer valid segment; freed slot zeroed.
+    assert torch.equal(out["route_lanes"][0, 0], expected_seg1)
+    kept = out["route_lanes"].abs().sum(dim=(2, 3)) > 0
+    assert kept[0, :3].all() and not kept[0, 3:].any()
+    # Speed-limit tensors shift in lockstep.
+    assert out["route_lanes_has_speed_limit"][0, :3].all()
+    assert not out["route_lanes_has_speed_limit"][0, 3:].any()
+
+
+def test_head_trim_skipped_when_route_too_short():
+    # 2 valid segments < 3 -> trimming would leave too little intent; no-op.
+    inputs = _make_route_inputs(num_valid=2, seg_len_m=50.0)
+    expected = {k: v.clone() for k, v in inputs.items()}
+    aug = RouteAugmentation(device="cpu", head_trim_prob=1.0)
+    out = aug(inputs)
+    for k in expected:
+        assert torch.equal(out[k], expected[k]), k
+
+
+def test_geometry_noise_is_constant_lateral_offset_per_segment():
+    inputs = _make_route_inputs(num_valid=3, seg_len_m=50.0)
+    orig_route = inputs["route_lanes"].clone()
+    torch.manual_seed(0)
+    aug = RouteAugmentation(device="cpu", geometry_noise_prob=1.0, geometry_noise_std_m=1.0)
+    out = aug(inputs)
+    route = out["route_lanes"]
+
+    moved = 0
+    for seg in range(3):
+        delta = route[0, seg, :, :2] - orig_route[0, seg, :, :2]  # [V, 2]
+        # Constant within the segment.
+        assert torch.allclose(delta, delta[0].expand_as(delta), atol=1e-6)
+        # Purely lateral: route runs along +x, so dx == 0 and only y moves.
+        assert torch.allclose(delta[:, 0], torch.zeros_like(delta[:, 0]), atol=1e-6)
+        moved += int(delta[0].norm() > 1e-3)
+    assert moved == 3  # std=1.0 makes a zero draw practically impossible
+
+    # Direction channels and everything beyond xy stay bit-identical.
+    assert torch.equal(route[..., 2:], orig_route[..., 2:])
+    # Padding rows stay all-zero.
+    assert torch.all(route[0, 3:] == 0.0)
+
+
+def test_geometry_noise_leaves_other_tensors_untouched():
+    inputs = _make_route_inputs(num_valid=3, seg_len_m=50.0)
+    expected = {k: v.clone() for k, v in inputs.items() if k != "route_lanes"}
+    aug = RouteAugmentation(device="cpu", geometry_noise_prob=1.0, geometry_noise_std_m=1.0)
+    out = aug(inputs)
+    for k in expected:
+        assert torch.equal(out[k], expected[k]), k

--- a/diffusion_planner/tests/test_route_augmentation.py
+++ b/diffusion_planner/tests/test_route_augmentation.py
@@ -1,0 +1,124 @@
+"""RouteAugmentation: route tail truncation must drop exactly the segments
+starting beyond the sampled arc-length budget (keeping the first segment and
+the all-zero padding convention, with the speed-limit tensors kept in sync),
+and speed-limit unknown dropout must clear lanes and route together."""
+
+import torch
+from diffusion_planner.utils.route_augmentation import RouteAugmentation
+
+_NUM_SEGMENTS = 25
+_POINTS = 20
+_DIM = 33
+
+
+def _make_route_inputs(num_valid: int, seg_len_m: float, batch: int = 1):
+    """Straight route along +x: ``num_valid`` segments of ``seg_len_m`` each."""
+    route = torch.zeros(batch, _NUM_SEGMENTS, _POINTS, _DIM)
+    step = seg_len_m / (_POINTS - 1)
+    for s in range(num_valid):
+        x0 = s * seg_len_m
+        xs = x0 + torch.arange(_POINTS) * step
+        route[:, s, :, 0] = xs
+        route[:, s, :, 1] = 1.0  # keep y non-zero so x=0 points stay valid
+        route[:, s, :, 2] = step  # dx
+    speed_limit = torch.zeros(batch, _NUM_SEGMENTS, 1)
+    speed_limit[:, :num_valid] = 10.0
+    has_speed_limit = torch.zeros(batch, _NUM_SEGMENTS, 1, dtype=torch.bool)
+    has_speed_limit[:, :num_valid] = True
+    lanes_speed_limit = torch.full((batch, 140, 1), 8.0)
+    lanes_has_speed_limit = torch.ones(batch, 140, 1, dtype=torch.bool)
+    return {
+        "route_lanes": route,
+        "route_lanes_speed_limit": speed_limit,
+        "route_lanes_has_speed_limit": has_speed_limit,
+        "lanes_speed_limit": lanes_speed_limit,
+        "lanes_has_speed_limit": lanes_has_speed_limit,
+    }
+
+
+def _truncation_aug(min_m: float, max_m: float, prob: float = 1.0):
+    return RouteAugmentation(
+        device="cpu",
+        truncation_prob=prob,
+        truncation_min_m=min_m,
+        truncation_max_m=max_m,
+        speed_limit_unknown_prob=0.0,
+    )
+
+
+def test_truncation_drops_far_segments_and_keeps_near():
+    # 5 segments x 50m; min == max == 120m makes the budget deterministic:
+    # segments starting at 0/50/100m stay, 150/200m are dropped.
+    inputs = _make_route_inputs(num_valid=5, seg_len_m=50.0)
+    aug = _truncation_aug(120.0, 120.0)
+    out = aug(inputs)
+
+    kept = out["route_lanes"].abs().sum(dim=(2, 3)) > 0  # [B, P]
+    assert kept[0, :3].all()
+    assert not kept[0, 3:].any()
+    # Speed-limit tensors follow the dropped rows.
+    assert out["route_lanes_has_speed_limit"][0, :3].all()
+    assert not out["route_lanes_has_speed_limit"][0, 3:].any()
+    assert torch.all(out["route_lanes_speed_limit"][0, 3:] == 0.0)
+
+
+def test_truncation_always_keeps_first_segment():
+    # A single 400m segment starts at 0m and must survive any budget.
+    inputs = _make_route_inputs(num_valid=3, seg_len_m=400.0)
+    aug = _truncation_aug(60.0, 60.0)
+    out = aug(inputs)
+    kept = out["route_lanes"].abs().sum(dim=(2, 3)) > 0
+    assert kept[0, 0]
+    assert not kept[0, 1:].any()
+
+
+def test_truncation_prob_zero_is_identity():
+    inputs = _make_route_inputs(num_valid=5, seg_len_m=50.0)
+    expected = {k: v.clone() for k, v in inputs.items()}
+    aug = RouteAugmentation(
+        device="cpu",
+        truncation_prob=0.0,
+        speed_limit_unknown_prob=0.0,
+    )
+    out = aug(inputs)
+    for k in expected:
+        assert torch.equal(out[k], expected[k]), k
+
+
+def test_truncation_preserves_padding_rows():
+    inputs = _make_route_inputs(num_valid=2, seg_len_m=30.0)
+    aug = _truncation_aug(200.0, 200.0)
+    out = aug(inputs)
+    # Nothing exceeds the budget; valid rows unchanged, padding still zero.
+    kept = out["route_lanes"].abs().sum(dim=(2, 3)) > 0
+    assert kept[0, :2].all()
+    assert torch.all(out["route_lanes"][0, 2:] == 0.0)
+
+
+def test_speed_limit_unknown_clears_lanes_and_route_together():
+    inputs = _make_route_inputs(num_valid=4, seg_len_m=50.0)
+    aug = RouteAugmentation(
+        device="cpu",
+        truncation_prob=0.0,
+        speed_limit_unknown_prob=1.0,
+    )
+    out = aug(inputs)
+    for prefix in ("lanes", "route_lanes"):
+        assert not out[f"{prefix}_has_speed_limit"].any(), prefix
+        assert torch.all(out[f"{prefix}_speed_limit"] == 0.0), prefix
+    # Route geometry itself is untouched by the speed-limit dropout.
+    kept = out["route_lanes"].abs().sum(dim=(2, 3)) > 0
+    assert kept[0, :4].all()
+
+
+def test_speed_limit_unknown_prob_zero_is_identity():
+    inputs = _make_route_inputs(num_valid=4, seg_len_m=50.0)
+    expected = {k: v.clone() for k, v in inputs.items()}
+    aug = RouteAugmentation(
+        device="cpu",
+        truncation_prob=0.0,
+        speed_limit_unknown_prob=0.0,
+    )
+    out = aug(inputs)
+    for k in expected:
+        assert torch.equal(out[k], expected[k]), k

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -74,6 +74,36 @@ def get_args(args_list=None):
         type=boolean,
         help="whether to apply smoothing to future trajectory",
     )
+    parser.add_argument(
+        "--use_route_augment",
+        default=False,
+        type=boolean,
+        help="enable route tail truncation / speed-limit unknown dropout augmentation",
+    )
+    parser.add_argument(
+        "--route_truncation_prob",
+        type=float,
+        default=0.5,
+        help="per-sample probability of truncating the route tail",
+    )
+    parser.add_argument(
+        "--route_truncation_min_m",
+        type=float,
+        default=60.0,
+        help="minimum kept route length [m] for route tail truncation",
+    )
+    parser.add_argument(
+        "--route_truncation_max_m",
+        type=float,
+        default=200.0,
+        help="maximum kept route length [m] for route tail truncation",
+    )
+    parser.add_argument(
+        "--speed_limit_unknown_prob",
+        type=float,
+        default=0.1,
+        help="per-scene probability of dropping speed limits to unknown (lanes + route)",
+    )
     parser.add_argument("--normalization_file_path", default="normalization.json", type=str)
     parser.add_argument("--num_workers", default=8, type=int)
     parser.add_argument("--pin-mem", action="store_true", help="Pin CPU memory in DataLoader")

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -104,6 +104,24 @@ def get_args(args_list=None):
         default=0.1,
         help="per-scene probability of dropping speed limits to unknown (lanes + route)",
     )
+    parser.add_argument(
+        "--route_geometry_noise_prob",
+        type=float,
+        default=0.5,
+        help="per-sample probability of lateral route geometry noise",
+    )
+    parser.add_argument(
+        "--route_geometry_noise_std_m",
+        type=float,
+        default=0.15,
+        help="std [m] of the per-segment constant lateral route offset",
+    )
+    parser.add_argument(
+        "--route_head_trim_prob",
+        type=float,
+        default=0.1,
+        help="per-sample probability of dropping the first route segment (shifted forward)",
+    )
     parser.add_argument("--normalization_file_path", default="normalization.json", type=str)
     parser.add_argument("--num_workers", default=8, type=int)
     parser.add_argument("--pin-mem", action="store_true", help="Pin CPU memory in DataLoader")

--- a/diffusion_planner/util_scripts/visualize_route_augmentation.py
+++ b/diffusion_planner/util_scripts/visualize_route_augmentation.py
@@ -121,6 +121,117 @@ def run_checks(orig: dict, aug: dict, sl_aug: dict, truncate_m: float) -> list[s
     return failures
 
 
+def _valid_segment_points(route: torch.Tensor, seg: int) -> torch.Tensor:
+    """Valid (non-padding) xy points of one route segment. route: [B, P, V, D]."""
+    pts = route[0, seg]
+    valid = pts[..., :_GEOM_DIM].abs().sum(-1) > 0
+    return pts[valid][:, :2]
+
+
+def render_truncation(orig, truncated, budget_m, status, npz_name, out_path):
+    """Original vs truncated on the scene render.
+
+    On the left panel the segments that the truncation removes are overdrawn in
+    red (with their start arc-length), the kept ones in green, so the exact
+    difference is visible even when the cut lies outside the view window.
+    """
+    route_o = orig["route_lanes"]
+    valid_o = (route_o.abs().sum(dim=(2, 3)) > 0)[0]
+    kept = (truncated["route_lanes"].abs().sum(dim=(2, 3)) > 0)[0]
+    cum_before = segment_start_distances(route_o)[0]
+    n_orig, n_kept = int(valid_o.sum()), int(kept.sum())
+
+    fig, axes = plt.subplots(1, 2, figsize=(20, 9))
+    visualize_inputs(copy.deepcopy(orig), ax=axes[0])
+    visualize_inputs(copy.deepcopy(truncated), ax=axes[1])
+    for seg in torch.where(valid_o)[0].tolist():
+        xy = _valid_segment_points(route_o, seg)
+        is_kept = bool(kept[seg])
+        color = "tab:green" if is_kept else "tab:red"
+        axes[0].plot(xy[:, 0], xy[:, 1], color=color, lw=3.5, alpha=0.6, zorder=20)
+        axes[0].annotate(
+            f"{cum_before[seg]:.0f}m",
+            xy=(float(xy[0, 0]), float(xy[0, 1])),
+            fontsize=9,
+            color=color,
+            fontweight="bold",
+            zorder=21,
+        )
+        if is_kept:
+            axes[1].plot(xy[:, 0], xy[:, 1], color="tab:green", lw=3.5, alpha=0.6, zorder=20)
+    axes[0].set_title(
+        f"original ({n_orig} route segments)  "
+        f"green=kept / red=dropped by {budget_m:.0f}m budget (label: start arc length)"
+    )
+    axes[1].set_title(f"after truncation @ {budget_m:.0f}m ({n_kept} route segments)")
+    fig.suptitle(
+        f"route tail truncation   {npz_name}   [{status}]",
+        color="red" if "NG" in status else "green",
+    )
+    plt.tight_layout()
+    plt.savefig(out_path, dpi=90, bbox_inches="tight")
+    plt.close(fig)
+
+
+def _render_speed_limit_panel(ax, inputs, title):
+    """Draw lane / route centerlines colored by their speed limit.
+
+    Blue->red colormap = limit value; gray dashed = unknown (has_speed_limit
+    False). Route segments are thicker and annotated with the value in m/s.
+    """
+    cmap = plt.get_cmap("coolwarm")
+    vmax = max(
+        float(inputs["lanes_speed_limit"].max()),
+        float(inputs["route_lanes_speed_limit"].max()),
+        1.0,
+    )
+    for key, lw in (("lanes", 1.5), ("route_lanes", 4.0)):
+        tensor = inputs[key]
+        limit = inputs[f"{key}_speed_limit"][0, :, 0]
+        has = inputs[f"{key}_has_speed_limit"][0, :, 0]
+        valid = (tensor.abs().sum(dim=(2, 3)) > 0)[0]
+        for seg in torch.where(valid)[0].tolist():
+            xy = _valid_segment_points(tensor, seg)
+            if bool(has[seg]):
+                color = cmap(float(limit[seg]) / vmax)
+                ax.plot(xy[:, 0], xy[:, 1], color=color, lw=lw, zorder=10)
+            else:
+                ax.plot(xy[:, 0], xy[:, 1], color="gray", lw=lw, ls="--", alpha=0.7, zorder=10)
+            if key == "route_lanes":
+                mid = xy[len(xy) // 2]
+                label = f"{float(limit[seg]):.1f}m/s" if bool(has[seg]) else "unknown"
+                ax.annotate(
+                    label,
+                    xy=(float(mid[0]), float(mid[1])),
+                    fontsize=9,
+                    fontweight="bold",
+                    color="black" if bool(has[seg]) else "dimgray",
+                    zorder=11,
+                )
+    ax.plot(0, 0, marker="*", color="black", markersize=12, zorder=12)  # ego
+    n_known = int(
+        inputs["lanes_has_speed_limit"].sum() + inputs["route_lanes_has_speed_limit"].sum()
+    )
+    ax.set_title(f"{title} (known speed limits: {n_known})")
+    ax.set_aspect("equal")
+    ax.set_xlim(-80, 80)
+    ax.set_ylim(-80, 80)
+    ax.grid(alpha=0.3)
+
+
+def render_speed_limit(orig, sl_dropped, status, npz_name, out_path):
+    fig, axes = plt.subplots(1, 2, figsize=(20, 9))
+    _render_speed_limit_panel(axes[0], orig, "original: color = speed limit, dashed gray = unknown")
+    _render_speed_limit_panel(axes[1], sl_dropped, "after unknown dropout (lanes + route together)")
+    fig.suptitle(
+        f"speed-limit unknown dropout   {npz_name}   [{status}]",
+        color="red" if "NG" in status else "green",
+    )
+    plt.tight_layout()
+    plt.savefig(out_path, dpi=90, bbox_inches="tight")
+    plt.close(fig)
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("npz_paths", type=Path, nargs="+")
@@ -156,18 +267,13 @@ def main():
         print(f"{npz_path.name}: {status} (route segments {n_orig} -> {n_kept})")
         any_fail |= bool(failures)
 
-        # Side-by-side render. visualize_inputs mutates its dict -> pass copies.
-        fig, axes = plt.subplots(1, 2, figsize=(20, 9))
-        visualize_inputs(copy.deepcopy(orig), ax=axes[0])
-        axes[0].set_title(f"original ({n_orig} route segments)")
-        visualize_inputs(copy.deepcopy(truncated), ax=axes[1])
-        axes[1].set_title(f"truncated @ {args.truncate_m:.0f}m ({n_kept} route segments)")
-        fig.suptitle(f"{npz_path.name}   [{status}]", color="red" if failures else "green")
-        out = args.out_dir / f"{npz_path.stem}_route_aug_check.png"
-        plt.tight_layout()
-        plt.savefig(out, dpi=90, bbox_inches="tight")
-        plt.close(fig)
-        print(f"  -> {out}")
+        # One before/after figure per augmentation type.
+        out_trunc = args.out_dir / f"{npz_path.stem}_truncation_check.png"
+        render_truncation(orig, truncated, args.truncate_m, status, npz_path.name, out_trunc)
+        print(f"  -> {out_trunc}")
+        out_sl = args.out_dir / f"{npz_path.stem}_speed_limit_check.png"
+        render_speed_limit(orig, sl_dropped, status, npz_path.name, out_sl)
+        print(f"  -> {out_sl}")
 
     sys.exit(1 if any_fail else 0)
 

--- a/diffusion_planner/util_scripts/visualize_route_augmentation.py
+++ b/diffusion_planner/util_scripts/visualize_route_augmentation.py
@@ -1,0 +1,176 @@
+"""Verify RouteAugmentation visually and numerically.
+
+Loads npz samples, applies route tail truncation (truncation_prob=1.0, with a
+deterministic min==max budget) and the scene-wide speed-limit unknown dropout
+(prob=1.0), renders original vs augmented side by side with visualize_inputs,
+and runs numeric invariant checks (kept segments untouched, dropped segments
+and their speed-limit rows zeroed, dropped set is a suffix starting beyond the
+budget, first segment always kept, non-route tensors untouched, prob=0
+identity). Exits non-zero if any check fails.
+
+Usage (from the diffusion_planner directory):
+    uv run python util_scripts/visualize_route_augmentation.py <npz> [<npz> ...] \
+        --out_dir <dir> [--truncate_m 100]
+"""
+
+import argparse
+import copy
+import sys
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from diffusion_planner.train_epoch import heading_to_cos_sin
+from diffusion_planner.utils.route_augmentation import RouteAugmentation
+from diffusion_planner.utils.visualize_input import visualize_inputs
+
+_GEOM_DIM = 8
+
+
+def load_inputs(npz_path: Path) -> dict:
+    """Build the batch dict exactly like train_epoch right before route_aug is applied."""
+    loaded = np.load(npz_path)
+    data = {}
+    for key, value in loaded.items():
+        if key in ("map_name", "token", "version"):
+            continue
+        t = torch.tensor(np.expand_dims(value, axis=0))
+        if t.dtype == torch.float64:
+            t = t.float()
+        data[key] = t
+    data["ego_agent_past"] = heading_to_cos_sin(data["ego_agent_past"])
+    data["goal_pose"] = heading_to_cos_sin(data["goal_pose"])
+    return data
+
+
+def segment_start_distances(route: torch.Tensor) -> torch.Tensor:
+    """Arc length from the route start to each segment's start, as in the aug."""
+    valid_pt = route[..., :_GEOM_DIM].abs().sum(-1) > 0
+    xy = route[..., :2]
+    step = (xy[:, :, 1:] - xy[:, :, :-1]).norm(dim=-1)
+    pair_valid = (valid_pt[:, :, 1:] & valid_pt[:, :, :-1]).to(step.dtype)
+    seg_len = (step * pair_valid).sum(-1)
+    return torch.cumsum(seg_len, dim=1) - seg_len
+
+
+def run_checks(orig: dict, aug: dict, sl_aug: dict, truncate_m: float) -> list[str]:
+    failures = []
+
+    def check(name, cond):
+        if not cond:
+            failures.append(name)
+
+    route_o = orig["route_lanes"]
+    route_a = aug["route_lanes"]
+    valid_o = route_o.abs().sum(dim=(2, 3)) > 0  # [B, P]
+    kept = route_a.abs().sum(dim=(2, 3)) > 0  # [B, P]
+
+    # 1. Expected drop set: valid segments starting at/beyond the budget (never seg 0).
+    cum_before = segment_start_distances(route_o)
+    expected_drop = (cum_before >= truncate_m) & valid_o
+    expected_drop[:, 0] = False
+    check("drop set matches budget", torch.equal(kept, valid_o & ~expected_drop))
+    check("first segment kept", bool(kept[0, 0] == valid_o[0, 0]))
+
+    # 2. Kept segments are bit-identical; dropped rows fully zeroed.
+    check(
+        "kept segments untouched",
+        torch.equal(route_a[valid_o & ~expected_drop], route_o[valid_o & ~expected_drop]),
+    )
+    check("dropped segments zeroed", bool(route_a[expected_drop].abs().sum() == 0))
+
+    # 3. Speed-limit tensors follow the dropped rows.
+    check(
+        "dropped speed_limit zeroed",
+        bool(aug["route_lanes_speed_limit"][expected_drop].abs().sum() == 0),
+    )
+    check(
+        "dropped has_speed_limit false",
+        bool(~aug["route_lanes_has_speed_limit"][expected_drop].any()),
+    )
+
+    # 4. Truncation must not touch anything but the three route tensors.
+    route_keys = {"route_lanes", "route_lanes_speed_limit", "route_lanes_has_speed_limit"}
+    for key in orig:
+        if key in route_keys:
+            continue
+        check(f"non-route key untouched ({key})", torch.equal(aug[key], orig[key]))
+
+    # 5. Speed-limit unknown dropout (prob=1): lanes and route cleared together,
+    #    geometry untouched.
+    for prefix in ("lanes", "route_lanes"):
+        check(
+            f"sl-dropout {prefix} values zero",
+            bool(sl_aug[f"{prefix}_speed_limit"].abs().sum() == 0),
+        )
+        check(f"sl-dropout {prefix} flags false", bool(~sl_aug[f"{prefix}_has_speed_limit"].any()))
+    check("sl-dropout geometry untouched", torch.equal(sl_aug["route_lanes"], orig["route_lanes"]))
+    check("sl-dropout lanes untouched", torch.equal(sl_aug["lanes"], orig["lanes"]))
+
+    # 6. prob=0 is the identity.
+    ident = RouteAugmentation(device="cpu", truncation_prob=0.0, speed_limit_unknown_prob=0.0)(
+        copy.deepcopy(orig)
+    )
+    for key in orig:
+        check(f"prob=0 identity ({key})", torch.equal(ident[key], orig[key]))
+
+    return failures
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("npz_paths", type=Path, nargs="+")
+    parser.add_argument("--out_dir", type=Path, required=True)
+    parser.add_argument(
+        "--truncate_m",
+        type=float,
+        default=100.0,
+        help="deterministic truncation budget (min == max) in meters",
+    )
+    args = parser.parse_args()
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    trunc_aug = RouteAugmentation(
+        device="cpu",
+        truncation_prob=1.0,
+        truncation_min_m=args.truncate_m,
+        truncation_max_m=args.truncate_m,
+        speed_limit_unknown_prob=0.0,
+    )
+    sl_only_aug = RouteAugmentation(device="cpu", truncation_prob=0.0, speed_limit_unknown_prob=1.0)
+
+    any_fail = False
+    for npz_path in args.npz_paths:
+        orig = load_inputs(npz_path)
+        truncated = trunc_aug(copy.deepcopy(orig))
+        sl_dropped = sl_only_aug(copy.deepcopy(orig))
+
+        failures = run_checks(orig, truncated, sl_dropped, args.truncate_m)
+        n_orig = int((orig["route_lanes"].abs().sum(dim=(2, 3)) > 0).sum())
+        n_kept = int((truncated["route_lanes"].abs().sum(dim=(2, 3)) > 0).sum())
+        status = "OK" if not failures else "NG: " + ", ".join(failures)
+        print(f"{npz_path.name}: {status} (route segments {n_orig} -> {n_kept})")
+        any_fail |= bool(failures)
+
+        # Side-by-side render. visualize_inputs mutates its dict -> pass copies.
+        fig, axes = plt.subplots(1, 2, figsize=(20, 9))
+        visualize_inputs(copy.deepcopy(orig), ax=axes[0])
+        axes[0].set_title(f"original ({n_orig} route segments)")
+        visualize_inputs(copy.deepcopy(truncated), ax=axes[1])
+        axes[1].set_title(f"truncated @ {args.truncate_m:.0f}m ({n_kept} route segments)")
+        fig.suptitle(f"{npz_path.name}   [{status}]", color="red" if failures else "green")
+        out = args.out_dir / f"{npz_path.stem}_route_aug_check.png"
+        plt.tight_layout()
+        plt.savefig(out, dpi=90, bbox_inches="tight")
+        plt.close(fig)
+        print(f"  -> {out}")
+
+    sys.exit(1 if any_fail else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/diffusion_planner/util_scripts/visualize_route_augmentation.py
+++ b/diffusion_planner/util_scripts/visualize_route_augmentation.py
@@ -121,6 +121,56 @@ def run_checks(orig: dict, aug: dict, sl_aug: dict, truncate_m: float) -> list[s
     return failures
 
 
+def run_checks_medium(orig: dict, jittered: dict, trimmed: dict) -> list[str]:
+    """Checks for the medium-priority augmentations (geometry noise, head trim)."""
+    failures = []
+
+    def check(name, cond):
+        if not cond:
+            failures.append(name)
+
+    route_o = orig["route_lanes"]
+    valid_o = (route_o.abs().sum(dim=(2, 3)) > 0)[0]
+    n_valid = int(valid_o.sum())
+
+    # Geometry noise: constant per-segment offset, perpendicular to the segment
+    # direction; direction channels and all other tensors bit-identical.
+    route_j = jittered["route_lanes"]
+    for seg in torch.where(valid_o)[0].tolist():
+        pts_valid = route_o[0, seg, :, :_GEOM_DIM].abs().sum(-1) > 0
+        delta = (route_j[0, seg, :, :2] - route_o[0, seg, :, :2])[pts_valid]
+        # float32 rounding on coordinates hundreds of meters out leaves ~1e-4
+        # jitter on the recovered offset; anything below 1cm is "constant".
+        check(
+            f"noise constant within segment {seg}",
+            torch.allclose(delta, delta[0].expand_as(delta), atol=1e-2),
+        )
+        mean_dir = route_o[0, seg, pts_valid, 2:4].sum(0)
+        unit = mean_dir / mean_dir.norm().clamp_min(1e-6)
+        check(f"noise lateral in segment {seg}", bool(abs(float(delta[0] @ unit)) < 1e-2))
+    check("noise keeps dx/dy+attrs", torch.equal(route_j[..., 2:], route_o[..., 2:]))
+    for key in orig:
+        if key == "route_lanes":
+            continue
+        check(f"noise leaves {key} untouched", torch.equal(jittered[key], orig[key]))
+
+    # Head trim: with >= 3 valid segments every route tensor shifts one slot
+    # forward (freed slot zeroed); otherwise it is a strict no-op.
+    for key in ("route_lanes", "route_lanes_speed_limit", "route_lanes_has_speed_limit"):
+        t_o, t_t = orig[key], trimmed[key]
+        if n_valid >= 3:
+            expected = torch.cat([t_o[:, 1:], torch.zeros_like(t_o[:, :1])], dim=1)
+            check(f"trim shifts {key}", torch.equal(t_t, expected))
+        else:
+            check(f"trim no-op {key}", torch.equal(t_t, t_o))
+    for key in orig:
+        if key.startswith("route_lanes"):
+            continue
+        check(f"trim leaves {key} untouched", torch.equal(trimmed[key], orig[key]))
+
+    return failures
+
+
 def _valid_segment_points(route: torch.Tensor, seg: int) -> torch.Tensor:
     """Valid (non-padding) xy points of one route segment. route: [B, P, V, D]."""
     pts = route[0, seg]
@@ -243,6 +293,108 @@ def render_speed_limit(orig, sl_dropped, status, npz_name, out_path):
     plt.close(fig)
 
 
+def render_geometry_noise(orig, jittered, std_m, status, npz_name, out_path):
+    """Original (black dashed) vs jittered (orange) route centerline overlay.
+
+    Left: whole route. Right: zoom on the first segment where the lateral
+    shift is readable. Per-segment offsets are annotated in meters.
+    """
+    route_o = orig["route_lanes"]
+    route_j = jittered["route_lanes"]
+    valid_o = (route_o.abs().sum(dim=(2, 3)) > 0)[0]
+    segs = torch.where(valid_o)[0].tolist()
+
+    fig, axes = plt.subplots(1, 2, figsize=(20, 9))
+    for ax, title_segs in ((axes[0], segs), (axes[1], segs[:1])):
+        for seg in title_segs:
+            xy_o = _valid_segment_points(route_o, seg)
+            xy_j = _valid_segment_points(route_j, seg)
+            offset = float((xy_j[0] - xy_o[0]).norm())
+            ax.plot(
+                xy_o[:, 0], xy_o[:, 1], "k--", lw=2, label="original" if seg == segs[0] else None
+            )
+            ax.plot(
+                xy_j[:, 0],
+                xy_j[:, 1],
+                color="tab:orange",
+                lw=2,
+                label="jittered" if seg == segs[0] else None,
+            )
+            mid = xy_j[len(xy_j) // 2]
+            ax.annotate(
+                f"{offset:.2f}m",
+                xy=(float(mid[0]), float(mid[1])),
+                fontsize=10,
+                color="tab:orange",
+                fontweight="bold",
+            )
+        ax.plot(0, 0, marker="*", color="black", markersize=12)
+        ax.set_aspect("equal")
+        ax.grid(alpha=0.3)
+        ax.legend(loc="upper right")
+    axes[0].set_title(f"whole route: constant lateral offset per segment (std={std_m}m)")
+    first = _valid_segment_points(route_o, segs[0])
+    c = first.mean(0)
+    axes[1].set_xlim(float(c[0]) - 30, float(c[0]) + 30)
+    axes[1].set_ylim(float(c[1]) - 30, float(c[1]) + 30)
+    axes[1].set_title("zoom: first segment (label: offset magnitude)")
+    fig.suptitle(
+        f"route geometry noise   {npz_name}   [{status}]",
+        color="red" if "NG" in status else "green",
+    )
+    plt.tight_layout()
+    plt.savefig(out_path, dpi=90, bbox_inches="tight")
+    plt.close(fig)
+
+
+def render_head_trim(orig, trimmed, status, npz_name, out_path):
+    """Original vs head-trimmed route with slot indices, on the scene render."""
+    route_o = orig["route_lanes"]
+    route_t = trimmed["route_lanes"]
+    valid_o = (route_o.abs().sum(dim=(2, 3)) > 0)[0]
+    valid_t = (route_t.abs().sum(dim=(2, 3)) > 0)[0]
+    n_orig, n_kept = int(valid_o.sum()), int(valid_t.sum())
+    trimmed_applied = n_kept < n_orig
+
+    fig, axes = plt.subplots(1, 2, figsize=(20, 9))
+    visualize_inputs(copy.deepcopy(orig), ax=axes[0])
+    visualize_inputs(copy.deepcopy(trimmed), ax=axes[1])
+    for seg in torch.where(valid_o)[0].tolist():
+        xy = _valid_segment_points(route_o, seg)
+        dropped = trimmed_applied and seg == 0
+        color = "tab:red" if dropped else "tab:green"
+        axes[0].plot(xy[:, 0], xy[:, 1], color=color, lw=3.5, alpha=0.6, zorder=20)
+        axes[0].annotate(
+            f"slot{seg}",
+            xy=(float(xy[0, 0]), float(xy[0, 1])),
+            fontsize=9,
+            color=color,
+            fontweight="bold",
+            zorder=21,
+        )
+    for seg in torch.where(valid_t)[0].tolist():
+        xy = _valid_segment_points(route_t, seg)
+        axes[1].plot(xy[:, 0], xy[:, 1], color="tab:green", lw=3.5, alpha=0.6, zorder=20)
+        axes[1].annotate(
+            f"slot{seg}",
+            xy=(float(xy[0, 0]), float(xy[0, 1])),
+            fontsize=9,
+            color="tab:green",
+            fontweight="bold",
+            zorder=21,
+        )
+    note = "red = trimmed first segment" if trimmed_applied else "no-op (fewer than 3 segments)"
+    axes[0].set_title(f"original ({n_orig} route segments)  {note}")
+    axes[1].set_title(f"after head trim ({n_kept} route segments, shifted to slot 0)")
+    fig.suptitle(
+        f"route head trim   {npz_name}   [{status}]",
+        color="red" if "NG" in status else "green",
+    )
+    plt.tight_layout()
+    plt.savefig(out_path, dpi=90, bbox_inches="tight")
+    plt.close(fig)
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("npz_paths", type=Path, nargs="+")
@@ -252,6 +404,13 @@ def main():
         type=float,
         default=100.0,
         help="deterministic truncation budget (min == max) in meters",
+    )
+    parser.add_argument(
+        "--geom_noise_std",
+        type=float,
+        default=0.5,
+        help="lateral noise std [m] for the visualization (larger than the "
+        "training default so the shift is visible)",
     )
     args = parser.parse_args()
     args.out_dir.mkdir(parents=True, exist_ok=True)
@@ -264,14 +423,21 @@ def main():
         speed_limit_unknown_prob=0.0,
     )
     sl_only_aug = RouteAugmentation(device="cpu", truncation_prob=0.0, speed_limit_unknown_prob=1.0)
+    noise_aug = RouteAugmentation(
+        device="cpu", geometry_noise_prob=1.0, geometry_noise_std_m=args.geom_noise_std
+    )
+    trim_aug = RouteAugmentation(device="cpu", head_trim_prob=1.0)
 
     any_fail = False
     for npz_path in args.npz_paths:
         orig = load_inputs(npz_path)
         truncated = trunc_aug(copy.deepcopy(orig))
         sl_dropped = sl_only_aug(copy.deepcopy(orig))
+        jittered = noise_aug(copy.deepcopy(orig))
+        trimmed = trim_aug(copy.deepcopy(orig))
 
         failures = run_checks(orig, truncated, sl_dropped, args.truncate_m)
+        failures += run_checks_medium(orig, jittered, trimmed)
         n_orig = int((orig["route_lanes"].abs().sum(dim=(2, 3)) > 0).sum())
         n_kept = int((truncated["route_lanes"].abs().sum(dim=(2, 3)) > 0).sum())
         status = "OK" if not failures else "NG: " + ", ".join(failures)
@@ -279,12 +445,29 @@ def main():
         any_fail |= bool(failures)
 
         # One before/after figure per augmentation type.
-        out_trunc = args.out_dir / f"{npz_path.stem}_truncation_check.png"
-        render_truncation(orig, truncated, args.truncate_m, status, npz_path.name, out_trunc)
-        print(f"  -> {out_trunc}")
-        out_sl = args.out_dir / f"{npz_path.stem}_speed_limit_check.png"
-        render_speed_limit(orig, sl_dropped, status, npz_path.name, out_sl)
-        print(f"  -> {out_sl}")
+        renders = (
+            (
+                "truncation",
+                lambda out: render_truncation(
+                    orig, truncated, args.truncate_m, status, npz_path.name, out
+                ),
+            ),
+            (
+                "speed_limit",
+                lambda out: render_speed_limit(orig, sl_dropped, status, npz_path.name, out),
+            ),
+            (
+                "geometry_noise",
+                lambda out: render_geometry_noise(
+                    orig, jittered, args.geom_noise_std, status, npz_path.name, out
+                ),
+            ),
+            ("head_trim", lambda out: render_head_trim(orig, trimmed, status, npz_path.name, out)),
+        )
+        for name, render in renders:
+            out = args.out_dir / f"{npz_path.stem}_{name}_check.png"
+            render(out)
+            print(f"  -> {out}")
 
     sys.exit(1 if any_fail else 0)
 

--- a/diffusion_planner/util_scripts/visualize_route_augmentation.py
+++ b/diffusion_planner/util_scripts/visualize_route_augmentation.py
@@ -144,6 +144,17 @@ def render_truncation(orig, truncated, budget_m, status, npz_name, out_path):
     fig, axes = plt.subplots(1, 2, figsize=(20, 9))
     visualize_inputs(copy.deepcopy(orig), ax=axes[0])
     visualize_inputs(copy.deepcopy(truncated), ax=axes[1])
+
+    # Widen the view (visualize_inputs defaults to +-60m around ego) so the
+    # whole original route, including the truncated tail, is inside the frame.
+    all_xy = torch.cat(
+        [_valid_segment_points(route_o, s) for s in torch.where(valid_o)[0].tolist()]
+    )
+    center = (all_xy.amin(0) + all_xy.amax(0)) / 2
+    half = float((all_xy.amax(0) - all_xy.amin(0)).max()) / 2 + 25.0
+    for ax in axes:
+        ax.set_xlim(float(center[0]) - half, float(center[0]) + half)
+        ax.set_ylim(float(center[1]) - half, float(center[1]) + half)
     for seg in torch.where(valid_o)[0].tolist():
         xy = _valid_segment_points(route_o, seg)
         is_kept = bool(kept[seg])


### PR DESCRIPTION
# Add route input augmentations (tail truncation, speed-limit dropout, geometry noise, head trim)

  ## Summary

  Adds `RouteAugmentation`, a set of four input-side augmentations for `route_lanes` that simulate the route variations the planner actually sees at deployment time. All components are **off by default**
  (`--use_route_augment False`) and are applied in `train_epoch` before `StatePerturbation`, on raw ego-centric inputs. Every transform preserves the all-zero padding convention and only removes or perturbs
  information — none of them fabricates a state that contradicts the ground-truth trajectory.

  Traffic-light unknown dropout and scene flip are intentionally **not** included here; they live on separate branches (`feat/traffic-light-dropout-augmentation`, `feat/flip-augmentation`).

  ## Augmentations

  | Augmentation | What it does | Deployment situation it simulates | Parameters (default) |
  |---|---|---|---|
  | **Route tail truncation** | Samples a forward budget `d ~ U(min, max)` per sample and zeroes route segments starting　beyond `d` along the route arc length. The first segment is always kept; `route_lanes_speed_limit` / `has_speed_limit` rows are cleared in sync. | Short routes near the goal or map edge, replan timing | `route_truncation_prob=0.5`,　`route_truncation_min_m=60`,  `route_truncation_max_m=200` |
  | **Speed-limit unknown dropout** | Scene-wide, sets `has_speed_limit=False` and the limit value to 0 on `lanes` and `route_lanes` **together**, so the same lanelet never disagrees between the two tensors.  Trains the encoder's `unknown_speed_emb` path, which is rarely exercised by natural data. | Missing speed-limit annotations in the map | `speed_limit_unknown_prob=0.1` |
  | **Route geometry noise** | Adds a **constant per-segment lateral offset** `~N(0, σ)` to the route centerline. Constant-within-segment keeps the per-point direction channels (dx, dy) and the relative boundary offsets exactly consistent; point-wise independent noise would corrupt them and is deliberately not done. | Map survey error / map version drift; loosens centerline snapping | `route_geometry_noise_prob=0.5`,  `route_geometry_noise_std_m=0.15` |
  | **Route head trim** | Drops the first route segment and shifts the rest one slot forward (keeping the "slot 0 = current lanelet" convention of the ordered positional embedding). Applied only when ≥ 3 segments are valid, so at least 2 segments of forward intent survive. | Nearest-lanelet s Jump to bottom (ctrl+End) ↓ start (lane changes, intersections, replan timing) | `route_head_trim_prob=0.1` |

  Application order: head trim → tail truncation → geometry noise → speed-limit dropout, so the truncation budget is measured from the (possibly shifted) route start, matching how a shifted nearest-lanelet pick
  would look at runtime.

  ## Usage

  ```bash
  uv run python train_predictor.py ... \
    --use_route_augment True \
    [--route_truncation_prob 0.5 --route_truncation_min_m 60 --route_truncation_max_m 200] \
    [--speed_limit_unknown_prob 0.1] \
    [--route_geometry_noise_prob 0.5 --route_geometry_noise_std_m 0.15] \
    [--route_head_trim_prob 0.1]
  ```

  Each component has an independent probability; setting a probability to 0 disables just that component.

  ## Verification
  
  - **Unit tests** (`diffusion_planner/tests/test_route_augmentation.py`, 10 cases): exact drop set vs. arc-length budget, first-segment retention, padding preservation, speed-limit tensor sync, lanes+route
  consistency of the speed-limit dropout, constant/lateral-only geometry offset with untouched direction channels, head-trim forward shift and short-route no-op, and prob=0 identity for every component.
  - **Visualization / verification script** (`diffusion_planner/util_scripts/visualize_route_augmentation.py`, same layout as the flip-augmentation branch): renders one before/after figure per augmentation type
  per sample and runs the numeric invariant checks, exiting non-zero on any failure. Verified on 6 mini-dataset samples (all OK).

  ```bash
  uv run python util_scripts/visualize_route_augmentation.py <npz...> --out_dir <dir> [--truncate_m 100] [--geom_noise_std 0.5]
  ```

  - Truncation figures fit the view to the full route extent and overdraw kept segments in green / dropped ones in red with their start arc length, so the removed tail is visible even when it lies outside the
  default ±60 m window.

  ## Notes

  - No behavior change with default settings: `use_route_augment` defaults to `False`, and the augmentation only runs in `train_epoch` (never in validation).
  - Pre-existing test failures on `dev` (`test_data_augmentation.py` signature mismatch with `StatePerturbation.__init__`, `test_cluster.py` missing sklearn) are unrelated to this change.

