### PR TITLE
fix: rename ade, fde to lateral error

### DIFF
--- a/diffusion_planner/tests/test_scenario_centerline_metric.py
+++ b/diffusion_planner/tests/test_scenario_centerline_metric.py
@@ -21,7 +21,22 @@ def test_centerline_metric_projects_to_segments():
         {"route_lanes": route_lanes},
     )
 
-    torch.testing.assert_allclose(distances, torch.tensor([[1.0, 2.0]]))
+    torch.testing.assert_close(distances, torch.tensor([[1.0, 2.0]]))
+
+
+def test_centerline_metric_ignores_duplicate_point_segments():
+    """A duplicate centerline point must not report a spurious zero error."""
+    prediction = torch.tensor([[[10.0, 0.0]]])
+    route_lanes = torch.zeros((1, 3, 8))
+    route_lanes[0, :, 0] = torch.tensor([0.0, 0.0, 3.0])
+    route_lanes[0, :, 2] = 1.0
+
+    distances = compute_centerline_distance_batch(prediction, {"route_lanes": route_lanes})
+    components = compute_centerline_error_components_batch(prediction, {"route_lanes": route_lanes})
+
+    torch.testing.assert_close(distances, torch.tensor([[7.0]]))
+    torch.testing.assert_close(components["lateral_error_m"], torch.tensor([[0.0]]))
+    torch.testing.assert_close(components["longitudinal_error_m"], torch.tensor([[7.0]]))
 
 
 def test_centerline_metric_returns_lateral_errors_at_requested_horizon():
@@ -38,8 +53,8 @@ def test_centerline_metric_returns_lateral_errors_at_requested_horizon():
         {"horizon_seconds": 0.2},
     )
 
-    torch.testing.assert_allclose(values["average_lateral_error_m"], torch.tensor([1.5]))
-    torch.testing.assert_allclose(values["final_lateral_error_m"], torch.tensor([2.0]))
+    torch.testing.assert_close(values["average_lateral_error_m"], torch.tensor([1.5]))
+    torch.testing.assert_close(values["final_lateral_error_m"], torch.tensor([2.0]))
 
 
 def test_centerline_error_components_separate_endpoint_overshoot():
@@ -54,5 +69,5 @@ def test_centerline_error_components_separate_endpoint_overshoot():
         {"route_lanes": route_lanes},
     )
 
-    torch.testing.assert_allclose(values["lateral_error_m"], torch.tensor([[0.0, 1.0]]))
-    torch.testing.assert_allclose(values["longitudinal_error_m"], torch.tensor([[1.0, 2.0]]))
+    torch.testing.assert_close(values["lateral_error_m"], torch.tensor([[0.0, 1.0]]))
+    torch.testing.assert_close(values["longitudinal_error_m"], torch.tensor([[1.0, 2.0]]))

--- a/diffusion_planner/tests/test_scenario_centerline_metric.py
+++ b/diffusion_planner/tests/test_scenario_centerline_metric.py
@@ -1,8 +1,12 @@
-"""Tests for route-centerline distance, ADE, and FDE metrics."""
+"""Tests for route-centerline distance and lateral error metrics."""
 
 import torch
 
-from planner_metrics.centerline import compute_centerline_distance_batch, evaluate_centerline
+from planner_metrics.centerline import (
+    compute_centerline_distance_batch,
+    compute_centerline_error_components_batch,
+    evaluate_centerline,
+)
 
 
 def test_centerline_metric_projects_to_segments():
@@ -20,8 +24,8 @@ def test_centerline_metric_projects_to_segments():
     torch.testing.assert_allclose(distances, torch.tensor([[1.0, 2.0]]))
 
 
-def test_centerline_metric_returns_ade_and_fde_at_requested_horizon():
-    """Compute ADE/FDE using only the configured prediction horizon."""
+def test_centerline_metric_returns_lateral_errors_at_requested_horizon():
+    """Compute average/final lateral errors using the configured horizon."""
     prediction = torch.tensor([[[0.0, 1.0, 1.0, 0.0], [1.0, 2.0, 1.0, 0.0], [2.0, 3.0, 1.0, 0.0]]])
     # [batch, singleton context, lane, point, feature]
     route_lanes = torch.zeros((1, 1, 1, 4, 8))
@@ -34,5 +38,21 @@ def test_centerline_metric_returns_ade_and_fde_at_requested_horizon():
         {"horizon_seconds": 0.2},
     )
 
