### PR TITLE
feat: propagate t4_dataset_id through bag_metadata

### DIFF
--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/io/bag_metadata.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/io/bag_metadata.hpp
@@ -27,6 +27,8 @@ struct BagMetadata
   std::string map_version_id;
   std::string date;
   std::string bag_time;
+  std::string t4_dataset_id;
+  std::string t4_dataset_version_id;
 };
 
 BagMetadata load_bag_metadata(const std::string & rosbag_path);

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/io/bag_metadata.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/io/bag_metadata.cpp
@@ -68,6 +68,8 @@ BagMetadata load_bag_metadata(const std::string & rosbag_path)
     meta.vehicle_id = get_string_or_empty(j, "vehicle_id");
     meta.project_id = get_string_or_empty(j, "project_id");
     meta.map_version_id = get_string_or_empty(j, "area_map_version_id");
+    meta.t4_dataset_id = get_string_or_empty(j, "t4_dataset_id");
+    meta.t4_dataset_version_id = get_string_or_empty(j, "t4_dataset_version_id");
 
     const std::string log_file_name = get_string_or_empty(j, "log_file_name");
     if (!log_file_name.empty()) {
@@ -90,4 +92,6 @@ void write_bag_metadata(nlohmann::json & j, const BagMetadata & bag_metadata)
   j["map_version_id"] = bag_metadata.map_version_id;
   j["date"] = bag_metadata.date;
   j["bag_time"] = bag_metadata.bag_time;
+  j["t4_dataset_id"] = bag_metadata.t4_dataset_id;
+  j["t4_dataset_version_id"] = bag_metadata.t4_dataset_version_id;
 }

--- a/cpp_tools/src/autoware_diffusion_planner_tools/test/test_bag_metadata.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/test/test_bag_metadata.cpp
@@ -59,6 +59,8 @@ TEST_F(BagMetadataTest, ValidJsonAllFields)
   EXPECT_EQ(meta.map_version_id, "1847-20250819054643702212");
   EXPECT_EQ(meta.date, "2026-01-16");
   EXPECT_EQ(meta.bag_time, "10-03-35");
+  EXPECT_EQ(meta.t4_dataset_id, "");
+  EXPECT_EQ(meta.t4_dataset_version_id, "");
 }
 
 TEST_F(BagMetadataTest, MissingFileReturnsEmptyStrings)
@@ -71,6 +73,8 @@ TEST_F(BagMetadataTest, MissingFileReturnsEmptyStrings)
   EXPECT_EQ(meta.map_version_id, "");
   EXPECT_EQ(meta.date, "");
   EXPECT_EQ(meta.bag_time, "");
+  EXPECT_EQ(meta.t4_dataset_id, "");
+  EXPECT_EQ(meta.t4_dataset_version_id, "");
 }
 
 TEST_F(BagMetadataTest, MalformedJsonReturnsEmptyStrings)
@@ -98,6 +102,22 @@ TEST_F(BagMetadataTest, MissingIndividualFieldsPartiallyPopulated)
   EXPECT_EQ(meta.map_version_id, "");
   EXPECT_EQ(meta.date, "");
   EXPECT_EQ(meta.bag_time, "");
+  EXPECT_EQ(meta.t4_dataset_id, "");
+  EXPECT_EQ(meta.t4_dataset_version_id, "");
+}
+
+TEST_F(BagMetadataTest, T4DatasetFieldsAreLoaded)
+{
+  write_json(R"({
+    "id": "abc-123",
+    "t4_dataset_id": "ds-001",
+    "t4_dataset_version_id": "7"
+  })");
+
+  const BagMetadata meta = load_bag_metadata(tmp_dir_.string());
+
+  EXPECT_EQ(meta.t4_dataset_id, "ds-001");
+  EXPECT_EQ(meta.t4_dataset_version_id, "7");
 }
 
 TEST_F(BagMetadataTest, LogFileNameWithoutDateTimePattern)

--- a/cpp_tools/src/autoware_diffusion_planner_tools/test/test_bag_metadata.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/test/test_bag_metadata.cpp
@@ -48,6 +48,8 @@ TEST_F(BagMetadataTest, ValidJsonAllFields)
     "vehicle_id": "cfa23601-97c4-4d47-a37e-edfc7e080d8c",
     "project_id": "x2_dev",
     "area_map_version_id": "1847-20250819054643702212",
+    "t4_dataset_id": "ds-001",
+    "t4_dataset_version_id": "7",
     "log_file_name": "cfa23601-97c4-4d47-a37e-edfc7e080d8c_2026-01-16-10-03-35_p0900_0.db3.zst"
   })");
 
@@ -59,8 +61,8 @@ TEST_F(BagMetadataTest, ValidJsonAllFields)
   EXPECT_EQ(meta.map_version_id, "1847-20250819054643702212");
   EXPECT_EQ(meta.date, "2026-01-16");
   EXPECT_EQ(meta.bag_time, "10-03-35");
-  EXPECT_EQ(meta.t4_dataset_id, "");
-  EXPECT_EQ(meta.t4_dataset_version_id, "");
+  EXPECT_EQ(meta.t4_dataset_id, "ds-001");
+  EXPECT_EQ(meta.t4_dataset_version_id, "7");
 }
 
 TEST_F(BagMetadataTest, MissingFileReturnsEmptyStrings)

--- a/cpp_tools/src/autoware_diffusion_planner_tools/test/test_frame_writer.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/test/test_frame_writer.cpp
@@ -21,7 +21,7 @@ namespace
 {
 BagMetadata make_test_metadata()
 {
-  return {"log-id-1", "vehicle-id-1", "x2_dev", "1847-ver", "2026-01-16", "10-03-35"};
+  return {"log-id-1", "vehicle-id-1", "x2_dev", "1847-ver", "2026-01-16", "10-03-35", "", ""};
 }
 }  // namespace
 


### PR DESCRIPTION
## What this PR does

Propagates upstream T4 dataset identity through the C++ rosbag → NPZ conversion path so converted datasets can carry `t4_dataset_id` / `t4_dataset_version_id` from `log_file_info.json` into frame / sidecar metadata.

This pairs with the meta-repo Evaluator download flow (`download_t4datasets_from_evaluator.py`), which already writes those fields into bag metadata JSON. Without this PR, the converter ignored them.

### Changes

- `BagMetadata` gains `t4_dataset_id` and `t4_dataset_version_id`.
- `load_bag_metadata` / `write_bag_metadata` read and write the fields (`get_string_or_empty` → missing keys become `""`).
- Unit tests: populated path (`T4DatasetFieldsAreLoaded`, `ValidJsonAllFields`) and empty / missing-file paths.

## Testing

- [ ] `test_bag_metadata` / `test_frame_writer` C++ unit tests pass
- [ ] Convert a bag whose `log_file_info.json` has T4 IDs and confirm they appear in output metadata