### PR TITLE
feat: --rl_paper_exact — reproduce the published HDP-RL configuration exactly

### DIFF
--- a/diffusion_planner/diffusion_planner/hdp_rl_epoch.py
+++ b/diffusion_planner/diffusion_planner/hdp_rl_epoch.py
@@ -871,13 +871,18 @@ def _train_cycle_epoch(data_loader, model, optimizer, trainable_params, args, em
         cleanup_previous_cycle,
         cycle_index,
         is_mine_epoch,
+        relay_epoch,
     )
 
     interval = int(args.rl_rollout_interval)
     replay_root = args.rl_replay_dir
     rank = ddp.get_rank()
     device = torch.device(args.device)
-    cycle = cycle_index(epoch, interval)
+    # The relay is numbered from one; `epoch` is the training loop's zero-based
+    # counter. Without the shift the first epoch of a fresh run asks for cycle -1
+    # and is treated as a replay epoch, so it dies on a cache nothing mined.
+    cycle_epoch = relay_epoch(epoch)
+    cycle = cycle_index(cycle_epoch, interval)
     epoch_loss_sums: dict = {}
     epoch_loss_counts: dict = {}
     model.train()
@@ -886,7 +891,7 @@ def _train_cycle_epoch(data_loader, model, optimizer, trainable_params, args, em
     rollout_generator.manual_seed(int(args.seed) + int(epoch) * 1_000_003 + rank * 10_007)
     wall_start = time.perf_counter()
 
-    if is_mine_epoch(epoch, interval):
+    if is_mine_epoch(cycle_epoch, interval):
         cleanup_previous_cycle(replay_root, cycle, rank)
         if bool(getattr(args, "ddp", False)):
             torch.distributed.barrier()
@@ -938,14 +943,14 @@ def _train_cycle_epoch(data_loader, model, optimizer, trainable_params, args, em
     ).float()
     # Policy iteration: the behavior policy stays frozen through mining and is
     # committed only after a replay epoch actually trained a proposal.
-    if ema is not None and not is_mine_epoch(epoch, interval):
+    if ema is not None and not is_mine_epoch(cycle_epoch, interval):
         proposal_relative_l2 = commit_ema_policy_update(model, ema, optimizer, args.ddp)
         epoch_mean_loss["policy_proposal_relative_l2"] = proposal_relative_l2
     if args.ddp:
         epoch_mean_loss = ddp.reduce_and_average_losses(epoch_mean_loss, device)
     epoch_mean_loss = _add_stationary_progress_conditionals(epoch_mean_loss)
     if rank == 0:
-        phase = "mine" if is_mine_epoch(epoch, interval) else "replay"
+        phase = "mine" if is_mine_epoch(cycle_epoch, interval) else "replay"
         print(
             f"cycle {cycle} {phase}: loss={float(epoch_mean_loss['loss']):.4f} "
             f"reward_mean={float(epoch_mean_loss['reward_mean']):.4f}"

--- a/diffusion_planner/diffusion_planner/hdp_rl_paper_exact.py
+++ b/diffusion_planner/diffusion_planner/hdp_rl_paper_exact.py
@@ -1,0 +1,407 @@
+"""Paper-exact HDP-RL configuration.
+
+``--rl_paper_exact`` pins every knob that shapes the RL objective to the value
+published in the Hyper Diffusion Planner paper, so a run can be certified as
+reproducing Eq. (14)-(17) and Table 3 rather than this repository's real-vehicle
+extensions.
+
+Authoritative sources, both vendored under ``reference/``:
+
+- ``reference/papers/hyper_diffusion_planner_paper/src/neurips_2026.tex``
+  -- Section "KL-Regularized RL" / "RL-Hybrid Loss" (Eq. ``eq:awr``,
+  ``eq:awr_hybrid``), Appendix ``app:rewards`` (reward definitions and the total
+  training reward), and Table ``tab:param`` (hyperparameters).
+- ``reference/papers/hyper_diffusion_planner_paper/src/code_rl.tex``
+  -- Algorithm 2, ``rl_hybrid_loss``.
+- ``reference/external/Hyper-Diffusion-Planner/HDP-navsim/hdp_navsim/agent/
+  dp_vla/dp_vla_rl_agent.py`` -- the authors' released implementation
+  (``_rl_rollout``, ``_rl_train_step``, ``compute_loss``,
+  ``on_train_epoch_start``) plus its config
+  ``hdp_navsim/config/agent/dp_vla_rl_agent.yaml``.
+
+``docs/hdp_rl_paper_fidelity.md`` records the full line-by-line audit behind the
+table below, including the three places where the paper text and the released
+code contradict each other and the one mechanism that cannot be reproduced
+verbatim in this action space.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping
+
+PAPER_REWARD_VARIANTS = ("multi", "single")
+
+
+@dataclass(frozen=True)
+class PaperExactSetting:
+    """One pinned field, with the citation that fixes its value.
+
+    ``value`` is the published constant, or a callable ``args -> value`` for the
+    handful of settings the paper states relative to the planning horizon L.
+    """
+
+    field: str
+    value: Any
+    source: str
+
+
+def _horizon_minus_one(args: Any) -> int:
+    """W = L - 1 for this run's planning horizon L."""
+    return max(1, int(args.future_len) - 1)
+
+
+def resolve_paper_exact_value(setting: PaperExactSetting, args: Any) -> Any:
+    """The published value of ``setting`` for this run's horizon."""
+    if callable(setting.value):
+        return setting.value(args)
+    return setting.value
+
+
+# Fields shared by both published reward settings.
+_COMMON: tuple[PaperExactSetting, ...] = (
+    # ---- Table 3 (tab:param), RL block -------------------------------------
+    PaperExactSetting(
+        "num_generations",
+        32,
+        "neurips_2026.tex tab:param -- RL / Group size = 32",
+    ),
+    PaperExactSetting(
+        "rl_reward_beta",
+        1.0,
+        "neurips_2026.tex tab:param -- RL / Temperature beta = 1.0; "
+        "matches dp_vla_rl_agent.py torch.exp(rewards) with no explicit beta",
+    ),
+    PaperExactSetting(
+        "rl_ema_update_rate",
+        0.05,
+        "neurips_2026.tex tab:param -- RL / EMA = 0.05; Sec. RL 'we employ "
+        "Exponential Moving Average (EMA) for policy updates'",
+    ),
+    # ---- Eq. (awr_hybrid) + Algorithm 2 + _rl_train_step -------------------
+    PaperExactSetting(
+        "rl_reward_normalize",
+        "group",
+        "neurips_2026.tex Sec. RL 'we apply reward group normalization'; "
+        "dp_vla_rl_agent.py _rl_train_step group-relative normalisation",
+    ),
+    PaperExactSetting(
+        "advantage_eps",
+        1e-6,
+        "code_rl.tex Algorithm 2 r.std() + 1e-6; dp_vla_rl_agent.py "
+        "reward_abs.std(dim=1, keepdim=True) + 1e-6",
+    ),
+    PaperExactSetting(
+        "rl_bc_weight",
+        0.0,
+        "neurips_2026.tex eq:awr_hybrid -- the RL loss is the weighted "
+        "regression alone; no expert-anchor term",
+    ),
+    PaperExactSetting(
+        "rl_diffusion_t_min",
+        0.0,
+        "neurips_2026.tex eq:awr_hybrid -- expectation over the full t range",
+    ),
+    PaperExactSetting(
+        "rl_diffusion_t_max",
+        1.0,
+        "neurips_2026.tex eq:awr_hybrid -- expectation over the full t range",
+    ),
+    # ---- The hybrid norm inside eq:awr_hybrid ------------------------------
+    # Eq. (awr_hybrid) weights the *hybrid* distance, so omega and W are part of
+    # the RL objective, not only of imitation pretraining. Both published
+    # implementations disagree with Table 3 here; see docs/hdp_rl_paper_fidelity.md.
+    PaperExactSetting(
+        "planning_hybrid_loss",
+        0.1,
+        "neurips_2026.tex tab:param -- Hybrid loss weight omega = 0.1; "
+        "code_rl.tex Algorithm 2 forwards omega into hybrid_loss()",
+    ),
+    PaperExactSetting(
+        "hybrid_loss_window",
+        _horizon_minus_one,
+        "neurips_2026.tex Appendix Hybrid Loss -- 'In practice, we set W=L-1'",
+    ),
+    # ---- Appendix app:rewards, "Total Training Reward" ---------------------
+    PaperExactSetting(
+        "rl_reward_source",
+        "native",
+        "neurips_2026.tex app:rewards -- the published reward set, not the "
+        "ported original-DP PDM objective",
+    ),
+    PaperExactSetting(
+        "rl_reward_aggregation",
+        "weighted_sum",
+        "neurips_2026.tex app:rewards -- r is a weighted sum of the components",
+    ),
+    PaperExactSetting(
+        "rl_behavior_gate",
+        "none",
+        "neurips_2026.tex app:rewards -- the published sum applies no gate to "
+        "the car-following / lane-keeping terms",
+    ),
+    PaperExactSetting(
+        "rl_reward_w_progress",
+        0.0,
+        "neurips_2026.tex app:rewards -- the published reward has no progress "
+        "term (real-vehicle extension of this repository)",
+    ),
+    PaperExactSetting(
+        "rl_reward_w_road_border",
+        0.0,
+        "neurips_2026.tex app:rewards -- the published reward has no "
+        "road-border term (real-vehicle extension of this repository)",
+    ),
+    PaperExactSetting(
+        "rl_red_light_constraint",
+        False,
+        "neurips_2026.tex app:rewards -- r_safety and r_risk carry no "
+        "traffic-light factor; this repository folds one into both",
+    ),
+    PaperExactSetting(
+        "rl_occupancy_use_road_border",
+        False,
+        "neurips_2026.tex app:rewards -- OCC is 'occupancy distance to "
+        "static/uncertain regions', not HD-map border geometry",
+    ),
+    PaperExactSetting(
+        "rl_reward_horizon_steps",
+        0,
+        "neurips_2026.tex app:rewards -- every reward is 'evaluated on the "
+        "candidate trajectory over the planning horizon of L steps'",
+    ),
+    PaperExactSetting(
+        "rl_candidate_loss_horizon",
+        0,
+        "neurips_2026.tex eq:awr_hybrid -- the regression covers the whole action tau^v_0",
+    ),
+    # ---- Released implementation: rollout / replay schedule ----------------
+    PaperExactSetting(
+        "rl_rollout_steps",
+        5,
+        "dp_vla_rl_agent.yaml rl_config.rollout_steps = 5",
+    ),
+    PaperExactSetting(
+        "rl_rollout_interval",
+        10,
+        "dp_vla_rl_agent.yaml rl_config.replay_buffer_update_epoch = 10; "
+        "dp_vla_rl_agent.py compute_loss / on_train_epoch_start epoch state "
+        "machine",
+    ),
+    PaperExactSetting(
+        "rl_updates_per_rollout",
+        1,
+        "dp_vla_rl_agent.yaml rl_config.diffusion_repeat_size = 1 -- one noising per replay draw",
+    ),
+    PaperExactSetting(
+        "rl_noise_scale",
+        1.0,
+        "dp_vla_rl_agent.py _rl_rollout -- model.generate() samples the prior at unit temperature",
+    ),
+    PaperExactSetting(
+        "rl_init_use_ema",
+        True,
+        "neurips_2026.tex Sec. RL -- pi^0 is the imitation model pretrained with the hybrid loss",
+    ),
+    # ---- Mechanisms absent from both sources -------------------------------
+    PaperExactSetting(
+        "rl_candidate_aug_prob",
+        0.0,
+        "not in neurips_2026.tex; the released augment_trajectory_batch adds a "
+        "constant waypoint offset, which is a first-step impulse under this "
+        "repository's velocity actions -- see docs/hdp_rl_paper_fidelity.md",
+    ),
+    PaperExactSetting(
+        "rl_first_waypoint_gate",
+        False,
+        "not in neurips_2026.tex nor dp_vla_rl_agent.py -- real-vehicle "
+        "candidate filter of this repository",
+    ),
+)
+
+# Appendix app:rewards, "Total Training Reward":
+#   r = r_safety                                                (single-reward)
+#   r = lambda_risk r_risk + lambda_follow r_follow
+#       + lambda_lane r_lane                                     (multi-reward)
+_REWARD_VARIANTS: Mapping[str, tuple[PaperExactSetting, ...]] = {
+    "multi": (
+        PaperExactSetting(
+            "rl_reward_w_safety",
+            0.0,
+            "neurips_2026.tex app:rewards -- the multi-reward setting replaces "
+            "r_safety with r_risk",
+        ),
+        PaperExactSetting(
+            "rl_reward_w_risk",
+            1.0,
+            "neurips_2026.tex tab:param -- RL / lambda_risk = 1.0",
+        ),
+        PaperExactSetting(
+            "rl_reward_w_follow",
+            3.0,
+            "neurips_2026.tex tab:param -- RL / lambda_follow = 3.0",
+        ),
+        PaperExactSetting(
+            "rl_reward_w_lane",
+            2.5,
+            "neurips_2026.tex tab:param -- RL / lambda_lane = 2.5",
+        ),
+    ),
+    "single": (
+        PaperExactSetting(
+            "rl_reward_w_safety",
+            1.0,
+            "neurips_2026.tex app:rewards -- 'The single-reward baseline uses "
+            "r_safety alone' (HDP-RL dagger)",
+        ),
+        PaperExactSetting(
+            "rl_reward_w_risk",
+            0.0,
+            "neurips_2026.tex app:rewards -- single-reward baseline",
+        ),
+        PaperExactSetting(
+            "rl_reward_w_follow",
+            0.0,
+            "neurips_2026.tex app:rewards -- single-reward baseline",
+        ),
+        PaperExactSetting(
+            "rl_reward_w_lane",
+            0.0,
+            "neurips_2026.tex app:rewards -- single-reward baseline",
+        ),
+    ),
+}
+
+
+def paper_exact_settings(reward_variant: str) -> tuple[PaperExactSetting, ...]:
+    """Every field pinned by ``--rl_paper_exact`` for one reward variant."""
+    if reward_variant not in _REWARD_VARIANTS:
+        raise ValueError(
+            f"Unsupported rl_paper_reward={reward_variant!r}; "
+            f"expected one of {PAPER_REWARD_VARIANTS}"
+        )
+    return _COMMON + _REWARD_VARIANTS[reward_variant]
+
+
+def paper_exact_values(reward_variant: str, args: Any = None) -> dict[str, Any]:
+    """``field -> published value`` mapping for one reward variant.
+
+    ``args`` supplies the planning horizon for the settings the paper states
+    relative to L, and is required whenever the variant contains one.
+    """
+    values: dict[str, Any] = {}
+    for setting in paper_exact_settings(reward_variant):
+        if callable(setting.value) and args is None:
+            raise ValueError(
+                f"{setting.field!r} is published relative to the planning horizon L; "
+                "pass args to resolve it"
+            )
+        values[setting.field] = resolve_paper_exact_value(setting, args)
+    return values
+
+
+def paper_exact_fields() -> tuple[str, ...]:
+    """Every field this mode controls, across all reward variants."""
+    fields: list[str] = [setting.field for setting in _COMMON]
+    for variant in PAPER_REWARD_VARIANTS:
+        for setting in _REWARD_VARIANTS[variant]:
+            if setting.field not in fields:
+                fields.append(setting.field)
+    return tuple(fields)
+
+
+def _same(current: Any, target: Any) -> bool:
+    if isinstance(target, bool) or isinstance(current, bool):
+        return bool(current) is bool(target)
+    if isinstance(target, float):
+        try:
+            return math.isclose(float(current), target, rel_tol=0.0, abs_tol=0.0)
+        except (TypeError, ValueError):
+            return False
+    return current == target
+
+
+def explicit_paper_exact_dests(
+    parser: argparse.ArgumentParser,
+    argv: list[str] | None,
+    fields: Iterable[str] | None = None,
+) -> set[str]:
+    """Which paper-exact fields the caller passed on the command line.
+
+    argparse only writes a default when the destination is absent from the
+    namespace, so pre-seeding every controlled destination with a sentinel makes
+    explicitly-passed options -- in any spelling, including ``--flag=value`` and
+    the ``--official_*`` aliases -- the only ones that get overwritten.
+    """
+    controlled = tuple(fields) if fields is not None else paper_exact_fields()
+    sentinel = object()
+    namespace = argparse.Namespace(**dict.fromkeys(controlled, sentinel))
+    parsed = parser.parse_args(argv, namespace=namespace)
+    return {name for name in controlled if getattr(parsed, name) is not sentinel}
+
+
+def apply_paper_exact_settings(
+    args,
+    reward_variant: str,
+    explicit_fields: Iterable[str] = (),
+) -> list[str]:
+    """Pin ``args`` to the published RL configuration.
+
+    Returns one human-readable line per field that had to change, for the run
+    log. Raises when the caller explicitly asked for a value the paper
+    contradicts: silently overriding an explicit flag would make the run log
+    lie about what was trained.
+    """
+    settings = paper_exact_settings(reward_variant)
+    explicit = set(explicit_fields)
+
+    conflicts = [
+        f"--{setting.field}={getattr(args, setting.field)!r} conflicts with the "
+        f"published {resolve_paper_exact_value(setting, args)!r} ({setting.source})"
+        for setting in settings
+        if setting.field in explicit
+        and not _same(getattr(args, setting.field), resolve_paper_exact_value(setting, args))
+    ]
+    if conflicts:
+        raise ValueError(
+            "--rl_paper_exact cannot be combined with these explicit overrides:\n  "
+            + "\n  ".join(conflicts)
+            + "\nDrop the flags, or drop --rl_paper_exact and document the deviation."
+        )
+
+    changed: list[str] = []
+    for setting in settings:
+        if not hasattr(args, setting.field):
+            raise AttributeError(
+                f"--rl_paper_exact controls unknown field {setting.field!r}; "
+                "the pinned table and the RL trainer have drifted apart"
+            )
+        current = getattr(args, setting.field)
+        target = resolve_paper_exact_value(setting, args)
+        if _same(current, target):
+            continue
+        setattr(args, setting.field, target)
+        changed.append(f"{setting.field}: {current!r} -> {target!r}  [{setting.source}]")
+
+    if getattr(args, "rl_rollout_interval", 0) > 0 and not getattr(args, "rl_replay_dir", None):
+        raise ValueError(
+            "--rl_paper_exact reproduces the released mine/replay epoch state "
+            "machine (replay_buffer_update_epoch = 10) and therefore requires "
+            "--rl_replay_dir"
+        )
+    return changed
+
+
+def assert_paper_exact(args, reward_variant: str | None = None) -> None:
+    """Raise unless ``args`` still matches the published configuration."""
+    variant = reward_variant if reward_variant is not None else args.rl_paper_reward
+    deviations = [
+        f"{setting.field}={getattr(args, setting.field, None)!r} != "
+        f"{resolve_paper_exact_value(setting, args)!r} ({setting.source})"
+        for setting in paper_exact_settings(variant)
+        if not _same(getattr(args, setting.field, None), resolve_paper_exact_value(setting, args))
+    ]
+    if deviations:
+        raise ValueError("Run is not paper-exact:\n  " + "\n  ".join(deviations))

--- a/diffusion_planner/diffusion_planner/hdp_rl_paper_exact.py
+++ b/diffusion_planner/diffusion_planner/hdp_rl_paper_exact.py
@@ -60,6 +60,211 @@ def resolve_paper_exact_value(setting: PaperExactSetting, args: Any) -> Any:
     return setting.value
 
 
+# ---------------------------------------------------------------------------
+# The hybrid norm: inherited from the frozen IL base, not pinned to the paper
+# ---------------------------------------------------------------------------
+#
+# Eq. (awr_hybrid) weights the *hybrid* distance, so omega and W really do
+# belong to the RL objective and not only to imitation pretraining. That is
+# precisely why they are not pinned to Table 3 here. This pipeline does not
+# retrain IL, and omega/W define the geometry of the norm the frozen base was
+# fitted under: post-training a base fitted at omega=0.01 / W=10 under
+# omega=0.1 / W=L-1 rescales the waypoint term 10x and widens the detach
+# window, so every RL gradient would be measured in a norm the policy has
+# never been optimized for.
+#
+# Paper-exact therefore inherits both fields from the checkpoint the run
+# starts from, and refuses a conflicting explicit value. Which pair is better
+# *for RL* is an empirical question, and ``--rl_hybrid_ablation`` is how it
+# gets asked: it releases the two fields and stamps the run as an ablation
+# arm, so a sweep reads as a sweep in args.json rather than as a paper-exact
+# run that quietly disagrees with its own base.
+
+HYBRID_FIELDS: tuple[str, ...] = ("planning_hybrid_loss", "hybrid_loss_window")
+
+_PAPER_HYBRID_SOURCES: Mapping[str, str] = {
+    "planning_hybrid_loss": "neurips_2026.tex tab:param -- Hybrid loss weight omega = 0.1",
+    "hybrid_loss_window": ("neurips_2026.tex Appendix Hybrid Loss -- 'In practice, we set W=L-1'"),
+}
+
+
+def paper_hybrid_values(args: Any) -> dict[str, Any]:
+    """What Table 3 and the Hybrid Loss appendix publish, for the run log.
+
+    Reported alongside the inherited values so a paper-exact run states plainly
+    where it departs from the paper and why.
+    """
+    return {
+        "planning_hybrid_loss": 0.1,
+        "hybrid_loss_window": _horizon_minus_one(args),
+    }
+
+
+def apply_frozen_base_hybrid(
+    args: Any,
+    base_args: Mapping[str, Any] | None,
+    base_label: str,
+    explicit_fields: Iterable[str],
+    *,
+    ablation: bool = False,
+) -> list[str]:
+    """Inherit the hybrid norm from the frozen IL base this run starts from.
+
+    ``base_args`` is the ``args.json`` written beside that checkpoint. Returns
+    one human-readable line per inherited field, for the run log and args.json.
+    Raises when an explicit flag contradicts the base and ``ablation`` is off.
+    """
+    if ablation:
+        published = paper_hybrid_values(args)
+        return [
+            "hybrid norm released for ablation: "
+            + ", ".join(f"{f}={getattr(args, f)!r}" for f in HYBRID_FIELDS)
+            + " (frozen base "
+            + (
+                ", ".join(f"{f}={base_args.get(f, '?')!r}" for f in HYBRID_FIELDS)
+                if base_args is not None
+                else "unknown"
+            )
+            + "; paper "
+            + ", ".join(f"{f}={published[f]!r}" for f in HYBRID_FIELDS)
+            + ")"
+        ]
+
+    if base_args is None:
+        raise ValueError(
+            "--rl_paper_exact inherits the hybrid norm (omega, W) from the checkpoint the run "
+            "starts from, but no args.json was found beside it. Point --init_weights_path at a "
+            "run directory that contains args.json, or pass --rl_hybrid_ablation True to set "
+            "omega and W deliberately as an ablation arm."
+        )
+
+    explicit = set(explicit_fields)
+    published = paper_hybrid_values(args)
+    conflicts: list[str] = []
+    changes: list[str] = []
+    for field in HYBRID_FIELDS:
+        if field not in base_args:
+            raise ValueError(
+                f"{base_label} does not record {field!r}, so the frozen IL base's hybrid norm "
+                "cannot be reproduced. Pass --rl_hybrid_ablation True to set it deliberately."
+            )
+        base_value = base_args[field]
+        current = getattr(args, field)
+        if field in explicit and current != base_value:
+            conflicts.append(
+                f"  --{field} {current!r} != {base_value!r} in {base_label}\n"
+                f"      [frozen IL base; the paper publishes {published[field]!r} "
+                f"-- {_PAPER_HYBRID_SOURCES[field]}]"
+            )
+            continue
+        # Both branches carry the same citation, including the published value
+        # this run does not use: a departure from the paper has to be readable
+        # in the run log whether or not the launcher happened to pass it already.
+        provenance = (
+            f"\n      [inherited from the frozen IL base {base_label}; "
+            f"the paper publishes {published[field]!r} -- {_PAPER_HYBRID_SOURCES[field]}]"
+        )
+        if current != base_value:
+            changes.append(f"{field}: {current!r} -> {base_value!r}{provenance}")
+            setattr(args, field, base_value)
+        else:
+            changes.append(f"{field}: {base_value!r} (unchanged){provenance}")
+    if conflicts:
+        raise ValueError(
+            "--rl_paper_exact keeps the hybrid norm of the IL base it post-trains, because this "
+            "pipeline does not retrain IL. These explicit overrides contradict that base:\n"
+            + "\n".join(conflicts)
+            + "\n  Drop them, or pass --rl_hybrid_ablation True to run this as a deliberate "
+            "omega/W ablation arm."
+        )
+    return changes
+
+
+# ---------------------------------------------------------------------------
+# The corpus: identical to the run that produced the frozen IL base
+# ---------------------------------------------------------------------------
+#
+# RL post-training moves the same policy on the same distribution; a different
+# corpus or a different perturbation makes the RL delta unattributable, because
+# any change could be the objective or could be the data. These fields are
+# therefore compared against the base run's args.json rather than trusted to
+# match by convention.
+#
+# The extra manifests are compared by basename: they are addressed as
+# ``${REPO}/artifacts/...``, so the same file has a different absolute path in
+# each checkout. Contents are verified separately by the launcher's input
+# fingerprint.
+
+_BASE_DATA_FIELDS: tuple[str, ...] = (
+    "train_set_list",
+    "valid_set_list",
+    "extra_train_set_repeat",
+    "filter_skipped",
+    "train_subsample_step",
+    "align_legacy_neighbor_futures",
+)
+
+_BASE_AUGMENT_FIELDS: tuple[str, ...] = (
+    "use_data_augment",
+    "augment_prob",
+    "augment_type",
+    "num_refine",
+    "ego_past_noise_std",
+    "use_smoothing_future_trajectory",
+)
+
+
+def _basenames(paths: Any) -> list[str]:
+    if paths is None:
+        return []
+    if isinstance(paths, str):
+        paths = [paths]
+    return sorted(str(p).rsplit("/", 1)[-1] for p in paths)
+
+
+def base_corpus_mismatches(args: Any, base_args: Mapping[str, Any]) -> list[str]:
+    """Every way this run's corpus or perturbation differs from the IL base's."""
+    mismatches: list[str] = []
+    for field in _BASE_DATA_FIELDS + _BASE_AUGMENT_FIELDS:
+        if field not in base_args:
+            mismatches.append(f"  {field}: the base args.json does not record it")
+            continue
+        current = getattr(args, field, None)
+        base_value = base_args[field]
+        if current != base_value:
+            mismatches.append(f"  --{field} {current!r} != {base_value!r} in the IL base")
+    current_extra = _basenames(getattr(args, "extra_train_set_list", None))
+    base_extra = _basenames(base_args.get("extra_train_set_list"))
+    if current_extra != base_extra:
+        mismatches.append(
+            f"  --extra_train_set_list {current_extra} != {base_extra} in the IL base"
+        )
+    # The normalizer is compared by resolved content, not by path: the same file
+    # lives at a different --normalization_file_path in each checkout.
+    for field in ("observation_normalizer", "state_normalizer"):
+        if field not in base_args:
+            continue
+        current = getattr(args, field, None)
+        current = current if isinstance(current, dict) else getattr(current, "config", None)
+        if current is not None and current != base_args[field]:
+            mismatches.append(f"  {field} differs from the IL base's resolved normalizer")
+    return mismatches
+
+
+def assert_base_corpus_identical(args: Any, base_args: Mapping[str, Any], base_label: str) -> None:
+    """Refuse to post-train on a corpus the frozen IL base was not fitted on."""
+    mismatches = base_corpus_mismatches(args, base_args)
+    if mismatches:
+        raise ValueError(
+            "--rl_paper_exact post-trains a frozen IL base, so the corpus and the input "
+            f"perturbation must be the ones that base was trained on ({base_label}). "
+            "These differ:\n"
+            + "\n".join(mismatches)
+            + "\n  Match the base run's launcher, or pass --rl_base_corpus_check False to "
+            "post-train on a deliberately different distribution."
+        )
+
+
 # Fields shared by both published reward settings.
 _COMMON: tuple[PaperExactSetting, ...] = (
     # ---- Table 3 (tab:param), RL block -------------------------------------
@@ -108,21 +313,6 @@ _COMMON: tuple[PaperExactSetting, ...] = (
         "rl_diffusion_t_max",
         1.0,
         "neurips_2026.tex eq:awr_hybrid -- expectation over the full t range",
-    ),
-    # ---- The hybrid norm inside eq:awr_hybrid ------------------------------
-    # Eq. (awr_hybrid) weights the *hybrid* distance, so omega and W are part of
-    # the RL objective, not only of imitation pretraining. Both published
-    # implementations disagree with Table 3 here; see docs/hdp_rl_paper_fidelity.md.
-    PaperExactSetting(
-        "planning_hybrid_loss",
-        0.1,
-        "neurips_2026.tex tab:param -- Hybrid loss weight omega = 0.1; "
-        "code_rl.tex Algorithm 2 forwards omega into hybrid_loss()",
-    ),
-    PaperExactSetting(
-        "hybrid_loss_window",
-        _horizon_minus_one,
-        "neurips_2026.tex Appendix Hybrid Loss -- 'In practice, we set W=L-1'",
     ),
     # ---- Appendix app:rewards, "Total Training Reward" ---------------------
     PaperExactSetting(

--- a/diffusion_planner/diffusion_planner/hdp_rl_replay.py
+++ b/diffusion_planner/diffusion_planner/hdp_rl_replay.py
@@ -7,6 +7,12 @@ that freezes this cache (no optimizer steps), and the following
 validity are frozen at mine time and never recomputed during replay — the
 upstream overlay-resurrection bug class is structurally impossible here.
 
+Epochs here are the source repository's one-based numbering, the same one the
+trainer prints as ``Epoch {epoch + 1}/{train_epochs}``. The training loop counts
+from zero, so call sites convert with :func:`relay_epoch` rather than passing
+their loop variable straight in — epoch 0 would otherwise land in cycle -1 and
+look like a replay epoch whose cache was never mined.
+
 Storage is one ``.pt`` shard per mined batch per rank on local NVMe, plus a
 fail-closed ``meta.json`` contract (reward fingerprint, group size, commit
 marker). A cycle directory missing its ``MINE_COMPLETE`` marker is discarded
@@ -53,6 +59,11 @@ _FINGERPRINT_FIELDS = (
 def reward_fingerprint(args) -> dict:
     """The frozen-cache contract: everything that shapes mined groups/weights."""
     return {name: repr(getattr(args, name, None)) for name in _FINGERPRINT_FIELDS}
+
+
+def relay_epoch(trainer_epoch: int) -> int:
+    """Map the trainer's zero-based epoch onto this module's one-based numbering."""
+    return int(trainer_epoch) + 1
 
 
 def cycle_index(epoch: int, interval: int) -> int:

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -156,6 +156,17 @@ class TrainConfig:
 
     # HDP RL objective. The branch intentionally keeps only the official-style
     # reward-weighted RL-Hybrid path.
+    #
+    # ``rl_paper_exact`` pins every field listed in
+    # ``diffusion_planner.hdp_rl_paper_exact`` to its published value (paper Table 3,
+    # Eq. (14)-(17), Appendix "Reward Function Details", and the authors' released
+    # dp_vla_rl_agent). It turns off every real-vehicle extension of this repository and
+    # fails on any explicit flag that contradicts the paper, so a run either reproduces
+    # HDP-RL exactly or refuses to start. See docs/hdp_rl_paper_fidelity.md.
+    rl_paper_exact: bool = False
+    # ``multi`` = lambda_risk r_risk + lambda_follow r_follow + lambda_lane r_lane (HDP-RL);
+    # ``single`` = r_safety alone (HDP-RL dagger, the paper's single-reward baseline).
+    rl_paper_reward: Literal["multi", "single"] = "multi"
     num_generations: int = 8
     rl_reward_normalize: Literal["group", "batch", "none"] = "group"
     rl_reward_beta: float = 0.5

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -167,6 +167,16 @@ class TrainConfig:
     # ``multi`` = lambda_risk r_risk + lambda_follow r_follow + lambda_lane r_lane (HDP-RL);
     # ``single`` = r_safety alone (HDP-RL dagger, the paper's single-reward baseline).
     rl_paper_reward: Literal["multi", "single"] = "multi"
+    # The one pair paper-exact does NOT take from the paper. ``planning_hybrid_loss``
+    # and ``hybrid_loss_window`` are the geometry of the norm the IL base was fitted
+    # in, and this pipeline never retrains IL, so paper-exact inherits them from the
+    # checkpoint it post-trains. Setting this True releases them and marks the run as
+    # an omega/W ablation arm -- the only way to reach the published pair.
+    rl_hybrid_ablation: bool = False
+    # RL moves the same policy on the same distribution, so paper-exact compares the
+    # corpus and the input perturbation against the IL base's args.json instead of
+    # trusting the launcher to match by convention.
+    rl_base_corpus_check: bool = True
     num_generations: int = 8
     rl_reward_normalize: Literal["group", "batch", "none"] = "group"
     rl_reward_beta: float = 0.5

--- a/diffusion_planner/slurm/run_hdp_rl.sbatch
+++ b/diffusion_planner/slurm/run_hdp_rl.sbatch
@@ -9,6 +9,15 @@
 
 set -euo pipefail
 
+# Slurm runs these jobs as a dedicated account; every path below is provisioned for it.
+# Running as anyone else silently produces unreadable credentials and unwritable outputs,
+# so fail immediately and say so instead of dying deep inside training.
+REQUIRED_USER=${HDP_REQUIRED_USER:-wang}
+if [[ "$(id -un)" != "${REQUIRED_USER}" ]]; then
+  echo "FATAL: this job must run as ${REQUIRED_USER}, got $(id -un)" >&2
+  exit 20
+fi
+
 REPO=${HDP_RL_REPO:-/mnt/nvme/Diffusion-Planner-hyper-diffusion-planner}
 NNODES=${SLURM_NNODES:-1}
 NPROC_PER_NODE=${HDP_RL_NPROC_PER_NODE:-${HDP_RL_NPROC:-8}}
@@ -434,7 +443,14 @@ if [[ "${VERIFY_MODE}" == resume ]]; then
   trap 'rm -f "${VERIFY_SOURCE_CKPT}"' EXIT
 fi
 
-export HOME=/home/ubuntu
+export HOME=${HDP_JOB_HOME:-${REPO}/home}
+export NETRC=${HOME}/.netrc
+mkdir -p "${HOME}"
+if [[ ! -r "${NETRC}" ]]; then
+  echo "FATAL: W&B credentials are not readable at ${NETRC}. Provision that file for" >&2
+  echo "       $(id -un), or point HDP_JOB_HOME at a directory that has one." >&2
+  exit 13
+fi
 export TMPDIR=${REPO}/tmp
 export XDG_CACHE_HOME=${REPO}/cache
 export TORCHINDUCTOR_CACHE_DIR=${REPO}/cache/torchinductor

--- a/diffusion_planner/slurm/run_hdp_rl.sbatch
+++ b/diffusion_planner/slurm/run_hdp_rl.sbatch
@@ -24,7 +24,8 @@ NUM_WORKERS=${HDP_RL_NUM_WORKERS:-8}
 TRAIN_SUBSAMPLE_STEP=${HDP_RL_TRAIN_SUBSAMPLE_STEP:-1}
 DEFAULT_RL_TRAIN_LIST=${HDP_DEFAULT_RL_TRAIN_LIST:-${HDP_DEFAULT_SFT_TRAIN_LIST:-/mnt/storage_rdma/diffusion_planner/dataset/20260707_vehicle_params_with_mirror/path_list_train_concatenated.json}}
 TRAIN_LIST=${HDP_RL_TRAIN_LIST:-${DEFAULT_RL_TRAIN_LIST}}
-VALID_LIST=${HDP_RL_VALID_LIST:?submit with HDP_RL_VALID_LIST=<manifest>}
+DEFAULT_RL_VALID_LIST=${HDP_DEFAULT_RL_VALID_LIST:-/mnt/storage_rdma/diffusion_planner/dataset/20260702_basic_dataset/path_list_valid_sft_balanced.json}
+VALID_LIST=${HDP_RL_VALID_LIST:-${DEFAULT_RL_VALID_LIST}}
 if [[ -n "${HDP_RL_FILTER_SKIPPED+x}" ]]; then
   FILTER_SKIPPED=${HDP_RL_FILTER_SKIPPED}
 elif [[ "${TRAIN_LIST}" == "${DEFAULT_RL_TRAIN_LIST}" ]]; then
@@ -32,8 +33,24 @@ elif [[ "${TRAIN_LIST}" == "${DEFAULT_RL_TRAIN_LIST}" ]]; then
 else
   FILTER_SKIPPED=True
 fi
-EXTRA_LISTS=${HDP_RL_EXTRA_LISTS:-}
-EXTRA_REPEAT=${HDP_RL_EXTRA_REPEAT:-0}
+# RL post-trains the IL base on the base's own corpus: same three right-turn
+# manifests at the same x10 repeat, so the RL delta is attributable to the
+# objective and not to a distribution shift. The trainer re-checks this against
+# the base checkpoint's args.json under --rl_paper_exact.
+RIGHT_TURN_DIR=${HDP_RIGHT_TURN_DIR:-${REPO}/artifacts/right_turn_is_skipped_filtered_20260716}
+DEFAULT_EXTRA_LISTS=${RIGHT_TURN_DIR}/path_list_train_unprotected_right_turn_is_skipped_filtered.json:${RIGHT_TURN_DIR}/path_list_unprotected_right_turn_xx1_is_skipped_filtered.json:${RIGHT_TURN_DIR}/path_list_unprotected_right_turn_xx1_psim_is_skipped_filtered.json
+EXTRA_LISTS=${HDP_RL_EXTRA_LISTS-${DEFAULT_EXTRA_LISTS}}
+EXTRA_REPEAT=${HDP_RL_EXTRA_REPEAT:-10}
+# StatePerturbation, identical to the base run. RL applies it before the rollout,
+# so the reward, the gate and the regression all see the same perturbed scene.
+USE_DATA_AUGMENT=${HDP_RL_USE_DATA_AUGMENT:-True}
+AUGMENT_TYPE=${HDP_RL_AUGMENT_TYPE:-quintic}
+AUGMENT_PROB=${HDP_RL_AUGMENT_PROB:-0.5}
+NUM_REFINE=${HDP_RL_NUM_REFINE:-20}
+EGO_PAST_NOISE_STD=${HDP_RL_EGO_PAST_NOISE_STD:-0.1}
+USE_SMOOTHING_FUTURE_TRAJECTORY=${HDP_RL_USE_SMOOTHING_FUTURE_TRAJECTORY:-True}
+HYBRID_ABLATION=${HDP_RL_HYBRID_ABLATION:-False}
+BASE_CORPUS_CHECK=${HDP_RL_BASE_CORPUS_CHECK:-True}
 INIT_CKPT=${HDP_RL_INIT_CKPT:-}
 RESUME_CKPT=${HDP_RL_RESUME_CKPT:-}
 EXPECTED_COMMIT=${HDP_EXPECTED_COMMIT:?submit with HDP_EXPECTED_COMMIT=<commit>}
@@ -176,8 +193,11 @@ case "${PAPER_EXACT}" in
     paper_pin NUM_GENERATIONS HDP_RL_NUM_GENERATIONS 32
     paper_pin REWARD_BETA HDP_RL_REWARD_BETA 1.0
     paper_pin EMA_UPDATE_RATE HDP_RL_EMA_UPDATE_RATE 0.05
-    paper_pin PLANNING_HYBRID_LOSS HDP_RL_PLANNING_HYBRID_LOSS 0.1
-    paper_pin HYBRID_LOSS_WINDOW HDP_RL_HYBRID_LOSS_WINDOW 79 # W = L - 1, L = 80
+    # omega and W are deliberately NOT pinned here. They are the geometry of the
+    # norm the frozen IL base was fitted in, IL is never retrained, and the trainer
+    # inherits them from the base checkpoint's args.json. The published pair
+    # (0.1, L-1) is reachable only through HDP_RL_HYBRID_ABLATION=True, which
+    # stamps the run as an ablation arm.
     # The published reward: a plain weighted sum of the four appendix terms.
     paper_pin REWARD_SOURCE HDP_RL_REWARD_SOURCE native
     paper_pin REWARD_AGGREGATION HDP_RL_REWARD_AGGREGATION weighted_sum
@@ -208,6 +228,32 @@ case "${PAPER_EXACT}" in
     exit 2
     ;;
 esac
+
+case "${HYBRID_ABLATION}" in
+  True | true | 1) HYBRID_ABLATION=True ;;
+  False | false | 0) HYBRID_ABLATION=False ;;
+  *)
+    echo "HDP_RL_HYBRID_ABLATION must be True or False; got ${HYBRID_ABLATION}" >&2
+    exit 2
+    ;;
+esac
+
+# omega and W are inherited from the IL base under --rl_paper_exact, so the
+# launcher must not hand the trainer its own defaults: argparse cannot tell a
+# default apart from a deliberate flag, and 0.01 / 10 would arrive as an explicit
+# override and be rejected against any base not fitted at that pair. They are
+# passed only when the operator set them, or when this is an ablation arm.
+HYBRID_ARGS=()
+hybrid_arg() { # hybrid_arg <flag> <env-var> <value>
+  local flag=$1 env=$2 value=$3
+  if [[ "${PAPER_EXACT}" == "True" && "${HYBRID_ABLATION}" != "True" && -z "${!env+set}" ]]; then
+    echo "paper-exact: ${flag} inherited from the IL base checkpoint's args.json"
+    return
+  fi
+  HYBRID_ARGS+=("${flag}" "${value}")
+}
+hybrid_arg --planning_hybrid_loss HDP_RL_PLANNING_HYBRID_LOSS "${PLANNING_HYBRID_LOSS}"
+hybrid_arg --hybrid_loss_window HDP_RL_HYBRID_LOSS_WINDOW "${HYBRID_LOSS_WINDOW}"
 
 RUN_NAME=${HDP_RL_RUN_NAME:-hdp_rl_${WORLD_SIZE}gpu_n${NUM_GENERATIONS}_${SLURM_JOB_ID}}
 SAVE_ROOT=${HDP_RL_SAVE_ROOT:-${REPO}/outputs}
@@ -463,6 +509,12 @@ TRAIN_ARGS=(
   "${EXTRA_ARGS[@]}" \
   --align_legacy_neighbor_futures False \
   --normalization_file_path "${REPO}/diffusion_planner/normalization.json" \
+  --use_data_augment "${USE_DATA_AUGMENT}" \
+  --augment_type "${AUGMENT_TYPE}" \
+  --augment_prob "${AUGMENT_PROB}" \
+  --num_refine "${NUM_REFINE}" \
+  --ego_past_noise_std "${EGO_PAST_NOISE_STD}" \
+  --use_smoothing_future_trajectory "${USE_SMOOTHING_FUTURE_TRAJECTORY}" \
   --num_workers "${NUM_WORKERS}" \
   --train_subsample_step "${TRAIN_SUBSAMPLE_STEP}" \
   --batch_size "${BATCH_SIZE}" \
@@ -546,7 +598,6 @@ TRAIN_ARGS=(
   --rl_init_use_ema True \
   --rl_train_scope "${TRAIN_SCOPE}" \
   "${CKPT_ARGS[@]}" \
-  --use_data_augment False \
   --enable_epdms_eval True \
   --epdms_eval_use_agent_boxes True \
   --epdms_eval_use_road_border True \
@@ -561,10 +612,11 @@ TRAIN_ARGS=(
   --num_heads 8 \
   --diffusion_sample_steps 6 \
   --use_velocity_representation True \
-  --planning_hybrid_loss "${PLANNING_HYBRID_LOSS}" \
-  --hybrid_loss_window "${HYBRID_LOSS_WINDOW}" \
+  "${HYBRID_ARGS[@]}" \
   --rl_paper_exact "${PAPER_EXACT}" \
   --rl_paper_reward "${PAPER_REWARD}" \
+  --rl_hybrid_ablation "${HYBRID_ABLATION}" \
+  --rl_base_corpus_check "${BASE_CORPUS_CHECK}" \
   --coeff_road_border_loss 0.0 \
   --coeff_neighbor_collision_loss 0.0 \
   --use_ema True \

--- a/diffusion_planner/slurm/run_hdp_rl.sbatch
+++ b/diffusion_planner/slurm/run_hdp_rl.sbatch
@@ -129,6 +129,86 @@ USE_WANDB=${HDP_RL_USE_WANDB:-True}
 WANDB_PROJECT=${HDP_RL_WANDB_PROJECT:-hdp-rl}
 WANDB_RUN_ID=${HDP_RL_WANDB_RUN_ID:-}
 STEP_LOG_INTERVAL=${HDP_RL_STEP_LOG_INTERVAL:-100}
+PLANNING_HYBRID_LOSS=${HDP_RL_PLANNING_HYBRID_LOSS:-0.01}
+HYBRID_LOSS_WINDOW=${HDP_RL_HYBRID_LOSS_WINDOW:-10}
+
+# ── Published HDP-RL configuration ──────────────────────────────────────────
+# HDP_RL_PAPER_EXACT=True reproduces the paper's RL post-training exactly: every
+# knob below is replaced by its published value, and the trainer then refuses to
+# start if anything still contradicts the paper (docs/hdp_rl_paper_fidelity.md).
+# An env var you set yourself is never silently overwritten -- it is passed
+# through so the trainer can name the conflict together with its citation.
+PAPER_EXACT=${HDP_RL_PAPER_EXACT:-False}
+PAPER_REWARD=${HDP_RL_PAPER_REWARD:-multi}
+
+paper_pin() { # paper_pin <shell-var> <env-var> <published-value>
+  local var=$1 env=$2 value=$3
+  if [[ -n "${!env+set}" ]]; then
+    echo "paper-exact: keeping explicit ${env}=${!env} (published ${value});" \
+      "the trainer rejects it if it conflicts"
+  else
+    printf -v "${var}" '%s' "${value}"
+  fi
+}
+
+case "${PAPER_EXACT}" in
+  True | true | 1)
+    PAPER_EXACT=True
+    case "${PAPER_REWARD}" in
+      multi) # neurips_2026.tex app:rewards, multi-reward setting
+        paper_pin REWARD_W_SAFETY HDP_RL_REWARD_W_SAFETY 0.0
+        paper_pin REWARD_W_RISK HDP_RL_REWARD_W_RISK 1.0
+        paper_pin REWARD_W_FOLLOW HDP_RL_REWARD_W_FOLLOW 3.0
+        paper_pin REWARD_W_LANE HDP_RL_REWARD_W_LANE 2.5
+        ;;
+      single) # neurips_2026.tex app:rewards, r_safety alone (HDP-RL dagger)
+        paper_pin REWARD_W_SAFETY HDP_RL_REWARD_W_SAFETY 1.0
+        paper_pin REWARD_W_RISK HDP_RL_REWARD_W_RISK 0.0
+        paper_pin REWARD_W_FOLLOW HDP_RL_REWARD_W_FOLLOW 0.0
+        paper_pin REWARD_W_LANE HDP_RL_REWARD_W_LANE 0.0
+        ;;
+      *)
+        echo "HDP_RL_PAPER_REWARD must be multi or single; got ${PAPER_REWARD}" >&2
+        exit 2
+        ;;
+    esac
+    # Table 3 and the RL-hybrid loss of Eq. (awr_hybrid).
+    paper_pin NUM_GENERATIONS HDP_RL_NUM_GENERATIONS 32
+    paper_pin REWARD_BETA HDP_RL_REWARD_BETA 1.0
+    paper_pin EMA_UPDATE_RATE HDP_RL_EMA_UPDATE_RATE 0.05
+    paper_pin PLANNING_HYBRID_LOSS HDP_RL_PLANNING_HYBRID_LOSS 0.1
+    paper_pin HYBRID_LOSS_WINDOW HDP_RL_HYBRID_LOSS_WINDOW 79 # W = L - 1, L = 80
+    # The published reward: a plain weighted sum of the four appendix terms.
+    paper_pin REWARD_SOURCE HDP_RL_REWARD_SOURCE native
+    paper_pin REWARD_AGGREGATION HDP_RL_REWARD_AGGREGATION weighted_sum
+    paper_pin BEHAVIOR_GATE HDP_RL_BEHAVIOR_GATE none
+    paper_pin REWARD_W_PROGRESS HDP_RL_REWARD_W_PROGRESS 0.0
+    paper_pin REWARD_W_ROAD_BORDER HDP_RL_REWARD_W_ROAD_BORDER 0.0
+    paper_pin RED_LIGHT_CONSTRAINT HDP_RL_RED_LIGHT_CONSTRAINT False
+    paper_pin OCCUPANCY_USE_ROAD_BORDER HDP_RL_OCCUPANCY_USE_ROAD_BORDER False
+    paper_pin REWARD_HORIZON_STEPS HDP_RL_REWARD_HORIZON_STEPS 0
+    paper_pin CANDIDATE_LOSS_HORIZON HDP_RL_CANDIDATE_LOSS_HORIZON 0
+    # The released rollout / replay schedule.
+    paper_pin ROLLOUT_STEPS HDP_RL_ROLLOUT_STEPS 5
+    paper_pin ROLLOUT_INTERVAL HDP_RL_ROLLOUT_INTERVAL 10
+    paper_pin UPDATES_PER_ROLLOUT HDP_RL_UPDATES_PER_ROLLOUT 1
+    paper_pin NOISE_SCALE HDP_RL_NOISE_SCALE 1.0
+    # Real-vehicle extensions of this repository, off.
+    paper_pin BC_WEIGHT HDP_RL_BC_WEIGHT 0.0
+    paper_pin CANDIDATE_AUG_PROB HDP_RL_CANDIDATE_AUG_PROB 0.0
+    paper_pin FIRST_WAYPOINT_GATE HDP_RL_FIRST_WAYPOINT_GATE False
+    paper_pin DIFFUSION_T_MIN HDP_RL_DIFFUSION_T_MIN 0.0
+    paper_pin DIFFUSION_T_MAX HDP_RL_DIFFUSION_T_MAX 1.0
+    ;;
+  False | false | 0)
+    PAPER_EXACT=False
+    ;;
+  *)
+    echo "HDP_RL_PAPER_EXACT must be True or False; got ${PAPER_EXACT}" >&2
+    exit 2
+    ;;
+esac
+
 RUN_NAME=${HDP_RL_RUN_NAME:-hdp_rl_${WORLD_SIZE}gpu_n${NUM_GENERATIONS}_${SLURM_JOB_ID}}
 SAVE_ROOT=${HDP_RL_SAVE_ROOT:-${REPO}/outputs}
 for gate_name in "${BEHAVIOR_GATE}" "${EVAL_BEHAVIOR_GATE}"; do
