### PR TITLE
feat: ClosedLoopEvaluation class framework (PR 2/6)

### DIFF
--- a/scenario_generation/closed_loop_ddp.py
+++ b/scenario_generation/closed_loop_ddp.py
@@ -1,0 +1,42 @@
+"""DDP sharding helpers for closed-loop evaluation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def shard_items(items: list, rank: int, world_size: int) -> list:
+    """Round-robin assignment: rank ``r`` gets indices r, r+world_size, ..."""
+    if world_size <= 1:
+        return items
+    return [items[i] for i in range(rank, len(items), world_size)]
+
+
+def write_eval_shard(
+    out_dir: Path,
+    rank: int,
+    *,
+    mode: str,
+    rows: list[dict],
+    video_mp4s: list[Path],
+    elapsed_sec: float,
+    extras: dict[str, Any] | None = None,
+    profile: bool = False,
+) -> Path:
+    """Write a per-rank shard under ``out_dir/ddp_shards/rank_XXX.json``."""
+    shard_dir = out_dir / "ddp_shards"
+    shard_dir.mkdir(parents=True, exist_ok=True)
+    path = shard_dir / f"rank_{rank:03d}.json"
+    payload: dict[str, Any] = {
+        "mode": mode,
+        "rank": rank,
+        "rows": rows,
+        "video_mp4s": [str(p) for p in video_mp4s],
+        "elapsed_sec": elapsed_sec,
+        "extras": extras or {},
+        "profile": profile,
+    }
+    path.write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
+    return path

--- a/scenario_generation/closed_loop_ddp.py
+++ b/scenario_generation/closed_loop_ddp.py
@@ -2,41 +2,9 @@
 
 from __future__ import annotations
 
-import json
-from pathlib import Path
-from typing import Any
-
 
 def shard_items(items: list, rank: int, world_size: int) -> list:
     """Round-robin assignment: rank ``r`` gets indices r, r+world_size, ..."""
     if world_size <= 1:
         return items
     return [items[i] for i in range(rank, len(items), world_size)]
-
-
-def write_eval_shard(
-    out_dir: Path,
-    rank: int,
-    *,
-    mode: str,
-    rows: list[dict],
-    video_mp4s: list[Path],
-    elapsed_sec: float,
-    extras: dict[str, Any] | None = None,
-    profile: bool = False,
-) -> Path:
-    """Write a per-rank shard under ``out_dir/ddp_shards/rank_XXX.json``."""
-    shard_dir = out_dir / "ddp_shards"
-    shard_dir.mkdir(parents=True, exist_ok=True)
-    path = shard_dir / f"rank_{rank:03d}.json"
-    payload: dict[str, Any] = {
-        "mode": mode,
-        "rank": rank,
-        "rows": rows,
-        "video_mp4s": [str(p) for p in video_mp4s],
-        "elapsed_sec": elapsed_sec,
-        "extras": extras or {},
-        "profile": profile,
-    }
-    path.write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
-    return path

--- a/scenario_generation/closed_loop_evaluation.py
+++ b/scenario_generation/closed_loop_evaluation.py
@@ -21,7 +21,12 @@ from pathlib import Path
 from typing import Any
 
 from scenario_generation.closed_loop_ddp import shard_items
-from scenario_generation.closed_loop_eval import aggregate, build_mp4, enumerate_multi_root_routes
+from scenario_generation.closed_loop_eval import (
+    aggregate,
+    build_mp4,
+    enumerate_multi_root_routes,
+    format_summary_lines,
+)
 from scenario_generation.perf_timer import Timers
 from scenario_generation.reproducer_rollout import render_segment
 from scenario_generation.route_timeline import RouteTimeline
@@ -432,10 +437,11 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
             build_mp4(png_dir, seg_mp4, self.config.fps)
             video_mp4s.append(seg_mp4)
             if self.config.verbose:
+                obj = metrics["object"]
                 print(
                     f"  [{job.route_key}] segment [{start},{end}] -> {seg_mp4.name}  "
-                    f"coll={metrics['n_collision_steps']} near={metrics['n_near_miss_steps']} "
-                    f"min_clr={metrics['min_clearance']:.3f}"
+                    f"coll={obj['collision_steps']} near={obj['miss_steps']} "
+                    f"min_clr={obj['clearance_min_m']:.3f}"
                 )
 
         extras: dict[str, Any] = {}
@@ -475,25 +481,10 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
             )
 
     def print_summary(self, summary: dict) -> None:
-        near_miss_thresh = self.config.params.near_miss_thresh
         n_seg = summary["n_segments"]
         print(f"\n=== closed-loop validation: {n_seg} segments in {summary['elapsed_sec']:.1f}s ===")
-        print(
-            f"collision: {summary['n_segments_with_collision']}/{n_seg} segments "
-            f"(rate {summary['collision_segment_rate']:.4f}), "
-            f"{summary['total_collision_steps']} steps (rate {summary['collision_step_rate']:.6f})"
-        )
-        print(
-            f"near-miss (<= {near_miss_thresh} m): "
-            f"{summary['n_segments_with_near_miss']}/{n_seg} segments "
-            f"(rate {summary['near_miss_segment_rate']:.4f}), {summary['total_near_miss_steps']} steps"
-        )
-        print(
-            f"global_min_clearance={summary['global_min_clearance']:.3f} m  "
-            f"mean_segment_min_clearance={summary['mean_segment_min_clearance']:.3f} m  "
-            f"mean_segment_mean_clearance={summary['mean_segment_mean_clearance']:.3f} m"
-        )
-        print(f"total_snaps={summary['total_snaps']}  terminated={summary['terminated_counts']}")
+        for line in format_summary_lines(summary):
+            print(line)
         print(f"videos: per-segment <route>_<start>_<end>.mp4 in {self.out_dir}")
 
     def prepare_ddp_merge_artifacts(self, result: JobRunResult) -> None:

--- a/scenario_generation/closed_loop_evaluation.py
+++ b/scenario_generation/closed_loop_evaluation.py
@@ -1,0 +1,496 @@
+"""Class-based closed-loop evaluation framework.
+
+``ClosedLoopEvaluation`` defines the shared workflow:
+
+  1. ``discover_jobs`` — what to evaluate (routes, bags, classification dates, …)
+  2. ``shard_jobs`` — DDP round-robin assignment (override for custom sharding)
+  3. ``run_job`` — rollout for one job unit (segments via ``render_segment``, etc.)
+  4. ``build_summary`` / ``write_artifacts`` / ``print_summary`` — serialize + terminal output
+
+``FullRouteClosedLoopEvaluation`` is the segment-wise evaluator (``segments.jsonl``) over every
+route under an npz_root.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from scenario_generation.closed_loop_ddp import shard_items
+from scenario_generation.closed_loop_eval import aggregate, build_mp4, enumerate_routes
+from scenario_generation.perf_timer import Timers
+from scenario_generation.reproducer_rollout import render_segment
+from scenario_generation.route_timeline import RouteTimeline
+
+
+@dataclass
+class RolloutParams:
+    """Rollout knobs for full-route segment evaluation."""
+
+    device: str = "cuda"
+    near_miss_thresh: float = 0.5
+    search_radius: float = 1.5
+    warmup_steps: int = 0
+    unstick_after: int = 300
+    unstick_advance_m: float = 2.5
+    unstick_radius_mult: float = 10.0
+    unstick_teleport_after: int = 300
+    draw_every: int = 8
+    replan_interval: int = 10
+    tracker_mode: str = "mpc"
+    neighbor_history_mode: str = "recorded"
+    # Early-abort a badly-diverged segment instead of burning the full step budget on a
+    # rollout that will never recover (e.g. an undertrained model driving off-lane). Set well
+    # above the unstick_* knobs above: unstick snaps the ego back onto GT to let a merely-stuck
+    # rollout continue; abort gives up on a rollout unstick can't save. 0 = disabled for either
+    # knob. See ``reproducer_rollout.render_segment`` for the exact trigger condition.
+    abort_deviation_m: float = 50.0
+    abort_after: int = 30
+    abort_max_snaps: int = 0
+    # Empty-world ablation: zero neighbor_agents_past + static_objects each step (map kept) —
+    # separates "reacts badly to traffic" from "can't follow the route/map". collision/near-miss
+    # are 0 by construction when this is set.
+    drop_objects: bool = False
+
+    def render_kwargs(self) -> dict[str, Any]:
+        return {
+            "device": self.device,
+            "near_miss_thresh": self.near_miss_thresh,
+            "search_radius": self.search_radius,
+            "warmup_steps": self.warmup_steps,
+            "unstick_after": self.unstick_after,
+            "unstick_advance_m": self.unstick_advance_m,
+            "unstick_radius_mult": self.unstick_radius_mult,
+            "unstick_teleport_after": self.unstick_teleport_after,
+            "draw_every": self.draw_every,
+            "replan_interval": self.replan_interval,
+            "tracker_mode": self.tracker_mode,
+            "neighbor_history_mode": self.neighbor_history_mode,
+            "abort_deviation_m": self.abort_deviation_m,
+            "abort_after": self.abort_after,
+            "abort_max_snaps": self.abort_max_snaps,
+            "drop_objects": self.drop_objects,
+        }
+
+
+@dataclass
+class ClosedLoopEvalConfig:
+    """Shared configuration for any closed-loop evaluation mode."""
+
+    out_dir: Path
+    params: RolloutParams
+    fps: float = 10.0
+    verbose: bool = True
+    profile: bool = False
+    max_jobs: int | None = None
+
+
+@dataclass
+class ClosedLoopJob:
+    """One schedulable unit (route, bag, classification date, …)."""
+
+    job_id: str
+
+
+@dataclass
+class JobRunResult:
+    """Accumulated rows + artifacts from one or more jobs on this rank."""
+
+    rows: list[dict] = field(default_factory=list)
+    video_mp4s: list[Path] = field(default_factory=list)
+    extras: dict[str, Any] = field(default_factory=dict)
+    elapsed_sec: float = 0.0
+
+
+class ClosedLoopEvaluation(ABC):
+    """Template-method closed-loop evaluation workflow."""
+
+    mode: str = "base"
+
+    def __init__(
+        self,
+        model,
+        model_args,
+        config: ClosedLoopEvalConfig,
+        *,
+        ddp_rank: int = 0,
+        ddp_world_size: int = 1,
+    ) -> None:
+        self.model = model
+        self.model_args = model_args
+        self.config = config
+        self.ddp_rank = ddp_rank
+        self.ddp_world_size = ddp_world_size
+        self.out_dir = Path(config.out_dir)
+        self.out_dir.mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
+    def load_model_pair(model_path: Path | str, device: str):
+        """Load a torch checkpoint or ONNX export (``args.json`` next to the file)."""
+        from scenario_generation.simulate import load_model, load_onnx_model
+
+        model_path = Path(model_path)
+        if model_path.suffix == ".onnx":
+            return load_onnx_model(model_path, device)
+        return load_model(model_path, device)
+
+    def run(self) -> dict:
+        """Discover jobs, optionally shard for DDP, execute, summarize, and persist."""
+        t0 = time.perf_counter()
+        jobs = self.discover_jobs()
+        if self.config.max_jobs is not None:
+            jobs = jobs[: self.config.max_jobs]
+        jobs = self.shard_jobs(jobs)
+        if self.config.verbose and jobs and self.ddp_world_size > 1:
+            print(
+                f"DDP rank {self.ddp_rank}/{self.ddp_world_size}: "
+                f"{len(jobs)} job(s) -> {[j.job_id for j in jobs]}"
+            )
+
+        result = self.execute_jobs(jobs)
+        elapsed_sec = time.perf_counter() - t0
+
+        if self.ddp_world_size > 1:
+            return self.finalize_ddp(result, elapsed_sec=elapsed_sec)
+
+        summary = self.build_summary(result, elapsed_sec=elapsed_sec)
+        summary["mode"] = self.mode
+        summary["ddp_rank"] = self.ddp_rank
+        summary["ddp_world_size"] = self.ddp_world_size
+        self.write_artifacts(summary, result)
+        if self.config.verbose:
+            self.print_summary(summary)
+        return summary
+
+    def run_distributed(self) -> dict:
+        """Run evaluation; under DDP, barrier then rank-0 ``merge_ddp_shards``."""
+        partial = self.run()
+        if self.ddp_world_size <= 1:
+            return partial
+        try:
+            import torch.distributed as dist
+        except ImportError:
+            return partial
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+        if self.ddp_rank != 0:
+            return {}
+        if partial.get("ddp_shard"):
+            return self.merge_ddp_shards(self.ddp_world_size)
+        return partial
+
+    def shard_jobs(self, jobs: list[ClosedLoopJob]) -> list[ClosedLoopJob]:
+        return shard_items(jobs, self.ddp_rank, self.ddp_world_size)
+
+    def initial_job_extras(self) -> dict[str, Any]:
+        return {}
+
+    def merge_job_result(self, merged: JobRunResult, partial: JobRunResult) -> None:
+        merged.rows.extend(partial.rows)
+        merged.video_mp4s.extend(partial.video_mp4s)
+        for key, value in partial.extras.items():
+            if key in merged.extras and isinstance(merged.extras[key], list):
+                merged.extras[key].extend(value)
+            elif key in merged.extras and isinstance(merged.extras[key], dict):
+                merged.extras[key].update(value)
+            elif key in merged.extras and isinstance(merged.extras[key], int):
+                merged.extras[key] = int(merged.extras[key]) + int(value)
+            else:
+                merged.extras[key] = value
+
+    def on_job_complete(
+        self,
+        job: ClosedLoopJob,
+        partial: JobRunResult,
+        index: int,
+        total: int,
+    ) -> None:
+        """Hook for per-job progress (subclasses print route/bag summaries here)."""
+
+    def execute_jobs(self, jobs: list[ClosedLoopJob]) -> JobRunResult:
+        merged = JobRunResult(extras=self.initial_job_extras())
+        for ri, job in enumerate(jobs):
+            partial = self.run_job(job)
+            self.merge_job_result(merged, partial)
+            self.on_job_complete(job, partial, ri, len(jobs))
+        return merged
+
+    def ddp_shard_extras(self, result: JobRunResult) -> dict[str, Any]:
+        return dict(result.extras)
+
+    def finalize_ddp(self, result: JobRunResult, *, elapsed_sec: float) -> dict:
+        from scenario_generation.closed_loop_ddp import write_eval_shard
+
+        write_eval_shard(
+            self.out_dir,
+            self.ddp_rank,
+            mode=self.mode,
+            rows=result.rows,
+            video_mp4s=result.video_mp4s,
+            elapsed_sec=elapsed_sec,
+            extras=self.ddp_shard_extras(result),
+            profile=self.config.profile,
+        )
+        return self.ddp_partial_summary(result, elapsed_sec=elapsed_sec)
+
+    def ddp_partial_summary(self, result: JobRunResult, *, elapsed_sec: float) -> dict:
+        return {
+            "mode": self.mode,
+            "ddp_shard": True,
+            "ddp_rank": self.ddp_rank,
+            "ddp_world_size": self.ddp_world_size,
+            "n_rows": len(result.rows),
+            "elapsed_sec": elapsed_sec,
+        }
+
+    def collect_ddp_shards(self, world_size: int) -> JobRunResult:
+        """Load per-rank shard JSON written under ``out_dir/ddp_shards/``."""
+        merged = JobRunResult()
+        for rank in range(world_size):
+            path = self.out_dir / "ddp_shards" / f"rank_{rank:03d}.json"
+            if not path.is_file():
+                continue
+            shard = json.loads(path.read_text(encoding="utf-8"))
+            merged.rows.extend(shard.get("rows") or [])
+            merged.video_mp4s.extend(Path(p) for p in shard.get("video_mp4s") or [])
+            merged.elapsed_sec = max(merged.elapsed_sec, float(shard.get("elapsed_sec", 0.0)))
+            self.merge_job_result(merged, JobRunResult(extras=shard.get("extras") or {}))
+        return merged
+
+    def merge_ddp_shards(self, world_size: int) -> dict:
+        """Rank-0: merge shard files, persist artifacts, and return the final summary."""
+        result = self.collect_ddp_shards(world_size)
+        self.prepare_ddp_merge_artifacts(result)
+        summary = self.build_summary(result, elapsed_sec=result.elapsed_sec)
+        summary["mode"] = self.mode
+        summary["ddp_shard"] = True
+        summary["ddp_world_size"] = world_size
+        self.write_artifacts(summary, result)
+        if self.config.verbose:
+            self.print_summary(summary)
+        return summary
+
+    def prepare_ddp_merge_artifacts(self, result: JobRunResult) -> None:
+        """Hook for mode-specific files written during rank-0 DDP merge."""
+
+    @abstractmethod
+    def discover_jobs(self) -> list[ClosedLoopJob]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def run_job(self, job: ClosedLoopJob) -> JobRunResult:
+        raise NotImplementedError
+
+    @abstractmethod
+    def build_summary(self, result: JobRunResult, *, elapsed_sec: float) -> dict:
+        raise NotImplementedError
+
+    @abstractmethod
+    def write_artifacts(self, summary: dict, result: JobRunResult) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def print_summary(self, summary: dict) -> None:
+        raise NotImplementedError
+
+
+@dataclass
+class FullRouteRouteJob(ClosedLoopJob):
+    """One route (bag-prefix group) under an NPZ root."""
+
+    npz_root: Path = field(default_factory=Path)
+    route_key: str = ""
+    route_paths: list[Path] = field(default_factory=list)
+    seg_len: int = 100_000
+
+
+class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
+    """Segment-wise full-route closed-loop over every route under ``npz_root``."""
+
+    mode = "full"
+
+    def __init__(
+        self,
+        model,
+        model_args,
+        config: ClosedLoopEvalConfig,
+        npz_root: Path | str,
+        *,
+        seg_len: int = 100_000,
+        ddp_rank: int = 0,
+        ddp_world_size: int = 1,
+    ) -> None:
+        super().__init__(
+            model,
+            model_args,
+            config,
+            ddp_rank=ddp_rank,
+            ddp_world_size=ddp_world_size,
+        )
+        self.npz_root = Path(npz_root)
+        self.seg_len = seg_len
+
+    @classmethod
+    def from_checkpoint(
+        cls,
+        model_path: Path | str,
+        npz_root: Path | str,
+        config: ClosedLoopEvalConfig,
+        *,
+        seg_len: int = 100_000,
+        ddp_rank: int = 0,
+        ddp_world_size: int = 1,
+    ) -> FullRouteClosedLoopEvaluation:
+        model, model_args = cls.load_model_pair(model_path, config.params.device)
+        return cls(
+            model,
+            model_args,
+            config,
+            npz_root,
+            seg_len=seg_len,
+            ddp_rank=ddp_rank,
+            ddp_world_size=ddp_world_size,
+        )
+
+    def discover_jobs(self) -> list[FullRouteRouteJob]:
+        routes = enumerate_routes(self.npz_root)
+        return [
+            FullRouteRouteJob(
+                job_id=key,
+                npz_root=self.npz_root,
+                route_key=key,
+                route_paths=routes[key],
+                seg_len=self.seg_len,
+            )
+            for key in sorted(routes)
+        ]
+
+    def initial_job_extras(self) -> dict[str, Any]:
+        return {"route_keys": []}
+
+    def execute_jobs(self, jobs: list[ClosedLoopJob]) -> JobRunResult:
+        """Stream per-segment rows to ``segments.jsonl`` while jobs run."""
+        merged = JobRunResult(extras={"route_keys": []})
+        segments_path = self.out_dir / "segments.jsonl"
+        with segments_path.open("w", encoding="utf-8") as fout:
+            for ri, job in enumerate(jobs):
+                assert isinstance(job, FullRouteRouteJob)
+                partial = self.run_job(job, segments_file=fout)
+                merged.rows.extend(partial.rows)
+                merged.video_mp4s.extend(partial.video_mp4s)
+                merged.extras["route_keys"].append(job.route_key)
+                self.on_job_complete(job, partial, ri, len(jobs))
+        return merged
+
+    def run_job(
+        self,
+        job: ClosedLoopJob,
+        *,
+        segments_file=None,
+    ) -> JobRunResult:
+        assert isinstance(job, FullRouteRouteJob)
+        params = self.config.params
+        timers = Timers() if self.config.profile else None
+        tl = RouteTimeline(job.route_paths, sidecar_dir=job.npz_root, timers=timers)
+        rows: list[dict] = []
+        video_mp4s: list[Path] = []
+
+        for start, end in tl.iter_segments(job.seg_len):
+            png_dir = self.out_dir / f"{job.route_key}_{start}_{end}"
+            metrics = render_segment(
+                self.model,
+                self.model_args,
+                tl,
+                start,
+                end,
+                png_dir,
+                **params.render_kwargs(),
+            )
+            row = {"route": job.route_key, **metrics}
+            if segments_file is not None:
+                segments_file.write(json.dumps(row, default=float) + "\n")
+                segments_file.flush()
+            rows.append(row)
+
+            if not any(png_dir.glob("*.png")):
+                if self.config.verbose:
+                    print(
+                        f"  [{job.route_key}] segment [{start},{end}] -> 0 frames, no video"
+                    )
+                continue
+            seg_mp4 = self.out_dir / f"{job.route_key}_{start}_{end}.mp4"
+            build_mp4(png_dir, seg_mp4, self.config.fps)
+            video_mp4s.append(seg_mp4)
+            if self.config.verbose:
+                print(
+                    f"  [{job.route_key}] segment [{start},{end}] -> {seg_mp4.name}  "
+                    f"coll={metrics['n_collision_steps']} near={metrics['n_near_miss_steps']} "
+                    f"min_clr={metrics['min_clearance']:.3f}"
+                )
+
+        extras: dict[str, Any] = {}
+        if timers is not None:
+            extras["timers"] = timers
+        return JobRunResult(rows=rows, video_mp4s=video_mp4s, extras=extras)
+
+    def on_job_complete(
+        self,
+        job: ClosedLoopJob,
+        partial: JobRunResult,
+        index: int,
+        total: int,
+    ) -> None:
+        assert isinstance(job, FullRouteRouteJob)
+        if self.config.verbose:
+            print(
+                f"[{index + 1}/{total}] {job.route_key}: "
+                f"{len(partial.video_mp4s)} segment video(s)"
+            )
+
+    def build_summary(self, result: JobRunResult, *, elapsed_sec: float) -> dict:
+        summary = aggregate(result.rows, self.config.params.near_miss_thresh)
+        summary["npz_root"] = str(self.npz_root)
+        summary["n_routes"] = len(set(result.extras.get("route_keys") or []))
+        summary["elapsed_sec"] = elapsed_sec
+        summary["video_mp4s"] = result.video_mp4s
+        summary["segments"] = result.rows
+        return summary
+
+    def write_artifacts(self, summary: dict, result: JobRunResult) -> None:
+        with open(self.out_dir / "summary.json", "w", encoding="utf-8") as f:
+            json.dump(
+                {k: v for k, v in summary.items() if k not in ("video_mp4s", "segments")},
+                f,
+                indent=4,
+            )
+
+    def print_summary(self, summary: dict) -> None:
+        near_miss_thresh = self.config.params.near_miss_thresh
+        n_seg = summary["n_segments"]
+        print(f"\n=== closed-loop validation: {n_seg} segments in {summary['elapsed_sec']:.1f}s ===")
+        print(
+            f"collision: {summary['n_segments_with_collision']}/{n_seg} segments "
+            f"(rate {summary['collision_segment_rate']:.4f}), "
+            f"{summary['total_collision_steps']} steps (rate {summary['collision_step_rate']:.6f})"
+        )
+        print(
+            f"near-miss (<= {near_miss_thresh} m): "
+            f"{summary['n_segments_with_near_miss']}/{n_seg} segments "
+            f"(rate {summary['near_miss_segment_rate']:.4f}), {summary['total_near_miss_steps']} steps"
+        )
+        print(
+            f"global_min_clearance={summary['global_min_clearance']:.3f} m  "
+            f"mean_segment_min_clearance={summary['mean_segment_min_clearance']:.3f} m  "
+            f"mean_segment_mean_clearance={summary['mean_segment_mean_clearance']:.3f} m"
+        )
+        print(f"total_snaps={summary['total_snaps']}  terminated={summary['terminated_counts']}")
+        print(f"videos: per-segment <route>_<start>_<end>.mp4 in {self.out_dir}")
+
+    def prepare_ddp_merge_artifacts(self, result: JobRunResult) -> None:
+        with open(self.out_dir / "segments.jsonl", "w", encoding="utf-8") as fout:
+            for row in result.rows:
+                fout.write(json.dumps(row, default=float) + "\n")

