### PR TITLE
fix: make post-warmup cosine LR scheduling effective and configurable

### DIFF
--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -20,7 +20,7 @@ from diffusion_planner.utils.data_augmentation_bridge import (
     StatePerturbation as BridgeStatePerturbation,
 )
 from diffusion_planner.utils.dataset import DiffusionPlannerData, DiffusionPlannerPairData
-from diffusion_planner.utils.lr_schedule import CosineAnnealingWarmUpRestarts
+from diffusion_planner.utils.lr_schedule import build_lr_scheduler
 from diffusion_planner.utils.normalizer import ObservationNormalizer, StateNormalizer
 from diffusion_planner.utils.onnx_export import export_checkpoint_onnx_guarded
 from diffusion_planner.utils.train_utils import resume_model, set_seed
@@ -328,7 +328,12 @@ def model_training(args: TrainConfig):
     ]
 
     optimizer = optim.AdamW(params)
-    scheduler = CosineAnnealingWarmUpRestarts(optimizer, train_epochs, args.warm_up_epoch)
+    scheduler = build_lr_scheduler(
+        optimizer,
+        train_epochs,
+        args.warm_up_epoch,
+        schedule_type=getattr(args, "lr_schedule_type", "cosine"),
+    )
 
     if args.resume_model_path is not None:
         print(f"Model loaded from {args.resume_model_path}")

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -20,7 +20,12 @@ from diffusion_planner.utils.data_augmentation_bridge import (
     StatePerturbation as BridgeStatePerturbation,
 )
 from diffusion_planner.utils.dataset import DiffusionPlannerData, DiffusionPlannerPairData
-from diffusion_planner.utils.lr_schedule import build_lr_scheduler
+from diffusion_planner.utils.lr_schedule import (
+    apply_legacy_final_phase_lr,
+    build_lr_scheduler,
+    rebuild_lr_scheduler,
+    resolve_lr_schedule_steps,
+)
 from diffusion_planner.utils.normalizer import ObservationNormalizer, StateNormalizer
 from diffusion_planner.utils.onnx_export import export_checkpoint_onnx_guarded
 from diffusion_planner.utils.train_utils import resume_model, set_seed
@@ -328,11 +333,21 @@ def model_training(args: TrainConfig):
     ]
 
     optimizer = optim.AdamW(params)
+    lr_schedule_steps = resolve_lr_schedule_steps(
+        total_epochs=train_epochs,
+        warm_up_epochs=args.warm_up_epoch,
+        steps_per_epoch=len(train_loader),
+        interval=args.lr_scheduler_interval,
+        cosine_t_max_epochs=args.lr_cosine_t_max,
+    )
     scheduler = build_lr_scheduler(
         optimizer,
-        train_epochs,
-        args.warm_up_epoch,
-        schedule_type=getattr(args, "lr_schedule_type", "cosine"),
+        lr_schedule_steps["total"],
+        lr_schedule_steps["warmup"],
+        schedule_type=args.lr_schedule_type,
+        start_factor=args.lr_start_factor,
+        eta_min=args.lr_eta_min,
+        cosine_t_max=lr_schedule_steps["cosine_t_max"],
     )
 
     if args.resume_model_path is not None:
@@ -342,10 +357,32 @@ def model_training(args: TrainConfig):
             args.resume_model_path, diffusion_planner, optimizer, scheduler, model_ema, args.device
         )
 
-        # Override learning rate with the new value
-        for param_group in optimizer.param_groups:
-            param_group["lr"] = args.learning_rate
-        print(f"Learning rate reset to {args.learning_rate}")
+        # Rebuild from the configured base LR at the resumed epoch. Directly
+        # assigning args.learning_rate here would jump a cosine run back to its
+        # peak while leaving the scheduler state at the checkpoint epoch.
+        resume_lr_schedule_steps = resolve_lr_schedule_steps(
+            total_epochs=train_epochs,
+            warm_up_epochs=args.warm_up_epoch,
+            steps_per_epoch=len(train_loader),
+            interval=args.lr_scheduler_interval,
+            cosine_t_max_epochs=args.lr_cosine_t_max,
+            completed_epochs=init_epoch,
+        )
+        scheduler = rebuild_lr_scheduler(
+            optimizer,
+            resume_lr_schedule_steps["total"],
+            resume_lr_schedule_steps["warmup"],
+            completed_epochs=resume_lr_schedule_steps["completed"],
+            learning_rate=args.learning_rate,
+            schedule_type=args.lr_schedule_type,
+            start_factor=args.lr_start_factor,
+            eta_min=args.lr_eta_min,
+            cosine_t_max=resume_lr_schedule_steps["cosine_t_max"],
+        )
+        print(
+            f"Learning rate schedule restored at epoch {init_epoch}: "
+            f"{optimizer.param_groups[0]['lr']}"
+        )
 
     else:
         init_epoch = 0