@@ -481,8 +561,10 @@ TRAIN_ARGS=(
   --num_heads 8 \
   --diffusion_sample_steps 6 \
   --use_velocity_representation True \
-  --planning_hybrid_loss 0.01 \
-  --hybrid_loss_window 10 \
+  --planning_hybrid_loss "${PLANNING_HYBRID_LOSS}" \
+  --hybrid_loss_window "${HYBRID_LOSS_WINDOW}" \
+  --rl_paper_exact "${PAPER_EXACT}" \
+  --rl_paper_reward "${PAPER_REWARD}" \
   --coeff_road_border_loss 0.0 \
   --coeff_neighbor_collision_loss 0.0 \
   --use_ema True \

--- a/diffusion_planner/tests/test_hdp_rl_paper_exact.py
+++ b/diffusion_planner/tests/test_hdp_rl_paper_exact.py
@@ -14,17 +14,22 @@ Where the sources contradict each other the divergence is recorded in
 ``docs/hdp_rl_paper_fidelity.md``; the tests lock the value this repository ships.
 """
 
+import json
+import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 import torch
 from diffusion_planner.hdp_rl_paper_exact import (
+    HYBRID_FIELDS,
     PAPER_REWARD_VARIANTS,
     apply_paper_exact_settings,
     assert_paper_exact,
+    base_corpus_mismatches,
     paper_exact_fields,
     paper_exact_values,
+    paper_hybrid_values,
 )
 from diffusion_planner.hdp_rl_utils import compute_reward_weighted_loss, compute_reward_weights
 from diffusion_planner.loss import _detached_integral
@@ -35,7 +40,40 @@ from diffusion_planner import hdp_rl_utils
 _NORMALIZATION = Path(__file__).resolve().parents[1] / "normalization.json"
 
 
-def _required_args():
+# The frozen IL base this pipeline post-trains. Paper-exact reads omega and W
+# from here rather than from Table 3, and checks the corpus against it, so the
+# tests need a base run directory that looks like a real one. The values are the
+# ones the shipped base80 run recorded (omega=0.01, W=10, StatePerturbation on).
+_BASE_ARGS = {
+    "planning_hybrid_loss": 0.01,
+    "hybrid_loss_window": 10,
+    "train_set_list": "train.json",
+    "valid_set_list": "valid.json",
+    "extra_train_set_list": [],
+    "extra_train_set_repeat": 0,
+    "filter_skipped": True,
+    "train_subsample_step": 1,
+    "align_legacy_neighbor_futures": False,
+    "use_data_augment": True,
+    "augment_type": "quintic",
+    "augment_prob": 0.5,
+    "num_refine": 20,
+    "ego_past_noise_std": 0.1,
+    "use_smoothing_future_trajectory": True,
+}
+
+_BASE_RUN = Path(tempfile.mkdtemp(prefix="hdp_paper_exact_base_"))
+(_BASE_RUN / "args.json").write_text(json.dumps(_BASE_ARGS), encoding="utf-8")
+
+
+def _write_base(**overrides):
+    """A second base run directory whose args.json differs from the default."""
+    run = Path(tempfile.mkdtemp(prefix="hdp_paper_exact_base_"))
+    (run / "args.json").write_text(json.dumps({**_BASE_ARGS, **overrides}), encoding="utf-8")
+    return run
+
+
+def _required_args(base_run=_BASE_RUN):
     return [
         "--exp_name",
         "paper_exact",
@@ -46,15 +84,15 @@ def _required_args():
         "--valid_set_list",
         "valid.json",
         "--init_weights_path",
-        "init.pth",
+        str(base_run / "latest.pth"),
         "--normalization_file_path",
         str(_NORMALIZATION),
     ]
 
 
-def _paper_args(*extra):
+def _paper_args(*extra, base_run=_BASE_RUN):
     return get_args(
-        _required_args() + ["--rl_paper_exact", "True", "--rl_replay_dir", "replay", *extra]
+        _required_args(base_run) + ["--rl_paper_exact", "True", "--rl_replay_dir", "replay", *extra]
     )
 
 
@@ -70,8 +108,8 @@ def test_table3_rl_hyperparameters_are_locked():
     assert args.rl_reward_w_risk == 1.0  # lambda_risk
     assert args.rl_reward_w_follow == 3.0  # lambda_follow
     assert args.rl_reward_w_lane == 2.5  # lambda_lane
-    assert args.planning_hybrid_loss == 0.1  # omega, IL block, reused by eq:awr_hybrid
-    assert args.hybrid_loss_window == args.future_len - 1  # Appendix: "we set W=L-1"
+    # omega and W are the one published pair this mode does NOT take from Table 3:
+    # see test_hybrid_norm_is_inherited_from_the_frozen_il_base.
 
 
 def test_total_training_reward_matches_the_appendix_cases():
@@ -165,8 +203,6 @@ def test_applied_changes_are_recorded_for_the_run_log():
         ("--num_generations", "8"),
         ("--rl_reward_beta", "0.5"),
         ("--rl_behavior_gate", "safety"),
-        ("--hybrid_loss_window", "10"),
-        ("--planning_hybrid_loss=0.01", None),
     ],
 )
 def test_explicit_flag_contradicting_the_paper_is_rejected(option, value):
@@ -207,14 +243,144 @@ def test_unknown_reward_variant_is_rejected():
 
 def test_horizon_relative_values_follow_the_configured_horizon():
     for horizon in (8, 80):
-        values = paper_exact_values("multi", SimpleNamespace(future_len=horizon))
+        values = paper_hybrid_values(SimpleNamespace(future_len=horizon))
         assert values["hybrid_loss_window"] == horizon - 1
+        assert values["planning_hybrid_loss"] == 0.1
 
 
 def test_apply_rejects_a_field_the_trainer_does_not_have():
     for variant in PAPER_REWARD_VARIANTS:
         with pytest.raises(AttributeError, match="drifted apart"):
             apply_paper_exact_settings(SimpleNamespace(future_len=80), variant)
+
+
+# ──────────── the hybrid norm: inherited from the frozen IL base ─────────────
+#
+# IL is never retrained here, so omega and W are taken from the checkpoint the
+# run post-trains rather than from Table 3. Which pair is better *for RL* is an
+# experiment, and --rl_hybrid_ablation is how it is asked.
+
+
+def test_hybrid_norm_is_inherited_from_the_frozen_il_base():
+    args = _paper_args()
+    assert args.planning_hybrid_loss == _BASE_ARGS["planning_hybrid_loss"]
+    assert args.hybrid_loss_window == _BASE_ARGS["hybrid_loss_window"]
+    # Not the published pair -- and the run log has to say so, with both values.
+    published = paper_hybrid_values(args)
+    assert published != {f: getattr(args, f) for f in HYBRID_FIELDS}
+    log = "\n".join(args.rl_paper_exact_changes)
+    for field in HYBRID_FIELDS:
+        assert field in log
+        assert repr(published[field]) in log
+    assert "frozen IL base" in log
+
+
+def test_hybrid_norm_follows_whichever_base_the_run_starts_from():
+    base = _write_base(planning_hybrid_loss=0.05, hybrid_loss_window=20)
+    args = _paper_args(base_run=base)
+    assert args.planning_hybrid_loss == 0.05
+    assert args.hybrid_loss_window == 20
+
+
+@pytest.mark.parametrize(
+    "option, value",
+    [
+        ("--planning_hybrid_loss", "0.1"),  # tab:param omega
+        ("--hybrid_loss_window", "79"),  # Appendix W = L - 1
+    ],
+)
+def test_explicit_hybrid_flag_contradicting_the_base_is_rejected(option, value):
+    with pytest.raises(ValueError, match="does not retrain IL"):
+        _paper_args(option, value)
+
+
+def test_explicit_hybrid_flag_agreeing_with_the_base_is_accepted():
+    args = _paper_args("--planning_hybrid_loss", "0.01", "--hybrid_loss_window", "10")
+    assert args.planning_hybrid_loss == 0.01
+    assert args.hybrid_loss_window == 10
+
+
+def test_ablation_releases_the_hybrid_norm_and_stamps_the_run():
+    args = _paper_args(
+        "--rl_hybrid_ablation",
+        "True",
+        "--planning_hybrid_loss",
+        "0.1",
+        "--hybrid_loss_window",
+        "79",
+    )
+    assert args.planning_hybrid_loss == 0.1
+    assert args.hybrid_loss_window == 79
+    log = "\n".join(args.rl_paper_exact_changes)
+    assert "released for ablation" in log
+    # The arm is only readable if the log carries both comparison points.
+    assert "frozen base" in log and "paper" in log
+
+
+def test_a_base_without_args_json_is_rejected():
+    orphan = Path(tempfile.mkdtemp(prefix="hdp_paper_exact_orphan_")) / "run"
+    orphan.mkdir()
+    with pytest.raises(ValueError, match="no args.json was found beside it"):
+        _paper_args(base_run=orphan)
+
+
+# ─────────── the corpus: identical to the run that produced the base ─────────
+
+
+@pytest.mark.parametrize(
+    "option, value",
+    [
+        ("--train_subsample_step", "10"),
+        ("--extra_train_set_repeat", "10"),
+        ("--filter_skipped", "False"),
+        ("--align_legacy_neighbor_futures", "True"),
+    ],
+)
+def test_a_different_corpus_than_the_base_is_rejected(option, value):
+    with pytest.raises(ValueError, match="corpus and the input perturbation"):
+        _paper_args(option, value)
+
+
+@pytest.mark.parametrize(
+    "option, value",
+    [
+        ("--use_data_augment", "False"),
+        ("--augment_prob", "0.25"),
+        ("--augment_type", "bridge"),
+        ("--num_refine", "5"),
+        ("--ego_past_noise_std", "0.0"),
+        ("--use_smoothing_future_trajectory", "False"),
+    ],
+)
+def test_a_different_perturbation_than_the_base_is_rejected(option, value):
+    with pytest.raises(ValueError, match="corpus and the input perturbation"):
+        _paper_args(option, value)
+
+
+def test_corpus_check_can_be_waived_deliberately():
+    args = _paper_args("--rl_base_corpus_check", "False", "--train_subsample_step", "10")
+    assert args.train_subsample_step == 10
+
+
+def test_extra_manifests_are_compared_by_basename():
+    # The same artifact has a different absolute path in each checkout, so the
+    # check must not fire on the prefix alone.
+    base_args = {**_BASE_ARGS, "extra_train_set_list": ["/node02/artifacts/right_turn.json"]}
+    args = SimpleNamespace(
+        **{k: v for k, v in _BASE_ARGS.items() if k != "extra_train_set_list"},
+        extra_train_set_list=["/node01/artifacts/right_turn.json"],
+    )
+    assert base_corpus_mismatches(args, base_args) == []
+    args.extra_train_set_list = ["/node01/artifacts/left_turn.json"]
+    assert any("extra_train_set_list" in m for m in base_corpus_mismatches(args, base_args))
+
+
+def test_a_base_that_does_not_record_a_corpus_field_is_reported():
+    base_args = {k: v for k, v in _BASE_ARGS.items() if k != "augment_prob"}
+    args = SimpleNamespace(**_BASE_ARGS)
+    assert base_corpus_mismatches(args, base_args) == [
+        "  augment_prob: the base args.json does not record it"
+    ]
 
 
 # ───────────────────── Algorithm 2, verbatim reimplementation ───────────────

--- a/diffusion_planner/tests/test_hdp_rl_paper_exact.py
+++ b/diffusion_planner/tests/test_hdp_rl_paper_exact.py
@@ -1,0 +1,352 @@
+"""Fidelity tests for ``--rl_paper_exact``: the published HDP-RL configuration.
+
+Every assertion here is anchored to a source that can be re-read:
+
+- ``reference/papers/hyper_diffusion_planner_paper/src/neurips_2026.tex``
+  (Eq. eq:optim / eq:awr / eq:awr_hybrid, Table tab:param, Appendix app:rewards,
+  Appendix ap:implementation, Appendix "Hybrid Loss");
+- ``reference/papers/.../src/code.tex`` (Algorithm 1) and ``code_rl.tex``
+  (Algorithm 2);
+- the authors' released code under ``reference/external/Hyper-Diffusion-Planner``
+  (``HDP-navsim/.../dp_vla_rl_agent.py``, ``HDP-nuplan/.../traj_kinematics.py``).
+
+Where the sources contradict each other the divergence is recorded in
+``docs/hdp_rl_paper_fidelity.md``; the tests lock the value this repository ships.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+from diffusion_planner.hdp_rl_paper_exact import (
+    PAPER_REWARD_VARIANTS,
+    apply_paper_exact_settings,
+    assert_paper_exact,
+    paper_exact_fields,
+    paper_exact_values,
+)
+from diffusion_planner.hdp_rl_utils import compute_reward_weighted_loss, compute_reward_weights
+from diffusion_planner.loss import _detached_integral
+from train_hdp_rl_predictor import get_args
+
+from diffusion_planner import hdp_rl_utils
+
+_NORMALIZATION = Path(__file__).resolve().parents[1] / "normalization.json"
+
+
+def _required_args():
+    return [
+        "--exp_name",
+        "paper_exact",
+        "--save_dir",
+        "out",
+        "--train_set_list",
+        "train.json",
+        "--valid_set_list",
+        "valid.json",
+        "--init_weights_path",
+        "init.pth",
+        "--normalization_file_path",
+        str(_NORMALIZATION),
+    ]
+
+
+def _paper_args(*extra):
+    return get_args(
+        _required_args() + ["--rl_paper_exact", "True", "--rl_replay_dir", "replay", *extra]
+    )
+
+
+# ───────────────────────── Table 3 and the reward appendix ──────────────────
+
+
+def test_table3_rl_hyperparameters_are_locked():
+    """neurips_2026.tex tab:param, the RL block."""
+    args = _paper_args()
+    assert args.num_generations == 32  # Group size
+    assert args.rl_reward_beta == 1.0  # Temperature beta
+    assert args.rl_ema_update_rate == 0.05  # EMA
+    assert args.rl_reward_w_risk == 1.0  # lambda_risk
+    assert args.rl_reward_w_follow == 3.0  # lambda_follow
+    assert args.rl_reward_w_lane == 2.5  # lambda_lane
+    assert args.planning_hybrid_loss == 0.1  # omega, IL block, reused by eq:awr_hybrid
+    assert args.hybrid_loss_window == args.future_len - 1  # Appendix: "we set W=L-1"
+
+
+def test_total_training_reward_matches_the_appendix_cases():
+    """app:rewards, "Total Training Reward"."""
+    multi = _paper_args()
+    assert multi.rl_reward_w_safety == 0.0
+    assert (
+        multi.rl_reward_w_risk,
+        multi.rl_reward_w_follow,
+        multi.rl_reward_w_lane,
+    ) == (1.0, 3.0, 2.5)
+
+    single = _paper_args("--rl_paper_reward", "single")
+    assert single.rl_reward_w_safety == 1.0
+    assert (
+        single.rl_reward_w_risk,
+        single.rl_reward_w_follow,
+        single.rl_reward_w_lane,
+    ) == (0.0, 0.0, 0.0)
+
+
+def test_total_reward_is_a_plain_weighted_sum():
+    """The appendix total reward has no gate, no progress term, no road-border term."""
+    args = _paper_args()
+    assert args.rl_reward_aggregation == "weighted_sum"
+    assert args.rl_behavior_gate == "none"
+    assert args.rl_reward_w_progress == 0.0
+    assert args.rl_reward_w_road_border == 0.0
+    assert args.rl_red_light_constraint is False
+    assert args.rl_occupancy_use_road_border is False
+
+
+def test_rewards_cover_the_full_planning_horizon():
+    """app:rewards: every reward is "evaluated ... over the planning horizon of L steps"."""
+    args = _paper_args()
+    assert args.rl_reward_horizon_steps == 0  # 0 == full horizon
+    assert args.rl_candidate_loss_horizon == 0
+
+
+def test_released_rollout_schedule_is_reproduced():
+    """HDP-navsim config/agent/dp_vla_rl_agent.yaml, ``rl_config``."""
+    args = _paper_args()
+    assert args.rl_rollout_steps == 5  # rollout_steps: 5
+    assert args.rl_rollout_interval == 10  # replay_buffer_update_epoch: 10
+    assert args.rl_updates_per_rollout == 1  # max_rollout_iter: 1
+
+
+def test_awr_objective_has_no_repo_only_terms():
+    """eq:awr_hybrid is exp(beta*r) times the hybrid loss and nothing else."""
+    args = _paper_args()
+    assert args.rl_bc_weight == 0.0  # no behaviour-cloning anchor in the paper
+    assert args.rl_candidate_aug_prob == 0.0  # candidates come from pi^{k-1} only
+    assert args.rl_first_waypoint_gate is False  # no candidate rejection in the paper
+    assert args.rl_noise_scale == 1.0  # pi^{k-1} sampled at its own temperature
+    assert args.rl_diffusion_t_min == 0.0  # expectation over the full t range
+    assert args.rl_diffusion_t_max == 1.0
+    assert args.rl_reward_source == "native"
+
+
+def test_group_normalization_and_ema_come_from_the_paper():
+    """ap:implementation: group normalization, constant-group discard, EMA."""
+    args = _paper_args()
+    assert args.rl_reward_normalize == "group"
+    assert args.advantage_eps == 1e-6  # the 1e-6 of code_rl.tex Algorithm 2
+    assert args.rl_init_use_ema is True
+
+
+# ─────────────────────────────── the mode itself ────────────────────────────
+
+
+def test_mode_is_off_by_default_and_changes_nothing():
+    args = get_args(_required_args())
+    assert args.rl_paper_exact is False
+    assert args.rl_paper_exact_changes == []
+    # A repo default that the paper contradicts, left untouched.
+    assert args.num_generations != 32
+
+
+def test_applied_changes_are_recorded_for_the_run_log():
+    args = _paper_args()
+    changed = {line.split(":", 1)[0] for line in args.rl_paper_exact_changes}
+    assert "num_generations" in changed
+    assert "rl_behavior_gate" in changed
+    # Every recorded line carries its citation.
+    assert all("  [" in line for line in args.rl_paper_exact_changes)
+
+
+@pytest.mark.parametrize(
+    "option, value",
+    [
+        ("--num_generations", "8"),
+        ("--rl_reward_beta", "0.5"),
+        ("--rl_behavior_gate", "safety"),
+        ("--hybrid_loss_window", "10"),
+        ("--planning_hybrid_loss=0.01", None),
+    ],
+)
+def test_explicit_flag_contradicting_the_paper_is_rejected(option, value):
+    extra = [option] if value is None else [option, value]
+    with pytest.raises(ValueError, match="cannot be combined with these explicit overrides"):
+        _paper_args(*extra)
+
+
+def test_explicit_flag_agreeing_with_the_paper_is_accepted():
+    args = _paper_args("--num_generations", "32", "--rl_reward_beta", "1.0")
+    assert args.num_generations == 32
+    assert args.rl_reward_beta == 1.0
+
+
+def test_replay_directory_is_required():
+    with pytest.raises(ValueError, match="requires\n?\\s*--rl_replay_dir"):
+        get_args(_required_args() + ["--rl_paper_exact", "True"])
+
+
+def test_assert_paper_exact_catches_later_mutation():
+    args = _paper_args()
+    assert_paper_exact(args, "multi")
+    args.rl_reward_beta = 0.5
+    with pytest.raises(ValueError, match="Run is not paper-exact"):
+        assert_paper_exact(args, "multi")
+
+
+def test_every_controlled_field_exists_on_the_trainer():
+    args = get_args(_required_args())
+    for field in paper_exact_fields():
+        assert hasattr(args, field), field
+
+
+def test_unknown_reward_variant_is_rejected():
+    with pytest.raises(ValueError, match="Unsupported rl_paper_reward"):
+        paper_exact_values("dagger", SimpleNamespace(future_len=80))
+
+
+def test_horizon_relative_values_follow_the_configured_horizon():
+    for horizon in (8, 80):
+        values = paper_exact_values("multi", SimpleNamespace(future_len=horizon))
+        assert values["hybrid_loss_window"] == horizon - 1
+
+
+def test_apply_rejects_a_field_the_trainer_does_not_have():
+    for variant in PAPER_REWARD_VARIANTS:
+        with pytest.raises(AttributeError, match="drifted apart"):
+            apply_paper_exact_settings(SimpleNamespace(future_len=80), variant)
+
+
+# ───────────────────── Algorithm 2, verbatim reimplementation ───────────────
+
+
+def _algorithm_2_weights(r, beta, eps=1e-6):
+    """code_rl.tex Algorithm 2, ``rl_hybrid_loss``.
+
+    The listing reads ``r_n = (r - r.mean() / (r.std() + 1e-6)`` -- an unbalanced
+    parenthesis that also divides only the mean. The intended expression, and the
+    one the released code implements, is the group-relative normalization of
+    deepseekmath cited next to it in ap:implementation.
+    """
+    r_n = (r - r.mean()) / (r.std() + eps)
+    return torch.exp(beta * r_n).detach()
+
+
+def test_group_weights_reproduce_algorithm_2():
+    reward = torch.tensor([0.10, 0.40, 0.35, 0.90])
+    weights, valid = compute_reward_weights(
+        reward,
+        num_scenes=1,
+        n=4,
+        normalize="group",
+        beta=1.0,
+        eps=1e-6,
+    )
+    assert bool(valid.all())
+    torch.testing.assert_close(weights, _algorithm_2_weights(reward, beta=1.0))
+
+
+def test_beta_enters_the_exponent_exactly_once():
+    reward = torch.tensor([0.10, 0.40, 0.35, 0.90])
+    for beta in (0.5, 1.0, 2.0):
+        weights, _ = compute_reward_weights(
+            reward, num_scenes=1, n=4, normalize="group", beta=beta, eps=1e-6
+        )
+        torch.testing.assert_close(weights, _algorithm_2_weights(reward, beta=beta))
+
+
+def test_constant_reward_group_is_discarded():
+    """ap:implementation: "we discard samples in which all actions receive identical rewards"."""
+    reward = torch.tensor([0.5, 0.5, 0.5, 0.5, 0.1, 0.9, 0.2, 0.8])
+    weights, valid = compute_reward_weights(
+        reward, num_scenes=2, n=4, normalize="group", beta=1.0, eps=1e-6
+    )
+    assert not bool(valid[:4].any())  # constant group dropped, not left at exp(0) == 1
+    assert bool(valid[4:].all())
+    assert float(weights[:4].abs().sum()) == 0.0
+
+
+def test_reward_weighted_loss_matches_algorithm_2(monkeypatch):
+    """eq:awr: the loss is the reward-weighted mean of the per-sample hybrid distance."""
+    per_sample = torch.tensor([1.0, 2.0, 3.0, 4.0])
+    reward = torch.tensor([0.10, 0.40, 0.35, 0.90])
+
+    def fake_policy_loss(_model, _inputs, target, _args, *_pos, **_kwargs):
+        assert target.shape[0] == per_sample.shape[0]
+        return {
+            "ego_loss_per_sample": per_sample,
+            "ego_hdp_diffusion_loss": per_sample.mean(),
+            "ego_hdp_waypoint_loss": per_sample.mean(),
+        }
+
+    monkeypatch.setattr(hdp_rl_utils, "_compute_policy_ego_loss_per_sample", fake_policy_loss)
+    result = compute_reward_weighted_loss(
+        model=None,
+        norm_inputs={},
+        ego_pseudo_gt=torch.zeros(4, 80, 4),
+        reward=reward,
+        num_scenes=1,
+        n=4,
+        args=SimpleNamespace(
+            rl_reward_normalize="group",
+            rl_reward_beta=1.0,
+            advantage_eps=1e-6,
+            ddp=False,
+            rl_bc_weight=0.0,
+            rl_bc_active_groups_only=True,
+        ),
+    )
+    expected = (_algorithm_2_weights(reward, beta=1.0) * per_sample).mean()
+    torch.testing.assert_close(result["loss"], expected)
+
+
+# ───────────────── Algorithm 1 / detached_integral, verbatim port ───────────
+
+
+def _released_detached_integral(u, detach_window_size):
+    """Verbatim ``detached_integral`` from HDP-navsim dp_vla_agent.py (correct axis)."""
+    cum_detach = torch.cumsum(u.detach(), dim=-2)
+    cum_normal = torch.cumsum(u, dim=-2)
+
+    shifted = torch.roll(cum_normal, shifts=detach_window_size, dims=-2)
+    shifted[..., :detach_window_size, :] = 0
+    sum_recent = cum_normal - shifted
+
+    cum_detach_shifted = torch.roll(cum_detach, shifts=detach_window_size, dims=-2)
+    cum_detach_shifted[..., :detach_window_size, :] = 0
+
+    return cum_detach_shifted + sum_recent
+
+
+@pytest.mark.parametrize("window", [1, 3, 7, 8])
+def test_detached_integral_matches_the_released_port(window):
+    base = torch.randn(2, 8, 2, dtype=torch.float64)
+
+    ours = base.clone().requires_grad_(True)
+    theirs = base.clone().requires_grad_(True)
+
+    out_ours = _detached_integral(ours, window)
+    out_theirs = _released_detached_integral(theirs, window)
+    torch.testing.assert_close(out_ours, out_theirs)
+
+    # The stop-gradient pattern is the point of Algorithm 1, so compare gradients too.
+    (out_ours * base).sum().backward()
+    (out_theirs * base).sum().backward()
+    torch.testing.assert_close(ours.grad, theirs.grad)
+
+
+def test_detach_window_slices_time_not_the_coordinate_axis():
+    """Regression guard for the HDP-nuplan axis bug.
+
+    ``traj_kinematics.py`` writes ``shifted[:, :, :detach_window_size] = 0`` on a
+    ``(B, T, D)`` tensor, which zeroes the whole tensor whenever ``W >= D``. The
+    window then has no effect at all and the loss reduces to a plain cumsum.
+    """
+    v = torch.randn(1, 6, 2, dtype=torch.float64, requires_grad=True)
+    out = _detached_integral(v, 3)
+    # Only the last step's gradient path is exercised, so a W-limited window must
+    # differ from the full-gradient cumsum the buggy indexing collapses to.
+    grad_windowed = torch.autograd.grad(out[0, -1].sum(), v, retain_graph=True)[0]
+    grad_full = torch.autograd.grad(torch.cumsum(v, dim=-2)[0, -1].sum(), v)[0]
+    assert not torch.allclose(grad_windowed, grad_full)
+    assert int(grad_windowed[0, :, 0].count_nonzero()) == 3  # exactly W time steps

--- a/diffusion_planner/tests/test_hdp_rl_replay.py
+++ b/diffusion_planner/tests/test_hdp_rl_replay.py
@@ -10,6 +10,7 @@ from diffusion_planner.hdp_rl_replay import (
     cleanup_previous_cycle,
     cycle_index,
     is_mine_epoch,
+    relay_epoch,
 )
 
 from diffusion_planner import hdp_rl_epoch
@@ -61,6 +62,22 @@ def test_relay_schedule_is_ten_cycles_of_ten():
     assert mine_epochs == [1, 11, 21, 31, 41, 51, 61, 71, 81, 91]
     assert [cycle_index(e, 10) for e in mine_epochs] == list(range(10))
     assert cycle_index(100, 10) == 9  # the last replay epoch trains cycle 9's cache
+
+
+def test_trainer_epoch_zero_mines_cycle_zero():
+    """The training loop counts from zero; the relay is numbered from one.
+
+    Without the shift, a fresh run's first epoch resolves to cycle -1 and reads as
+    a replay epoch, so it aborts on a cache that no mining pass ever wrote.
+    """
+    assert is_mine_epoch(relay_epoch(0), 10)
+    assert cycle_index(relay_epoch(0), 10) == 0
+    assert not is_mine_epoch(relay_epoch(1), 10)
+    assert cycle_index(relay_epoch(9), 10) == 0
+    assert is_mine_epoch(relay_epoch(10), 10)
+    assert cycle_index(relay_epoch(10), 10) == 1
+    trainer_mine_epochs = [e for e in range(100) if is_mine_epoch(relay_epoch(e), 10)]
+    assert trainer_mine_epochs == [0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
 
 
 def test_writer_reader_roundtrip_preserves_frozen_weights(tmp_path):

--- a/diffusion_planner/train_hdp_rl_predictor.py
+++ b/diffusion_planner/train_hdp_rl_predictor.py
@@ -34,6 +34,12 @@ from diffusion_planner.hdp_rl_epoch import (
     train_hdp_rl_epoch,
     validate_hdp_reward_policy,
 )
+from diffusion_planner.hdp_rl_paper_exact import (
+    PAPER_REWARD_VARIANTS,
+    apply_paper_exact_settings,
+    assert_paper_exact,
+    explicit_paper_exact_dests,
+)
 from diffusion_planner.model.diffusion_planner import Diffusion_Planner
 from diffusion_planner.train import (
     assert_checkpoint_compatible,
@@ -235,7 +241,7 @@ def _checkpoint_bool(path: str, key: str, default: bool) -> bool:
     return bool(value)
 
 
-def get_args():
+def get_args(argv: list[str] | None = None):
     parser = argparse.ArgumentParser(description="HDP RL training")
     parser.add_argument("--exp_name", type=str, required=True)
     parser.add_argument("--save_dir", type=str, help="save path for model ckpt", required=True)
@@ -825,6 +831,22 @@ def get_args():
         help="tangent test applies only above this displacement (5 cm floor is mandatory)",
     )
     parser.add_argument(
+        "--rl_paper_exact",
+        type=boolean,
+        default=_train_config_default("rl_paper_exact"),
+        help="pin every RL knob to the published HDP-RL configuration and reject "
+        "contradicting overrides; see docs/hdp_rl_paper_fidelity.md",
+    )
+    parser.add_argument(
+        "--rl_paper_reward",
+        type=str,
+        choices=list(PAPER_REWARD_VARIANTS),
+        default=_train_config_default("rl_paper_reward"),
+        help="published reward setting selected by --rl_paper_exact: 'multi' = "
+        "lambda_risk r_risk + lambda_follow r_follow + lambda_lane r_lane, "
+        "'single' = r_safety alone",
+    )
+    parser.add_argument(
         "--rl_reward_normalize",
         "--official_reward_normalize",
         dest="rl_reward_normalize",
@@ -1080,10 +1102,20 @@ def get_args():
     parser.add_argument("--closed_loop_unstick_after", type=int, default=300)
     parser.add_argument("--closed_loop_unstick_advance_m", type=float, default=2.5)
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     # This metadata is an invariant of the model, not a command-line mode.
     args.policy_uses_turn_indicator_history = False
     args.turn_indicator_output_dim = TURN_INDICATOR_OUTPUT_DIM
+    # Pin the published configuration before any validation runs, so every bound check
+    # below sees the values the run will actually train with.
+    args.rl_paper_exact_changes = []
+    if args.rl_paper_exact:
+        args.rl_paper_exact_changes = apply_paper_exact_settings(
+            args,
+            args.rl_paper_reward,
+            explicit_paper_exact_dests(parser, argv),
+        )
+        assert_paper_exact(args, args.rl_paper_reward)
     if args.resume_model_path is not None and args.init_weights_path is not None:
         raise ValueError("--resume_model_path and --init_weights_path are mutually exclusive")
     if args.resume_model_path is None and args.init_weights_path is None:
@@ -1575,6 +1607,15 @@ def model_training(args):
 
     if global_rank == 0:
         print("------------- {} -------------".format(args.exp_name))
+        if args.rl_paper_exact:
+            # Print the full pin table so the log itself is the fidelity record: every
+            # field the published configuration overrode, with its previous value.
+            print("HDP-RL paper-exact mode: ON (reward variant: {})".format(args.rl_paper_reward))
+            if args.rl_paper_exact_changes:
+                for change in args.rl_paper_exact_changes:
+                    print("  paper-exact pin: {}".format(change))
+            else:
+                print("  paper-exact pin: none (every controlled field already matched)")
         print("Scenes per step (batch_size): {}".format(args.batch_size))
         print("Validation batch size: {}".format(args.valid_batch_size))
         print("Group size (num_generations): {}".format(args.num_generations))

--- a/diffusion_planner/train_hdp_rl_predictor.py
+++ b/diffusion_planner/train_hdp_rl_predictor.py
@@ -35,13 +35,17 @@ from diffusion_planner.hdp_rl_epoch import (
     validate_hdp_reward_policy,
 )
 from diffusion_planner.hdp_rl_paper_exact import (
+    HYBRID_FIELDS,
     PAPER_REWARD_VARIANTS,
+    apply_frozen_base_hybrid,
     apply_paper_exact_settings,
+    assert_base_corpus_identical,
     assert_paper_exact,
     explicit_paper_exact_dests,
 )
 from diffusion_planner.model.diffusion_planner import Diffusion_Planner
 from diffusion_planner.train import (
+    _checkpoint_args_path,
     assert_checkpoint_compatible,
     closed_loop_validate,
     load_weights_only,
@@ -847,6 +851,22 @@ def get_args(argv: list[str] | None = None):
         "'single' = r_safety alone",
     )
     parser.add_argument(
+        "--rl_hybrid_ablation",
+        type=boolean,
+        default=_train_config_default("rl_hybrid_ablation"),
+        help="release --planning_hybrid_loss / --hybrid_loss_window from the frozen IL "
+        "base's values and stamp the run as an omega/W ablation arm; the published "
+        "pair is only reachable this way because IL is never retrained",
+    )
+    parser.add_argument(
+        "--rl_base_corpus_check",
+        type=boolean,
+        default=_train_config_default("rl_base_corpus_check"),
+        help="under --rl_paper_exact, require the corpus and the input perturbation to "
+        "be the ones the frozen IL base was trained on; set False only to post-train "
+        "on a deliberately different distribution",
+    )
+    parser.add_argument(
         "--rl_reward_normalize",
         "--official_reward_normalize",
         dest="rl_reward_normalize",
@@ -1120,6 +1140,29 @@ def get_args(argv: list[str] | None = None):
         raise ValueError("--resume_model_path and --init_weights_path are mutually exclusive")
     if args.resume_model_path is None and args.init_weights_path is None:
         raise ValueError("HDP-RL requires --init_weights_path or --resume_model_path")
+    if args.rl_paper_exact:
+        # omega and W are the geometry of the norm the frozen IL base was fitted in,
+        # and IL is never retrained, so they are inherited from that base rather than
+        # pinned to Table 3. This runs after the mutual-exclusion checks above so the
+        # checkpoint it reads is unambiguous.
+        base_path = args.init_weights_path or args.resume_model_path
+        base_args_path = _checkpoint_args_path(base_path)
+        base_args = None
+        if base_args_path is not None:
+            with open(base_args_path, "r", encoding="utf-8") as handle:
+                base_args = json.load(handle)
+        base_label = str(base_args_path) if base_args_path is not None else base_path
+        args.rl_paper_exact_changes += apply_frozen_base_hybrid(
+            args,
+            base_args,
+            base_label,
+            explicit_paper_exact_dests(parser, argv, fields=HYBRID_FIELDS),
+            ablation=args.rl_hybrid_ablation,
+        )
+        # A resume compares against its own args.json, where the corpus is by
+        # construction the one this check already passed on the fresh run.
+        if args.rl_base_corpus_check and base_args is not None and args.init_weights_path:
+            assert_base_corpus_identical(args, base_args, base_label)
     if args.train_subsample_step < 1:
         raise ValueError("--train_subsample_step must be >= 1")
     if args.extra_train_set_repeat < 0:
@@ -1611,6 +1654,13 @@ def model_training(args):
             # Print the full pin table so the log itself is the fidelity record: every
             # field the published configuration overrode, with its previous value.
             print("HDP-RL paper-exact mode: ON (reward variant: {})".format(args.rl_paper_reward))
+            if args.rl_hybrid_ablation:
+                print(
+                    "  omega/W ablation arm: planning_hybrid_loss={} hybrid_loss_window={} "
+                    "(released from the frozen IL base on purpose)".format(
+                        args.planning_hybrid_loss, args.hybrid_loss_window
+                    )
+                )
             if args.rl_paper_exact_changes:
                 for change in args.rl_paper_exact_changes:
                     print("  paper-exact pin: {}".format(change))

--- a/docs/hdp_rl_paper_fidelity.md
+++ b/docs/hdp_rl_paper_fidelity.md
@@ -1,0 +1,239 @@
+# HDP-RL paper fidelity: `--rl_paper_exact`
+
+`--rl_paper_exact true` runs the RL post-training exactly as published, and refuses
+to start otherwise. It pins every field listed below to its cited value, turns off
+every real-vehicle extension this repository added on top of the paper, and raises
+on any explicit command-line flag that contradicts a published value — so a run
+either reproduces HDP-RL or fails loudly. The applied pin table is printed on rank 0
+and written to `args.json` as `rl_paper_exact_changes`.
+
+```bash
+python train_hdp_rl_predictor.py ... \
+  --rl_paper_exact true \
+  --rl_paper_reward multi \      # multi = HDP-RL;  single = HDP-RL† (r_safety alone)
+  --rl_replay_dir <dir>          # required: the mine/replay epoch state machine
+```
+
+## Sources
+
+Everything below is anchored to a file that can be re-read:
+
+| Short name | Path |
+| --- | --- |
+| `neurips_2026.tex` | `reference/papers/hyper_diffusion_planner_paper/src/neurips_2026.tex` |
+| `code.tex` | `reference/papers/hyper_diffusion_planner_paper/src/code.tex` (Algorithm 1, hybrid loss) |
+| `code_rl.tex` | `reference/papers/hyper_diffusion_planner_paper/src/code_rl.tex` (Algorithm 2, RL-hybrid loss) |
+| `dp_vla_rl_agent.py` | `reference/external/Hyper-Diffusion-Planner/HDP-navsim/hdp_navsim/agent/dp_vla/dp_vla_rl_agent.py` |
+| `dp_vla_agent.py` | `reference/external/Hyper-Diffusion-Planner/HDP-navsim/hdp_navsim/agent/dp_vla/dp_vla_agent.py` |
+| `dp_vla_rl_agent.yaml` | `reference/external/Hyper-Diffusion-Planner/HDP-navsim/hdp_navsim/config/agent/dp_vla_rl_agent.yaml` |
+| `agent_lightning_module.py` | `reference/external/Hyper-Diffusion-Planner/HDP-navsim/hdp_navsim/training/agent_lightning_module.py` |
+| `traj_kinematics.py` | `reference/external/Hyper-Diffusion-Planner/HDP-nuplan/hdp_nuplan/utils/traj_kinematics.py` |
+| `train_predictor.py` (nuplan) | `reference/external/Hyper-Diffusion-Planner/HDP-nuplan/train_predictor.py` |
+
+Key anchors in `neurips_2026.tex`: `eq:optim` (line 605), `eq:awr` (615),
+`eq:awr_hybrid` (622), the RL section text (635–642), Appendix C / MDP (1122),
+the hybrid-loss appendix (1278), `ap:implementation` (1353), `app:rewards` (1366),
+and Table `tab:param` (1380–1404).
+
+## What the paper's RL actually is
+
+KL-regularized advantage-weighted regression, one epoch-scale iteration at a time:
+
+- Eq. `eq:optim`: `max_pi E[r] - (1/beta) KL(pi^k || pi^{k-1})`.
+- Closed form: `pi^{k*} ∝ pi^{k-1} · exp(beta · r)`.
+- Eq. `eq:awr`: `L_RL = E[ exp(beta·r) · || tau^{v;k}_theta(tau^v_t, t, C) - tau^v_0 ||^2 ]`,
+  where the actions `tau^v_0` in `D` are **drawn from `pi^{k-1}`** — the regression
+  target is the sampled candidate, not the human trajectory.
+- Eq. `eq:awr_hybrid`: same expression with the hybrid norm `||·||^2_P`, i.e. the
+  velocity MSE plus `omega` times the waypoint MSE of the `W`-detached integral.
+- `ap:implementation`: reward group normalization, discard of constant-reward
+  groups, and EMA for policy updates.
+
+That is the whole objective. There is no expert anchor, no candidate filtering, no
+gating, and no shaping term beyond the four rewards of `app:rewards`.
+
+## Pin table
+
+`repo default` is the value a normal (non-paper-exact) run of this repository uses;
+`paper-exact` is what the mode pins. Rows where the two agree are still pinned, so
+that a future default change cannot silently break a paper-exact run.
+
+### Table 3 (`tab:param`) and Eq. (`eq:awr_hybrid`)
+
+| Field | Repo default | Paper-exact | Source |
+| --- | --- | --- | --- |
+| `num_generations` | 8 | **32** | `tab:param` RL / Group size |
+| `rl_reward_beta` | 0.5 | **1.0** | `tab:param` RL / Temperature β |
+| `rl_ema_update_rate` | 0.05 | 0.05 | `tab:param` RL / EMA (decay = 1 − rate = 0.95) |
+| `rl_reward_w_risk` | 1.0 | 1.0 | `tab:param` λ_risk |
+| `rl_reward_w_follow` | 3.0 | 3.0 | `tab:param` λ_follow |
+| `rl_reward_w_lane` | 2.5 | 2.5 | `tab:param` λ_lane |
+| `planning_hybrid_loss` (ω) | 0.01 | **0.1** | `tab:param` IL / Hybrid loss weight — see contradiction 2 |
+| `hybrid_loss_window` (W) | 10 | **L − 1 = 79** | hybrid-loss appendix, "In practice, we set W=L−1" — see contradiction 3 |
+| `advantage_eps` | 1e-6 | 1e-6 | `code_rl.tex` `r.std() + 1e-6` |
+| `rl_reward_normalize` | `group` | `group` | `ap:implementation`, reward group normalization |
+| `rl_init_use_ema` | True | True | Sec. RL, `pi^0` is the hybrid-loss imitation model |
+
+### The reward (`app:rewards`)
+
+| Field | Repo default | Paper-exact (`multi`) | Paper-exact (`single`) | Source |
+| --- | --- | --- | --- | --- |
+| `rl_reward_w_safety` | 0.0 | 0.0 | **1.0** | "the single-reward baseline uses r_safety alone" |
+| `rl_reward_w_risk` | 1.0 | 1.0 | **0.0** | Total Training Reward |
+| `rl_reward_w_follow` | 3.0 | 3.0 | **0.0** | Total Training Reward |
+| `rl_reward_w_lane` | 2.5 | 2.5 | **0.0** | Total Training Reward |
+| `rl_reward_aggregation` | `weighted_sum` | `weighted_sum` | ditto | `r` is a plain weighted sum |
+| `rl_behavior_gate` | `safety` | **`none`** | ditto | the published sum has no gate |
+| `rl_reward_w_progress` | 3.0 | **0.0** | ditto | no progress term in the paper |
+| `rl_reward_w_road_border` | 0.0 | 0.0 | ditto | no road-border term in the paper |
+| `rl_red_light_constraint` | True | **False** | ditto | neither r_safety nor r_risk has a traffic-light factor |
+| `rl_occupancy_use_road_border` | True | **False** | ditto | OCC is "occupancy distance to static/uncertain regions", not HD-map border geometry |
+| `rl_reward_horizon_steps` | 0 (full) | 0 | ditto | rewards are "evaluated … over the planning horizon of L steps" |
+| `rl_reward_source` | `native` | `native` | ditto | the published reward set, not the ported original-DP PDM objective |
+
+### The rollout / replay schedule (`dp_vla_rl_agent.yaml`, `dp_vla_rl_agent.py`)
+
+| Field | Repo default | Paper-exact | Source |
+| --- | --- | --- | --- |
+| `rl_rollout_steps` | 6 | **5** | `rl_config.rollout_steps: 5` |
+| `rl_rollout_interval` | 0 (mine every epoch) | **10** | `rl_config.replay_buffer_update_epoch: 10`; the `compute_loss` / `on_train_epoch_start` epoch state machine |
+| `rl_updates_per_rollout` | 1 | 1 | `rl_config.diffusion_repeat_size: 1` |
+| `rl_noise_scale` | 1.5 | **1.0** | `_rl_rollout` samples the prior at unit temperature |
+
+`--rl_paper_exact` therefore requires `--rl_replay_dir`; a 10-epoch mine interval
+without a replay cache would silently train ten epochs on nothing.
+
+### Extensions of this repository that the mode switches off
+
+| Field | Repo default | Paper-exact | Why |
+| --- | --- | --- | --- |
+| `rl_bc_weight` | 0.0 | 0.0 | `eq:awr_hybrid` is the weighted regression alone |
+| `rl_candidate_loss_horizon` | 0 | 0 | the regression covers the whole action `tau^v_0` |
+| `rl_diffusion_t_min` / `rl_diffusion_t_max` | 0.0 / 1.0 | 0.0 / 1.0 | expectation over the full `t` range |
+| `rl_candidate_aug_prob` | 0.0 | 0.0 | see "deliberate non-verbatim item" below |
+| `rl_first_waypoint_gate` | True | **False** | a real-vehicle candidate filter; not in the paper and not in the released agent |
+
+## Three contradictions between the sources
+
+These are properties of the published material, not of this repository. Where the
+paper and the released code disagree, paper-exact mode follows the **paper**,
+because the `.tex` is the only self-consistent, citable configuration.
+
+### 1. `code_rl.tex` Algorithm 2 does not parse
+
+The listing reads, verbatim:
+
+```python
+def rl_hybrid_loss(r, beta, pred_v, gt_v, W, omega):
+    r_n = (r - r.mean() / (r.std() + 1e-6)
+    weight = torch.exp(beta * r_n).detach()
+    return weight * hybrid_loss(pred_v, gt_v, W, omega)
+```
+
+The second line has an unbalanced parenthesis, and as written it divides only the
+mean rather than the centred reward: `r - (r.mean() / (r.std() + 1e-6))`. The
+intended expression is the group-relative normalization `(r - mean) / (std + 1e-6)`
+that `ap:implementation` cites to deepseekmath and that `dp_vla_rl_agent.py:632-634`
+implements:
+
+```python
+rewards = (reward_abs - reward_abs.mean(dim=1, keepdim=True)) / (
+    reward_abs.std(dim=1, keepdim=True) + 1e-6
+)
+```
+
+We implement the corrected form. `tests/test_hdp_rl_paper_exact.py` locks
+`compute_reward_weights` against a verbatim reimplementation of it.
+
+### 2. ω = 0.1 (paper) vs 0.01 / 0.05 / 0.0 (code)
+
+- `tab:param`: hybrid loss weight **ω = 0.1**.
+- `HDP-nuplan/train_predictor.py:77`: `--planning_hybrid_loss` default **0.01**.
+- `HDP-navsim/config/agent/dp_vla_agent_hdp.yaml:33`: `hybrid_loss_weight: 0.05`.
+- `dp_vla_rl_agent.yaml`: does not set `hybrid_loss_weight` at all, and
+  `dp_vla_rl_agent.py:664` falls back to `0.0` — i.e. the released navsim RL config
+  runs the RL-hybrid loss with **no waypoint term**, which is precisely the ablation
+  baseline the paper argues against in "RL-Hybrid Loss Matters".
+
+This repository's normal default is 0.01 (it follows the released nuplan trainer,
+which is the codebase our planner descends from). Paper-exact mode pins 0.1.
+
+**Practical consequence:** our IL base checkpoints were trained at ω = 0.01, so a
+strictly paper-exact RL run changes the waypoint-term scale 10× relative to the
+pretraining it starts from. A fully paper-exact pipeline would pretrain at ω = 0.1
+as well. This is the one pin worth reviewing before a long run.
+
+### 3. W = L−1 (paper) vs a real axis bug (nuplan) vs W = 1 (navsim)
+
+- Paper, hybrid-loss appendix: "In practice, we set **W = L−1**" — i.e. essentially
+  the full gradient, with only the oldest step detached.
+- `traj_kinematics.py:13,17` writes, on a tensor documented as `u: (B, T=80, D)`:
+
+  ```python
+  shifted[:, :, :detach_window_size] = 0
+  ```
+
+  The third index is the **coordinate** axis `D`, not time. With `D ∈ {2,3}` and
+  `detach_window_size = 10`, the slice covers the whole axis, so `shifted` becomes
+  all-zero, `sum_recent = cum_normal`, `cum_detach_shifted = 0`, and the function
+  returns a plain `cumsum`. The released nuplan hybrid loss therefore performs **no
+  detaching at all** (effectively W = L), which happens to land near the paper's
+  W = L−1.
+- The navsim copy at `dp_vla_agent.py:230,234` uses the correct
+  `[..., :detach_window_size, :]`, but its default is `detach_window_size = 1`
+  (`dp_vla_rl_agent.py:669`), the opposite extreme.
+
+Our `diffusion_planner/loss.py:80` `_detached_integral` uses the correct time-axis
+slice, and `tests/test_hdp_rl_paper_exact.py` both checks it against a verbatim port
+of the navsim function (values *and* gradients, for W = 1, 3, 7, 8) and guards
+against the nuplan axis bug regressing into it.
+
+## Two further places the released code departs from its own paper
+
+Neither is a contradiction we had to resolve — in both, our implementation already
+follows the paper — but they are worth knowing when comparing runs.
+
+- **Constant-reward groups are not discarded in the released code.**
+  `ap:implementation` says "we discard samples in which all actions receive
+  identical rewards". `dp_vla_rl_agent.py:660` computes `weights = torch.exp(rewards)`
+  unconditionally, so a group whose rewards are all equal contributes at
+  `exp(0) = 1` — unweighted self-distillation on exactly the scenes that carry no
+  preference signal. `compute_reward_weights` in
+  `diffusion_planner/hdp_rl_utils.py:2057` drops those groups.
+- **No EMA runs in the released navsim RL.** `tab:param` lists EMA = 0.05 and the
+  RL section says "we employ Exponential Moving Average (EMA) for policy updates",
+  but the `ModelEma(..., decay=0.999)` block in `agent_lightning_module.py:66-68`
+  is commented out. We implement the paper: `decay = 1 − rl_ema_update_rate = 0.95`.
+
+## The one deliberate non-verbatim item
+
+`dp_vla_rl_agent.py:534-535` augments rollout candidates while `current_epoch < 5`
+with `augment_trajectory_batch` (`scoring.py:131`), which adds a **constant
+along-track / lateral offset** (both drawn at σ = 0.5, `scoring.py:139-140`) to the
+whole waypoint sequence. Paper-exact mode leaves
+`rl_candidate_aug_prob = 0.0`, i.e. it does not reproduce that augmentation.
+
+Reason: the released agent's action is a waypoint sequence, where a constant offset
+is a rigid translation of the trajectory. Our action is the **velocity** sequence
+(`use_velocity_representation`), where the same constant offset applied to the action
+is a first-step impulse followed by nothing — a physically different perturbation,
+and one this repository's `augment_rollout_candidates` explicitly rejects
+(`hdp_rl_utils.py:1820` hard-fails on `ramp_steps < 1` for exactly this reason).
+Reproducing the *code* here would not reproduce the *perturbation*. The augmentation
+is also absent from `neurips_2026.tex`, so switching it off is the paper-faithful
+choice; a ramped equivalent remains available outside paper-exact mode.
+
+## What this mode does not change
+
+- **Scale.** `tab:param` IL gives 6 blocks / 256 hidden / 8 heads, which is what this
+  repository implements. The released navsim reproduction is a different model
+  (`_shared/model.yaml`: 1024 hidden, depth 12, 16 heads, 8 actions) trained on
+  navsim with a PDM scorer, and cannot be run on Tier IV data at all.
+- **Simulator.** The paper trains against a non-reactive pseudo-closed-loop
+  simulator built on real logs (`ap:implementation`); our reward runs on logged
+  Tier IV NPZ scenes with the same non-reactive assumption. The reward *definitions*
+  are pinned; the underlying scene source is necessarily ours.
+- **Checkpoint selection.** Unchanged and non-negotiable: always `latest.pth`
+  (see `docs/checkpoint_selection.md`). The RL trainer's `best_model/` bookkeeping
+  is internal accept/reject state that never rolls back the live policy, so it does
+  not affect the trained trajectory and needs no paper-exact override.

--- a/docs/hdp_rl_paper_fidelity.md
+++ b/docs/hdp_rl_paper_fidelity.md
@@ -68,8 +68,8 @@ that a future default change cannot silently break a paper-exact run.
 | `rl_reward_w_risk` | 1.0 | 1.0 | `tab:param` λ_risk |
 | `rl_reward_w_follow` | 3.0 | 3.0 | `tab:param` λ_follow |
 | `rl_reward_w_lane` | 2.5 | 2.5 | `tab:param` λ_lane |
-| `planning_hybrid_loss` (ω) | 0.01 | **0.1** | `tab:param` IL / Hybrid loss weight — see contradiction 2 |
-| `hybrid_loss_window` (W) | 10 | **L − 1 = 79** | hybrid-loss appendix, "In practice, we set W=L−1" — see contradiction 3 |
+| `planning_hybrid_loss` (ω) | 0.01 | *inherited from the frozen IL base* | `tab:param` publishes 0.1 — see contradiction 2 and "The one pair not taken from the paper" |
+| `hybrid_loss_window` (W) | 10 | *inherited from the frozen IL base* | hybrid-loss appendix publishes W = L−1 — see contradiction 3 and the section below |
 | `advantage_eps` | 1e-6 | 1e-6 | `code_rl.tex` `r.std() + 1e-6` |
 | `rl_reward_normalize` | `group` | `group` | `ap:implementation`, reward group normalization |
 | `rl_init_use_ema` | True | True | Sec. RL, `pi^0` is the hybrid-loss imitation model |
@@ -117,7 +117,9 @@ without a replay cache would silently train ten epochs on nothing.
 
 These are properties of the published material, not of this repository. Where the
 paper and the released code disagree, paper-exact mode follows the **paper**,
-because the `.tex` is the only self-consistent, citable configuration.
+because the `.tex` is the only self-consistent, citable configuration. The single
+exception is the hybrid norm (ω, W) of contradictions 2 and 3, which is inherited
+from the frozen IL base instead — see "The one pair not taken from the paper".
 
 ### 1. `code_rl.tex` Algorithm 2 does not parse
 
@@ -156,12 +158,9 @@ We implement the corrected form. `tests/test_hdp_rl_paper_exact.py` locks
   baseline the paper argues against in "RL-Hybrid Loss Matters".
 
 This repository's normal default is 0.01 (it follows the released nuplan trainer,
-which is the codebase our planner descends from). Paper-exact mode pins 0.1.
-
-**Practical consequence:** our IL base checkpoints were trained at ω = 0.01, so a
-strictly paper-exact RL run changes the waypoint-term scale 10× relative to the
-pretraining it starts from. A fully paper-exact pipeline would pretrain at ω = 0.1
-as well. This is the one pin worth reviewing before a long run.
+which is the codebase our planner descends from). Paper-exact mode does **not**
+pin 0.1: it inherits ω from the IL base it post-trains — see "The one pair not
+taken from the paper" below.
 
 ### 3. W = L−1 (paper) vs a real axis bug (nuplan) vs W = 1 (navsim)
 
@@ -186,7 +185,67 @@ as well. This is the one pin worth reviewing before a long run.
 Our `diffusion_planner/loss.py:80` `_detached_integral` uses the correct time-axis
 slice, and `tests/test_hdp_rl_paper_exact.py` both checks it against a verbatim port
 of the navsim function (values *and* gradients, for W = 1, 3, 7, 8) and guards
-against the nuplan axis bug regressing into it.
+against the nuplan axis bug regressing into it. As with ω, paper-exact mode does
+not pin W = L−1; it inherits it.
+
+## The one pair not taken from the paper: the hybrid norm (ω, W)
+
+`eq:awr_hybrid` weights the *hybrid* distance, and `code_rl.tex` Algorithm 2
+forwards `W, omega` straight into `hybrid_loss()`, so ω and W genuinely belong to
+the RL objective and not only to imitation pretraining. That is exactly why
+paper-exact mode does not pin them.
+
+**IL is never retrained in this pipeline.** RL post-trains a frozen IL base, and
+ω and W are the geometry of the norm that base was fitted in. Our base80
+checkpoint was fitted at ω = 0.01, W = 10. Running RL on it at ω = 0.1, W = L−1
+rescales the waypoint term 10× and widens the detach window from 10 steps to 79 —
+every RL gradient would then be measured in a norm the policy has never been
+optimized for. Pinning the published pair would be paper-exact in the table and
+not paper-exact in the thing the table describes.
+
+So `--rl_paper_exact` reads ω and W out of the `args.json` beside the checkpoint
+in `--init_weights_path` and copies them onto the run:
+
+- the run log and `args.json` record the inherited value **and** the published
+  value it departs from, with the citation, so the departure is never silent;
+- an explicit `--planning_hybrid_loss` / `--hybrid_loss_window` that contradicts
+  the base is **rejected**, with the same citation in the error;
+- a base directory with no `args.json` is rejected rather than guessed at.
+
+Which pair is better *for RL* is an empirical question, not a citation question,
+and `--rl_hybrid_ablation True` is how it gets asked: it releases both fields and
+stamps the run as an ω/W ablation arm in `args.json`, so a sweep reads as a sweep
+instead of as a paper-exact run that quietly disagrees with its own base. The
+published pair (ω = 0.1, W = L−1) is reachable only through that flag:
+
+```bash
+HDP_RL_HYBRID_ABLATION=True \
+HDP_RL_PLANNING_HYBRID_LOSS=0.1 HDP_RL_HYBRID_LOSS_WINDOW=79 \
+  sbatch diffusion_planner/slurm/run_hdp_rl.sbatch
+```
+
+## The corpus and the input perturbation must match the IL base
+
+RL post-training moves the same policy on the same distribution. If the corpus or
+the augmentation differs from the base run's, the RL delta is unattributable —
+any change could be the objective or could be the data. Paper-exact mode therefore
+compares the run against the base's `args.json` and refuses a mismatch:
+
+- corpus: `train_set_list`, `valid_set_list`, `extra_train_set_list` (by basename,
+  since the same artifact has a different absolute path in each checkout),
+  `extra_train_set_repeat`, `filter_skipped`, `train_subsample_step`,
+  `align_legacy_neighbor_futures`;
+- perturbation: `use_data_augment`, `augment_type`, `augment_prob`, `num_refine`,
+  `ego_past_noise_std`, `use_smoothing_future_trajectory`;
+- the normalizer, compared by **resolved content** rather than by path.
+
+`run_hdp_rl.sbatch` defaults every one of these to base train's value, so the
+launcher reproduces the base corpus without being told to. Augmentation is applied
+before the rollout in both the training path (`hdp_rl_epoch.py:512-519`) and the
+mining path (`:757-762`), so the reward, the gate and the regression all see the
+same augmented candidate — turning it on does not desynchronise the objective.
+`--rl_base_corpus_check False` waives the check for a deliberately different
+distribution.
 
 ## Two further places the released code departs from its own paper
 


### PR DESCRIPTION
## Why

The RL post-training in this repository has drifted from the paper it implements. A behaviour gate, a progress term, a road-border term, a traffic-light factor, candidate augmentation, a first-waypoint gate, prefix reward/loss horizons and a behaviour-cloning anchor were all added for the real vehicle, and Table 3's group size (32→8), temperature and EMA were retuned along the way. None of that is wrong for the vehicle — but it means no run in this repo can be cited as reproducing the paper.

`--rl_paper_exact True` gives back a run that can.

## What it does

Pins all 30 controlled fields to their published values, refuses to start if an explicit flag still contradicts the paper, prints the pin table on rank 0, and records it in `args.json`. Off by default; changes nothing when off.

```bash
HDP_RL_PAPER_EXACT=True HDP_RL_PAPER_REWARD=multi sbatch diffusion_planner/slurm/run_hdp_rl.sbatch
```

Sources, all vendored under `reference/`:

| Source | Fixes |
|---|---|
| `neurips_2026.tex` `tab:param` | group size 32, β 1.0, EMA 0.05, λ_risk 1.0, λ_follow 3.0, λ_lane 2.5 |
| `neurips_2026.tex` `app:rewards` | the four reward terms, their full-horizon evaluation, and the plain weighted sum |
| `neurips_2026.tex` `eq:awr` / `eq:awr_hybrid` | the objective: `exp(βr)` times the hybrid distance, nothing else |
| `code_rl.tex` Algorithm 2 | group normalization, `1e-6`, ω and W forwarded into `hybrid_loss()` |
| `dp_vla_rl_agent.py` / `.yaml` | rollout schedule: 5 steps, replay refresh every 10 epochs, 1 update per draw |

Additive rather than a change of defaults, because the six in-flight launchers pass every `rl_*` knob explicitly through env-overridable variables — a silent default change would be invisible in their run logs.

The launcher pins the same values but never silently overwrites an env var you set — it passes yours through and prints a note, so the trainer is the single place that raises, with the citation attached.

## The one published pair this mode does *not* pin: ω and W

`eq:awr_hybrid` weights the *hybrid* distance and Algorithm 2 forwards `(W, omega)` into `hybrid_loss()`, so `planning_hybrid_loss` (ω) and `hybrid_loss_window` (W) genuinely belong to the RL objective. That is exactly why they are not pinned.

**IL is never retrained here.** RL post-trains a frozen IL base, and ω/W are the geometry of the norm that base was fitted in. Our base80 checkpoint was fitted at ω = 0.01, W = 10; running RL on it at ω = 0.1, W = L−1 rescales the waypoint term 10× and widens the detach window from 10 steps to 79, so every RL gradient would be measured in a norm the policy has never been optimized for. Pinning the published pair would be paper-exact in the table and not paper-exact in the thing the table describes.

So `--rl_paper_exact` reads ω and W out of the `args.json` beside `--init_weights_path` and copies them onto the run:

- the log and `args.json` record the inherited value **and** the published value it departs from, with the citation — the departure is never silent;
- an explicit `--planning_hybrid_loss` / `--hybrid_loss_window` that contradicts the base is rejected, with the same citation in the error;
- a base directory with no `args.json` is rejected rather than guessed at.

Which pair is better *for RL* is an experiment, not a citation. `--rl_hybrid_ablation True` releases both fields and stamps the run as an ω/W ablation arm in `args.json`, so a sweep reads as a sweep instead of as a paper-exact run that quietly disagrees with its own base. The published pair is reachable only that way:

```bash
HDP_RL_HYBRID_ABLATION=True \
HDP_RL_PLANNING_HYBRID_LOSS=0.1 HDP_RL_HYBRID_LOSS_WINDOW=79 \
  sbatch diffusion_planner/slurm/run_hdp_rl.sbatch
```

## The corpus and the augmentation are pinned to the IL base

RL post-training moves the same policy on the same distribution. If the corpus or the perturbation differs from the base run's, the RL delta is unattributable — the change could be the objective or it could be the data. `--rl_base_corpus_check` (on by default) compares the run against the same base `args.json` and refuses a mismatch:

- corpus: `train_set_list`, `valid_set_list`, `extra_train_set_list` (by basename — the same artifact has a different absolute path in each checkout), `extra_train_set_repeat`, `filter_skipped`, `train_subsample_step`, `align_legacy_neighbor_futures`;
- perturbation: `use_data_augment`, `augment_type`, `augment_prob`, `num_refine`, `ego_past_noise_std`, `use_smoothing_future_trajectory`;
- the normalizer, compared by resolved content rather than by path.

`run_hdp_rl.sbatch` now defaults every one of these to base train's value, so the launcher reproduces the base corpus without being told to: the three right-turn manifests at ×10, augmentation on at quintic / 0.5 / 20 / 0.1 / smoothing, and the base valid list instead of a required `HDP_RL_VALID_LIST`. It also stops passing `--use_data_augment False`, and under paper-exact it omits `--planning_hybrid_loss` / `--hybrid_loss_window` entirely unless you set them — argparse cannot tell its own default apart from a deliberate override, and 0.01/10 arriving as an explicit flag would be rejected against any base not fitted at that pair.

Augmentation is safe to turn on in RL: `hdp_rl_epoch.py:512-519` (training) and `:757-762` (mining) apply it before the rollout, so the reward, the gate and the regression all see the same perturbed scene.

## Contradictions between the sources

Recorded in full in `docs/hdp_rl_paper_fidelity.md`; the tests lock the value this repo ships.

1. **Algorithm 2 has an unbalanced parenthesis** and divides only the mean: `r_n = (r - r.mean() / (r.std() + 1e-6)`. We implement the group-relative normalization of the deepseekmath citation next to it, which is what the released code does.
2. **ω is published four different ways** — 0.1 (Table 3), 0.01 (nuplan `train_predictor.py:77`), 0.05 (`dp_vla_agent_hdp.yaml:33`), and 0.0 in the RL run itself (the RL yaml never sets `hybrid_loss_weight`, so `dp_vla_rl_agent.py:664` falls back to 0.0 — the very ablation the paper argues against). We follow the frozen IL base, for the reason above.
3. **W is published three different ways** — `L−1` (paper), effectively 0 in nuplan (`traj_kinematics.py:13,17` writes `shifted[:, :, :W] = 0` on a `(B,T,D)` tensor, so it zeroes the coordinate axis instead of the time axis and the term collapses to a plain cumsum), and `detach_window_size=1` in navsim. We follow the frozen IL base for the *value*, but our `_detached_integral` implements the paper's *semantics*, and `test_detach_window_slices_time_not_the_coordinate_axis` is a regression guard against that axis bug.

Two further places the released code departs from its own paper, where we follow the paper:

- **Constant-reward groups are not discarded** — `weights = torch.exp(rewards)` leaves them at `exp(0) = 1`, though `ap:implementation` says to discard them.
- **No EMA runs at all** — `ModelEma(..., decay=0.999)` is commented out at `agent_lightning_module.py:66-68`, despite Table 3's EMA 0.05.

## Not changed

Model scale (this repo implements Table 3's real-vehicle 6 blocks / 256 hidden / 8 heads, not the 1024/12/16 navsim reproduction), the simulator, and checkpoint selection — always `latest.pth`.

## Tests

`diffusion_planner/tests/test_hdp_rl_paper_exact.py`, 48 tests, each anchored to a re-readable source. Beyond the pin tables: `test_group_weights_reproduce_algorithm_2`, `test_beta_enters_the_exponent_exactly_once`, `test_constant_reward_group_is_discarded`, `test_reward_weighted_loss_matches_algorithm_2`, and a verbatim port of the released `detached_integral` checked against ours on values *and* gradients for W ∈ {1,3,7,8}.

The ω/W inheritance, the ablation release, the missing-`args.json` refusal and the corpus/perturbation checks each have coverage, including the basename comparison for extras.

Also verified end-to-end against the **real base80 `args.json`**: ω/W inherit as 0.01/10, the corpus check passes with the launcher's defaults across the node01/node02 checkout-path difference, the published pair is rejected, the ablation arm is accepted and stamped, and corpus or augmentation drift is rejected.

Full suite: 403 passed. `ruff check` and `ruff format --check` clean. Launcher `bash -n` clean, and its ω/W argument assembly probed across all five modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
