### PR TITLE
feat: standalone multi-site + objects/no-objects CLI runner (PR 5/6)

### DIFF
--- a/diffusion_planner/run_all_sites_closed_loop.py
+++ b/diffusion_planner/run_all_sites_closed_loop.py
@@ -1,0 +1,279 @@
+"""Run ``valid_predictor_closed_loop.py`` once per site in a curated JSON manifest.
+
+``--sites_npz_root`` is a curated ``.json`` path-list file (the same format as
+``--npz_root``'s JSON-list convention, e.g. ``path_list_closed_loop_x2.json``) --
+entries are grouped into per-site route pools by
+``site_discovery.discover_sites_from_json``. A "site" is the path component
+immediately before the first recognized split dir (``valid``/``manual``/``auto``)
+in each entry, matching the existing
+``{project}/{area_map_id}_{area_map_name}/{split}/...`` layout convention (e.g.
+``x2_dev/2231_odaiba_shinagawa_copied_from_xx1``). Each site's routes are never
+grouped across sites — this avoids the cross-directory filename-collision failure
+mode of pointing --npz_root at a shared parent that mixes multiple sites' npz
+together.
+
+Per-site outputs land in ``<out_root>/<site_name>/`` (summary.json,
+segments.jsonl, videos), exactly as a standalone single-site run would
+produce. A ``sites_summary.json`` at ``<out_root>`` records which npz_root was
+used for which site name, for downstream reporting.
+
+Example::
+
+    python diffusion_planner/run_all_sites_closed_loop.py \\
+        --sites_npz_root /media/.../path_list_closed_loop_x2.json \\
+        --model_path /media/.../best_model.pth \\
+        --out_root /media/.../cl_results/all_sites \\
+        --near_miss_thresh 0.3 --replan_interval 10 --draw_every 8
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scenario_generation.closed_loop_html_report import build_html_report
+from scenario_generation.site_discovery import discover_sites_from_json
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sites_npz_root",
+        required=True,
+        type=Path,
+        help="curated .json path-list manifest, grouped into per-site route pools by "
+        "site_discovery.discover_sites_from_json",
+    )
+    parser.add_argument("--model_path", required=True, type=Path)
+    parser.add_argument("--out_root", required=True, type=Path)
+    parser.add_argument("--only_sites", nargs="*", default=None, help="run only these site names")
+    parser.add_argument(
+        "--object_modes",
+        nargs="+",
+        choices=("objects", "noobj"),
+        default=["objects", "noobj"],
+        help="run each site once per mode: 'objects'=normal, 'noobj'=empty-world ablation "
+        "(--drop_objects, no dynamic/static objects, map kept). Output/site label for noobj "
+        "gets a '__noobj' suffix so both show up as separate sites — overlaid per metric in "
+        "W&B, side-by-side rows in the local report.",
+    )
+    parser.add_argument(
+        "--extra_args",
+        nargs=argparse.REMAINDER,
+        default=[],
+        help="passed through verbatim to valid_predictor_closed_loop.py (e.g. --near_miss_thresh 0.3)",
+    )
+    parser.add_argument(
+        "--no_report",
+        action="store_true",
+        help="skip writing the local HTML gallery (report.html) at --out_root",
+    )
+    parser.add_argument(
+        "--wandb_project",
+        type=str,
+        default=None,
+        help="optional: log this evaluation run to wandb (one run, all sites as "
+        "closed_loop/<site>/... + cross-site aggregate + a link to the local report.html), "
+        "so separate model/dataset iterations can be tracked and compared as wandb runs "
+        "the same way training epochs are.",
+    )
+    parser.add_argument("--wandb_run_name", type=str, default=None)
+    parser.add_argument(
+        "--wandb_video_pick",
+        choices=("worst", "first", "longest"),
+        default="worst",
+        help="which single episode per site gets its video + trajectory colormap uploaded",
+    )
+    parser.add_argument(
+        "--wandb_colormap_metrics",
+        nargs="*",
+        choices=("clearance", "collision", "near_miss", "speed", "road_border"),
+        default=["clearance", "collision", "near_miss", "speed", "road_border"],
+        help="per-step metrics rendered as trajectory-colormap images for the wandb "
+        "representative episode (default: all — cheap images, unlike video/episode picking)",
+    )
+    parser.add_argument(
+        "--report_colormap_metrics",
+        nargs="*",
+        choices=("clearance", "collision", "near_miss", "speed", "road_border"),
+        default=["clearance", "collision", "near_miss", "speed", "road_border"],
+        help="per-step metrics rendered as trajectory-colormap images in the local HTML "
+        "report (every episode, not just the wandb representative one)",
+    )
+    parser.add_argument(
+        "--report_base_url",
+        type=str,
+        default=None,
+        help="if --out_root is served over HTTP from this base, wandb records a clickable "
+        "report URL instead of just the local path",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    sites = discover_sites_from_json(args.sites_npz_root)
+    if args.only_sites:
+        sites = {name: root for name, root in sites.items() if name in args.only_sites}
+    if not sites:
+        print(f"No sites with npz found under {args.sites_npz_root}", file=sys.stderr)
+        return 1
+
+    cli_path = Path(__file__).resolve().parent / "valid_predictor_closed_loop.py"
+    args.out_root.mkdir(parents=True, exist_ok=True)
+    results: dict[str, dict] = {}
+    for site_name, npz_root in sites.items():
+        for mode in args.object_modes:
+            # "noobj" gets a distinct site label (suffix) rather than a separate axis — this
+            # lets it ride the existing per-site machinery (HTML rows/cards, W&B per-site keys,
+            # metric_regex overlay) completely unchanged.
+            label = site_name if mode == "objects" else f"{site_name}__noobj"
+            site_out_dir = args.out_root / label
+            site_out_dir.mkdir(parents=True, exist_ok=True)
+            # A site may span several curated roots (e.g. multiple date/time entries) --
+            # valid_predictor_closed_loop.py's --npz_root takes one path, so a multi-root site
+            # is handed through as a small JSON path-list file (the same convention
+            # resolve_npz_roots already reads for a single --npz_root).
+            npz_root_arg = site_out_dir / "npz_roots.json"
+            npz_root_arg.write_text(json.dumps([str(p) for p in npz_root]))
+            print(f"=== [{label}] npz_root={npz_root} -> out_dir={site_out_dir} ===")
+            cmd = [
+                sys.executable,
+                str(cli_path),
+                "--model_path",
+                str(args.model_path),
+                "--npz_root",
+                str(npz_root_arg),
+                "--out_dir",
+                str(site_out_dir),
+                *args.extra_args,
+            ]
+            if mode == "noobj":
+                cmd.append("--drop_objects")
+            # One site's failure (e.g. a transient disk I/O error partway through a long route
+            # sweep) must not abort the remaining sites — each site is an independent evaluation.
+            error = None
+            for attempt in range(1, 3):
+                try:
+                    subprocess.run(cmd, check=True)
+                    error = None
+                    break
+                except subprocess.CalledProcessError as e:
+                    error = e
+                    print(f"  [{label}] attempt {attempt}/2 failed: {e}", file=sys.stderr)
+            summary_path = site_out_dir / "summary.json"
+            results[label] = {
+                "npz_root": [str(p) for p in npz_root],
+                "out_dir": str(site_out_dir),
+                "error": str(error) if error else None,
+                "summary": json.loads(summary_path.read_text()) if summary_path.is_file() else None,
+            }
+
+    # Merge into any existing manifest instead of overwriting it outright, so a targeted
+    # --only_sites re-run doesn't drop the other sites' entries from a prior full run.
+    manifest_path = args.out_root / "sites_summary.json"
+    merged = {}
+    if manifest_path.is_file():
+        merged = json.loads(manifest_path.read_text())
+    merged.update(results)
+    manifest_path.write_text(json.dumps(merged, indent=2, ensure_ascii=False))
+    print(f"\nWrote {manifest_path}")
+    for site_name, r in results.items():
+        s = r["summary"] or {}
+        obj = s.get("object") or {}
+        print(
+            f"  {site_name}: n_routes={s.get('n_routes')} "
+            f"collision_segment_rate={obj.get('collision_segment_rate')} "
+            f"near_miss_segment_rate={obj.get('miss_segment_rate')}"
+        )
+
+    # All site names with a summary (from THIS run's `merged`, so a targeted --only_sites
+    # re-run's report still covers every previously-completed site, not just the ones just run).
+    all_site_names = sorted(name for name, r in merged.items() if r.get("summary") is not None)
+    report_path = None
+    if not args.no_report and all_site_names:
+        report_path = build_html_report(
+            args.out_root,
+            all_site_names,
+            title="Per-Site Closed-Loop Evaluation",
+            subtitle=f"sites_npz_root={args.sites_npz_root}",
+            colormap_metrics=tuple(args.report_colormap_metrics),
+        )
+        if report_path:
+            print(f"Wrote {report_path}")
+
+    if args.wandb_project:
+        _log_to_wandb(args, all_site_names, merged, report_path)
+    return 0
+
+
+def _log_to_wandb(
+    args: argparse.Namespace,
+    site_names: list[str],
+    merged: dict,
+    report_path: Path | None,
+) -> None:
+    """One evaluation-only wandb run covering every site in this call — lets separate
+    model/dataset iterations (e.g. this vs. a previous checkpoint) be tracked and compared
+    as wandb runs, the same way training epochs are (see closed_loop_validate in train.py,
+    which this mirrors: per-site scalars/table/representative video, cross-site aggregate,
+    a link to the local report instead of uploading every video).
+    """
+    import wandb
+    from scenario_generation.wandb_closed_loop import (
+        build_combined_episode_table,
+        build_full_closed_loop_wandb_log,
+        build_sites_aggregate_log,
+        resolve_report_link,
+    )
+
+    run = wandb.init(project=args.wandb_project, name=args.wandb_run_name)
+    try:
+        log: dict = {}
+        site_summaries: dict[str, dict] = {}
+        episode_data: list = []  # (site, rows, out_dir) for the ONE combined table
+        for site_name in site_names:
+            r = merged.get(site_name) or {}
+            summary = r.get("summary")
+            if not summary:
+                continue
+            site_out_dir = r.get("out_dir") or str(args.out_root / site_name)
+            segments_path = Path(site_out_dir) / "segments.jsonl"
+            rows = []
+            if segments_path.is_file():
+                with segments_path.open(encoding="utf-8") as f:
+                    rows = [json.loads(line) for line in f if line.strip()]
+            summary_with_rows = {**summary, "segments": rows}
+            # build_full returns final section-based keys (closed_loop_scores/... etc.) — merge as-is.
+            log.update(
+                build_full_closed_loop_wandb_log(
+                    summary_with_rows,
+                    out_dir=site_out_dir,
+                    site=site_name,
+                    video_pick=args.wandb_video_pick,
+                    colormap_metrics=tuple(args.wandb_colormap_metrics),
+                    near_miss_thresh=summary.get("near_miss_thresh", 0.5),
+                    report_base_url=args.report_base_url,
+                )
+            )
+            site_summaries[site_name] = summary_with_rows
+            episode_data.append((site_name, rows, site_out_dir))
+        if episode_data:
+            log["closed_loop_episodes/all"] = build_combined_episode_table(episode_data)
+        if len(site_summaries) > 1:
+            log.update(build_sites_aggregate_log(site_summaries))
+        if report_path is not None:
+            log["closed_loop_links/report"] = resolve_report_link(
+                args.out_root, args.report_base_url
+            )
+        wandb.log(log)
+        print(f"wandb: logged {len(site_summaries)} site(s) to run {run.id}")
+    finally:
+        wandb.finish()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/diffusion_planner/run_all_sites_closed_loop.py
+++ b/diffusion_planner/run_all_sites_closed_loop.py
@@ -90,16 +90,48 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--wandb_colormap_metrics",
         nargs="*",
-        choices=("clearance", "collision", "near_miss", "speed", "road_border"),
-        default=["clearance", "collision", "near_miss", "speed", "road_border"],
+        choices=(
+            "clearance",
+            "collision",
+            "near_miss",
+            "speed",
+            "road_border",
+            "red_light",
+            "strong_brake",
+        ),
+        default=[
+            "clearance",
+            "collision",
+            "near_miss",
+            "speed",
+            "road_border",
+            "red_light",
+            "strong_brake",
+        ],
         help="per-step metrics rendered as trajectory-colormap images for the wandb "
         "representative episode (default: all — cheap images, unlike video/episode picking)",
     )
     parser.add_argument(
         "--report_colormap_metrics",
         nargs="*",
-        choices=("clearance", "collision", "near_miss", "speed", "road_border"),
-        default=["clearance", "collision", "near_miss", "speed", "road_border"],
+        choices=(
+            "clearance",
+            "collision",
+            "near_miss",
+            "speed",
+            "road_border",
+            "red_light",
+            "strong_brake",
+        ),
+        default=[
+            "clearance",
+            "collision",
+            "near_miss",
+            "speed",
+            "road_border",
+            "red_light",
+            "strong_brake",
+        ],
         help="per-step metrics rendered as trajectory-colormap images in the local HTML "
         "report (every episode, not just the wandb representative one)",
     )

--- a/diffusion_planner/run_all_sites_closed_loop.py
+++ b/diffusion_planner/run_all_sites_closed_loop.py
@@ -255,6 +255,7 @@ def _log_to_wandb(
     a link to the local report instead of uploading every video).
     """
     import wandb