-    torch.testing.assert_allclose(values["ade_m"], torch.tensor([1.5]))
-    torch.testing.assert_allclose(values["fde_m"], torch.tensor([2.0]))
+    torch.testing.assert_allclose(values["average_lateral_error_m"], torch.tensor([1.5]))
+    torch.testing.assert_allclose(values["final_lateral_error_m"], torch.tensor([2.0]))
+
+
+def test_centerline_error_components_separate_endpoint_overshoot():
+    """Endpoint overshoot is longitudinal, not lateral, error."""
+    prediction = torch.tensor([[[4.0, 0.0], [5.0, 1.0]]])
+    route_lanes = torch.zeros((1, 2, 8))
+    route_lanes[0, :, 0] = torch.tensor([0.0, 3.0])
+    route_lanes[0, :, 2] = 1.0
+
+    values = compute_centerline_error_components_batch(
+        prediction,
+        {"route_lanes": route_lanes},
+    )
+
+    torch.testing.assert_allclose(values["lateral_error_m"], torch.tensor([[0.0, 1.0]]))
+    torch.testing.assert_allclose(values["longitudinal_error_m"], torch.tensor([[1.0, 2.0]]))

--- a/planner_metrics/centerline.py
+++ b/planner_metrics/centerline.py
@@ -11,6 +11,7 @@ from planner_metrics.geometry import (
 )
 
 _PREDICTION_TIMESTEP_SECONDS = 0.1
