### PR TITLE
feat: cost-sensitive turn-indicator intent objective and deployment calibration

### DIFF
--- a/diffusion_planner/diffusion_planner/loss.py
+++ b/diffusion_planner/diffusion_planner/loss.py
@@ -1,6 +1,15 @@
+import math
+from argparse import Namespace
+
 import torch
 import torch.nn.functional as F
 
+from diffusion_planner.dimensions import (
+    TURN_INDICATOR_OUTPUT_DIM,
+    TURN_INDICATOR_OUTPUT_DISABLE,
+    TURN_INDICATOR_OUTPUT_ENABLE_LEFT,
+    TURN_INDICATOR_OUTPUT_ENABLE_RIGHT,
+)
 from planner_metrics.collision_geometry import center_rect_to_points
 
 _NEIGHBOR_EVAL_STEPS = [0, 20, 40, 60, 79]
@@ -117,6 +126,186 @@ def make_turn_indicator_gt(
         values = torch.unique(raw_values[invalid]).detach().cpu().tolist()
         raise ValueError(f"Invalid TurnIndicatorsReport values at current frame: {values}")
     return raw_labels - 1
+
+
+# Opposite driving state per dense class; OFF has no opposite direction.
+_TURN_INDICATOR_OPPOSITE = {
+    TURN_INDICATOR_OUTPUT_ENABLE_LEFT: TURN_INDICATOR_OUTPUT_ENABLE_RIGHT,
+    TURN_INDICATOR_OUTPUT_ENABLE_RIGHT: TURN_INDICATOR_OUTPUT_ENABLE_LEFT,
+}
+
+
+def turn_indicator_geometry_evidence(
+    ego_future: torch.Tensor,  # [B, T, >=4] raw ego-frame waypoints (x, y, cos, sin)
+    *,
+    min_yaw_rad: float,
+    full_yaw_rad: float,
+    min_lateral_m: float,
+    full_lateral_m: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Which way the expert future actually turns, and how unambiguously.
+
+    Mirrors ``util_scripts/audit_turn_indicator_events.py``: ``y`` and yaw are
+    left-positive, yaw is measured from the first future frame, and evidence is the
+    horizon maximum of the same-side quantity. Strength ramps 0->1 between the audited
+    weak bar (5 deg / 0.5 m) and a strong bar, and is reduced by whatever evidence the
+    opposite side shows, so an S-shaped future cannot masquerade as a turn.
+
+    Returns ``(direction, strength)`` with direction in the dense OFF/LEFT/RIGHT space
+    and ``strength`` in [0, 1]; direction is OFF exactly where strength is zero.
+    """
+    if ego_future.ndim != 3 or ego_future.shape[-1] < 4:
+        raise ValueError(f"ego_future must be [B, T, >=4], got {tuple(ego_future.shape)}")
+    if not 0.0 <= min_yaw_rad < full_yaw_rad:
+        raise ValueError(
+            f"require 0 <= min_yaw_rad < full_yaw_rad, got {min_yaw_rad}/{full_yaw_rad}"
+        )
+    if not 0.0 <= min_lateral_m < full_lateral_m:
+        raise ValueError(
+            f"require 0 <= min_lateral_m < full_lateral_m, got {min_lateral_m}/{full_lateral_m}"
+        )
+
+    # Unwrapped heading relative to the first future frame: wrapping the per-step delta
+    # keeps a hard turn monotonic instead of folding it back at +-pi.
+    yaw = torch.atan2(ego_future[..., 3], ego_future[..., 2])  # [B, T]
+    delta = torch.diff(yaw, dim=-1)
+    delta = torch.atan2(torch.sin(delta), torch.cos(delta))
+    yaw = torch.cat([torch.zeros_like(yaw[:, :1]), torch.cumsum(delta, dim=-1)], dim=-1)
+    lateral = ego_future[..., 1]
+
+    def ramp(value: torch.Tensor, low: float, high: float) -> torch.Tensor:
+        return ((value - low) / (high - low)).clamp(0.0, 1.0)
+
+    def side_strength(sign: float) -> torch.Tensor:
+        return torch.maximum(
+            ramp((sign * yaw).amax(dim=-1), min_yaw_rad, full_yaw_rad),
+            ramp((sign * lateral).amax(dim=-1), min_lateral_m, full_lateral_m),
+        )
+
+    left = side_strength(1.0)
+    right = side_strength(-1.0)
+    strength = (left - right).abs()
+    direction = torch.where(
+        strength > 0,
+        torch.where(
+            left >= right,
+            torch.full_like(strength, TURN_INDICATOR_OUTPUT_ENABLE_LEFT),
+            torch.full_like(strength, TURN_INDICATOR_OUTPUT_ENABLE_RIGHT),
+        ),
+        torch.full_like(strength, TURN_INDICATOR_OUTPUT_DISABLE),
+    ).long()
+    return direction, strength
+
+
+def turn_indicator_soft_targets(
+    target: torch.Tensor,  # [B] dense OFF/LEFT/RIGHT labels
+    implied_direction: torch.Tensor,  # [B]
+    implied_strength: torch.Tensor,  # [B]
+    *,
+    smoothing: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Relax OFF labels whose expert future already commits to a turn.
+
+    Human lever timing leads the maneuver by a median 3.5 s (1.6-6.8 s p10-p90), so an
+    OFF frame with a clearly turning future is a late annotation rather than a negative.
+    At most ``smoothing`` of that sample's target mass moves from OFF onto the implied
+    direction. Active labels stay one-hot and mass is never moved between LEFT and
+    RIGHT, so the objective can never learn that the two directions are interchangeable.
+
+    Returns ``(soft_target, moved_mass)``; both are plain data with no autograd history.
+    """
+    if not 0.0 <= smoothing < 1.0:
+        raise ValueError(f"turn-indicator smoothing must be in [0, 1), got {smoothing}")
+    soft = F.one_hot(target, TURN_INDICATOR_OUTPUT_DIM).to(dtype=implied_strength.dtype)
+    moved = torch.zeros_like(implied_strength)
+    if smoothing > 0.0:
+        eligible = (target == TURN_INDICATOR_OUTPUT_DISABLE) & (
+            implied_direction != TURN_INDICATOR_OUTPUT_DISABLE
+        )
+        moved = smoothing * implied_strength * eligible.to(dtype=implied_strength.dtype)
+        soft[:, TURN_INDICATOR_OUTPUT_DISABLE] = soft[:, TURN_INDICATOR_OUTPUT_DISABLE] - moved
+        # ``moved`` is zero wherever the implied direction is OFF, so scattering it back
+        # into column OFF for those rows is a no-op.
+        soft = soft.scatter_add(1, implied_direction.unsqueeze(-1), moved.unsqueeze(-1))
+    return soft, moved
+
+
+def turn_indicator_objective(
+    logit: torch.Tensor,  # [B, TURN_INDICATOR_OUTPUT_DIM] fp32 logits
+    target: torch.Tensor,  # [B] dense OFF/LEFT/RIGHT labels
+    ego_future: torch.Tensor | None,  # [B, T, >=4] raw expert future, or None
+    args: Namespace,
+) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+    """Per-sample turn-intent loss priced by the deployment cost of each error.
+
+    Cross entropy against the (optionally relaxed) target keeps the head a proper
+    scoring rule, because the deployment state machine gates on absolute probabilities
+    rather than on the argmax. Added to it is the one cost plain cross entropy gets
+    wrong: commanding the opposite direction is not interchangeable with a late or
+    leaked signal, so opposite-direction probability mass carries an explicit expected
+    cost. Both terms reduce to the legacy objective at their zero defaults.
+
+    Returns the unreduced per-sample loss and detached scalar diagnostics.
+    """
+    if logit.shape[-1] != TURN_INDICATOR_OUTPUT_DIM:
+        raise ValueError(f"turn-indicator logits must be [B, {TURN_INDICATOR_OUTPUT_DIM}]")
+    smoothing = float(getattr(args, "turn_indicator_implied_intent_smoothing", 0.0))
+    opposite_weight = float(getattr(args, "turn_indicator_opposite_direction_weight", 0.0))
+    if opposite_weight < 0.0:
+        raise ValueError(
+            f"turn_indicator_opposite_direction_weight must be non-negative, got {opposite_weight}"
+        )
+
+    if smoothing > 0.0 and ego_future is not None:
+        # Evidence comes from the expert future in fp32 regardless of the autocast dtype:
+        # a bf16 heading integral would make the ramp thresholds batch-dependent.
+        implied_direction, implied_strength = turn_indicator_geometry_evidence(
+            ego_future.float(),
+            min_yaw_rad=math.radians(
+                float(getattr(args, "turn_indicator_implied_intent_min_yaw_deg", 5.0))
+            ),
+            full_yaw_rad=math.radians(
+                float(getattr(args, "turn_indicator_implied_intent_full_yaw_deg", 20.0))
+            ),
+            min_lateral_m=float(getattr(args, "turn_indicator_implied_intent_min_lateral_m", 0.5)),
+            full_lateral_m=float(
+                getattr(args, "turn_indicator_implied_intent_full_lateral_m", 2.0)
+            ),
+        )
+    else:
+        smoothing = 0.0
+        implied_direction = torch.full_like(target, TURN_INDICATOR_OUTPUT_DISABLE)
+        implied_strength = torch.zeros(target.shape, dtype=logit.dtype, device=logit.device)
+
+    soft_target, moved = turn_indicator_soft_targets(
+        target, implied_direction, implied_strength.to(dtype=logit.dtype), smoothing=smoothing
+    )
+    loss = -(soft_target * F.log_softmax(logit, dim=-1)).sum(dim=-1)  # [B]
+
+    opposite = torch.full_like(target, TURN_INDICATOR_OUTPUT_DISABLE)
+    for active, mirrored in _TURN_INDICATOR_OPPOSITE.items():
+        opposite = torch.where(target == active, torch.full_like(opposite, mirrored), opposite)
+    active_mask = target != TURN_INDICATOR_OUTPUT_DISABLE
+    opposite_probability = F.softmax(logit, dim=-1).gather(1, opposite.unsqueeze(-1)).squeeze(-1)
+    opposite_probability = opposite_probability * active_mask.to(dtype=logit.dtype)
+    if opposite_weight > 0.0:
+        loss = loss + opposite_weight * opposite_probability
+
+    with torch.no_grad():
+        diagnostics = {
+            "turn_indicator_opposite_probability": _masked_mean(opposite_probability, active_mask),
+            "turn_indicator_implied_intent_mass": _masked_mean(
+                moved, target == TURN_INDICATOR_OUTPUT_DISABLE
+            ),
+        }
+    return loss, diagnostics
+
+
+def _masked_mean(values: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+    """Mean of ``values`` over ``mask``, or zero when the mask selects nothing."""
+    count = mask.sum()
+    total = (values * mask.to(dtype=values.dtype)).sum()
+    return total / count.to(dtype=values.dtype) if count > 0 else torch.zeros_like(total)
 
 
 def loss_func(

--- a/diffusion_planner/diffusion_planner/model/module/decoder.py
+++ b/diffusion_planner/diffusion_planner/model/module/decoder.py
@@ -16,6 +16,7 @@ from diffusion_planner.loss import (
     normalize_ego_state,
     normalize_ego_velocity,
     sample_diffusion_time,
+    turn_indicator_objective,
     velocity_to_waypoints,
     waypoints_to_velocity,
 )
@@ -313,11 +314,11 @@ def compute_training_loss(
         "turn_indicator_expert_logit", turn_indicator_logit
     ).float()
     turn_indicator_gt = make_turn_indicator_gt(inputs["turn_indicators"])  # [B,]
-    generated_turn_indicator_loss = nn.functional.cross_entropy(
-        turn_indicator_logit, turn_indicator_gt, reduction="none"
+    generated_turn_indicator_loss, turn_indicator_diagnostics = turn_indicator_objective(
+        turn_indicator_logit, turn_indicator_gt, ego_future, args
     )
-    expert_turn_indicator_loss = nn.functional.cross_entropy(
-        turn_indicator_expert_logit, turn_indicator_gt, reduction="none"
+    expert_turn_indicator_loss, _ = turn_indicator_objective(
+        turn_indicator_expert_logit, turn_indicator_gt, ego_future, args
     )
     # The generated branch consumes x_start predicted at the sampled diffusion time;
     # near t=1 that trajectory is close to the conditional mean and teaches the head
@@ -350,6 +351,7 @@ def compute_training_loss(
         loss["turn_indicator_accuracy"] = generated_accuracy
         loss["turn_indicator_generated_accuracy"] = generated_accuracy
         loss["turn_indicator_expert_accuracy"] = expert_accuracy
+        loss.update(turn_indicator_diagnostics)
 
     non_finite_losses = [
         key
@@ -408,14 +410,21 @@ def compute_turn_indicator_head_training_loss(
 
     expert_logit = decoder_output["turn_indicator_expert_logit"].float()
     target = make_turn_indicator_gt(inputs["turn_indicators"])
-    expert_loss = nn.functional.cross_entropy(expert_logit, target)
+    expert_sample_loss, expert_diagnostics = turn_indicator_objective(
+        expert_logit, target, ego_future, args
+    )
+    expert_loss = expert_sample_loss.mean()
+    turn_indicator_diagnostics = expert_diagnostics
     if training_mode == "expert":
         total = expert_loss
         generated_logit = None
         generated_loss = None
     else:
         generated_logit = decoder_output["turn_indicator_logit"].float()
-        generated_loss = nn.functional.cross_entropy(generated_logit, target)
+        generated_sample_loss, turn_indicator_diagnostics = turn_indicator_objective(
+            generated_logit, target, ego_future, args
+        )
+        generated_loss = generated_sample_loss.mean()
         generated_weight = float(getattr(args, "turn_indicator_generated_loss_weight", 1.0))
         expert_weight = float(getattr(args, "turn_indicator_expert_loss_weight", 1.0))
         total = (generated_weight * generated_loss + expert_weight * expert_loss) / max(
@@ -436,6 +445,9 @@ def compute_turn_indicator_head_training_loss(
         "turn_indicator_expert_loss": expert_loss.detach(),
         "turn_indicator_accuracy": accuracy,
         "turn_indicator_expert_accuracy": expert_accuracy,
+        # Diagnostics follow the branch this stage deploys: the generated trajectory when
+        # one exists, otherwise the expert trajectory the head is being pretrained on.
+        **turn_indicator_diagnostics,
     }
     if generated_loss is not None:
         result["turn_indicator_generated_loss"] = generated_loss.detach()

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -156,6 +156,8 @@ def _turn_indicator_validation_metrics(agg: dict) -> tuple[float | None, dict, d
         "turn_indicator_active_recall",
         "turn_indicator_active_f1",
         "turn_indicator_direction_accuracy",
+        "turn_indicator_nll",
+        "turn_indicator_ece",
     )
     metrics = {
         f"valid_turn_indicator/{key.removeprefix('turn_indicator_')}": agg[key]
@@ -416,6 +418,12 @@ def assert_checkpoint_compatible(
             "turn_indicator_expert_loss_weight",
             "supervised_training_stage",
             "turn_indicator_head_training_mode",
+            "turn_indicator_opposite_direction_weight",
+            "turn_indicator_implied_intent_smoothing",
+            "turn_indicator_implied_intent_min_yaw_deg",
+            "turn_indicator_implied_intent_full_yaw_deg",
+            "turn_indicator_implied_intent_min_lateral_m",
+            "turn_indicator_implied_intent_full_lateral_m",
             "use_ema",
             "amp_dtype",
             "tf32",
@@ -490,8 +498,24 @@ def assert_checkpoint_compatible(
             "rl_road_border_critical_m",
             "rl_road_border_safe_m",
         )
+        # The cost-sensitive intent-objective fields postdate the first head checkpoints.
+        # A checkpoint written before them was trained at the documented legacy setting
+        # (both weights 0.0), so absence is meaningful rather than corrupt; an explicit
+        # value must still match exactly.
+        objective_migration_fields = {
+            "turn_indicator_opposite_direction_weight",
+            "turn_indicator_implied_intent_smoothing",
+            "turn_indicator_implied_intent_min_yaw_deg",
+            "turn_indicator_implied_intent_full_yaw_deg",
+            "turn_indicator_implied_intent_min_lateral_m",
+            "turn_indicator_implied_intent_full_lateral_m",
+        }
         missing_training_fields = [
-            field for field in training_fields if hasattr(args, field) and field not in ckpt_args
+            field
+            for field in training_fields
+            if hasattr(args, field)
+            and field not in ckpt_args
+            and field not in objective_migration_fields
         ]
         if missing_training_fields:
             raise RuntimeError(

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -105,6 +105,24 @@ class TrainConfig:
     # joint ablation), never by policy-only Base/SFT.
     turn_indicator_generated_loss_weight: float = 1.0
     turn_indicator_expert_loss_weight: float = 1.0
+    # Cost-sensitive intent objective. Cross entropy stays the calibration backbone
+    # because the deployment state machine gates on absolute probabilities, but plain
+    # cross entropy prices a LEFT/RIGHT swap exactly like a late signal even though the
+    # first commands the opposite maneuver. This is the expected cost of opposite-
+    # direction probability mass on active ground truth; 0.0 restores plain CE.
+    turn_indicator_opposite_direction_weight: float = 1.0
+    # The Base80 audit measured a median 3.5 s (1.6-6.4 s p10-p90 left, 1.4-6.8 s right)
+    # from lever to motion, so an OFF frame whose expert future already turns is a late
+    # annotation, not a negative. Move at most this much target mass from OFF onto the
+    # geometrically implied direction, ramped by evidence strength. Mass never moves
+    # between LEFT and RIGHT, and active labels stay one-hot. 0.0 restores hard labels.
+    turn_indicator_implied_intent_smoothing: float = 0.2
+    # Evidence bars, in the same quantities the audit tool reports. The weak pair is the
+    # audit's own activation-confirmation bar; the strong pair is its next bucket.
+    turn_indicator_implied_intent_min_yaw_deg: float = 5.0
+    turn_indicator_implied_intent_full_yaw_deg: float = 20.0
+    turn_indicator_implied_intent_min_lateral_m: float = 0.5
+    turn_indicator_implied_intent_full_lateral_m: float = 2.0
     # The production SFT contract is deliberately staged: ``policy`` adapts the
     # trajectory planner without evaluating or updating the auxiliary head, then
     # ``turn_indicator`` freezes the planner and trains the detached head below.

--- a/diffusion_planner/diffusion_planner/utils/turn_indicator.py
+++ b/diffusion_planner/diffusion_planner/utils/turn_indicator.py
@@ -21,10 +21,22 @@ class TurnIndicatorStateMachineConfig:
     direction_switch_seconds: float = 0.50
     minimum_active_seconds: float = 1.00
     probability_ema_alpha: float = 0.50
+    # Every gate above is an absolute probability, so their meaning depends on how well
+    # the head is calibrated. This is the deployment-side temperature applied to the
+    # logits before the softmax: >1 flattens an over-confident head, <1 sharpens an
+    # under-confident one, and 1.0 leaves the network distribution untouched. Fit it on
+    # sequential validation predictions with ``fit_probability_temperature`` and freeze
+    # it as configuration; it never changes the argmax, only when a gate opens.
+    probability_temperature: float = 1.0
 
     def __post_init__(self):
         if self.frequency_hz <= 0:
             raise ValueError("frequency_hz must be positive")
+        if not math.isfinite(self.probability_temperature) or self.probability_temperature <= 0:
+            raise ValueError(
+                f"probability_temperature must be positive and finite, "
+                f"got {self.probability_temperature}"
+            )
         for name in (
             "activation_threshold",
             "deactivation_threshold",
@@ -105,6 +117,14 @@ class TurnIndicatorStateMachine:
             (probabilities < 0).any() or abs(float(probabilities.sum()) - 1.0) > 1e-4
         ):
             raise ValueError("Probabilities must be non-negative and sum to one")
+        temperature = self.config.probability_temperature
+        if temperature != 1.0:
+            # Softmax is shift-invariant, so re-softmaxing scaled log-probabilities is
+            # exactly softmax(logits / T) and works for either input form.
+            probabilities = torch.softmax(
+                probabilities.clamp_min(torch.finfo(probabilities.dtype).tiny).log() / temperature,
+                dim=0,
+            )
 
         alpha = self.config.probability_ema_alpha
         if self._smoothed_probabilities is None:
@@ -141,3 +161,57 @@ class TurnIndicatorStateMachine:
             self._candidate = candidate
             self._candidate_frames = 0
         return self.state
+
+
+def fit_probability_temperature(
+    logits: torch.Tensor,  # [N, TURN_INDICATOR_OUTPUT_DIM]
+    labels: torch.Tensor,  # [N] dense OFF/LEFT/RIGHT labels
+    *,
+    bounds: tuple[float, float] = (0.05, 20.0),
+    iterations: int = 64,
+) -> float:
+    """Temperature that minimizes validation NLL, for ``probability_temperature``.
+
+    Deterministic golden-section search on a single scalar: no optimizer state, no
+    initialization sensitivity, and identical results across runs. Rescaling logits
+    cannot change the argmax, so every accuracy metric is invariant; what changes is
+    whether the state machine's absolute-probability gates fire when they should.
+    """
+    if logits.ndim != 2 or logits.shape[-1] != TURN_INDICATOR_OUTPUT_DIM:
+        raise ValueError(
+            f"logits must be [N, {TURN_INDICATOR_OUTPUT_DIM}], got {tuple(logits.shape)}"
+        )
+    if labels.shape != logits.shape[:1]:
+        raise ValueError(f"labels must be [{logits.shape[0]}], got {tuple(labels.shape)}")
+    if logits.numel() == 0:
+        raise ValueError("cannot fit a temperature without validation samples")
+    low, high = bounds
+    if not 0 < low < high:
+        raise ValueError(f"require 0 < low < high, got {bounds}")
+    # Accumulate the objective in float64: this runs once over a whole validation split,
+    # so the summation error of a float32 reduction would otherwise dominate the fit.
+    values = logits.detach().double()
+    targets = labels.detach().long()
+
+    def nll(temperature: float) -> float:
+        return float(
+            torch.nn.functional.cross_entropy(values / temperature, targets, reduction="mean")
+        )
+
+    # Search in log-temperature: the objective is far closer to symmetric there, so the
+    # same iteration count brackets both an over- and an under-confident head equally.
+    lo, hi = math.log(low), math.log(high)
+    inverse_phi = (math.sqrt(5.0) - 1.0) / 2.0
+    left = hi - inverse_phi * (hi - lo)
+    right = lo + inverse_phi * (hi - lo)
+    left_value, right_value = nll(math.exp(left)), nll(math.exp(right))
+    for _ in range(max(int(iterations), 1)):
+        if left_value <= right_value:
+            hi, right, right_value = right, left, left_value
+            left = hi - inverse_phi * (hi - lo)
+            left_value = nll(math.exp(left))
+        else:
+            lo, left, left_value = left, right, right_value
+            right = lo + inverse_phi * (hi - lo)
+            right_value = nll(math.exp(right))
+    return math.exp(0.5 * (lo + hi))

--- a/diffusion_planner/diffusion_planner/validate_model.py
+++ b/diffusion_planner/diffusion_planner/validate_model.py
@@ -29,6 +29,10 @@ EPDMS_DT = 0.1
 MULTISAMPLE_ADE_THRESHOLD_M = 4.0
 MULTISAMPLE_FDE_THRESHOLD_M = 8.0
 TURN_INDICATOR_CLASS_NAMES = ("disable", "enable_left", "enable_right")
+# Reliability-diagram resolution for the intent head. The deployment state machine gates
+# on absolute probabilities, so how well those probabilities mean what they say is a
+# first-class metric here, not a post-hoc curiosity.
+TURN_INDICATOR_CALIBRATION_BINS = 10
 
 
 def turn_indicator_metrics_from_confusion(confusion: list[int]) -> dict[str, float]:
@@ -78,6 +82,61 @@ def turn_indicator_metrics_from_confusion(confusion: list[int]) -> dict[str, flo
             (matrix[1][1] + matrix[2][2]) / active_true if active_true else 0.0
         ),
     }
+
+
+def turn_indicator_calibration_counts(
+    logit: torch.Tensor,  # [B, TURN_INDICATOR_OUTPUT_DIM]
+    target: torch.Tensor,  # [B] dense OFF/LEFT/RIGHT labels
+) -> list[float]:
+    """Reliability increments for one batch, laid out as a flat all-reducible list.
+
+    Layout: ``[samples, nll_sum, per-bin count..., per-bin confidence sum...,
+    per-bin correct count...]``, binned on the top-class probability the state machine
+    actually thresholds.
+    """
+    probabilities = torch.softmax(logit.detach().float(), dim=-1)
+    confidence, prediction = probabilities.max(dim=-1)
+    nll_sum = float(
+        -probabilities.clamp_min(torch.finfo(probabilities.dtype).tiny)
+        .log()
+        .gather(1, target.view(-1, 1))
+        .sum()
+    )
+    bins = TURN_INDICATOR_CALIBRATION_BINS
+    # A confidence of exactly 1.0 belongs to the last bin, not to a nonexistent bin+1.
+    index = (confidence * bins).long().clamp(max=bins - 1)
+    counts = torch.bincount(index, minlength=bins).double()
+    confidence_sums = torch.bincount(index, weights=confidence.double(), minlength=bins)
+    correct = (prediction == target).double()
+    correct_sums = torch.bincount(index, weights=correct, minlength=bins)
+    return [
+        float(target.numel()),
+        nll_sum,
+        *(
+            value
+            for tensor in (counts, confidence_sums, correct_sums)
+            for value in tensor.cpu().tolist()
+        ),
+    ]
+
+
+def turn_indicator_calibration_metrics(counts: list[float]) -> dict[str, float]:
+    """Mean NLL and expected calibration error from accumulated reliability counts."""
+    bins = TURN_INDICATOR_CALIBRATION_BINS
+    if len(counts) != 2 + 3 * bins:
+        raise ValueError(f"Expected {2 + 3 * bins} calibration entries, got {len(counts)}")
+    samples, nll_sum = counts[0], counts[1]
+    bin_counts = counts[2 : 2 + bins]
+    bin_confidence = counts[2 + bins : 2 + 2 * bins]
+    bin_correct = counts[2 + 2 * bins :]
+    if samples <= 0:
+        return {"turn_indicator_nll": 0.0, "turn_indicator_ece": 0.0}
+    ece = sum(
+        abs(bin_correct[index] - bin_confidence[index]) / samples
+        for index in range(bins)
+        if bin_counts[index] > 0
+    )
+    return {"turn_indicator_nll": nll_sum / samples, "turn_indicator_ece": ece}
 
 
 def _valid_xy(points: np.ndarray) -> np.ndarray:
@@ -403,6 +462,7 @@ def validate_model(model, val_loader, args, return_pred=False) -> tuple[float, f
 
     total_result_dict = defaultdict(list)
     turn_indicator_confusion = [0] * (TURN_INDICATOR_OUTPUT_DIM**2)
+    turn_indicator_calibration = [0.0] * (2 + 3 * TURN_INDICATOR_CALIBRATION_BINS)
 
     total_batches = len(val_loader)
     pbar = tqdm(total=total_batches, desc="validate", disable=ddp.get_rank() != 0)
@@ -495,6 +555,13 @@ def validate_model(model, val_loader, args, return_pred=False) -> tuple[float, f
                 old + int(new)
                 for old, new in zip(turn_indicator_confusion, batch_confusion, strict=False)
             ]
+            batch_calibration = turn_indicator_calibration_counts(
+                turn_indicator_logit, turn_indicator_gt
+            )
+            turn_indicator_calibration = [
+                old + new
+                for old, new in zip(turn_indicator_calibration, batch_calibration, strict=True)
+            ]
         if return_pred:
             predictions.append(prediction.cpu())
             if evaluate_turn_indicator:
@@ -578,6 +645,7 @@ def validate_model(model, val_loader, args, return_pred=False) -> tuple[float, f
             turn_indicators = torch.empty(0, dtype=torch.long)
             turn_indicator_logits = torch.empty(0, TURN_INDICATOR_OUTPUT_DIM)
     turn_metrics = turn_indicator_metrics_from_confusion(turn_indicator_confusion)
+    turn_metrics.update(turn_indicator_calibration_metrics(turn_indicator_calibration))
     return {
         "avg_loss_ego": avg_loss_ego,
         "avg_loss_neighbor": avg_loss_neighbor,
@@ -595,6 +663,7 @@ def validate_model(model, val_loader, args, return_pred=False) -> tuple[float, f
         "_loss_neighbor_sum": total_loss_neighbor,
         "_samples_neighbor": total_samples_neighbor,
         "_turn_confusion": turn_indicator_confusion,
+        "_turn_calibration": turn_indicator_calibration,
         "_turn_indicator_evaluated": evaluate_turn_indicator,
         **total_result_dict,
     }
@@ -618,6 +687,10 @@ def aggregate_valid_metrics(valid_dict, device):
     turn_confusion = [
         int(value) for value in ddp.all_reduce_sum_values(valid_dict["_turn_confusion"], device)
     ]
+    turn_calibration = ddp.all_reduce_sum_values(
+        valid_dict.get("_turn_calibration", [0.0] * (2 + 3 * TURN_INDICATOR_CALIBRATION_BINS)),
+        device,
+    )
     turn_indicator_evaluated = bool(valid_dict.get("_turn_indicator_evaluated", True))
     turn_matrix = [
         turn_confusion[row * TURN_INDICATOR_OUTPUT_DIM : (row + 1) * TURN_INDICATOR_OUTPUT_DIM]
@@ -683,6 +756,7 @@ def aggregate_valid_metrics(valid_dict, device):
         "avg_loss_ego": loss_ego_sum / max(samples_ego, 1),
         "avg_loss_neighbor": loss_nei_sum / max(samples_nei, 1),
         **turn_indicator_metrics_from_confusion(turn_confusion),
+        **turn_indicator_calibration_metrics(turn_calibration),
         "turn_indicator_class_accuracy": turn_class_accuracy,
         "turn_indicator_class_count": turn_class_count,
         "turn_indicator_evaluated": turn_indicator_evaluated,

--- a/diffusion_planner/tests/test_turn_indicator_state_head.py
+++ b/diffusion_planner/tests/test_turn_indicator_state_head.py
@@ -1,11 +1,17 @@
 """Three-state turn-intent head and temporal output stabilization."""
 
+import math
 from unittest.mock import patch
 
 import pytest
 import torch
 from diffusion_planner.dimensions import TURN_INDICATOR_OUTPUT_DIM
-from diffusion_planner.loss import make_turn_indicator_gt
+from diffusion_planner.loss import (
+    make_turn_indicator_gt,
+    turn_indicator_geometry_evidence,
+    turn_indicator_objective,
+    turn_indicator_soft_targets,
+)
 from diffusion_planner.model.diffusion_planner import Diffusion_Planner
 from diffusion_planner.model.module.decoder import (
     Decoder,
@@ -25,11 +31,23 @@ from diffusion_planner.utils.onnx_export import (
 from diffusion_planner.utils.turn_indicator import (
     TurnIndicatorStateMachine,
     TurnIndicatorStateMachineConfig,
+    fit_probability_temperature,
 )
 from diffusion_planner.validate_model import (
+    TURN_INDICATOR_CALIBRATION_BINS,
     TURN_INDICATOR_CLASS_NAMES,
+    turn_indicator_calibration_counts,
+    turn_indicator_calibration_metrics,
     turn_indicator_metrics_from_confusion,
 )
+
+# The audit tool's activation-confirmation bar and its next stronger bucket.
+_EVIDENCE_BARS = {
+    "min_yaw_rad": math.radians(5.0),
+    "full_yaw_rad": math.radians(20.0),
+    "min_lateral_m": 0.5,
+    "full_lateral_m": 2.0,
+}
 
 
 def _hdp_config(**overrides):
@@ -340,6 +358,8 @@ def test_expert_head_stage_skips_diffusion_and_only_updates_head():
     assert torch.isfinite(loss["turn_indicator_loss"])
     assert "turn_indicator_generated_loss" not in loss
     assert "turn_indicator_generated_accuracy" not in loss
+    assert torch.isfinite(loss["turn_indicator_opposite_probability"])
+    assert torch.isfinite(loss["turn_indicator_implied_intent_mass"])
     loss["turn_indicator_loss"].backward()
     assert all(parameter.grad is None for parameter in model.encoder.parameters())
     assert all(parameter.grad is None for parameter in model.decoder.dit.parameters())
@@ -371,6 +391,178 @@ def test_onnx_policy_inputs_have_no_signal_feedback_and_head_has_proprioception(
         "ego_current_state",
     ]
     assert "turn_indicators" not in build_dummy_inputs()
+
+
+def _turning_future(batch: int, *, yaw_rad: float, lateral_m: float, steps: int = 80):
+    """Ego-frame future that ramps linearly to ``yaw_rad`` and ``lateral_m``."""
+    ramp = torch.linspace(0.0, 1.0, steps)
+    yaw = yaw_rad * ramp
+    return torch.stack(
+        [
+            torch.stack([ramp * 10.0, lateral_m * ramp, yaw.cos(), yaw.sin()], dim=-1)
+            for _ in range(batch)
+        ]
+    )
+
+
+def test_geometry_evidence_reads_the_committed_turn_direction():
+    left = turn_indicator_geometry_evidence(
+        _turning_future(1, yaw_rad=0.7, lateral_m=3.0), **_EVIDENCE_BARS
+    )
+    assert left[0].tolist() == [1]
+    assert left[1].tolist() == pytest.approx([1.0])
+
+    right = turn_indicator_geometry_evidence(
+        _turning_future(1, yaw_rad=-0.7, lateral_m=-3.0), **_EVIDENCE_BARS
+    )
+    assert right[0].tolist() == [2]
+    assert right[1].tolist() == pytest.approx([1.0])
+
+    straight = turn_indicator_geometry_evidence(
+        _turning_future(1, yaw_rad=0.0, lateral_m=0.0), **_EVIDENCE_BARS
+    )
+    assert straight[0].tolist() == [0]
+    assert straight[1].tolist() == [0.0]
+
+
+def test_geometry_evidence_discounts_a_future_that_swerves_and_returns():
+    steps = 80
+    ramp = torch.linspace(0.0, 1.0, steps)
+    # Out-and-back: peak lateral offset of 1.5 m with equal left and right heading.
+    lateral = 1.5 * torch.sin(math.pi * ramp)
+    yaw = 0.2 * torch.sin(2.0 * math.pi * ramp)
+    swerve = torch.stack([ramp * 10.0, lateral, yaw.cos(), yaw.sin()], dim=-1)[None]
+    direction, strength = turn_indicator_geometry_evidence(swerve, **_EVIDENCE_BARS)
+    committed = turn_indicator_geometry_evidence(
+        _turning_future(1, yaw_rad=0.2, lateral_m=1.5), **_EVIDENCE_BARS
+    )
+    assert direction.tolist() == [1]
+    # Same peak excursion, but the opposite-side evidence removes most of the strength.
+    assert 0.0 < float(strength) < 0.5 * float(committed[1])
+
+
+def test_soft_targets_relax_late_off_labels_without_mixing_directions():
+    target = torch.tensor([0, 0, 1])
+    implied = torch.tensor([1, 2, 2])
+    strength = torch.tensor([1.0, 0.5, 1.0])
+    soft, moved = turn_indicator_soft_targets(target, implied, strength, smoothing=0.2)
+    assert soft[0].tolist() == pytest.approx([0.8, 0.2, 0.0])
+    assert soft[1].tolist() == pytest.approx([0.9, 0.0, 0.1])
+    # An active label is never relaxed, so no mass reaches the opposite direction.
+    assert soft[2].tolist() == pytest.approx([0.0, 1.0, 0.0])
+    assert moved.tolist() == pytest.approx([0.2, 0.1, 0.0])
+    assert soft.sum(dim=-1).tolist() == pytest.approx([1.0, 1.0, 1.0])
+
+
+def test_objective_reproduces_plain_cross_entropy_at_legacy_settings():
+    torch.manual_seed(3)
+    args = _hdp_config(
+        turn_indicator_opposite_direction_weight=0.0,
+        turn_indicator_implied_intent_smoothing=0.0,
+    )
+    logit = torch.randn(6, 3)
+    target = torch.tensor([0, 1, 2, 0, 1, 2])
+    loss, diagnostics = turn_indicator_objective(
+        logit, target, _turning_future(6, yaw_rad=0.7, lateral_m=3.0), args
+    )
+    torch.testing.assert_close(
+        loss, torch.nn.functional.cross_entropy(logit, target, reduction="none")
+    )
+    assert diagnostics["turn_indicator_implied_intent_mass"] == 0.0
+    # The diagnostic still reports opposite-direction mass even when it is not priced.
+    assert diagnostics["turn_indicator_opposite_probability"] > 0.0
+
+
+def test_objective_prices_opposite_direction_mass_only_on_active_labels():
+    args = _hdp_config(
+        turn_indicator_opposite_direction_weight=2.0,
+        turn_indicator_implied_intent_smoothing=0.0,
+    )
+    # Row 0 is OFF ground truth, row 1 is LEFT ground truth; both put half their mass on
+    # RIGHT, which is an opposite-direction error only for row 1.
+    logit = torch.tensor([[0.0, 0.0, math.log(2.0)], [0.0, 0.0, math.log(2.0)]])
+    target = torch.tensor([0, 1])
+    loss, diagnostics = turn_indicator_objective(logit, target, None, args)
+    baseline = torch.nn.functional.cross_entropy(logit, target, reduction="none")
+    torch.testing.assert_close(loss[0], baseline[0])
+    torch.testing.assert_close(loss[1], baseline[1] + 2.0 * 0.5)
+    assert float(diagnostics["turn_indicator_opposite_probability"]) == pytest.approx(0.5)
+
+
+def test_objective_stops_punishing_an_early_signal_on_a_turning_future():
+    args = _hdp_config(
+        turn_indicator_opposite_direction_weight=0.0,
+        turn_indicator_implied_intent_smoothing=0.2,
+    )
+    # OFF ground truth on a future that clearly turns left: the head predicts LEFT.
+    logit = torch.tensor([[0.0, 2.0, 0.0]])
+    target = torch.tensor([0])
+    turning, _ = turn_indicator_objective(
+        logit, target, _turning_future(1, yaw_rad=0.7, lateral_m=3.0), args
+    )
+    straight, _ = turn_indicator_objective(
+        logit, target, _turning_future(1, yaw_rad=0.0, lateral_m=0.0), args
+    )
+    baseline = torch.nn.functional.cross_entropy(logit, target, reduction="none")
+    torch.testing.assert_close(straight, baseline)
+    assert float(turning) < float(straight)
+
+
+def test_calibration_metrics_match_a_hand_built_reliability_diagram():
+    logit = torch.tensor(
+        [
+            [math.log(0.7), math.log(0.2), math.log(0.1)],
+            [math.log(0.4), math.log(0.5), math.log(0.1)],
+        ]
+    )
+    target = torch.tensor([0, 0])
+    metrics = turn_indicator_calibration_metrics(turn_indicator_calibration_counts(logit, target))
+    assert metrics["turn_indicator_nll"] == pytest.approx(
+        -(math.log(0.7) + math.log(0.4)) / 2, rel=1e-6
+    )
+    # Bin 0.7: one sample, confidence 0.7, accuracy 1.0. Bin 0.5: confidence 0.5, accuracy 0.
+    assert metrics["turn_indicator_ece"] == pytest.approx(0.3 / 2 + 0.5 / 2, rel=1e-6)
+
+
+def test_empty_calibration_accumulator_is_reported_as_unevaluated_zeros():
+    metrics = turn_indicator_calibration_metrics([0.0] * (2 + 3 * TURN_INDICATOR_CALIBRATION_BINS))
+    assert metrics == {"turn_indicator_nll": 0.0, "turn_indicator_ece": 0.0}
+
+
+def test_fit_probability_temperature_recovers_a_known_over_confidence():
+    probabilities = [0.6, 0.25, 0.15]
+    labels = torch.tensor([0] * 60 + [1] * 25 + [2] * 15)
+    calibrated = torch.tensor([[math.log(value) for value in probabilities]]).repeat(100, 1)
+    assert fit_probability_temperature(calibrated, labels) == pytest.approx(1.0, rel=1e-4)
+    # Sharpening the same logits by 3x is exactly a temperature-3 miscalibration.
+    assert fit_probability_temperature(3.0 * calibrated, labels) == pytest.approx(3.0, rel=1e-4)
+
+
+def test_deployment_temperature_moves_the_gate_without_moving_the_argmax():
+    logit = torch.tensor([0.3, 0.5, 0.2]).log()
+    uncalibrated = TurnIndicatorStateMachine(
+        TurnIndicatorStateMachineConfig(probability_ema_alpha=1.0, activation_seconds=0.3)
+    )
+    # The head is right about the direction but never reaches the 0.60 activation gate.
+    assert [uncalibrated.update(logit) for _ in range(10)] == [0] * 10
+    sharpened = TurnIndicatorStateMachine(
+        TurnIndicatorStateMachineConfig(
+            probability_ema_alpha=1.0, activation_seconds=0.3, probability_temperature=0.5
+        )
+    )
+    assert [sharpened.update(logit) for _ in range(3)] == [0, 0, 1]
+    # Feeding probabilities instead of logits must scale identically.
+    equivalent = TurnIndicatorStateMachine(
+        TurnIndicatorStateMachineConfig(
+            probability_ema_alpha=1.0, activation_seconds=0.3, probability_temperature=0.5
+        )
+    )
+    assert [equivalent.update(logit.exp(), logits=False) for _ in range(3)] == [0, 0, 1]
+
+
+def test_state_machine_rejects_an_unusable_temperature():
+    with pytest.raises(ValueError, match="probability_temperature"):
+        TurnIndicatorStateMachineConfig(probability_temperature=0.0)
 
 
 def test_state_machine_debounces_activation_and_holds_minimum_duration():

--- a/diffusion_planner/train_hdp_rl_predictor.py
+++ b/diffusion_planner/train_hdp_rl_predictor.py
@@ -1503,6 +1503,8 @@ def turn_indicator_metrics(agg):
             "turn_indicator_active_recall",
             "turn_indicator_active_f1",
             "turn_indicator_direction_accuracy",
+            "turn_indicator_nll",
+            "turn_indicator_ece",
         )
     } | {
         **{

--- a/diffusion_planner/valid_predictor.py
+++ b/diffusion_planner/valid_predictor.py
@@ -416,6 +416,8 @@ def run_validation(valid_cfg: ValidConfig):
             "turn_indicator_active_recall",
             "turn_indicator_active_f1",
             "turn_indicator_direction_accuracy",
+            "turn_indicator_nll",
+            "turn_indicator_ece",
         ):
             print(f"{metric}={agg[metric]:.4f}")
         for name, accuracy in agg["turn_indicator_class_accuracy"].items():
@@ -446,6 +448,8 @@ def run_validation(valid_cfg: ValidConfig):
                 "turn_indicator_active_recall",
                 "turn_indicator_active_f1",
                 "turn_indicator_direction_accuracy",
+                "turn_indicator_nll",
+                "turn_indicator_ece",
             )
         },
         **{

--- a/docs/hdp_turn_indicator_sft.md
+++ b/docs/hdp_turn_indicator_sft.md
@@ -35,8 +35,9 @@ state probabilities; temporal stability is handled after the network.
 
 The exact default SFT manifest was audited independently: all 4,578,036 samples
 are valid, with 62.07% disable, 20.34% left, and 17.59% right. This distribution
-does not justify the old 10x active-state class weighting; ordinary per-sample
-cross entropy preserves calibration for the output state machine.
+does not justify the old 10x active-state class weighting; per-sample cross entropy
+preserves calibration for the output state machine. The two cost terms added on top
+of it are error-conditional rather than class-conditional; see "Head objective".
 
 ## Model contract
 
@@ -107,6 +108,48 @@ mirror manifest, the same three `is_skipped`-filtered right-turn manifests repea
 their SHA256 values and compares the paths/repeat count with the Base `args.json`
 before loading a checkpoint.
 
+## Head objective
+
+`diffusion_planner.loss.turn_indicator_objective` computes the per-sample head loss
+for every mode (joint, expert, deployment). Cross entropy stays the backbone: the
+state machine gates on absolute probabilities, not on the argmax, so the head must
+remain a proper scoring rule and the rejected 10x class weighting stays rejected.
+Two terms correct the two costs plain cross entropy prices wrong.
+
+**Opposite-direction expected cost.** Cross entropy treats a left-for-right swap as
+just another log-loss increment, but in deployment the two errors are not
+interchangeable: a late or leaked signal is a comfort defect, while commanding the
+opposite direction actively misleads surrounding traffic. On active ground truth the
+probability mass on the mirrored class therefore carries an explicit expected cost,
+`turn_indicator_opposite_direction_weight` (default 1.0). The Bayes-optimal opposite
+probability is 0 whenever the label is a definite direction, so this term does not
+trade away calibration on the classes the gates actually read. It targets the
+measured weakness of the expert head: epoch-1 direction accuracy 0.760 with
+`enable_right` recall 0.724 against `enable_left` 0.798.
+
+**Evidence-conditional one-sided label smoothing.** Median lever-to-motion time is
+3.5 s (10th-to-90th percentile 1.6-6.8 s), so a large share of frames labelled off
+belong to a turn the driver has already committed to and simply has not signalled
+yet. `turn_indicator_geometry_evidence` re-reads the expert future with the audit
+tool's own bars - weak at 5 degrees same-side yaw or 0.5 m same-side lateral offset,
+saturating at 20 degrees or 2.0 m - and returns the implied direction plus a 0-to-1
+strength in which opposite-side evidence cancels, so an out-and-back swerve is
+discounted while a genuine lane change is not. For off-labelled frames with non-zero
+evidence, `turn_indicator_implied_intent_smoothing` (default 0.2) moves
+`smoothing * strength` of the target mass from off onto the implied direction only.
+Active labels stay one-hot and left is never smoothed toward right, so the term
+relieves the under-triggering visible in active precision 0.929 against recall 0.770
+without ever teaching a direction error.
+
+Both terms reduce to the legacy objective at weight/smoothing 0.0, and the
+`supervised_training_stage=policy` stage returns before the head loss is computed, so
+Base and policy-stage SFT runs are numerically unaffected by these defaults. Two
+diagnostics are logged next to the head loss:
+`turn_indicator_opposite_probability` (mean opposite-class probability over active
+ground truth) and `turn_indicator_implied_intent_mass` (mean target mass moved off
+the off class). The six fields are strict-resume `training_fields`, exempted only from
+the missing-field check so that checkpoints predating them can still be resumed.
+
 ## Temporal output
 
 `diffusion_planner.utils.turn_indicator.TurnIndicatorStateMachine` is a pure
@@ -116,7 +159,21 @@ postprocessor. It never feeds state back to the policy. Defaults at 10 Hz are:
 - deactivation confidence at least 0.60 for 0.3 s;
 - opposite-direction confidence at least 0.70 for 0.5 s;
 - minimum active duration of 1.0 s;
-- probability EMA alpha of 0.50.
+- probability EMA alpha of 0.50;
+- probability temperature of 1.0.
+
+Every gate above is an absolute probability, so when a gate opens depends on how well
+the head is calibrated, not only on what it ranks first. `probability_temperature`
+divides the logits before the softmax: above 1.0 flattens an over-confident head,
+below 1.0 sharpens an under-confident one, and 1.0 leaves the network distribution
+untouched. Because the softmax is shift-invariant, the state machine applies it by
+re-softmaxing scaled log-probabilities, which is exactly `softmax(logits / T)` and
+therefore works whether `update` is fed logits or probabilities. Fit it with
+`fit_probability_temperature`, a deterministic golden-section search on
+log-temperature over sequential validation predictions, then freeze it as deployment
+configuration. Rescaling cannot change the argmax, so every accuracy metric is
+invariant; the temperature is not part of the network and does not appear in any ONNX
+graph.
 
 These values are initial safety-oriented defaults. Tune them on sequential SFT
 validation predictions and then freeze them as deployment configuration. The
@@ -131,7 +188,18 @@ measures annotator timing more than usable intent quality. Log:
 - balanced accuracy and macro-F1;
 - active precision, recall, and F1 (off versus either direction);
 - direction accuracy over active ground truth;
-- per-class recall and counts.
+- per-class recall and counts;
+- negative log-likelihood and expected calibration error.
+
+`turn_indicator_nll` and `turn_indicator_ece` come from
+`diffusion_planner.validate_model.turn_indicator_calibration_counts`, which
+accumulates a 10-bin reliability diagram over the top-class probability alongside the
+summed NLL. Only summed counts cross the DDP boundary, so the reduction is
+rank-count-independent; the accumulation is float64 and clamps probability 1.0 into
+the last bin. ECE is the count-weighted mean gap between top-class confidence and
+top-class correctness. These two numbers, not accuracy, say whether the state
+machine's absolute-probability gates are reading a trustworthy scale, and they are
+what `fit_probability_temperature` minimizes and diagnoses.
 
 Sequential deployment evaluation should additionally report event onset delay,
 early activations, missed events, false activation duration, and output switches


### PR DESCRIPTION
## What this changes

The turn-indicator head now trains against the cost of each error in deployment instead of against undifferentiated log loss, and its probability scale is now measurable and correctable.

Stacked on #305 (base `feature/hdp-final-20260727`).

## Why

The finished expert-head run (`hdp_turn_indicator_expert_head1_...from_epoch70`, epoch 1) fails in two specific ways, not generically:

| metric | value |
| --- | --- |
| direction accuracy (active GT) | 0.760 |
| enable_right recall | 0.724 |
| enable_left recall | 0.798 |
| active precision | 0.929 |
| active recall | 0.770 |

It confuses left with right, and it under-triggers. Plain cross entropy prices a left-for-right swap identically to a signal that fires half a second late, while `TurnIndicatorStateMachine` gates on **absolute probabilities** (0.60 / 0.60 / 0.70) — so both the relative cost of errors and the calibration of the scale matter, and neither was being addressed.

## Head objective

`turn_indicator_objective` (used by joint, expert, and deployment modes) keeps cross entropy as the proper-scoring-rule backbone and adds two error-conditional terms:

**Opposite-direction expected cost** — `turn_indicator_opposite_direction_weight` (default 1.0) prices probability mass on the mirrored class, on active ground truth only. The Bayes-optimal opposite probability is 0 whenever the label is a definite direction, so this term cannot trade away calibration on the classes the gates read.

**Evidence-conditional one-sided label smoothing** — median lever-to-motion time is 3.5 s (p10–p90 1.6–6.8 s), so many off-labelled frames belong to a turn the driver has already committed to. `turn_indicator_geometry_evidence` re-reads the expert future with the audit tool's own bars (5° / 0.5 m weak, 20° / 2.0 m saturating), and cancels opposite-side evidence so an out-and-back swerve is discounted while a genuine lane change is not. `turn_indicator_implied_intent_smoothing` (default 0.2) then moves `smoothing * strength` from off onto the implied direction **only**. Active labels stay one-hot and left is never smoothed toward right, so this relieves under-triggering without ever teaching a direction error.

Class weighting stays rejected — the audited 62.07/20.34/17.59 distribution does not justify it, per `docs/hdp_turn_indicator_sft.md`.

New diagnostics logged next to the head loss: `turn_indicator_opposite_probability`, `turn_indicator_implied_intent_mass`.

## Deployment calibration

- `TurnIndicatorStateMachineConfig.probability_temperature` (default 1.0) divides logits before the softmax. Implemented by re-softmaxing scaled log-probabilities, which is exactly `softmax(logits / T)` by shift-invariance, so it works whether `update` is fed logits or probabilities.
- `fit_probability_temperature` — deterministic golden-section search on log-temperature, objective accumulated in float64. No optimizer state, identical across runs.
- `turn_indicator_nll` / `turn_indicator_ece` from a 10-bin reliability diagram over the top-class probability. Only summed counts cross the DDP boundary, so the reduction is rank-count-independent.

The temperature lives in deployment configuration, not in the network — ONNX graphs, head tensors, and strict `load_state_dict` are all untouched, and rescaling never moves the argmax, so every accuracy metric is invariant.

## Backwards compatibility

- Both new terms reduce to the legacy objective at 0.0, which is the `getattr` default, so a bare `Namespace` reproduces the old loss exactly.
- `compute_training_loss` returns before the head loss when `supervised_training_stage == "policy"`, so **Base and policy-stage SFT runs are numerically unaffected** by the new defaults being on.
- The six new fields are strict-resume `training_fields`, added to an `objective_migration_fields` exemption for the *missing*-field check only — pre-existing checkpoints resume, and any mismatch is still rejected.
- No new parameters or buffers in `TurnIndicatorHead`.

## Testing

- `pytest diffusion_planner/tests/test_turn_indicator_state_head.py -q` → **31 passed** (10 new: geometry evidence left/right/straight, swerve cancellation, soft targets, legacy-CE equivalence, opposite-direction pricing, early-signal relief, hand-computed reliability diagram, empty accumulator, temperature recovery at T=1.0 and T=3.0, gate timing that only opens under temperature)
- `pytest diffusion_planner/tests -q` → **366 passed**
- `pytest planner_metrics scenario_generation/tests -q` → **217 passed, 15 skipped**
- `ruff check diffusion_planner/` → clean; `ruff format --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