+
     from scenario_generation.wandb_closed_loop import (
         build_combined_episode_table,
         build_full_closed_loop_wandb_log,

--- a/diffusion_planner/valid_predictor_closed_loop.py
+++ b/diffusion_planner/valid_predictor_closed_loop.py
@@ -16,9 +16,9 @@ always produces video: one MP4 per route (``<route>.mp4``). Per-route metrics ar
 Clearance t-digest sketches used for multi-GPU p5 merge are written beside them as
 ``tdigests.jsonl`` / ``tdigests_{rank}.jsonl`` so ``segments.jsonl`` stays human-readable.
 
-Only ``--model_path`` and ``--npz_root`` are required; all outputs are written next to
-the checkpoint (``<model_path dir>/closed_loop/``) and the rollout knobs default to the
-closed-loop mining config. ``--npz_root`` is either one NPZ dir tree or a .json path list of
+Only ``--model_path`` and ``--npz_root`` are required; outputs default to next to the checkpoint
+(``<model_path dir>/closed_loop/``, override with ``--out_dir``) and the rollout knobs default to
+the closed-loop mining config. ``--npz_root`` is either one NPZ dir tree or a .json path list of
 route dirs; given a path list of multiple routes, the rollout automatically fans out one worker
 process per visible GPU (each its own model copy), which also parallelizes the matplotlib render.
 Example (1st epoch of a GRPO run)::
@@ -66,6 +66,13 @@ def parse_args() -> argparse.Namespace:
         help="dir tree of route NPZ frames (recursively globbed, grouped into routes), OR a .json "
         "path list of such dirs (one route dir per entry, like --train_set_list). Pose JSON "
         "sidecars are read from next to each .npz, falling back to its own source tree.",
+    )
+    p.add_argument(
+        "--out_dir",
+        type=Path,
+        default=None,
+        help="output dir for segments.jsonl/summary.json/videos. Default: "
+        "<model_path dir>/closed_loop/<timestamp>/",
     )
     # --- tunable knobs (default to the closed-loop mining config) ---
     p.add_argument("--device", type=str, default="cuda", help="'cuda' or 'cpu'")
