### PR TITLE
feat: zstd-compress path lists in wandb dataset artifacts

### DIFF
--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -1,5 +1,6 @@
 import json
 import os
+import tempfile
 from pathlib import Path
 
 import pandas as pd
@@ -41,6 +42,25 @@ def find_upward(start_file: str, target_name: str) -> Path:
     raise FileNotFoundError(f"{target_name} up {directory}")
 
 
+def _add_path_list_compressed(artifact: wandb.Artifact, path: Path, tmp_dir: Path) -> None:
+    """Attach a path-list json to the artifact as zstd-compressed ``<name>.zst``.
+
+    Raw path lists are multi-GB of near-identical absolute paths; zstd shrinks them
+    ~100x in a few seconds. openjson() reads ``*.zst`` transparently on download.
+    """
+    try:
+        import zstandard
+    except ImportError:
+        print(f"zstandard not installed; uploading {path.name} uncompressed.")
+        artifact.add_file(str(path), name=path.name)
+        return
+    dst = tmp_dir / f"{path.name}.zst"
+    cctx = zstandard.ZstdCompressor(level=3, threads=-1)
+    with open(path, "rb") as fin, open(dst, "wb") as fout:
+        cctx.copy_stream(fin, fout)
+    artifact.add_file(str(dst), name=dst.name)
+
+
 def log_dataset_artifact(
     run: wandb.sdk.wandb_run.Run, exp_name: str, train_set_list: str, valid_set_list: str
 ) -> None:
@@ -49,21 +69,23 @@ def log_dataset_artifact(
         type="dataset",
         metadata={"train_set_list": train_set_list, "valid_set_list": valid_set_list},
     )
-    train_path = Path(train_set_list)
-    valid_path = Path(valid_set_list)
-    artifact.add_file(str(train_path), name=train_path.name)
-    artifact.add_file(str(valid_path), name=valid_path.name)
-    try:
-        summary_csv = find_upward(train_set_list, "summary.csv")
-        artifact.add_file(str(summary_csv), name="summary.csv")
-    except FileNotFoundError:
-        print("summary.csv not found, skipping.")
-    try:
-        rosbag_summary_csv = find_upward(train_set_list, "rosbag_summary.csv")
-        artifact.add_file(str(rosbag_summary_csv), name="rosbag_summary.csv")
-    except FileNotFoundError:
-        print("rosbag_summary.csv not found, skipping.")
-    run.use_artifact(artifact)
+    with tempfile.TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str)
+        _add_path_list_compressed(artifact, Path(train_set_list), tmp_dir)
+        _add_path_list_compressed(artifact, Path(valid_set_list), tmp_dir)
+        try:
+            summary_csv = find_upward(train_set_list, "summary.csv")
+            artifact.add_file(str(summary_csv), name="summary.csv")
+        except FileNotFoundError:
+            print("summary.csv not found, skipping.")
+        try:
+            rosbag_summary_csv = find_upward(train_set_list, "rosbag_summary.csv")
+            artifact.add_file(str(rosbag_summary_csv), name="rosbag_summary.csv")
+        except FileNotFoundError:
+            print("rosbag_summary.csv not found, skipping.")
+        # add_file() copies into wandb's staging cache, so the temp dir can be
+        # removed as soon as use_artifact() returns.
+        run.use_artifact(artifact)
 
 
 def mean_ego_loss(loss_dict):

--- a/diffusion_planner/diffusion_planner/utils/train_utils.py
+++ b/diffusion_planner/diffusion_planner/utils/train_utils.py
@@ -7,6 +7,15 @@ import torch
 
 
 def openjson(path):
+    """Load a json file; transparently handles zstd-compressed ``*.zst`` files."""
+    if str(path).endswith(".zst"):
+        import io
+
+        import zstandard
+
+        with open(path, "rb") as f:
+            reader = zstandard.ZstdDecompressor().stream_reader(f)
+            return json.load(io.TextIOWrapper(reader, encoding="utf-8"))
     with open(path, "r", encoding="utf-8") as f:
         dict = json.load(f)
     return dict

--- a/diffusion_planner/pyproject.toml
+++ b/diffusion_planner/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "torch",
     "tqdm",
     "wandb",
+    "zstandard>=0.25.0",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -373,6 +373,7 @@ dependencies = [
     { name = "torch" },
     { name = "tqdm" },
     { name = "wandb" },
+    { name = "zstandard" },
 ]
 
 [package.metadata]
