### PR TITLE
feat: add `allow_hold_past_end`

### DIFF
--- a/cpp_tools/src/autoware_diffusion_planner_tools/CMakeLists.txt
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/CMakeLists.txt
@@ -174,6 +174,23 @@ if(BUILD_TESTING)
     target_include_directories(test_bag_metadata PRIVATE include src)
   endif()
 
+  # processing/stopped_tail + the ego-future hold it gates in processing/ego_sequence
+  ament_add_gtest(test_stopped_tail
+    test/test_stopped_tail.cpp
+    src/processing/ego_sequence.cpp
+  )
+  if(TARGET test_stopped_tail)
+    target_include_directories(test_stopped_tail PRIVATE include src)
+    ament_target_dependencies(test_stopped_tail SYSTEM
+      nav_msgs
+      autoware_perception_msgs
+      autoware_planning_msgs
+      autoware_vehicle_msgs
+      geometry_msgs
+      autoware_diffusion_planner
+    )
+  endif()
+
   # processing/neighbor_processor — future array filling; needs autoware_diffusion_planner
   ament_add_gtest(test_neighbor_processor
     test/test_neighbor_processor.cpp

--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/processing/ego_sequence.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/processing/ego_sequence.hpp
@@ -24,9 +24,17 @@
 #include <optional>
 #include <vector>
 
+// Build a [num_timesteps, 4] (x, y, cos, sin) ego trajectory in the frame given by
+// map2bl_matrix, whose last timestep lands on reference_time.
+//
+// allow_hold_past_end decides what happens when the requested window reaches past the last frame
+// of data_list: false gives up (nullopt), true holds the final pose for the remaining timesteps.
+// Holding is only faithful for a sequence that ends standing still, so callers gate it on
+// stopped_tail::ends_stopped; pass false for a window that cannot overrun (the past window) to
+// keep that intent visible at the call site.
 std::optional<std::vector<float>> create_ego_sequence(
   const std::vector<FrameData> & data_list, const int64_t start_idx, const size_t num_timesteps,
   const Eigen::Matrix4d & map2bl_matrix, const rclcpp::Time & reference_time,
-  const bool use_interpolation);
+  const bool use_interpolation, const bool allow_hold_past_end);
 
 #endif  // PROCESSING__EGO_SEQUENCE_HPP_

