### PR TITLE
Allow from-scratch SFT in verify_dataset_training

### DIFF
--- a/rlvr/autoresearch/tools/verify_dataset_training.py
+++ b/rlvr/autoresearch/tools/verify_dataset_training.py
@@ -1,14 +1,16 @@
 """Smoke-test that a v1-style dataset can still train every pipeline.
 
 Point this at a dataset built by ``build_small_dataset.py`` and it runs a tiny,
-fast pass of each training pipeline — each **warmstarted from ``--base_model``** —
-reporting PASS/FAIL per pipeline, EMITTING each pipeline's trained model, and
-showing a base-vs-trained regression check:
+fast pass of each training pipeline — warmstarted from ``--base_model`` (SFT may also
+run **from scratch** when no base is given) — reporting PASS/FAIL per pipeline, EMITTING
+each pipeline's trained model, and showing a base-vs-trained regression check:
 
-* **SFT**   - ``diffusion_planner/train_predictor.py`` on the frame set, warmstarted
-  (``train_epochs = base_epoch + N``, computed from the checkpoint). PASS = finite
-  train+val loss + a saved checkpoint. Reports **base->trained L2** (ego/neighbor via
-  ``valid_predictor``) as the regression signal.
+* **SFT**   - ``diffusion_planner/train_predictor.py`` on the frame set. Warmstarted
+  from ``--base_model`` when given (``train_epochs = base_epoch + N``, computed from the
+  checkpoint), or **from scratch** when ``--base_model`` is omitted (the README cold-start
+  recipe; ``train_epochs = N``). PASS = finite train+val loss + a saved checkpoint. With a
+  base it reports **base->trained L2** (ego/neighbor via ``valid_predictor``) as the
+  regression signal; from scratch there is no base to regress against.
 * **RSFT**  - ``rlvr.autoresearch.run_experiment`` (K-sample ranked SFT), warmstarted.
   PASS = finite per-epoch loss + reward + a LoRA save. Reports **base->trained reward**
   and merges the LoRA into a full model.
@@ -35,14 +37,20 @@ the dataset layout produced by ``build_small_dataset.py``::
       contiguous/reproducer_chunks.jsonl  # R2LPL chunk manifest (failure corpus)
       normalization.json        # (or pass --normalization)
 
-The base model (``--base_model``) is required (warmstart) and must have an
-``args.json`` beside it (the standard deploy-dir layout).
+The base model (``--base_model``) must have an ``args.json`` beside it (the standard
+deploy-dir layout). It is required whenever RSFT or R2LPL runs (they warmstart from it);
+an SFT-only run may omit it to train from scratch (README cold-start).
 
 Usage:
+    # warmstart smoke of all three pipelines
     python -m rlvr.autoresearch.tools.verify_dataset_training \
         --dataset_root <v1_dir> --base_model <best_model.pth> \
         [--skip_sft] [--skip_rsft] [--skip_r2lpl] [--no-emit-models] [--no_l2] \
         [--device auto]
+
+    # from-scratch SFT (no base model): omit --base_model and skip the warmstart-only pipelines
+    python -m rlvr.autoresearch.tools.verify_dataset_training \
+        --dataset_root <v1_dir> --skip_rsft --skip_r2lpl [--device auto]
 """
 
 from __future__ import annotations
@@ -354,8 +362,17 @@ def run_sft(ds, cfg, args, env) -> tuple[bool, str]:
     ok = rc == 0 and _finite(tr_loss) and _finite(va_loss) and best.exists()
     l2_note = ""
     if ok and not args.no_l2:
-        l2_note, l2_ok = _regression_l2(args.base_model, best, work / "val.json", work, args, env)
-        ok = ok and l2_ok
+        if args.base_model:
+            l2_note, l2_ok = _regression_l2(
+                args.base_model, best, work / "val.json", work, args, env
+            )
+            ok = ok and l2_ok
+        else:
+            # From-scratch SFT: no base checkpoint exists, so a base-vs-trained L2
+            # regression is undefined. The PASS contract is finite train/val loss + a
+            # written checkpoint (reported below). Flag the gate as N/A loudly rather
+            # than silently skipping it.
+            l2_note = " [from-scratch: no base for L2 regression]"
     saved = _emit_model(best, "sft", args) if (ok and best.exists() and args.emit_models) else None
     detail = (
         f"rc={rc} train_loss={tr_loss[-1] if tr_loss else 'NONE'} "
@@ -733,10 +750,16 @@ def main() -> None:
     if not pipelines:
         print("Nothing to do: all pipelines skipped.")
         return
-    # Every pipeline warmstarts from the base model and reports base-vs-trained metrics,
-    # so it is required for all three (not just RSFT/R2LPL) — no silent from-scratch SFT.
-    if not args.base_model:
-        raise SystemExit("--base_model is required (every pipeline warmstarts from it)")
+    # RSFT and R2LPL always warmstart from the base model (and report base-vs-trained
+    # metrics against it), so a base is required whenever either is enabled. SFT can also
+    # train from scratch (no --base_model) — the README's cold-start recipe — so an
+    # SFT-only run may omit it. Fail loud if a warmstart-only pipeline has no base.
+    needs_base = any(name in ("RSFT", "R2LPL") for name, _, _ in pipelines)
+    if needs_base and not args.base_model:
+        raise SystemExit(
+            "--base_model is required for RSFT/R2LPL (they warmstart from it). "
+            "For from-scratch SFT, run with --skip_rsft --skip_r2lpl and omit --base_model."
+        )
 
     print(f"dataset_root: {root}")
     print(f"out_dir:      {args.out_dir}")


### PR DESCRIPTION
## What

`verify_dataset_training.py` hard-required `--base_model` for every run, so the SFT pipeline could only be exercised **warmstarted**. This makes `--base_model` optional when SFT is the only enabled pipeline, so the verifier can run the README's **from-scratch** training path (`train_predictor.py` with no `--resume_model_path`, `train_epochs = N`).

- RSFT and R2LPL still require a base model (they warmstart from it) and fail loud without one.
- From-scratch SFT reports the base-vs-trained L2 gate as **N/A** (no base to regress against) rather than silently skipping a requested check.
- Docstring/usage updated with a from-scratch example.

## Why

The from-scratch trainer the public README documents is the same `train_predictor.py` this verifier already invokes — only `--resume_model_path` differs. Exposing the no-base mode lets the same tool smoke-test the cold-start recipe, not just warmstart.

## Testing

On the portable v1 dataset (400 train / 100 val), `sft_ci` config:

| Mode | Result | Detail |
|---|---|---|
| From-scratch SFT (no base) | PASS | rc=0, finite train/val loss, checkpoint emitted, L2 reported N/A |
| Warmstart SFT (`--no_l2`) | PASS | train_loss 0.0666, valid_loss_ego 1.803, ckpt + model emitted |

Note: warmstart **with** the L2 gate currently fails on legacy base checkpoints whose `args.json` predates the `neighbor_collision_margin_vehicle` field (canonical default lives in `train_config.py`). That is a pre-existing code-vs-old-checkpoint mismatch, independent of this change.