--- a/scenario_generation/closed_loop_evaluation.py
+++ b/scenario_generation/closed_loop_evaluation.py
@@ -429,9 +429,7 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
 
             if not any(png_dir.glob("*.png")):
                 if self.config.verbose:
-                    print(
-                        f"  [{job.route_key}] segment [{start},{end}] -> 0 frames, no video"
-                    )
+                    print(f"  [{job.route_key}] segment [{start},{end}] -> 0 frames, no video")
                 continue
             seg_mp4 = self.out_dir / f"{job.route_key}_{start}_{end}.mp4"
             build_mp4(png_dir, seg_mp4, self.config.fps)
@@ -459,8 +457,7 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
         assert isinstance(job, FullRouteRouteJob)
         if self.config.verbose:
             print(
-                f"[{index + 1}/{total}] {job.route_key}: "
-                f"{len(partial.video_mp4s)} segment video(s)"
+                f"[{index + 1}/{total}] {job.route_key}: {len(partial.video_mp4s)} segment video(s)"
             )
 
     def build_summary(self, result: JobRunResult, *, elapsed_sec: float) -> dict:
@@ -482,7 +479,9 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
 
     def print_summary(self, summary: dict) -> None:
         n_seg = summary["n_segments"]
-        print(f"\n=== closed-loop validation: {n_seg} segments in {summary['elapsed_sec']:.1f}s ===")
+        print(
+            f"\n=== closed-loop validation: {n_seg} segments in {summary['elapsed_sec']:.1f}s ==="
+        )
         for line in format_summary_lines(summary):
             print(line)
         print(f"videos: per-segment <route>_<start>_<end>.mp4 in {self.out_dir}")