@@ -133,6 +140,25 @@ def parse_args() -> argparse.Namespace:
         "dominant cost; this throttles it without touching the rollout. Frames are encoded at --fps "
         "regardless, so the video also plays N x faster (shorter). For real-time use --fps 10/N",
     )
+    p.add_argument(
+        "--abort_deviation_m",
+        type=float,
+        default=0.0,
+        help="early-abort a segment (terminated='diverged') once GT deviation exceeds this "
+        "(m) for --abort_after steps (0=disabled)",
+    )
+    p.add_argument("--abort_after", type=int, default=30)
+    p.add_argument(
+        "--abort_max_snaps",
+        type=int,
+        default=0,
+        help="early-abort a segment after this many unstick teleports (0=disabled)",
+    )
+    p.add_argument(
+        "--drop_objects",
+        action="store_true",
+        help="empty-world ablation: zero out dynamic/static objects each step (map kept)",
+    )
     return p.parse_args()
 
 
@@ -164,6 +190,10 @@ def _eval_knobs(args: argparse.Namespace) -> dict:
         neighbor_history_mode="recorded",
         tracker_mode="perfect",
         strong_brake_mps2=args.strong_brake_mps2,
+        abort_deviation_m=args.abort_deviation_m,
+        abort_after=args.abort_after,
+        abort_max_snaps=args.abort_max_snaps,
+        drop_objects=args.drop_objects,
     )
 
 