@@ -422,22 +459,28 @@ def model_training(args: TrainConfig):
         if args.ddp:
             torch.distributed.barrier()
 
-        # Adjust learning rate for final 10 epochs
-        final_epoch_count = 10
-        if epoch >= train_epochs - final_epoch_count:
-            base_lr = args.learning_rate
-            if epoch >= train_epochs - final_epoch_count // 2:  # Last 5 epochs: LR * 1/100
-                adjusted_lr = base_lr * 0.01
-            else:  # First 5 of final 10 epochs: LR * 1/10
-                adjusted_lr = base_lr * 0.1
-            for param_group in optimizer.param_groups:
-                param_group["lr"] = adjusted_lr
+        # Preserve the old final step-down only for legacy reproduction. The
+        # cosine schedule must remain the sole owner of LR in cosine mode.
+        adjusted_lr = apply_legacy_final_phase_lr(
+            optimizer,
+            current_epoch=epoch,
+            total_epochs=train_epochs,
+            base_lr=args.learning_rate,
+            schedule_type=args.lr_schedule_type,
+        )
+        if adjusted_lr is not None:
             if global_rank == 0:
-                print(f"Final phase: Epoch {epoch + 1}, LR adjusted to {adjusted_lr}")
+                print(f"Legacy final phase: Epoch {epoch + 1}, LR adjusted to {adjusted_lr}")
 
         # training step
         train_loss, train_total_loss = train_epoch(
-            train_loader, diffusion_planner, optimizer, args, model_ema, aug
+            train_loader,
+            diffusion_planner,
+            optimizer,
+            args,
+            model_ema,
+            aug,
+            scheduler=scheduler,
         )
 
         valid_dict = validate_model(diffusion_planner, valid_loader, args)
@@ -571,7 +614,8 @@ def model_training(args: TrainConfig):
                     external_data=False,
                 )
 
-        scheduler.step()
+        if args.lr_scheduler_interval == "epoch":
+            scheduler.step()
         train_sampler.set_epoch(epoch + 1)
 
     if global_rank == 0 and wandb.run is not None:

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -79,6 +79,11 @@ class TrainConfig:
     # legacy behavior that holds the peak lr for the whole run (kept for
     # backward-compatible reproduction of pre-existing runs).
     lr_schedule_type: Literal["cosine", "constant"] = "cosine"
+    lr_start_factor: float = 0.1
+    lr_eta_min: float = 1e-6
+    # Number of cosine-decay epochs. 0 derives it from train_epochs - warm_up_epoch.
+    lr_cosine_t_max: int = 0
+    lr_scheduler_interval: Literal["epoch", "batch"] = "epoch"
     encoder_drop_path_rate: float = 0.1
     decoder_drop_path_rate: float = 0.1
     use_ego_history: bool = True

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -74,6 +74,11 @@ class TrainConfig:
     save_utd: int = 10
     learning_rate: float = 1e-4
     warm_up_epoch: int = 5
+    # LR schedule after warmup. "cosine" (default): cosine-decay to ~1e-6 over the
+    # remaining epochs (recommended; prevents the post-warmup collapse). "constant":
+    # legacy behavior that holds the peak lr for the whole run (kept for
+    # backward-compatible reproduction of pre-existing runs).
+    lr_schedule_type: Literal["cosine", "constant"] = "cosine"
     encoder_drop_path_rate: float = 0.1
     decoder_drop_path_rate: float = 0.1
     use_ego_history: bool = True

--- a/diffusion_planner/diffusion_planner/train_epoch.py
+++ b/diffusion_planner/diffusion_planner/train_epoch.py
@@ -32,7 +32,15 @@ def heading_to_cos_sin(x):
     )
 
 
-def train_epoch(data_loader, model, optimizer, args, ema, aug: StatePerturbation = None):
+def train_epoch(
+    data_loader,
+    model,
+    optimizer,
+    args,
+    ema,
+    aug: StatePerturbation = None,
+    scheduler=None,
+):
     epoch_loss = []
 
     model.train()