--- a/scenario_generation/closed_loop_evaluation.py
+++ b/scenario_generation/closed_loop_evaluation.py
@@ -186,6 +186,7 @@ class ClosedLoopEvaluation(ABC):
         merging before every other rank has finished writing its ``segments_{rank}.jsonl``
         shard, silently producing a summary built from a partial/incomplete set of ranks.
         """
+        t0 = time.perf_counter()
         partial = self.run()
         if self.ddp_world_size <= 1:
             return partial
@@ -201,7 +202,7 @@ class ClosedLoopEvaluation(ABC):
         if self.ddp_rank != 0:
             return {}
         if partial.get("ddp_shard"):
-            return self.merge_ddp_shards(self.ddp_world_size)
+            return self.merge_ddp_shards(self.ddp_world_size, elapsed_sec=time.perf_counter() - t0)
         return partial
 
     def shard_jobs(self, jobs: list[ClosedLoopJob]) -> list[ClosedLoopJob]:
@@ -279,11 +280,11 @@ class ClosedLoopEvaluation(ABC):
         video_mp4s = sorted(self.out_dir.glob("*.mp4"))
         return JobRunResult(rows=rows, video_mp4s=video_mp4s)
 
-    def merge_ddp_shards(self, world_size: int) -> dict:
+    def merge_ddp_shards(self, world_size: int, *, elapsed_sec: float = 0.0) -> dict:
         """Rank-0: merge shard files, persist artifacts, and return the final summary."""
         result = self.collect_ddp_shards(world_size)
         self.prepare_ddp_merge_artifacts(result)
-        summary = self.build_summary(result, elapsed_sec=result.elapsed_sec)
+        summary = self.build_summary(result, elapsed_sec=elapsed_sec)
         summary["mode"] = self.mode
         summary["ddp_shard"] = True
         summary["ddp_world_size"] = world_size

--- a/scenario_generation/closed_loop_evaluation.py
+++ b/scenario_generation/closed_loop_evaluation.py
@@ -243,9 +243,6 @@ class ClosedLoopEvaluation(ABC):
         ``segments_{rank}.jsonl`` (+ tdigest sidecar) directly -- no separate shard blob to write
         here, so a crashed rank can't leave stale/inconsistent shard state behind.
         """
