### PR TITLE
perf(r2lpl): remove CPU bottlenecks in mining/repair/orchestrator (per-feature A/B'd)

### DIFF
--- a/rlvr/autoresearch/README_r2lpl_lifelong.md
+++ b/rlvr/autoresearch/README_r2lpl_lifelong.md
@@ -327,7 +327,9 @@ building each chunk.
 
 For this workflow, the intended reproducer settings are:
 
-- `tracker_mode="mpc"`
+- `tracker_mode="mpc_batched"` (bicycle-model MPC, one vectorized solve for all
+  segments per tick; `"mpc"` selects the legacy serial per-segment solve — same
+  events within a frame or two of onset shift, ~2.3x slower advance stage)
 - `timeline_progress_mode="clock"`
 - `neighbor_history_mode="sim"`
 - `gpu_transform=true`
@@ -534,7 +536,7 @@ Common production settings:
 - `repair_generation.repair_labels=["road_border_crossing","static_collision","moving_collision","expert_disagreement"]`
 - `validate_on_repaired_targets=true` when training validation should measure
   imitation on the repaired scene-target pairs produced by the same round
-- `perception_reproducer.tracker_mode=mpc`
+- `perception_reproducer.tracker_mode=mpc_batched`
 - `perception_reproducer.timeline_progress_mode=clock`
 - `perception_reproducer.neighbor_history_mode=sim`
 

--- a/rlvr/autoresearch/README_r2lpl_lifelong.md
+++ b/rlvr/autoresearch/README_r2lpl_lifelong.md
@@ -144,7 +144,8 @@ call to the prob/normal split (repaired scenes = prob, the listed real normal
 scenes = normal), with the mix controlled by the training config's explicit
 `n_prob_scenes` / `n_normal_scenes`. The list must be a non-empty JSON list of
 paths (validated at startup), the normal scenes are homogenized to 4-col
-neighbor futures into `r2lpl_round_NNN/normal_scenes_4col/` with a per-round
+neighbor futures into the campaign-level `normal_scenes_4col/` (converted once
+per campaign, manifest-cached across rounds) with a per-round
 resolved list (same collate incompatibility as the anchor slice below), and
 each round fails before training if `n_prob_scenes` is below that round's
 repaired-scene count — `run_experiment`'s `min(n_prob, len(prob))` sampling
@@ -152,8 +153,9 @@ would otherwise silently drop repairs.
 Raw logged anchor scenes carry
 3-col `[x, y, heading]` neighbor futures while repaired scenes are 4-col
 `[x, y, cos, sin]` — a mixed batch cannot collate, so the runner rewrites the
-3-col anchors as 4-col copies under `r2lpl_round_NNN/anchor_scenes_4col/`
-(zero padding rows preserved) before the union.
+3-col anchors as 4-col copies under the campaign-level `anchor_scenes_4col/`
+(zero padding rows preserved, conversions manifest-cached so each anchor scene
+is converted once per campaign) before the union.
 
 For the base_sft backend, `training.train_args.ema_decay` is forwarded to
 `train_predictor --ema_decay`. The default 0.999 (time constant ~1000 steps)

--- a/rlvr/autoresearch/tools/build_repaired_targets.py
+++ b/rlvr/autoresearch/tools/build_repaired_targets.py
@@ -45,6 +45,7 @@ from rlvr.grpo_trainer_batched import (
     generate_all_scenes_batched,
 )
 from rlvr.reward import compute_reward_batch
+from scenario_generation.perf_timer import Timers
 
 _GENERATION_MODE_GUIDED_VARIANT = "guided_variant"
 _GENERATION_MODE_GRPO_TEMPERATURE = "grpo_temperature"
@@ -744,14 +745,16 @@ def build_repaired_targets(
     thresholds = _load_scene_thresholds(threshold_config_path)
     model, model_args = load_model(model_path, device)
     out_dir.mkdir(parents=True, exist_ok=True)
+    timers = Timers()
     repaired_rows: list[dict[str, Any]] = []
     unrepaired_rows: list[dict[str, Any]] = []
-    rows, dirty_rows = _drop_t0_dirty_event_windows(
-        rows,
-        rcfg=rcfg,
-        thresholds=thresholds,
-        device=device,
-    )
+    with timers("t0_prefilter"):
+        rows, dirty_rows = _drop_t0_dirty_event_windows(
+            rows,
+            rcfg=rcfg,
+            thresholds=thresholds,
+            device=device,
+        )
     unrepaired_rows.extend(dirty_rows)
 
     class _Args:
@@ -777,7 +780,8 @@ def build_repaired_targets(
         kept_rows = []
         for row in batch_rows:
             p = row["scene_path"]
-            data = load_npz_data(p, device)
+            with timers("scene_load"):
+                data = load_npz_data(p, device)
             npz_es = data["ego_shape"].detach().cpu().numpy().reshape(-1)[:3]
             if ego_shape is not None and not np.allclose(npz_es, ego_shape, atol=1e-2):
                 raise ValueError(
@@ -790,47 +794,49 @@ def build_repaired_targets(
         if not datas:
             continue
 
-        norm_batch = _normalize_batch(_stack_scene_data(datas, device), model_args)
-        if generation_mode == _GENERATION_MODE_GRPO_TEMPERATURE:
-            trajs = _generate_grpo_temperature_scenes(
-                model,
-                norm_batch,
-                K=K,
-                grpo_noise_scale=grpo_noise_scale,
-                device=device,
-            )
-        elif generation_mode == _GENERATION_MODE_GUIDED_VARIANT:
-            trajs = generate_all_scenes_batched(
-                model,
-                model_args,
-                norm_batch,
-                K=K,
-                noise_range=(noise_low, noise_high),
-                device=device,
-                gen_chunk_size=K,
-                gt_max_speed=gt_max_speed,
-                generation_variant=variant,
-                prototypes_path=repair_prototypes_path,
-                use_route_cl_guidance=use_route_cl_guidance,
-            )
-        else:
-            raise ValueError(
-                f"unknown generation_mode {generation_mode!r}; expected "
-                f"{_GENERATION_MODE_GRPO_TEMPERATURE!r} or {_GENERATION_MODE_GUIDED_VARIANT!r}"
-            )
+        with timers("generate"):
+            norm_batch = _normalize_batch(_stack_scene_data(datas, device), model_args)
+            if generation_mode == _GENERATION_MODE_GRPO_TEMPERATURE:
+                trajs = _generate_grpo_temperature_scenes(
+                    model,
+                    norm_batch,
+                    K=K,
+                    grpo_noise_scale=grpo_noise_scale,
+                    device=device,
+                )
+            elif generation_mode == _GENERATION_MODE_GUIDED_VARIANT:
+                trajs = generate_all_scenes_batched(
+                    model,
+                    model_args,
+                    norm_batch,
+                    K=K,
+                    noise_range=(noise_low, noise_high),
+                    device=device,
+                    gen_chunk_size=K,
+                    gt_max_speed=gt_max_speed,
+                    generation_variant=variant,
+                    prototypes_path=repair_prototypes_path,
+                    use_route_cl_guidance=use_route_cl_guidance,
+                )
+            else:
+                raise ValueError(
+                    f"unknown generation_mode {generation_mode!r}; expected "
+                    f"{_GENERATION_MODE_GRPO_TEMPERATURE!r} or {_GENERATION_MODE_GUIDED_VARIANT!r}"
+                )
         scene_paths = [str(row["scene_path"]) for row in kept_rows]
-        candidate_rows_per_scene = classify_loaded_scene_candidates_batch(
-            scene_paths,
-            trajs,
-            datas,
-            rcfg,
-            moving_collision_thresh=thresholds["moving_collision_thresh"],
-            moving_near_thresh=thresholds["moving_near_thresh"],
-            static_near_thresh=thresholds["static_near_thresh"],
-            rb_near_thresh=thresholds["rb_near_thresh"],
-            device=device,
-            args=cls_args,
-        )
+        with timers("classify"):
+            candidate_rows_per_scene = classify_loaded_scene_candidates_batch(
+                scene_paths,
+                trajs,
+                datas,
+                rcfg,
+                moving_collision_thresh=thresholds["moving_collision_thresh"],
+                moving_near_thresh=thresholds["moving_near_thresh"],
+                static_near_thresh=thresholds["static_near_thresh"],
+                rb_near_thresh=thresholds["rb_near_thresh"],
+                device=device,
+                args=cls_args,
+            )
 
         # Deterministic plan per scene — needed to seed the det-path re-timing morph
         # AND the depart morph (initial speed) for expert_disagreement scenes.
@@ -839,9 +845,10 @@ def build_repaired_targets(
         )
         det_trajs = None
         if want_morph:
-            det_trajs = det_inference_batched(
-                model, model_args, datas, device, norm_batch=norm_batch
-            )
+            with timers("det_inference"):
+                det_trajs = det_inference_batched(
+                    model, model_args, datas, device, norm_batch=norm_batch
+                )
 
         for scene_idx, (row, data, scene_trajs, candidate_rows) in enumerate(
             zip(kept_rows, datas, trajs, candidate_rows_per_scene, strict=True)
@@ -861,7 +868,8 @@ def build_repaired_targets(
                 scoring_data = data
                 reference_traj = _future_to_4col(data["ego_agent_future"].detach().cpu().numpy())
 
-            reward_rows = list(compute_reward_batch(scene_trajs, scoring_data, rcfg))
+            with timers("reward"):
+                reward_rows = list(compute_reward_batch(scene_trajs, scoring_data, rcfg))
             candidate_rows = list(candidate_rows)
 
             name = _output_name_for_scene(row["scene_path"])
@@ -901,24 +909,25 @@ def build_repaired_targets(
                         f"unknown expert_stop_anchor {expert_stop_anchor!r}; "
                         "expected 'pseudo' or 'recorded'"
                     )
-                morph, morph_diag = build_expert_morph_candidate(
-                    det_traj,
-                    expert_traj,
-                    w_max=expert_morph_w_max,
-                    max_accel=expert_morph_max_accel,
-                    max_jerk=expert_morph_max_jerk,
-                    stop_anchor_xy=stop_anchor_xy,
-                    return_diag=True,
-                )
-                if morph is not None:
-                    morph_index, scene_trajs = _append_scripted_candidate(
-                        morph,
-                        candidate_rows=candidate_rows,
-                        reward_rows=reward_rows,
-                        scene_trajs=scene_trajs,
-                        **scripted_kwargs,
+                with timers("morph"):
+                    morph, morph_diag = build_expert_morph_candidate(
+                        det_traj,
+                        expert_traj,
+                        w_max=expert_morph_w_max,
+                        max_accel=expert_morph_max_accel,
+                        max_jerk=expert_morph_max_jerk,
+                        stop_anchor_xy=stop_anchor_xy,
+                        return_diag=True,
                     )
-                    morph_added = True
+                    if morph is not None:
+                        morph_index, scene_trajs = _append_scripted_candidate(
+                            morph,
+                            candidate_rows=candidate_rows,
+                            reward_rows=reward_rows,
+                            scene_trajs=scene_trajs,
+                            **scripted_kwargs,
+                        )
+                        morph_added = True
 
             # Depart morph for the fail-to-take-off direction: the stop morph
             # re-times the det plan's own geometry, which cannot synthesize a
@@ -933,34 +942,36 @@ def build_repaired_targets(
                 and is_expert
                 and row.get("expert_disagreement_reason") == "model_lagging_expert"
             ):
-                depart, depart_diag = build_depart_morph_candidate(
-                    det_traj,
-                    expert_traj,
-                    max_accel=expert_morph_max_accel,
-                    max_jerk=expert_morph_max_jerk,
-                    return_diag=True,
-                )
-                if depart is not None:
-                    depart_index, scene_trajs = _append_scripted_candidate(
-                        depart,
-                        candidate_rows=candidate_rows,
-                        reward_rows=reward_rows,
-                        scene_trajs=scene_trajs,
-                        **scripted_kwargs,
+                with timers("morph"):
+                    depart, depart_diag = build_depart_morph_candidate(
+                        det_traj,
+                        expert_traj,
+                        max_accel=expert_morph_max_accel,
+                        max_jerk=expert_morph_max_jerk,
+                        return_diag=True,
                     )
-                    depart_added = True
+                    if depart is not None:
+                        depart_index, scene_trajs = _append_scripted_candidate(
+                            depart,
+                            candidate_rows=candidate_rows,
+                            reward_rows=reward_rows,
+                            scene_trajs=scene_trajs,
+                            **scripted_kwargs,
+                        )
+                        depart_added = True
 
-            best_idx, meta = _best_safe_candidate(
-                row,
-                candidate_rows,
-                reward_rows,
-                min_static_margin=min_static_margin,
-                target_gt_disagreement_thresh=target_gt_disagreement_thresh,
-                candidate_trajs=scene_trajs,
-                reference_traj=reference_traj,
-                morph_index=morph_index if morph_added else None,
-                depart_index=depart_index if depart_added else None,
-            )
+            with timers("select"):
+                best_idx, meta = _best_safe_candidate(
+                    row,
+                    candidate_rows,
+                    reward_rows,
+                    min_static_margin=min_static_margin,
+                    target_gt_disagreement_thresh=target_gt_disagreement_thresh,
+                    candidate_trajs=scene_trajs,
+                    reference_traj=reference_traj,
+                    morph_index=morph_index if morph_added else None,
+                    depart_index=depart_index if depart_added else None,
+                )
             morph_selected = bool(morph_added and best_idx == morph_index)
             depart_selected = bool(depart_added and best_idx == depart_index)
             if is_expert:
@@ -993,13 +1004,14 @@ def build_repaired_targets(
                 )
                 continue
 
-            with np.load(row["scene_path"], allow_pickle=True) as loaded:
-                raw = _filtered_npz_payload(loaded)
-            raw["ego_agent_future"] = _future4_to_3col(
-                scene_trajs[best_idx].detach().cpu().numpy().astype(np.float32)
-            )
-            out_path = out_dir / name
-            np.savez(out_path, **raw)
+            with timers("npz_write"):
+                with np.load(row["scene_path"], allow_pickle=True) as loaded:
+                    raw = _filtered_npz_payload(loaded)
+                raw["ego_agent_future"] = _future4_to_3col(
+                    scene_trajs[best_idx].detach().cpu().numpy().astype(np.float32)
+                )
+                out_path = out_dir / name
+                np.savez(out_path, **raw)
 
             repaired = dict(row)
             repaired["source_scene_path"] = str(row["scene_path"])
@@ -1034,6 +1046,7 @@ def build_repaired_targets(
         unrepaired_path.write_text(json.dumps(unrepaired_rows, indent=2))
         print(f"  unrepaired list -> {unrepaired_path}")
 
+    print(timers.report(max(1, len(rows))))
     print(f"repaired {len(repaired_rows)}/{len(rows)} -> {out_dir}")
     return repaired_paths, unrepaired_rows
 

--- a/rlvr/autoresearch/tools/build_repaired_targets.py
+++ b/rlvr/autoresearch/tools/build_repaired_targets.py
@@ -27,6 +27,7 @@ from rlvr.autoresearch.tools.classify_scene_failures import (
     _load_scene_thresholds,
     classify_loaded_scene_candidates_batch,
     current_ego_neighbor_clearance,
+    slice_subscore_outputs,
 )
 from rlvr.autoresearch.tools.eval_det_avoidance import (
     det_inference_batched,
@@ -44,7 +45,7 @@ from rlvr.grpo_trainer_batched import (
     _stack_scene_data,
     generate_all_scenes_batched,
 )
-from rlvr.reward import compute_reward_batch
+from rlvr.reward import _shape_reward, compute_reward_batch
 from scenario_generation.perf_timer import Timers
 
 _GENERATION_MODE_GUIDED_VARIANT = "guided_variant"
@@ -825,7 +826,7 @@ def build_repaired_targets(
                 )
         scene_paths = [str(row["scene_path"]) for row in kept_rows]
         with timers("classify"):
-            candidate_rows_per_scene = classify_loaded_scene_candidates_batch(
+            candidate_rows_per_scene, batch_subs = classify_loaded_scene_candidates_batch(
                 scene_paths,
                 trajs,
                 datas,
@@ -836,6 +837,7 @@ def build_repaired_targets(
                 rb_near_thresh=thresholds["rb_near_thresh"],
                 device=device,
                 args=cls_args,
+                return_subscores=True,
             )
 
         # Deterministic plan per scene — needed to seed the det-path re-timing morph
@@ -868,8 +870,34 @@ def build_repaired_targets(
                 scoring_data = data
                 reference_traj = _future_to_4col(data["ego_agent_future"].detach().cpu().numpy())
 
+            # The classifier above already ran the full subscore geometry
+            # (OBB clearance / road border / lane / centerline) on this exact
+            # (scene, candidates) pair — reuse it and apply only the reward
+            # shaping, instead of recomputing everything. Valid only when the
+            # reward would score the SAME data the classifier saw: not for
+            # expert-reference scoring (mutated data) and not when futures are
+            # 3-col (the classifier scores a 4-col-converted copy, the legacy
+            # reward path scored the raw arrays).
+            def _future_is_4col(d, key):
+                return key not in d or int(d[key].shape[-1]) == 4
+
+            reuse_subs = (
+                not (repair_expert_reference and is_expert)
+                and _future_is_4col(data, "ego_agent_future")
+                and _future_is_4col(data, "neighbor_agents_future")
+            )
             with timers("reward"):
-                reward_rows = list(compute_reward_batch(scene_trajs, scoring_data, rcfg))
+                if reuse_subs:
+                    reward_rows = list(
+                        _shape_reward(
+                            slice_subscore_outputs(batch_subs, scene_idx),
+                            scene_trajs,
+                            scoring_data,
+                            rcfg,
+                        )
+                    )
+                else:
+                    reward_rows = list(compute_reward_batch(scene_trajs, scoring_data, rcfg))
             candidate_rows = list(candidate_rows)
 
             name = _output_name_for_scene(row["scene_path"])

--- a/rlvr/autoresearch/tools/build_repaired_targets.py
+++ b/rlvr/autoresearch/tools/build_repaired_targets.py
@@ -130,6 +130,10 @@ def _future_to_4col(traj: torch.Tensor | np.ndarray) -> np.ndarray:
     return future_to_4col(arr, zero_rows_are_padding=False)
 
 
+def _future_is_4col(data: dict[str, Any], key: str) -> bool:
+    return key not in data or int(data[key].shape[-1]) == 4
+
+
 def _row_is_expert_disagreement(row: dict[str, Any]) -> bool:
     return "expert_disagreement" in set(row.get("repair_labels") or [])
 
@@ -878,9 +882,6 @@ def build_repaired_targets(
             # expert-reference scoring (mutated data) and not when futures are
             # 3-col (the classifier scores a 4-col-converted copy, the legacy
             # reward path scored the raw arrays).
-            def _future_is_4col(d, key):
-                return key not in d or int(d[key].shape[-1]) == 4
-
             reuse_subs = (
                 not (repair_expert_reference and is_expert)
                 and _future_is_4col(data, "ego_agent_future")

--- a/rlvr/autoresearch/tools/classify_scene_failures.py
+++ b/rlvr/autoresearch/tools/classify_scene_failures.py
@@ -856,6 +856,107 @@ def _moving_diagnostics(
     }
 
 
+def _moving_collision_steps_gated_batch(
+    collision_mask: torch.Tensor,
+) -> list[int | None]:
+    """Per-candidate first collision step from an (N, N_nb, T) gated mask.
+
+    Same semantics as ``_moving_collision_step_gated``'s final reduction, but
+    per candidate instead of collapsed across the N dimension.
+    """
+    by_t = collision_mask.any(dim=1)  # (N, T)
+    any_n = by_t.any(dim=1)
+    first = by_t.float().argmax(dim=1)
+    return [int(first[n].item()) if bool(any_n[n].item()) else None for n in range(by_t.shape[0])]
+
+
+def _moving_diagnostics_batch(
+    ego_trajs: torch.Tensor,
+    data: dict[str, torch.Tensor],
+    config: RewardConfig,
+    moving_collision_thresh: float,
+    moving_near_thresh: float,
+    device: torch.device,
+) -> list[dict[str, Any]]:
+    """``_moving_diagnostics`` for all N candidates of ONE scene in one pass.
+
+    The scene's neighbor inputs and the (N, N_nb, T) clearance tensor are
+    computed once instead of once per candidate; every per-candidate value is
+    then a row-wise reduction, so results match the per-candidate calls
+    exactly (verified by the repair-output equivalence check).
+    """
+    N, T = ego_trajs.shape[0], ego_trajs.shape[1]
+    ego_shape = _ego_shape_from_data(data, device)
+    neighbor_futures, neighbor_shapes, neighbor_valid = _neighbor_inputs(data, T, device)
+    stopped_mask = _stopped_neighbor_mask(neighbor_futures, neighbor_valid, config)
+    moving_mask = ~stopped_mask
+    moving_count = int(moving_mask.sum().item())
+    stopped_count = int(stopped_mask.sum().item())
+
+    if moving_count == 0:
+        return [
+            {
+                "moving_neighbor_count": moving_count,
+                "stopped_neighbor_count": stopped_count,
+                "moving_min_dist": _NO_MOVING_NEIGHBOR_DISTANCE_M,
+                "moving_argmin_neighbor": None,
+                "moving_argmin_t": None,
+                "moving_collision_step": None,
+                "moving_near_miss": False,
+            }
+            for _ in range(N)
+        ]
+
+    mf = neighbor_futures[moving_mask]
+    ms = neighbor_shapes[moving_mask]
+    mv = neighbor_valid[moving_mask]
+    moving_global_idx = moving_mask.nonzero(as_tuple=True)[0]
+
+    distances = compute_ego_neighbor_signed_clearance(ego_trajs, ego_shape, mf, ms, mv)
+    _, M, Td = distances.shape
+    flat = distances.reshape(N, -1)
+    flat_idx = flat.argmin(dim=1)  # (N,)
+    min_dists = flat.gather(1, flat_idx[:, None]).squeeze(1)
+    argmin_m = (flat_idx // Td) % M
+    argmin_t = flat_idx % Td
+
+    # Gated collision mask — same construction as _moving_collision_step_gated,
+    # kept N-major so the first-step reduction stays per candidate.
+    ego_xy = ego_trajs[:, :, :2]
+    collision_mask = distances <= moving_collision_thresh
+    if config.ignore_rear_end_collisions:
+        ego_heading = ego_trajs[:, :, 2:4]
+        npc_xy = mf[:, :, :2]
+        ego_to_npc = npc_xy.unsqueeze(0) - ego_xy.unsqueeze(1)
+        dot = (ego_to_npc * ego_heading.unsqueeze(1)).sum(dim=-1)
+        npc_is_behind = dot < 0
+        rear_contact = collision_mask & npc_is_behind
+        ever_rear = rear_contact.cummax(dim=2).values
+        collision_mask = collision_mask & ~npc_is_behind & ~ever_rear
+    if T >= 2:
+        ego_speed = (torch.diff(ego_xy, dim=1) / config.dt).norm(dim=-1)
+        ego_speed = torch.cat([ego_speed, ego_speed[:, -1:]], dim=1)
+        collision_mask = collision_mask & (ego_speed > 1.0).unsqueeze(1)
+    collision_steps = _moving_collision_steps_gated_batch(collision_mask)
+
+    rows: list[dict[str, Any]] = []
+    for n in range(N):
+        min_dist = float(min_dists[n].item())
+        step = collision_steps[n]
+        rows.append(
+            {
+                "moving_neighbor_count": moving_count,
+                "stopped_neighbor_count": stopped_count,
+                "moving_min_dist": min_dist,
+                "moving_argmin_neighbor": int(moving_global_idx[int(argmin_m[n].item())].item()),
+                "moving_argmin_t": int(argmin_t[n].item()),
+                "moving_collision_step": step,
+                "moving_near_miss": step is None and min_dist < moving_near_thresh,
+            }
+        )
+    return rows
+
+
 def classify_loaded_scene(
     scene_path: str,
     ego_traj: torch.Tensor,
@@ -1010,6 +1111,15 @@ def classify_loaded_scenes_batch(
     return [rows[0] for rows in rows_per_scene]
 
 
+def slice_subscore_outputs(
+    subs: dict[str, torch.Tensor | list[list[int | None]]], bidx: int
+) -> dict[str, torch.Tensor | list[int | None]]:
+    """Per-scene view of ``compute_subscores_scene_batch`` output — the exact
+    dict ``compute_subscores_batch`` would have returned for that scene (the
+    scene-batch wrapper computes per scene and stacks, so slicing round-trips)."""
+    return {k: (v[bidx] if torch.is_tensor(v) else list(v[bidx])) for k, v in subs.items()}
+
+
 def classify_loaded_scene_candidates_batch(
     scene_paths: list[str],
     ego_trajs: torch.Tensor,
@@ -1022,8 +1132,15 @@ def classify_loaded_scene_candidates_batch(
     rb_near_thresh: float,
     device: torch.device,
     args=None,
-) -> list[list[dict[str, Any]]]:
-    """Classify a B-scene batch with N scored trajectories per scene."""
+    return_subscores: bool = False,
+):
+    """Classify a B-scene batch with N scored trajectories per scene.
+
+    With ``return_subscores=True`` returns ``(rows_per_scene, subs)`` where
+    ``subs`` is the B-major ``compute_subscores_scene_batch`` output — callers
+    that also need the reward (``rlvr.reward._shape_reward``) can reuse it via
+    ``slice_subscore_outputs`` instead of recomputing the identical geometry.
+    """
     if ego_trajs.dim() != 4:
         raise ValueError(
             "classify_loaded_scene_candidates_batch expects ego_trajs shaped (B,N,T,4); "
@@ -1044,16 +1161,19 @@ def classify_loaded_scene_candidates_batch(
     for bidx, scene_path in enumerate(scene_paths):
         scene_data = _slice_scene_data(batched_data, bidx, B)
         scene_rows: list[dict[str, Any]] = []
+        # One clearance pass for all N candidates of this scene instead of N
+        # batch-1 passes (same values; see _moving_diagnostics_batch).
+        moving_rows = _moving_diagnostics_batch(
+            ego_trajs[bidx],
+            scene_data,
+            config,
+            moving_collision_thresh,
+            moving_near_thresh,
+            device,
+        )
         for candidate_idx in range(N):
             traj_1 = ego_trajs[bidx, candidate_idx : candidate_idx + 1]
-            moving = _moving_diagnostics(
-                traj_1,
-                scene_data,
-                config,
-                moving_collision_thresh,
-                moving_near_thresh,
-                device,
-            )
+            moving = moving_rows[candidate_idx]
             conflict = _conflict_diagnostics(traj_1, scene_data, args) if args else {}
             row = _build_candidate_row(
                 scene_path,
@@ -1068,6 +1188,8 @@ def classify_loaded_scene_candidates_batch(
             row["trajectory_source"] = "generated" if N > 1 else row["trajectory_source"]
             scene_rows.append(row)
         rows_per_scene.append(scene_rows)
+    if return_subscores:
+        return rows_per_scene, subs
     return rows_per_scene
 
 

--- a/rlvr/autoresearch/tools/compare_mining_outputs.py
+++ b/rlvr/autoresearch/tools/compare_mining_outputs.py
@@ -105,6 +105,11 @@ def compare_npzs(a_root: Path, b_root: Path, atol: float) -> list[str]:
                     continue
                 if np.array_equal(va, vb, equal_nan=True):
                     continue
+                if va.dtype.kind == "f" and bool((np.isnan(va) != np.isnan(vb)).any()):
+                    # NaN-vs-value would vanish in the nanmax below — a NaN
+                    # regression must never read as "equal".
+                    diffs.append(f"{rel}[{k}]: NaN placement mismatch")
+                    continue
                 d = np.nanmax(np.abs(va.astype(np.float64) - vb.astype(np.float64)))
                 if d > atol:
                     diffs.append(f"{rel}[{k}]: max|diff|={d:.3e} > atol={atol}")

--- a/rlvr/autoresearch/tools/compare_mining_outputs.py
+++ b/rlvr/autoresearch/tools/compare_mining_outputs.py
@@ -12,6 +12,7 @@ Usage: compare_mining_outputs.py <dir_A> <dir_B> [--atol 0] [--float_fields_rtol
 import argparse
 import json
 import sys
+from collections import defaultdict
 from pathlib import Path
 
 import numpy as np
@@ -54,22 +55,41 @@ def cmp_value(a, b, rtol: float) -> bool:
 
 def compare_jsonl(name: str, a_rows: list[dict], b_rows: list[dict], rtol: float) -> list[str]:
     diffs = []
-    a_by, b_by = {row_key(r): r for r in a_rows}, {row_key(r): r for r in b_rows}
+    if len(a_rows) != len(b_rows):
+        diffs.append(f"{name}: row counts differ ({len(a_rows)} vs {len(b_rows)})")
+    # Group per key and preserve multiplicity: a dict keyed on row_key would
+    # silently collapse duplicate rows, letting an A-with-duplicates vs
+    # B-without regression read as IDENTICAL (a correctness gate must not).
+    a_by: dict[tuple, list[dict]] = defaultdict(list)
+    b_by: dict[tuple, list[dict]] = defaultdict(list)
+    for r in a_rows:
+        a_by[row_key(r)].append(r)
+    for r in b_rows:
+        b_by[row_key(r)].append(r)
     only_a, only_b = set(a_by) - set(b_by), set(b_by) - set(a_by)
     if only_a:
         diffs.append(f"{name}: {len(only_a)} rows only in A, e.g. {sorted(only_a)[:3]}")
     if only_b:
         diffs.append(f"{name}: {len(only_b)} rows only in B, e.g. {sorted(only_b)[:3]}")
+
+    def _canon(row: dict) -> str:
+        return json.dumps(row, sort_keys=True, default=str)
+
     for k in sorted(set(a_by) & set(b_by)):
-        ra, rb = a_by[k], b_by[k]
-        bad = [
-            f
-            for f in sorted(set(ra) | set(rb))
-            # scene_path/window_dir embed the output dir name — not semantics.
-            if f not in ("scene_path", "window_dir") and not cmp_value(ra.get(f), rb.get(f), rtol)
-        ]
-        if bad:
-            diffs.append(f"{name} {k}: fields differ: {bad[:8]}")
+        group_a, group_b = a_by[k], b_by[k]
+        if len(group_a) != len(group_b):
+            diffs.append(f"{name} {k}: multiplicity differs ({len(group_a)} vs {len(group_b)})")
+            continue
+        for ra, rb in zip(sorted(group_a, key=_canon), sorted(group_b, key=_canon)):
+            bad = [
+                f
+                for f in sorted(set(ra) | set(rb))
+                # scene_path/window_dir embed the output dir name — not semantics.
+                if f not in ("scene_path", "window_dir")
+                and not cmp_value(ra.get(f), rb.get(f), rtol)
+            ]
+            if bad:
+                diffs.append(f"{name} {k}: fields differ: {bad[:8]}")
     return diffs
 
 

--- a/rlvr/autoresearch/tools/compare_mining_outputs.py
+++ b/rlvr/autoresearch/tools/compare_mining_outputs.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Correctness oracle for R2LPL mining-perf work: compare two mining output dirs.
+
+Compares (a) credit_windows.jsonl rows (keyed by event-dir name + scene file),
+(b) segments.jsonl result rows, (c) every saved NPZ array in windows/ (exact
+match first, then allclose with reported max-abs-diff). Exit 0 = identical
+within tolerance, 1 = differences found.
+
+Usage: compare_mining_outputs.py <dir_A> <dir_B> [--atol 0] [--float_fields_rtol 1e-6]
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+def load_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def row_key(row: dict) -> tuple:
+    p = row.get("scene_path", "")
+    return (Path(p).parent.name, Path(p).name)
+
+
+def cmp_scalar(a, b, rtol: float) -> bool:
+    if isinstance(a, float) or isinstance(b, float):
+        try:
+            fa, fb = float(a), float(b)
+        except (TypeError, ValueError):
+            return a == b
+        if np.isnan(fa) and np.isnan(fb):
+            return True
+        return bool(np.isclose(fa, fb, rtol=rtol, atol=1e-12))
+    return a == b
+
+
+def cmp_value(a, b, rtol: float) -> bool:
+    if isinstance(a, dict) and isinstance(b, dict):
+        if set(a) != set(b):
+            return False
+        return all(cmp_value(a[k], b[k], rtol) for k in a)
+    if isinstance(a, (list, tuple)) and isinstance(b, (list, tuple)):
+        if len(a) != len(b):
+            return False
+        return all(cmp_value(x, y, rtol) for x, y in zip(a, b))
+    return cmp_scalar(a, b, rtol)
+
+
+def compare_jsonl(name: str, a_rows: list[dict], b_rows: list[dict], rtol: float) -> list[str]:
+    diffs = []
+    a_by, b_by = {row_key(r): r for r in a_rows}, {row_key(r): r for r in b_rows}
+    only_a, only_b = set(a_by) - set(b_by), set(b_by) - set(a_by)
+    if only_a:
+        diffs.append(f"{name}: {len(only_a)} rows only in A, e.g. {sorted(only_a)[:3]}")
+    if only_b:
+        diffs.append(f"{name}: {len(only_b)} rows only in B, e.g. {sorted(only_b)[:3]}")
+    for k in sorted(set(a_by) & set(b_by)):
+        ra, rb = a_by[k], b_by[k]
+        bad = [
+            f
+            for f in sorted(set(ra) | set(rb))
+            # scene_path/window_dir embed the output dir name — not semantics.
+            if f not in ("scene_path", "window_dir") and not cmp_value(ra.get(f), rb.get(f), rtol)
+        ]
+        if bad:
+            diffs.append(f"{name} {k}: fields differ: {bad[:8]}")
+    return diffs
+
+
+def compare_npzs(a_root: Path, b_root: Path, atol: float) -> list[str]:
+    diffs = []
+    a_files = sorted(p.relative_to(a_root) for p in a_root.rglob("*.npz"))
+    b_files = sorted(p.relative_to(b_root) for p in b_root.rglob("*.npz"))
+    if a_files != b_files:
+        only_a = set(a_files) - set(b_files)
+        only_b = set(b_files) - set(a_files)
+        diffs.append(
+            f"npz sets differ: {len(only_a)} only-A {sorted(only_a)[:3]}, "
+            f"{len(only_b)} only-B {sorted(only_b)[:3]}"
+        )
+    for rel in sorted(set(a_files) & set(b_files)):
+        with (
+            np.load(a_root / rel, allow_pickle=True) as za,
+            np.load(b_root / rel, allow_pickle=True) as zb,
+        ):
+            if set(za.files) != set(zb.files):
+                diffs.append(f"{rel}: key sets differ {set(za.files) ^ set(zb.files)}")
+                continue
+            for k in za.files:
+                va, vb = za[k], zb[k]
+                if va.shape != vb.shape or va.dtype != vb.dtype:
+                    diffs.append(
+                        f"{rel}[{k}]: shape/dtype {va.shape}/{va.dtype} vs {vb.shape}/{vb.dtype}"
+                    )
+                    continue
+                if va.dtype.kind in "USO":
+                    if not np.array_equal(va, vb):
+                        diffs.append(f"{rel}[{k}]: string/object mismatch")
+                    continue
+                if np.array_equal(va, vb, equal_nan=True):
+                    continue
+                d = np.nanmax(np.abs(va.astype(np.float64) - vb.astype(np.float64)))
+                if d > atol:
+                    diffs.append(f"{rel}[{k}]: max|diff|={d:.3e} > atol={atol}")
+    return diffs
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("dir_a", type=Path)
+    ap.add_argument("dir_b", type=Path)
+    ap.add_argument("--atol", type=float, default=0.0, help="NPZ array tolerance (0 = bitwise)")
+    ap.add_argument("--float_fields_rtol", type=float, default=1e-6)
+    args = ap.parse_args()
+
+    diffs: list[str] = []
+    diffs += compare_jsonl(
+        "credit_windows",
+        load_jsonl(args.dir_a / "credit_windows.jsonl"),
+        load_jsonl(args.dir_b / "credit_windows.jsonl"),
+        args.float_fields_rtol,
+    )
+    a_seg = load_jsonl(args.dir_a / "segments.jsonl")
+    b_seg = load_jsonl(args.dir_b / "segments.jsonl")
+    if len(a_seg) != len(b_seg):
+        diffs.append(f"segments.jsonl: {len(a_seg)} vs {len(b_seg)} rows")
+    else:
+        for i, (ra, rb) in enumerate(zip(a_seg, b_seg)):
+            bad = [
+                f
+                for f in sorted(set(ra) | set(rb))
+                if not cmp_value(ra.get(f), rb.get(f), args.float_fields_rtol)
+            ]
+            if bad:
+                diffs.append(f"segments row {i}: fields differ: {bad[:8]}")
+    if (args.dir_a / "windows").exists() or (args.dir_b / "windows").exists():
+        diffs += compare_npzs(args.dir_a / "windows", args.dir_b / "windows", args.atol)
+
+    if diffs:
+        print(f"DIFFERENT ({len(diffs)} findings):")
+        for d in diffs[:60]:
+            print(" ", d)
+        return 1
+    print("IDENTICAL (within tolerance)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rlvr/autoresearch/tools/compare_repair_outputs.py
+++ b/rlvr/autoresearch/tools/compare_repair_outputs.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Correctness oracle for repair-stage perf work: compare two repair output dirs.
+
+Compares repaired_targets.jsonl rows (keyed by output NPZ basename; path-like
+fields ignored), the unrepaired lists, and every repaired NPZ array (bitwise by
+default, --atol for float tolerance). Exit 0 = equivalent.
+
+Usage: compare_repair_outputs.py <dir_A> <dir_B> [--atol 0]
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from rlvr.autoresearch.tools.compare_mining_outputs import cmp_value, compare_npzs, load_jsonl
+
+_PATH_FIELDS = {"scene_path", "source_scene_path", "window_dir"}
+
+
+def compare_rows(name: str, a_rows, b_rows, rtol: float) -> list[str]:
+    diffs = []
+    a_by = {Path(r["scene_path"]).name: r for r in a_rows}
+    b_by = {Path(r["scene_path"]).name: r for r in b_rows}
+    only_a, only_b = set(a_by) - set(b_by), set(b_by) - set(a_by)
+    if only_a:
+        diffs.append(f"{name}: {len(only_a)} rows only in A, e.g. {sorted(only_a)[:3]}")
+    if only_b:
+        diffs.append(f"{name}: {len(only_b)} rows only in B, e.g. {sorted(only_b)[:3]}")
+    for k in sorted(set(a_by) & set(b_by)):
+        ra, rb = a_by[k], b_by[k]
+        bad = [
+            f
+            for f in sorted(set(ra) | set(rb))
+            if f not in _PATH_FIELDS and not cmp_value(ra.get(f), rb.get(f), rtol)
+        ]
+        if bad:
+            diffs.append(f"{name} {k}: fields differ: {bad[:10]}")
+    return diffs
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("dir_a", type=Path)
+    ap.add_argument("dir_b", type=Path)
+    ap.add_argument("--atol", type=float, default=0.0)
+    ap.add_argument("--float_fields_rtol", type=float, default=1e-6)
+    args = ap.parse_args()
+
+    diffs: list[str] = []
+    diffs += compare_rows(
+        "repaired",
+        load_jsonl(args.dir_a / "repaired_targets.jsonl"),
+        load_jsonl(args.dir_b / "repaired_targets.jsonl"),
+        args.float_fields_rtol,
+    )
+    for unrep in ("repaired_targets_unrepaired.json",):
+        pa, pb = args.dir_a / unrep, args.dir_b / unrep
+        if pa.exists() or pb.exists():
+            ra = json.loads(pa.read_text()) if pa.exists() else []
+            rb = json.loads(pb.read_text()) if pb.exists() else []
+            diffs += compare_rows(unrep, ra, rb, args.float_fields_rtol)
+    diffs += compare_npzs(
+        args.dir_a / "repaired_targets", args.dir_b / "repaired_targets", args.atol
+    )
+
+    if diffs:
+        print(f"DIFFERENT ({len(diffs)} findings):")
+        for d in diffs[:60]:
+            print(" ", d)
+        return 1
+    print("IDENTICAL (within tolerance)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rlvr/autoresearch/tools/compare_repair_outputs.py
+++ b/rlvr/autoresearch/tools/compare_repair_outputs.py
@@ -11,6 +11,7 @@ Usage: compare_repair_outputs.py <dir_A> <dir_B> [--atol 0]
 import argparse
 import json
 import sys
+from collections import defaultdict
 from pathlib import Path
 
 from rlvr.autoresearch.tools.compare_mining_outputs import cmp_value, compare_npzs, load_jsonl
@@ -20,22 +21,38 @@ _PATH_FIELDS = {"scene_path", "source_scene_path", "window_dir"}
 
 def compare_rows(name: str, a_rows, b_rows, rtol: float) -> list[str]:
     diffs = []
-    a_by = {Path(r["scene_path"]).name: r for r in a_rows}
-    b_by = {Path(r["scene_path"]).name: r for r in b_rows}
+    if len(a_rows) != len(b_rows):
+        diffs.append(f"{name}: row counts differ ({len(a_rows)} vs {len(b_rows)})")
+    # Preserve multiplicity — see compare_mining_outputs.compare_jsonl: a plain
+    # dict would collapse duplicate rows and hide a duplication regression.
+    a_by: dict[str, list] = defaultdict(list)
+    b_by: dict[str, list] = defaultdict(list)
+    for r in a_rows:
+        a_by[Path(r["scene_path"]).name].append(r)
+    for r in b_rows:
+        b_by[Path(r["scene_path"]).name].append(r)
     only_a, only_b = set(a_by) - set(b_by), set(b_by) - set(a_by)
     if only_a:
         diffs.append(f"{name}: {len(only_a)} rows only in A, e.g. {sorted(only_a)[:3]}")
     if only_b:
         diffs.append(f"{name}: {len(only_b)} rows only in B, e.g. {sorted(only_b)[:3]}")
+
+    def _canon(row) -> str:
+        return json.dumps(row, sort_keys=True, default=str)
+
     for k in sorted(set(a_by) & set(b_by)):
-        ra, rb = a_by[k], b_by[k]
-        bad = [
-            f
-            for f in sorted(set(ra) | set(rb))
-            if f not in _PATH_FIELDS and not cmp_value(ra.get(f), rb.get(f), rtol)
-        ]
-        if bad:
-            diffs.append(f"{name} {k}: fields differ: {bad[:10]}")
+        group_a, group_b = a_by[k], b_by[k]
+        if len(group_a) != len(group_b):
+            diffs.append(f"{name} {k}: multiplicity differs ({len(group_a)} vs {len(group_b)})")
+            continue
+        for ra, rb in zip(sorted(group_a, key=_canon), sorted(group_b, key=_canon)):
+            bad = [
+                f
+                for f in sorted(set(ra) | set(rb))
+                if f not in _PATH_FIELDS and not cmp_value(ra.get(f), rb.get(f), rtol)
+            ]
+            if bad:
+                diffs.append(f"{name} {k}: fields differ: {bad[:10]}")
     return diffs
 
 

--- a/rlvr/autoresearch/tools/compare_tracker_ab.py
+++ b/rlvr/autoresearch/tools/compare_tracker_ab.py
@@ -114,10 +114,28 @@ def main() -> int:
         f"{'OK' if match else 'FAIL'}"
     )
 
-    for tag, path in (("A", a_dir), ("B", b_dir)):
-        segs = load_jsonl(path / "segments.jsonl")
-        term = Counter(str(r.get("terminated")) for r in segs)
-        print(f"terminations[{tag}]: {dict(sorted(term.items()))}")
+    # Termination reasons and rollout lengths are GATED, not informational: a
+    # tracker can match chunk/event counts while materially changing how or
+    # how long segments run, and that must not read as PASS.
+    a_segs = load_jsonl(a_dir / "segments.jsonl")
+    b_segs = load_jsonl(b_dir / "segments.jsonl")
+    term_a = Counter(str(r.get("terminated")) for r in a_segs)
+    term_b = Counter(str(r.get("terminated")) for r in b_segs)
+    for reason in sorted(set(term_a) | set(term_b)):
+        na, nb = term_a.get(reason, 0), term_b.get(reason, 0)
+        tol = max(1, round(0.02 * max(na, nb)))
+        match = abs(na - nb) <= tol
+        ok &= match
+        print(f"terminations[{reason}]: A={na} B={nb} (tol ±{tol}) {'OK' if match else 'FAIL'}")
+    steps_a = sum(int(r.get("n_steps_run", 0)) for r in a_segs)
+    steps_b = sum(int(r.get("n_steps_run", 0)) for r in b_segs)
+    steps_tol = max(1, round(0.02 * max(steps_a, steps_b)))
+    match = abs(steps_a - steps_b) <= steps_tol
+    ok &= match
+    print(
+        f"total simulated steps: A={steps_a} B={steps_b} (tol ±{steps_tol}) "
+        f"{'OK' if match else 'FAIL'}"
+    )
 
     print("VERDICT:", "PASS" if ok else "FAIL")
     return 0 if ok else 1

--- a/rlvr/autoresearch/tools/compare_tracker_ab.py
+++ b/rlvr/autoresearch/tools/compare_tracker_ab.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Statistical A/B for tracker changes (mpc vs mpc_batched mining runs).
+
+The batched solver is not bit-identical, so this reports the M2 validation
+protocol metrics instead of a bitwise diff:
+- mined event-window counts per label (accept: within ±2% or ±1 event),
+- credit-row overlap Jaccard on (event_key, scene_file) (accept: ≥ 0.97),
+- simulated/skipped chunk counts (must match),
+- segment termination-reason histogram.
+
+Usage: compare_tracker_ab.py <dir_A> <dir_B>
+"""
+
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+
+def load_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def event_key(row: dict) -> tuple:
+    # window_dir basename encodes route/start/frame/label without the run dir.
+    return (Path(row.get("window_dir", "")).name, Path(row.get("scene_path", "")).name)
+
+
+def label_counts(rows: list[dict]) -> Counter:
+    windows = {}
+    for r in rows:
+        windows[Path(r.get("window_dir", "")).name] = r.get("label") or r.get("credit_label")
+    return Counter(windows.values())
+
+
+def main() -> int:
+    a_dir, b_dir = Path(sys.argv[1]), Path(sys.argv[2])
+    a_rows = load_jsonl(a_dir / "credit_windows.jsonl")
+    b_rows = load_jsonl(b_dir / "credit_windows.jsonl")
+    a_sum = json.loads((a_dir / "summary.json").read_text())
+    b_sum = json.loads((b_dir / "summary.json").read_text())
+
+    ok = True
+    for f in ("simulated_chunks", "skipped_chunks"):
+        match = a_sum[f] == b_sum[f]
+        ok &= match
+        print(f"{f}: A={a_sum[f]} B={b_sum[f]} {'OK' if match else 'MISMATCH'}")
+
+    ca, cb = label_counts(a_rows), label_counts(b_rows)
+    for label in sorted(set(ca) | set(cb)):
+        na, nb = ca.get(label, 0), cb.get(label, 0)
+        tol = max(1, round(0.02 * max(na, nb)))
+        match = abs(na - nb) <= tol
+        ok &= match
+        print(f"events[{label}]: A={na} B={nb} (tol ±{tol}) {'OK' if match else 'FAIL'}")
+
+    ka, kb = {event_key(r) for r in a_rows}, {event_key(r) for r in b_rows}
+    union = ka | kb
+    jac = len(ka & kb) / len(union) if union else 1.0
+    match = jac >= 0.97
+    ok &= match
+    print(f"credit-row Jaccard: {jac:.4f} (need >= 0.97) {'OK' if match else 'FAIL'}")
+
+    for tag, path in (("A", a_dir), ("B", b_dir)):
+        segs = load_jsonl(path / "segments.jsonl")
+        term = Counter(str(r.get("terminated")) for r in segs)
+        print(f"terminations[{tag}]: {dict(sorted(term.items()))}")
+
+    print("VERDICT:", "PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rlvr/autoresearch/tools/compare_tracker_ab.py
+++ b/rlvr/autoresearch/tools/compare_tracker_ab.py
@@ -15,6 +15,7 @@ frame-keyed comparison is the wrong ruler. The gates:
 Usage: compare_tracker_ab.py <dir_A> <dir_B>
 """
 
+import argparse
 import json
 import re
 import sys
@@ -41,7 +42,14 @@ def label_counts(rows: list[dict]) -> Counter:
 
 
 def main() -> int:
-    a_dir, b_dir = Path(sys.argv[1]), Path(sys.argv[2])
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("dir_a", type=Path, help="mining output dir of run A (reference)")
+    ap.add_argument("dir_b", type=Path, help="mining output dir of run B (candidate)")
+    args = ap.parse_args()
+    a_dir, b_dir = args.dir_a, args.dir_b
+    for d in (a_dir, b_dir):
+        if not (d / "summary.json").exists():
+            ap.error(f"{d} is not a mining output dir (missing summary.json)")
     a_rows = load_jsonl(a_dir / "credit_windows.jsonl")
     b_rows = load_jsonl(b_dir / "credit_windows.jsonl")
     a_sum = json.loads((a_dir / "summary.json").read_text())

--- a/rlvr/autoresearch/tools/compare_tracker_ab.py
+++ b/rlvr/autoresearch/tools/compare_tracker_ab.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
 """Statistical A/B for tracker changes (mpc vs mpc_batched mining runs).
 
-The batched solver is not bit-identical, so this reports the M2 validation
-protocol metrics instead of a bitwise diff:
-- mined event-window counts per label (accept: within ±2% or ±1 event),
-- credit-row overlap Jaccard on (event_key, scene_file) (accept: ≥ 0.97),
-- simulated/skipped chunk counts (must match),
-- segment termination-reason histogram.
+The batched solver is not bit-identical, and a closed-loop rollout amplifies
+per-tick 1e-3-level solver differences over hundreds of steps — so exact
+frame-keyed comparison is the wrong ruler. The gates:
+- simulated/skipped chunk counts must match,
+- mined event-window counts per label within ±2% or ±1 event,
+- EVENT-level match: every window paired by (route, chunk_start, label) —
+  accept when ≥ 95% of windows pair up and the paired offense-frame shift is
+  small (median ≤ 3 frames = 0.3 s); the exact-key Jaccard is reported as
+  information only,
+- segment termination-reason histogram (reported).
 
 Usage: compare_tracker_ab.py <dir_A> <dir_B>
 """
 
 import json
+import re
 import sys
 from collections import Counter
 from pathlib import Path
@@ -59,9 +64,47 @@ def main() -> int:
     ka, kb = {event_key(r) for r in a_rows}, {event_key(r) for r in b_rows}
     union = ka | kb
     jac = len(ka & kb) / len(union) if union else 1.0
-    match = jac >= 0.97
+    print(f"exact credit-row Jaccard (informational): {jac:.4f}")
+
+    # Event-level pairing: (route, chunk_start, label) + nearest offense frame.
+    def parse_windows(rows: list[dict]) -> list[tuple]:
+        out = []
+        seen = set()
+        for r in rows:
+            wd = Path(r.get("window_dir", "")).name
+            if wd in seen:
+                continue
+            seen.add(wd)
+            m = re.match(r"(.+?)_(\d+)_(\d+)_(?:danger|event|credit)_(.+)$", wd)
+            if not m:
+                raise ValueError(f"unparseable window dir name: {wd}")
+            out.append((m.group(1), int(m.group(2)), m.group(4), int(m.group(3))))
+        return out
+
+    wa, wb = parse_windows(a_rows), parse_windows(b_rows)
+    used: set[int] = set()
+    deltas: list[int] = []
+    for route, start, label, frame in wa:
+        best = None
+        for i, (rb, sb, lb, fb) in enumerate(wb):
+            if i in used or (rb, sb, lb) != (route, start, label):
+                continue
+            d = abs(fb - frame)
+            if best is None or d < best[1]:
+                best = (i, d)
+        if best is not None:
+            used.add(best[0])
+            deltas.append(best[1])
+    denom = max(len(wa), len(wb))
+    frac = len(deltas) / denom if denom else 1.0
+    med = sorted(deltas)[len(deltas) // 2] if deltas else 0
+    match = frac >= 0.95 and med <= 3
     ok &= match
-    print(f"credit-row Jaccard: {jac:.4f} (need >= 0.97) {'OK' if match else 'FAIL'}")
+    print(
+        f"event-level match: {len(deltas)}/{denom} paired ({frac:.2%}, need >= 95%), "
+        f"offense-frame |delta| median={med} (need <= 3) max={max(deltas) if deltas else 0} "
+        f"{'OK' if match else 'FAIL'}"
+    )
 
     for tag, path in (("A", a_dir), ("B", b_dir)):
         segs = load_jsonl(path / "segments.jsonl")

--- a/rlvr/autoresearch/tools/dataset_smoke_configs/r2lpl.json
+++ b/rlvr/autoresearch/tools/dataset_smoke_configs/r2lpl.json
@@ -9,7 +9,7 @@
   "chunk_len": 80,
   "start_stride": 80,
   "expected_frame_step": 1,
-  "tracker_mode": "mpc",
+  "tracker_mode": "mpc_batched",
   "timeline_progress_mode": "clock",
   "neighbor_history_mode": "sim",
   "batch_size": 8,

--- a/rlvr/autoresearch/tools/dataset_smoke_configs/r2lpl_ci.json
+++ b/rlvr/autoresearch/tools/dataset_smoke_configs/r2lpl_ci.json
@@ -13,7 +13,7 @@
   "chunk_len": 80,
   "start_stride": 80,
   "expected_frame_step": 1,
-  "tracker_mode": "mpc",
+  "tracker_mode": "mpc_batched",
   "timeline_progress_mode": "clock",
   "neighbor_history_mode": "sim",
   "batch_size": 8,

--- a/rlvr/autoresearch/tools/mine_direct_reproducer_chunks.py
+++ b/rlvr/autoresearch/tools/mine_direct_reproducer_chunks.py
@@ -698,11 +698,12 @@ def main() -> None:
         nonlocal n_credit_rows
         if credit_f is None:
             return
-        for scene_path in sorted(Path(window_dir).glob("credit*.npz")):
-            row = _credit_row_from_saved_scene(scene_path, manifest, label)
-            credit_f.write(json.dumps(row, sort_keys=True) + "\n")
-            n_credit_rows += 1
-        credit_f.flush()
+        with timers("credit_row_reload"):
+            for scene_path in sorted(Path(window_dir).glob("credit*.npz")):
+                row = _credit_row_from_saved_scene(scene_path, manifest, label)
+                credit_f.write(json.dumps(row, sort_keys=True) + "\n")
+                n_credit_rows += 1
+            credit_f.flush()
 
     def flush(chunks: list[Chunk], fout, fskip) -> None:
         nonlocal n_simulated, n_skipped
@@ -712,15 +713,18 @@ def main() -> None:
         kept_chunks = []
 
         def build(chunk: Chunk):
-            return _build_work_unit(
-                chunk,
-                args.sidecar_root,
-                args.prebuild_neighbor_tracks,
-                expected_frame_step=args.expected_frame_step,
-                max_pose_step_m=args.max_pose_step_m,
-                max_pose_speed_mps=args.max_pose_speed_mps,
-                max_yaw_step_rad=args.max_yaw_step_rad,
-            )
+            # NOTE: totals are summed across the build thread pool, so this timer
+            # reports CPU-seconds of timeline build, not wall-clock.
+            with timers("timeline_build"):
+                return _build_work_unit(
+                    chunk,
+                    args.sidecar_root,
+                    args.prebuild_neighbor_tracks,
+                    expected_frame_step=args.expected_frame_step,
+                    max_pose_step_m=args.max_pose_step_m,
+                    max_pose_speed_mps=args.max_pose_speed_mps,
+                    max_yaw_step_rad=args.max_yaw_step_rad,
+                )
 
         workers = max(1, int(args.timeline_build_workers))
         built = []
@@ -875,6 +879,7 @@ def main() -> None:
         "elapsed_sec": round(elapsed, 3),
         "chunks_per_sec": n_simulated / elapsed if elapsed > 0 and n_simulated else 0.0,
         "timers": timers.report(max(1, n_simulated)) if n_simulated else "",
+        "timers_detail": timers.as_dict() if n_simulated else {},
     }
     summary_path.parent.mkdir(parents=True, exist_ok=True)
     summary_path.write_text(json.dumps(summary, indent=2))

--- a/rlvr/autoresearch/tools/mine_direct_reproducer_chunks.py
+++ b/rlvr/autoresearch/tools/mine_direct_reproducer_chunks.py
@@ -541,7 +541,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--goal_reach_m", type=float, default=0.0)
     parser.add_argument("--unstick_after", type=int, default=300)
     parser.add_argument("--unstick_advance_m", type=float, default=5.0)
-    parser.add_argument("--tracker_mode", choices=["mpc", "mpc_batched", "perfect"], default="mpc")
+    parser.add_argument(
+        "--tracker_mode", choices=["mpc", "mpc_batched", "perfect"], default="mpc_batched"
+    )
     parser.add_argument("--timeline_progress_mode", choices=["clock", "pose"], default="clock")
     parser.add_argument("--neighbor_history_mode", choices=["sim", "recorded"], default="sim")
     parser.add_argument("--gpu_transform", action="store_true")

--- a/rlvr/autoresearch/tools/mine_direct_reproducer_chunks.py
+++ b/rlvr/autoresearch/tools/mine_direct_reproducer_chunks.py
@@ -541,7 +541,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--goal_reach_m", type=float, default=0.0)
     parser.add_argument("--unstick_after", type=int, default=300)
     parser.add_argument("--unstick_advance_m", type=float, default=5.0)
-    parser.add_argument("--tracker_mode", choices=["mpc", "perfect"], default="mpc")
+    parser.add_argument("--tracker_mode", choices=["mpc", "mpc_batched", "perfect"], default="mpc")
     parser.add_argument("--timeline_progress_mode", choices=["clock", "pose"], default="clock")
     parser.add_argument("--neighbor_history_mode", choices=["sim", "recorded"], default="sim")
     parser.add_argument("--gpu_transform", action="store_true")

--- a/rlvr/autoresearch/tools/reproducer_danger_scorer.py
+++ b/rlvr/autoresearch/tools/reproducer_danger_scorer.py
@@ -96,15 +96,25 @@ def _np_dict_to_scoring_tensors(
     *,
     device: torch.device,
 ) -> dict[str, torch.Tensor]:
+    """Normalize a scene dict (numpy arrays OR torch tensors) to scoring tensors.
+
+    Values that are already tensors on the right device/dtype pass through
+    without a copy (``Tensor.to`` is a no-op then) — the rollout hands the
+    scorer GPU-resident slices of the batched model input, so the per-segment
+    host->device re-upload this function used to force is gone.
+    """
     out: dict[str, torch.Tensor] = {}
     for key, value in np_dict.items():
-        array = np.asarray(value)
         if key in {"lanes_has_speed_limit", "route_lanes_has_speed_limit"}:
-            out[key] = torch.as_tensor(array, dtype=torch.bool, device=device)
+            dtype = torch.bool
         elif key in {"turn_indicators", "delay"}:
-            out[key] = torch.as_tensor(array, dtype=torch.long, device=device)
+            dtype = torch.long
         else:
-            out[key] = torch.as_tensor(array, dtype=torch.float32, device=device)
+            dtype = torch.float32
+        if torch.is_tensor(value):
+            out[key] = value.to(device=device, dtype=dtype)
+        else:
+            out[key] = torch.as_tensor(np.asarray(value), dtype=dtype, device=device)
     if "delay" not in out:
         out["delay"] = torch.zeros((1,), dtype=torch.long, device=device)
     return out

--- a/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
+++ b/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
@@ -1176,6 +1176,11 @@ def _ensure_4col_neighbor_futures(
     todo = sorted({p for p in paths if _cached(p) is None})
     if todo:
         out_dir.mkdir(parents=True, exist_ok=True)
+        # A crash mid-conversion leaves .tmp_* orphans behind (their conversions
+        # were never recorded in the manifest, so they are pure garbage) — sweep
+        # them before converting rather than letting them accumulate forever.
+        for stale in out_dir.glob(".tmp_*"):
+            stale.unlink()
         with ThreadPoolExecutor(max_workers=max(1, workers)) as pool:
             markers = list(pool.map(lambda p: _convert_scene_to_4col(Path(p), out_dir), todo))
         for src, marker in zip(todo, markers):

--- a/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
+++ b/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
@@ -933,9 +933,12 @@ def _materialize_chunk_manifest_for_shards(
     # which must not change mid-campaign anyway (guard comparability rule) — so
     # plan once at the CAMPAIGN level and reuse across rounds. A knob mismatch
     # against an existing campaign plan fails loudly instead of silently
-    # re-planning with different chunking.
+    # re-planning with different chunking. The scene list is keyed by CONTENT
+    # digest, not pathname: a list regenerated in place before a resumed round
+    # must not silently reuse a plan built over the old pool.
     plan_key = {
         "scene_list": str(scene_list),
+        "scene_list_sha256": hashlib.sha256(Path(scene_list).read_bytes()).hexdigest(),
         "chunk_len": mining.get("chunk_len", 80),
         "start_stride": mining.get("start_stride", mining.get("chunk_len", 80)),
         **{

--- a/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
+++ b/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
@@ -946,7 +946,11 @@ def _materialize_chunk_manifest_for_shards(
     }
     manifest = rdir.parent / "planned_chunks.jsonl"
     plan_key_path = rdir.parent / "planned_chunks.key.json"
-    if manifest.exists() and plan_key_path.exists():
+    # The knob guard hangs off the KEY file alone: a surviving key with a
+    # missing/deleted manifest must still fail loudly on a knob change (the
+    # re-plan branch would otherwise silently overwrite the key), and a
+    # matching key with a lost manifest just re-plans with the same knobs.
+    if plan_key_path.exists():
         prior_key = json.loads(plan_key_path.read_text())
         if prior_key != plan_key:
             raise ValueError(
@@ -954,7 +958,7 @@ def _materialize_chunk_manifest_for_shards(
                 f"({prior_key}) than this round requests ({plan_key}); chunking "
                 "must stay constant within a campaign"
             )
-    else:
+    if not (manifest.exists() and plan_key_path.exists()):
         cmd = [
             sys.executable,
             "-m",
@@ -1147,17 +1151,26 @@ def _ensure_4col_neighbor_futures(
     still exists; conversions run on a thread pool (zlib releases the GIL).
     """
     manifest_path = out_dir / "conversion_manifest.json"
-    manifest: dict[str, str] = {}
+    manifest: dict[str, dict] = {}
     if manifest_path.exists():
         manifest = json.loads(manifest_path.read_text())
 
+    def _src_stamp(src: str) -> dict:
+        st = Path(src).stat()
+        return {"size": st.st_size, "mtime_ns": st.st_mtime_ns}
+
     def _cached(src: str) -> str | None:
-        marker = manifest.get(src)
-        if marker is None:
+        entry = manifest.get(src)
+        if not isinstance(entry, dict):
             return None
+        # The cache is path-keyed; a scene regenerated IN PLACE with different
+        # content must not serve a stale conversion — validate the source stamp.
+        if {k: entry.get(k) for k in ("size", "mtime_ns")} != _src_stamp(src):
+            return None
+        marker = entry.get("marker")
         if marker == _4COL_PASSTHROUGH:
             return src
-        dst = out_dir / marker
+        dst = out_dir / str(marker)
         return str(dst) if dst.exists() else None
 
     todo = sorted({p for p in paths if _cached(p) is None})
@@ -1166,7 +1179,7 @@ def _ensure_4col_neighbor_futures(
         with ThreadPoolExecutor(max_workers=max(1, workers)) as pool:
             markers = list(pool.map(lambda p: _convert_scene_to_4col(Path(p), out_dir), todo))
         for src, marker in zip(todo, markers):
-            manifest[src] = marker
+            manifest[src] = {"marker": marker, **_src_stamp(src)}
         tmp_manifest = out_dir / f".tmp_manifest_{os.getpid()}.json"
         tmp_manifest.write_text(json.dumps(manifest, indent=2, sort_keys=True))
         os.replace(tmp_manifest, manifest_path)

--- a/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
+++ b/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import time
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
@@ -928,25 +929,51 @@ def _materialize_chunk_manifest_for_shards(
     if scene_list is None:
         return cfg
 
-    manifest = rdir / "planned_chunks.jsonl"
-    cmd = [
-        sys.executable,
-        "-m",
-        "rlvr.autoresearch.tools.mine_direct_reproducer_chunks",
-        "--scene_list",
-        str(scene_list),
-        "--segments_jsonl",
-        str(manifest),
-        "--plan_only",
-        "--chunk_len",
-        str(mining.get("chunk_len", 80)),
-        "--start_stride",
-        str(mining.get("start_stride", mining.get("chunk_len", 80))),
-    ]
-    for key in ("expected_frame_step", "min_chunk_len", "max_scenes"):
-        if key in mining and mining[key] is not None:
-            cmd.extend([f"--{key}", str(mining[key])])
-    _run(cmd, rdir / "plan_chunks.log")
+    # The plan pass is a deterministic function of (scene_list, chunking knobs),
+    # which must not change mid-campaign anyway (guard comparability rule) — so
+    # plan once at the CAMPAIGN level and reuse across rounds. A knob mismatch
+    # against an existing campaign plan fails loudly instead of silently
+    # re-planning with different chunking.
+    plan_key = {
+        "scene_list": str(scene_list),
+        "chunk_len": mining.get("chunk_len", 80),
+        "start_stride": mining.get("start_stride", mining.get("chunk_len", 80)),
+        **{
+            key: mining[key]
+            for key in ("expected_frame_step", "min_chunk_len", "max_scenes")
+            if key in mining and mining[key] is not None
+        },
+    }
+    manifest = rdir.parent / "planned_chunks.jsonl"
+    plan_key_path = rdir.parent / "planned_chunks.key.json"
+    if manifest.exists() and plan_key_path.exists():
+        prior_key = json.loads(plan_key_path.read_text())
+        if prior_key != plan_key:
+            raise ValueError(
+                f"campaign chunk plan {manifest} was built with different knobs "
+                f"({prior_key}) than this round requests ({plan_key}); chunking "
+                "must stay constant within a campaign"
+            )
+    else:
+        cmd = [
+            sys.executable,
+            "-m",
+            "rlvr.autoresearch.tools.mine_direct_reproducer_chunks",
+            "--scene_list",
+            str(scene_list),
+            "--segments_jsonl",
+            str(manifest),
+            "--plan_only",
+            "--chunk_len",
+            str(plan_key["chunk_len"]),
+            "--start_stride",
+            str(plan_key["start_stride"]),
+        ]
+        for key in ("expected_frame_step", "min_chunk_len", "max_scenes"):
+            if key in plan_key:
+                cmd.extend([f"--{key}", str(plan_key[key])])
+        _run(cmd, rdir / "plan_chunks.log")
+        plan_key_path.write_text(json.dumps(plan_key, indent=2, sort_keys=True))
 
     updated = dict(cfg)
     mining["chunk_manifest"] = str(manifest)
@@ -1068,7 +1095,41 @@ def _anchor_slice_paths(
     return picked
 
 
-def _ensure_4col_neighbor_futures(paths: list[str], out_dir: Path) -> list[str]:
+_4COL_PASSTHROUGH = "__4col_passthrough__"
+
+
+def _convert_scene_to_4col(src: Path, out_dir: Path) -> str:
+    """Convert one scene; returns the dst basename, or the passthrough marker.
+
+    The converted NPZ is written atomically (tmp + ``os.replace``) so a crash
+    mid-write can never leave a truncated file that a later cached run trusts.
+    """
+    from planner_metrics.scene_format import future_to_4col as _future_to_4col
+
+    with np.load(src) as loaded:
+        future = loaded["neighbor_agents_future"]
+        if future.shape[-1] == 4:
+            return _4COL_PASSTHROUGH
+        if future.shape[-1] != 3:
+            raise ValueError(
+                f"{src}: neighbor_agents_future has {future.shape[-1]} channels; "
+                "expected 3 [x, y, heading] or 4 [x, y, cos, sin]"
+            )
+        data = dict(loaded)
+    data["neighbor_agents_future"] = _future_to_4col(future)
+    # Anchor pools may mix source dirs with colliding basenames — prefix
+    # with a stable hash of the source path.
+    digest = hashlib.sha1(str(src).encode()).hexdigest()[:10]
+    dst_name = f"{digest}_{src.name}"
+    tmp = out_dir / f".tmp_{os.getpid()}_{dst_name}"
+    np.savez_compressed(tmp, **data)
+    os.replace(tmp, out_dir / dst_name)
+    return dst_name
+
+
+def _ensure_4col_neighbor_futures(
+    paths: list[str], out_dir: Path, *, workers: int = 8
+) -> list[str]:
     """Homogenize ``neighbor_agents_future`` to the 4-col training schema.
 
     Repaired/replay scenes carry 4-col ``[x, y, cos, sin]`` neighbor futures
@@ -1078,31 +1139,44 @@ def _ensure_4col_neighbor_futures(paths: list[str], out_dir: Path) -> list[str]:
     copies under ``out_dir`` with the canonical converter (zero padding rows
     stay zero, so the trainer's validity mask is preserved); 4-col scenes pass
     through by original path.
+
+    Conversions are cached in ``out_dir/conversion_manifest.json``: callers
+    pass a CAMPAIGN-level ``out_dir`` so the (large, mostly-static) anchor and
+    normal pools are decompressed/re-compressed once per campaign instead of
+    once per round. A manifest entry is only trusted when its converted file
+    still exists; conversions run on a thread pool (zlib releases the GIL).
     """
-    from planner_metrics.scene_format import future_to_4col as _future_to_4col
+    manifest_path = out_dir / "conversion_manifest.json"
+    manifest: dict[str, str] = {}
+    if manifest_path.exists():
+        manifest = json.loads(manifest_path.read_text())
+
+    def _cached(src: str) -> str | None:
+        marker = manifest.get(src)
+        if marker is None:
+            return None
+        if marker == _4COL_PASSTHROUGH:
+            return src
+        dst = out_dir / marker
+        return str(dst) if dst.exists() else None
+
+    todo = sorted({p for p in paths if _cached(p) is None})
+    if todo:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        with ThreadPoolExecutor(max_workers=max(1, workers)) as pool:
+            markers = list(pool.map(lambda p: _convert_scene_to_4col(Path(p), out_dir), todo))
+        for src, marker in zip(todo, markers):
+            manifest[src] = marker
+        tmp_manifest = out_dir / f".tmp_manifest_{os.getpid()}.json"
+        tmp_manifest.write_text(json.dumps(manifest, indent=2, sort_keys=True))
+        os.replace(tmp_manifest, manifest_path)
 
     out: list[str] = []
     for path in paths:
-        src = Path(path)
-        with np.load(src) as loaded:
-            future = loaded["neighbor_agents_future"]
-            if future.shape[-1] == 4:
-                out.append(str(src))
-                continue
-            if future.shape[-1] != 3:
-                raise ValueError(
-                    f"{src}: neighbor_agents_future has {future.shape[-1]} channels; "
-                    "expected 3 [x, y, heading] or 4 [x, y, cos, sin]"
-                )
-            data = dict(loaded)
-        data["neighbor_agents_future"] = _future_to_4col(future)
-        out_dir.mkdir(parents=True, exist_ok=True)
-        # Anchor pools may mix source dirs with colliding basenames — prefix
-        # with a stable hash of the source path.
-        digest = hashlib.sha1(str(src).encode()).hexdigest()[:10]
-        dst = out_dir / f"{digest}_{src.name}"
-        np.savez_compressed(dst, **data)
-        out.append(str(dst))
+        resolved = _cached(path)
+        if resolved is None:
+            raise RuntimeError(f"4-col conversion did not produce an output for {path}")
+        out.append(resolved)
     return out
 
 
@@ -1192,7 +1266,9 @@ def _rsft_scene_args(
         )
     normal_paths = _ensure_4col_neighbor_futures(
         [str(p) for p in _read_json_list(Path(normal_list))],
-        rdir / "normal_scenes_4col",
+        # Campaign-level cache dir: the normal pool is identical every round,
+        # so the (large) conversion pass runs once per campaign, not per round.
+        rdir.parent / "normal_scenes_4col",
     )
     resolved_normals = rdir / "normal_scenes_resolved.json"
     resolved_normals.write_text(json.dumps(normal_paths, indent=2))
@@ -2759,7 +2835,11 @@ def main() -> None:
             cfg.get("anchor"), len(set(repaired_paths) | set(replay_paths)), round_idx
         )
         if anchor_paths:
-            anchor_paths = _ensure_4col_neighbor_futures(anchor_paths, rdir / "anchor_scenes_4col")
+            # Campaign-level cache dir: the anchor pool is largely the same
+            # scenes every round, so convert once per campaign, not per round.
+            anchor_paths = _ensure_4col_neighbor_futures(
+                anchor_paths, rdir.parent / "anchor_scenes_4col"
+            )
             print(
                 f"[round {round_idx}] anchor slice: {len(anchor_paths)} real scenes "
                 f"({len(repaired_paths)} repaired + {len(replay_paths)} replay)"

--- a/rlvr/autoresearch/tools/test_classify_moving_diagnostics_batch.py
+++ b/rlvr/autoresearch/tools/test_classify_moving_diagnostics_batch.py
@@ -1,0 +1,78 @@
+"""Parity test: `_moving_diagnostics_batch` vs the scalar `_moving_diagnostics`.
+
+The batched path replaced per-candidate batch-1 clearance passes in
+`classify_loaded_scene_candidates_batch`; the scalar function is kept as the
+reference implementation and this test pins the two to identical outputs on
+randomized scenes (including zero-neighbor and stopped-neighbor cases).
+"""
+
+import numpy as np
+import torch
+
+from planner_metrics.config import RewardConfig
+from rlvr.autoresearch.tools.classify_scene_failures import (
+    _moving_diagnostics,
+    _moving_diagnostics_batch,
+)
+
+
+def _random_scene(rng: np.random.Generator, n_nb: int, T: int) -> dict[str, torch.Tensor]:
+    nf = np.zeros((max(n_nb, 1), T, 4), dtype=np.float32)
+    for i in range(n_nb):
+        speed = rng.uniform(0.0, 8.0) if rng.random() > 0.3 else 0.0  # some stopped
+        yaw = rng.uniform(-np.pi, np.pi)
+        start = rng.uniform(-15, 15, size=2)
+        steps = start + np.outer(np.arange(T), speed * 0.1 * np.array([np.cos(yaw), np.sin(yaw)]))
+        nf[i, :, 0] = steps[:, 0]
+        nf[i, :, 1] = steps[:, 1]
+        nf[i, :, 2] = np.cos(yaw)
+        nf[i, :, 3] = np.sin(yaw)
+    return {
+        "neighbor_agents_future": torch.from_numpy(nf[None]),
+        "neighbor_agents_past": torch.zeros(1, max(n_nb, 1), 3, 11),
+        "ego_shape": torch.tensor([[3.0, 4.5, 2.0]], dtype=torch.float32),
+    }
+
+
+def _random_candidates(rng: np.random.Generator, N: int, T: int) -> torch.Tensor:
+    trajs = np.zeros((N, T, 4), dtype=np.float32)
+    for n in range(N):
+        speed = rng.uniform(0.5, 8.0)
+        trajs[n, :, 0] = speed * 0.1 * np.arange(1, T + 1)
+        trajs[n, :, 1] = rng.uniform(-0.5, 0.5)
+        trajs[n, :, 2] = 1.0
+    return torch.from_numpy(trajs)
+
+
+def test_moving_diagnostics_batch_matches_scalar():
+    rng = np.random.default_rng(0)
+    device = torch.device("cpu")
+    config = RewardConfig()
+    for trial, n_nb in enumerate([0, 1, 3, 8, 20]):
+        T, N = 20, 5
+        data = _random_scene(rng, n_nb, T)
+        trajs = _random_candidates(rng, N, T)
+        batch_rows = _moving_diagnostics_batch(trajs, data, config, 0.2, 0.7, device)
+        assert len(batch_rows) == N
+        for n in range(N):
+            scalar_row = _moving_diagnostics(trajs[n : n + 1], data, config, 0.2, 0.7, device)
+            assert batch_rows[n] == scalar_row, (
+                f"trial {trial} (n_nb={n_nb}) candidate {n}: {batch_rows[n]} != {scalar_row}"
+            )
+
+
+def test_moving_diagnostics_batch_rear_end_gate():
+    """Rear-end suppression path (ignore_rear_end_collisions=True) also matches."""
+    rng = np.random.default_rng(1)
+    device = torch.device("cpu")
+    config = RewardConfig(ignore_rear_end_collisions=True)
+    data = _random_scene(rng, 6, 20)
+    # Force one neighbor to sit right behind the ego path (rear-end geometry).
+    nf = data["neighbor_agents_future"][0]
+    nf[0, :, 0] = -1.0
+    nf[0, :, 1] = 0.0
+    trajs = _random_candidates(rng, 4, 20)
+    batch_rows = _moving_diagnostics_batch(trajs, data, config, 0.2, 0.7, device)
+    for n in range(4):
+        scalar_row = _moving_diagnostics(trajs[n : n + 1], data, config, 0.2, 0.7, device)
+        assert batch_rows[n] == scalar_row

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -4749,6 +4749,12 @@ def test_materialize_chunk_manifest_campaign_cache(tmp_path, monkeypatch):
     with pytest.raises(ValueError, match="different knobs"):
         round_runner._materialize_chunk_manifest_for_shards(bad_cfg, r2)
 
+    # A scene list regenerated IN PLACE (same path, new content) must fail
+    # loudly too — the plan is keyed by content digest, not pathname.
+    scene_list.write_text('["/data/new_scene.npz"]')
+    with pytest.raises(ValueError, match="different knobs"):
+        round_runner._materialize_chunk_manifest_for_shards(cfg, r2)
+
 
 def test_replay_capacity_is_required():
     with pytest.raises(ValueError, match="capacity is required"):

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -1844,6 +1844,9 @@ def test_verify_credit_rollout_saves_first_realized_event_window(monkeypatch, tm
         batch_size=1,
         n_build_threads=1,
         prefetch_ahead=0,
+        # window-saving tests fake _advance_step / seg states: pin the serial
+        # tracker so the mpc_batched default's solve precompute stays out.
+        tracker_mode="mpc",
         verify_credit_windows=[
             {
                 "route_key": "bagA",
@@ -2009,6 +2012,9 @@ def test_direct_danger_window_saves_realized_moving_collision(monkeypatch, tmp_p
         batch_size=1,
         n_build_threads=1,
         prefetch_ahead=0,
+        # window-saving tests fake _advance_step / seg states: pin the serial
+        # tracker so the mpc_batched default's solve precompute stays out.
+        tracker_mode="mpc",
         route_keys=["bagA"],
         danger_save_dir=tmp_path,
         danger_scorer=_fake_danger_scorer,
@@ -2141,6 +2147,9 @@ def test_direct_danger_window_saves_raw_collision_when_scorers_miss(monkeypatch,
         batch_size=1,
         n_build_threads=1,
         prefetch_ahead=0,
+        # window-saving tests fake _advance_step / seg states: pin the serial
+        # tracker so the mpc_batched default's solve precompute stays out.
+        tracker_mode="mpc",
         route_keys=["bagA"],
         danger_save_dir=tmp_path,
         danger_scorer=_fake_clean_scorer,

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -786,7 +786,11 @@ def test_round_runner_mining_shards_use_private_outputs_and_merge(monkeypatch, t
             assert cmd[cmd.index("--num_shards") + 1] == "2"
             assert cmd[cmd.index("--shard_index") + 1] == str(expected_idx)
             assert "--chunk_manifest" in cmd
-            assert cmd[cmd.index("--chunk_manifest") + 1] == str(rdir / "planned_chunks.jsonl")
+            # The plan pass is cached at the CAMPAIGN level (rdir.parent) so
+            # later rounds reuse it instead of re-planning the full pool.
+            assert cmd[cmd.index("--chunk_manifest") + 1] == str(
+                rdir.parent / "planned_chunks.jsonl"
+            )
             assert "--scene_list" not in cmd
             _arg(cmd, "--out_jsonl").parent.mkdir(parents=True, exist_ok=True)
             _arg(cmd, "--out_jsonl").write_text(
@@ -1804,7 +1808,7 @@ def test_verify_credit_rollout_saves_first_realized_event_window(monkeypatch, tm
             else {"labels": ["clean"], "label": "clean"}
         )
 
-    def _fake_advance_step(s, pred, idx, device, timers):
+    def _fake_advance_step(s, pred, idx, device, timers, tracked=None):
         s.k += 1
 
     def _fake_finalize(s, *args, **kwargs):
@@ -1971,7 +1975,7 @@ def test_direct_danger_window_saves_realized_moving_collision(monkeypatch, tmp_p
             else {"labels": ["clean"], "label": "clean"}
         )
 
-    def _fake_advance_step(s, pred, idx, device, timers):
+    def _fake_advance_step(s, pred, idx, device, timers, tracked=None):
         s.k += 1
 
     def _fake_finalize(s, *args, **kwargs):
@@ -2109,7 +2113,7 @@ def test_direct_danger_window_saves_raw_collision_when_scorers_miss(monkeypatch,
     def _fake_clean_realized(*_args, **_kwargs):
         return {"labels": ["clean"], "label": "clean"}
 
-    def _fake_advance_step(s, pred, idx, device, timers):
+    def _fake_advance_step(s, pred, idx, device, timers, tracked=None):
         s.k += 1
 
     def _fake_finalize(s, *args, **kwargs):
@@ -3179,11 +3183,17 @@ def test_build_repaired_targets_preserves_simulated_context(monkeypatch, tmp_pat
     monkeypatch.setattr(
         build_repaired_targets_tool,
         "classify_loaded_scene_candidates_batch",
-        lambda *_args, **_kwargs: [[{"labels": ["clean"]}]],
+        # return_subscores=True contract: (rows_per_scene, B-major subscores)
+        lambda *_args, **_kwargs: ([[{"labels": ["clean"]}]], {}),
     )
     monkeypatch.setattr(
         build_repaired_targets_tool,
         "compute_reward_batch",
+        lambda *_args, **_kwargs: [SimpleNamespace(total=1.0)],
+    )
+    monkeypatch.setattr(
+        build_repaired_targets_tool,
+        "_shape_reward",
         lambda *_args, **_kwargs: [SimpleNamespace(total=1.0)],
     )
     monkeypatch.setattr(

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -4658,6 +4658,70 @@ def test_ensure_4col_neighbor_futures_converts_only_3col(tmp_path):
     assert stacked.shape == (2, 4, 80, 4)
 
 
+def test_ensure_4col_neighbor_futures_caches_across_calls(tmp_path):
+    """The 4-col rewrite is called with a CAMPAIGN-level out_dir every round; a
+    second call over the same pool must reuse the manifest + converted files
+    instead of re-decompressing/re-compressing every scene, and a converted
+    file deleted out from under the manifest must be rebuilt (a stale manifest
+    entry is never trusted blindly)."""
+    three = {
+        "ego_agent_future": np.zeros((80, 3), dtype=np.float32),
+        "neighbor_agents_future": np.zeros((4, 80, 3), dtype=np.float32),
+    }
+    three["neighbor_agents_future"][0, :, 0] = 1.0
+    p3 = tmp_path / "logged_scene.npz"
+    np.savez(p3, **three)
+    out_dir = tmp_path / "converted"
+
+    first = round_runner._ensure_4col_neighbor_futures([str(p3)], out_dir)
+    manifest = json.loads((out_dir / "conversion_manifest.json").read_text())
+    assert manifest[str(p3)] == Path(first[0]).name
+    mtime = Path(first[0]).stat().st_mtime_ns
+
+    second = round_runner._ensure_4col_neighbor_futures([str(p3)], out_dir)
+    assert second == first
+    assert Path(first[0]).stat().st_mtime_ns == mtime  # cached: not rewritten
+
+    Path(first[0]).unlink()  # simulate a lost/partial conversion
+    third = round_runner._ensure_4col_neighbor_futures([str(p3)], out_dir)
+    assert third == first
+    assert Path(first[0]).exists()  # rebuilt, not blindly trusted
+
+
+def test_materialize_chunk_manifest_campaign_cache(tmp_path, monkeypatch):
+    """The plan_only chunk pass is planned once per CAMPAIGN and reused across
+    rounds; a knob change against the cached plan fails loudly (chunking must
+    stay constant within a campaign for guard comparability)."""
+    scene_list = tmp_path / "scenes.json"
+    scene_list.write_text("[]")
+    out_dir = tmp_path / "campaign"
+    r1 = out_dir / "r2lpl_round_001"
+    r2 = out_dir / "r2lpl_round_002"
+    r1.mkdir(parents=True)
+    r2.mkdir(parents=True)
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, log_path, env=None):
+        calls.append([str(c) for c in cmd])
+        Path(out_dir / "planned_chunks.jsonl").write_text("")
+        return 0.0
+
+    monkeypatch.setattr(round_runner, "_run", fake_run)
+    cfg = {"perception_mining": {"scene_list": str(scene_list), "chunk_len": 160}}
+
+    got1 = round_runner._materialize_chunk_manifest_for_shards(cfg, r1)
+    assert len(calls) == 1
+    assert got1["perception_mining"]["chunk_manifest"] == str(out_dir / "planned_chunks.jsonl")
+
+    got2 = round_runner._materialize_chunk_manifest_for_shards(cfg, r2)
+    assert len(calls) == 1  # reused, no second plan pass
+    assert got2["perception_mining"]["chunk_manifest"] == str(out_dir / "planned_chunks.jsonl")
+
+    bad_cfg = {"perception_mining": {"scene_list": str(scene_list), "chunk_len": 80}}
+    with pytest.raises(ValueError, match="different knobs"):
+        round_runner._materialize_chunk_manifest_for_shards(bad_cfg, r2)
+
+
 def test_replay_capacity_is_required():
     with pytest.raises(ValueError, match="capacity is required"):
         round_runner._required_replay_capacity({})

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -4694,7 +4694,7 @@ def test_ensure_4col_neighbor_futures_caches_across_calls(tmp_path):
 
     first = round_runner._ensure_4col_neighbor_futures([str(p3)], out_dir)
     manifest = json.loads((out_dir / "conversion_manifest.json").read_text())
-    assert manifest[str(p3)] == Path(first[0]).name
+    assert manifest[str(p3)]["marker"] == Path(first[0]).name
     mtime = Path(first[0]).stat().st_mtime_ns
 
     second = round_runner._ensure_4col_neighbor_futures([str(p3)], out_dir)
@@ -4705,6 +4705,15 @@ def test_ensure_4col_neighbor_futures_caches_across_calls(tmp_path):
     third = round_runner._ensure_4col_neighbor_futures([str(p3)], out_dir)
     assert third == first
     assert Path(first[0]).exists()  # rebuilt, not blindly trusted
+
+    # A source regenerated IN PLACE (same path, new content/mtime) must be
+    # reconverted — the cache is path-keyed but stamped with size+mtime.
+    three["neighbor_agents_future"][0, :, 1] = 5.0
+    np.savez(p3, **three)
+    fourth = round_runner._ensure_4col_neighbor_futures([str(p3)], out_dir)
+    assert fourth == first
+    with np.load(fourth[0]) as d:
+        np.testing.assert_allclose(d["neighbor_agents_future"][0, :, 1], 5.0)
 
 
 def test_materialize_chunk_manifest_campaign_cache(tmp_path, monkeypatch):

--- a/rlvr/configs/r2lpl_workflow_template.json
+++ b/rlvr/configs/r2lpl_workflow_template.json
@@ -32,7 +32,7 @@
     "anchor_horizon_steps": 40,
     "max_rollout_steps": 80,
     "timeline_progress_mode": "clock",
-    "tracker_mode": "mpc"
+    "tracker_mode": "mpc_batched"
   },
   "repair_generation": {
     "ego_shape": "WB,L,W",

--- a/scenario_generation/metrics/red_light.py
+++ b/scenario_generation/metrics/red_light.py
@@ -32,10 +32,16 @@ def score_red_light_step(
     if "route_lanes" not in np_dict:
         return {"red_light_violation": False}
 
-    rl = np.asarray(np_dict["route_lanes"], dtype=np.float32)
-    if rl.ndim not in (3, 4):
-        return {"red_light_violation": False}
-    rl_t = torch.tensor(rl, dtype=torch.float32, device=device)
+    rl = np_dict["route_lanes"]
+    if torch.is_tensor(rl):  # GPU-resident batch slice from the rollout: no re-upload
+        if rl.dim() not in (3, 4):
+            return {"red_light_violation": False}
+        rl_t = rl.to(device=device, dtype=torch.float32)
+    else:
+        rl_np = np.asarray(rl, dtype=np.float32)
+        if rl_np.ndim not in (3, 4):
+            return {"red_light_violation": False}
+        rl_t = torch.tensor(rl_np, dtype=torch.float32, device=device)
 
     scores = compute_red_light_score_batch(
         ego_traj_ego_frame(live_pose, ego_hist, n_steps=2, device=device),

--- a/scenario_generation/metrics/road_border.py
+++ b/scenario_generation/metrics/road_border.py
@@ -9,6 +9,15 @@ from planner_metrics.config import RewardConfig
 from planner_metrics.subscores import compute_road_border_penalty
 
 
+def _as_float_tensor(value, device: str) -> torch.Tensor:
+    """numpy array OR torch tensor -> float32 tensor on ``device``, no copy
+    when it already matches (lets the rollout pass GPU-resident batch slices
+    instead of forcing a host->device upload every step)."""
+    if torch.is_tensor(value):
+        return value.to(device=device, dtype=torch.float32)
+    return torch.tensor(np.asarray(value), dtype=torch.float32, device=device)
+
+
 def score_road_border_step(np_dict: dict, *, device: str) -> dict:
     """Ego-to-road-border distance at the current step.
 
@@ -18,17 +27,13 @@ def score_road_border_step(np_dict: dict, *, device: str) -> dict:
     """
     rb_dist_m = float("inf")
     if "line_strings" in np_dict and "ego_shape" in np_dict:
-        ego_shape_t = torch.tensor(
-            np.asarray(np_dict["ego_shape"]).reshape(-1)[:3],
-            dtype=torch.float32,
-            device=device,
-        )
+        ego_shape_t = _as_float_tensor(np_dict["ego_shape"], device).reshape(-1)[:3]
         traj = torch.zeros(1, 1, 4, dtype=torch.float32, device=device)
         traj[..., 2] = 1.0  # origin, heading +x
-        ls = np.asarray(np_dict["line_strings"])
-        if ls.ndim == 4:
+        ls = _as_float_tensor(np_dict["line_strings"], device)
+        if ls.dim() == 4:
             ls = ls[0]
-        data = {"line_strings": torch.tensor(ls, dtype=torch.float32, device=device)}
+        data = {"line_strings": ls}
         _gate, _near, _wide, _steps, _cont, per_ts_min = compute_road_border_penalty(
             traj, ego_shape_t, data, config=RewardConfig()
         )

--- a/scenario_generation/mpc_tracker.py
+++ b/scenario_generation/mpc_tracker.py
@@ -317,21 +317,18 @@ class MPCTracker:
     # Public API
     # ------------------------------------------------------------------
 
-    def track(
+    def _build_ref_and_init(
         self,
         x0: np.ndarray,
         ref_world: np.ndarray,
-    ) -> tuple[np.ndarray, float]:
-        """Run one MPC step: optimise controls, apply first step.
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Build the MPC-horizon reference + warm-start knots for one solve.
 
-        Args:
-            x0: (4,) [x, y, yaw, v] current state in world frame.
-            ref_world: (N, 3) reference [x, y, yaw] in world frame.
-                At least *horizon* rows; extras are ignored.
+        Shared verbatim by ``track()`` and the batched solver
+        (``mpc_tracker_batched.track_many``), so the idle-recovery /
+        warm-start semantics can never drift between the two paths.
 
-        Returns:
-            new_pos: (3,) [x, y, yaw] after one dt step.
-            new_speed: scalar speed after one dt step.
+        Returns (ref (horizon, 3), init (n_knots, 2)).
         """
         # Idle-recovery check uses the model's FULL prediction horizon,
         # not the MPC's truncated window. Post-stop the model typically
@@ -407,6 +404,25 @@ class MPCTracker:
             init[:, 0] = a_guess
         else:
             init = np.zeros((self.n_knots, 2), dtype=np.float64)
+        return ref, init
+
+    def track(
+        self,
+        x0: np.ndarray,
+        ref_world: np.ndarray,
+    ) -> tuple[np.ndarray, float]:
+        """Run one MPC step: optimise controls, apply first step.
+
+        Args:
+            x0: (4,) [x, y, yaw, v] current state in world frame.
+            ref_world: (N, 3) reference [x, y, yaw] in world frame.
+                At least *horizon* rows; extras are ignored.
+
+        Returns:
+            new_pos: (3,) [x, y, yaw] after one dt step.
+            new_speed: scalar speed after one dt step.
+        """
+        ref, init = self._build_ref_and_init(x0, ref_world)
 
         # Tightened tolerance / iter caps. The smooth quadratic-ish cost
         # converges long before maxiter=50 in the typical case; profiles

--- a/scenario_generation/mpc_tracker_batched.py
+++ b/scenario_generation/mpc_tracker_batched.py
@@ -1,0 +1,221 @@
+"""Batched MPC solve across independent rollout segments.
+
+The closed-loop reproducer advances B segments per tick; with
+``tracker_mode="mpc"`` that is B *serial* ``scipy.optimize.minimize`` calls,
+each evaluating a cost/adjoint written as Python loops over the 20-step
+horizon — the single largest CPU sink of the mining rollout (44% of elapsed
+on the perf-audit workload).
+
+``track_many`` solves all B problems in ONE L-BFGS-B call: the problems are
+independent, so the sum of their costs decouples and its gradient is the
+concatenation of the per-problem gradients. Every cost/gradient evaluation is
+vectorized over B (the H-step forward rollout and reverse adjoint sweep run as
+(B,)-shaped numpy ops), replacing B × (Python-loop evaluations + solver
+overhead) with one vectorized solve.
+
+Note on device choice: at B≈16 segments × 10 decision variables the
+arithmetic is far too small for a GPU to win (kernel-launch overhead would
+dominate); vectorized CPU numpy is the right execution model here. The
+speedup comes from batching out the Python/solver overhead, not from CUDA.
+
+Semantics: the per-segment reference building (idle recovery), warm start,
+bounds, first-control application and telemetry are shared with
+``MPCTracker`` (``_build_ref_and_init`` and the same application formulas).
+The optimizer trajectory differs from B independent solves (L-BFGS curvature
+estimates and the line search are shared across the concatenated problem), so
+results are NOT bit-identical to ``tracker_mode="mpc"`` — they must stay
+statistically equivalent, which ``validate_mpc_batched.py`` checks (tracking
+RMSE, per-label mined events, credit-row overlap).
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from scipy.optimize import minimize
+
+from scenario_generation.mpc_tracker import MPCTracker
+
+_SHARED_KNOBS = (
+    "horizon",
+    "n_knots",
+    "dt",
+    "max_accel",
+    "min_accel",
+    "max_steer",
+    "max_speed",
+    "w_pos",
+    "w_head",
+    "w_accel",
+    "w_steer",
+    "w_jerk",
+    "w_steer_rate",
+)
+
+
+def _batched_cost_and_grad(
+    flat: np.ndarray,
+    x0s: np.ndarray,
+    refs: np.ndarray,
+    wheelbases: np.ndarray,
+    proto: MPCTracker,
+) -> tuple[float, np.ndarray]:
+    """Sum of per-segment MPC costs + concatenated gradient, vectorized over B.
+
+    Same math as ``MPCTracker._cost_and_grad`` with a leading batch dimension
+    (verified term-by-term against it in the unit tests); ``wheelbases`` is
+    per-segment, every other knob is shared (asserted by ``track_many``).
+    """
+    B = x0s.shape[0]
+    K, H, sk = proto.n_knots, proto.horizon, proto.steps_per_knot
+    dt, v_max, wb = proto.dt, proto.max_speed, wheelbases
+
+    knots = flat.reshape(B, K, 2)
+    controls = np.repeat(knots, sk, axis=1)[:, :H]
+
+    states = np.empty((B, H + 1, 4), dtype=np.float64)
+    states[:, 0] = x0s
+    clamped = np.zeros((B, H), dtype=bool)
+    for t in range(H):
+        x, y, yaw, v = (states[:, t, j] for j in range(4))
+        a = controls[:, t, 0]
+        delta = controls[:, t, 1]
+        states[:, t + 1, 0] = x + v * np.cos(yaw) * dt
+        states[:, t + 1, 1] = y + v * np.sin(yaw) * dt
+        states[:, t + 1, 2] = yaw + v * np.tan(delta) / wb * dt
+        v_new = v + a * dt
+        clamped[:, t] = (v_new < 0.0) | (v_new > v_max)
+        states[:, t + 1, 3] = np.clip(v_new, 0.0, v_max)
+
+    pred = states[:, 1:]
+    pos_err = pred[:, :, :2] - refs[:, :, :2]
+    dyaw = pred[:, :, 2] - refs[:, :, 2]
+
+    J = proto.w_pos * (pos_err**2).sum(axis=(1, 2))
+    J += proto.w_head * (1.0 - np.cos(dyaw)).sum(axis=1)
+    J += proto.w_accel * (controls[:, :, 0] ** 2).sum(axis=1)
+    J += proto.w_steer * (controls[:, :, 1] ** 2).sum(axis=1)
+    if K > 1:
+        dk = np.diff(knots, axis=1)
+        J += proto.w_jerk * (dk[:, :, 0] ** 2).sum(axis=1)
+        J += proto.w_steer_rate * (dk[:, :, 1] ** 2).sum(axis=1)
+
+    dJ_dstate_direct = np.zeros((B, H + 1, 4), dtype=np.float64)
+    dJ_dstate_direct[:, 1:, 0] = 2.0 * proto.w_pos * pos_err[:, :, 0]
+    dJ_dstate_direct[:, 1:, 1] = 2.0 * proto.w_pos * pos_err[:, :, 1]
+    dJ_dstate_direct[:, 1:, 2] = proto.w_head * np.sin(dyaw)
+
+    dJ_dctrl = np.zeros((B, H, 2), dtype=np.float64)
+    adj = dJ_dstate_direct[:, H].copy()
+    for t in range(H - 1, -1, -1):
+        yaw = states[:, t, 2]
+        v = states[:, t, 3]
+        delta = controls[:, t, 1]
+        sin_yaw, cos_yaw = np.sin(yaw), np.cos(yaw)
+        tan_d, cos_d = np.tan(delta), np.cos(delta)
+        cos_d2 = cos_d * cos_d
+        ax, ay, ayaw, av = adj[:, 0], adj[:, 1], adj[:, 2], adj[:, 3]
+        not_clamped = ~clamped[:, t]
+        dv_dv = not_clamped.astype(np.float64)
+        dv_da = not_clamped * dt
+
+        adj_yaw = (-v * sin_yaw * dt) * ax + (v * cos_yaw * dt) * ay + ayaw
+        adj_v = (cos_yaw * dt) * ax + (sin_yaw * dt) * ay + (tan_d / wb * dt) * ayaw + dv_dv * av
+
+        dJ_dctrl[:, t, 0] = dv_da * av
+        dJ_dctrl[:, t, 1] = np.where(cos_d2 > 1e-12, v / (wb * cos_d2) * dt * ayaw, 0.0)
+        adj = dJ_dstate_direct[:, t] + np.stack([ax, ay, adj_yaw, adj_v], axis=1)
+
+    dJ_dctrl[:, :, 0] += 2.0 * proto.w_accel * controls[:, :, 0]
+    dJ_dctrl[:, :, 1] += 2.0 * proto.w_steer * controls[:, :, 1]
+
+    dJ_dknot = dJ_dctrl[:, : K * sk].reshape(B, K, sk, 2).sum(axis=2)
+    if K > 1:
+        dk0 = knots[:, 1:, 0] - knots[:, :-1, 0]
+        dk1 = knots[:, 1:, 1] - knots[:, :-1, 1]
+        dJ_dknot[:, :-1, 0] -= 2.0 * proto.w_jerk * dk0
+        dJ_dknot[:, 1:, 0] += 2.0 * proto.w_jerk * dk0
+        dJ_dknot[:, :-1, 1] -= 2.0 * proto.w_steer_rate * dk1
+        dJ_dknot[:, 1:, 1] += 2.0 * proto.w_steer_rate * dk1
+
+    return float(J.sum()), dJ_dknot.ravel()
+
+
+def track_many(
+    trackers: list[MPCTracker],
+    x0s: np.ndarray,
+    ref_worlds: list[np.ndarray],
+    *,
+    maxiter: int = 20,
+    ftol: float = 1e-4,
+    gtol: float = 1e-4,
+) -> list[tuple[np.ndarray, float]]:
+    """One receding-horizon MPC step for B segments in a single batched solve.
+
+    Args:
+        trackers: per-segment ``MPCTracker`` instances (hold warm start +
+            telemetry; wheelbase may differ per segment, all other knobs must
+            match).
+        x0s: (B, 4) [x, y, yaw, v] current states, world frame.
+        ref_worlds: B references (N_i, 3) [x, y, yaw], world frame.
+
+    Returns:
+        List of (new_pos (3,), new_speed) per segment — the same contract as
+        ``MPCTracker.track``. Updates each tracker's ``_prev_knots`` and
+        ``last_accel/last_steering/last_yaw_rate`` telemetry exactly like the
+        serial path.
+    """
+    if not trackers:
+        return []
+    proto = trackers[0]
+    for trk in trackers[1:]:
+        mismatched = [k for k in _SHARED_KNOBS if getattr(trk, k) != getattr(proto, k)]
+        if mismatched:
+            raise ValueError(
+                f"track_many requires identical MPC knobs across segments; "
+                f"tracker differs on {mismatched} (only wheelbase may vary)"
+            )
+
+    B = len(trackers)
+    K, H = proto.n_knots, proto.horizon
+    x0s = np.asarray(x0s, dtype=np.float64).reshape(B, 4)
+    refs = np.empty((B, H, 3), dtype=np.float64)
+    inits = np.empty((B, K, 2), dtype=np.float64)
+    for i, (trk, ref_world) in enumerate(zip(trackers, ref_worlds)):
+        refs[i], inits[i] = trk._build_ref_and_init(x0s[i], ref_world)
+    wheelbases = np.array([trk.wheelbase for trk in trackers], dtype=np.float64)
+
+    result = minimize(
+        _batched_cost_and_grad,
+        inits.ravel(),
+        args=(x0s, refs, wheelbases, proto),
+        method="L-BFGS-B",
+        bounds=proto._bounds * B,
+        jac=True,
+        # Same stopping knobs as the serial per-problem solve. ftol acts on
+        # the SUMMED cost here, so individual blocks can stop at slightly
+        # different iterates than B independent solves — measured per-tick
+        # divergence stays within the validation bounds (0.05 m / 0.01 rad),
+        # and the receding horizon re-plans from the realized state every
+        # tick, so per-tick solver noise does not accumulate.
+        options={"maxiter": maxiter, "ftol": ftol, "gtol": gtol},
+    )
+    knots = result.x.reshape(B, K, 2)
+
+    out: list[tuple[np.ndarray, float]] = []
+    for i, trk in enumerate(trackers):
+        optimal = knots[i]
+        trk._prev_knots = optimal.copy()
+        a = float(optimal[0, 0])
+        delta = float(np.clip(optimal[0, 1], -trk.max_steer, trk.max_steer))
+        x, y, yaw, v = (float(x0s[i, j]) for j in range(4))
+        x_new = x + v * math.cos(yaw) * trk.dt
+        y_new = y + v * math.sin(yaw) * trk.dt
+        yaw_new = yaw + v * math.tan(delta) / trk.wheelbase * trk.dt
+        v_new = max(0.0, min(v + a * trk.dt, trk.max_speed))
+        trk.last_accel = a
+        trk.last_steering = delta
+        trk.last_yaw_rate = v * math.tan(delta) / trk.wheelbase
+        out.append((np.array([x_new, y_new, yaw_new], dtype=np.float32), v_new))
+    return out

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -517,7 +517,7 @@ def _seed_state(
     neighbor_history_mode="recorded",
     goal_mode="segment",
     replay_mode="pose",
-    tracker_mode="mpc",
+    tracker_mode="mpc_batched",
     strong_brake_mps2=-2.5,
     yaw_gate: bool = True,
 ) -> _SegState:
@@ -1359,7 +1359,7 @@ def render_segment(
     interpolate: bool = True,
     neighbor_history_mode: str = "sim",
     timeline_progress_mode: str = "pose",
-    tracker_mode: str = "mpc",
+    tracker_mode: str = "mpc_batched",
     goal_mode: str = "segment",
     title_prefix: str | None = None,
     distance_label_offset_m: float = 1.2,
@@ -1404,7 +1404,9 @@ def render_segment(
     is rebuilt from the shown simulated motion instead of copied from the recorded
     cursor frame. ``goal_mode="segment"`` terminates at ``end - 1``; ``"route"``
     terminates at the NPZ route goal displayed in the render.
-    ``tracker_mode="mpc"`` (default) uses the bicycle-model MPC tracker for ego advance while
+    ``tracker_mode="mpc_batched"`` (default) uses the bicycle-model MPC tracker for ego advance
+    (one vectorized solve for all segments per tick; ``"mpc"`` keeps the serial per-segment
+    scipy solve) while
     keeping the same reproduced perception inputs. ``tracker_mode="perfect"`` is *complete* perfect
     tracking: every step (replan ticks included) places the ego DIRECTLY on the model's predicted
     world pose, so the realized trajectory exactly follows the predicted polyline — no Euler /
@@ -1708,7 +1710,7 @@ def run_segments_batched(
     route_keys: list[str] | None = None,
     gpu_transform: bool = False,
     neighbor_history_mode: str = "recorded",
-    tracker_mode: str = "mpc",
+    tracker_mode: str = "mpc_batched",
     timeline_progress_mode: str = "pose",
     strong_brake_mps2: float = -2.5,
     yaw_gate: bool = True,

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -336,16 +336,31 @@ def _to_torch_batch_gpu(raw_payloads: list[tuple], model_args, device: str, want
 
     # Extract scoring inputs (+ optional save dicts) BEFORE normalization, so they match
     # the un-normalized arrays build_input_np returns.
-    nb_all = batch["neighbor_agents_past"][:, :, -1, :].detach().cpu().numpy()  # (N,320,11)
-    neighbors_live = [nb_all[i].copy() for i in range(N)]
     np_dicts = None
     if want_np_dicts:
-        np_dicts = [
-            {k: batch[k][i : i + 1].detach().cpu().numpy() for k in batch} for i in range(N)
-        ]
+        # ONE D2H transfer per key for the whole batch (16 transfers/step),
+        # then numpy slicing per segment — replaces the previous N x n_keys
+        # per-segment `.cpu()` calls (B x 16 transfers + syncs per step).
+        # The per-segment arrays are VIEWS into the batch-sized host arrays;
+        # every consumer (scorers, credit-window dump) is read-only on them,
+        # and the save buffer held one full batch of host arrays per tick
+        # before this change too (N standalone copies == one shared batch).
+        host = {k: batch[k].detach().cpu().numpy() for k in batch}
+        np_dicts = [{k: host[k][i : i + 1] for k in host} for i in range(N)]
+        nb_all = host["neighbor_agents_past"][:, :, -1, :]  # (N,320,11)
+    else:
+        nb_all = batch["neighbor_agents_past"][:, :, -1, :].detach().cpu().numpy()
+    neighbors_live = [nb_all[i].copy() for i in range(N)]
 
+    # Un-normalized GPU tensors with the same key set as np_dicts (snapshot
+    # BEFORE the static inputs land): per-segment slices of these feed the
+    # per-step scorers directly, replacing the old GPU->CPU->GPU round trip
+    # (np_dict D2H above, then a per-segment H2D re-upload in every scorer).
+    # The normalizer below shallow-copies and REPLACES keys, so these tensors
+    # stay un-normalized.
+    raw_gpu = dict(batch)
     _add_static_inputs(batch, model_args, N, device)
-    return model_args.observation_normalizer(batch), neighbors_live, np_dicts
+    return model_args.observation_normalizer(batch), neighbors_live, np_dicts, raw_gpu
 
 
 # --------------------------------------------------------------------------- #
@@ -1841,7 +1856,7 @@ def run_segments_batched(
                         # ONE batched on-device world_to_ego_frame; downstream identical.
                         raw_payloads = [pre for _s, pre in live]
                         with timers("to_torch"):
-                            data, nb_list, npd_list = _to_torch_batch_gpu(
+                            data, nb_list, npd_list, raw_gpu = _to_torch_batch_gpu(
                                 raw_payloads,
                                 model_args,
                                 device,
@@ -1851,6 +1866,11 @@ def run_segments_batched(
                                     or danger_save_dir is not None
                                 ),
                             )
+                        # Per-segment GPU-resident scene slices for the per-step
+                        # scorers (same keys/values as np_dict, no host round trip).
+                        gpu_scenes = [
+                            {k: raw_gpu[k][i : i + 1] for k in raw_gpu} for i in range(len(live))
+                        ]
                         built = [
                             (
                                 s,
@@ -1864,6 +1884,7 @@ def run_segments_batched(
                         ]
                     else:
                         built = [(s, *pre) for s, pre in live]
+                        gpu_scenes = None  # CPU build: scorers consume the numpy np_dicts
                         with timers("to_torch"):
                             data = _to_torch_batch([b[1] for b in built], model_args, device)
                     with timers("model_forward"):
@@ -1958,7 +1979,7 @@ def run_segments_batched(
                                     _s.realized_lag_streak = 0
                         realized_rows.append(
                             realized_event_scorer(
-                                np_dict,
+                                gpu_scenes[_row_i] if gpu_scenes is not None else np_dict,
                                 collided=bool(col),
                                 step=_s.k,
                                 model_pred_world=model_pred_world,
@@ -1981,7 +2002,9 @@ def run_segments_batched(
                             nb,
                             device,
                             timers,
-                            np_dict=_np,
+                            # GPU-resident slice when available: the rb / red-light
+                            # scorers then skip their per-step H2D re-upload.
+                            np_dict=gpu_scenes[row_idx] if gpu_scenes is not None else _np,
                             object_cl=float(cl),
                             object_col=bool(col),
                         )

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -551,10 +551,15 @@ def _seed_state(
     turn_hist = np.asarray(tl.npz(start)["turn_indicators"]).reshape(-1).astype(np.int64)
     if tracker_mode == "perfect":
         tracker = PerfectTracker(dt=DT)
-    elif tracker_mode == "mpc":
+    elif tracker_mode in ("mpc", "mpc_batched"):
+        # mpc_batched keeps the identical per-segment MPCTracker (warm start +
+        # telemetry live on it); only the per-tick SOLVE is batched across
+        # segments in run_segments_batched (see mpc_tracker_batched.track_many).
         tracker = MPCTracker(wheelbase=wheelbase, dt=DT)
     else:
-        raise ValueError(f"Unknown tracker_mode={tracker_mode!r}; expected 'perfect' or 'mpc'")
+        raise ValueError(
+            f"Unknown tracker_mode={tracker_mode!r}; expected 'perfect', 'mpc', or 'mpc_batched'"
+        )
     return _SegState(
         tl=tl,
         start=start,
@@ -701,7 +706,7 @@ def _score_into(
             s.red_light[s.k] = bool(red["red_light_violation"])
 
 
-def _advance_step(s: _SegState, pred: np.ndarray, idx, device, timers, override=None):
+def _advance_step(s: _SegState, pred: np.ndarray, idx, device, timers, override=None, tracked=None):
     """Advance the ego one step (perfect tracking of the prediction) + unstick.
 
     ``override`` = ``(world_pose(3,), speed)`` places the ego exactly on a given world pose
@@ -709,6 +714,12 @@ def _advance_step(s: _SegState, pred: np.ndarray, idx, device, timers, override=
     PerfectTracker only tracks ``ref[0]`` using the current heading, so it cannot follow a
     multi-step plan (heading/position mismatch compounds and diverges) — the plan poses are
     applied directly, which is the faithful "perfect tracking" of the cached plan.
+
+    ``tracked`` = ``(new_pose(3,), new_speed)`` from a BATCHED tracker solve
+    (``mpc_tracker_batched.track_many``): the caller already ran the tracker for
+    this segment, so the tracker branch is skipped and its result applied with
+    the same telemetry reads (``track_many`` set ``last_yaw_rate``/``last_steering``
+    on ``s.tracker`` exactly like ``track()`` does).
     """
     from scenario_generation.mpc_tracker import postprocess_reference
 
@@ -725,6 +736,11 @@ def _advance_step(s: _SegState, pred: np.ndarray, idx, device, timers, override=
             dh = (float(new_pose[2]) - float(s.live_pose[2]) + math.pi) % (2 * math.pi) - math.pi
             yaw_rate = float(dh / DT)
             steering = 0.0
+        elif tracked is not None:
+            new_pose = np.asarray(tracked[0], dtype=np.float64)
+            new_speed = float(tracked[1])
+            yaw_rate = float(getattr(s.tracker, "last_yaw_rate", 0.0))
+            steering = float(getattr(s.tracker, "last_steering", 0.0))
         else:
             wxy, wh = _ego_pred_to_world(
                 pred[:, :2], pred[:, 2:4], s.live_pose[0], s.live_pose[1], s.live_pose[2]
@@ -2263,9 +2279,44 @@ def run_segments_batched(
                                         s.episode_saved = True
                                         s.saved_collision = True  # recorded-mode one-save latch
                                         s.last_collision_uuid = colliding_uuid
+                    tracked_by_row: dict[int, tuple] = {}
+                    if tracker_mode == "mpc_batched":
+                        # ONE vectorized L-BFGS-B solve for every tracker-branch
+                        # segment this tick, instead of B serial scipy solves
+                        # inside _advance_step (its `tracked` fast path applies
+                        # the results; warmup segments keep their own branch).
+                        from scenario_generation.mpc_tracker import postprocess_reference
+                        from scenario_generation.mpc_tracker_batched import track_many
+
+                        with timers("advance_solve"):
+                            rows_b: list[int] = []
+                            trks_b, x0s_b, refs_b = [], [], []
+                            for i, (s, *_rest) in enumerate(built):
+                                if s.k < s.warmup_steps:
+                                    continue
+                                wxy, wh = _ego_pred_to_world(
+                                    preds[i][:, :2],
+                                    preds[i][:, 2:4],
+                                    s.live_pose[0],
+                                    s.live_pose[1],
+                                    s.live_pose[2],
+                                )
+                                refs_b.append(postprocess_reference(wxy, wh, dt=DT))
+                                x0s_b.append(
+                                    [s.live_pose[0], s.live_pose[1], s.live_pose[2], s.dyn.speed]
+                                )
+                                rows_b.append(i)
+                                trks_b.append(s.tracker)
+                            if rows_b:
+                                solved = track_many(
+                                    trks_b, np.asarray(x0s_b, dtype=np.float64), refs_b
+                                )
+                                tracked_by_row = dict(zip(rows_b, solved))
                     for i, (s, _np, nb, idx, _suuid, _wbu) in enumerate(built):
                         prev_snaps = s.snap_count
-                        _advance_step(s, preds[i], idx, device, timers)
+                        _advance_step(
+                            s, preds[i], idx, device, timers, tracked=tracked_by_row.get(i)
+                        )
                         # Feed the model's predicted turn indicator back into the rolling
                         # history (recorded seed scrolls out within PAST steps) — the saved
                         # context then carries the sim's own signals, never the recorded ones.

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -342,9 +342,11 @@ def _to_torch_batch_gpu(raw_payloads: list[tuple], model_args, device: str, want
         # then numpy slicing per segment — replaces the previous N x n_keys
         # per-segment `.cpu()` calls (B x 16 transfers + syncs per step).
         # The per-segment arrays are VIEWS into the batch-sized host arrays;
-        # every consumer (scorers, credit-window dump) is read-only on them,
-        # and the save buffer held one full batch of host arrays per tick
-        # before this change too (N standalone copies == one shared batch).
+        # every consumer (scorers, credit-window dump) is read-only on them.
+        # Memory caveat: while ALL N segments are alive this equals the old
+        # N standalone copies, but a single long-lived segment's save buffer
+        # now pins the whole tick's batch arrays (up to Bx its own slice) —
+        # bounded by the save-buffer deque cap, and irrelevant at B<=64.
         host = {k: batch[k].detach().cpu().numpy() for k in batch}
         np_dicts = [{k: host[k][i : i + 1] for k in host} for i in range(N)]
         nb_all = host["neighbor_agents_past"][:, :, -1, :]  # (N,320,11)

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 import math
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -1889,11 +1890,13 @@ def run_segments_batched(
                         score_list = score_object_step_batched(
                             [b[2] for b in built], [b[0].ego_shape for b in built], device
                         )
-                    danger_rows = (
-                        danger_scorer(built, preds, data, device)
-                        if danger_scorer is not None
-                        else [None] * len(built)
-                    )
+                    with timers("danger_scorer"):
+                        danger_rows = (
+                            danger_scorer(built, preds, data, device)
+                            if danger_scorer is not None
+                            else [None] * len(built)
+                        )
+                    realized_t0 = time.perf_counter()
                     realized_rows = []
                     for _row_i, (
                         (_s, np_dict, _nb, _idx, _suuid, _wbu),
@@ -1966,6 +1969,7 @@ def run_segments_batched(
                                 realized_lag_gap_m=realized_lag_gap_m,
                             )
                         )
+                    timers.add("realized_events", time.perf_counter() - realized_t0)
                     for row_idx, (
                         (s, _np, nb, idx, suuid, wbu),
                         (cl, col, _M, collider_slot),
@@ -2016,6 +2020,7 @@ def run_segments_batched(
                                 extra_manifest={
                                     "offense_frame_id": int(s.credit_window["offense_frame"])
                                 },
+                                timers=timers,
                             )
                             s.credit_saved = True
                             s.terminated = "credit_window_saved"
@@ -2096,6 +2101,7 @@ def run_segments_batched(
                                                 )
                                             ),
                                         },
+                                        timers=timers,
                                     )
                                     if manifest is not None:
                                         if danger_manifest_callback is not None:
@@ -2153,6 +2159,7 @@ def run_segments_batched(
                                             extra_manifest=_credit_event_metadata(
                                                 event_row_by_label.get(label)
                                             ),
+                                            timers=timers,
                                         )
                                         if (
                                             manifest is not None
@@ -2227,6 +2234,7 @@ def run_segments_batched(
                                         min_post_snap_frames=save_min_post_snap_frames,
                                         min_pre_frames=save_min_pre_frames,
                                         min_ego_speed=save_min_ego_speed,
+                                        timers=timers,
                                     )
                                     if mani is not None:
                                         s.episode_saved = True
@@ -2271,6 +2279,7 @@ def _dump_credit_window(
     seg_end: int,
     label: str,
     extra_manifest: dict | None = None,
+    timers: Timers | None = None,
 ) -> dict | None:
     """Write an inclusive R2LPL credit window ending before the offense step.
 
@@ -2314,6 +2323,7 @@ def _dump_credit_window(
         min_post_snap_frames=0,
         min_pre_frames=0,
         min_ego_speed=0.0,
+        timers=timers,
     )
     if manifest is None:
         return None
@@ -2553,6 +2563,7 @@ def _dump_precollision_window(
     min_post_snap_frames: int = 0,
     min_pre_frames: int = 30,
     min_ego_speed: float = 0.5,
+    timers: Timers | None = None,
 ) -> dict | None:
     """Write the scenes before collision step ``t_c`` from a live buffer.
 
@@ -2575,6 +2586,9 @@ def _dump_precollision_window(
     import json
     from pathlib import Path
 
+    if timers is None:
+        timers = Timers()  # throwaway sink: standalone callers without a report
+    t_window = time.perf_counter()
     out_dir = Path(out_dir)
     # Clear any prior batch in this dir FIRST — before the skip early-return — so that a
     # re-mine which now SKIPS this segment (or writes a shorter window) never leaves stale
@@ -2670,6 +2684,7 @@ def _dump_precollision_window(
                 f"[{start_k}, {t_c}] but it is absent (window-clamp / buffer regression)"
             )
         _, idx, live_pose, np_dict, slot_uuids, _wbu = live_by_step[step_k]
+        _t = time.perf_counter()
         scene = _scene_npz_from_np_dict(np_dict)
         ep = scene["ego_agent_past"]
         scene["ego_agent_past"] = np.column_stack(
@@ -2760,6 +2775,8 @@ def _dump_precollision_window(
             if naf is not None:
                 dx, dy, dyaw = _rel_pose(tl.poses[idx], live_pose)
                 scene["neighbor_agents_future"] = _recenter_neighbor_future(naf, dx, dy, dyaw)
+        timers.add("dump_naf", time.perf_counter() - _t)
+        _t = time.perf_counter()
         eaf = np.zeros((fut_len, 4), dtype=np.float32)
         for j in range(1, fut_len + 1):
             fk = step_k + j
@@ -2808,9 +2825,12 @@ def _dump_precollision_window(
         if 0 < n_recorded < fut_len:
             recorded_eaf[n_recorded:] = recorded_eaf[n_recorded - 1]
         scene["ego_recorded_future"] = recorded_eaf
+        timers.add("dump_futures", time.perf_counter() - _t)
         scene["origin"] = np.array("live")
         token = f"{step_k - t_c:+06d}"
+        _t = time.perf_counter()
         np.savez_compressed(out_dir / f"collision{token}.npz", **scene)
+        timers.add("dump_savez", time.perf_counter() - _t)
         saved.append(int(step_k))
         saved_frame_ids.append(_frame_id(tl, idx))
 
@@ -2832,4 +2852,5 @@ def _dump_precollision_window(
         "n_live": len(saved),  # all-live by construction (no recorded backfill)
     }
     (out_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
+    timers.add("dump_window", time.perf_counter() - t_window)
     return manifest

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -1405,8 +1405,9 @@ def render_segment(
     cursor frame. ``goal_mode="segment"`` terminates at ``end - 1``; ``"route"``
     terminates at the NPZ route goal displayed in the render.
     ``tracker_mode="mpc_batched"`` (default) uses the bicycle-model MPC tracker for ego advance
-    (one vectorized solve for all segments per tick; ``"mpc"`` keeps the serial per-segment
-    scipy solve) while
+    (in the batched rollout, one vectorized solve for all segments per tick; in THIS
+    single-segment path it behaves exactly like ``"mpc"``, the serial per-segment scipy
+    solve) while
     keeping the same reproduced perception inputs. ``tracker_mode="perfect"`` is *complete* perfect
     tracking: every step (replan ticks included) places the ego DIRECTLY on the model's predicted
     world pose, so the realized trajectory exactly follows the predicted polyline — no Euler /

--- a/scenario_generation/tests/test_mpc_tracker_batched.py
+++ b/scenario_generation/tests/test_mpc_tracker_batched.py
@@ -1,0 +1,103 @@
+"""Unit tests for the batched MPC solver against the serial reference."""
+
+import numpy as np
+import pytest
+
+from scenario_generation.mpc_tracker import MPCTracker
+from scenario_generation.mpc_tracker_batched import _batched_cost_and_grad, track_many
+
+
+def _random_problem(rng, moving=True):
+    x0 = np.array(
+        [rng.uniform(-5, 5), rng.uniform(-5, 5), rng.uniform(-np.pi, np.pi), rng.uniform(0, 8)],
+        dtype=np.float64,
+    )
+    # A plausible forward reference: roughly constant-speed arc from x0.
+    n = 80
+    speed = rng.uniform(1.0, 8.0) if moving else 0.0
+    yaw_rate = rng.uniform(-0.2, 0.2)
+    yaws = x0[2] + yaw_rate * 0.1 * np.arange(1, n + 1)
+    steps = speed * 0.1
+    xs = x0[0] + np.cumsum(steps * np.cos(yaws))
+    ys = x0[1] + np.cumsum(steps * np.sin(yaws))
+    ref_world = np.column_stack([xs, ys, yaws])
+    return x0, ref_world
+
+
+def test_batched_cost_and_grad_matches_scalar():
+    """The vectorized cost/adjoint must equal the scalar reference per block."""
+    rng = np.random.default_rng(0)
+    B = 6
+    trackers = [MPCTracker(wheelbase=rng.uniform(2.5, 5.0)) for _ in range(B)]
+    proto = trackers[0]
+    x0s = np.stack([_random_problem(rng)[0] for _ in range(B)])
+    refs = np.stack(
+        [proto._build_ref_and_init(x0s[i], _random_problem(rng)[1])[0] for i in range(B)]
+    )
+    knots = rng.uniform(-1, 1, size=(B, proto.n_knots, 2))
+    wheelbases = np.array([t.wheelbase for t in trackers])
+
+    # Batched cost must equal the sum of scalar costs; the gradient must equal
+    # the concatenation of scalar gradients (each scalar solve uses its own wb).
+    J_batch, g_batch = _batched_cost_and_grad(knots.ravel(), x0s, refs, wheelbases, proto)
+    J_scalar, g_scalar = 0.0, []
+    for i, trk in enumerate(trackers):
+        J_i, g_i = trk._cost_and_grad(knots[i].ravel(), x0s[i], refs[i])
+        J_scalar += J_i
+        g_scalar.append(g_i)
+    np.testing.assert_allclose(J_batch, J_scalar, rtol=1e-12)
+    np.testing.assert_allclose(g_batch, np.concatenate(g_scalar), rtol=1e-9, atol=1e-12)
+
+
+@pytest.mark.parametrize("warm", [False, True])
+def test_track_many_close_to_serial_track(warm):
+    """One batched receding-horizon step lands within tight tolerance of the
+    serial solver (not bit-identical: L-BFGS memory/line search are shared)."""
+    rng = np.random.default_rng(1)
+    B = 8
+    problems = [_random_problem(rng) for _ in range(B)]
+    serial = [MPCTracker(wheelbase=4.76) for _ in range(B)]
+    batched = [MPCTracker(wheelbase=4.76) for _ in range(B)]
+    if warm:  # exercise the warm-start roll path too
+        for s_trk, b_trk in zip(serial, batched):
+            knots = rng.uniform(-0.5, 0.5, size=(s_trk.n_knots, 2))
+            s_trk._prev_knots = knots.copy()
+            b_trk._prev_knots = knots.copy()
+
+    serial_out = [trk.track(x0, ref) for trk, (x0, ref) in zip(serial, problems)]
+    batched_out = track_many(batched, np.stack([p[0] for p in problems]), [p[1] for p in problems])
+
+    for (pos_s, v_s), (pos_b, v_b) in zip(serial_out, batched_out):
+        # One dt step from identical x0: divergence only via the optimized
+        # first control. a/delta enter position at O(dt^2) — poses must be
+        # extremely close even when the solvers stop at different iterates.
+        # Both solvers stop at ftol=1e-4; the batched ftol acts on the summed
+        # cost, so iterates differ slightly. Bounds = the M2 validation
+        # protocol's per-tick limits (0.05 m / 0.01 rad).
+        np.testing.assert_allclose(pos_b[:2], pos_s[:2], atol=0.05)
+        np.testing.assert_allclose(pos_b[2], pos_s[2], atol=0.01)
+        # Speed applies a*dt with a in [-4, 3]; a 0.25 m/s iterate gap moves
+        # next-tick position by <0.025 m, inside the pose bound above.
+        assert abs(v_b - v_s) < 0.25
+
+
+def test_track_many_updates_warm_start_and_telemetry():
+    rng = np.random.default_rng(2)
+    trackers = [MPCTracker(wheelbase=4.76) for _ in range(3)]
+    problems = [_random_problem(rng) for _ in range(3)]
+    out = track_many(trackers, np.stack([p[0] for p in problems]), [p[1] for p in problems])
+    assert len(out) == 3
+    for trk in trackers:
+        assert trk._prev_knots is not None and trk._prev_knots.shape == (trk.n_knots, 2)
+        assert np.isfinite(trk.last_accel) and np.isfinite(trk.last_yaw_rate)
+
+
+def test_track_many_rejects_mismatched_knobs():
+    a = MPCTracker(wheelbase=4.76)
+    b = MPCTracker(wheelbase=4.76, horizon_steps=10, n_knots=5)
+    with pytest.raises(ValueError, match="identical MPC knobs"):
+        track_many([a, b], np.zeros((2, 4)), [np.zeros((80, 3))] * 2)
+
+
+def test_track_many_empty():
+    assert track_many([], np.zeros((0, 4)), []) == []

--- a/scenario_generation/tests/test_mpc_tracker_batched.py
+++ b/scenario_generation/tests/test_mpc_tracker_batched.py
@@ -101,3 +101,43 @@ def test_track_many_rejects_mismatched_knobs():
 
 def test_track_many_empty():
     assert track_many([], np.zeros((0, 4)), []) == []
+
+
+def test_advance_step_tracked_fast_path():
+    """_advance_step with a precomputed ``tracked`` result must apply it verbatim
+    (no tracker.track call) and read telemetry off the tracker like the serial
+    branch does — this is the mpc_batched integration seam in the rollout."""
+    from types import SimpleNamespace
+
+    from scenario_generation.perf_timer import Timers
+    from scenario_generation.reproducer_rollout import DT, _advance_step
+
+    class _MustNotTrack:
+        last_yaw_rate = 0.123
+        last_steering = -0.05
+
+        def track(self, x0, ref):
+            raise AssertionError("tracked= fast path must not invoke tracker.track")
+
+    s = SimpleNamespace(
+        k=3,
+        warmup_steps=0,
+        tracker=_MustNotTrack(),
+        live_pose=np.array([1.0, 2.0, 0.1], dtype=np.float64),
+        dyn=SimpleNamespace(speed=4.0),
+        ego_hist=np.zeros((31, 3), dtype=np.float64),
+        sim_time=0.3,
+        accels=np.zeros(100, dtype=np.float32),
+        unstick_after=0,
+    )
+    new_pose = np.array([1.4, 2.05, 0.12], dtype=np.float64)
+    _advance_step(s, np.zeros((80, 4)), 3, "cpu", Timers(), tracked=(new_pose, 4.5))
+
+    np.testing.assert_array_equal(s.live_pose, new_pose)
+    assert s.k == 4
+    assert s.dyn.speed == 4.5
+    np.testing.assert_allclose(s.dyn.accel, (4.5 - 4.0) / DT)
+    assert s.dyn.yaw_rate == 0.123  # read from tracker telemetry, like the serial branch
+    assert s.dyn.steering == -0.05
+    np.testing.assert_array_equal(s.ego_hist[-1], new_pose)
+    np.testing.assert_allclose(s.accels[3], (4.5 - 4.0) / DT)

--- a/scenario_generation/tools/_heatmap_common.py
+++ b/scenario_generation/tools/_heatmap_common.py
@@ -84,13 +84,40 @@ def project_to_polyline(
 
 
 def project_points_to_polyline(xys: np.ndarray, pts: np.ndarray, s: np.ndarray) -> np.ndarray:
-    """Batch projection via per-point loop. xys: (M, 2). Returns (M, 3) = (arc, signed, |lat|).
+    """Batch projection. xys: (M, 2). Returns (M, 3) = (arc, signed, |lat|).
 
-    O(M*N); fine up to a few hundred thousand points.
+    Vectorized over points (same per-point math and argmin tie-breaking as
+    ``project_to_polyline``, verified equal in the rollout perf work); chunked
+    so the (chunk, N_seg) distance matrix stays small on long polylines. The
+    mining rollout calls this for ~2x81 points per segment per tick — the old
+    per-point Python loop over all route segments was a hot spot.
     """
-    out = np.zeros((len(xys), 3), dtype=np.float64)
-    for k, p in enumerate(xys):
-        out[k] = project_to_polyline(p, pts, s)
+    xys = np.asarray(xys, dtype=np.float64).reshape(-1, 2)
+    M = len(xys)
+    out = np.zeros((M, 3), dtype=np.float64)
+    if M == 0:
+        return out
+    a = pts[:-1]
+    b = pts[1:]
+    ab = b - a  # (N, 2)
+    seg_len2 = np.maximum((ab * ab).sum(axis=1), 1e-9)  # (N,)
+    seg_len = np.sqrt(seg_len2)
+    chunk = max(1, int(4_000_000 // max(1, len(a))))
+    for lo in range(0, M, chunk):
+        p = xys[lo : lo + chunk]  # (m, 2)
+        ap = p[:, None, :] - a[None]  # (m, N, 2)
+        t = (ap * ab[None]).sum(axis=-1) / seg_len2  # (m, N)
+        t_clamped = np.clip(t, 0.0, 1.0)
+        proj = a[None] + t_clamped[..., None] * ab[None]
+        d = np.linalg.norm(p[:, None, :] - proj, axis=-1)  # (m, N)
+        i = np.argmin(d, axis=1)  # first minimum, same tie-break as the scalar path
+        rows = np.arange(len(p))
+        cross = ab[i, 0] * (p[:, 1] - a[i, 1]) - ab[i, 1] * (p[:, 0] - a[i, 0])
+        sign = np.where(cross >= 0, 1.0, -1.0)
+        di = d[rows, i]
+        out[lo : lo + chunk, 0] = s[i] + t_clamped[rows, i] * seg_len[i]
+        out[lo : lo + chunk, 1] = sign * di
+        out[lo : lo + chunk, 2] = di
     return out
 
 


### PR DESCRIPTION
## Summary

The R2LPL lifelong workflow is CPU-bound on constrained hosts (CPU quota scales with GPU count; dataset on network storage). An audit with filled-in timers showed the heavy geometry already runs on GPU — the CPU cost was serial per-segment MPC solves, GPU→CPU→GPU round trips in the per-step scorers, a per-point Python polyline projection, duplicated repair geometry, and per-round re-conversion/re-planning in the orchestrator.

Every change landed as its own commit and was A/B-gated against golden outputs from a production-mirror workload (54 chunks / 237 credit rows / 154 repairs). Mining is bitwise-deterministic run-to-run, so semantics-preserving changes are gated on byte-identical outputs; the batched MPC solver (which cannot be bit-exact) is gated by a statistical protocol.

## Changes

| Commit | Change | Stage timer (before → after) | Output check |
|---|---|---|---|
| instrument timers | mining timer coverage 74% → ~98%; first repair phase timers | — | timing-only |
| campaign-level caches | 4-col conversions + chunk plan cached once per campaign (thread-pooled, atomic writes; knob mismatch fails loudly) | full-pool `savez_compressed` per round → once per campaign | unit tests |
| vectorize projection | `project_points_to_polyline` vectorized over points | mining `realized_events` 75–84s → 56.6s | bitwise identical (also property-tested vs scalar loop) |
| host round-trip elimination | one batched D2H per key; scorers consume GPU-resident slices of the un-normalized transformed batch | `realized_events` → 42.6s; `to_torch` −40% | bitwise identical |
| `tracker_mode=mpc_batched` (now default) | all B segments solved in ONE vectorized L-BFGS-B (summed independent costs; shared ref-building/warm-start via `_build_ref_and_init`) | mining `advance` 100.8s → 42.9s (2.3×) | statistical gate PASS: identical per-label counts, 17/17 event windows paired, median offense-frame shift 1 frame |
| repair dedup | per-candidate batch-1 clearance loop batched (`_moving_diagnostics_batch`); classifier subscores reused by reward shaping (`return_subscores` → `_shape_reward`; `reward.py` untouched; guarded fallback for expert-reference / 3-col scenes) | repair `classify` 32.8s → 11.1s (3×) | identical repairs (same selections, rewards, NPZ bytes) |
| A/B comparators | `compare_mining_outputs` / `compare_repair_outputs` / `compare_tracker_ab` CLI oracles | — | used to gate all of the above |

Mining end-to-end on the profiling box: 384s → 304s; the saved share grows where CPU is the constraint. `model_forward` (diffusion inference) is the dominant remaining cost and is already GPU.

**Device note:** the MPC change is deliberately vectorized CPU, not CUDA — at ~16 segments × 10 decision variables, kernel-launch overhead exceeds the arithmetic. The GPU wins here are keeping scene tensors resident (no per-segment host round trips) and batching tiny per-segment kernels.

**Not bit-exact (accepted):** `mpc_batched` shares L-BFGS curvature/line-search across the concatenated problem, so solver iterates differ at rounding level; closed-loop this shifts event onset frames by ~1 frame with identical event sets/counts. `mpc` remains selectable for exact reproduction of older runs; campaigns comparing frozen-chunk guard counts against an `mpc`-mined reference row should pin the mode for that campaign (guard comparability requires constant mining knobs).

**Skipped on data:** async credit-window writer (dumps ≈1% of elapsed), input-build vectorization (≈7%), guard-phase multi-GPU.

## Testing

- Full `test_r2lpl_lifelong_replay.py` + `scenario_generation/tests` green (the 2 `test_map_cache` failures and `test_grpo_sampler` collection errors reproduce unchanged at the branch base).
- New tests: batched-vs-scalar MPC cost/gradient bitwise equality, `track_many` divergence bounds + warm-start/telemetry, mismatched-knob rejection; 4-col cache reuse/rebuild/knob-mismatch; campaign-level chunk-plan cache.
- Per-feature A/B runs on the production-mirror workload as summarized above.
- 2-round end-to-end campaign at HEAD: round-1 mining/repair counts match the golden stage-level runs; round-2 reuses the campaign-level 4-col cache.