+_CENTERLINE_SEGMENT_MIN_LENGTH = 1e-6
 
 
 def _centerline_segments(lanes: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
@@ -19,6 +20,8 @@ def _centerline_segments(lanes: torch.Tensor) -> tuple[torch.Tensor, torch.Tenso
     centerlines = lanes[..., :2]
     valid_points = lanes[..., :4].abs().sum(dim=-1) > 1e-6
     valid_segments = valid_points[:, :-1] & valid_points[:, 1:]
+    segment_lengths = (centerlines[:, 1:] - centerlines[:, :-1]).norm(dim=-1)
+    valid_segments &= segment_lengths > _CENTERLINE_SEGMENT_MIN_LENGTH
     if not valid_segments.any():
         raise ValueError("centerline metric found no valid route-centerline segments")
     return (

--- a/planner_metrics/centerline.py
+++ b/planner_metrics/centerline.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import torch
 
 from planner_metrics.evaluation import MetricEvaluation
-from planner_metrics.geometry import _point_to_segments_min_dist
+from planner_metrics.geometry import (
+    _point_to_segments_error_components,
+    _point_to_segments_min_dist,
+)
 
 _PREDICTION_TIMESTEP_SECONDS = 0.1
 
@@ -70,23 +73,80 @@ def compute_centerline_distance_batch(
 
 
 @torch.no_grad()
-def compute_centerline_ade_batch(
+def compute_centerline_error_components_batch(
     ego_trajs: torch.Tensor,
     data: dict[str, torch.Tensor],
     horizon_steps: int | None = None,
-) -> torch.Tensor:
-    """Return centerline ADE for each trajectory, shape ``(N,)``."""
-    return compute_centerline_distance_batch(ego_trajs, data, horizon_steps).mean(dim=1)
+) -> dict[str, torch.Tensor]:
+    """Return lateral and beyond-segment longitudinal errors per timestep.
+
+    Lateral error is measured against the selected centerline segment's
+    supporting line.  Thus longitudinal overshoot beyond a segment endpoint is
+    reported separately instead of being folded into lateral error.
+    """
+    if ego_trajs.ndim != 3 or ego_trajs.shape[-1] < 2:
+        raise ValueError(f"ego_trajs must have shape (N, T, D>=2), got {tuple(ego_trajs.shape)}")
+    if horizon_steps is None:
+        horizon_steps = ego_trajs.shape[1]
+    if not 1 <= horizon_steps <= ego_trajs.shape[1]:
+        raise ValueError(f"horizon_steps must be in [1, {ego_trajs.shape[1]}]")
+
+    lanes = data.get("route_lanes", data.get("lanes"))
+    if lanes is None:
+        raise ValueError("centerline metric requires route_lanes or lanes in data")
+    if lanes.ndim == 5:
+        if lanes.shape[1] != 1:
+            raise ValueError(
+                f"expected singleton route_lanes context axis, got {tuple(lanes.shape)}"
+            )
+        lanes = lanes[:, 0]
+    if lanes.ndim == 3:
+        lanes = lanes.unsqueeze(0)
+    if lanes.ndim != 4 or lanes.shape[0] not in (1, ego_trajs.shape[0]):
+        raise ValueError(
+            "lanes must have shape (S,P,D), (1,S,P,D), or (N,S,P,D); "
+            f"got {tuple(lanes.shape)} for N={ego_trajs.shape[0]}"
+        )
+
+    lateral_errors = []
+    longitudinal_errors = []
+    for index in range(ego_trajs.shape[0]):
+        scene_lanes = lanes[0 if lanes.shape[0] == 1 else index]
+        seg_p1, seg_p2 = _centerline_segments(scene_lanes)
+        points = ego_trajs[index, :horizon_steps, :2]
+        lateral, longitudinal = _point_to_segments_error_components(
+            points, seg_p1.to(points), seg_p2.to(points)
+        )
+        lateral_errors.append(lateral)
+        longitudinal_errors.append(longitudinal)
+    return {
+        "lateral_error_m": torch.stack(lateral_errors, dim=0),
+        "longitudinal_error_m": torch.stack(longitudinal_errors, dim=0),
+    }
 
 
 @torch.no_grad()
-def compute_centerline_fde_batch(
+def compute_centerline_average_lateral_error_batch(
     ego_trajs: torch.Tensor,
     data: dict[str, torch.Tensor],
     horizon_steps: int | None = None,
 ) -> torch.Tensor:
-    """Return centerline FDE for each trajectory, shape ``(N,)``."""
-    return compute_centerline_distance_batch(ego_trajs, data, horizon_steps)[:, -1]
+    """Return average lateral error for each trajectory, shape ``(N,)``."""
+    return compute_centerline_error_components_batch(ego_trajs, data, horizon_steps)[
+        "lateral_error_m"
+    ].mean(dim=1)
+
+
+@torch.no_grad()
+def compute_centerline_final_lateral_error_batch(
+    ego_trajs: torch.Tensor,
+    data: dict[str, torch.Tensor],
+    horizon_steps: int | None = None,
+) -> torch.Tensor:
+    """Return final lateral error for each trajectory, shape ``(N,)``."""
+    return compute_centerline_error_components_batch(ego_trajs, data, horizon_steps)[
+        "lateral_error_m"
+    ][:, -1]
 
 
 def evaluate_centerline(
@@ -94,16 +154,18 @@ def evaluate_centerline(
     data: dict[str, torch.Tensor],
     parameters: dict,
 ) -> dict[str, torch.Tensor]:
-    """Return per-trajectory centerline ADE/FDE using a configurable horizon."""
+    """Return average/final lateral error using a configurable horizon."""
     horizon_seconds = float(parameters.get("horizon_seconds", 8.0))
     if horizon_seconds <= 0:
         raise ValueError("centerline horizon_seconds must be positive")
     steps = min(int(round(horizon_seconds / _PREDICTION_TIMESTEP_SECONDS)), ego_trajs.shape[1])
     if steps < 1:
         raise ValueError("centerline horizon selects zero prediction steps")
+    components = compute_centerline_error_components_batch(ego_trajs, data, steps)
+    lateral_error = components["lateral_error_m"]
     return {
-        "ade_m": compute_centerline_ade_batch(ego_trajs, data, steps),
-        "fde_m": compute_centerline_fde_batch(ego_trajs, data, steps),
+        "average_lateral_error_m": lateral_error.mean(dim=1),
+        "final_lateral_error_m": lateral_error[:, -1],
     }
 
 
@@ -115,15 +177,16 @@ def evaluate_centerline_with_details(
     """Evaluate centerline metrics using the common open-loop result format.
 
     Centerline currently has no additional per-sample detail fields, so the
-    result contains only the ADE/FDE score tensors.
+    result contains only the average/final lateral error score tensors.
     """
     return MetricEvaluation(scores=evaluate_centerline(ego_trajs, data, parameters))
 
 
 __all__ = [
-    "compute_centerline_ade_batch",
+    "compute_centerline_average_lateral_error_batch",
     "compute_centerline_distance_batch",
-    "compute_centerline_fde_batch",
+    "compute_centerline_error_components_batch",
+    "compute_centerline_final_lateral_error_batch",
     "evaluate_centerline",
     "evaluate_centerline_with_details",
 ]

--- a/planner_metrics/geometry.py
+++ b/planner_metrics/geometry.py
@@ -723,6 +723,59 @@ def _point_to_segments_min_dist(
     return torch.cat(results)
 
 
+def _point_to_segments_error_components(
+    points: torch.Tensor,
+    seg_p1: torch.Tensor,
+    seg_p2: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return lateral and beyond-segment longitudinal errors per point.
+
+    The nearest segment is selected using the usual clamped point-to-segment
+    distance.  Once selected, lateral error is measured against the infinite
+    supporting line, rather than against a clamped endpoint.  This prevents a
+    point beyond a centerline endpoint from turning longitudinal overshoot into
+    lateral error.  Longitudinal error is the distance beyond the selected
+    segment's endpoint; it is zero while the perpendicular projection lies
+    inside the segment.
+
+    Returns:
+        ``(lateral_error, longitudinal_error)`` with shape ``(Q,)``.
+    """
+    Q = points.shape[0]
+    E = seg_p1.shape[0]
+    if E == 0:
+        raise ValueError("at least one segment is required")
+
+    _MAX_QE = 10_000_000
+    chunk_size = max(1, _MAX_QE // E)
+    lateral_results = []
+    longitudinal_results = []
+
+    for start in range(0, Q, chunk_size):
+        end = min(start + chunk_size, Q)
+        chunk = points[start:end]
+        seg = seg_p2 - seg_p1
+        seg_len2 = (seg**2).sum(-1).clamp(min=1e-10)
+        seg_len = seg_len2.sqrt()
+        diff = chunk[:, None, :] - seg_p1[None, :, :]
+        t_raw = (diff * seg[None, :, :]).sum(-1) / seg_len2[None, :]
+        t = t_raw.clamp(0, 1)
+        closest = seg_p1[None, :, :] + t[:, :, None] * seg[None, :, :]
+        distances = (chunk[:, None, :] - closest).norm(dim=-1)
+        nearest = distances.argmin(dim=1)
+        rows = torch.arange(chunk.shape[0], device=chunk.device)
+
+        nearest_seg = seg[nearest]
+        nearest_len = seg_len[nearest]
+        nearest_diff = diff[rows, nearest]
+        nearest_t_raw = t_raw[rows, nearest]
+        cross = nearest_seg[:, 0] * nearest_diff[:, 1] - nearest_seg[:, 1] * nearest_diff[:, 0]
+        lateral_results.append(cross.abs() / nearest_len)
+        longitudinal_results.append((nearest_t_raw - nearest_t_raw.clamp(0, 1)).abs() * nearest_len)
+
+    return torch.cat(lateral_results), torch.cat(longitudinal_results)
+
+
 def _points_inside_intersection_areas(
     points: torch.Tensor,
     polygons_tensor: torch.Tensor,


### PR DESCRIPTION
This pull request refactors the centerline evaluation metrics to more accurately separate lateral and longitudinal errors, replacing the previous ADE/FDE (Average/Final Displacement Error) metrics with average/final lateral error metrics. The changes clarify metric definitions, add a new function to compute error components, and update tests and public APIs accordingly.

**Metric API and Implementation Updates:**

* Replaced ADE/FDE metrics with `average_lateral_error_m` and `final_lateral_error_m` in `evaluate_centerline` and related functions, updating their signatures, docstrings, and return values for clarity and correctness. [[1]](diffhunk://#diff-f6fe88a8fe68c79e73bb8776c9ce688c79123a377e753028be8f29533fa4b240L73-R168) [[2]](diffhunk://#diff-f6fe88a8fe68c79e73bb8776c9ce688c79123a377e753028be8f29533fa4b240L118-R189)
* Added `compute_centerline_error_components_batch` to return both lateral and longitudinal errors per timestep, and exposed it in the module API. [[1]](diffhunk://#diff-f6fe88a8fe68c79e73bb8776c9ce688c79123a377e753028be8f29533fa4b240L73-R168) [[2]](diffhunk://#diff-f6fe88a8fe68c79e73bb8776c9ce688c79123a377e753028be8f29533fa4b240L118-R189)
* Updated import paths and function names to reflect the new metrics and error components. [[1]](diffhunk://#diff-f6fe88a8fe68c79e73bb8776c9ce688c79123a377e753028be8f29533fa4b240L8-R11) [[2]](diffhunk://#diff-f6fe88a8fe68c79e73bb8776c9ce688c79123a377e753028be8f29533fa4b240L118-R189)

**Geometry Utilities:**

* Added `_point_to_segments_error_components` to `geometry.py` to separately compute lateral error (against the supporting line) and longitudinal error (overshoot beyond segment endpoints), ensuring more accurate metric decomposition.

**Tests and Documentation:**

* Updated and added tests in `test_scenario_centerline_metric.py` to verify the new error components and metric outputs, and revised docstrings and comments to match the new metric semantics. [[1]](diffhunk://#diff-67bbbb001e9042e49849c630bdb76c5c9d83f320cb50f56597b8919f1eb5323bL1-R9) [[2]](diffhunk://#diff-67bbbb001e9042e49849c630bdb76c5c9d83f320cb50f56597b8919f1eb5323bL23-R28) [[3]](diffhunk://#diff-67bbbb001e9042e49849c630bdb76c5c9d83f320cb50f56597b8919f1eb5323bL37-R58)

These changes improve the interpretability and correctness of centerline-based evaluation metrics by clearly distinguishing between lateral deviation and endpoint overshoot.