--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/processing/stopped_tail.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/processing/stopped_tail.hpp
@@ -1,0 +1,49 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PROCESSING__STOPPED_TAIL_HPP_
+#define PROCESSING__STOPPED_TAIL_HPP_
+
+// Does this sequence end standing still?
+//
+// Two things follow from that single judgement in process_sequence: the final pose is taken as
+// the goal, and the GT ego future is allowed to hold that pose past the end of the recording. The
+// second is what lets conversion run through the final stop: the future spans OUTPUT_T ticks, so
+// the frame loop otherwise has to give up OUTPUT_T ticks early, dropping exactly the deceleration
+// into the stop. A stopped ego really does stay at that pose, so the held future stays faithful;
+// a sequence that ends while still moving has an unknown continuation and keeps the hard cut.
+
+#include "types/frame_data.hpp"
+
+#include <cmath>
+#include <vector>
+
+namespace stopped_tail
+{
+
+// Speed below which a sequence counts as ending standing still. The absolute speed is used so a
+// reversing ego does not count as stopped.
+inline constexpr double kEndStoppedSpeedMps = 0.5;
+
+inline bool ends_stopped(const std::vector<FrameData> & data_list)
+{
+  if (data_list.empty()) {
+    return false;
+  }
+  return std::abs(data_list.back().kinematic_state.twist.twist.linear.x) < kEndStoppedSpeedMps;
+}
+
+}  // namespace stopped_tail
+
+#endif  // PROCESSING__STOPPED_TAIL_HPP_

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/ego_sequence.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/ego_sequence.cpp
@@ -22,35 +22,44 @@
 std::optional<std::vector<float>> create_ego_sequence(
   const std::vector<FrameData> & data_list, const int64_t start_idx, const size_t num_timesteps,
   const Eigen::Matrix4d & map2bl_matrix, const rclcpp::Time & reference_time,
-  const bool use_interpolation)
+  const bool use_interpolation, const bool allow_hold_past_end)
 {
+  const int64_t last_idx = static_cast<int64_t>(data_list.size()) - 1;
+  if (last_idx < 0 || start_idx < 0) {
+    return std::nullopt;
+  }
+
   std::deque<nav_msgs::msg::Odometry> odom_deque;
 
   if (use_interpolation) {
-    // Collect odom messages from start_idx until timestamp >= reference_time
-    for (size_t j = static_cast<size_t>(std::max(int64_t(0), start_idx)); j < data_list.size();
-         ++j) {
+    // Collect odom messages from start_idx until timestamp >= reference_time. A window that
+    // starts one past the last frame still gets the final pose, which is all a fully held
+    // window needs.
+    for (int64_t j = std::min(start_idx, last_idx); j <= last_idx; ++j) {
       odom_deque.push_back(data_list[j].kinematic_state);
       if (rclcpp::Time(data_list[j].kinematic_state.header.stamp) >= reference_time) {
         break;
       }
     }
 
-    // Error: data doesn't cover the reference_time
-    if (odom_deque.empty() || rclcpp::Time(odom_deque.back().header.stamp) < reference_time) {
+    // Data doesn't cover reference_time. create_ego_agent_past holds the final pose for every
+    // target time past its last message, which only the callers that verified the sequence ends
+    // standing still may accept.
+    if (rclcpp::Time(odom_deque.back().header.stamp) < reference_time && !allow_hold_past_end) {
       return std::nullopt;
     }
 
     return autoware::diffusion_planner::preprocess::create_ego_agent_past(
       odom_deque, num_timesteps, map2bl_matrix, reference_time);
   } else {
-    // Without interpolation: collect exactly num_timesteps frames by index
+    // Without interpolation: collect exactly num_timesteps frames by index, holding the last
+    // frame once the window overruns it — the same hold as above, gated the same way.
+    if (start_idx + static_cast<int64_t>(num_timesteps) - 1 > last_idx && !allow_hold_past_end) {
+      return std::nullopt;
+    }
+
     for (size_t j = 0; j < num_timesteps; ++j) {
-      const int64_t index =
-        std::min(start_idx + static_cast<int64_t>(j), static_cast<int64_t>(data_list.size()) - 1);
-      if (index < 0) {
-        return std::nullopt;
-      }
+      const int64_t index = std::min(start_idx + static_cast<int64_t>(j), last_idx);
       odom_deque.push_back(data_list[index].kinematic_state);
     }
 

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_processor.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/processing/frame_processor.cpp
@@ -20,6 +20,7 @@
 #include "processing/ego_sequence.hpp"
 #include "processing/frame_skip_decision.hpp"
 #include "processing/neighbor_processor.hpp"
+#include "processing/stopped_tail.hpp"
 #include "types/skipping_info.hpp"
 #include "utils/timestamp_utils.hpp"
 
@@ -111,15 +112,16 @@ void process_sequence(
     return;
   }
 
-  bool goal_pose_overwritten = false;
-  {
-    const auto & last_state = seq.data_list.back().kinematic_state;
-    const double last_speed = std::abs(last_state.twist.twist.linear.x);
-    if (last_speed < 0.5) {
-      seq.route.goal_pose = last_state.pose.pose;
-      goal_pose_overwritten = true;
-    }
+  // A sequence that ends standing still ended where the ego meant to stop, so the final pose is
+  // taken as the goal — and, below, may be held for the part of the GT future that reaches past
+  // the last frame, so that the stop itself is converted instead of the loop giving up OUTPUT_T
+  // ticks early.
+  const bool ends_stopped = stopped_tail::ends_stopped(seq.data_list);
+  if (ends_stopped) {
+    seq.route.goal_pose = seq.data_list.back().kinematic_state.pose.pose;
   }
+  const bool goal_pose_overwritten = ends_stopped;
+  std::cout << "Ends stopped: " << (ends_stopped ? "yes" : "no") << std::endl;
 
   save_route_json(
     route_save_dir, rosbag_dir_name, sequence_id_str, n, traveled_distance, start_ts, end_ts,
@@ -148,7 +150,7 @@ void process_sequence(
     const rclcpp::Time past_reference_time(seq.data_list[i].kinematic_state.header.stamp);
     const auto ego_past_opt = create_ego_sequence(
       seq.data_list, i - INPUT_T_WITH_CURRENT + 1, INPUT_T_WITH_CURRENT, map2bl,
-      past_reference_time, options.use_interpolation);
+      past_reference_time, options.use_interpolation, false);
     if (!ego_past_opt) {
       std::cout << "Failed to create ego past at frame " << i << std::endl;
       break;
@@ -159,8 +161,11 @@ void process_sequence(
       past_reference_time +
       rclcpp::Duration::from_seconds(OUTPUT_T * constants::PREDICTION_TIME_STEP_S);
     const auto ego_future_opt = create_ego_sequence(
-      seq.data_list, i + 1, OUTPUT_T, map2bl, future_reference_time, options.use_interpolation);
+      seq.data_list, i + 1, OUTPUT_T, map2bl, future_reference_time, options.use_interpolation,
+      ends_stopped);
     if (!ego_future_opt) {
+      // Only reachable when the sequence does not end standing still; otherwise the final pose
+      // is held and the loop runs to the last frame.
       std::cout << "Reached end of sequence at frame " << i << "/" << n << std::endl;
       break;
     }

--- a/cpp_tools/src/autoware_diffusion_planner_tools/test/test_stopped_tail.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/test/test_stopped_tail.cpp
@@ -1,0 +1,156 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "processing/ego_sequence.hpp"
+#include "processing/stopped_tail.hpp"
+
+#include <Eigen/Core>
+#include <autoware/diffusion_planner/constants.hpp>
+#include <autoware/diffusion_planner/dimensions.hpp>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace
+{
+
+constexpr int64_t kPeriodNs = 100'000'000LL;  // 10 Hz, the rate build_sequences assembles at
+
+// Build a sequence of 10 Hz frames with the given per-frame ego longitudinal speeds. Poses
+// advance along +x by speed * period so the frames are self-consistent.
+std::vector<FrameData> make_frames(const std::vector<double> & speeds_mps)
+{
+  constexpr double period_s = static_cast<double>(kPeriodNs) * 1e-9;
+  std::vector<FrameData> data_list;
+  double x = 0.0;
+  for (size_t i = 0; i < speeds_mps.size(); ++i) {
+    FrameData frame;
+    frame.timestamp = static_cast<int64_t>(i) * kPeriodNs;
+    frame.kinematic_state.header.stamp.sec = static_cast<int32_t>(i / 10);
+    frame.kinematic_state.header.stamp.nanosec = static_cast<uint32_t>((i % 10) * kPeriodNs);
+    frame.kinematic_state.pose.pose.orientation.w = 1.0;
+    frame.kinematic_state.pose.pose.position.x = x;
+    frame.kinematic_state.twist.twist.linear.x = speeds_mps[i];
+    frame.max_msg_age_ns = 0;
+    data_list.push_back(frame);
+    x += speeds_mps[i] * period_s;
+  }
+  return data_list;
+}
+
+}  // namespace
+
+TEST(EndsStoppedTest, EmptySequenceDoesNotEndStopped)
+{
+  EXPECT_FALSE(stopped_tail::ends_stopped({}));
+}
+
+TEST(EndsStoppedTest, SequenceEndingWhileMovingDoesNotEndStopped)
+{
+  EXPECT_FALSE(stopped_tail::ends_stopped(make_frames({0.0, 0.0, 3.0})));
+}
+
+TEST(EndsStoppedTest, SequenceEndingAtRestEndsStopped)
+{
+  EXPECT_TRUE(stopped_tail::ends_stopped(make_frames({5.0, 2.0, 0.0})));
+}
+
+TEST(EndsStoppedTest, ThresholdIsExclusive)
+{
+  EXPECT_FALSE(stopped_tail::ends_stopped(make_frames({stopped_tail::kEndStoppedSpeedMps})));
+  EXPECT_TRUE(stopped_tail::ends_stopped(make_frames({stopped_tail::kEndStoppedSpeedMps - 1e-3})));
+}
+
+TEST(EndsStoppedTest, ReversingEgoDoesNotEndStopped)
+{
+  // Negative speed is motion, not a stop (the absolute speed is compared).
+  EXPECT_FALSE(stopped_tail::ends_stopped(make_frames({0.0, -2.0})));
+}
+
+// ---------------------------------------------------------------------------
+// create_ego_sequence hold behaviour, which ends_stopped gates
+// ---------------------------------------------------------------------------
+
+namespace
+{
+
+using autoware::diffusion_planner::OUTPUT_T;
+using autoware::diffusion_planner::POSE_DIM;
+
+// The GT future of frame `index`, as process_sequence requests it.
+std::optional<std::vector<float>> future_at(
+  const std::vector<FrameData> & data_list, const int64_t index, const bool use_interpolation,
+  const bool allow_hold_past_end)
+{
+  const rclcpp::Time current_time(
+    data_list[static_cast<size_t>(index)].kinematic_state.header.stamp);
+  const rclcpp::Time reference_time =
+    current_time + rclcpp::Duration::from_seconds(
+                     OUTPUT_T * autoware::diffusion_planner::constants::PREDICTION_TIME_STEP_S);
+  return create_ego_sequence(
+    data_list, index + 1, OUTPUT_T, Eigen::Matrix4d::Identity(), reference_time, use_interpolation,
+    allow_hold_past_end);
+}
+
+}  // namespace
+
+TEST(EgoFutureHoldTest, GivesUpPastTheEndWhenHoldIsNotAllowed)
+{
+  // 10 stopped frames is far less than the OUTPUT_T the future needs.
+  const std::vector<FrameData> data_list = make_frames(std::vector<double>(10, 0.0));
+  EXPECT_FALSE(future_at(data_list, 0, true, false).has_value());
+  EXPECT_FALSE(future_at(data_list, 0, false, false).has_value());
+}
+
+TEST(EgoFutureHoldTest, HoldsTheFinalPoseWhenAllowed)
+{
+  const std::vector<FrameData> data_list = make_frames(std::vector<double>(10, 0.0));
+  const double last_x = data_list.back().kinematic_state.pose.pose.position.x;
+
+  for (const bool use_interpolation : {true, false}) {
+    const auto future = future_at(data_list, 0, use_interpolation, true);
+    ASSERT_TRUE(future.has_value()) << "use_interpolation=" << use_interpolation;
+    ASSERT_EQ(future->size(), static_cast<size_t>(OUTPUT_T * POSE_DIM));
+    // Every timestep past the recording sits on the final pose (frame 0 is the origin here).
+    for (int64_t t = 0; t < OUTPUT_T; ++t) {
+      EXPECT_NEAR((*future)[t * POSE_DIM + 0], last_x, 1e-3)
+        << "t=" << t << " use_interpolation=" << use_interpolation;
+      EXPECT_NEAR((*future)[t * POSE_DIM + 1], 0.0, 1e-3);
+    }
+  }
+}
+
+TEST(EgoFutureHoldTest, LastFrameOfTheSequenceStillGetsAFuture)
+{
+  // start_idx is one past the last frame here: the whole future is held.
+  const std::vector<FrameData> data_list = make_frames(std::vector<double>(10, 0.0));
+  const int64_t last = static_cast<int64_t>(data_list.size()) - 1;
+  EXPECT_TRUE(future_at(data_list, last, true, true).has_value());
+  EXPECT_TRUE(future_at(data_list, last, false, true).has_value());
+}
+
+TEST(EgoFutureHoldTest, HoldIsNotUsedWhileTheRecordingStillCoversTheHorizon)
+{
+  // Moving ego with more than OUTPUT_T frames left: the future comes entirely from the data, so
+  // allowing the hold changes nothing.
+  const std::vector<FrameData> data_list = make_frames(std::vector<double>(OUTPUT_T + 5, 2.0));
+  const auto without_hold = future_at(data_list, 0, true, false);
+  const auto with_hold = future_at(data_list, 0, true, true);
+  ASSERT_TRUE(without_hold.has_value());
+  ASSERT_TRUE(with_hold.has_value());
+  EXPECT_EQ(*without_hold, *with_hold);
+  // The last future timestep advanced by 2 m/s * 8 s from the current pose.
+  EXPECT_NEAR((*with_hold)[(OUTPUT_T - 1) * POSE_DIM + 0], 16.0, 1e-2);
+}


### PR DESCRIPTION
Currently, the data converter deletes the data upon shutdown, so I will modify it to preserve that data.

## Before

The ego vehicle is still moving at the last frame.

https://github.com/user-attachments/assets/f82e1c1f-cb19-4964-bd47-6f59ca55c8ec

## After

The sequence ends with a stop.

https://github.com/user-attachments/assets/457509d6-fc5b-4905-9d7f-c690b070bfae

## Note

This implementation depends on the autoware_universe implementation

<https://github.com/autowarefoundation/autoware_universe/blob/c7a6d0a1aac3a00c1c26277f66277bcfb25d8bf6/planning/autoware_diffusion_planner/src/preprocessing/preprocessing_utils.cpp#L181-L182>