@@ -85,6 +93,8 @@ def train_epoch(data_loader, model, optimizer, args, ema, aug: StatePerturbation
 
         nn.utils.clip_grad_norm_(model.parameters(), 5)
         optimizer.step()
+        if scheduler is not None and args.lr_scheduler_interval == "batch":
+            scheduler.step()
 
         ema.update(model)
 

--- a/diffusion_planner/diffusion_planner/utils/lr_schedule.py
+++ b/diffusion_planner/diffusion_planner/utils/lr_schedule.py
@@ -1,15 +1,69 @@
-from torch.optim.lr_scheduler import LinearLR, MultiplicativeLR, SequentialLR
+from torch.optim.lr_scheduler import (
+    CosineAnnealingLR,
+    LinearLR,
+    MultiplicativeLR,
+    SequentialLR,
+)
 
 
-def CosineAnnealingWarmUpRestarts(optimizer, epoch, warm_up_epoch, start_factor=0.1):
+def WarmupConstantLR(optimizer, epoch, warm_up_epoch, start_factor=0.1):
+    """Linear warmup for ``warm_up_epoch`` epochs, then HOLD the lr constant.
+
+    This is the original schedule, formerly (mis)named
+    ``CosineAnnealingWarmUpRestarts``: the post-warmup phase is
+    ``MultiplicativeLR(lambda=1.0)``, so the learning rate never decays. Kept
+    under an accurate name for backward-compatible reproduction of pre-existing
+    runs and resumed checkpoints. New training should prefer
+    :func:`WarmupCosineAnnealingLR`.
+
+    Called with ``scheduler.step()`` once per epoch, so the sub-schedulers count
+    in epochs.
+    """
     assert epoch >= warm_up_epoch
-    T_warmup = warm_up_epoch
+    warmup = LinearLR(optimizer, start_factor=start_factor, total_iters=warm_up_epoch - 1)
+    fixed = MultiplicativeLR(optimizer, lr_lambda=lambda e: 1.0)
+    return SequentialLR(optimizer, schedulers=[warmup, fixed], milestones=[warm_up_epoch])
 
-    warmup_scheduler = LinearLR(optimizer, start_factor=start_factor, total_iters=warm_up_epoch - 1)
-    fixed_scheduler = MultiplicativeLR(optimizer, lr_lambda=lambda epoch: 1.0)
 
-    scheduler = SequentialLR(
-        optimizer, schedulers=[warmup_scheduler, fixed_scheduler], milestones=[T_warmup]
+def WarmupCosineAnnealingLR(optimizer, epoch, warm_up_epoch, start_factor=0.1, eta_min=1e-6):
+    """Linear warmup for ``warm_up_epoch`` epochs, then cosine-decay to
+    ``eta_min`` over the remaining epochs.
+
+    Replaces the constant post-warmup phase of :func:`WarmupConstantLR`, which
+    let training collapse right after warmup: the learning rate stayed at its
+    peak for the whole run, so every model peaked in the warmup epochs and then
+    degraded. Decaying with a proper cosine schedule (matching original planTF)
+    keeps the lr low enough after the initial phase to actually converge.
+
+    Called with ``scheduler.step()`` once per epoch, so the sub-schedulers count
+    in epochs. ``max(..., 1)`` guards the ``warm_up_epoch == 1`` /
+    ``epoch == warm_up_epoch`` edge cases so the sub-schedulers always get
+    positive spans.
+    """
+    assert epoch >= warm_up_epoch
+    warmup = LinearLR(optimizer, start_factor=start_factor, total_iters=max(warm_up_epoch - 1, 1))
+    cosine = CosineAnnealingLR(optimizer, T_max=max(epoch - warm_up_epoch, 1), eta_min=eta_min)
+    return SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[warm_up_epoch])
+
+
+# Backward-compatible alias. The original public name advertised cosine annealing
+# but the implementation held the lr constant after warmup; keep the name bound
+# to that exact (constant) behavior so existing imports and resumed checkpoints
+# reproduce unchanged. New code should call WarmupCosineAnnealingLR directly (or
+# select it via TrainConfig.lr_schedule_type="cosine").
+CosineAnnealingWarmUpRestarts = WarmupConstantLR
+
+
+def build_lr_scheduler(optimizer, epoch, warm_up_epoch, schedule_type="cosine", **kwargs):
+    """Dispatch to the configured lr schedule.
+
+    ``schedule_type="cosine"`` (default) -> :func:`WarmupCosineAnnealingLR`;
+    ``"constant"`` -> :func:`WarmupConstantLR` (the legacy behavior).
+    """
+    if schedule_type == "cosine":
+        return WarmupCosineAnnealingLR(optimizer, epoch, warm_up_epoch, **kwargs)
+    if schedule_type == "constant":
+        return WarmupConstantLR(optimizer, epoch, warm_up_epoch)
+    raise ValueError(
+        f"Unknown lr schedule_type: {schedule_type!r} (expected 'cosine' or 'constant')"
     )
-
-    return scheduler

--- a/diffusion_planner/diffusion_planner/utils/lr_schedule.py
+++ b/diffusion_planner/diffusion_planner/utils/lr_schedule.py
@@ -1,3 +1,5 @@
+import warnings
+
 from torch.optim.lr_scheduler import (
     CosineAnnealingLR,
     LinearLR,
@@ -25,7 +27,14 @@ def WarmupConstantLR(optimizer, epoch, warm_up_epoch, start_factor=0.1):
     return SequentialLR(optimizer, schedulers=[warmup, fixed], milestones=[warm_up_epoch])
 
 
-def WarmupCosineAnnealingLR(optimizer, epoch, warm_up_epoch, start_factor=0.1, eta_min=1e-6):
+def WarmupCosineAnnealingLR(
+    optimizer,
+    epoch,
+    warm_up_epoch,
+    start_factor=0.1,
+    eta_min=1e-6,
+    cosine_t_max=None,
+):
     """Linear warmup for ``warm_up_epoch`` epochs, then cosine-decay to
     ``eta_min`` over the remaining epochs.
 
@@ -42,7 +51,10 @@ def WarmupCosineAnnealingLR(optimizer, epoch, warm_up_epoch, start_factor=0.1, e
     """
     assert epoch >= warm_up_epoch
     warmup = LinearLR(optimizer, start_factor=start_factor, total_iters=max(warm_up_epoch - 1, 1))
-    cosine = CosineAnnealingLR(optimizer, T_max=max(epoch - warm_up_epoch, 1), eta_min=eta_min)
+    t_max = max(epoch - warm_up_epoch, 1) if cosine_t_max is None else cosine_t_max
+    if t_max <= 0:
+        raise ValueError(f"cosine_t_max must be positive, got {t_max}")
+    cosine = CosineAnnealingLR(optimizer, T_max=t_max, eta_min=eta_min)
     return SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[warm_up_epoch])
 
 
@@ -54,16 +66,133 @@ def WarmupCosineAnnealingLR(optimizer, epoch, warm_up_epoch, start_factor=0.1, e
 CosineAnnealingWarmUpRestarts = WarmupConstantLR
 
 
-def build_lr_scheduler(optimizer, epoch, warm_up_epoch, schedule_type="cosine", **kwargs):
+def build_lr_scheduler(
+    optimizer,
+    epoch,
+    warm_up_epoch,
+    schedule_type="cosine",
+    start_factor=0.1,
+    eta_min=1e-6,
+    cosine_t_max=None,
+):
     """Dispatch to the configured lr schedule.
 
     ``schedule_type="cosine"`` (default) -> :func:`WarmupCosineAnnealingLR`;
     ``"constant"`` -> :func:`WarmupConstantLR` (the legacy behavior).
     """
     if schedule_type == "cosine":
-        return WarmupCosineAnnealingLR(optimizer, epoch, warm_up_epoch, **kwargs)
+        return WarmupCosineAnnealingLR(
+            optimizer,
+            epoch,
+            warm_up_epoch,
+            start_factor=start_factor,
+            eta_min=eta_min,
+            cosine_t_max=cosine_t_max,
+        )
     if schedule_type == "constant":
-        return WarmupConstantLR(optimizer, epoch, warm_up_epoch)
+        return WarmupConstantLR(
+            optimizer,
+            epoch,
+            warm_up_epoch,
+            start_factor=start_factor,
+        )
     raise ValueError(
         f"Unknown lr schedule_type: {schedule_type!r} (expected 'cosine' or 'constant')"
     )
+
+
+def rebuild_lr_scheduler(
+    optimizer,
+    epoch,
+    warm_up_epoch,
+    completed_epochs,
+    learning_rate,
+    schedule_type="cosine",
+    start_factor=0.1,
+    eta_min=1e-6,
+    cosine_t_max=None,
+):
+    """Rebuild a scheduler at the LR corresponding to a resumed epoch.
+
+    Loading an optimizer checkpoint restores the scheduled LR, but the training
+    entry point also supports selecting a new base LR when resuming. Directly
+    assigning that base LR would restart training at the peak and leave the
+    scheduler's internal epoch out of sync. Rebuilding and fast-forwarding keeps
+    both the optimizer LR and scheduler state aligned.
+    """
+    if not 0 <= completed_epochs <= epoch:
+        raise ValueError(f"completed_epochs must be in [0, {epoch}], got {completed_epochs}")
+
+    for param_group in optimizer.param_groups:
+        param_group["lr"] = learning_rate
+        param_group["initial_lr"] = learning_rate
+
+    scheduler = build_lr_scheduler(
+        optimizer,
+        epoch,
+        warm_up_epoch,
+        schedule_type=schedule_type,
+        start_factor=start_factor,
+        eta_min=eta_min,
+        cosine_t_max=cosine_t_max,
+    )
+    if completed_epochs:
+        # Fast-forwarding does not update parameters. Suppress PyTorch's generic
+        # ordering warning because there is intentionally no optimizer step here.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=r"Detected call of `lr_scheduler\.step\(\)` before `optimizer\.step\(\)`",
+            )
+            for _ in range(completed_epochs):
+                scheduler.step()
+    return scheduler
+
+
+def apply_legacy_final_phase_lr(
+    optimizer,
+    current_epoch,
+    total_epochs,
+    base_lr,
+    schedule_type,
+    final_epoch_count=10,
+):
+    """Apply the pre-cosine final LR step-down only for the legacy schedule."""
+    if final_epoch_count < 0:
+        raise ValueError(f"final_epoch_count must be non-negative, got {final_epoch_count}")
+    if schedule_type != "constant" or current_epoch < total_epochs - final_epoch_count:
+        return None
+
+    if current_epoch >= total_epochs - final_epoch_count // 2:
+        adjusted_lr = base_lr * 0.01
+    else:
+        adjusted_lr = base_lr * 0.1
+    for param_group in optimizer.param_groups:
+        param_group["lr"] = adjusted_lr
+    return adjusted_lr
+
+
+def resolve_lr_schedule_steps(
+    total_epochs,
+    warm_up_epochs,
+    steps_per_epoch,
+    interval="epoch",
+    cosine_t_max_epochs=0,
+    completed_epochs=0,
+):
+    """Convert user-facing epoch durations to scheduler-step durations."""
+    if interval not in {"epoch", "batch"}:
+        raise ValueError(f"Unknown lr scheduler interval: {interval!r}")
+    if steps_per_epoch <= 0:
+        raise ValueError(f"steps_per_epoch must be positive, got {steps_per_epoch}")
+    if cosine_t_max_epochs < 0:
+        raise ValueError(f"cosine_t_max_epochs must be non-negative, got {cosine_t_max_epochs}")
+
+    multiplier = steps_per_epoch if interval == "batch" else 1
+    cosine_t_max = cosine_t_max_epochs * multiplier if cosine_t_max_epochs else None
+    return {
+        "total": total_epochs * multiplier,
+        "warmup": warm_up_epochs * multiplier,
+        "completed": completed_epochs * multiplier,
+        "cosine_t_max": cosine_t_max,
+    }

--- a/diffusion_planner/tests/test_lr_schedule.py
+++ b/diffusion_planner/tests/test_lr_schedule.py
@@ -11,7 +11,10 @@ from diffusion_planner.utils.lr_schedule import (
     CosineAnnealingWarmUpRestarts,
     WarmupConstantLR,
     WarmupCosineAnnealingLR,
+    apply_legacy_final_phase_lr,
     build_lr_scheduler,
+    rebuild_lr_scheduler,
+    resolve_lr_schedule_steps,
 )
 
 PEAK_LR = 1e-3
@@ -31,6 +34,32 @@ def _run(scheduler, epochs=EPOCHS):
     lrs = []
     for _ in range(epochs):
         lrs.append(optimizer.param_groups[0]["lr"])
+        optimizer.step()
+        scheduler.step()
+    return lrs
+
+
+def _run_training_loop(schedule_type, epochs=EPOCHS, warmup=WARMUP):
+    """Mirror the LR-related ordering in model_training."""
+    optimizer = _make_optimizer()
+    scheduler = build_lr_scheduler(
+        optimizer,
+        epochs,
+        warmup,
+        schedule_type=schedule_type,
+        eta_min=ETA_MIN,
+    )
+    lrs = []
+    for current_epoch in range(epochs):
+        apply_legacy_final_phase_lr(
+            optimizer,
+            current_epoch=current_epoch,
+            total_epochs=epochs,
+            base_lr=PEAK_LR,
+            schedule_type=schedule_type,
+        )
+        lrs.append(optimizer.param_groups[0]["lr"])
+        optimizer.step()
         scheduler.step()
     return lrs
 
@@ -98,3 +127,175 @@ def test_cosine_handles_short_warmup_edge_case():
     opt2 = _make_optimizer()
     sched = WarmupCosineAnnealingLR(opt2, 10, 1)
     _run(sched, epochs=10)
+
+
+def test_training_loop_does_not_override_cosine_in_final_ten_epochs():
+    lrs = _run_training_loop("cosine", epochs=20, warmup=5)
+    expected = _run(
+        build_lr_scheduler(
+            _make_optimizer(),
+            20,
+            5,
+            schedule_type="cosine",
+            eta_min=ETA_MIN,
+        ),
+        epochs=20,
+    )
+    assert lrs == pytest.approx(expected)
+    assert all(b < a for a, b in zip(lrs[5:], lrs[6:]))
+
+
+def test_short_training_loop_distinguishes_cosine_from_legacy_constant():
+    cosine = _run_training_loop("cosine", epochs=2, warmup=1)
+    constant = _run_training_loop("constant", epochs=2, warmup=1)
+    assert cosine != pytest.approx(constant)
+    assert constant == pytest.approx([PEAK_LR * 0.01] * 2)
+
+
+def test_resume_rebuild_matches_uninterrupted_cosine_schedule():
+    optimizer = _make_optimizer()
+    uninterrupted_scheduler = build_lr_scheduler(
+        optimizer,
+        100,
+        5,
+        schedule_type="cosine",
+        eta_min=ETA_MIN,
+    )
+    uninterrupted = _run(uninterrupted_scheduler, epochs=100)
+
+    resumed_optimizer = _make_optimizer()
+    resumed_scheduler = rebuild_lr_scheduler(
+        resumed_optimizer,
+        100,
+        5,
+        completed_epochs=50,
+        learning_rate=PEAK_LR,
+        schedule_type="cosine",
+        eta_min=ETA_MIN,
+    )
+    resumed = _run(resumed_scheduler, epochs=50)
+
+    assert resumed == pytest.approx(uninterrupted[50:])
+
+
+def test_resume_rebuild_rebases_schedule_to_new_learning_rate():
+    new_lr = PEAK_LR / 2
+    optimizer = _make_optimizer()
+    scheduler = rebuild_lr_scheduler(
+        optimizer,
+        EPOCHS,
+        WARMUP,
+        completed_epochs=10,
+        learning_rate=new_lr,
+        schedule_type="cosine",
+        eta_min=ETA_MIN,
+    )
+
+    expected_optimizer = _make_optimizer()
+    expected_optimizer.param_groups[0]["lr"] = new_lr
+    expected_optimizer.param_groups[0]["initial_lr"] = new_lr
+    expected = _run(
+        build_lr_scheduler(
+            expected_optimizer,
+            EPOCHS,
+            WARMUP,
+            schedule_type="cosine",
+            eta_min=ETA_MIN,
+        ),
+        epochs=EPOCHS,
+    )
+    assert optimizer.param_groups[0]["lr"] == pytest.approx(expected[10])
+    assert _run(scheduler, epochs=EPOCHS - 10) == pytest.approx(expected[10:])
+
+
+def test_all_cosine_parameters_are_configurable():
+    start_factor = 0.25
+    eta_min = 2e-5
+    cosine_t_max = 7
+    optimizer = _make_optimizer()
+    scheduler = build_lr_scheduler(
+        optimizer,
+        EPOCHS,
+        WARMUP,
+        schedule_type="cosine",
+        start_factor=start_factor,
+        eta_min=eta_min,
+        cosine_t_max=cosine_t_max,
+    )
+
+    assert optimizer.param_groups[0]["lr"] == pytest.approx(PEAK_LR * start_factor)
+    cosine = scheduler._schedulers[1]
+    assert cosine.eta_min == eta_min
+    assert cosine.T_max == cosine_t_max
+
+
+def test_batch_interval_converts_epoch_durations_to_optimizer_steps():
+    resolved = resolve_lr_schedule_steps(
+        total_epochs=20,
+        warm_up_epochs=5,
+        steps_per_epoch=8,
+        interval="batch",
+        cosine_t_max_epochs=12,
+        completed_epochs=7,
+    )
+    assert resolved == {
+        "total": 160,
+        "warmup": 40,
+        "completed": 56,
+        "cosine_t_max": 96,
+    }
+
+
+def test_epoch_interval_keeps_epoch_durations():
+    resolved = resolve_lr_schedule_steps(
+        total_epochs=20,
+        warm_up_epochs=5,
+        steps_per_epoch=8,
+        interval="epoch",
+        cosine_t_max_epochs=0,
+        completed_epochs=7,
+    )
+    assert resolved == {
+        "total": 20,
+        "warmup": 5,
+        "completed": 7,
+        "cosine_t_max": None,
+    }
+
+
+def test_batch_interval_resume_matches_uninterrupted_schedule():
+    resolved = resolve_lr_schedule_steps(
+        total_epochs=20,
+        warm_up_epochs=5,
+        steps_per_epoch=8,
+        interval="batch",
+        cosine_t_max_epochs=12,
+        completed_epochs=7,
+    )
+    optimizer = _make_optimizer()
+    uninterrupted_scheduler = build_lr_scheduler(
+        optimizer,
+        resolved["total"],
+        resolved["warmup"],
+        schedule_type="cosine",
+        eta_min=ETA_MIN,
+        cosine_t_max=resolved["cosine_t_max"],
+    )
+    uninterrupted = _run(uninterrupted_scheduler, epochs=resolved["total"])
+
+    resumed_optimizer = _make_optimizer()
+    resumed_scheduler = rebuild_lr_scheduler(
+        resumed_optimizer,
+        resolved["total"],
+        resolved["warmup"],
+        completed_epochs=resolved["completed"],
+        learning_rate=PEAK_LR,
+        schedule_type="cosine",
+        eta_min=ETA_MIN,
+        cosine_t_max=resolved["cosine_t_max"],
+    )
+    resumed = _run(
+        resumed_scheduler,
+        epochs=resolved["total"] - resolved["completed"],
+    )
+    assert resumed == pytest.approx(uninterrupted[resolved["completed"] :])

--- a/diffusion_planner/tests/test_lr_schedule.py
+++ b/diffusion_planner/tests/test_lr_schedule.py
@@ -1,0 +1,100 @@
+"""Tests for the warmup + post-warmup lr schedules.
+
+Covers the fix where the post-warmup phase held the lr constant (the old
+`CosineAnnealingWarmUpRestarts`) vs. the new cosine decay, plus the
+backward-compatible alias and the dispatcher.
+"""
+
+import pytest
+import torch
+from diffusion_planner.utils.lr_schedule import (
+    CosineAnnealingWarmUpRestarts,
+    WarmupConstantLR,
+    WarmupCosineAnnealingLR,
+    build_lr_scheduler,
+)
+
+PEAK_LR = 1e-3
+WARMUP = 5
+EPOCHS = 25
+ETA_MIN = 1e-6
+
+
+def _make_optimizer():
+    param = torch.nn.Parameter(torch.zeros(1))
+    return torch.optim.SGD([param], lr=PEAK_LR)
+
+
+def _run(scheduler, epochs=EPOCHS):
+    """Return the lr seen at the start of each epoch (step() once per epoch)."""
+    optimizer = scheduler.optimizer
+    lrs = []
+    for _ in range(epochs):
+        lrs.append(optimizer.param_groups[0]["lr"])
+        scheduler.step()
+    return lrs
+
+
+def test_warmup_ramps_from_start_factor_to_peak():
+    opt = _make_optimizer()
+    lrs = _run(WarmupCosineAnnealingLR(opt, EPOCHS, WARMUP, start_factor=0.1, eta_min=ETA_MIN))
+    # first epoch starts at start_factor * peak, peak reached by end of warmup
+    assert lrs[0] == pytest.approx(0.1 * PEAK_LR, rel=1e-6)
+    assert max(lrs) == pytest.approx(PEAK_LR, rel=1e-6)
+    assert lrs[WARMUP] == pytest.approx(PEAK_LR, rel=1e-6)
+
+
+def test_constant_holds_peak_after_warmup():
+    opt = _make_optimizer()
+    lrs = _run(WarmupConstantLR(opt, EPOCHS, WARMUP, start_factor=0.1))
+    # every post-warmup epoch stays at the peak lr
+    post_warmup = lrs[WARMUP:]
+    assert all(lr == pytest.approx(PEAK_LR, rel=1e-6) for lr in post_warmup)
+
+
+def test_cosine_decays_after_warmup():
+    opt = _make_optimizer()
+    lrs = _run(WarmupCosineAnnealingLR(opt, EPOCHS, WARMUP, start_factor=0.1, eta_min=ETA_MIN))
+    post_warmup = lrs[WARMUP:]
+    # strictly decreasing after the peak, and lands near eta_min by the end
+    assert all(b < a for a, b in zip(post_warmup, post_warmup[1:]))
+    assert lrs[-1] < 0.5 * PEAK_LR
+    assert lrs[-1] >= ETA_MIN
+
+
+def test_cosine_differs_from_constant():
+    opt_c = _make_optimizer()
+    opt_k = _make_optimizer()
+    cosine = _run(WarmupCosineAnnealingLR(opt_c, EPOCHS, WARMUP, eta_min=ETA_MIN))
+    constant = _run(WarmupConstantLR(opt_k, EPOCHS, WARMUP))
+    # identical through warmup, diverge afterwards
+    assert cosine[:WARMUP] == pytest.approx(constant[:WARMUP], rel=1e-6)
+    assert cosine[-1] < constant[-1]
+
+
+def test_alias_preserves_legacy_constant_behavior():
+    # The old public name must keep the exact (constant) behavior for compat.
+    opt_alias = _make_optimizer()
+    opt_const = _make_optimizer()
+    alias = _run(CosineAnnealingWarmUpRestarts(opt_alias, EPOCHS, WARMUP))
+    constant = _run(WarmupConstantLR(opt_const, EPOCHS, WARMUP))
+    assert alias == pytest.approx(constant, rel=1e-6)
+
+
+def test_build_lr_scheduler_dispatch():
+    opt_cos = _make_optimizer()
+    opt_con = _make_optimizer()
+    cosine = _run(build_lr_scheduler(opt_cos, EPOCHS, WARMUP, schedule_type="cosine"))
+    constant = _run(build_lr_scheduler(opt_con, EPOCHS, WARMUP, schedule_type="constant"))
+    assert cosine[-1] < constant[-1]
+    with pytest.raises(ValueError):
+        build_lr_scheduler(_make_optimizer(), EPOCHS, WARMUP, schedule_type="bogus")
+
+
+def test_cosine_handles_short_warmup_edge_case():
+    # warm_up_epoch == 1 and epoch == warm_up_epoch must not raise.
+    opt = _make_optimizer()
+    WarmupCosineAnnealingLR(opt, 1, 1)
+    opt2 = _make_optimizer()
+    sched = WarmupCosineAnnealingLR(opt2, 10, 1)
+    _run(sched, epochs=10)

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -94,6 +94,31 @@ def get_args(args_list=None):
         choices=["cosine", "constant"],
         help="post-warmup lr schedule: 'cosine' decay (default) or legacy 'constant' hold",
     )