-        return self.ddp_partial_summary(result, elapsed_sec=elapsed_sec)
-
-    def ddp_partial_summary(self, result: JobRunResult, *, elapsed_sec: float) -> dict:
         return {
             "mode": self.mode,
             "ddp_shard": True,

--- a/scenario_generation/closed_loop_evaluation.py
+++ b/scenario_generation/closed_loop_evaluation.py
@@ -26,6 +26,9 @@ from scenario_generation.closed_loop_eval import (
     build_mp4,
     enumerate_multi_root_routes,
     format_summary_lines,
+    load_segment_rows_with_tdigests,
+    segment_row_for_json,
+    tdigest_sidecar_row,
 )
 from scenario_generation.perf_timer import Timers
 from scenario_generation.reproducer_rollout import render_segment
@@ -172,16 +175,25 @@ class ClosedLoopEvaluation(ABC):
         return summary
 
     def run_distributed(self) -> dict:
-        """Run evaluation; under DDP, barrier then rank-0 ``merge_ddp_shards``."""
+        """Run evaluation; under DDP, barrier then rank-0 ``merge_ddp_shards``.
+
+        Requires an initialized process group whenever ``ddp_world_size > 1``: skipping the
+        barrier (e.g. because torch.distributed was never initialized) would let rank-0 start
+        merging before every other rank has finished writing its ``segments_{rank}.jsonl``
+        shard, silently producing a summary built from a partial/incomplete set of ranks.
+        """
         partial = self.run()
         if self.ddp_world_size <= 1:
             return partial
-        try:
-            import torch.distributed as dist
-        except ImportError:
-            return partial
-        if dist.is_available() and dist.is_initialized():
-            dist.barrier()
+        import torch.distributed as dist
+
+        if not (dist.is_available() and dist.is_initialized()):
+            raise RuntimeError(
+                f"closed-loop run_distributed: ddp_world_size={self.ddp_world_size} > 1 but "
+                "torch.distributed is not initialized -- refusing to merge without a barrier "
+                "to guarantee every rank finished writing its shard first."
+            )
+        dist.barrier()
         if self.ddp_rank != 0:
             return {}
         if partial.get("ddp_shard"):
@@ -224,22 +236,13 @@ class ClosedLoopEvaluation(ABC):
             self.on_job_complete(job, partial, ri, len(jobs))
         return merged
 
-    def ddp_shard_extras(self, result: JobRunResult) -> dict[str, Any]:
-        return dict(result.extras)
-
     def finalize_ddp(self, result: JobRunResult, *, elapsed_sec: float) -> dict:
-        from scenario_generation.closed_loop_ddp import write_eval_shard
+        """Signal rank-0 to merge once every rank reaches the barrier.
 
-        write_eval_shard(
-            self.out_dir,
-            self.ddp_rank,
-            mode=self.mode,
-            rows=result.rows,
-            video_mp4s=result.video_mp4s,
-            elapsed_sec=elapsed_sec,
-            extras=self.ddp_shard_extras(result),
-            profile=self.config.profile,
-        )
+        Per-rank rows are already durably persisted by ``execute_jobs`` writing
+        ``segments_{rank}.jsonl`` (+ tdigest sidecar) directly -- no separate shard blob to write
+        here, so a crashed rank can't leave stale/inconsistent shard state behind.
+        """
         return self.ddp_partial_summary(result, elapsed_sec=elapsed_sec)
 
     def ddp_partial_summary(self, result: JobRunResult, *, elapsed_sec: float) -> dict:
@@ -253,18 +256,27 @@ class ClosedLoopEvaluation(ABC):
         }
 
     def collect_ddp_shards(self, world_size: int) -> JobRunResult:
-        """Load per-rank shard JSON written under ``out_dir/ddp_shards/``."""
-        merged = JobRunResult()
-        for rank in range(world_size):
-            path = self.out_dir / "ddp_shards" / f"rank_{rank:03d}.json"
-            if not path.is_file():
-                continue
-            shard = json.loads(path.read_text(encoding="utf-8"))
-            merged.rows.extend(shard.get("rows") or [])
-            merged.video_mp4s.extend(Path(p) for p in shard.get("video_mp4s") or [])
-            merged.elapsed_sec = max(merged.elapsed_sec, float(shard.get("elapsed_sec", 0.0)))
-            self.merge_job_result(merged, JobRunResult(extras=shard.get("extras") or {}))
-        return merged
+        """Load every rank's ``segments_{rank}.jsonl`` (+ tdigest sidecar), the same convention
+        ``closed_loop_eval.run_closed_loop_eval`` uses for its own multi-GPU shards.
+
+        Fails loudly if any rank's file is missing (crashed before writing, or never reached
+        ``finalize_ddp``) instead of silently merging a partial result as a "successful" summary.
+        Videos are found by globbing the shared ``out_dir`` directly -- every rank renders into
+        the same directory with globally-unique route-keyed filenames, so there's nothing to
+        track per-shard.
+        """
+        missing = [
+            r for r in range(world_size) if not (self.out_dir / f"segments_{r}.jsonl").is_file()
+        ]
+        if missing:
+            raise RuntimeError(
+                f"closed-loop DDP merge: missing segments_<rank>.jsonl for rank(s) {missing} "
+                f"under {self.out_dir} (world_size={world_size}) -- one or more ranks likely "
+                "crashed or never reached finalize_ddp; refusing to merge a partial result."
+            )
+        rows = load_segment_rows_with_tdigests(self.out_dir, shard_glob="segments_*.jsonl")
+        video_mp4s = sorted(self.out_dir.glob("*.mp4"))
+        return JobRunResult(rows=rows, video_mp4s=video_mp4s)
 
     def merge_ddp_shards(self, world_size: int) -> dict:
         """Rank-0: merge shard files, persist artifacts, and return the final summary."""