@@ -208,7 +238,9 @@ def _write_summary(out_dir: Path, summary: dict) -> None:
 def main() -> None:
     args = parse_args()
 
-    out_dir = args.model_path.parent / "closed_loop" / datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_dir = args.out_dir or (
+        args.model_path.parent / "closed_loop" / datetime.now().strftime("%Y%m%d_%H%M%S")
+    )
     out_dir.mkdir(parents=True, exist_ok=True)
     knobs = _eval_knobs(args)
 

--- a/diffusion_planner/valid_predictor_closed_loop.py
+++ b/diffusion_planner/valid_predictor_closed_loop.py
@@ -219,10 +219,22 @@ def _run_shard(rank, num_workers, gpu_ids, model_path, npz_root, out_dir, knobs)
 def _merge_shards(
     out_dir: Path, npz_root, near_miss_thresh: float, *, strong_brake_mps2: float
 ) -> dict:
-    """Aggregate every worker's segments_{rank}.jsonl (+ tdigests sidecars) into one summary."""
-    from scenario_generation.closed_loop_eval import aggregate, load_segment_rows_with_tdigests
+    """Aggregate every worker's segments_{rank}.jsonl (+ tdigests sidecars) into one summary.
+
+    Also writes a merged, human-readable ``segments.jsonl`` (same tdigest-stripped shape the
+    sequential path writes) -- downstream consumers like closed_loop_html_report only look for
+    the unsharded filename, so without this a parallel-run site's videos never show up there.
+    """
+    from scenario_generation.closed_loop_eval import (
+        aggregate,
+        load_segment_rows_with_tdigests,
+        segment_row_for_json,
+    )
 
     rows = load_segment_rows_with_tdigests(out_dir)
