### PR TITLE
feat: enable TF32 for torch GPU inference to match ORT CUDA EP

### DIFF
--- a/scenario_generation/simulate.py
+++ b/scenario_generation/simulate.py
@@ -41,6 +41,13 @@ def load_model(model_path: str | Path, device: str = "cuda"):
     from diffusion_planner.model.diffusion_planner import Diffusion_Planner
     from diffusion_planner.utils.config import Config
 
+    if str(device).startswith("cuda"):
+        # ORT's CUDAExecutionProvider defaults to TF32 matmuls on Ampere+; torch keeps matmul
+        # TF32 off by default, so the .pth and .onnx GPU rollouts diverge (~1e-3/layer, then
+        # amplified by the closed loop). Opt torch in so both runtimes compute the same way.
+        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.cudnn.allow_tf32 = True
+
     args_file = str(Path(model_path).parent / "args.json")
     args = Config(args_file)
     model = Diffusion_Planner(args)


### PR DESCRIPTION
## Background

pth and onnx inference results match on CPU but diverge by ~1e-3 on GPU, and the closed-loop sim results drift significantly as a consequence.

The root cause is that ONNX Runtime's CUDAExecutionProvider defaults to TF32 matmuls (10-bit mantissa) on Ampere+ GPUs, while PyTorch keeps matmul TF32 disabled by default. This injects ~1e-3 relative error at every layer, which then gets amplified exponentially by the iterative diffusion denoising and the closed-loop feedback.

## Changes

In `load_model` of `scenario_generation/simulate.py`, enable TF32 on the torch side when the device is cuda, aligning it with the ORT CUDA EP default:

- `torch.backends.cuda.matmul.allow_tf32 = True`
- `torch.backends.cudnn.allow_tf32 = True`

This removes the dominant source of the pth(GPU) vs onnx(GPU) mismatch with no speed penalty (the pth side actually gets faster).

## Trade-offs

- pth(GPU) numerical precision drops to TF32 level, so it no longer serves as a strict-FP32 reference (metrics are not strictly continuous with past FP32 closed-loop results)
- `torch.backends.*` flags are process-global: they affect all torch computation in the process after `load_model` is called
- Kernel-selection and reduction-order differences (~1e-5) still remain — this removes the dominant cause, it does not guarantee bitwise parity
- No-op on pre-Ampere GPUs

## Related

Complementary approach that makes the export-time validation strict FP32: branch `feat/strict-fp32-onnx-validation`