+    parser.add_argument(
+        "--lr_start_factor",
+        type=float,
+        default=_train_config_default("lr_start_factor"),
+        help="initial LR as a fraction of learning_rate during warmup",
+    )
+    parser.add_argument(
+        "--lr_eta_min",
+        type=float,
+        default=_train_config_default("lr_eta_min"),
+        help="minimum LR for cosine annealing",
+    )
+    parser.add_argument(
+        "--lr_cosine_t_max",
+        type=int,
+        default=_train_config_default("lr_cosine_t_max"),
+        help="cosine-decay duration in epochs; 0 uses train_epochs - warm_up_epoch",
+    )
+    parser.add_argument(
+        "--lr_scheduler_interval",
+        type=str,
+        choices=["epoch", "batch"],
+        default=_train_config_default("lr_scheduler_interval"),
+        help="call scheduler.step() after each epoch or each optimizer batch",
+    )
     parser.add_argument("--encoder_drop_path_rate", type=float, default=0.1)
     parser.add_argument("--decoder_drop_path_rate", type=float, default=0.1)
     parser.add_argument("--use_ego_history", type=boolean, default=True)

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -87,6 +87,13 @@ def get_args(args_list=None):
     parser.add_argument("--save_utd", type=int, default=10)
     parser.add_argument("--learning_rate", type=float, default=1e-4)
     parser.add_argument("--warm_up_epoch", type=int, default=5)
