### PR TITLE
fix(ddp): use a per-job init file for process-group rendezvous

### DIFF
--- a/diffusion_planner/diffusion_planner/utils/ddp.py
+++ b/diffusion_planner/diffusion_planner/utils/ddp.py
@@ -7,6 +7,26 @@ import torch.distributed as dist
 from torch.distributed import init_process_group
 
 
+def dist_init_file() -> str:
+    """Path of the FileStore used to rendezvous the process group.
+
+    This must be unique per job. A FileStore keyed on a fixed path silently cross-connects two
+    jobs that land on the same node with the same ``world_size`` -- they rendezvous into each
+    other's process group, and the resulting collectives mix tensors from unrelated runs. Slurm
+    here runs with ``JobContainerType=(null)``, so ``/tmp`` is shared between jobs on a node and
+    the fixed path this used to hardcode was reachable by every concurrent run.
+
+    Defaults to a per-``SLURM_JOB_ID`` path, with ``DP_DDP_INIT_FILE`` as an explicit override
+    for launchers that are not slurm (or for tests). The bare fallback is only for a machine
+    running a single job at a time.
+    """
+    override = os.environ.get("DP_DDP_INIT_FILE")
+    if override:
+        return override
+    job_id = os.environ.get("SLURM_JOB_ID")
+    return f"/tmp/tmp_dist_init_{job_id}" if job_id else "/tmp/tmp_dist_init"
+
+
 def ddp_setup_universal(verbose=False, args=None):
     if args.ddp == False:
         print(f"do not use ddp, train on GPU 0")
@@ -39,7 +59,7 @@ def ddp_setup_universal(verbose=False, args=None):
     dist_backend = "nccl"
     # I don't know why but this is needed for DDP to work instead of 'env://'
     dist_url = "file://"
-    file_path = "/tmp/tmp_dist_init"
+    file_path = dist_init_file()
     print("| distributed init (rank {}): {}, gpu {}".format(rank, dist_url, gpu), flush=True)
     init_process_group(
         init_method=f"{dist_url}{file_path}",

--- a/diffusion_planner/tests/test_ddp_init_file.py
+++ b/diffusion_planner/tests/test_ddp_init_file.py
@@ -1,0 +1,45 @@
+"""The DDP rendezvous FileStore path must be unique per job.
+
+Two jobs sharing one FileStore path with the same ``world_size`` rendezvous into each other's
+process group. On this cluster ``/tmp`` is shared between jobs on a node
+(``JobContainerType=(null)``), so the previously hardcoded ``/tmp/tmp_dist_init`` was reachable
+by every concurrent run.
+"""
+
+from __future__ import annotations
+
+import pytest
+from diffusion_planner.utils.ddp import dist_init_file
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("DP_DDP_INIT_FILE", raising=False)
+    monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+
+
+def test_distinct_slurm_jobs_get_distinct_files(monkeypatch):
+    monkeypatch.setenv("SLURM_JOB_ID", "1783")
+    first = dist_init_file()
+    monkeypatch.setenv("SLURM_JOB_ID", "1793")
+    second = dist_init_file()
+    assert first != second, "two slurm jobs would rendezvous into the same process group"
+    assert "1783" in first and "1793" in second
+
+
+def test_env_override_wins_over_slurm_job_id(monkeypatch):
+    """Non-slurm launchers (and tests) need to set this explicitly."""
+    monkeypatch.setenv("SLURM_JOB_ID", "1783")
+    monkeypatch.setenv("DP_DDP_INIT_FILE", "/tmp/explicit_path")
+    assert dist_init_file() == "/tmp/explicit_path"
+
+
+def test_falls_back_when_not_under_slurm():
+    assert dist_init_file() == "/tmp/tmp_dist_init"
+
+
+def test_empty_override_is_ignored(monkeypatch):
+    """An unset-but-exported shell variable must not produce an empty rendezvous path."""
+    monkeypatch.setenv("DP_DDP_INIT_FILE", "")
+    monkeypatch.setenv("SLURM_JOB_ID", "42")
+    assert dist_init_file() == "/tmp/tmp_dist_init_42"


### PR DESCRIPTION
## Problem

`init_process_group` used a fixed FileStore path, `/tmp/tmp_dist_init`. `/tmp` is shared between
jobs on this cluster (`JobContainerType=(null)`), so two concurrent jobs with the same world size
cross-connect into each other's process group.

This is not theoretical: a stale `/tmp/tmp_dist_init` owned by another user blocked every arm of
a measurement run on first launch.

## Fix

The path is now per-job and overridable by env var. The choice is factored into
`dist_init_file()` so it can be tested.

## Tests

4 unit tests over `dist_init_file()` (per-job path, env override, fallback).
