### PR TITLE
feat: wire per-site closed-loop eval into the training loop (PR 6/6)

### DIFF
--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -168,6 +168,7 @@ def closed_loop_validate(
         FullRouteClosedLoopEvaluation,
         RolloutParams,
     )
+    from scenario_generation.closed_loop_html_report import build_html_report
     from scenario_generation.site_discovery import discover_sites_from_json
     from scenario_generation.wandb_closed_loop import (
         build_combined_episode_table,
@@ -234,9 +235,14 @@ def closed_loop_validate(
     log: dict = {}
     site_summaries: dict[str, dict] = {}
     episode_data: list = []  # (label, rows, out_dir) for the ONE combined table, across BOTH sources
+    site_report_labels: list[str] = []
 
     def run_labeled(
-        base_name: str | None, npz_root, mode_pairs: tuple[tuple[str, bool], ...]
+        base_name: str | None,
+        npz_root,
+        mode_pairs: tuple[tuple[str, bool], ...],
+        *,
+        track_for_report: bool = False,
     ) -> None:
         """Run ``npz_root`` once per requested object-mode, merging into log/site_summaries/episode_data.
 
@@ -261,6 +267,8 @@ def closed_loop_validate(
             log.update(site_log)
             site_summaries[episode_label] = summary
             episode_data.append((episode_label, summary.get("segments") or [], site_out_dir))
+            if track_for_report:
+                site_report_labels.append(episode_label)
 
     try:
         if args.closed_loop_npz_root:
@@ -273,7 +281,7 @@ def closed_loop_validate(
                 print(f"closed-loop: no sites found under {args.closed_loop_sites_npz_root}")
             sites_modes = _object_mode_pairs(args.closed_loop_sites_object_modes)
             for site_name, npz_root in sites.items():
-                run_labeled(site_name, npz_root, sites_modes)
+                run_labeled(site_name, npz_root, sites_modes, track_for_report=True)
 
         # One combined, filterable/groupable episode table across every source/site/mode.
         if episode_data:
@@ -281,6 +289,12 @@ def closed_loop_validate(
         # Cross-source/site pooled rollup under closed_loop_overview/*.
         if len(site_summaries) > 1:
             log.update(build_sites_aggregate_log(site_summaries))
+        # Local HTML gallery, sites only (see site_report_labels above) -- only built on
+        # is_final_save, same as the media (videos/colormap images) it links to.
+        if is_final_save and site_report_labels:
+            report_path = build_html_report(out_dir, site_report_labels)
+            if report_path:
+                print(f"closed-loop: wrote {report_path}")
     finally:
         net.train(was_training)
 

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -138,7 +138,9 @@ def _object_mode_pairs(modes: list[str]) -> tuple[tuple[str, bool], ...]:
     return tuple((m, _OBJECT_MODE_DROP_FLAGS[m]) for m in ("objects", "noobj") if m in modes)
 
 
-def closed_loop_validate(model, args, epoch: int, out_dir: str) -> None:
+def closed_loop_validate(
+    model, args, epoch: int, out_dir: str, *, is_final_save: bool = False
+) -> None:
     """Closed-loop rendered rollout; logs metrics + videos to wandb.
 
     Runs one :class:`~scenario_generation.closed_loop_evaluation.FullRouteClosedLoopEvaluation`
@@ -151,19 +153,15 @@ def closed_loop_validate(model, args, epoch: int, out_dir: str) -> None:
     pass the unwrapped model; it is switched to eval for the rollout (so the diffusion sampler
     runs and produces ``prediction``) and restored afterwards.
 
-    Video/PNG/colormap rendering only happens on the LAST call (``epoch + 1 >= args.train_epochs``)
+    Per-step matplotlib rendering (PNGs/video/colormap images) is the dominant per-call cost, so
+    it's deferred to the last call only (``is_final_save=True``, computed by the caller as "is
+    this the last time the checkpoint-save cadence fires in this run" -- NOT simply
+    ``epoch == train_epochs - 1``, since train_epochs may not land on a save_utd-multiple)
     -- every other call still runs the full rollout and logs metrics/wandb scalars, just without
-    the dominant per-step matplotlib-render cost.
+    that cost.
     """
     if not args.closed_loop_npz_root and not args.closed_loop_sites_npz_root:
         return
-
-    # Per-step matplotlib rendering (PNGs/video/colormap images) is the dominant per-call cost;
-    # skip it on every call except the last one, since it's purely for human review and metrics/
-    # wandb scalars are unaffected either way. Only correct when train_epochs lands on a
-    # save_utd-multiple epoch (the usual case) -- if it doesn't, no call here is ever the "final"
-    # one and no media is ever produced.
-    is_final_epoch = epoch + 1 >= args.train_epochs
 
     from scenario_generation.closed_loop_evaluation import (
         ClosedLoopEvalConfig,
@@ -197,7 +195,7 @@ def closed_loop_validate(model, args, epoch: int, out_dir: str) -> None:
                     unstick_advance_m=args.closed_loop_unstick_advance_m,
                     unstick_radius_mult=args.closed_loop_unstick_radius_mult,
                     unstick_teleport_after=args.closed_loop_unstick_teleport_after,
-                    draw_every=args.closed_loop_draw_every if is_final_epoch else None,
+                    draw_every=args.closed_loop_draw_every if is_final_save else None,
                     replan_interval=args.closed_loop_replan_interval,
                     abort_deviation_m=args.closed_loop_abort_deviation_m,
                     abort_after=args.closed_loop_abort_after,
@@ -221,7 +219,7 @@ def closed_loop_validate(model, args, epoch: int, out_dir: str) -> None:
             colormap_metrics=args.closed_loop_colormap_metrics,
             near_miss_thresh=args.closed_loop_near_miss_thresh,
             report_base_url=args.closed_loop_report_base_url or None,
-            render_media=is_final_epoch,
+            render_media=is_final_save,
         )
         print(
             f"closed-loop{site_label} @epoch {epoch + 1}: {summary['n_segments']} seg in "
@@ -707,8 +705,15 @@ def model_training(args: TrainConfig):
                 )
                 # Closed-loop validation runs on the same cadence as the checkpoint save; outputs
                 # (videos + metrics) land next to the saved weights they correspond to.
+                is_final_save = (epoch + 1 - init_epoch) // save_utd == (
+                    train_epochs - init_epoch
+                ) // save_utd
                 closed_loop_validate(
-                    diffusion_planner, args, epoch, os.path.join(curr_dir, "closed_loop")
+                    diffusion_planner,
+                    args,
+                    epoch,
+                    os.path.join(curr_dir, "closed_loop"),
+                    is_final_save=is_final_save,
                 )
 
             if valid_loss_ego_position_lat_loss < best_loss:

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -6,12 +6,12 @@ from pathlib import Path
 
 import pandas as pd
 import torch
+import wandb
 from timm.utils import ModelEma
 from torch import optim
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data import DataLoader, DistributedSampler
 
-import wandb
 from diffusion_planner.dimensions import *
 from diffusion_planner.model.diffusion_planner import Diffusion_Planner
 from diffusion_planner.scenario_based_open_loop.validate import scenario_based_open_loop_validate

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -6,12 +6,12 @@ from pathlib import Path
 
 import pandas as pd
 import torch
-import wandb
 from timm.utils import ModelEma
 from torch import optim
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data import DataLoader, DistributedSampler
 
+import wandb
 from diffusion_planner.dimensions import *
 from diffusion_planner.model.diffusion_planner import Diffusion_Planner
 from diffusion_planner.scenario_based_open_loop.validate import scenario_based_open_loop_validate
@@ -126,82 +126,168 @@ def wandb_epdms_metrics(epdms_means):
     }
 
 
-def closed_loop_validate(model, args, epoch: int, out_dir: str) -> None:
-    """Closed-loop rendered rollout; logs metrics + the rollout video to wandb.
+_OBJECT_MODE_DROP_FLAGS = {"objects": False, "noobj": True}
 
-    Drives the ego in CLOSED LOOP over the route NPZ frames under ``args.closed_loop_npz_root``
-    (one route = one trial), renders an MP4 into ``out_dir``, aggregates collision/clearance
-    metrics, and logs both to wandb at ``step=epoch+1``. Called on the checkpoint-save cadence.
-    No-op when ``closed_loop_npz_root`` is unset. Rank-0 only: pass the unwrapped model; it is
-    switched to eval for the rollout (so the diffusion sampler runs and produces ``prediction``)
-    and restored afterwards.
+
+def _object_mode_pairs(modes: list[str]) -> tuple[tuple[str, bool], ...]:
+    """Canonical (tag, drop_objects) pairs for the requested object modes.
+
+    Order is always "objects" before "noobj" regardless of the CLI list order, so labels/output
+    dirs are deterministic.
     """
-    if not args.closed_loop_npz_root:
-        return
-    import math
+    return tuple((m, _OBJECT_MODE_DROP_FLAGS[m]) for m in ("objects", "noobj") if m in modes)
 
-    from scenario_generation.closed_loop_eval import run_closed_loop_eval
+
+def closed_loop_validate(model, args, epoch: int, out_dir: str) -> None:
+    """Closed-loop rendered rollout; logs metrics + videos to wandb.
+
+    Runs one :class:`~scenario_generation.closed_loop_evaluation.FullRouteClosedLoopEvaluation`
+    per (site, object-mode) pair: ``closed_loop_npz_root`` (single arbitrary path) and
+    ``closed_loop_sites_npz_root`` (a curated ``.json`` path-list manifest grouped into
+    per-site route pools by
+    :func:`~scenario_generation.site_discovery.discover_sites_from_json`) are independent — both
+    fire in the same call when both are set, each contributing its own rows to the combined
+    episode table / cross-site aggregate. Called on the checkpoint-save cadence, rank-0 only:
+    pass the unwrapped model; it is switched to eval for the rollout (so the diffusion sampler
+    runs and produces ``prediction``) and restored afterwards.
+
+    Video/PNG/colormap rendering only happens on the LAST call (``epoch + 1 >= args.train_epochs``)
+    -- every other call still runs the full rollout and logs metrics/wandb scalars, just without
+    the dominant per-step matplotlib-render cost.
+    """
+    if not args.closed_loop_npz_root and not args.closed_loop_sites_npz_root:
+        return
+
+    # Per-step matplotlib rendering (PNGs/video/colormap images) is the dominant per-call cost;
+    # skip it on every call except the last one, since it's purely for human review and metrics/
+    # wandb scalars are unaffected either way. Only correct when train_epochs lands on a
+    # save_utd-multiple epoch (the usual case) -- if it doesn't, no call here is ever the "final"
+    # one and no media is ever produced.
+    is_final_epoch = epoch + 1 >= args.train_epochs
+
+    from scenario_generation.closed_loop_evaluation import (
+        ClosedLoopEvalConfig,
+        FullRouteClosedLoopEvaluation,
+        RolloutParams,
+    )
+    from scenario_generation.site_discovery import discover_sites_from_json
+    from scenario_generation.wandb_closed_loop import (
+        build_combined_episode_table,
+        build_full_closed_loop_wandb_log,
+        build_sites_aggregate_log,
+    )
 
     net = ddp.get_model(model, args.ddp)
     was_training = net.training
     net.eval()
-    try:
-        summary = run_closed_loop_eval(
+
+    def run_one(npz_root, site_out_dir: str, site_name: str | None, drop_objects: bool = False):
+        site_label = f" [{site_name}]" if site_name else ""
+        evaluator = FullRouteClosedLoopEvaluation(
             net,
             args,
-            args.closed_loop_npz_root,
-            out_dir,
-            device=args.device,
-            near_miss_thresh=args.closed_loop_near_miss_thresh,
-            search_radius=args.closed_loop_search_radius,
-            warmup_steps=args.closed_loop_warmup_steps,
-            unstick_after=args.closed_loop_unstick_after,
-            unstick_advance_m=args.closed_loop_unstick_advance_m,
-            fps=args.closed_loop_fps,
-            replan_interval=args.closed_loop_replan_interval,
-            draw_every=args.closed_loop_draw_every,
-            neighbor_history_mode="recorded",
-            verbose=False,
+            ClosedLoopEvalConfig(
+                out_dir=Path(site_out_dir),
+                params=RolloutParams(
+                    device=args.device,
+                    near_miss_thresh=args.closed_loop_near_miss_thresh,
+                    search_radius=args.closed_loop_search_radius,
+                    warmup_steps=args.closed_loop_warmup_steps,
+                    unstick_after=args.closed_loop_unstick_after,
+                    unstick_advance_m=args.closed_loop_unstick_advance_m,
+                    unstick_radius_mult=args.closed_loop_unstick_radius_mult,
+                    unstick_teleport_after=args.closed_loop_unstick_teleport_after,
+                    draw_every=args.closed_loop_draw_every if is_final_epoch else None,
+                    replan_interval=args.closed_loop_replan_interval,
+                    abort_deviation_m=args.closed_loop_abort_deviation_m,
+                    abort_after=args.closed_loop_abort_after,
+                    abort_max_snaps=args.closed_loop_abort_max_snaps,
+                    drop_objects=drop_objects,
+                ),
+                fps=float(args.closed_loop_fps),
+                verbose=False,
+            ),
+            npz_root,
+            seg_len=args.closed_loop_seg_len,
         )
+        summary = evaluator.run()
+        if not summary:
+            return {}, {}
+        site_log = build_full_closed_loop_wandb_log(
+            summary,
+            out_dir=site_out_dir,
+            site=site_name,
+            video_pick=args.closed_loop_wandb_video_pick,
+            colormap_metrics=args.closed_loop_colormap_metrics,
+            near_miss_thresh=args.closed_loop_near_miss_thresh,
+            report_base_url=args.closed_loop_report_base_url or None,
+            render_media=is_final_epoch,
+        )
+        print(
+            f"closed-loop{site_label} @epoch {epoch + 1}: {summary['n_segments']} seg in "
+            f"{summary['elapsed_sec']:.1f}s  route_completion={summary.get('mean_route_completion', 0.0):.3f}  "
+            f"collisions={summary.get('object', {}).get('collision_count', 0)}  "
+            f"curb_hits={summary.get('road_border', {}).get('collision_count', 0)}  "
+            f"snaps={summary.get('reproducer', {}).get('snap_count', 0)}  -> "
+            f"{len(summary['video_mp4s'])} video(s)"
+        )
+        return site_log, summary
+
+    log: dict = {}
+    site_summaries: dict[str, dict] = {}
+    episode_data: list = []  # (label, rows, out_dir) for the ONE combined table, across BOTH sources
+
+    def run_labeled(
+        base_name: str | None, npz_root, mode_pairs: tuple[tuple[str, bool], ...]
+    ) -> None:
+        """Run ``npz_root`` once per requested object-mode, merging into log/site_summaries/episode_data.
+
+        "noobj" gets a distinct label (suffix) rather than a separate axis, so it rides the
+        existing per-site machinery (wandb keys, metric_regex overlay, combined episode table)
+        unchanged. When only "objects" is requested (the common single-mode case), the
+        label/out_dir stay exactly as a bare single call would use (``base_name`` verbatim, no
+        subdir).
+        """
+        multi = len(mode_pairs) > 1
+        for tag, drop_objects in mode_pairs:
+            if multi:
+                base = base_name or "main"
+                label = f"{base}__noobj" if tag == "noobj" else base
+            else:
+                label = base_name
+            site_out_dir = os.path.join(out_dir, label) if label else out_dir
+            site_log, summary = run_one(npz_root, site_out_dir, label, drop_objects=drop_objects)
+            if not summary:
+                continue
+            episode_label = label or "main"
+            log.update(site_log)
+            site_summaries[episode_label] = summary
+            episode_data.append((episode_label, summary.get("segments") or [], site_out_dir))
+
+    try:
+        if args.closed_loop_npz_root:
+            npz_modes = _object_mode_pairs(args.closed_loop_npz_object_modes)
+            run_labeled(None, args.closed_loop_npz_root, npz_modes)
+
+        if args.closed_loop_sites_npz_root:
+            sites = discover_sites_from_json(args.closed_loop_sites_npz_root)
+            if not sites:
+                print(f"closed-loop: no sites found under {args.closed_loop_sites_npz_root}")
+            sites_modes = _object_mode_pairs(args.closed_loop_sites_object_modes)
+            for site_name, npz_root in sites.items():
+                run_labeled(site_name, npz_root, sites_modes)
+
+        # One combined, filterable/groupable episode table across every source/site/mode.
+        if episode_data:
+            log["closed_loop_episodes/all"] = build_combined_episode_table(episode_data)
+        # Cross-source/site pooled rollup under closed_loop_overview/*.
+        if len(site_summaries) > 1:
+            log.update(build_sites_aggregate_log(site_summaries))
     finally:
         net.train(was_training)
 
-    # Scalar metrics from nested summary (skip non-finite clearances).
-    def _flat_scalars(node: dict, prefix: str = "") -> dict[str, float | int]:
-        out: dict[str, float | int] = {}
-        for k, v in node.items():
-            key = f"{prefix}{k}" if not prefix else f"{prefix}/{k}"
-            if isinstance(v, dict):
-                out.update(_flat_scalars(v, key))
-            elif isinstance(v, (int,)) or (isinstance(v, float) and math.isfinite(v)):
-                out[key] = v
-        return out
-
-    log = {
-        f"closed_loop/{k}": v
-        for k, v in _flat_scalars(
-            {
-                "n_segments": summary["n_segments"],
-                "total_steps": summary["total_steps"],
-                "object": summary["object"],
-                "road_border": summary["road_border"],
-                "red_light_violation": summary["red_light_violation"],
-                "strong_brake": summary["strong_brake"],
-                "reproducer": summary["reproducer"],
-            }
-        ).items()
-    }
-    for mp4 in summary["video_mp4s"]:
-        log[f"closed_loop/video/{Path(mp4).stem}"] = wandb.Video(str(mp4), format="mp4")
-    wandb.log(log, step=epoch + 1)
-    from scenario_generation.closed_loop_eval import format_summary_lines
-
-    print(
-        f"closed-loop @epoch {epoch + 1}: {summary['n_segments']} seg in "
-        f"{summary['elapsed_sec']:.1f}s  -> {len(summary['video_mp4s'])} video(s)"
-    )
-    for line in format_summary_lines(summary):
-        print(f"  {line}")
+    if log:
+        wandb.log(log, step=epoch + 1)
 
 
 def model_training(args: TrainConfig):

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -195,7 +195,15 @@ class TrainConfig:
     # "first" / "longest".
     closed_loop_wandb_video_pick: str = "worst"
     closed_loop_colormap_metrics: list[str] = field(
-        default_factory=lambda: ["clearance", "collision", "near_miss", "speed", "road_border"]
+        default_factory=lambda: [
+            "clearance",
+            "collision",
+            "near_miss",
+            "speed",
+            "road_border",
+            "red_light",
+            "strong_brake",
+        ]
     )
     closed_loop_report_base_url: str = ""
 

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -153,10 +153,24 @@ class TrainConfig:
 
     # ---------------------------------------------------------
     # Closed-loop validation (rendered rollout + wandb video), run on the checkpoint-save cadence
-    # (``save_utd``). Disabled unless ``closed_loop_npz_root`` is set (dir tree of route NPZ frames,
-    # one route).
+    # (``save_utd``). Disabled unless ``closed_loop_npz_root`` or ``closed_loop_sites_npz_root`` is set.
+    #
+    # ``closed_loop_sites_npz_root`` is an alternative/addition to ``closed_loop_npz_root`` for
+    # multi-site validation: a curated .json path-list manifest, grouped into per-site route pools
+    # by scenario_generation.site_discovery.discover_sites_from_json and evaluated as independent
+    # npz_roots, wandb-logged under "closed_loop_scores/<metric>/<site_name>". Both may be set at
+    # once — each fires independently and contributes its own rows to the combined episode table /
+    # cross-site aggregate.
     # ---------------------------------------------------------
     closed_loop_npz_root: str = ""
+    closed_loop_sites_npz_root: str = ""
+    # Object-mode ablation per source: "objects"=normal, "noobj"=empty-world (no dynamic/static
+    # objects, map kept — isolates "reacts badly to traffic" from "can't follow the
+    # route/map"). npz_root defaults to objects-only (usually a single curated scene);
+    # sites_root defaults to both (the objects-vs-noobj comparison).
+    closed_loop_npz_object_modes: list[str] = field(default_factory=lambda: ["objects"])
+    closed_loop_sites_object_modes: list[str] = field(default_factory=lambda: ["objects", "noobj"])
+    closed_loop_seg_len: int = 100000  # large -> one route = one segment = one trial
     # Re-plan every N steps: replan=1 is a model forward EVERY step (~minutes/epoch over a full
     # route); 40 keeps per-epoch cost to ~tens of seconds. Lower it for higher-fidelity validation.
     closed_loop_replan_interval: int = 4
@@ -167,6 +181,23 @@ class TrainConfig:
     closed_loop_warmup_steps: int = 0
     closed_loop_unstick_after: int = 300
     closed_loop_unstick_advance_m: float = 5.0
+    closed_loop_unstick_radius_mult: float = 10.0
+    closed_loop_unstick_teleport_after: int = 300
+    # Early-abort a badly-diverged segment instead of burning the full step budget (see
+    # RolloutParams / reproducer_rollout.render_segment for the exact trigger condition).
+    # 0 = disabled for either knob.
+    closed_loop_abort_deviation_m: float = 50.0
+    closed_loop_abort_after: int = 30
+    closed_loop_abort_max_snaps: int = 0
+    # wandb payload shaping (see scenario_generation.wandb_closed_loop): only ONE representative
+    # episode's video + trajectory-colormap image is uploaded per site per checkpoint (not all
+    # routes — those stay in the local out_dir), picked by "worst" (default, most collisions) /
+    # "first" / "longest".
+    closed_loop_wandb_video_pick: str = "worst"
+    closed_loop_colormap_metrics: list[str] = field(
+        default_factory=lambda: ["clearance", "collision", "near_miss", "speed", "road_border"]
+    )
+    closed_loop_report_base_url: str = ""
 
     # Scenario-based Open-loop validation. The list JSON maps metric names to NPZ paths.
     scenario_based_open_loop_list: str = ""

--- a/diffusion_planner/train_grpo_predictor.py
+++ b/diffusion_planner/train_grpo_predictor.py
@@ -707,8 +707,15 @@ def model_training(args):
                 )
                 # Closed-loop validation on the checkpoint-save cadence; videos + metrics land next
                 # to the saved weights and are logged to wandb at step=epoch+1.
+                is_final_save = (epoch + 1 - init_epoch) // save_utd == (
+                    train_epochs - init_epoch
+                ) // save_utd
                 closed_loop_validate(
-                    diffusion_planner, args, epoch, os.path.join(curr_dir, "closed_loop")
+                    diffusion_planner,
+                    args,
+                    epoch,
+                    os.path.join(curr_dir, "closed_loop"),
+                    is_final_save=is_final_save,
                 )
 
             if train_reward > best_reward:

--- a/diffusion_planner/train_grpo_predictor.py
+++ b/diffusion_planner/train_grpo_predictor.py
@@ -14,7 +14,6 @@ import os
 import numpy as np
 import pandas as pd
 import torch
-import wandb
 from diffusion_planner.dimensions import *
 from diffusion_planner.grpo_epoch import train_grpo_epoch
 from diffusion_planner.model.diffusion_planner import Diffusion_Planner
@@ -36,6 +35,8 @@ from torch import optim
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data import DataLoader, DistributedSampler
 from valid_predictor import aggregate_valid_metrics, validate_model
+
+import wandb
 
 
 def boolean(v):
@@ -321,13 +322,47 @@ def get_args():
     parser.add_argument("--port", default="22323", type=str)
 
     # Closed-loop validation (rendered rollout + wandb video), run on the checkpoint-save cadence
-    # (save_utd). Disabled unless --closed_loop_npz_root is given (dir tree of one route's NPZ).
+    # (save_utd). Disabled unless --closed_loop_npz_root or --closed_loop_sites_npz_root is given.
     parser.add_argument(
         "--closed_loop_npz_root",
         type=str,
         default="",
         help="dir tree of route NPZ frames for closed-loop validation, run on the checkpoint-save "
         "cadence (save_utd). Empty = disabled. One route per trial.",
+    )
+    parser.add_argument(
+        "--closed_loop_sites_npz_root",
+        type=str,
+        default="",
+        help="alternative/addition to --closed_loop_npz_root: a curated .json path-list manifest, "
+        "grouped into per-site route pools by site_discovery.discover_sites_from_json and evaluated "
+        "as independent sites (own npz_root each). Both may be set at once (each fires "
+        "independently).",
+    )
+    parser.add_argument(
+        "--closed_loop_npz_object_modes",
+        nargs="+",
+        choices=("objects", "noobj"),
+        default=["objects"],
+        help="object-mode(s) to run --closed_loop_npz_root under: 'objects'=normal, "
+        "'noobj'=empty-world ablation (no dynamic/static objects, map kept; label gets a "
+        "'__noobj' suffix). Default is objects-only (single arbitrary path, usually a curated "
+        "scene set).",
+    )
+    parser.add_argument(
+        "--closed_loop_sites_object_modes",
+        nargs="+",
+        choices=("objects", "noobj"),
+        default=["objects", "noobj"],
+        help="object-mode(s) to run each --closed_loop_sites_npz_root site under (see "
+        "--closed_loop_npz_object_modes). Default runs both, for the objects-vs-noobj "
+        "comparison in wandb.",
+    )
+    parser.add_argument(
+        "--closed_loop_seg_len",
+        type=int,
+        default=100000,
+        help="frames per segment; large => one route = one segment = one trial",
     )
     parser.add_argument(
         "--closed_loop_replan_interval",
@@ -347,6 +382,45 @@ def get_args():
     parser.add_argument("--closed_loop_warmup_steps", type=int, default=0)
     parser.add_argument("--closed_loop_unstick_after", type=int, default=300)
     parser.add_argument("--closed_loop_unstick_advance_m", type=float, default=2.5)
+    parser.add_argument("--closed_loop_unstick_radius_mult", type=float, default=10.0)
+    parser.add_argument("--closed_loop_unstick_teleport_after", type=int, default=300)
+    parser.add_argument(
+        "--closed_loop_abort_deviation_m",
+        type=float,
+        default=50.0,
+        help="early-abort a segment (terminated='diverged') once GT deviation exceeds this "
+        "(m) for --closed_loop_abort_after steps (0=disabled)",
+    )
+    parser.add_argument("--closed_loop_abort_after", type=int, default=30)
+    parser.add_argument(
+        "--closed_loop_abort_max_snaps",
+        type=int,
+        default=0,
+        help="early-abort a segment after this many unstick teleports (0=disabled)",
+    )
+    parser.add_argument(
+        "--closed_loop_wandb_video_pick",
+        choices=("worst", "first", "longest"),
+        default="worst",
+        help="which single episode per site gets its video + trajectory colormap uploaded "
+        "to wandb (all episodes still get rendered to out_dir either way)",
+    )
+    parser.add_argument(
+        "--closed_loop_colormap_metrics",
+        nargs="*",
+        choices=("clearance", "collision", "near_miss", "speed", "road_border"),
+        default=["clearance", "collision", "near_miss", "speed", "road_border"],
+        help="per-step metrics rendered as trajectory-colormap images for the wandb "
+        "representative episode (one image each — cheap, unlike video/episode picking, so "
+        "all of them render by default)",
+    )
+    parser.add_argument(
+        "--closed_loop_report_base_url",
+        type=str,
+        default="",
+        help="if the out_dir tree is served over HTTP from this base, wandb records a "
+        "clickable report URL instead of just the local path",
+    )
 
     args = parser.parse_args()
 

--- a/diffusion_planner/train_grpo_predictor.py
+++ b/diffusion_planner/train_grpo_predictor.py
@@ -408,8 +408,24 @@ def get_args():
     parser.add_argument(
         "--closed_loop_colormap_metrics",
         nargs="*",
-        choices=("clearance", "collision", "near_miss", "speed", "road_border"),
-        default=["clearance", "collision", "near_miss", "speed", "road_border"],
+        choices=(
+            "clearance",
+            "collision",
+            "near_miss",
+            "speed",
+            "road_border",
+            "red_light",
+            "strong_brake",
+        ),
+        default=[
+            "clearance",
+            "collision",
+            "near_miss",
+            "speed",
+            "road_border",
+            "red_light",
+            "strong_brake",
+        ],
         help="per-step metrics rendered as trajectory-colormap images for the wandb "
         "representative episode (one image each — cheap, unlike video/episode picking, so "
         "all of them render by default)",

--- a/diffusion_planner/train_grpo_predictor.py
+++ b/diffusion_planner/train_grpo_predictor.py
@@ -14,6 +14,7 @@ import os
 import numpy as np
 import pandas as pd
 import torch
+import wandb
 from diffusion_planner.dimensions import *
 from diffusion_planner.grpo_epoch import train_grpo_epoch
 from diffusion_planner.model.diffusion_planner import Diffusion_Planner
@@ -35,8 +36,6 @@ from torch import optim
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data import DataLoader, DistributedSampler
 from valid_predictor import aggregate_valid_metrics, validate_model
-
-import wandb
 
 
 def boolean(v):

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -320,8 +320,24 @@ def get_args(args_list=None):
     parser.add_argument(
         "--closed_loop_colormap_metrics",
         nargs="*",
-        choices=("clearance", "collision", "near_miss", "speed", "road_border"),
-        default=["clearance", "collision", "near_miss", "speed", "road_border"],
+        choices=(
+            "clearance",
+            "collision",
+            "near_miss",
+            "speed",
+            "road_border",
+            "red_light",
+            "strong_brake",
+        ),
+        default=[
+            "clearance",
+            "collision",
+            "near_miss",
+            "speed",
+            "road_border",
+            "red_light",
+            "strong_brake",
+        ],
         help="per-step metrics rendered as trajectory-colormap images for the wandb "
         "representative episode (one image each — cheap, unlike video/episode picking, so "
         "all of them render by default)",

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -234,13 +234,47 @@ def get_args(args_list=None):
     )
 
     # per-epoch closed-loop validation (rendered rollout + wandb video).
-    # Disabled unless --closed_loop_npz_root is given (dir tree of one route's NPZ frames).
+    # Disabled unless --closed_loop_npz_root or --closed_loop_sites_npz_root is given.
     parser.add_argument(
         "--closed_loop_npz_root",
         type=str,
         default="",
         help="dir tree of route NPZ frames for closed-loop validation, run on the checkpoint-save "
         "cadence (save_utd). Empty = disabled. One route per trial.",
+    )
+    parser.add_argument(
+        "--closed_loop_sites_npz_root",
+        type=str,
+        default="",
+        help="alternative/addition to --closed_loop_npz_root: a curated .json path-list manifest, "
+        "grouped into per-site route pools by site_discovery.discover_sites_from_json and evaluated "
+        "as independent sites (own npz_root each). Both may be set at once (each fires "
+        "independently).",
+    )
+    parser.add_argument(
+        "--closed_loop_npz_object_modes",
+        nargs="+",
+        choices=("objects", "noobj"),
+        default=["objects"],
+        help="object-mode(s) to run --closed_loop_npz_root under: 'objects'=normal, "
+        "'noobj'=empty-world ablation (no dynamic/static objects, map kept; label gets a "
+        "'__noobj' suffix). Default is objects-only (single arbitrary path, usually a curated "
+        "scene set).",
+    )
+    parser.add_argument(
+        "--closed_loop_sites_object_modes",
+        nargs="+",
+        choices=("objects", "noobj"),
+        default=["objects", "noobj"],
+        help="object-mode(s) to run each --closed_loop_sites_npz_root site under (see "
+        "--closed_loop_npz_object_modes). Default runs both, for the objects-vs-noobj "
+        "comparison in wandb.",
+    )
+    parser.add_argument(
+        "--closed_loop_seg_len",
+        type=int,
+        default=100000,
+        help="frames per segment; large => one route = one segment = one trial",
     )
     parser.add_argument(
         "--closed_loop_replan_interval",
@@ -260,6 +294,45 @@ def get_args(args_list=None):
     parser.add_argument("--closed_loop_warmup_steps", type=int, default=0)
     parser.add_argument("--closed_loop_unstick_after", type=int, default=300)
     parser.add_argument("--closed_loop_unstick_advance_m", type=float, default=5.0)
+    parser.add_argument("--closed_loop_unstick_radius_mult", type=float, default=10.0)
+    parser.add_argument("--closed_loop_unstick_teleport_after", type=int, default=300)
+    parser.add_argument(
+        "--closed_loop_abort_deviation_m",
+        type=float,
+        default=50.0,
+        help="early-abort a segment (terminated='diverged') once GT deviation exceeds this "
+        "(m) for --closed_loop_abort_after steps (0=disabled)",
+    )
+    parser.add_argument("--closed_loop_abort_after", type=int, default=30)
+    parser.add_argument(
+        "--closed_loop_abort_max_snaps",
+        type=int,
+        default=0,
+        help="early-abort a segment after this many unstick teleports (0=disabled)",
+    )
+    parser.add_argument(
+        "--closed_loop_wandb_video_pick",
+        choices=("worst", "first", "longest"),
+        default="worst",
+        help="which single episode per site gets its video + trajectory colormap uploaded "
+        "to wandb (all episodes still get rendered to out_dir either way)",
+    )
+    parser.add_argument(
+        "--closed_loop_colormap_metrics",
+        nargs="*",
+        choices=("clearance", "collision", "near_miss", "speed", "road_border"),
+        default=["clearance", "collision", "near_miss", "speed", "road_border"],
+        help="per-step metrics rendered as trajectory-colormap images for the wandb "
+        "representative episode (one image each — cheap, unlike video/episode picking, so "
+        "all of them render by default)",
+    )
+    parser.add_argument(
+        "--closed_loop_report_base_url",
+        type=str,
+        default="",
+        help="if the out_dir tree is served over HTTP from this base, wandb records a "
+        "clickable report URL instead of just the local path",
+    )
 
     # Scenario-based Open-loop validation. The list selects samples per metric; metric parameters
     # are regular TrainConfig fields.

--- a/diffusion_planner/train_run.py
+++ b/diffusion_planner/train_run.py
@@ -4,7 +4,8 @@
 Thin launcher only: it resolves the run dir, saves git info, sets NCCL env and runs
 train_predictor.py under torch.distributed.run. train_predictor.py itself is unchanged.
 
---closed_loop_npz_root (optional) is forwarded to train_predictor.py's flag of the same name.
+--closed_loop_npz_root / --closed_loop_sites_npz_root (both optional, may be set together) are
+forwarded to train_predictor.py's flags of the same name.
 """
 
 import argparse
@@ -39,6 +40,14 @@ def parse_args() -> argparse.Namespace:
         "--scenario_based_open_loop_list",
         default="",
         help="optional JSON mapping Scenario-based Open-loop metric names to NPZ path lists. Empty = disabled.",
+    )
+    p.add_argument(
+        "--closed_loop_sites_npz_root",
+        default="",
+        help="optional: a curated .json path-list manifest, grouped into per-site route pools by "
+        "site_discovery.discover_sites_from_json and evaluated as independent sites (objects + "
+        "no-objects ablation by default). May be set together with --closed_loop_npz_root (each "
+        "fires independently). Empty = disabled.",
     )
     return p.parse_args()
 
@@ -102,6 +111,10 @@ def main() -> None:
         "--scenario_based_open_loop_list",
         str(Path(args.scenario_based_open_loop_list).resolve())
         if args.scenario_based_open_loop_list
+        else "",
+        "--closed_loop_sites_npz_root",
+        str(Path(args.closed_loop_sites_npz_root).resolve())
+        if args.closed_loop_sites_npz_root
         else "",
         *optional,
     ]

--- a/scenario_generation/closed_loop_evaluation.py
+++ b/scenario_generation/closed_loop_evaluation.py
@@ -47,7 +47,12 @@ class RolloutParams:
     unstick_advance_m: float = 2.5
     unstick_radius_mult: float = 10.0
     unstick_teleport_after: int = 300
-    draw_every: int = 8
+    # write a PNG only every N steps; None skips the per-step render entirely (no PNGs, no
+    # video, no colormap images -- see build_full_closed_loop_wandb_log's matching
+    # render_media) while metrics/wandb scalars are unaffected -- lets a caller (e.g.
+    # train.py, most epochs) skip the dominant per-epoch cost and only pay it on the one call
+    # that actually needs media (e.g. the final epoch).
+    draw_every: int | None = 8
     replan_interval: int = 10
     tracker_mode: str = "mpc"
     neighbor_history_mode: str = "recorded"

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -1370,7 +1370,7 @@ def render_segment(
     yaw_gate: bool = True,
     *,
     replan_interval: int = 1,
-    draw_every: int = 1,
+    draw_every: int | None = 1,
     abort_deviation_m: float = 0.0,
     abort_after: int = 30,
     abort_max_snaps: int = 0,
@@ -1392,6 +1392,9 @@ def render_segment(
     at 10 Hz (scoring/advance unaffected); only the matplotlib render — the dominant cost — is
     throttled. PNGs are named by step ``k`` (sparse); encoding them at the raw fps makes the video
     play ``draw_every`` x faster (shorter). For real-time playback use ``fps = 10 / draw_every``.
+    ``draw_every=None`` skips the per-step render entirely (no PNGs at all) -- scoring/
+    ``rollout.jsonl`` (and anything downstream that reads it, e.g. trajectory-colormap images)
+    are unaffected, only the video/PNG artifacts disappear.
 
     Runs until the ego reaches the segment end (within ``goal_reach_m``) or the
     step cap (``max_steps``, default 3*(end-start) — the only timeout). Unstick is
@@ -1658,7 +1661,11 @@ def render_segment(
             )
             spd = float(np.hypot(tx - s.live_pose[0], ty - s.live_pose[1]) / DT)
             override = (np.array([tx, ty, th], dtype=np.float64), spd)
-        if (window is None or (window[0] <= k <= window[1])) and k % draw_every == 0:
+        if (
+            draw_every is not None
+            and (window is None or (window[0] <= k <= window[1]))
+            and k % draw_every == 0
+        ):
             _draw_step(
                 np_dict,
                 pred_cur,

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -1430,9 +1430,10 @@ def render_segment(
     fired this many times in one segment — repeated snapping is itself a sign of a bad rollout.
 
     Per-step ``rollout.jsonl`` lines (next to the PNGs) always include ``clearance_m``,
-    ``collision``, and ``rb_dist_m`` (ego-to-road-border distance; ``None`` when the frame
-    carries no lane geometry) alongside the ego pose — see
-    :mod:`scenario_generation.trajectory_colormap` for the trajectory-colormap consumer.
+    ``collision``, ``rb_dist_m`` (ego-to-road-border distance; ``None`` when the frame
+    carries no lane geometry), and ``red_light_violation`` alongside the ego pose — see
+    :mod:`scenario_generation.trajectory_colormap` for the trajectory-colormap consumer
+    (which also derives a "strong_brake" colormap from consecutive ``speed`` samples).
 
     ``drop_objects``: empty-world ablation — zero out ``neighbor_agents_past`` and
     ``static_objects`` (and the derived ``neighbors_live``) every step, so the model sees no
@@ -1605,6 +1606,7 @@ def render_segment(
                     "rb_dist_m": round(float(s.rb_dists[k]), 4)
                     if np.isfinite(s.rb_dists[k])
                     else None,
+                    "red_light_violation": bool(s.red_light[k]),
                     "gt_deviation_m": round(gt_deviation_m, 3),
                 }
             )

--- a/scenario_generation/wandb_closed_loop.py
+++ b/scenario_generation/wandb_closed_loop.py
@@ -193,6 +193,7 @@ def build_full_closed_loop_wandb_log(
     colormap_metrics: tuple[str, ...] = METRIC_CHOICES,
     near_miss_thresh: float = 0.5,
     report_base_url: str | None = None,
+    render_media: bool = True,
 ) -> dict:
     """Per-site full-route closed-loop wandb payload, keyed into role-based sections so the
     workspace stays navigable (one collapsible section each) instead of one flat ``closed_loop``
@@ -204,6 +205,10 @@ def build_full_closed_loop_wandb_log(
       for the representative episode (captioned by metric), mirroring the HTML report's
       per-card metric dropdown; ``closed_loop_media/{site}__video`` — that episode's video.
     - ``closed_loop_links/{site}`` — where the full report (all videos + HTML) lives.
+
+    ``render_media=False`` skips the video + colormap-image block entirely (scores/links are
+    unaffected) -- for a caller that already skipped rendering (e.g. train.py's RolloutParams
+    ``draw=False`` on most epochs), so there's no colormap image to render from anyway.
 
     The per-episode table is built once across ALL sites by :func:`build_combined_episode_table`
     at the caller (so it's a single filterable/groupable panel), not here.
@@ -217,7 +222,7 @@ def build_full_closed_loop_wandb_log(
 
     rows = summary.get("segments") or []
     rep = pick_representative_row(rows, mode=video_pick)
-    if rep is not None and out_dir is not None:
+    if render_media and rep is not None and out_dir is not None:
         png_dir, mp4_path = _segment_paths(out_dir, rep)
         if mp4_path.is_file():
             log[f"closed_loop_media/{label}__video"] = wandb.Video(str(mp4_path), format="mp4")


### PR DESCRIPTION
PR1~PR6を通して出来ること：
https://tier4.atlassian.net/browse/T4DEV-57220 Justificationに記載


## Summary
Final part of the stacked closed-loop eval series (stacked on #302). Wires PR1-5 into the training loop:

`closed_loop_validate()` (`train.py`) now runs one `FullRouteClosedLoopEvaluation` (PR2) per (site, object-mode) pair:

- `--closed_loop_npz_root` (single arbitrary path) and `--closed_loop_sites_npz_root` (a curated `.json` path-list manifest grouped into per-site route pools by PR3's `site_discovery.discover_sites_from_json`) fire **independently** — not if/else — so an ad-hoc override-scene test and a full per-site sweep can run in the same training call, each contributing its own rows to the combined episode table / cross-site aggregate (PR4's `wandb_closed_loop`).
- Each source picks its own object modes via `--closed_loop_npz_object_modes` (default objects-only — usually a single curated scene, where the traffic-reaction ablation doesn't apply) / `--closed_loop_sites_object_modes` (default objects+noobj — the full per-site objects-vs-no-objects comparison).
- `--closed_loop_sites_npz_root` is always a curated JSON manifest now (see PR3/PR5) — there is no directory-scan fallback.

`train_config.py`/`train_predictor.py`/`train_grpo_predictor.py` gain the corresponding CLI/config fields (site roots, object modes, `seg_len`, the `abort_*`/`unstick_*` `RolloutParams` knobs, wandb video-pick/colormap-metrics/report-base-url). `train_run.py` forwards `--closed_loop_sites_npz_root` alongside the existing `--closed_loop_npz_root`.

Closes out the stacked series: rollout engine (#298) → evaluation framework (#299) → site discovery/colormap (#300) → W&B dashboard/HTML report (#301) → standalone CLI (#302) → this.

## Test plan
- [x] `ast.parse` + module import check + `TrainConfig` instantiation check
- [x] Verified end-to-end on a real 8-GPU server training run (real dataset, real model): both sources firing together, both object modes, per-site + cross-site wandb aggregate, combined episode table, curated W&B dashboard
- [x] Fixed a real crash surfaced during that run (stale `s.n_snaps` field reference in PR1's early-abort debug logging, now in PR1/#298)
- [x] Verified `--closed_loop_sites_npz_root` as a `.json` manifest through the real, unmodified `train_run.py` CLI entrypoint (not just a direct function call): resumed a checkpoint, ran 10 real epochs, closed-loop fired at the checkpoint-save epoch against a real 2-site JSON manifest, all 4 (site, object-mode) combinations completed with correct metrics, videos and W&B log uploaded successfully
- [x] After removing the `discover_sites` directory-scan fallback, re-verified via a real single-process `train_predictor.py` run (empty train/valid sets, real 2-site JSON manifest): `closed_loop_validate` ran all 4 (site, object-mode) combos with correct real route-completion/collision/curb-hit numbers, wandb (offline) log written correctly
