### PR TITLE
fix(replay): make agent colours independent of PYTHONHASHSEED

### DIFF
--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -54,6 +54,7 @@ import json
 import math
 import os
 import random
+import zlib
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from dataclasses import asdict, dataclass, field
@@ -1196,6 +1197,21 @@ _STATIC_NPC_VIZ_THRESH_M = 2.0
 _CLEARANCE_LOG_MAX_M = 30.0
 
 
+def stable_palette_index(agent_id: str) -> int:
+    """Palette slot for an agent id: ``npc_5`` -> 5, anything else -> a hash of the id.
+
+    The hash MUST NOT be the builtin ``hash()``: ``PYTHONHASHSEED`` is randomised per
+    interpreter, so the same id would take a different slot in every process — a different
+    colour on every run, and a different colour in each rendering worker. ``zlib.crc32`` is
+    fixed by the standard. See ``test_stable_palette_index.py``.
+    """
+    if "_" in agent_id:
+        suffix = agent_id.rsplit("_", 1)[-1]
+        if suffix.isdigit():
+            return int(suffix)
+    return zlib.crc32(agent_id.encode())
+
+
 def _draw_lane_network(ax, map_data, alpha: float = 0.7) -> None:
     """Draw lane centerlines **and** left/right borders from the 33-dim tensor.
 
@@ -1600,16 +1616,7 @@ def save_step_figure(
     def _stable_color(agent) -> str:
         if agent.id == scene.ego_agent_id:
             return _EGO_COLOR
-        # npc_5 → 5; falls back to Python hash otherwise.
-        sid = agent.id
-        idx = None
-        if "_" in sid:
-            suffix = sid.rsplit("_", 1)[-1]
-            if suffix.isdigit():
-                idx = int(suffix)
-        if idx is None:
-            idx = abs(hash(sid))
-        return _agent_color(agent.agent_type, idx)
+        return _agent_color(agent.agent_type, stable_palette_index(agent.id))
 
     for agent in scene.agents:
         is_ego = agent.id == scene.ego_agent_id

--- a/scenario_generation/tests/test_stable_palette_index.py
+++ b/scenario_generation/tests/test_stable_palette_index.py
@@ -1,0 +1,54 @@
+"""The id -> palette-slot mapping must be seed-independent: reverting ``stable_palette_index``
+to ``abs(hash(agent_id))`` fails ``test_index_is_identical_under_different_hash_seeds``."""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+from scenario_generation.replay import stable_palette_index
+
+# Hex track UUIDs as ``_draw_step`` builds them: no all-digit suffix, so these take the
+# hashed branch -- the one that used to be seed-dependent.
+UUID_IDS = ["nb_a3f91c2e", "nb_7bd4e10a", "nb_ffc23b90", "nb_00d1f4bc"]
+
+_PROBE = (
+    "import json,sys;"
+    "from scenario_generation.replay import stable_palette_index as f;"
+    "print(json.dumps([f(s) for s in sys.argv[1:]]))"
+)
+
+
+def _indices_with_hash_seed(seed: str) -> list[int]:
+    """Palette slots computed in a fresh interpreter with the given PYTHONHASHSEED."""
+    env = {**os.environ, "PYTHONHASHSEED": seed}
+    out = subprocess.run(
+        [sys.executable, "-c", _PROBE, *UUID_IDS],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return __import__("json").loads(out.stdout.strip().splitlines()[-1])
+
+
+def test_numeric_suffix_is_used_directly():
+    assert stable_palette_index("npc_5") == 5
+    assert stable_palette_index("npc_0") == 0
+
+
+def test_index_is_deterministic_in_process():
+    assert [stable_palette_index(s) for s in UUID_IDS] == [
+        stable_palette_index(s) for s in UUID_IDS
+    ]
+
+
+@pytest.mark.parametrize("seed", ["1", "12345"])
+def test_index_is_identical_under_different_hash_seeds(seed):
+    """Pinning PYTHONHASHSEED to two different values reproduces "parent vs spawned worker"
+    without needing a pool."""
+    baseline = _indices_with_hash_seed("0")
+    assert _indices_with_hash_seed(seed) == baseline
+    # the in-process value agrees too, whatever seed the test runner happens to have
+    assert [stable_palette_index(s) for s in UUID_IDS] == baseline


### PR DESCRIPTION
## Problem

Agent colours are picked from the agent id. Ids without a numeric suffix — every reproducer
frame, since `_draw_step` renames neighbours to `nb_<track_uuid[:8]>` — fell through to builtin
`hash()`, which `PYTHONHASHSEED` randomises per interpreter. The same scene rendered a different
palette on every run; it only looked stable because one process rendered a whole video.

## Fix

Extract the id → palette-slot mapping to `stable_palette_index()` and derive it from
`zlib.crc32`. `npc_N` ids keep the numeric branch, so sim-path colours are unchanged.

## Result

Colours become a pure function of the id, in any process. No baseline is broken — any two runs
already disagreed, and only UUID-named tracks change.

Prerequisite for #338: with a per-process hash seed, each render worker picks its own colours,
so a pooled video flickers.

## Tests

`test_stable_palette_index.py` computes the slots in fresh interpreters under different
`PYTHONHASHSEED` values and asserts they agree. Reverting to `abs(hash(...))` fails it.

## Note

Bottom of a 2-PR stack: **#334 (this PR)** ← `tier4-main`, #338 ← #334.
