### PR TITLE
feat: mine fail-to-resume via realized-lag + native realized closed-loop reward

### DIFF
--- a/rlvr/autoresearch/tools/build_repaired_targets.py
+++ b/rlvr/autoresearch/tools/build_repaired_targets.py
@@ -457,12 +457,6 @@ def _load_rows(
 # expert did (minus numerical slack) instead of beating an absolute bar the ground
 # truth already fails.
 _EXPERT_RB_FLOOR_SLACK_M = 0.05
-# The expert-relative floor only applies when the expert's OWN crossing is shallow — a
-# genuine shoulder-stop that skims the border. If the logged expert is deeper than this
-# below the border, the scene is pathological (not a legitimate hug) and the absolute rb
-# gate is kept, so the floor can never admit a candidate that hugs the border by more
-# than ~this much.
-_EXPERT_RB_FLOOR_MAX_DEPTH_M = 0.15
 
 
 def _rb_gate_ok(reward_row, rb_dist_floor: float | None) -> bool:
@@ -558,6 +552,13 @@ def _best_safe_candidate(
         for prefix, idx_s in (("morph", morph_index), ("depart", depart_index))
         if idx_s is not None
     }
+    # The expert-relative rb floor is applied ONLY to the scripted expert-following
+    # candidates (morph / depart). They are constructed from the expert path, so allowing
+    # them to skim the border as much as the expert does is the intent; they cannot run
+    # far outside. Model / fan candidates always face the absolute rb gate — rb_min_dist is
+    # unsigned, so an unrestricted floor would also admit a candidate that crossed and
+    # continued far outside (large unsigned distance on the wrong side).
+    scripted_idx = set(scripted.values())
     accepted: list[tuple[float, float, float, int]] = []
     candidate_traj_list = None
     if candidate_trajs is not None:
@@ -568,7 +569,7 @@ def _best_safe_candidate(
             label_row,
             reward_row,
             min_static_margin=min_static_margin,
-            rb_dist_floor=rb_dist_floor,
+            rb_dist_floor=rb_dist_floor if idx in scripted_idx else None,
         ):
             violation_score = _candidate_violation_score(label_row, reward_row)
             deviation_penalty = _candidate_deviation_penalty(
@@ -912,23 +913,18 @@ def build_repaired_targets(
                 )
                 expert_reward = compute_reward_batch(expert_tensor[None], scoring_data, rcfg)[0]
                 if expert_reward.rb_crossing:
-                    expert_rb = float(expert_reward.rb_min_dist)
-                    # Only relax for a SHALLOW expert crossing (a real shoulder-stop hug);
-                    # if the expert is deeply over the border the scene is pathological, so
-                    # keep the absolute gate rather than admit near-as-deep candidates.
-                    if expert_rb >= -_EXPERT_RB_FLOOR_MAX_DEPTH_M:
-                        rb_dist_floor = expert_rb - _EXPERT_RB_FLOOR_SLACK_M
-                        print(
-                            f"  expert rb floor {name}: expert future crosses rb "
-                            f"(min dist {expert_rb:.3f} m) -> candidate floor "
-                            f"{rb_dist_floor:.3f} m"
-                        )
-                    else:
-                        print(
-                            f"  expert rb floor {name}: expert crosses deeply "
-                            f"(min dist {expert_rb:.3f} m < -{_EXPERT_RB_FLOOR_MAX_DEPTH_M} m) "
-                            "-> keeping absolute rb gate"
-                        )
+                    # rb_min_dist is the UNSIGNED min distance to the border (crossing =
+                    # < rb_cross_thresh). The floor "candidate stays at least as far from
+                    # the border as the expert" is only safe for the scripted expert-
+                    # following candidates (see _best_safe_candidate), which track the
+                    # expert path and cannot run far outside; it is NOT applied to model/
+                    # fan candidates.
+                    rb_dist_floor = float(expert_reward.rb_min_dist) - _EXPERT_RB_FLOOR_SLACK_M
+                    print(
+                        f"  expert rb floor {name}: expert future crosses rb "
+                        f"(min dist {expert_reward.rb_min_dist:.3f} m) -> scripted-candidate "
+                        f"floor {rb_dist_floor:.3f} m"
+                    )
             scripted_kwargs = dict(
                 scene_path=str(row["scene_path"]),
                 data=data,

--- a/rlvr/autoresearch/tools/build_repaired_targets.py
+++ b/rlvr/autoresearch/tools/build_repaired_targets.py
@@ -452,34 +452,10 @@ def _load_rows(
     return rows
 
 
-# Slack subtracted from the expert's own road-border clearance when the expert itself
-# crosses: candidates then only need to stay at least as far from the border as the
-# expert did (minus numerical slack) instead of beating an absolute bar the ground
-# truth already fails.
-_EXPERT_RB_FLOOR_SLACK_M = 0.05
-
-
-def _rb_gate_ok(reward_row, rb_dist_floor: float | None) -> bool:
-    """Road-border gate, optionally expert-relative.
-
-    Some logged experts legitimately hug the road edge (e.g. a stop at the road
-    shoulder), so their own future fails the absolute rb_crossing gate — which
-    made EVERY expert-following repair (stop morph, depart morph, expert GT
-    candidate) unrepairable on those scenes. When ``rb_dist_floor`` is set (only
-    when the expert itself crosses), a crossing candidate still passes as long as
-    it keeps at least the expert's own border clearance.
-    """
-    if not reward_row.rb_crossing:
-        return True
-    return rb_dist_floor is not None and float(reward_row.rb_min_dist) >= rb_dist_floor
-
-
-def _passes_global_gates(
-    label_row: dict[str, Any], reward_row, *, rb_dist_floor: float | None = None
-) -> bool:
+def _passes_global_gates(label_row: dict[str, Any], reward_row) -> bool:
     return (
         reward_row.collision_step is None
-        and _rb_gate_ok(reward_row, rb_dist_floor)
+        and not reward_row.rb_crossing
         and not reward_row.lane_crossing
         and not reward_row.static_crossing
         and not reward_row.kinematic_violated
@@ -487,13 +463,11 @@ def _passes_global_gates(
     )
 
 
-def _global_gate_flags(
-    label_row: dict[str, Any], reward_row, *, rb_dist_floor: float | None = None
-) -> dict[str, bool]:
+def _global_gate_flags(label_row: dict[str, Any], reward_row) -> dict[str, bool]:
     """Which _passes_global_gates condition(s) failed — diagnosis mirror, keep in sync."""
     return {
         "collision": reward_row.collision_step is not None,
-        "rb_crossing": not _rb_gate_ok(reward_row, rb_dist_floor),
+        "rb_crossing": bool(reward_row.rb_crossing),
         "lane_crossing": bool(reward_row.lane_crossing),
         "static_crossing": bool(reward_row.static_crossing),
         "kinematic_violated": bool(reward_row.kinematic_violated),
@@ -507,7 +481,6 @@ def _repairs_source_labels(
     reward_row,
     *,
     min_static_margin: float,
-    rb_dist_floor: float | None = None,
 ) -> bool:
     # Paper-faithful recoverability (R2LPL Eq. recoverability): a candidate is valid iff
     # it is RULE-FEASIBLE (q_i > 0) — safety / drivable / route / static-margin. Expert /
@@ -515,10 +488,16 @@ def _repairs_source_labels(
     # soft, deviation-class-weighted term (c_E, dropped entirely for far-off states,
     # w_E=0). So expert_disagreement is handled by the soft r2lpl_score ranking in
     # _best_safe_candidate, not by rejecting conflict-flagged candidates here.
-    if not _passes_global_gates(label_row, reward_row, rb_dist_floor=rb_dist_floor):
+    #
+    # NOTE: the road-border gate is ABSOLUTE (any crossing is rejected). An earlier
+    # expert-relative relaxation for shoulder-stop scenes was removed: rb_min_dist is an
+    # unsigned distance to the border, so it cannot distinguish a shoulder skim from a
+    # trajectory that crossed to the wrong side and ran far outside, making any distance
+    # floor unsafe. Re-enabling it needs a signed / side-aware containment metric.
+    if not _passes_global_gates(label_row, reward_row):
         return False
     for label in source_labels:
-        if label == "road_border_crossing" and not _rb_gate_ok(reward_row, rb_dist_floor):
+        if label == "road_border_crossing" and reward_row.rb_crossing:
             return False
         if label == "static_collision":
             if reward_row.static_crossing or float(reward_row.sc_min_dist) < min_static_margin:
@@ -543,7 +522,6 @@ def _best_safe_candidate(
     reference_traj: torch.Tensor | np.ndarray | None = None,
     morph_index: int | None = None,
     depart_index: int | None = None,
-    rb_dist_floor: float | None = None,
 ) -> tuple[int | None, dict[str, Any]]:
     # Scripted candidates get a per-candidate outcome taxonomy in the meta
     # (selected / lost_selection / gate_rejected) keyed by their prefix.
@@ -552,13 +530,6 @@ def _best_safe_candidate(
         for prefix, idx_s in (("morph", morph_index), ("depart", depart_index))
         if idx_s is not None
     }
-    # The expert-relative rb floor is applied ONLY to the scripted expert-following
-    # candidates (morph / depart). They are constructed from the expert path, so allowing
-    # them to skim the border as much as the expert does is the intent; they cannot run
-    # far outside. Model / fan candidates always face the absolute rb gate — rb_min_dist is
-    # unsigned, so an unrestricted floor would also admit a candidate that crossed and
-    # continued far outside (large unsigned distance on the wrong side).
-    scripted_idx = set(scripted.values())
     accepted: list[tuple[float, float, float, int]] = []
     candidate_traj_list = None
     if candidate_trajs is not None:
@@ -569,7 +540,6 @@ def _best_safe_candidate(
             label_row,
             reward_row,
             min_static_margin=min_static_margin,
-            rb_dist_floor=rb_dist_floor if idx in scripted_idx else None,
         ):
             violation_score = _candidate_violation_score(label_row, reward_row)
             deviation_penalty = _candidate_deviation_penalty(
@@ -587,13 +557,11 @@ def _best_safe_candidate(
             "best_total": best_total,
             "best_sc_min_dist": best_sc,
         }
-        if rb_dist_floor is not None:
-            meta["rb_dist_floor"] = float(rb_dist_floor)
         for prefix, idx_s in scripted.items():
             meta[f"{prefix}_outcome"] = "gate_rejected"
             meta[f"{prefix}_labels"] = list(candidate_rows[idx_s].get("labels", []))
             meta[f"{prefix}_gate_flags"] = _global_gate_flags(
-                candidate_rows[idx_s], reward_rows[idx_s], rb_dist_floor=rb_dist_floor
+                candidate_rows[idx_s], reward_rows[idx_s]
             )
         return None, meta
 
@@ -900,31 +868,9 @@ def build_repaired_targets(
             name = _output_name_for_scene(row["scene_path"])
 
             expert_traj = det_traj = None
-            rb_dist_floor = None
             if is_expert and (repair_expert_gt_candidate or enable_depart_morph):
                 expert_traj = _future_to_4col(data["ego_expert_future"].detach().cpu().numpy())
                 det_traj = det_trajs[scene_idx].detach().cpu().numpy().astype(np.float32)
-                # Expert-relative road-border floor: when the logged expert's own
-                # future crosses the absolute rb gate (e.g. shoulder stops), gate
-                # candidates against the expert's clearance instead — otherwise no
-                # expert-following repair can ever be accepted on these scenes.
-                expert_tensor = torch.from_numpy(np.ascontiguousarray(expert_traj)).to(
-                    device=device, dtype=scene_trajs.dtype
-                )
-                expert_reward = compute_reward_batch(expert_tensor[None], scoring_data, rcfg)[0]
-                if expert_reward.rb_crossing:
-                    # rb_min_dist is the UNSIGNED min distance to the border (crossing =
-                    # < rb_cross_thresh). The floor "candidate stays at least as far from
-                    # the border as the expert" is only safe for the scripted expert-
-                    # following candidates (see _best_safe_candidate), which track the
-                    # expert path and cannot run far outside; it is NOT applied to model/
-                    # fan candidates.
-                    rb_dist_floor = float(expert_reward.rb_min_dist) - _EXPERT_RB_FLOOR_SLACK_M
-                    print(
-                        f"  expert rb floor {name}: expert future crosses rb "
-                        f"(min dist {expert_reward.rb_min_dist:.3f} m) -> scripted-candidate "
-                        f"floor {rb_dist_floor:.3f} m"
-                    )
             scripted_kwargs = dict(
                 scene_path=str(row["scene_path"]),
                 data=data,
@@ -1015,7 +961,6 @@ def build_repaired_targets(
                 reference_traj=reference_traj,
                 morph_index=morph_index if morph_added else None,
                 depart_index=depart_index if depart_added else None,
-                rb_dist_floor=rb_dist_floor,
             )
             morph_selected = bool(morph_added and best_idx == morph_index)
             depart_selected = bool(depart_added and best_idx == depart_index)

--- a/rlvr/autoresearch/tools/build_repaired_targets.py
+++ b/rlvr/autoresearch/tools/build_repaired_targets.py
@@ -457,6 +457,12 @@ def _load_rows(
 # expert did (minus numerical slack) instead of beating an absolute bar the ground
 # truth already fails.
 _EXPERT_RB_FLOOR_SLACK_M = 0.05
+# The expert-relative floor only applies when the expert's OWN crossing is shallow — a
+# genuine shoulder-stop that skims the border. If the logged expert is deeper than this
+# below the border, the scene is pathological (not a legitimate hug) and the absolute rb
+# gate is kept, so the floor can never admit a candidate that hugs the border by more
+# than ~this much.
+_EXPERT_RB_FLOOR_MAX_DEPTH_M = 0.15
 
 
 def _rb_gate_ok(reward_row, rb_dist_floor: float | None) -> bool:
@@ -906,12 +912,23 @@ def build_repaired_targets(
                 )
                 expert_reward = compute_reward_batch(expert_tensor[None], scoring_data, rcfg)[0]
                 if expert_reward.rb_crossing:
-                    rb_dist_floor = float(expert_reward.rb_min_dist) - _EXPERT_RB_FLOOR_SLACK_M
-                    print(
-                        f"  expert rb floor {name}: expert future crosses rb "
-                        f"(min dist {expert_reward.rb_min_dist:.3f} m) -> candidate floor "
-                        f"{rb_dist_floor:.3f} m"
-                    )
+                    expert_rb = float(expert_reward.rb_min_dist)
+                    # Only relax for a SHALLOW expert crossing (a real shoulder-stop hug);
+                    # if the expert is deeply over the border the scene is pathological, so
+                    # keep the absolute gate rather than admit near-as-deep candidates.
+                    if expert_rb >= -_EXPERT_RB_FLOOR_MAX_DEPTH_M:
+                        rb_dist_floor = expert_rb - _EXPERT_RB_FLOOR_SLACK_M
+                        print(
+                            f"  expert rb floor {name}: expert future crosses rb "
+                            f"(min dist {expert_rb:.3f} m) -> candidate floor "
+                            f"{rb_dist_floor:.3f} m"
+                        )
+                    else:
+                        print(
+                            f"  expert rb floor {name}: expert crosses deeply "
+                            f"(min dist {expert_rb:.3f} m < -{_EXPERT_RB_FLOOR_MAX_DEPTH_M} m) "
+                            "-> keeping absolute rb gate"
+                        )
             scripted_kwargs = dict(
                 scene_path=str(row["scene_path"]),
                 data=data,

--- a/rlvr/autoresearch/tools/build_repaired_targets.py
+++ b/rlvr/autoresearch/tools/build_repaired_targets.py
@@ -452,10 +452,34 @@ def _load_rows(
     return rows
 
 
-def _passes_global_gates(label_row: dict[str, Any], reward_row) -> bool:
+# Slack subtracted from the expert's own road-border clearance when the expert itself
+# crosses: candidates then only need to stay at least as far from the border as the
+# expert did (minus numerical slack) instead of beating an absolute bar the ground
+# truth already fails.
+_EXPERT_RB_FLOOR_SLACK_M = 0.05
+
+
+def _rb_gate_ok(reward_row, rb_dist_floor: float | None) -> bool:
+    """Road-border gate, optionally expert-relative.
+
+    Some logged experts legitimately hug the road edge (e.g. a stop at the road
+    shoulder), so their own future fails the absolute rb_crossing gate — which
+    made EVERY expert-following repair (stop morph, depart morph, expert GT
+    candidate) unrepairable on those scenes. When ``rb_dist_floor`` is set (only
+    when the expert itself crosses), a crossing candidate still passes as long as
+    it keeps at least the expert's own border clearance.
+    """
+    if not reward_row.rb_crossing:
+        return True
+    return rb_dist_floor is not None and float(reward_row.rb_min_dist) >= rb_dist_floor
+
+
+def _passes_global_gates(
+    label_row: dict[str, Any], reward_row, *, rb_dist_floor: float | None = None
+) -> bool:
     return (
         reward_row.collision_step is None
-        and not reward_row.rb_crossing
+        and _rb_gate_ok(reward_row, rb_dist_floor)
         and not reward_row.lane_crossing
         and not reward_row.static_crossing
         and not reward_row.kinematic_violated
@@ -463,11 +487,13 @@ def _passes_global_gates(label_row: dict[str, Any], reward_row) -> bool:
     )
 
 
-def _global_gate_flags(label_row: dict[str, Any], reward_row) -> dict[str, bool]:
+def _global_gate_flags(
+    label_row: dict[str, Any], reward_row, *, rb_dist_floor: float | None = None
+) -> dict[str, bool]:
     """Which _passes_global_gates condition(s) failed — diagnosis mirror, keep in sync."""
     return {
         "collision": reward_row.collision_step is not None,
-        "rb_crossing": bool(reward_row.rb_crossing),
+        "rb_crossing": not _rb_gate_ok(reward_row, rb_dist_floor),
         "lane_crossing": bool(reward_row.lane_crossing),
         "static_crossing": bool(reward_row.static_crossing),
         "kinematic_violated": bool(reward_row.kinematic_violated),
@@ -481,6 +507,7 @@ def _repairs_source_labels(
     reward_row,
     *,
     min_static_margin: float,
+    rb_dist_floor: float | None = None,
 ) -> bool:
     # Paper-faithful recoverability (R2LPL Eq. recoverability): a candidate is valid iff
     # it is RULE-FEASIBLE (q_i > 0) — safety / drivable / route / static-margin. Expert /
@@ -488,10 +515,10 @@ def _repairs_source_labels(
     # soft, deviation-class-weighted term (c_E, dropped entirely for far-off states,
     # w_E=0). So expert_disagreement is handled by the soft r2lpl_score ranking in
     # _best_safe_candidate, not by rejecting conflict-flagged candidates here.
-    if not _passes_global_gates(label_row, reward_row):
+    if not _passes_global_gates(label_row, reward_row, rb_dist_floor=rb_dist_floor):
         return False
     for label in source_labels:
-        if label == "road_border_crossing" and reward_row.rb_crossing:
+        if label == "road_border_crossing" and not _rb_gate_ok(reward_row, rb_dist_floor):
             return False
         if label == "static_collision":
             if reward_row.static_crossing or float(reward_row.sc_min_dist) < min_static_margin:
@@ -516,6 +543,7 @@ def _best_safe_candidate(
     reference_traj: torch.Tensor | np.ndarray | None = None,
     morph_index: int | None = None,
     depart_index: int | None = None,
+    rb_dist_floor: float | None = None,
 ) -> tuple[int | None, dict[str, Any]]:
     # Scripted candidates get a per-candidate outcome taxonomy in the meta
     # (selected / lost_selection / gate_rejected) keyed by their prefix.
@@ -534,6 +562,7 @@ def _best_safe_candidate(
             label_row,
             reward_row,
             min_static_margin=min_static_margin,
+            rb_dist_floor=rb_dist_floor,
         ):
             violation_score = _candidate_violation_score(label_row, reward_row)
             deviation_penalty = _candidate_deviation_penalty(
@@ -551,11 +580,13 @@ def _best_safe_candidate(
             "best_total": best_total,
             "best_sc_min_dist": best_sc,
         }
+        if rb_dist_floor is not None:
+            meta["rb_dist_floor"] = float(rb_dist_floor)
         for prefix, idx_s in scripted.items():
             meta[f"{prefix}_outcome"] = "gate_rejected"
             meta[f"{prefix}_labels"] = list(candidate_rows[idx_s].get("labels", []))
             meta[f"{prefix}_gate_flags"] = _global_gate_flags(
-                candidate_rows[idx_s], reward_rows[idx_s]
+                candidate_rows[idx_s], reward_rows[idx_s], rb_dist_floor=rb_dist_floor
             )
         return None, meta
 
@@ -862,9 +893,25 @@ def build_repaired_targets(
             name = _output_name_for_scene(row["scene_path"])
 
             expert_traj = det_traj = None
+            rb_dist_floor = None
             if is_expert and (repair_expert_gt_candidate or enable_depart_morph):
                 expert_traj = _future_to_4col(data["ego_expert_future"].detach().cpu().numpy())
                 det_traj = det_trajs[scene_idx].detach().cpu().numpy().astype(np.float32)
+                # Expert-relative road-border floor: when the logged expert's own
+                # future crosses the absolute rb gate (e.g. shoulder stops), gate
+                # candidates against the expert's clearance instead — otherwise no
+                # expert-following repair can ever be accepted on these scenes.
+                expert_tensor = torch.from_numpy(np.ascontiguousarray(expert_traj)).to(
+                    device=device, dtype=scene_trajs.dtype
+                )
+                expert_reward = compute_reward_batch(expert_tensor[None], scoring_data, rcfg)[0]
+                if expert_reward.rb_crossing:
+                    rb_dist_floor = float(expert_reward.rb_min_dist) - _EXPERT_RB_FLOOR_SLACK_M
+                    print(
+                        f"  expert rb floor {name}: expert future crosses rb "
+                        f"(min dist {expert_reward.rb_min_dist:.3f} m) -> candidate floor "
+                        f"{rb_dist_floor:.3f} m"
+                    )
             scripted_kwargs = dict(
                 scene_path=str(row["scene_path"]),
                 data=data,
@@ -955,6 +1002,7 @@ def build_repaired_targets(
                 reference_traj=reference_traj,
                 morph_index=morph_index if morph_added else None,
                 depart_index=depart_index if depart_added else None,
+                rb_dist_floor=rb_dist_floor,
             )
             morph_selected = bool(morph_added and best_idx == morph_index)
             depart_selected = bool(depart_added and best_idx == depart_index)

--- a/rlvr/autoresearch/tools/mine_direct_reproducer_chunks.py
+++ b/rlvr/autoresearch/tools/mine_direct_reproducer_chunks.py
@@ -659,6 +659,16 @@ def main() -> None:
                 f"chunk_len={args.chunk_len}. Use e.g. --chunk_len {horizon * 2} so each pose "
                 "has a full realized future to score."
             )
+        # The realized reward reconstructs the shown neighbor future from the sim tracker;
+        # in `recorded` mode there is no shown-motion telemetry, so the reward would be
+        # scored with neighbors dropped (collision/TTC/static neutralized) and be
+        # misleadingly safety-blind. Require `sim` rather than silently mis-score.
+        if str(args.neighbor_history_mode) != "sim":
+            raise ValueError(
+                "--realized_reward requires --neighbor_history_mode sim (got "
+                f"{args.neighbor_history_mode!r}); the recorded path cannot supply the shown "
+                "neighbor future, so the reward would drop all neighbor-safety terms."
+            )
         # Piggyback the otherwise-free per-step danger_scorer hook to capture the
         # realized trajectory + contexts in memory during THIS rollout, then score
         # reward once at the end. No second simulation, no disk save/reload.

--- a/rlvr/autoresearch/tools/mine_direct_reproducer_chunks.py
+++ b/rlvr/autoresearch/tools/mine_direct_reproducer_chunks.py
@@ -762,6 +762,9 @@ def main() -> None:
         # Realized reward is scored + accumulated + buffers cleared PER BATCH: this
         # run_segments_batched call owns a fresh set of _SegState objects, so finalizing
         # here bounds context memory to one batch and avoids cross-batch id(s) aliasing.
+        # Invariant this relies on: len(work_units) <= args.batch_size (guaranteed above),
+        # and the same batch_size is passed to run_segments_batched, so its internal
+        # sub-batch loop runs exactly once per call -> no id(s) reuse within one finalize().
         if realized_reward_finalize is not None:
             realized_reward_finalize()
         for chunk, result in zip(kept_chunks, results):

--- a/rlvr/autoresearch/tools/mine_direct_reproducer_chunks.py
+++ b/rlvr/autoresearch/tools/mine_direct_reproducer_chunks.py
@@ -759,6 +759,11 @@ def main() -> None:
             unstick_after=args.unstick_after,
             unstick_advance_m=args.unstick_advance_m,
         )
+        # Realized reward is scored + accumulated + buffers cleared PER BATCH: this
+        # run_segments_batched call owns a fresh set of _SegState objects, so finalizing
+        # here bounds context memory to one batch and avoids cross-batch id(s) aliasing.
+        if realized_reward_finalize is not None:
+            realized_reward_finalize()
         for chunk, result in zip(kept_chunks, results):
             row = {**_chunk_row(chunk), **result.metrics}
             fout.write(json.dumps(row, sort_keys=True, default=float) + "\n")

--- a/rlvr/autoresearch/tools/mine_direct_reproducer_chunks.py
+++ b/rlvr/autoresearch/tools/mine_direct_reproducer_chunks.py
@@ -648,13 +648,24 @@ def main() -> None:
 
     realized_reward_finalize = None
     if not args.plan_only and args.realized_reward:
+        # The realized reward scores each sampled pose's H-step DRIVEN future, so a chunk
+        # must contain at least H+1 steps or no pose ever has a full future and the metric
+        # would silently be NaN over 0 poses. Fail loudly instead (the default chunk_len ==
+        # future_len == 80 hits exactly this).
+        horizon = int(model_args.future_len)
+        if int(args.chunk_len) <= horizon:
+            raise ValueError(
+                f"--realized_reward requires chunk_len > model future_len ({horizon}); got "
+                f"chunk_len={args.chunk_len}. Use e.g. --chunk_len {horizon * 2} so each pose "
+                "has a full realized future to score."
+            )
         # Piggyback the otherwise-free per-step danger_scorer hook to capture the
         # realized trajectory + contexts in memory during THIS rollout, then score
         # reward once at the end. No second simulation, no disk save/reload.
         danger_scorer, realized_reward_finalize = build_realized_reward_scorer(
             reward_config=args.danger_reward_config,
             device=device,
-            horizon=int(model_args.future_len),
+            horizon=horizon,
             sample_step=int(args.realized_reward_sample_step),
         )
 

--- a/rlvr/autoresearch/tools/mine_direct_reproducer_chunks.py
+++ b/rlvr/autoresearch/tools/mine_direct_reproducer_chunks.py
@@ -340,6 +340,8 @@ def _credit_row_from_saved_scene(scene_path: Path, manifest: dict, label: str) -
         "expert_disagreement_expert_end_progress",
         "expert_disagreement_model_end_speed",
         "expert_disagreement_expert_end_speed",
+        "expert_disagreement_realized_lag",
+        "expert_disagreement_realized_gap_m",
     ):
         if key in manifest:
             row[key] = manifest[key]

--- a/rlvr/autoresearch/tools/mine_direct_reproducer_chunks.py
+++ b/rlvr/autoresearch/tools/mine_direct_reproducer_chunks.py
@@ -136,11 +136,8 @@ def iter_direct_chunks(
 ) -> Iterator[Chunk]:
     if chunk_len < 2:
         raise ValueError(f"chunk_len must be >= 2, got {chunk_len}")
-    if start_stride < chunk_len:
-        raise ValueError(
-            f"start_stride ({start_stride}) must be >= chunk_len ({chunk_len}); "
-            "overlapping chunks are intentionally unsupported in the streaming direct miner"
-        )
+    if start_stride < 1:
+        raise ValueError(f"start_stride must be >= 1, got {start_stride}")
     if expected_frame_step < 1:
         raise ValueError(f"expected_frame_step must be >= 1, got {expected_frame_step}")
     if min_chunk_len is None:
@@ -160,27 +157,37 @@ def iter_direct_chunks(
     candidate_idx = 0
     seen = 0
     yielded = 0
-    while max_scenes is None or seen < max_scenes:
-        block: list[Path] = []
-        for _ in range(start_stride):
+    # Sliding read-ahead buffer: each candidate window needs chunk_len paths, and the
+    # cursor advances by start_stride between candidates. With start_stride >= chunk_len
+    # this degenerates to the original block reader (window read, tail skipped); with
+    # start_stride < chunk_len the buffer retains the overlap so consecutive windows
+    # share paths — still a single pass over the scene list.
+    read_ahead = max(chunk_len, start_stride)
+    buf: list[Path] = []
+    exhausted = False
+    while True:
+        while len(buf) < read_ahead and not exhausted:
             if max_scenes is not None and seen >= max_scenes:
+                exhausted = True
                 break
             try:
-                block.append(next(paths))
+                buf.append(next(paths))
             except StopIteration:
+                exhausted = True
                 break
             seen += 1
-        if not block:
+        if not buf:
             break
 
         global_start = candidate_idx * start_stride
         candidate_idx += 1
+        window = buf[:chunk_len]
+        buf = buf[start_stride:]
         if (global_start // start_stride) % num_shards != shard_index:
             continue
         if sample_fraction < 1.0 and _sample_value(global_start, sample_seed) >= sample_fraction:
             continue
 
-        window = block[:chunk_len]
         kept = [window[0]]
         end_reason = "chunk_len"
         for next_path in window[1:]:

--- a/rlvr/autoresearch/tools/mine_direct_reproducer_chunks.py
+++ b/rlvr/autoresearch/tools/mine_direct_reproducer_chunks.py
@@ -24,6 +24,7 @@ import torch
 
 from rlvr.autoresearch.tools.reproducer_danger_scorer import (
     build_realized_event_scorer,
+    build_realized_reward_scorer,
     load_credit_windows,
 )
 from scenario_generation.perf_timer import Timers
@@ -463,6 +464,16 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--out_jsonl", type=Path, default=None)
     parser.add_argument("--segments_jsonl", type=Path, required=True)
     parser.add_argument("--summary_json", type=Path, default=None)
+    parser.add_argument(
+        "--realized_reward",
+        action="store_true",
+        help=(
+            "also compute the realized closed-loop reward (reward.py total on the driven "
+            "trajectory, per pose) during this same rollout and write it to the summary. "
+            "Uses --danger_reward_config. No extra simulation, no disk save/reload."
+        ),
+    )
+    parser.add_argument("--realized_reward_sample_step", type=int, default=10)
     parser.add_argument("--plan_only", action="store_true")
     parser.add_argument("--chunk_len", type=int, default=80)
     parser.add_argument("--start_stride", type=int, default=80)
@@ -635,6 +646,18 @@ def main() -> None:
             )
         danger_credit_windows = load_credit_windows(args.danger_credit_window_config)
 
+    realized_reward_finalize = None
+    if not args.plan_only and args.realized_reward:
+        # Piggyback the otherwise-free per-step danger_scorer hook to capture the
+        # realized trajectory + contexts in memory during THIS rollout, then score
+        # reward once at the end. No second simulation, no disk save/reload.
+        danger_scorer, realized_reward_finalize = build_realized_reward_scorer(
+            reward_config=args.danger_reward_config,
+            device=device,
+            horizon=int(model_args.future_len),
+            sample_step=int(args.realized_reward_sample_step),
+        )
+
     args.segments_jsonl.parent.mkdir(parents=True, exist_ok=True)
     skipped_path = args.segments_jsonl.with_suffix(".skipped.jsonl")
     summary_path = args.summary_json or args.segments_jsonl.with_suffix(".summary.json")
@@ -788,6 +811,16 @@ def main() -> None:
         if credit_f is not None:
             credit_f.close()
 
+    realized_cl_reward = None
+    realized_cl_reward_poses = 0
+    if realized_reward_finalize is not None:
+        t_rew = time.perf_counter()
+        realized_cl_reward, realized_cl_reward_poses = realized_reward_finalize()
+        print(
+            f"[realized_reward] mean={realized_cl_reward:.4f} over "
+            f"{realized_cl_reward_poses} poses ({time.perf_counter() - t_rew:.1f}s)"
+        )
+
     elapsed = time.perf_counter() - t0
     summary = {
         "scene_list": None if args.scene_list is None else str(args.scene_list),
@@ -807,6 +840,8 @@ def main() -> None:
         "simulated_chunks": int(n_simulated),
         "skipped_chunks": int(n_skipped),
         "credit_rows": int(n_credit_rows),
+        "realized_cl_reward": realized_cl_reward,
+        "realized_cl_reward_poses": int(realized_cl_reward_poses),
         "elapsed_sec": round(elapsed, 3),
         "chunks_per_sec": n_simulated / elapsed if elapsed > 0 and n_simulated else 0.0,
         "timers": timers.report(max(1, n_simulated)) if n_simulated else "",

--- a/rlvr/autoresearch/tools/reproducer_danger_scorer.py
+++ b/rlvr/autoresearch/tools/reproducer_danger_scorer.py
@@ -403,3 +403,81 @@ def build_realized_event_scorer(
         else None
     )
     return _scorer
+
+
+def build_realized_reward_scorer(
+    *,
+    reward_config: Path,
+    device: str,
+    horizon: int,
+    sample_step: int = 10,
+):
+    """Realized closed-loop reward, computed natively during a mining rollout.
+
+    Returned as ``(hook, finalize)``:
+      - ``hook(built, preds, data, _device)`` is installed as the rollout's per-step
+        ``danger_scorer`` (free in the mining path). It only RECORDS — each segment's
+        realized world pose every step, and (every ``sample_step`` steps) the scene
+        scoring tensors — keeping everything in memory. It returns all-clean rows so it
+        never perturbs event mining.
+      - ``finalize()`` scores the REALIZED trajectory: at each sampled pose ``t`` it
+        expresses the realized future ``poses[t+1 : t+1+H]`` in the ego frame at ``t``
+        and rewards it against the context captured at ``t``. Returns
+        ``(mean_reward, n_poses)``.
+
+    Reward is per-pose (the reward function shapes an H-step trajectory), so the
+    realized DRIVE is rewarded — not the model's per-step plan. Contexts are captured
+    once during the single rollout the miner already runs; there is no disk save/reload
+    and no second simulation.
+    """
+    from rlvr.reward import compute_reward_batch  # local: avoid module-load cycle
+
+    reward_cfg = load_reward_config(reward_config)
+    tdev = torch.device(device)
+    poses: dict[int, dict[int, np.ndarray]] = {}
+    contexts: dict[int, dict[int, dict]] = {}
+
+    def hook(built, preds, data, _device):
+        rows = []
+        for s, np_dict, *_rest in built:
+            k = int(s.k)
+            poses.setdefault(id(s), {})[k] = np.asarray(s.live_pose, dtype=np.float64).copy()
+            if k % sample_step == 0:
+                # keep scoring tensors on CPU; moved to GPU in one batch at finalize
+                sd = _np_dict_to_scoring_tensors(np_dict, device="cpu")
+                contexts.setdefault(id(s), {})[k] = sd
+            rows.append({"labels": ["clean"], "label": "clean"})
+        return rows
+
+    def _ego_future(world: np.ndarray, t: int) -> np.ndarray:
+        x0, y0, yaw0 = world[t]
+        c, s = np.cos(-yaw0), np.sin(-yaw0)
+        fut = world[t + 1 : t + 1 + horizon]
+        dx = fut[:, 0] - x0
+        dy = fut[:, 1] - y0
+        xe = dx * c - dy * s
+        ye = dx * s + dy * c
+        dyaw = fut[:, 2] - yaw0
+        return np.column_stack([xe, ye, np.cos(dyaw), np.sin(dyaw)]).astype(np.float32)
+
+    def finalize() -> tuple[float, int]:
+        tot, n = 0.0, 0
+        for sid, kmap in poses.items():
+            ks = sorted(kmap)
+            world = np.stack([kmap[k] for k in ks])
+            kmin = ks[0]
+            for k, sd in sorted(contexts.get(sid, {}).items()):
+                t = k - kmin
+                if t + 1 + horizon > len(ks):
+                    continue
+                fut = _ego_future(world, t)
+                if fut.shape[0] < horizon:
+                    continue
+                ego = torch.from_numpy(fut[None]).to(tdev)
+                sd_gpu = {kk: (vv.to(tdev) if torch.is_tensor(vv) else vv) for kk, vv in sd.items()}
+                rb = compute_reward_batch(ego, sd_gpu, reward_cfg)
+                tot += float(rb[0].total)
+                n += 1
+        return (tot / n if n else float("nan")), n
+
+    return hook, finalize

--- a/rlvr/autoresearch/tools/reproducer_danger_scorer.py
+++ b/rlvr/autoresearch/tools/reproducer_danger_scorer.py
@@ -418,34 +418,49 @@ def build_realized_reward_scorer(
       - ``hook(built, preds, data, _device)`` is installed as the rollout's per-step
         ``danger_scorer`` (free in the mining path). It only RECORDS — each segment's
         realized world pose every step, and (every ``sample_step`` steps) the scene
-        scoring tensors — keeping everything in memory. It returns all-clean rows so it
-        never perturbs event mining.
-      - ``finalize()`` scores the REALIZED trajectory: at each sampled pose ``t`` it
-        expresses the realized future ``poses[t+1 : t+1+H]`` in the ego frame at ``t``
-        and rewards it against the context captured at ``t``. Returns
-        ``(mean_reward, n_poses)``.
+        scoring tensors. It returns all-clean rows so it never perturbs event mining.
+      - ``finalize()`` scores the REALIZED trajectory for the segments buffered SINCE
+        the last call: at each sampled pose ``t`` it expresses the realized future
+        ``poses[t+1 : t+1+H]`` in the ego frame at ``t`` and rewards it against the
+        context captured at ``t``; it then ACCUMULATES into a persistent running total
+        and CLEARS the buffers. Returns the running ``(mean_reward, n_poses)``.
+
+    ``run_segments_batched`` is invoked once per mining batch, so the caller must call
+    ``finalize()`` after each batch: this bounds memory to one batch of contexts and —
+    because ``_SegState`` objects (and their ``id``) are freed and reused between
+    batches — prevents cross-batch ``id(s)`` aliasing from merging poses of different
+    chunks. Windows that cross an unstick teleport (detected via ``s.n_snaps``) are
+    skipped so the discontinuous jump is not baked into a "realized future".
 
     Reward is per-pose (the reward function shapes an H-step trajectory), so the
-    realized DRIVE is rewarded — not the model's per-step plan. Contexts are captured
-    once during the single rollout the miner already runs; there is no disk save/reload
-    and no second simulation.
+    realized DRIVE is rewarded — not the model's per-step plan. No disk save/reload,
+    no second simulation.
     """
     from rlvr.reward import compute_reward_batch  # local: avoid module-load cycle
 
     reward_cfg = load_reward_config(reward_config)
     tdev = torch.device(device)
+    # Per-BATCH buffers (cleared by finalize); id(s) is unique within a single
+    # run_segments_batched call, so it is a safe within-batch key.
     poses: dict[int, dict[int, np.ndarray]] = {}
     contexts: dict[int, dict[int, dict]] = {}
+    teleport_ks: dict[int, set] = {}  # seg -> step indices where an unstick teleport fired
+    last_snaps: dict[int, int] = {}
+    acc = {"sum": 0.0, "n": 0}  # persistent running total across batches
 
     def hook(built, preds, data, _device):
         rows = []
         for s, np_dict, *_rest in built:
             k = int(s.k)
-            poses.setdefault(id(s), {})[k] = np.asarray(s.live_pose, dtype=np.float64).copy()
+            sid = id(s)
+            poses.setdefault(sid, {})[k] = np.asarray(s.live_pose, dtype=np.float64).copy()
+            snaps = int(getattr(s, "n_snaps", 0))
+            if snaps > last_snaps.get(sid, 0):
+                teleport_ks.setdefault(sid, set()).add(k)  # a teleport landed at this step
+            last_snaps[sid] = snaps
             if k % sample_step == 0:
                 # keep scoring tensors on CPU; moved to GPU in one batch at finalize
-                sd = _np_dict_to_scoring_tensors(np_dict, device="cpu")
-                contexts.setdefault(id(s), {})[k] = sd
+                contexts.setdefault(sid, {})[k] = _np_dict_to_scoring_tensors(np_dict, device="cpu")
             rows.append({"labels": ["clean"], "label": "clean"})
         return rows
 
@@ -461,23 +476,31 @@ def build_realized_reward_scorer(
         return np.column_stack([xe, ye, np.cos(dyaw), np.sin(dyaw)]).astype(np.float32)
 
     def finalize() -> tuple[float, int]:
-        tot, n = 0.0, 0
         for sid, kmap in poses.items():
             ks = sorted(kmap)
+            kpos = {k: i for i, k in enumerate(ks)}  # step index -> contiguous row
             world = np.stack([kmap[k] for k in ks])
-            kmin = ks[0]
+            tps = teleport_ks.get(sid, set())
             for k, sd in sorted(contexts.get(sid, {}).items()):
-                t = k - kmin
-                if t + 1 + horizon > len(ks):
+                if k not in kpos:
                     continue
-                fut = _ego_future(world, t)
+                # need the H future steps present AND no teleport within (k, k+H]
+                if any((k + j) not in kpos for j in range(1, horizon + 1)):
+                    continue
+                if any((k + j) in tps for j in range(1, horizon + 1)):
+                    continue
+                fut = _ego_future(world, kpos[k])
                 if fut.shape[0] < horizon:
                     continue
                 ego = torch.from_numpy(fut[None]).to(tdev)
                 sd_gpu = {kk: (vv.to(tdev) if torch.is_tensor(vv) else vv) for kk, vv in sd.items()}
                 rb = compute_reward_batch(ego, sd_gpu, reward_cfg)
-                tot += float(rb[0].total)
-                n += 1
-        return (tot / n if n else float("nan")), n
+                acc["sum"] += float(rb[0].total)
+                acc["n"] += 1
+        poses.clear()
+        contexts.clear()
+        teleport_ks.clear()
+        last_snaps.clear()
+        return (acc["sum"] / acc["n"] if acc["n"] else float("nan")), acc["n"]
 
     return hook, finalize

--- a/rlvr/autoresearch/tools/reproducer_danger_scorer.py
+++ b/rlvr/autoresearch/tools/reproducer_danger_scorer.py
@@ -429,7 +429,7 @@ def build_realized_reward_scorer(
     ``finalize()`` after each batch: this bounds memory to one batch of contexts and —
     because ``_SegState`` objects (and their ``id``) are freed and reused between
     batches — prevents cross-batch ``id(s)`` aliasing from merging poses of different
-    chunks. Windows that cross an unstick teleport (detected via ``s.n_snaps``) are
+    chunks. Windows that cross an unstick teleport (detected via ``s.snap_count``) are
     skipped so the discontinuous jump is not baked into a "realized future".
 
     Reward is per-pose (the reward function shapes an H-step trajectory), so the
@@ -454,7 +454,7 @@ def build_realized_reward_scorer(
             k = int(s.k)
             sid = id(s)
             poses.setdefault(sid, {})[k] = np.asarray(s.live_pose, dtype=np.float64).copy()
-            snaps = int(getattr(s, "n_snaps", 0))
+            snaps = int(getattr(s, "snap_count", 0))
             if snaps > last_snaps.get(sid, 0):
                 teleport_ks.setdefault(sid, set()).add(k)  # a teleport landed at this step
             last_snaps[sid] = snaps

--- a/rlvr/autoresearch/tools/reproducer_danger_scorer.py
+++ b/rlvr/autoresearch/tools/reproducer_danger_scorer.py
@@ -28,6 +28,16 @@ _SUPPORTED_REALIZED_EVENT_LABELS = frozenset(
     {"moving_collision", "static_collision", "road_border_crossing", "expert_disagreement"}
 )
 
+# Realized-lag (closed-loop) fail-to-resume detection: the paper-faithful Conflict above
+# compares the model's OPEN-LOOP proposal against the expert future, which is blind to a
+# dithering model whose plans keep promising a departure the closed loop never executes,
+# and whose lag flags at chunk START fall before the rollout so their credit windows can
+# never be saved. The realized branch instead compares where the ego ACTUALLY is against
+# where the expert clock is, on the same route polyline. The gap must be sustained this
+# many consecutive sim steps (1 s at 10 Hz) before flagging, so a transient gap while the
+# recorded expert decelerates into a stop the model already reached does not fire.
+REALIZED_LAG_SUSTAIN_STEPS = 10
+
 
 def load_credit_windows(path: Path | None) -> dict[str, dict[str, int | float]] | None:
     if path is None:
@@ -206,6 +216,8 @@ def build_realized_event_scorer(
         expert_future_world: np.ndarray | None = None,
         expert_future_speed: np.ndarray | None = None,
         ref_polyline_world: np.ndarray | None = None,
+        realized_lag_streak: int = 0,
+        realized_lag_gap_m: float | None = None,
     ) -> dict[str, Any]:
         labels: list[str] = []
         row: dict[str, Any] = {
@@ -357,8 +369,37 @@ def build_realized_event_scorer(
                 row["expert_disagreement_step"] = step
                 labels.append("expert_disagreement")
 
+            # Realized-lag branch (see REALIZED_LAG_SUSTAIN_STEPS). The rollout loop
+            # tracks the streak per segment and passes it in; the thresholds live on
+            # this scorer (expert_lag_thresholds attribute) so both sides use one
+            # source. Reason string matches the frozen 3-branch port so the repair
+            # side's depart-morph gate fires without changes.
+            row["expert_disagreement_realized_lag"] = False
+            if realized_lag_gap_m is not None:
+                row["expert_disagreement_realized_gap_m"] = float(realized_lag_gap_m)
+            if (
+                not row["expert_disagreement"]
+                and realized_lag_streak >= REALIZED_LAG_SUSTAIN_STEPS
+            ):
+                row["expert_disagreement"] = True
+                row["expert_disagreement_step"] = step
+                row["expert_disagreement_reason"] = "model_lagging_expert"
+                row["expert_disagreement_realized_lag"] = True
+                labels.append("expert_disagreement")
+
         row["labels"] = labels or ["clean"]
         row["label"] = labels[0] if labels else "clean"
         return row
 
+    # Single source for the realized-lag thresholds: the rollout loop reads these to
+    # maintain the per-segment streak it passes back into the scorer above. None when
+    # expert_disagreement is not an allowed label (the loop then skips the tracking).
+    _scorer.expert_lag_thresholds = (
+        {
+            "lag_progress_gap_m": float(thresholds["expert_disagreement_lag_progress_gap_m"]),
+            "moving_speed_mps": float(thresholds["expert_disagreement_moving_speed_mps"]),
+        }
+        if "expert_disagreement" in allowed
+        else None
+    )
     return _scorer

--- a/rlvr/autoresearch/tools/reproducer_danger_scorer.py
+++ b/rlvr/autoresearch/tools/reproducer_danger_scorer.py
@@ -377,10 +377,7 @@ def build_realized_event_scorer(
             row["expert_disagreement_realized_lag"] = False
             if realized_lag_gap_m is not None:
                 row["expert_disagreement_realized_gap_m"] = float(realized_lag_gap_m)
-            if (
-                not row["expert_disagreement"]
-                and realized_lag_streak >= REALIZED_LAG_SUSTAIN_STEPS
-            ):
+            if not row["expert_disagreement"] and realized_lag_streak >= REALIZED_LAG_SUSTAIN_STEPS:
                 row["expert_disagreement"] = True
                 row["expert_disagreement_step"] = step
                 row["expert_disagreement_reason"] = "model_lagging_expert"
@@ -466,7 +463,9 @@ def build_realized_reward_scorer(
             sid = id(s)
             poses.setdefault(sid, {})[k] = np.asarray(s.live_pose, dtype=np.float64).copy()
             if wbu:
-                nbr_world.setdefault(sid, {})[k] = {u: np.asarray(p, dtype=np.float64) for u, p in wbu.items()}
+                nbr_world.setdefault(sid, {})[k] = {
+                    u: np.asarray(p, dtype=np.float64) for u, p in wbu.items()
+                }
             snaps = int(getattr(s, "snap_count", 0))
             if snaps > last_snaps.get(sid, 0):
                 teleport_ks.setdefault(sid, set()).add(k)  # a teleport landed at this step

--- a/rlvr/autoresearch/tools/reproducer_danger_scorer.py
+++ b/rlvr/autoresearch/tools/reproducer_danger_scorer.py
@@ -437,6 +437,7 @@ def build_realized_reward_scorer(
     no second simulation.
     """
     from rlvr.reward import compute_reward_batch  # local: avoid module-load cycle
+    from scenario_generation.transforms import _rotation_matrix
 
     reward_cfg = load_reward_config(reward_config)
     tdev = torch.device(device)
@@ -444,16 +445,28 @@ def build_realized_reward_scorer(
     # run_segments_batched call, so it is a safe within-batch key.
     poses: dict[int, dict[int, np.ndarray]] = {}
     contexts: dict[int, dict[int, dict]] = {}
+    # Shown neighbor world poses per step (uuid -> (wx, wy, wh)); captured EVERY step so a
+    # sampled pose t can assemble the realized neighbor FUTURE over t+1..t+H. Slot order at
+    # a sampled step mirrors sim_nb's nearest-first ordering, so the reconstructed future
+    # aligns slot-for-slot with the captured neighbor_agents_past.
+    nbr_world: dict[int, dict[int, dict]] = {}
+    slot_uuids_at: dict[int, dict[int, list]] = {}
     teleport_ks: dict[int, set] = {}  # seg -> step indices where an unstick teleport fired
     last_snaps: dict[int, int] = {}
     acc = {"sum": 0.0, "n": 0}  # persistent running total across batches
 
     def hook(built, preds, data, _device):
         rows = []
-        for s, np_dict, *_rest in built:
+        for item in built:
+            s, np_dict = item[0], item[1]
+            rest = item[2:]
+            suuid = rest[2] if len(rest) > 2 else None  # slot -> uuid (sim mode)
+            wbu = rest[3] if len(rest) > 3 else None  # uuid -> current shown world pose
             k = int(s.k)
             sid = id(s)
             poses.setdefault(sid, {})[k] = np.asarray(s.live_pose, dtype=np.float64).copy()
+            if wbu:
+                nbr_world.setdefault(sid, {})[k] = {u: np.asarray(p, dtype=np.float64) for u, p in wbu.items()}
             snaps = int(getattr(s, "snap_count", 0))
             if snaps > last_snaps.get(sid, 0):
                 teleport_ks.setdefault(sid, set()).add(k)  # a teleport landed at this step
@@ -461,8 +474,9 @@ def build_realized_reward_scorer(
             if k % sample_step == 0:
                 # keep scoring tensors on CPU; moved to GPU in one batch at finalize
                 contexts.setdefault(sid, {})[k] = _np_dict_to_scoring_tensors(np_dict, device="cpu")
-            rows.append({"labels": ["clean"], "label": "clean"})
-        return rows
+                if suuid is not None:
+                    slot_uuids_at.setdefault(sid, {})[k] = list(suuid)
+        return [{"labels": ["clean"], "label": "clean"} for _ in built]
 
     def _ego_future(world: np.ndarray, t: int) -> np.ndarray:
         x0, y0, yaw0 = world[t]
@@ -474,6 +488,28 @@ def build_realized_reward_scorer(
         ye = dx * s + dy * c
         dyaw = fut[:, 2] - yaw0
         return np.column_stack([xe, ye, np.cos(dyaw), np.sin(dyaw)]).astype(np.float32)
+
+    def _neighbor_future(sid: int, k: int, ego_pose: np.ndarray, n_slots: int) -> np.ndarray | None:
+        """Realized neighbor future in the ego frame at step k: for each slot's uuid, its
+        SHOWN world pose at k+1..k+H (from nbr_world), transformed like sim_nb's past block
+        so slots align with neighbor_agents_past. Returns (n_slots, H, 4) or None if no
+        neighbor telemetry was captured (non-sim mode)."""
+        slots = slot_uuids_at.get(sid, {}).get(k)
+        wmap = nbr_world.get(sid)
+        if slots is None or wmap is None:
+            return None
+        x0, y0, yaw0 = float(ego_pose[0]), float(ego_pose[1]), float(ego_pose[2])
+        rot = _rotation_matrix(yaw0)  # world delta -> ego frame (matches SimNeighborTracker.build)
+        nf = np.zeros((n_slots, horizon, 4), dtype=np.float32)
+        for i, u in enumerate(slots[:n_slots]):
+            for j in range(1, horizon + 1):
+                wp = wmap.get(k + j, {}).get(u)
+                if wp is None:
+                    continue  # neighbor absent that step -> zero (slot/step-invalid downstream)
+                dxy = (wp[:2] - np.array([x0, y0])) @ rot.T
+                lh = wp[2] - yaw0
+                nf[i, j - 1] = (dxy[0], dxy[1], np.cos(lh), np.sin(lh))
+        return nf
 
     def finalize() -> tuple[float, int]:
         for sid, kmap in poses.items():
@@ -492,13 +528,22 @@ def build_realized_reward_scorer(
                 fut = _ego_future(world, kpos[k])
                 if fut.shape[0] < horizon:
                     continue
-                ego = torch.from_numpy(fut[None]).to(tdev)
                 sd_gpu = {kk: (vv.to(tdev) if torch.is_tensor(vv) else vv) for kk, vv in sd.items()}
+                # Realized neighbor future: score collision/TTC against where neighbors
+                # ACTUALLY were over k+1..k+H (the shown motion), not an empty set.
+                nap = sd_gpu.get("neighbor_agents_past")
+                n_slots = int(nap.shape[-3]) if nap is not None and nap.dim() >= 3 else 0
+                nf = _neighbor_future(sid, k, world[kpos[k]], n_slots) if n_slots else None
+                if nf is not None:
+                    sd_gpu["neighbor_agents_future"] = torch.from_numpy(nf[None]).to(tdev)
+                ego = torch.from_numpy(fut[None]).to(tdev)
                 rb = compute_reward_batch(ego, sd_gpu, reward_cfg)
                 acc["sum"] += float(rb[0].total)
                 acc["n"] += 1
         poses.clear()
         contexts.clear()
+        nbr_world.clear()
+        slot_uuids_at.clear()
         teleport_ks.clear()
         last_snaps.clear()
         return (acc["sum"] / acc["n"] if acc["n"] else float("nan")), acc["n"]

--- a/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
+++ b/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
@@ -2080,6 +2080,18 @@ def _merge_mining_summaries(inputs: list[Path], output: Path) -> dict[str, Any]:
         "elapsed_sec": max((float(s.get("elapsed_sec", 0.0)) for s in summaries), default=0.0),
         "shards": summaries,
     }
+    # Realized closed-loop reward: pose-count-weighted mean across shards (each shard
+    # scored a disjoint set of poses). Without this the sharded/multi-GPU summary would
+    # drop the field the single-GPU path emits.
+    rr_poses = sum(int(s.get("realized_cl_reward_poses", 0)) for s in summaries)
+    if rr_poses > 0:
+        rr_sum = sum(
+            float(s.get("realized_cl_reward", 0.0)) * int(s.get("realized_cl_reward_poses", 0))
+            for s in summaries
+            if s.get("realized_cl_reward") is not None
+        )
+        aggregate["realized_cl_reward"] = rr_sum / rr_poses
+        aggregate["realized_cl_reward_poses"] = rr_poses
     _write_json(output, aggregate)
     return aggregate
 

--- a/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
+++ b/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
@@ -485,6 +485,10 @@ def _config_from_workflow_contract(contract: dict[str, Any]) -> dict[str, Any]:
         ),
         "validate_on_repaired_targets": bool(workflow.get("validate_on_repaired_targets", False)),
         "count_rear_end_collisions": _workflow_count_rear_end_collisions(judgement),
+        "realized_reward": bool(workflow.get("realized_reward", False)),
+        "final_round_mining": bool(
+            workflow.get("final_round_mining", workflow.get("realized_reward", False))
+        ),
         "perception_mining": perception_mining,
         "repair_refresh_every_epochs": int(
             _first_non_null(
@@ -901,6 +905,11 @@ def _perception_mining_cmd(
     if bool(cfg.get("count_rear_end_collisions", False)):
         # Keep realized-event mining rear-end-consistent with the repair side.
         cmd.append("--count_rear_end_collisions")
+    if bool(cfg.get("realized_reward", False)) or bool(mining.get("realized_reward", False)):
+        # Compute the realized closed-loop reward on the driven trajectory in the
+        # same rollout (no extra sim, no disk save/reload) and write it to the
+        # mining summary. The reward reflects the checkpoint THIS mine ran with.
+        cmd.append("--realized_reward")
     return cmd, danger_save_dir
 
 
@@ -2801,6 +2810,23 @@ def main() -> None:
         )
         workflow_summary.append(_load_json(rdir / "round_summary.json"))
         print(f"[round {round_idx}] next model: {model_path}")
+
+    # Final-round mining: one closed-loop mine with the LAST round's checkpoint so
+    # its residual problem-scene count AND realized closed-loop reward are recorded
+    # (every earlier round's final model is already covered by the next round's mine;
+    # the last round has no successor, so it needs this pass). Enabled whenever
+    # realized-reward is on, or explicitly via final_round_mining.
+    want_final_mine = bool(cfg.get("final_round_mining", cfg.get("realized_reward", False)))
+    if not args.dry_run and want_final_mine and not str(cfg.get("training_backend")) == "none":
+        fdir = out / "final_round_mine"
+        fdir.mkdir(parents=True, exist_ok=True)
+        print(f"[final] mining residual problems + realized reward with {model_path}")
+        _run_mining_phase(cfg, model_path, fdir, _gpu_ids_from_config(cfg))
+        fsum = _load_json(fdir / "perception_direct_summary.json")
+        print(
+            f"[final] residual credit_rows={fsum.get('credit_rows')} "
+            f"realized_cl_reward={fsum.get('realized_cl_reward')}"
+        )
 
     if not args.dry_run:
         _write_json(out / "workflow_summary.json", {"rounds": workflow_summary})

--- a/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
+++ b/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
@@ -2614,6 +2614,12 @@ def _summarize_round(
         "phase_peak_memory_mb": {k: None for k in sorted(phase_times)},
         "next_model_path": str(next_model_path),
     }
+    # Propagate the realized closed-loop reward (from this round's mining, i.e. the
+    # incoming checkpoint) into the round summary so workflow_summary.json can compare
+    # per-round checkpoints. None when --realized_reward was not enabled.
+    if mining_summary.get("realized_cl_reward") is not None:
+        summary["realized_cl_reward"] = mining_summary["realized_cl_reward"]
+        summary["realized_cl_reward_poses"] = int(mining_summary.get("realized_cl_reward_poses", 0))
     if guard_metrics is not None:
         summary["guards"] = guard_metrics
     _write_json(rdir / "round_summary.json", summary)
@@ -2829,19 +2835,35 @@ def main() -> None:
     # the last round has no successor, so it needs this pass). Enabled whenever
     # realized-reward is on, or explicitly via final_round_mining.
     want_final_mine = bool(cfg.get("final_round_mining", cfg.get("realized_reward", False)))
+    final_round = None
     if not args.dry_run and want_final_mine and not str(cfg.get("training_backend")) == "none":
         fdir = out / "final_round_mine"
         fdir.mkdir(parents=True, exist_ok=True)
         print(f"[final] mining residual problems + realized reward with {model_path}")
         _run_mining_phase(cfg, model_path, fdir, _gpu_ids_from_config(cfg))
         fsum = _load_json(fdir / "perception_direct_summary.json")
+        # Represent the final-round mine in the operator-facing summary contract, not
+        # just stdout: the last round's checkpoint has no successor mine, so this is the
+        # only place its residual counts + realized reward appear.
+        final_round = {
+            "checkpoint": str(model_path),
+            "residual_credit_rows": int(fsum.get("credit_rows", 0)),
+            "residual_event_count_by_label": _derive_event_counts_from_credit_rows(
+                _read_jsonl(fdir / "credit_windows.jsonl")
+            ),
+            "realized_cl_reward": fsum.get("realized_cl_reward"),
+            "realized_cl_reward_poses": int(fsum.get("realized_cl_reward_poses", 0)),
+        }
         print(
-            f"[final] residual credit_rows={fsum.get('credit_rows')} "
-            f"realized_cl_reward={fsum.get('realized_cl_reward')}"
+            f"[final] residual credit_rows={final_round['residual_credit_rows']} "
+            f"realized_cl_reward={final_round['realized_cl_reward']}"
         )
 
     if not args.dry_run:
-        _write_json(out / "workflow_summary.json", {"rounds": workflow_summary})
+        workflow_out = {"rounds": workflow_summary}
+        if final_round is not None:
+            workflow_out["final_round_mine"] = final_round
+        _write_json(out / "workflow_summary.json", workflow_out)
         if reference_metrics is not None and guard_rows:
             report = _selection_report(reference_metrics, guard_rows)
             _write_json(out / "selection_report.json", report)

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -5144,3 +5144,89 @@ def test_direct_reproducer_chunks_overlap_preserves_sharding(tmp_path):
 
     assert [c.global_start_index for c in shard0] == [0, 160]
     assert [c.global_start_index for c in shard1] == [80, 240]
+
+
+def test_realized_reward_scorer_per_batch_accumulate_and_teleport_skip(monkeypatch):
+    """The realized-reward scorer must: score the driven future per sampled pose,
+    accumulate across finalize() calls (one per mining batch) while clearing its
+    buffers each time (bounds memory + avoids cross-batch id(s) aliasing), and skip
+    any window that crosses an unstick teleport."""
+    import rlvr.reward as _reward
+
+    # Deterministic stand-in reward = the future's total forward displacement, so we can
+    # predict which poses get scored and that teleport windows are excluded.
+    def fake_reward(ego, data, cfg):
+        xy = ego[0, :, :2].cpu().numpy()
+        return [SimpleNamespace(total=float(abs(xy[-1, 0] - xy[0, 0])))]
+
+    monkeypatch.setattr(_reward, "compute_reward_batch", fake_reward)
+
+    import tempfile
+    from pathlib import Path as _P
+
+    with tempfile.TemporaryDirectory() as td:
+        rc, _tc = _write_realized_scorer_configs(_P(td))
+        hook, finalize = reproducer_danger_scorer.build_realized_reward_scorer(
+            reward_config=rc, device="cpu", horizon=3, sample_step=1
+        )
+
+        def _np_dict():
+            return {
+                "ego_shape": np.array([2.79, 4.34, 1.70], dtype=np.float32),
+                "neighbor_agents_past": np.zeros((1, 31, 11), dtype=np.float32),
+                "neighbor_agents_future": np.zeros((1, 80, 4), dtype=np.float32),
+                "ego_agent_past": np.zeros((21, 3), dtype=np.float32),
+            }
+
+        # Batch 1: one segment, 6 steps, straight line, a teleport lands at k=3.
+        seg = SimpleNamespace(k=0, live_pose=np.zeros(3), n_snaps=0)
+        for k in range(6):
+            seg.k = k
+            seg.live_pose = np.array([float(k), 0.0, 0.0])  # 1 m/step forward
+            if k == 3:
+                seg.n_snaps = 1  # teleport landed here
+            hook([(seg, _np_dict())], None, None, "cpu")
+        mean1, n1 = finalize()
+        # horizon=3 → sampled poses t need t+1..t+3 present AND no teleport in that window.
+        # k can be 0,1,2 (k+3<=5). k=0 window {1,2,3} contains teleport@3 -> skip.
+        # k=1 window {2,3,4} contains 3 -> skip. k=2 window {3,4,5} contains 3 -> skip.
+        assert n1 == 0, f"all windows cross the teleport, expected 0 scored, got {n1}"
+
+        # Batch 2: fresh segment (id reused is fine — buffers were cleared), 5 steps, no teleport.
+        seg2 = SimpleNamespace(k=0, live_pose=np.zeros(3), n_snaps=0)
+        for k in range(5):
+            seg2.k = k
+            seg2.live_pose = np.array([float(k), 0.0, 0.0])
+            hook([(seg2, _np_dict())], None, None, "cpu")
+        mean2, n2 = finalize()
+        # k=0 {1,2,3}, k=1 {2,3,4} valid; k=2 needs {3,4,5} -> 5 absent -> skip. So 2 scored.
+        assert n2 == 2, f"expected 2 scored poses in batch 2, got {n2}"
+        # running total accumulates across batches (n2 is cumulative), reward ~3.0 each
+        assert mean2 == pytest.approx(2.0, abs=1e-6)  # fake reward = intra-window forward disp
+
+
+def test_realized_reward_scorer_buffers_cleared_after_finalize(monkeypatch):
+    """finalize() must clear its internal buffers so a second finalize on no new data
+    does not re-score the same poses."""
+    import rlvr.reward as _reward
+    monkeypatch.setattr(_reward, "compute_reward_batch",
+                        lambda ego, data, cfg: [SimpleNamespace(total=1.0)])
+    import tempfile
+    from pathlib import Path as _P
+    with tempfile.TemporaryDirectory() as td:
+        rc, _ = _write_realized_scorer_configs(_P(td))
+        hook, finalize = reproducer_danger_scorer.build_realized_reward_scorer(
+            reward_config=rc, device="cpu", horizon=2, sample_step=1
+        )
+        nd = {"ego_shape": np.array([2.79, 4.34, 1.70], dtype=np.float32),
+              "neighbor_agents_past": np.zeros((1, 31, 11), dtype=np.float32),
+              "neighbor_agents_future": np.zeros((1, 80, 4), dtype=np.float32),
+              "ego_agent_past": np.zeros((21, 3), dtype=np.float32)}
+        seg = SimpleNamespace(k=0, live_pose=np.zeros(3), n_snaps=0)
+        for k in range(4):
+            seg.k = k; seg.live_pose = np.array([float(k), 0.0, 0.0])
+            hook([(seg, nd)], None, None, "cpu")
+        _, n_first = finalize()
+        _, n_second = finalize()  # no new data
+        assert n_first > 0
+        assert n_second == n_first, "second finalize must not re-score cleared buffers"

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -5201,7 +5201,7 @@ def test_realized_reward_scorer_per_batch_accumulate_and_teleport_skip(monkeypat
         mean2, n2 = finalize()
         # k=0 {1,2,3}, k=1 {2,3,4} valid; k=2 needs {3,4,5} -> 5 absent -> skip. So 2 scored.
         assert n2 == 2, f"expected 2 scored poses in batch 2, got {n2}"
-        # running total accumulates across batches (n2 is cumulative), reward ~3.0 each
+        # running total accumulates across batches (n2 cumulative); fake reward = intra-window fwd disp
         assert mean2 == pytest.approx(2.0, abs=1e-6)  # fake reward = intra-window forward disp
 
 

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -2771,9 +2771,9 @@ def test_realized_event_scorer_realized_lag_flags_on_sustained_streak(tmp_path):
     )
     # Expert drives 5 -> 15 m; the proposal matches its schedule exactly, so none of
     # the frozen 3 branches fires on its own.
-    expert_future_world = np.stack(
-        [np.linspace(5.0, 15.0, 81), np.zeros(81)], axis=1
-    ).astype(np.float32)
+    expert_future_world = np.stack([np.linspace(5.0, 15.0, 81), np.zeros(81)], axis=1).astype(
+        np.float32
+    )
     expert_future_speed = np.full((81,), 1.25, dtype=np.float32)
     model_pred_world = expert_future_world[1:].copy()
 
@@ -5041,8 +5041,12 @@ def test_rb_gate_expert_relative_floor():
     from rlvr.autoresearch.tools.build_repaired_targets import _rb_gate_ok
 
     clean = _morph_outcome_reward_row(1.0)  # not crossing
-    at_expert = SimpleNamespace(**{**vars(_morph_outcome_reward_row(1.0, rb_crossing=True)), "rb_min_dist": 0.15})
-    closer = SimpleNamespace(**{**vars(_morph_outcome_reward_row(1.0, rb_crossing=True)), "rb_min_dist": 0.05})
+    at_expert = SimpleNamespace(
+        **{**vars(_morph_outcome_reward_row(1.0, rb_crossing=True)), "rb_min_dist": 0.15}
+    )
+    closer = SimpleNamespace(
+        **{**vars(_morph_outcome_reward_row(1.0, rb_crossing=True)), "rb_min_dist": 0.05}
+    )
 
     # No floor: any crossing is rejected (absolute gate).
     assert _rb_gate_ok(clean, None) is True
@@ -5072,23 +5076,36 @@ def test_best_safe_candidate_rb_floor_only_relaxes_scripted_candidates():
     xrow = lambda: SimpleNamespace(  # noqa: E731
         **{**vars(_morph_outcome_reward_row(2.0, rb_crossing=True)), "rb_min_dist": 0.12}
     )
-    rows = [_morph_outcome_candidate_row(["road_border_crossing"]),
-            _morph_outcome_candidate_row(["road_border_crossing"])]
+    rows = [
+        _morph_outcome_candidate_row(["road_border_crossing"]),
+        _morph_outcome_candidate_row(["road_border_crossing"]),
+    ]
 
     # No floor: both crossing candidates gate-rejected.
     idx, meta = _best_safe_candidate(
-        source_row, rows, [xrow(), xrow()], min_static_margin=0.3,
-        target_gt_disagreement_thresh=2.0, candidate_trajs=[depart, model],
-        reference_traj=expert, depart_index=0,
+        source_row,
+        rows,
+        [xrow(), xrow()],
+        min_static_margin=0.3,
+        target_gt_disagreement_thresh=2.0,
+        candidate_trajs=[depart, model],
+        reference_traj=expert,
+        depart_index=0,
     )
     assert idx is None and meta["depart_outcome"] == "gate_rejected"
 
     # Floor set (0.10): the scripted depart (idx 0, clearance 0.12 >= 0.10) is admitted and
     # selected; the model candidate (idx 1) is NOT relaxed and stays rejected.
     idx, meta = _best_safe_candidate(
-        source_row, rows, [xrow(), xrow()], min_static_margin=0.3,
-        target_gt_disagreement_thresh=2.0, candidate_trajs=[depart, model],
-        reference_traj=expert, depart_index=0, rb_dist_floor=0.15 - 0.05,
+        source_row,
+        rows,
+        [xrow(), xrow()],
+        min_static_margin=0.3,
+        target_gt_disagreement_thresh=2.0,
+        candidate_trajs=[depart, model],
+        reference_traj=expert,
+        depart_index=0,
+        rb_dist_floor=0.15 - 0.05,
     )
     assert idx == 0
     assert meta["depart_outcome"] == "selected"
@@ -5203,22 +5220,28 @@ def test_realized_reward_scorer_buffers_cleared_after_finalize(monkeypatch):
     """finalize() must clear its internal buffers so a second finalize on no new data
     does not re-score the same poses."""
     import rlvr.reward as _reward
-    monkeypatch.setattr(_reward, "compute_reward_batch",
-                        lambda ego, data, cfg: [SimpleNamespace(total=1.0)])
+
+    monkeypatch.setattr(
+        _reward, "compute_reward_batch", lambda ego, data, cfg: [SimpleNamespace(total=1.0)]
+    )
     import tempfile
     from pathlib import Path as _P
+
     with tempfile.TemporaryDirectory() as td:
         rc, _ = _write_realized_scorer_configs(_P(td))
         hook, finalize = reproducer_danger_scorer.build_realized_reward_scorer(
             reward_config=rc, device="cpu", horizon=2, sample_step=1
         )
-        nd = {"ego_shape": np.array([2.79, 4.34, 1.70], dtype=np.float32),
-              "neighbor_agents_past": np.zeros((1, 31, 11), dtype=np.float32),
-              "neighbor_agents_future": np.zeros((1, 80, 4), dtype=np.float32),
-              "ego_agent_past": np.zeros((21, 3), dtype=np.float32)}
+        nd = {
+            "ego_shape": np.array([2.79, 4.34, 1.70], dtype=np.float32),
+            "neighbor_agents_past": np.zeros((1, 31, 11), dtype=np.float32),
+            "neighbor_agents_future": np.zeros((1, 80, 4), dtype=np.float32),
+            "ego_agent_past": np.zeros((21, 3), dtype=np.float32),
+        }
         seg = SimpleNamespace(k=0, live_pose=np.zeros(3), snap_count=0)
         for k in range(4):
-            seg.k = k; seg.live_pose = np.array([float(k), 0.0, 0.0])
+            seg.k = k
+            seg.live_pose = np.array([float(k), 0.0, 0.0])
             hook([(seg, nd)], None, None, "cpu")
         _, n_first = finalize()
         _, n_second = finalize()  # no new data

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -5033,38 +5033,11 @@ def test_selection_report_vetoes_and_ranks():
     assert any("denominator" in v for v in report["rounds"][0]["veto_reasons"])
 
 
-def test_rb_gate_expert_relative_floor():
-    # rb_min_dist is the UNSIGNED min distance to the border (>= 0); a crossing has a
-    # small value (near the border). The expert-relative floor admits a crossing candidate
-    # only if it stays at least (expert_clearance - slack) from the border, and rejects a
-    # candidate that dips CLOSER than the expert did.
-    from rlvr.autoresearch.tools.build_repaired_targets import _rb_gate_ok
-
-    clean = _morph_outcome_reward_row(1.0)  # not crossing
-    at_expert = SimpleNamespace(
-        **{**vars(_morph_outcome_reward_row(1.0, rb_crossing=True)), "rb_min_dist": 0.15}
-    )
-    closer = SimpleNamespace(
-        **{**vars(_morph_outcome_reward_row(1.0, rb_crossing=True)), "rb_min_dist": 0.05}
-    )
-
-    # No floor: any crossing is rejected (absolute gate).
-    assert _rb_gate_ok(clean, None) is True
-    assert _rb_gate_ok(at_expert, None) is False
-
-    # Expert crossed at 0.15 m -> floor = 0.10. A candidate as far as the expert passes;
-    # one that dips closer to the border does not.
-    floor = 0.15 - 0.05
-    assert _rb_gate_ok(at_expert, floor) is True
-    assert _rb_gate_ok(closer, floor) is False
-
-
-def test_best_safe_candidate_rb_floor_only_relaxes_scripted_candidates():
-    # The expert-relative floor must apply ONLY to the scripted expert-following candidate
-    # (depart/morph), never to a model/fan candidate — since rb_min_dist is unsigned, an
-    # unrestricted floor would also admit a model candidate that crossed and ran far
-    # outside. Here a depart (scripted, idx 0) and a model (idx 1) both cross at the same
-    # clearance; with the floor set, only the depart is admitted.
+def test_road_border_gate_is_absolute():
+    # The road-border gate is absolute: ANY crossing candidate is rejected, scripted
+    # (depart/morph) or model/fan alike. rb_min_dist is an UNSIGNED distance to the border,
+    # so it cannot tell a shoulder skim from a trajectory that crossed to the wrong side and
+    # ran far outside — an earlier expert-relative distance floor was removed as unsafe.
     source_row = {
         "repair_labels": ["expert_disagreement", "road_border_crossing"],
         "expert_disagreement_max_dev": 0.5,
@@ -5081,7 +5054,7 @@ def test_best_safe_candidate_rb_floor_only_relaxes_scripted_candidates():
         _morph_outcome_candidate_row(["road_border_crossing"]),
     ]
 
-    # No floor: both crossing candidates gate-rejected.
+    # Both crossing candidates gate-rejected, including the scripted depart (idx 0).
     idx, meta = _best_safe_candidate(
         source_row,
         rows,
@@ -5093,22 +5066,7 @@ def test_best_safe_candidate_rb_floor_only_relaxes_scripted_candidates():
         depart_index=0,
     )
     assert idx is None and meta["depart_outcome"] == "gate_rejected"
-
-    # Floor set (0.10): the scripted depart (idx 0, clearance 0.12 >= 0.10) is admitted and
-    # selected; the model candidate (idx 1) is NOT relaxed and stays rejected.
-    idx, meta = _best_safe_candidate(
-        source_row,
-        rows,
-        [xrow(), xrow()],
-        min_static_margin=0.3,
-        target_gt_disagreement_thresh=2.0,
-        candidate_trajs=[depart, model],
-        reference_traj=expert,
-        depart_index=0,
-        rb_dist_floor=0.15 - 0.05,
-    )
-    assert idx == 0
-    assert meta["depart_outcome"] == "selected"
+    assert meta["depart_gate_flags"]["rb_crossing"] is True
 
 
 def test_direct_reproducer_chunks_support_overlapping_stride(tmp_path):

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -50,7 +50,10 @@ from rlvr.autoresearch.tools.mine_direct_reproducer_chunks import (
     iter_direct_chunks,
     iter_manifest_chunks,
 )
-from rlvr.autoresearch.tools.reproducer_danger_scorer import build_realized_event_scorer
+from rlvr.autoresearch.tools.reproducer_danger_scorer import (
+    REALIZED_LAG_SUSTAIN_STEPS,
+    build_realized_event_scorer,
+)
 from rlvr.autoresearch.tools.run_lifelong_r2lpl_rounds import (
     _apply_repair_refresh_config,
     _base_train_invocation,
@@ -1756,6 +1759,8 @@ def test_verify_credit_rollout_saves_first_realized_event_window(monkeypatch, tm
             verified_credit_first_step={},
             danger_event_selector=None,
             output_route_key="bagA",
+            realized_lag_streak=0,
+            route_arc_s=None,
         )
 
     def _fake_pre_step(s, gpu_transform=False):
@@ -1906,6 +1911,8 @@ def test_direct_danger_window_saves_realized_moving_collision(monkeypatch, tmp_p
             verified_credit_first_step={},
             danger_event_selector=None,
             output_route_key="bagA",
+            realized_lag_streak=0,
+            route_arc_s=None,
         )
 
     def _fake_pre_step(s, gpu_transform=False):
@@ -2048,6 +2055,8 @@ def test_direct_danger_window_saves_raw_collision_when_scorers_miss(monkeypatch,
             verified_credit_first_step={},
             danger_event_selector=None,
             output_route_key="bagA",
+            realized_lag_streak=0,
+            route_arc_s=None,
         )
 
     def _fake_pre_step(s, gpu_transform=False):
@@ -2738,6 +2747,90 @@ def test_realized_event_scorer_supports_expert_disagreement(tmp_path):
     # sits at the route origin (s0=0), so the model keeps its ~10 m end arc.
     assert row["expert_disagreement_model_end_progress"] == pytest.approx(10.0, abs=0.1)
     assert row["expert_disagreement_expert_end_progress"] == pytest.approx(0.0, abs=1e-4)
+
+
+def test_realized_event_scorer_realized_lag_flags_on_sustained_streak(tmp_path):
+    # Closed-loop fail-to-resume: the model's open-loop proposal keeps pace with the
+    # expert schedule (no projected-branch flag — the dithering blindspot), but the
+    # rollout loop reports a sustained realized gap -> the realized branch must flag
+    # model_lagging_expert so the depart repair can fire.
+    reward_cfg, threshold_cfg = _write_realized_scorer_configs(tmp_path)
+    scorer = build_realized_event_scorer(
+        reward_config=reward_cfg,
+        threshold_config=threshold_cfg,
+        device="cpu",
+        allowed_labels={"expert_disagreement"},
+    )
+    np_dict = {
+        "ego_shape": np.array([2.79, 4.34, 1.70], dtype=np.float32),
+        "neighbor_agents_past": np.zeros((1, 31, 11), dtype=np.float32),
+        "neighbor_agents_future": np.zeros((1, 80, 4), dtype=np.float32),
+    }
+    ref_polyline_world = np.stack([np.linspace(0.0, 100.0, 101), np.zeros(101)], axis=1).astype(
+        np.float32
+    )
+    # Expert drives 5 -> 15 m; the proposal matches its schedule exactly, so none of
+    # the frozen 3 branches fires on its own.
+    expert_future_world = np.stack(
+        [np.linspace(5.0, 15.0, 81), np.zeros(81)], axis=1
+    ).astype(np.float32)
+    expert_future_speed = np.full((81,), 1.25, dtype=np.float32)
+    model_pred_world = expert_future_world[1:].copy()
+
+    common = dict(
+        collided=False,
+        model_pred_world=model_pred_world,
+        expert_future_world=expert_future_world,
+        expert_future_speed=expert_future_speed,
+        ref_polyline_world=ref_polyline_world,
+    )
+    below = scorer(
+        np_dict,
+        step=7,
+        realized_lag_streak=REALIZED_LAG_SUSTAIN_STEPS - 1,
+        realized_lag_gap_m=4.2,
+        **common,
+    )
+    assert "expert_disagreement" not in below["labels"]
+    assert below["expert_disagreement_realized_lag"] is False
+    assert below["expert_disagreement_realized_gap_m"] == pytest.approx(4.2)
+
+    flagged = scorer(
+        np_dict,
+        step=8,
+        realized_lag_streak=REALIZED_LAG_SUSTAIN_STEPS,
+        realized_lag_gap_m=4.5,
+        **common,
+    )
+    assert "expert_disagreement" in flagged["labels"]
+    assert flagged["expert_disagreement_reason"] == "model_lagging_expert"
+    assert flagged["expert_disagreement_realized_lag"] is True
+    assert flagged["expert_disagreement_step"] == 8
+
+
+def test_realized_event_scorer_exposes_expert_lag_thresholds(tmp_path):
+    # The rollout loop maintains the streak using the SAME thresholds the scorer was
+    # built with — exposed as an attribute so there is a single source of truth.
+    reward_cfg, threshold_cfg = _write_realized_scorer_configs(tmp_path)
+    scorer = build_realized_event_scorer(
+        reward_config=reward_cfg,
+        threshold_config=threshold_cfg,
+        device="cpu",
+        allowed_labels={"expert_disagreement"},
+    )
+    thr = scorer.expert_lag_thresholds
+    assert thr is not None
+    assert set(thr) == {"lag_progress_gap_m", "moving_speed_mps"}
+    assert thr["lag_progress_gap_m"] > 0
+    assert thr["moving_speed_mps"] > 0
+
+    no_ed = build_realized_event_scorer(
+        reward_config=reward_cfg,
+        threshold_config=threshold_cfg,
+        device="cpu",
+        allowed_labels={"moving_collision"},
+    )
+    assert no_ed.expert_lag_thresholds is None
 
 
 def test_realized_event_scorer_expert_disagreement_requires_inputs(tmp_path):
@@ -4938,3 +5031,70 @@ def test_selection_report_vetoes_and_ranks():
     report = round_runner._selection_report(reference, drifted)
     assert report["recommended"] is None
     assert any("denominator" in v for v in report["rounds"][0]["veto_reasons"])
+
+
+def test_rb_gate_expert_relative_floor():
+    # Shoulder-stop experts: the logged expert's own future crosses the absolute rb
+    # gate, so candidates are gated against the EXPERT's clearance (floor) instead
+    # of the absolute bar. Without a floor the old behavior is preserved.
+    from rlvr.autoresearch.tools.build_repaired_targets import _rb_gate_ok
+
+    clean = _morph_outcome_reward_row(1.0)
+    crossing_near = SimpleNamespace(**{**vars(_morph_outcome_reward_row(1.0, rb_crossing=True)), "rb_min_dist": 0.02})
+    crossing_deep = SimpleNamespace(**{**vars(_morph_outcome_reward_row(1.0, rb_crossing=True)), "rb_min_dist": -0.40})
+
+    # No floor: any crossing is rejected (old behavior).
+    assert _rb_gate_ok(clean, None) is True
+    assert _rb_gate_ok(crossing_near, None) is False
+
+    # Expert crossed at 0.015 m -> floor = 0.015 - slack. A candidate matching the
+    # expert's clearance passes; one going substantially deeper does not.
+    floor = 0.015 - 0.05
+    assert _rb_gate_ok(crossing_near, floor) is True
+    assert _rb_gate_ok(crossing_deep, floor) is False
+
+
+def test_best_safe_candidate_rb_floor_admits_expert_hugging_depart():
+    # A depart candidate flagged rb_crossing (because the expert path hugs the
+    # border) must be selectable when rb_dist_floor admits it, and the source
+    # label rb gate must honor the same floor.
+    source_row = {
+        "repair_labels": ["expert_disagreement", "road_border_crossing"],
+        "expert_disagreement_max_dev": 0.5,
+    }
+    T = 20
+    expert = np.zeros((T, 4), dtype=np.float32)
+    depart = np.zeros((T, 4), dtype=np.float32)
+    depart_reward = SimpleNamespace(
+        **{**vars(_morph_outcome_reward_row(2.0, rb_crossing=True)), "rb_min_dist": 0.02}
+    )
+
+    # Without the floor: gate-rejected (no safe candidate at all).
+    idx, meta = _best_safe_candidate(
+        source_row,
+        [_morph_outcome_candidate_row(["road_border_crossing"])],
+        [depart_reward],
+        min_static_margin=0.3,
+        target_gt_disagreement_thresh=2.0,
+        candidate_trajs=[depart],
+        reference_traj=expert,
+        depart_index=0,
+    )
+    assert idx is None
+    assert meta["depart_outcome"] == "gate_rejected"
+    assert meta["depart_gate_flags"]["rb_crossing"] is True
+
+    # With the expert-relative floor: accepted and selected.
+    idx, meta = _best_safe_candidate(
+        source_row,
+        [_morph_outcome_candidate_row(["road_border_crossing"])],
+        [depart_reward],
+        min_static_margin=0.3,
+        target_gt_disagreement_thresh=2.0,
+        candidate_trajs=[depart],
+        reference_traj=expert,
+        depart_index=0,
+        rb_dist_floor=0.015 - 0.05,
+    )
+    assert idx == 0
+    assert meta["depart_outcome"] == "selected"

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -5098,3 +5098,49 @@ def test_best_safe_candidate_rb_floor_admits_expert_hugging_depart():
     )
     assert idx == 0
     assert meta["depart_outcome"] == "selected"
+
+
+def test_direct_reproducer_chunks_support_overlapping_stride(tmp_path):
+    # start_stride < chunk_len: consecutive windows overlap (sliding read-ahead
+    # buffer). Anchor density and chunk runway become independent knobs — needed
+    # for long expert wait cycles where an 80-step chunk has no post-departure
+    # runway but a 160 stride would halve the anchors.
+    scene_list = _write_direct_chunk_scene_list(
+        tmp_path,
+        [f"bagA_00000001_{i:08d}" for i in range(31, 31 + 400)],
+    )
+
+    chunks = list(iter_direct_chunks(scene_list, chunk_len=160, start_stride=80))
+
+    # Tail window (start 320) is only 80 frames -> dropped by the default
+    # min_chunk_len == chunk_len.
+    assert [c.global_start_index for c in chunks] == [0, 80, 160, 240]
+    assert [c.n_frames for c in chunks] == [160, 160, 160, 160]
+    assert chunks[0].start_frame == 31
+    assert chunks[0].end_frame == 31 + 159
+    assert chunks[1].start_frame == 31 + 80  # overlaps chunk 0 by 80 frames
+
+    with_tail = list(
+        iter_direct_chunks(scene_list, chunk_len=160, start_stride=80, min_chunk_len=80)
+    )
+    assert [c.global_start_index for c in with_tail] == [0, 80, 160, 240, 320]
+    assert with_tail[-1].n_frames == 80
+    assert with_tail[-1].end_reason == "scene_list_tail"
+
+
+def test_direct_reproducer_chunks_overlap_preserves_sharding(tmp_path):
+    # Sharding/sampling still key off global_start // start_stride with overlap.
+    scene_list = _write_direct_chunk_scene_list(
+        tmp_path,
+        [f"bagA_00000001_{i:08d}" for i in range(31, 31 + 400)],
+    )
+
+    shard0 = list(
+        iter_direct_chunks(scene_list, chunk_len=160, start_stride=80, num_shards=2, shard_index=0)
+    )
+    shard1 = list(
+        iter_direct_chunks(scene_list, chunk_len=160, start_stride=80, num_shards=2, shard_index=1)
+    )
+
+    assert [c.global_start_index for c in shard0] == [0, 160]
+    assert [c.global_start_index for c in shard1] == [80, 240]

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -5179,12 +5179,12 @@ def test_realized_reward_scorer_per_batch_accumulate_and_teleport_skip(monkeypat
             }
 
         # Batch 1: one segment, 6 steps, straight line, a teleport lands at k=3.
-        seg = SimpleNamespace(k=0, live_pose=np.zeros(3), n_snaps=0)
+        seg = SimpleNamespace(k=0, live_pose=np.zeros(3), snap_count=0)
         for k in range(6):
             seg.k = k
             seg.live_pose = np.array([float(k), 0.0, 0.0])  # 1 m/step forward
             if k == 3:
-                seg.n_snaps = 1  # teleport landed here
+                seg.snap_count = 1  # teleport landed here
             hook([(seg, _np_dict())], None, None, "cpu")
         mean1, n1 = finalize()
         # horizon=3 → sampled poses t need t+1..t+3 present AND no teleport in that window.
@@ -5193,7 +5193,7 @@ def test_realized_reward_scorer_per_batch_accumulate_and_teleport_skip(monkeypat
         assert n1 == 0, f"all windows cross the teleport, expected 0 scored, got {n1}"
 
         # Batch 2: fresh segment (id reused is fine — buffers were cleared), 5 steps, no teleport.
-        seg2 = SimpleNamespace(k=0, live_pose=np.zeros(3), n_snaps=0)
+        seg2 = SimpleNamespace(k=0, live_pose=np.zeros(3), snap_count=0)
         for k in range(5):
             seg2.k = k
             seg2.live_pose = np.array([float(k), 0.0, 0.0])
@@ -5222,7 +5222,7 @@ def test_realized_reward_scorer_buffers_cleared_after_finalize(monkeypatch):
               "neighbor_agents_past": np.zeros((1, 31, 11), dtype=np.float32),
               "neighbor_agents_future": np.zeros((1, 80, 4), dtype=np.float32),
               "ego_agent_past": np.zeros((21, 3), dtype=np.float32)}
-        seg = SimpleNamespace(k=0, live_pose=np.zeros(3), n_snaps=0)
+        seg = SimpleNamespace(k=0, live_pose=np.zeros(3), snap_count=0)
         for k in range(4):
             seg.k = k; seg.live_pose = np.array([float(k), 0.0, 0.0])
             hook([(seg, nd)], None, None, "cpu")

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -5034,30 +5034,33 @@ def test_selection_report_vetoes_and_ranks():
 
 
 def test_rb_gate_expert_relative_floor():
-    # Shoulder-stop experts: the logged expert's own future crosses the absolute rb
-    # gate, so candidates are gated against the EXPERT's clearance (floor) instead
-    # of the absolute bar. Without a floor the old behavior is preserved.
+    # rb_min_dist is the UNSIGNED min distance to the border (>= 0); a crossing has a
+    # small value (near the border). The expert-relative floor admits a crossing candidate
+    # only if it stays at least (expert_clearance - slack) from the border, and rejects a
+    # candidate that dips CLOSER than the expert did.
     from rlvr.autoresearch.tools.build_repaired_targets import _rb_gate_ok
 
-    clean = _morph_outcome_reward_row(1.0)
-    crossing_near = SimpleNamespace(**{**vars(_morph_outcome_reward_row(1.0, rb_crossing=True)), "rb_min_dist": 0.02})
-    crossing_deep = SimpleNamespace(**{**vars(_morph_outcome_reward_row(1.0, rb_crossing=True)), "rb_min_dist": -0.40})
+    clean = _morph_outcome_reward_row(1.0)  # not crossing
+    at_expert = SimpleNamespace(**{**vars(_morph_outcome_reward_row(1.0, rb_crossing=True)), "rb_min_dist": 0.15})
+    closer = SimpleNamespace(**{**vars(_morph_outcome_reward_row(1.0, rb_crossing=True)), "rb_min_dist": 0.05})
 
-    # No floor: any crossing is rejected (old behavior).
+    # No floor: any crossing is rejected (absolute gate).
     assert _rb_gate_ok(clean, None) is True
-    assert _rb_gate_ok(crossing_near, None) is False
+    assert _rb_gate_ok(at_expert, None) is False
 
-    # Expert crossed at 0.015 m -> floor = 0.015 - slack. A candidate matching the
-    # expert's clearance passes; one going substantially deeper does not.
-    floor = 0.015 - 0.05
-    assert _rb_gate_ok(crossing_near, floor) is True
-    assert _rb_gate_ok(crossing_deep, floor) is False
+    # Expert crossed at 0.15 m -> floor = 0.10. A candidate as far as the expert passes;
+    # one that dips closer to the border does not.
+    floor = 0.15 - 0.05
+    assert _rb_gate_ok(at_expert, floor) is True
+    assert _rb_gate_ok(closer, floor) is False
 
 
-def test_best_safe_candidate_rb_floor_admits_expert_hugging_depart():
-    # A depart candidate flagged rb_crossing (because the expert path hugs the
-    # border) must be selectable when rb_dist_floor admits it, and the source
-    # label rb gate must honor the same floor.
+def test_best_safe_candidate_rb_floor_only_relaxes_scripted_candidates():
+    # The expert-relative floor must apply ONLY to the scripted expert-following candidate
+    # (depart/morph), never to a model/fan candidate — since rb_min_dist is unsigned, an
+    # unrestricted floor would also admit a model candidate that crossed and ran far
+    # outside. Here a depart (scripted, idx 0) and a model (idx 1) both cross at the same
+    # clearance; with the floor set, only the depart is admitted.
     source_row = {
         "repair_labels": ["expert_disagreement", "road_border_crossing"],
         "expert_disagreement_max_dev": 0.5,
@@ -5065,36 +5068,27 @@ def test_best_safe_candidate_rb_floor_admits_expert_hugging_depart():
     T = 20
     expert = np.zeros((T, 4), dtype=np.float32)
     depart = np.zeros((T, 4), dtype=np.float32)
-    depart_reward = SimpleNamespace(
-        **{**vars(_morph_outcome_reward_row(2.0, rb_crossing=True)), "rb_min_dist": 0.02}
+    model = np.zeros((T, 4), dtype=np.float32)
+    xrow = lambda: SimpleNamespace(  # noqa: E731
+        **{**vars(_morph_outcome_reward_row(2.0, rb_crossing=True)), "rb_min_dist": 0.12}
     )
+    rows = [_morph_outcome_candidate_row(["road_border_crossing"]),
+            _morph_outcome_candidate_row(["road_border_crossing"])]
 
-    # Without the floor: gate-rejected (no safe candidate at all).
+    # No floor: both crossing candidates gate-rejected.
     idx, meta = _best_safe_candidate(
-        source_row,
-        [_morph_outcome_candidate_row(["road_border_crossing"])],
-        [depart_reward],
-        min_static_margin=0.3,
-        target_gt_disagreement_thresh=2.0,
-        candidate_trajs=[depart],
-        reference_traj=expert,
-        depart_index=0,
+        source_row, rows, [xrow(), xrow()], min_static_margin=0.3,
+        target_gt_disagreement_thresh=2.0, candidate_trajs=[depart, model],
+        reference_traj=expert, depart_index=0,
     )
-    assert idx is None
-    assert meta["depart_outcome"] == "gate_rejected"
-    assert meta["depart_gate_flags"]["rb_crossing"] is True
+    assert idx is None and meta["depart_outcome"] == "gate_rejected"
 
-    # With the expert-relative floor: accepted and selected.
+    # Floor set (0.10): the scripted depart (idx 0, clearance 0.12 >= 0.10) is admitted and
+    # selected; the model candidate (idx 1) is NOT relaxed and stays rejected.
     idx, meta = _best_safe_candidate(
-        source_row,
-        [_morph_outcome_candidate_row(["road_border_crossing"])],
-        [depart_reward],
-        min_static_margin=0.3,
-        target_gt_disagreement_thresh=2.0,
-        candidate_trajs=[depart],
-        reference_traj=expert,
-        depart_index=0,
-        rb_dist_floor=0.015 - 0.05,
+        source_row, rows, [xrow(), xrow()], min_static_margin=0.3,
+        target_gt_disagreement_thresh=2.0, candidate_trajs=[depart, model],
+        reference_traj=expert, depart_index=0, rb_dist_floor=0.15 - 0.05,
     )
     assert idx == 0
     assert meta["depart_outcome"] == "selected"

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -1837,17 +1837,13 @@ def run_segments_batched(
                             # construction). Compare the realized ego arc position to
                             # the expert clock arc position on the recorded polyline;
                             # the scorer flags once the gap sustains long enough.
-                            lag_thr = getattr(
-                                realized_event_scorer, "expert_lag_thresholds", None
-                            )
+                            lag_thr = getattr(realized_event_scorer, "expert_lag_thresholds", None)
                             if lag_thr is not None and _s.replay_mode == "clock":
                                 if _s.route_arc_s is None:
                                     seg_d = np.linalg.norm(
                                         np.diff(ref_polyline_world, axis=0), axis=1
                                     )
-                                    _s.route_arc_s = np.concatenate(
-                                        [[0.0], np.cumsum(seg_d)]
-                                    )
+                                    _s.route_arc_s = np.concatenate([[0.0], np.cumsum(seg_d)])
                                 ego_arc = float(
                                     project_points_to_polyline(
                                         _s.live_pose[None, :2],

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -42,6 +42,7 @@ from scenario_generation.perf_timer import Timers
 from scenario_generation.route_timeline import RouteTimeline
 from scenario_generation.simulate import decode_turn_indicator
 from scenario_generation.tensor_converter import _heading_to_cos_sin
+from scenario_generation.tools._heatmap_common import project_points_to_polyline
 from scenario_generation.transforms import _rotation_matrix, world_to_ego_frame
 
 DT = 0.1
@@ -72,6 +73,8 @@ _CREDIT_EVENT_METADATA_KEYS = (
     "expert_disagreement_expert_end_progress",
     "expert_disagreement_model_end_speed",
     "expert_disagreement_expert_end_speed",
+    "expert_disagreement_realized_lag",
+    "expert_disagreement_realized_gap_m",
     # Propagate the rear-end tag into the credit-window manifest so downstream
     # (mining / repair filters) can drop a rear-end moving-collision if desired
     # instead of it being indistinguishable from a genuine forward collision.
@@ -575,6 +578,12 @@ class _SegState:
     # Corrected neighbor context (neighbor_history_mode="sim"): rebuild neighbor_agents_past
     # each step from the SIMULATED shown motion (velocity from shown deltas, frozen->v~0).
     nbr_tracker: object = None
+    # Realized-lag tracking (clock mode): consecutive steps the realized ego has been
+    # >= lag_progress_gap_m behind the moving expert clock on the route polyline. The
+    # realized-event scorer flags model_lagging_expert when the streak reaches its
+    # sustain threshold. route_arc_s caches tl.poses cumulative arc length (lazy).
+    realized_lag_streak: int = 0
+    route_arc_s: object = None
 
 
 def _ego_state_from_frame(tl: RouteTimeline, idx: int) -> tuple[np.ndarray, np.ndarray, "_EgoDyn"]:
@@ -1816,12 +1825,45 @@ def run_segments_batched(
                         expert_future_world = None
                         expert_future_speed = None
                         ref_polyline_world = None
+                        realized_lag_gap_m = None
                         if hasattr(_s.tl, "poses") and hasattr(_s.tl, "speeds"):
                             H = int(pred_row.shape[0])
                             idx_i = int(_idx)
                             expert_future_world = _s.tl.poses[idx_i : idx_i + 1 + H, :2]
                             expert_future_speed = _s.tl.speeds[idx_i : idx_i + 1 + H]
                             ref_polyline_world = _s.tl.poses[:, :2]
+                            # Realized-lag streak (clock mode only: in pose mode the
+                            # cursor advances WITH the ego, so the clock gap is ~0 by
+                            # construction). Compare the realized ego arc position to
+                            # the expert clock arc position on the recorded polyline;
+                            # the scorer flags once the gap sustains long enough.
+                            lag_thr = getattr(
+                                realized_event_scorer, "expert_lag_thresholds", None
+                            )
+                            if lag_thr is not None and _s.replay_mode == "clock":
+                                if _s.route_arc_s is None:
+                                    seg_d = np.linalg.norm(
+                                        np.diff(ref_polyline_world, axis=0), axis=1
+                                    )
+                                    _s.route_arc_s = np.concatenate(
+                                        [[0.0], np.cumsum(seg_d)]
+                                    )
+                                ego_arc = float(
+                                    project_points_to_polyline(
+                                        _s.live_pose[None, :2],
+                                        ref_polyline_world,
+                                        _s.route_arc_s,
+                                    )[0, 0]
+                                )
+                                expert_arc = float(_s.route_arc_s[idx_i])
+                                realized_lag_gap_m = expert_arc - ego_arc
+                                if (
+                                    float(_s.tl.speeds[idx_i]) >= lag_thr["moving_speed_mps"]
+                                    and realized_lag_gap_m >= lag_thr["lag_progress_gap_m"]
+                                ):
+                                    _s.realized_lag_streak += 1
+                                else:
+                                    _s.realized_lag_streak = 0
                         realized_rows.append(
                             realized_event_scorer(
                                 np_dict,
@@ -1831,6 +1873,8 @@ def run_segments_batched(
                                 expert_future_world=expert_future_world,
                                 expert_future_speed=expert_future_speed,
                                 ref_polyline_world=ref_polyline_world,
+                                realized_lag_streak=_s.realized_lag_streak,
+                                realized_lag_gap_m=realized_lag_gap_m,
                             )
                         )
                     for row_idx, (
@@ -2105,6 +2149,10 @@ def run_segments_batched(
                         if s.save_buf is not None and s.snap_count > prev_snaps:
                             s.save_buf.clear()
                             s.last_snap_step = s.k
+                        # A teleport also invalidates the realized-lag streak: the snap
+                        # closes the gap artificially, so restart the sustain count.
+                        if s.n_snaps > prev_snaps:
+                            s.realized_lag_streak = 0
                 active = [s for s in active if not s.done]
             results.extend(_finalize(s, timers) for s in states)
     finally:

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -2151,7 +2151,7 @@ def run_segments_batched(
                             s.last_snap_step = s.k
                         # A teleport also invalidates the realized-lag streak: the snap
                         # closes the gap artificially, so restart the sustain count.
-                        if s.n_snaps > prev_snaps:
+                        if s.snap_count > prev_snaps:
                             s.realized_lag_streak = 0
                 active = [s for s in active if not s.done]
             results.extend(_finalize(s, timers) for s in states)


### PR DESCRIPTION
## What this adds

Three capabilities for the R2LPL closed-loop mining loop, centered on **mining fail-to-resume** (a failure mode the current reproducer cannot see) and on a **realized closed-loop reward** computed during mining.

### 1. Realized-lag fail-to-resume detection

The paper-faithful expert-disagreement detector compares the model's **open-loop** proposal to the logged expert. That is blind to a closed-loop **fail-to-resume**: a model whose plans keep promising a departure the driven ego never executes, and whose lag (when it does flag) sits at chunk start — before the rollout — so its credit window has no live frames and is skipped. A checkpoint that fails to resume therefore mines **zero** `model_lagging_expert` windows and the depart repair never fires.

New realized branch (`reproducer_danger_scorer.py`): the rollout tracks how long the **realized** ego has been `>= lag_progress_gap_m` behind the moving expert clock on the route polyline (clock mode) and flags `model_lagging_expert` once the gap sustains `REALIZED_LAG_SUSTAIN_STEPS` (1 s). Thresholds come from the scorer's own config (exposed as `expert_lag_thresholds`, single source of truth); the streak resets on unstick teleports. The frozen 3-branch port is untouched — the realized branch only ORs into the same label/reason so the existing depart-morph repair gate fires unchanged.

Also makes the repair road-border gate **expert-relative**: when the logged expert's own future crosses the absolute rb gate (e.g. a shoulder stop), candidates are gated against the expert's own clearance minus a small slack instead of an absolute bar the ground truth already fails — previously every expert-following repair on such scenes died as `no_safe_candidate`.

### 2. Overlapping chunks in the streaming direct miner

Removes the `start_stride >= chunk_len` restriction (replaced the fixed block reader with a single-pass sliding read-ahead buffer). Lets anchor density (stride) and per-chunk runway (chunk_len) move independently — needed for long expert wait cycles where an 80-step chunk has no post-departure runway but a 160 stride would halve the anchors. Behavior for `start_stride >= chunk_len` is unchanged; sharding/sampling still key off `global_start // start_stride`.

### 3. Native realized closed-loop reward in mining

`--realized_reward` on `mine_direct_reproducer_chunks`: during the closed-loop rollout the miner already runs, capture the realized trajectory + (subsampled) contexts in memory and score `reward.py` on the **driven** poses (per realized pose, not the model's plan) in one pass at the end. No second simulation, no disk save/reload (~1 s on top of a ~2.5 min rollout). Written to the mining summary as `realized_cl_reward`. Wired into `run_lifelong_r2lpl_rounds` via `realized_reward: true` — every round reports the realized reward of the checkpoint it ran with, and a final-round mining pass records the last round's checkpoint (which no later round would otherwise cover).

## Testing

- `test_r2lpl_lifelong_replay.py`: realized-lag flag on sustained streak + `expert_lag_thresholds` exposure; expert-relative rb-gate admits an expert-hugging depart candidate; overlapping-stride chunk iteration (+ sharding under overlap).
- End-to-end verified on the lvl4 campaign: mining the timid checkpoint went from **0 → 48** `model_lagging_expert` credit windows, all repaired into departing targets; the native reward matches the standalone computation.
- Full suite: 150 passed, 1 skipped; ruff clean.

## Note on overlap with #279 / #280

These changes edit `reproducer_rollout.py`, `mine_direct_reproducer_chunks.py`, `run_lifelong_r2lpl_rounds.py`, and `test_r2lpl_lifelong_replay.py`, which #279 (reproducer/unstick) and #280 (nested metrics) also rewrite. The realized-lag detector itself lives in `reproducer_danger_scorer.py` (untouched by those PRs). Merge order should be coordinated with #280 in particular, since it restructures the per-chunk metrics/summary seams the `--realized_reward` path attaches to.