@@ -384,13 +396,20 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
         return {"route_keys": []}
 
     def execute_jobs(self, jobs: list[ClosedLoopJob]) -> JobRunResult:
-        """Stream per-segment rows to ``segments.jsonl`` while jobs run."""
+        """Stream per-segment rows to ``segments.jsonl`` (``segments_{rank}.jsonl`` + a tdigest
+        sidecar under DDP sharding -- the same convention ``run_closed_loop_eval`` uses), while
+        jobs run."""
         merged = JobRunResult(extras={"route_keys": []})
-        segments_path = self.out_dir / "segments.jsonl"
-        with segments_path.open("w", encoding="utf-8") as fout:
+        suffix = f"_{self.ddp_rank}" if self.ddp_world_size > 1 else ""
+        segments_path = self.out_dir / f"segments{suffix}.jsonl"
+        digests_path = self.out_dir / f"tdigests{suffix}.jsonl"
+        with (
+            segments_path.open("w", encoding="utf-8") as fout,
+            digests_path.open("w", encoding="utf-8") as fdigest,
+        ):
             for ri, job in enumerate(jobs):
                 assert isinstance(job, FullRouteRouteJob)
-                partial = self.run_job(job, segments_file=fout)
+                partial = self.run_job(job, segments_file=fout, digest_file=fdigest)
                 merged.rows.extend(partial.rows)
                 merged.video_mp4s.extend(partial.video_mp4s)
                 merged.extras["route_keys"].append(job.route_key)