+    with open(out_dir / "segments.jsonl", "w") as f:
+        for r in sorted(rows, key=lambda r: r["route"]):
+            f.write(json.dumps(segment_row_for_json(r, route=r["route"]), default=float) + "\n")
     summary = aggregate(rows, near_miss_thresh, strong_brake_mps2=strong_brake_mps2)
     summary["npz_root"] = str(npz_root)
     summary["n_routes"] = len({r["route"] for r in rows})

--- a/scenario_generation/closed_loop_html_report.py
+++ b/scenario_generation/closed_loop_html_report.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from scenario_generation.closed_loop_score_keys import extract_score
 from scenario_generation.trajectory_colormap import METRIC_CHOICES, render_trajectory_colormaps
+from scenario_generation.wandb_closed_loop import episode_stem
 
 # Shown first in each card's metric dropdown when available (the rest follow METRIC_CHOICES
 # order) — clearance is the most broadly useful default view.
@@ -75,7 +76,7 @@ def collect_site_data(
                     continue
                 r = json.loads(line)
                 start, end = r["segment"]
-                stem = f"{r['route']}_{start}_{end}"
+                stem = episode_stem(site_dir, r)
                 video_name = f"{stem}.mp4"
                 video_path = site_dir / video_name
 

--- a/scenario_generation/wandb_closed_loop.py
+++ b/scenario_generation/wandb_closed_loop.py
@@ -23,12 +23,28 @@ def _is_noobj_label(label: str) -> bool:
     return label.endswith("__noobj")
 
 
-def _segment_paths(out_dir: str | Path, row: dict) -> tuple[Path, Path]:
-    """(png_dir, mp4_path) for one segments.jsonl row, matching FullRouteClosedLoopEvaluation's
-    naming (``run_job``): ``{out_dir}/{route}_{start}_{end}`` (dir) and ``...mp4``."""
-    start, end = row["segment"]
-    stem = f"{row['route']}_{start}_{end}"
+def episode_stem(out_dir: str | Path, row: dict) -> str:
+    """Base filename stem for one segments.jsonl row's video/png-dir/colormap files.
+
+    FullRouteClosedLoopEvaluation (PR2, train-time closed-loop validation) names these
+    ``{route}_{start}_{end}`` (segment-suffixed). PR1's ``run_closed_loop_eval`` (the
+    ``valid_predictor_closed_loop.py`` / ``run_all_sites_closed_loop.py`` CLI path) names
+    them just ``{route}`` -- one route = one whole-route rollout, no sub-segmenting.
+    Prefer the segment-suffixed form and fall back to the bare route name when that
+    file/dir doesn't exist, so callers resolve videos correctly for either pipeline.
+    """
     out_dir = Path(out_dir)
+    start, end = row["segment"]
+    segmented_stem = f"{row['route']}_{start}_{end}"
+    if (out_dir / f"{segmented_stem}.mp4").is_file() or (out_dir / segmented_stem).is_dir():
+        return segmented_stem
+    return row["route"]
+
+
+def _segment_paths(out_dir: str | Path, row: dict) -> tuple[Path, Path]:
+    """(png_dir, mp4_path) for one segments.jsonl row -- see :func:`episode_stem`."""
+    out_dir = Path(out_dir)
+    stem = episode_stem(out_dir, row)
     return out_dir / stem, out_dir / f"{stem}.mp4"
 
 


### PR DESCRIPTION
## Summary
Part 5 of the stacked closed-loop eval series (stacked on #301). Wires PR1-4 into a standalone (non-training) multi-site runner:

- `valid_predictor_closed_loop.py`: adds `--out_dir` (override the default `<model_path dir>/closed_loop/<timestamp>/`), `--drop_objects`, and the `abort_deviation_m`/`abort_after`/`abort_max_snaps` knobs (PR1) to the existing multi-GPU route-sharding CLI.
- New `run_all_sites_closed_loop.py`: runs `valid_predictor_closed_loop.py` once per site under `--sites_npz_root` — a curated `.json` path-list manifest grouped into per-site route pools by `site_discovery.discover_sites_from_json` (PR3) — once per requested `--object_modes` (objects/noobj, default both — "noobj" gets a `<site>__noobj` label suffix so it rides the same per-site machinery unchanged), merges into a `sites_summary.json` manifest, and optionally builds the local HTML report (PR4) and/or logs everything to one wandb run (PR4's `wandb_closed_loop` helpers) covering every site — so separate model/dataset iterations can be tracked and compared as wandb runs the same way training epochs are. A JSON-manifest site's route pool may span several curated roots, so it's handed through to `valid_predictor_closed_loop.py`'s `--npz_root` as a small per-site JSON path-list file under its own `out_dir`, reusing the same convention `resolve_npz_roots` already reads.

`--sites_npz_root` (originally named `--sites_root`) is always a curated JSON manifest now — there is no directory-scan fallback (see PR3): every caller already has curated manifests, and directory-scanning was the exact mechanism behind an earlier NCCL-timeout production incident.


sample command
```
  .venv/bin/python3 diffusion_planner/run_all_sites_closed_loop.py \
    --sites_npz_root "real_path_list.json" \
    --model_path /media/kosuke55/sandisk_ssd/diffusion_planner_local_dataset/best_model.pth \
    --out_root "run_all_sites_rename_test" \
    --object_modes objects noobj \
    --extra_args --replan_interval 40 --draw_every 8

```

## Test plan
- [x] `ast.parse` + module import check
- [x] Verified end-to-end on real server + local multi-site data (5 sites x 2 object modes, HTML report + wandb log)
- [x] Verified `--sites_npz_root` as a real 2-site JSON manifest (odaiba + takanawa): both sites ran through the temp per-site manifest with correct real metrics, `sites_summary.json` and `report.html` written as expected
- [x] Found & fixed a stale flat-key bug surfaced by that same real run: the final per-site print read `collision_segment_rate`/`near_miss_segment_rate` from the old flat summary shape instead of the nested `object.collision_segment_rate`/`object.miss_segment_rate`; re-verified with real numbers (not `None`) after the fix