+    parser.add_argument(
+        "--lr_schedule_type",
+        type=str,
+        default="cosine",
+        choices=["cosine", "constant"],
+        help="post-warmup lr schedule: 'cosine' decay (default) or legacy 'constant' hold",
+    )
     parser.add_argument("--encoder_drop_path_rate", type=float, default=0.1)
     parser.add_argument("--decoder_drop_path_rate", type=float, default=0.1)
     parser.add_argument("--use_ego_history", type=boolean, default=True)


### PR DESCRIPTION
## Summary

Fix the learning-rate schedule so that cosine decay is applied correctly after warmup.

The previous `CosineAnnealingWarmUpRestarts` implementation used
`MultiplicativeLR(lambda=1.0)` after warmup. Despite its name, it therefore kept
the learning rate constant instead of applying cosine annealing.

This PR introduces a real linear-warmup → cosine-decay schedule while preserving
the previous behavior for backward-compatible experiments.

Based on `dev`.

## Changes

### Scheduler behavior

- Add `WarmupCosineAnnealingLR`: linear warmup followed by
  `CosineAnnealingLR`.
- Rename the previous warmup → constant implementation to
  `WarmupConstantLR`.
- Keep `CosineAnnealingWarmUpRestarts` as an alias for the legacy constant
  implementation to preserve existing imports.