@@ -402,6 +421,7 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
         job: ClosedLoopJob,
         *,
         segments_file=None,
+        digest_file=None,
     ) -> JobRunResult:
         assert isinstance(job, FullRouteRouteJob)
         params = self.config.params
@@ -423,8 +443,16 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
             )
             row = {"route": job.route_key, **metrics}
             if segments_file is not None:
-                segments_file.write(json.dumps(row, default=float) + "\n")
+                # Human-readable segments.jsonl never carries the raw _tdigest blobs; those go to
+                # the sidecar so a later DDP merge (or a re-load of this run) can still pool an
+                # approximate global clearance percentile without the full per-step samples.
+                segments_file.write(json.dumps(segment_row_for_json(row), default=float) + "\n")
                 segments_file.flush()
+                if digest_file is not None:
+                    side = tdigest_sidecar_row(row)
+                    if side is not None:
+                        digest_file.write(json.dumps(side, default=float) + "\n")
+                        digest_file.flush()
             rows.append(row)
 
             if not any(png_dir.glob("*.png")):
@@ -463,7 +491,10 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
     def build_summary(self, result: JobRunResult, *, elapsed_sec: float) -> dict:
         summary = aggregate(result.rows, self.config.params.near_miss_thresh)
         summary["npz_root"] = str(self.npz_root)
-        summary["n_routes"] = len(set(result.extras.get("route_keys") or []))
+        # Derived straight from the merged rows (each carries its own "route") rather than
+        # extras["route_keys"] -- extras aren't reconstructed across a DDP merge (see
+        # collect_ddp_shards), so this stays correct for both the single-process and merged path.
+        summary["n_routes"] = len({r["route"] for r in result.rows})
         summary["elapsed_sec"] = elapsed_sec
         summary["video_mp4s"] = result.video_mp4s
         summary["segments"] = result.rows
@@ -487,6 +518,9 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
         print(f"videos: per-segment <route>_<start>_<end>.mp4 in {self.out_dir}")
 
     def prepare_ddp_merge_artifacts(self, result: JobRunResult) -> None:
+        """Rewrite ``segments.jsonl`` as the single merged, human-readable view across every
+        rank's ``segments_{rank}.jsonl`` (digests stripped, same convention ``execute_jobs`` uses
+        for the non-sharded path)."""
         with open(self.out_dir / "segments.jsonl", "w", encoding="utf-8") as fout:
             for row in result.rows:
-                fout.write(json.dumps(row, default=float) + "\n")
+                fout.write(json.dumps(segment_row_for_json(row), default=float) + "\n")

--- a/scenario_generation/closed_loop_evaluation.py
+++ b/scenario_generation/closed_loop_evaluation.py
@@ -115,7 +115,6 @@ class JobRunResult:
     rows: list[dict] = field(default_factory=list)
     video_mp4s: list[Path] = field(default_factory=list)
     extras: dict[str, Any] = field(default_factory=dict)
-    elapsed_sec: float = 0.0
 
 
 class ClosedLoopEvaluation(ABC):

--- a/scenario_generation/closed_loop_evaluation.py
+++ b/scenario_generation/closed_loop_evaluation.py
@@ -51,6 +51,8 @@ class RolloutParams:
     replan_interval: int = 10
     tracker_mode: str = "mpc"
     neighbor_history_mode: str = "recorded"
+    yaw_gate: bool = True
+    strong_brake_mps2: float = -2.5
     # Early-abort a badly-diverged segment instead of burning the full step budget on a
     # rollout that will never recover (e.g. an undertrained model driving off-lane). Set well
     # above the unstick_* knobs above: unstick snaps the ego back onto GT to let a merely-stuck
@@ -78,6 +80,8 @@ class RolloutParams:
             "replan_interval": self.replan_interval,
             "tracker_mode": self.tracker_mode,
             "neighbor_history_mode": self.neighbor_history_mode,
