### PR TITLE
fix(data_augmentation): fix goal pose mask

### DIFF
--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -429,7 +429,10 @@ class StatePerturbation:
         inputs["ego_agent_future"] = ego_future
 
         # goal pose (x, y, cos, sin)
-        mask = torch.sum(torch.ne(inputs["goal_pose"], 0), dim=-1) == 0
+        # Validity is decided from the position only: heading_to_cos_sin turns an
+        # all-zero (x, y, heading) goal into (0, 0, 1, 0), so a full-width zero test
+        # never fires and an absent goal would survive as a goal at the ego itself.
+        mask = torch.sum(torch.ne(inputs["goal_pose"][..., :2], 0), dim=-1) == 0
         inputs["goal_pose"][..., :2] = vector_transform(
             inputs["goal_pose"][..., :2], transform_matrix, center_xy
         )

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_bridge.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_bridge.py
@@ -1415,7 +1415,10 @@ class StatePerturbation:
         inputs["ego_agent_future"] = ego_future
 
         # goal pose (x, y, cos, sin)
-        mask = torch.sum(torch.ne(inputs["goal_pose"], 0), dim=-1) == 0
+        # Validity is decided from the position only: heading_to_cos_sin turns an
+        # all-zero (x, y, heading) goal into (0, 0, 1, 0), so a full-width zero test
+        # never fires and an absent goal would survive as a goal at the ego itself.
+        mask = torch.sum(torch.ne(inputs["goal_pose"][..., :2], 0), dim=-1) == 0
         inputs["goal_pose"][..., :2] = vector_transform(
             inputs["goal_pose"][..., :2], transform_matrix, center_xy
         )


### PR DESCRIPTION
## What

`centric_transform` decided `goal_pose` validity with a full-width zero test:

```python
mask = torch.sum(torch.ne(inputs["goal_pose"], 0), dim=-1) == 0
```

`train_epoch` runs `heading_to_cos_sin` on `goal_pose` before augmentation, so an
all-zero `(x, y, heading)` goal arrives as `(0, 0, 1, 0)`. The `cos` channel is
non-zero, so the test never fires and an absent goal survives the transform as a
goal **at the ego's own pose** — a strong "stop here" signal.

This narrows the test to the position channels, which covers both on-disk layouts
(`_EGO_POSE_WIDTHS = (3, 4)`, `rlvr/autoresearch/scene_features.py`):

```python
mask = torch.sum(torch.ne(inputs["goal_pose"][..., :2], 0), dim=-1) == 0
```

Applied to both the quintic and the bridge augmentation path.

## Why the position alone is sufficient

The sibling masks in `centric_transform` exist to keep zero **padding** invariant
across an affine transform: `vector_transform(x, R, bias=c)` computes `R @ (x - c)`,
so a padded `(0, 0)` slot moves to `R @ (-c) != 0` for any perturbed row, and every
encoder plus `ObservationNormalizer` treat "all-zero" as "invalid".

`goal_pose` has no padding concept — it is a single always-present entry
(`goal_pose_num = 1`) — so for this field the test can only ever mean "no goal",
and the position channels are what carry that sentinel.

## Verification

Both perturbed and unperturbed rows, over both on-disk layouts:

| raw `goal_pose` | perturbation | after transform |
| --- | --- | --- |
| valid 3-col `(60, 2, 0)` | no | `[+60.0000, +2.0000, +1.0000, +0.0000]` |
| valid 3-col `(60, 2, 0)` | yes | `[+59.0523, -10.6951, +0.9801, -0.1987]` |
| invalid 3-col `(0, 0, 0)` | no | `[0, 0, 0, 0]` — **now zeroed (was `(0,0,1,0)`)** |
| invalid 3-col `(0, 0, 0)` | yes | `[0, 0, 0, 0]` — **now zeroed** |
| invalid 4-col `(0, 0, 0, 0)` | no / yes | `[0, 0, 0, 0]` (unchanged) |

Valid goals and the 4-column layout behave exactly as before.

## Notes / follow-ups

- `GoalPoseEncoder` hard-codes `mask = torch.zeros((B, 1), dtype=torch.bool)`, i.e. the
  goal token is always attended. Zeroing therefore produces an all-zero *embedding*
  rather than removing the token. Fully representing "no goal" additionally needs the
  encoder-side mask.
- A zeroed `goal_pose` has never reached training before this change, so that input
  pattern is unlearned by existing checkpoints.
- The mask fires only on an exact `(0, 0)` position. If the converter writes exact
  zeros for an "arrived at the goal" frame, such frames are now treated as no-goal.
  Worth checking the zero rate and column width of `goal_pose` in the corpus.
- `tests/test_data_augmentation.py` is currently 32 failed / 26 passed. Verified
  identical on `tier4-main` without this change (the tests call `StatePerturbation()`
  with no arguments while the constructor requires 5) — pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
