### PR TITLE
fix: make HDP-RL survive DDP and a restart onto a mine epoch

### DIFF
--- a/diffusion_planner/diffusion_planner/hdp_rl_epoch.py
+++ b/diffusion_planner/diffusion_planner/hdp_rl_epoch.py
@@ -875,6 +875,7 @@ def _train_cycle_epoch(data_loader, model, optimizer, trainable_params, args, em
         CycleReplayWriter,
         cleanup_previous_cycle,
         cycle_index,
+        cycle_is_replayable,
         is_mine_epoch,
     )
 
@@ -891,7 +892,28 @@ def _train_cycle_epoch(data_loader, model, optimizer, trainable_params, args, em
     rollout_generator.manual_seed(int(args.seed) + int(epoch) * 1_000_003 + rank * 10_007)
     wall_start = time.perf_counter()
 
-    if is_mine_epoch(epoch, interval):
+    # A restart that lands back on a mine epoch would either re-pay for a cache it
+    # already has or die in the writer's overwrite guard. Mining takes no optimizer
+    # steps, so replaying a finalized cache costs nothing scientifically and saves
+    # the whole rollout pass. Decide collectively: a rank that mines while its peers
+    # replay never reaches the finalize barrier.
+    mine_epoch = is_mine_epoch(epoch, interval)
+    if mine_epoch:
+        replayable = cycle_is_replayable(replay_root, cycle, rank, args)
+        if bool(getattr(args, "ddp", False)):
+            vote = torch.tensor([1.0 if replayable else 0.0], device=device)
+            torch.distributed.all_reduce(vote, op=torch.distributed.ReduceOp.MIN)
+            replayable = bool(vote.item() > 0.5)
+        if replayable:
+            mine_epoch = False
+            if rank == 0:
+                print(
+                    f"cycle {cycle}: replaying the finalized cache under {replay_root} "
+                    "instead of re-mining it",
+                    flush=True,
+                )
+
+    if mine_epoch:
         cleanup_previous_cycle(replay_root, cycle, rank)
         if bool(getattr(args, "ddp", False)):
             torch.distributed.barrier()
@@ -943,14 +965,14 @@ def _train_cycle_epoch(data_loader, model, optimizer, trainable_params, args, em
     ).float()
     # Policy iteration: the behavior policy stays frozen through mining and is
     # committed only after a replay epoch actually trained a proposal.
-    if ema is not None and not is_mine_epoch(epoch, interval):
+    if ema is not None and not mine_epoch:
         proposal_relative_l2 = commit_ema_policy_update(model, ema, optimizer, args.ddp)
         epoch_mean_loss["policy_proposal_relative_l2"] = proposal_relative_l2
     if args.ddp:
         epoch_mean_loss = ddp.reduce_and_average_losses(epoch_mean_loss, device)
     epoch_mean_loss = _add_stationary_progress_conditionals(epoch_mean_loss)
     if rank == 0:
-        phase = "mine" if is_mine_epoch(epoch, interval) else "replay"
+        phase = "mine" if mine_epoch else "replay"
         print(
             f"cycle {cycle} {phase}: loss={float(epoch_mean_loss['loss']):.4f} "
             f"reward_mean={float(epoch_mean_loss['reward_mean']):.4f}"

--- a/diffusion_planner/diffusion_planner/hdp_rl_epoch.py
+++ b/diffusion_planner/diffusion_planner/hdp_rl_epoch.py
@@ -325,12 +325,17 @@ def _backward_reward_weighted_update(
     ranges = [
         (start, min(start + scene_chunk, num_scenes)) for start in range(0, num_scenes, scene_chunk)
     ]
-    objective_keys = {"loss", "rl_loss", "reward_weighted_loss", "bc_loss"}
-    mean_keys = {
+    # Tuples, not sets: these drive the insertion order of `accumulated`, which
+    # `reduce_and_average_losses` packs positionally. Set iteration order over
+    # strings follows PYTHONHASHSEED, which torchrun randomizes per rank, so a set
+    # here gives every rank a differently ordered dict and the epoch-end reduce
+    # rejects the batch.
+    objective_keys = ("loss", "rl_loss", "reward_weighted_loss", "bc_loss")
+    mean_keys = (
         "ego_reconstruction_loss",
         "ego_hdp_diffusion_loss",
         "ego_hdp_waypoint_loss",
-    }
+    )
     accumulated: dict[str, torch.Tensor] = {}
     total_candidates = float(num_scenes * n)
     diffusion_time = sample_diffusion_time(

--- a/diffusion_planner/diffusion_planner/hdp_rl_replay.py
+++ b/diffusion_planner/diffusion_planner/hdp_rl_replay.py
@@ -161,6 +161,30 @@ class CycleReplayReader:
         return {key: value.to(device, non_blocking=True) for key, value in batch.items()}
 
 
+def cycle_is_replayable(root: str | Path, cycle: int, rank: int, args) -> bool:
+    """True when this cycle was already mined to completion under the same objective.
+
+    Mining is the expensive half of the relay and it takes no optimizer steps, so a
+    run that restarts onto a mine epoch should train from the finalized cache rather
+    than pay for it twice — :class:`CycleReplayWriter` refuses to overwrite one in
+    any case. Every condition :class:`CycleReplayReader` would raise on is checked
+    here, including shards for this rank, so a cache mined by a different world size
+    is reported as not replayable instead of failing mid-epoch.
+    """
+    directory = Path(root) / f"cycle_{cycle:03d}"
+    if not (directory / _MARKER).exists():
+        return False
+    try:
+        meta = json.loads((directory / _META).read_text())
+    except (OSError, ValueError, KeyError):
+        return False
+    if meta.get("fingerprint") != reward_fingerprint(args):
+        return False
+    if int(meta.get("group_size", -1)) != int(args.num_generations):
+        return False
+    return any(directory.glob(f"rank{rank:02d}_shard*.pt"))
+
+
 def cleanup_previous_cycle(root: str | Path, cycle: int, rank: int) -> None:
     """Bound disk use to one cycle: drop the finished cycle before mining the next."""
     if rank != 0 or cycle <= 0:

--- a/diffusion_planner/diffusion_planner/utils/ddp.py
+++ b/diffusion_planner/diffusion_planner/utils/ddp.py
@@ -148,10 +148,14 @@ def reduce_and_average_losses(loss_dict, device):
     if not loss_dict and (not dist.is_available() or not dist.is_initialized()):
         return loss_dict
     world_size = dist.get_world_size()
-    keys = list(loss_dict)
-    # Packing relies on identical key order on every rank. Check that contract
-    # before the all-reduce so a rank-divergent diagnostic cannot silently pair
-    # unrelated scalars. This function runs once per epoch, not in the step hot path.
+    # Sort rather than trust insertion order: packing is positional, and a caller
+    # that builds its dict by iterating a set gets a different order on every rank
+    # because torchrun randomizes PYTHONHASHSEED per process. Sorting makes the
+    # check below mean what it says -- a real difference in *which* keys exist.
+    keys = sorted(loss_dict)
+    # Packing relies on identical keys on every rank. Check that contract before the
+    # all-reduce so a rank-divergent diagnostic cannot silently pair unrelated
+    # scalars. This function runs once per epoch, not in the step hot path.
     key_digest = int.from_bytes(
         hashlib.sha256("\0".join(keys).encode("utf-8")).digest()[:8],
         byteorder="little",
@@ -186,9 +190,11 @@ def reduce_scalar_metrics(metric_dict, device, op):
     """Reduce detached scalar diagnostics with the requested distributed operation."""
     if not metric_dict and (not dist.is_available() or not dist.is_initialized()):
         return {}
-    keys = list(metric_dict)
-    # Packing relies on identical key order on every rank. Validate the contract
-    # before reducing so a rank-divergent diagnostic cannot silently pair values.
+    keys = sorted(metric_dict)
+    # Sorted for the same reason as `reduce_and_average_losses`: packing is
+    # positional and insertion order is not a rank-stable property. Validate the
+    # remaining contract before reducing so a rank-divergent diagnostic cannot
+    # silently pair values.
     key_digest = int.from_bytes(
         hashlib.sha256("\0".join(keys).encode("utf-8")).digest()[:8],
         byteorder="little",

--- a/diffusion_planner/tests/test_ddp_metric_reduce_order.py
+++ b/diffusion_planner/tests/test_ddp_metric_reduce_order.py
@@ -1,0 +1,93 @@
+"""Cross-rank pairing for the epoch metric reducers.
+
+Both reducers pack values positionally, so they are only correct if every rank
+agrees on the key order. The rest of the suite monkeypatches them, which is how a
+caller that built its dict by iterating a set literal reached production: under
+torchrun ``PYTHONHASHSEED`` is randomized per process, so eight ranks produced
+eight insertion orders and every replay epoch died in the key-digest check. These
+tests run the real reducers on real gloo ranks with deliberately divergent order.
+"""
+
+import ast
+import inspect
+import textwrap
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from diffusion_planner.utils.ddp import reduce_and_average_losses, reduce_scalar_metrics
+
+from diffusion_planner import hdp_rl_epoch
+
+KEYS = ("loss", "rl_loss", "reward_weighted_loss", "bc_loss")
+TRUTH = {"loss": 1.0, "rl_loss": 2.0, "reward_weighted_loss": 3.0, "bc_loss": 4.0}
+WORLD_SIZE = 4
+
+
+def _rank_body(rank: int, world_size: int, init_file: str, errors) -> None:
+    dist.init_process_group(
+        backend="gloo",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=world_size,
+    )
+    try:
+        # A rank-specific rotation stands in for per-process set iteration order.
+        order = KEYS[rank % len(KEYS) :] + KEYS[: rank % len(KEYS)]
+        built = {key: torch.tensor(TRUTH[key]) for key in order}
+        if list(built) != list(order):
+            errors.append(f"rank {rank}: dict did not honour insertion order")
+            return
+
+        averaged = reduce_and_average_losses(dict(built), torch.device("cpu"))
+        summed = reduce_scalar_metrics(dict(built), torch.device("cpu"), dist.ReduceOp.SUM)
+
+        # Averaging identical per-rank values must return them unchanged, and summing
+        # must scale by the world size. Any mispairing shows up as a swapped value.
+        for key, value in averaged.items():
+            if abs(float(value) - TRUTH[key]) > 1e-9:
+                errors.append(f"rank {rank}: {key} averaged to {value}, expected {TRUTH[key]}")
+        for key, value in summed.items():
+            if abs(float(value) - TRUTH[key] * world_size) > 1e-9:
+                errors.append(f"rank {rank}: {key} summed to {value}")
+    finally:
+        dist.destroy_process_group()
+
+
+def test_reducers_pair_values_with_their_own_keys_across_ranks(tmp_path):
+    init_file = tmp_path / "gloo_rendezvous"
+    with mp.Manager() as manager:
+        errors = manager.list()
+        mp.spawn(
+            _rank_body,
+            args=(WORLD_SIZE, str(init_file), errors),
+            nprocs=WORLD_SIZE,
+            join=True,
+        )
+        assert not list(errors), list(errors)
+
+
+def test_reduced_metric_keys_are_never_ordered_by_a_set():
+    """Guard the root cause, not just the reducer that reported it.
+
+    Sorting inside the reducers makes divergent insertion order survivable, but a
+    caller that iterates a set is still building a dict whose order is a function of
+    ``PYTHONHASHSEED``. Keep the sources of these key lists ordered types so the two
+    halves of the fix cannot drift apart.
+    """
+    source = inspect.getsource(hdp_rl_epoch._backward_reward_weighted_update)
+    tree = ast.parse(textwrap.dedent(source))
+
+    assigned = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if isinstance(target, ast.Name) and target.id.endswith("_keys"):
+                assigned[target.id] = node.value
+
+    assert set(assigned) >= {"objective_keys", "mean_keys"}, sorted(assigned)
+    for name, value in assigned.items():
+        assert not isinstance(value, (ast.Set, ast.SetComp)), (
+            f"{name} is a set literal; the metric dict it fills would be ordered by "
+            "PYTHONHASHSEED, which torchrun randomizes per rank"
+        )

--- a/diffusion_planner/train_hdp_rl_predictor.py
+++ b/diffusion_planner/train_hdp_rl_predictor.py
@@ -2161,7 +2161,14 @@ def model_training(args):
             source_policy_within_guard = all(
                 value for key, value in source_guards.items() if key != "available"
             )
-            raw_selection_score = selection_score_from_reward_metrics(valid_reward_metrics, args)
+            # Held-out reward metrics only exist on a full-eval epoch. `improves_best`
+            # below already requires one, so an epoch that skipped the eval has no
+            # selection score to compute rather than a missing key to raise on.
+            raw_selection_score = (
+                selection_score_from_reward_metrics(valid_reward_metrics, args)
+                if run_full_eval
+                else float("nan")
+            )
             selection_score = (
                 raw_selection_score if math.isfinite(raw_selection_score) else float("nan")
             )


### PR DESCRIPTION
## Two bugs that make HDP-RL unrunnable, found by running it

Both were hit in production on 8×H100 while training the paper-exact RL configuration, and both are present on this base — neither is specific to `--rl_paper_exact`.

### 1. No HDP-RL replay epoch could ever finish under DDP

`_backward_reward_weighted_update` built its returned metric dict by iterating two **set literals**:

```python
objective_keys = {"loss", "rl_loss", "reward_weighted_loss", "bc_loss"}   # a set
for key in objective_keys:
    accumulated[key] = ...
```

so the dict's insertion order followed set iteration order, which follows `PYTHONHASHSEED` — and torchrun randomizes that per process. `reduce_and_average_losses` packs values **positionally** and validates a sha256 of the joined key list, so eight ranks produced eight orderings and the epoch-end reduce raised

```
RuntimeError: Distributed loss dictionaries have different keys or ordering
```

**This was never intermittent.** Eight independent interpreters agreeing on the order of four strings is vanishingly unlikely, so no HDP-RL replay epoch could ever have completed under DDP. It stayed hidden because the mine epoch does not call this path, and because the rest of the suite monkeypatches the reducers — nothing exercised the real cross-rank pairing. Finding it cost a full 39-minute replay epoch on 8 GPUs.

Fixed on both sides: the set literals become tuples (the real fix), and both `reduce_and_average_losses` and `reduce_scalar_metrics` now `sorted()` their keys, because packing is positional and insertion order is not a rank-stable property. Sorting is safe — both functions rebuild their result by key (`zip(keys, ..., strict=True)`), so no caller sees a reordering.

### 2. A restart onto a mine epoch dies, one way or the other

Two failure modes on the same code path:

- The post-epoch selection block called `selection_score_from_reward_metrics` unconditionally, but held-out reward metrics only exist on a full-eval epoch. With `rl_full_eval_utd > 1`, epoch 0 raised `KeyError: "Held-out reward metrics are missing selection key 'deterministic_mean'"` **after** the epoch's work was already done — 2h48m of mining thrown away. `improves_best` already requires `run_full_eval`, so the score simply has nothing to compute; it is now `nan` on a skipped eval, which the existing non-finite handling already absorbs.
- A relaunch that lands back on a mine epoch whose cache is already finalized dies in `CycleReplayWriter`'s `"refusing to overwrite a completed replay cycle"` guard, and there is no `latest.pth` to resume from if the first epoch never completed. New `cycle_is_replayable` checks every condition `CycleReplayReader` would raise on — marker, fingerprint, group size, and shards *for this rank*, so a cache mined at a different world size reports not-replayable instead of failing mid-epoch. The relay then replays the finalized cache instead of re-mining it.

Reusing the cache is free, not a shortcut: **the mine epoch performs zero optimizer steps** (`optimizer_steps = 0.0`, and `commit_ema_policy_update` is skipped), so a finalized cache is interchangeable with re-mining it — confirmed empirically in the run below, where the mine epoch leaves `valid_loss_ego` bit-identical to the previous epoch. The decision is made **collectively** via a MIN all-reduce: a rank that mines while its peers replay would never reach the finalize barrier.

## Verification

Beyond the unit tests, this is the branch's content running a real 8×H100 campaign (30-epoch paper-exact RL, ω=0.01 / W=79, batch 512, lr 1e-7, `rl_full_eval_utd=2`). Before these fixes it could not complete a single epoch; it has now completed a full 10-epoch cycle plus the next cycle's mine:

| epoch | `deterministic_mean` (selector) | `valid_loss_ego` | `valid_epdms_total` | accepted |
|---|---|---|---|---|
| base (SFT) | 4.295980 | 2.324168 | 0.849247 | — |
| 2 | 4.297186 | 2.321748 | 0.849963 | ✅ |
| 4 | 4.298220 | 2.320540 | 0.850198 | ✅ |
| 6 | 4.299186 | 2.324146 | 0.850202 | ✅ |
| 8 | 4.299922 | 2.318017 | 0.850380 | ✅ |
| 10 | 4.302861 | 2.309850 | 0.851871 | ✅ |

`optimizer_steps_per_epoch = 11974` on every replay epoch and `0` on the mine epoch, exactly as the relay intends.

## Test plan

- `pytest diffusion_planner/tests/test_ddp_metric_reduce_order.py` — four real gloo ranks with rotated key order, asserting each value returns paired with its own key; plus an AST guard that the caller's key lists stay ordered types. Both fail on `ac53f01e` and pass here.
- `pytest diffusion_planner/tests/test_ddp_setup.py tests/test_hdp_rl_replay.py tests/test_rl_trainer_helpers.py` — 31 passed.
- The 8×H100 production run above.

## Note on scope

`cycle_is_replayable`'s upstream commit on the paper-exact branch also moves the relay to `cycle_epoch = epoch + 1`. That is a behavioural change to *which* epochs mine, so it is deliberately **not** included here — this branch keeps the base's `epoch` semantics and carries only the restart-safety and DDP-correctness fixes, so it can merge independently of #310.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