+            "yaw_gate": self.yaw_gate,
+            "strong_brake_mps2": self.strong_brake_mps2,
             "abort_deviation_m": self.abort_deviation_m,
             "abort_after": self.abort_after,
             "abort_max_snaps": self.abort_max_snaps,
@@ -486,7 +490,11 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
             )
 
     def build_summary(self, result: JobRunResult, *, elapsed_sec: float) -> dict:
-        summary = aggregate(result.rows, self.config.params.near_miss_thresh)
+        summary = aggregate(
+            result.rows,
+            self.config.params.near_miss_thresh,
+            strong_brake_mps2=self.config.params.strong_brake_mps2,
+        )
         summary["npz_root"] = str(self.npz_root)
         # Derived straight from the merged rows (each carries its own "route") rather than
         # extras["route_keys"] -- extras aren't reconstructed across a DDP merge (see

--- a/scenario_generation/closed_loop_evaluation.py
+++ b/scenario_generation/closed_loop_evaluation.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import Any
 
 from scenario_generation.closed_loop_ddp import shard_items
-from scenario_generation.closed_loop_eval import aggregate, build_mp4, enumerate_routes
+from scenario_generation.closed_loop_eval import aggregate, build_mp4, enumerate_multi_root_routes
 from scenario_generation.perf_timer import Timers
 from scenario_generation.reproducer_rollout import render_segment
 from scenario_generation.route_timeline import RouteTimeline
@@ -309,7 +309,13 @@ class FullRouteRouteJob(ClosedLoopJob):
 
 
 class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
-    """Segment-wise full-route closed-loop over every route under ``npz_root``."""
+    """Segment-wise full-route closed-loop over every route under ``npz_root``.
+
+    ``npz_root`` accepts anything ``closed_loop_eval.resolve_npz_roots`` does: a single
+    directory tree, a ``.json`` path-list file, or an already-resolved list of root paths
+    (e.g. one site's several curated date/time entries from a JSON-manifest-based site
+    discovery) -- ``discover_jobs`` merges routes across all of them.
+    """
 
     mode = "full"
 
@@ -318,7 +324,7 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
         model,
         model_args,
         config: ClosedLoopEvalConfig,
-        npz_root: Path | str,
+        npz_root: Path | str | list[Path | str],
         *,
         seg_len: int = 100_000,
         ddp_rank: int = 0,
@@ -331,14 +337,14 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
             ddp_rank=ddp_rank,
             ddp_world_size=ddp_world_size,
         )
-        self.npz_root = Path(npz_root)
+        self.npz_root = npz_root
         self.seg_len = seg_len
 
     @classmethod
     def from_checkpoint(
         cls,
         model_path: Path | str,
-        npz_root: Path | str,
+        npz_root: Path | str | list[Path | str],
         config: ClosedLoopEvalConfig,
         *,
         seg_len: int = 100_000,
@@ -357,11 +363,11 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
         )
 
     def discover_jobs(self) -> list[FullRouteRouteJob]:
-        routes = enumerate_routes(self.npz_root)
+        routes, route_sidecar_dir = enumerate_multi_root_routes(self.npz_root)
         return [
             FullRouteRouteJob(
                 job_id=key,
-                npz_root=self.npz_root,
+                npz_root=route_sidecar_dir[key],
                 route_key=key,
                 route_paths=routes[key],
                 seg_len=self.seg_len,


### PR DESCRIPTION
## Summary
Part 2 of the stacked closed-loop eval series (stacked on #298). Introduces the ``ClosedLoopEvaluation`` template-method class framework:

- `ClosedLoopEvaluation` (ABC): `discover_jobs` -> `shard_jobs` -> `run_job` -> `build_summary`/`write_artifacts`/`print_summary`, plus a DDP finalize/merge-shards path — `run_distributed()` requires an already-initialized process group and calls `dist.barrier()` before any rank-0 merge, so it can't silently merge a partial result if a rank crashed before writing its shard.
- `FullRouteClosedLoopEvaluation`: concrete segment-wise implementation over every route under an npz_root, using PR1's `render_segment`/`aggregate`. `npz_root` now accepts anything PR1's `resolve_npz_roots` does — a single directory, a `.json` path-list file, or an already-resolved list of roots — not just a single directory: `discover_jobs` merges routes across all of them via PR1's `enumerate_multi_root_routes`, and each route's own source root is threaded through as its job's sidecar dir.
- `RolloutParams`/`ClosedLoopEvalConfig`: shared config dataclasses, including PR1's `drop_objects`/`abort_*` knobs.
- `closed_loop_ddp.py`: just `shard_items` (DDP route sharding) now. Per-rank persistence reuses tier4-main's existing `segments_{rank}.jsonl`/`tdigests_{rank}.jsonl` convention (PR1's sidecar helpers) instead of a separate shard-blob format, so there's nothing left for `finalize_ddp` to write beyond the barrier signal, and `collect_ddp_shards` raises if any rank's file is missing rather than merging a partial result.
- `print_summary`/per-segment logging read PR1's nested `object`/`road_border`/`red_light_violation`/`strong_brake`/`reproducer` metric shape.

Not wired into anything yet — this is the foundation the rest of the stack (site sweep, W&B dashboard, training-loop wiring) builds on.

## Test plan
- [x] `ast.parse` + module import check
- [x] Verified `FullRouteClosedLoopEvaluation` with a real two-site rollout (odaiba + takanawa npz roots passed as a list): both routes ran with correct per-route sidecar dirs and merged into one aggregate summary
- [x] Verified the DDP shard-persistence rewrite: a 2-rank simulation merges correctly, a missing rank's `segments_<rank>.jsonl` fails fast with `RuntimeError`, and calling `run_distributed()` without an initialized process group also fails fast
- [x] Reviewed alongside PR #298 (merged)
