### PR TITLE
fix: make latest.pth the checkpoint everywhere, never best_model

### DIFF
--- a/diffusion_planner/valid_run.sh
+++ b/diffusion_planner/valid_run.sh
@@ -12,7 +12,17 @@ NUM_GPUS=$(nvidia-smi -L | wc -l)
 # Set training data path
 MODEL_DIR=${1}
 VALID_SET_LIST_PATH=${2}
-MODEL_PATH="$MODEL_DIR/best_model.pth"
+# Checkpoint selection is always the latest weights; see docs/checkpoint_selection.md.
+# The best_model/ and best_epdms_model/ artifacts are selected by a validation proxy
+# that does not predict closed-loop or real-vehicle behaviour, and every launcher
+# chains stages through latest.pth (strict resume, epoch assertions, EMA hand-off), so
+# evaluating a different checkpoint reports numbers for weights nothing downstream uses.
+MODEL_PATH="${MODEL_PATH:-$MODEL_DIR/latest.pth}"
+if [[ ! -r "$MODEL_PATH" ]]; then
+  echo "No readable checkpoint at $MODEL_PATH." >&2
+  echo "Pass the run directory that holds latest.pth, not a best_model/ directory." >&2
+  exit 1
+fi
 ARGS_JSON_PATH="$MODEL_DIR/args.json"
 TIME=$(date +%Y%m%d_%H%M%S)
 SAVE_DIR=$MODEL_DIR/validation_result_$TIME/predictions

--- a/docs/checkpoint_selection.md
+++ b/docs/checkpoint_selection.md
@@ -1,0 +1,38 @@
+# Checkpoint selection: always `latest.pth`
+
+The checkpoint for **every** downstream use is `<run_dir>/latest.pth`. This covers
+SFT / RL / staged-head initialization, validation and closed-loop evaluation, ONNX
+export, and any checkpoint a report or recommendation points at.
+
+Never select `best_model/` or `best_epdms_model/`. Those directories are written by a
+validation-proxy selector (`valid_epdms_total`, `valid_loss_ego`) measured on a small
+split that does not predict closed-loop or real-vehicle behaviour. The whole pipeline
+is built on the last weights instead:
+
+- `run_hdp_ego_only_base_node01.sbatch` and `run_hdp_ego_only_base80_node02.sbatch`
+  strict-resume from `${SAVE_DIR}/latest.pth` and verify the final epoch through it;
+- `run_hdp_ego_only_sft_node01.sbatch` initializes from `${BASE_RUN}/latest.pth` and
+  asserts that checkpoint is at the expected epoch with an EMA policy present;
+- `run_hdp_staged_sft_node02.sbatch` hands each stage's `latest.pth` EMA to the next
+  stage, and `run_hdp_policy_lr_probe_node02.sbatch` initializes from
+  `${BASE_RUN}/latest.pth`;
+- `valid_run.sh` evaluates `${MODEL_DIR}/latest.pth`.
+
+Substituting an earlier "best" checkpoint silently desyncs a run from those epoch
+assertions and from the EMA state the next stage expects, and reports numbers for
+weights nothing downstream ever consumes.
+
+If a validation metric peaked early, report it — that is a real fact about
+overfitting, and it may be a reason to change the *epoch budget* of the next run. It
+is not a reason to change which checkpoint is used.
+
+Two things that look like exceptions but are not:
+
+- `epochNNNN/best_model.pth` is a filename quirk. Those are plain periodic epoch
+  snapshots, not a selection. The rule is about never picking the `best_model/`
+  directory.
+- In `train_hdp_rl_predictor.py`, `best_model/` holds the last *accepted* RL policy
+  and the `best_valid_score` bookkeeping that strict resume restores. That is internal
+  trainer state, not a checkpoint-selection knob.
+
+Any new tool or script that takes a checkpoint must default to `latest.pth`.


### PR DESCRIPTION
## Rule

**The checkpoint is always `<run_dir>/latest.pth`. Never `best_model/`, never `best_epdms_model/`.** For initialization, evaluation, ONNX export, and anything a report points at.

## Why this was already true everywhere except one file

| site | selection |
| --- | --- |
| `run_hdp_ego_only_base_node01.sbatch`, `run_hdp_ego_only_base80_node02.sbatch` | strict-resume from `${SAVE_DIR}/latest.pth`, final epoch verified through it |
| `run_hdp_ego_only_sft_node01.sbatch` | `${BASE_RUN}/latest.pth`, asserts expected epoch + EMA present |
| `run_hdp_staged_sft_node02.sbatch` | each stage's `latest.pth` EMA feeds the next |
| `run_hdp_policy_lr_probe_node02.sbatch` | `${BASE_RUN}/latest.pth` |
| **`valid_run.sh`** | **was `${MODEL_DIR}/best_model.pth`** ← fixed here |

`best_model/` and `best_epdms_model/` are written by a validation-proxy selector (`valid_epdms_total`, `valid_loss_ego`) on a small split that does not predict closed-loop or real-vehicle behaviour. Beyond the metric being the wrong one, picking an earlier checkpoint desyncs a run from the launchers' epoch assertions and from the EMA state the next stage expects — so evaluation could report numbers for weights nothing downstream ever consumes.

## Changes

- `valid_run.sh` defaults to `${MODEL_DIR}/latest.pth`, overridable via `MODEL_PATH`, and now fails with a pointed message ("pass the run directory that holds latest.pth, not a best_model/ directory") instead of running against a missing path.
- `docs/checkpoint_selection.md` records the rule so new tools default the same way, including the two cases that look like exceptions and are not:
  - `epochNNNN/best_model.pth` is a filename quirk — a periodic epoch snapshot, not a selection;
  - `train_hdp_rl_predictor.py`'s `best_model/` is internal accepted-policy and `best_valid_score` bookkeeping for strict resume, not a selection knob.

An early validation peak stays worth reporting — it can justify a shorter epoch budget on the *next* run. It is not a reason to change which checkpoint is used.

`bash -n diffusion_planner/valid_run.sh` clean. No Python touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