- Add `build_lr_scheduler(...)` to select `cosine` or `constant`.
- Prevent the legacy final-10-epoch manual LR step-down from overriding the
  cosine schedule. The legacy step-down remains active only in `constant` mode.

### Resume behavior

- Rebuild and fast-forward the scheduler to the completed training progress
  when resuming from a checkpoint.
- Avoid resetting a resumed cosine run directly to the peak learning rate.
- Preserve schedule continuity when resuming with either the same or a new base
  learning rate.
- Convert completed epochs to optimizer steps when using batch-level scheduler
  updates.

### Configuration

The following options are available through `TrainConfig` and
`train_predictor.py`:

| Option | Default | Description |
|---|---:|---|
| `lr_schedule_type` | `cosine` | `cosine` or legacy `constant` |
| `learning_rate` | `1e-4` | Peak/base learning rate |
| `warm_up_epoch` | `5` | Warmup duration in epochs |
| `lr_start_factor` | `0.1` | Initial LR as a fraction of the peak LR |
| `lr_eta_min` | `1e-6` | Minimum cosine LR |
| `lr_cosine_t_max` | `0` | Cosine duration in epochs; `0` selects the remaining epochs automatically |
| `lr_scheduler_interval` | `epoch` | Update the scheduler per `epoch` or per `batch` |

When `lr_scheduler_interval=batch`, warmup duration, explicit `T_max`, and
resume progress are converted from epochs to optimizer steps using the training
DataLoader length.

The legacy final-phase parameters remain unchanged.

## Behavior change and compatibility

- New training runs use actual cosine decay by default.
- The previous training policy remains available with
  `--lr_schedule_type constant`.
- Existing imports of `CosineAnnealingWarmUpRestarts` continue to work and
  retain the previous warmup → constant scheduler behavior.
- To reproduce an older run when resuming, explicitly select
  `--lr_schedule_type constant`.

## Verification

- LR scheduler tests: `15 passed`
- Ruff lint: passed
- Ruff format check: passed
- Pre-commit hooks: passed
- Verified cosine and legacy constant behavior with the mini dataset.
- Verified checkpoint resume without an LR jump.
- Verified custom `start_factor`, `eta_min`, `T_max`, and batch-level scheduler
  updates with a mini-dataset training run.