@@ -397,6 +398,7 @@ requires-dist = [
     { name = "torch" },
     { name = "tqdm" },
     { name = "wandb" },
+    { name = "zstandard", specifier = ">=0.25.0" },
 ]
 
 [[package]]
@@ -2317,4 +2319,28 @@ wheels = [
     { url = "https://pypi.flatt.tech/files/packages/a0/71/ad95c33da18897e4c636528bbc24a1dd23fe16797de8bc4ec667b8db0ba4/yarl-1.23.0-cp310-cp310-win_amd64.whl", hash = "sha256:ab5f043cb8a2d71c981c09c510da013bc79fd661f5c60139f00dd3c3cc4f2ffb", size = 87328, upload-time = "2026-03-01T22:04:39.558Z" },
     { url = "https://pypi.flatt.tech/files/packages/e2/14/dfa369523c79bccf9c9c746b0a63eb31f65db9418ac01275f7950962e504/yarl-1.23.0-cp310-cp310-win_arm64.whl", hash = "sha256:263cd4f47159c09b8b685890af949195b51d1aa82ba451c5847ca9bc6413c220", size = 82463, upload-time = "2026-03-01T22:04:41.454Z" },
     { url = "https://pypi.flatt.tech/files/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+source = { registry = "https://pypi.flatt.tech/simple/" }
+sdist = { url = "https://pypi.flatt.tech/files/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
+wheels = [
+    { url = "https://pypi.flatt.tech/files/packages/56/7a/28efd1d371f1acd037ac64ed1c5e2b41514a6cc937dd6ab6a13ab9f0702f/zstandard-0.25.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e59fdc271772f6686e01e1b3b74537259800f57e24280be3f29c8a0deb1904dd", size = 795256, upload-time = "2025-09-14T22:15:56.415Z" },
+    { url = "https://pypi.flatt.tech/files/packages/96/34/ef34ef77f1ee38fc8e4f9775217a613b452916e633c4f1d98f31db52c4a5/zstandard-0.25.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4d441506e9b372386a5271c64125f72d5df6d2a8e8a2a45a0ae09b03cb781ef7", size = 640565, upload-time = "2025-09-14T22:15:58.177Z" },
+    { url = "https://pypi.flatt.tech/files/packages/9d/1b/4fdb2c12eb58f31f28c4d28e8dc36611dd7205df8452e63f52fb6261d13e/zstandard-0.25.0-cp310-cp310-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:ab85470ab54c2cb96e176f40342d9ed41e58ca5733be6a893b730e7af9c40550", size = 5345306, upload-time = "2025-09-14T22:16:00.165Z" },
+    { url = "https://pypi.flatt.tech/files/packages/73/28/a44bdece01bca027b079f0e00be3b6bd89a4df180071da59a3dd7381665b/zstandard-0.25.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e05ab82ea7753354bb054b92e2f288afb750e6b439ff6ca78af52939ebbc476d", size = 5055561, upload-time = "2025-09-14T22:16:02.22Z" },
+    { url = "https://pypi.flatt.tech/files/packages/e9/74/68341185a4f32b274e0fc3410d5ad0750497e1acc20bd0f5b5f64ce17785/zstandard-0.25.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:78228d8a6a1c177a96b94f7e2e8d012c55f9c760761980da16ae7546a15a8e9b", size = 5402214, upload-time = "2025-09-14T22:16:04.109Z" },
+    { url = "https://pypi.flatt.tech/files/packages/8b/67/f92e64e748fd6aaffe01e2b75a083c0c4fd27abe1c8747fee4555fcee7dd/zstandard-0.25.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b6bd67528ee8b5c5f10255735abc21aa106931f0dbaf297c7be0c886353c3d0", size = 5449703, upload-time = "2025-09-14T22:16:06.312Z" },
+    { url = "https://pypi.flatt.tech/files/packages/fd/e5/6d36f92a197c3c17729a2125e29c169f460538a7d939a27eaaa6dcfcba8e/zstandard-0.25.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4b6d83057e713ff235a12e73916b6d356e3084fd3d14ced499d84240f3eecee0", size = 5556583, upload-time = "2025-09-14T22:16:08.457Z" },
+    { url = "https://pypi.flatt.tech/files/packages/d7/83/41939e60d8d7ebfe2b747be022d0806953799140a702b90ffe214d557638/zstandard-0.25.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9174f4ed06f790a6869b41cba05b43eeb9a35f8993c4422ab853b705e8112bbd", size = 5045332, upload-time = "2025-09-14T22:16:10.444Z" },
+    { url = "https://pypi.flatt.tech/files/packages/b3/87/d3ee185e3d1aa0133399893697ae91f221fda79deb61adbe998a7235c43f/zstandard-0.25.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:25f8f3cd45087d089aef5ba3848cd9efe3ad41163d3400862fb42f81a3a46701", size = 5572283, upload-time = "2025-09-14T22:16:12.128Z" },
+    { url = "https://pypi.flatt.tech/files/packages/0a/1d/58635ae6104df96671076ac7d4ae7816838ce7debd94aecf83e30b7121b0/zstandard-0.25.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3756b3e9da9b83da1796f8809dd57cb024f838b9eeafde28f3cb472012797ac1", size = 4959754, upload-time = "2025-09-14T22:16:14.225Z" },
+    { url = "https://pypi.flatt.tech/files/packages/75/d6/57e9cb0a9983e9a229dd8fd2e6e96593ef2aa82a3907188436f22b111ccd/zstandard-0.25.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:81dad8d145d8fd981b2962b686b2241d3a1ea07733e76a2f15435dfb7fb60150", size = 5266477, upload-time = "2025-09-14T22:16:16.343Z" },
+    { url = "https://pypi.flatt.tech/files/packages/d1/a9/ee891e5edf33a6ebce0a028726f0bbd8567effe20fe3d5808c42323e8542/zstandard-0.25.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:a5a419712cf88862a45a23def0ae063686db3d324cec7edbe40509d1a79a0aab", size = 5440914, upload-time = "2025-09-14T22:16:18.453Z" },
+    { url = "https://pypi.flatt.tech/files/packages/58/08/a8522c28c08031a9521f27abc6f78dbdee7312a7463dd2cfc658b813323b/zstandard-0.25.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:e7360eae90809efd19b886e59a09dad07da4ca9ba096752e61a2e03c8aca188e", size = 5819847, upload-time = "2025-09-14T22:16:20.559Z" },
+    { url = "https://pypi.flatt.tech/files/packages/6f/11/4c91411805c3f7b6f31c60e78ce347ca48f6f16d552fc659af6ec3b73202/zstandard-0.25.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:75ffc32a569fb049499e63ce68c743155477610532da1eb38e7f24bf7cd29e74", size = 5363131, upload-time = "2025-09-14T22:16:22.206Z" },
+    { url = "https://pypi.flatt.tech/files/packages/ef/d6/8c4bd38a3b24c4c7676a7a3d8de85d6ee7a983602a734b9f9cdefb04a5d6/zstandard-0.25.0-cp310-cp310-win32.whl", hash = "sha256:106281ae350e494f4ac8a80470e66d1fe27e497052c8d9c3b95dc4cf1ade81aa", size = 436469, upload-time = "2025-09-14T22:16:25.002Z" },
+    { url = "https://pypi.flatt.tech/files/packages/93/90/96d50ad417a8ace5f841b3228e93d1bb13e6ad356737f42e2dde30d8bd68/zstandard-0.25.0-cp310-cp310-win_amd64.whl", hash = "sha256:ea9d54cc3d8064260114a0bbf3479fc4a98b21dffc89b3459edd506b69262f6e", size = 506100, upload-time = "2025-09-14T22:16:23.569Z" },
 ]


### PR DESCRIPTION
## Summary

`log_dataset_artifact()` uploaded raw path_list JSONs to wandb at the start of every training run, registering artifacts of up to 7.7 GB per experiment (57+ GB total across dataset artifacts in the project). This PR compresses the path lists with zstd before uploading.

## Changes

- `train.py`: `log_dataset_artifact()` now zstd-compresses the train/valid path lists (level 3, multithreaded) in a temporary directory and adds them to the artifact as `<name>.json.zst`. If `zstandard` is not installed, it prints a warning and falls back to the previous uncompressed upload
- `train_utils.py`: `openjson()` now transparently decompresses paths ending in `.zst` (behavior for plain `.json` is unchanged), so files fetched via `artifact.download()` can be loaded as-is
- `pyproject.toml` / `uv.lock`: add `zstandard` as a dependency

## Results (measured)

- `path_list_train.json`: 6.7 GB (36,045,881 entries) → **62 MB** (~1/108)
- Compression time: ~4 s (`-T0` on 96 cores)
- Verified the full round trip — compress → upload → download → decompress — yields JSON identical to the original

🤖 Generated with [Claude Code](https://claude.com/claude-code)
