### PR TITLE
perf(route_timeline): read one array per frame for the track-anchor scan

### DIFF
--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -991,7 +991,7 @@ def _build_neighbor_interp(tl: RouteTimeline, lo: int, hi: int, eps: float = 0.1
             continue
         pose = tl.poses[idx]
         c, s = math.cos(pose[2]), math.sin(pose[2])
-        nb = tl.npz(idx)["neighbor_agents_past"][:, -1]  # (320, 11) ego frame
+        nb = tl.neighbor_last(idx)  # (320, 11) ego frame — single-key load (fast)
         for slot in range(min(len(ids), nb.shape[0])):
             row = nb[slot]
             if np.abs(row[:6]).sum() == 0:

--- a/scenario_generation/route_timeline.py
+++ b/scenario_generation/route_timeline.py
@@ -234,10 +234,17 @@ class RouteTimeline:
     def neighbor_last(self, idx: int) -> np.ndarray:
         """Load ONLY ``neighbor_agents_past[:, -1]`` (current neighbor row, (320, 11)) for a frame.
 
-        The sim-mode track-build scans EVERY frame of the route and needs only this slice — not
-        the lanes/routes/polygons/etc. that ``npz()`` decompresses. ``np.load`` is lazy per-key,
-        so reading just this one key is ~10x cheaper per frame (it dominated timeline_load_npz).
-        Not cached: the track-build touches each frame once."""
+        The track-build scans EVERY frame of the route and needs only this slice — not the
+        lanes/routes/polygons/etc. that ``npz()`` decompresses. ``np.load`` is lazy per-key, so
+        reading just this one key is ~10x cheaper per frame. An uncached frame is not inserted
+        into the cache: a route is far longer than the cache, so caching the scan would evict
+        exactly the frames the step loop is about to ask for."""
+        with self._cache_lock:
+            cached = self._npz_cache.get(idx)
+            if cached is not None:
+                self._npz_cache.move_to_end(idx)  # LRU touch
+        if cached is not None:
+            return cached["neighbor_agents_past"][:, -1]
         with self.timers("timeline_load_npz"):
             with np.load(self.npz_paths[idx], allow_pickle=True) as z:
                 return z["neighbor_agents_past"][:, -1]

--- a/scenario_generation/tests/test_neighbor_last.py
+++ b/scenario_generation/tests/test_neighbor_last.py
@@ -1,0 +1,69 @@
+"""``RouteTimeline.neighbor_last``: same values as the full read, without evicting the cache."""
+
+import json
+
+import numpy as np
+import pytest
+
+from scenario_generation.route_timeline import RouteTimeline
+
+N_FRAMES = 6
+N_NEIGHBORS = 4
+
+
+def _write_frame(tmp_path, i: int):
+    p = tmp_path / f"route_{i:010d}.npz"
+    nb = np.arange(N_NEIGHBORS * 31 * 11, dtype=np.float32).reshape(N_NEIGHBORS, 31, 11) + i
+    np.savez_compressed(
+        p,
+        neighbor_agents_past=nb,
+        ego_agent_past=np.zeros((31, 3), dtype=np.float32),
+        ego_shape=np.array([4.0, 2.0, 1.5], dtype=np.float32),
+        turn_indicators=np.zeros(31, dtype=np.int64),
+        lanes=np.zeros((140, 20, 33), dtype=np.float32),  # the bulk npz() would decompress
+    )
+    (tmp_path / f"route_{i:010d}.json").write_text(
+        json.dumps(
+            {
+                "timestamp": float(i) * 0.1,
+                "x": float(i),
+                "y": 0.0,
+                "z": 0.0,
+                "qx": 0.0,
+                "qy": 0.0,
+                "qz": 0.0,
+                "qw": 1.0,
+            }
+        )
+    )
+    return p
+
+
+@pytest.fixture
+def timeline(tmp_path):
+    return RouteTimeline([_write_frame(tmp_path, i) for i in range(N_FRAMES)])
+
+
+def test_values_match_the_full_read(timeline):
+    for i in range(N_FRAMES):
+        expected = timeline.npz(i)["neighbor_agents_past"][:, -1]
+        assert np.array_equal(timeline.neighbor_last(i), expected)
+
+
+def test_uncached_frame_is_not_cached(timeline):
+    assert not timeline._npz_cache, "fixture should start with a cold cache"
+
+    for i in range(N_FRAMES):
+        timeline.neighbor_last(i)
+
+    assert not timeline._npz_cache, "the narrow read must leave the frame cache untouched"
+
+
+def test_cached_frame_is_served_from_the_cache(timeline):
+    full = timeline.npz(3)  # populates the cache
+    assert 3 in timeline._npz_cache
+
+    got = timeline.neighbor_last(3)
+
+    assert np.array_equal(got, full["neighbor_agents_past"][:, -1])
+    assert np.shares_memory(got, full["neighbor_agents_past"])  # a view of the cached array


### PR DESCRIPTION
## Problem

Before its step loop, `render_segment` scans every frame of the route to build interpolation
anchors. It needs one array per frame — `neighbor_agents_past[:, -1]` — but `_build_neighbor_interp`
read it through `RouteTimeline.npz()`, which decompresses all of `_NEEDED_KEYS` and caches the frame.

The cache holds 768 frames; a route is several thousand. The scan evicts the early frames before
the step loop, which starts at frame 0, reaches them, so every frame is decompressed twice.

## Fix

Use the existing `RouteTimeline.neighbor_last()` — it reads only that member (npz members
decompress lazily) and does not cache it. `neighbor_last()` now serves an already-cached frame
from the frame cache instead of re-opening the file.

## Result

Full workload (4 sites x 2 object modes, 38 segments, 64,109 steps), 1xH100, exclusive node:

**-4.8% wall.** Cross-arm noise +/-2-3%.

Output is identical.

## Tests

`scenario_generation/tests/test_neighbor_last.py` — values match the full read, an uncached frame
does not enter the cache, a cached frame is still served from it.

`scenario_generation/tests`: 218 passed. The 2 `test_map_cache.py` failures also fail at
`tier4-main`.

## Note

Bottom of a 3-PR stack that reduces the cost of the same scan from different angles:

- **#333 (this PR)** ← `tier4-main`
- #340 ← #333
- #341 ← #340

Merge bottom-up. Each PR's % figure was measured standalone against `tier4-main`, not as an
increment within the stack — #340 (skip) and #341 (cache) both shrink this PR's marginal
contribution.
