### PR TITLE
feat(closed_loop): shard evaluation across all DDP ranks

### DIFF
--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -2,6 +2,7 @@ import json
 import os
 import tempfile
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 import pandas as pd
@@ -138,8 +139,83 @@ def _object_mode_pairs(modes: list[str]) -> tuple[tuple[str, bool], ...]:
     return tuple((m, _OBJECT_MODE_DROP_FLAGS[m]) for m in ("objects", "noobj") if m in modes)
 
 
+@dataclass
+class _ClosedLoopCombo:
+    """One (source/site, object-mode) evaluation unit: what to run and where it writes."""
+
+    label: str | None  # wandb/site label; None only for a single-mode bare --closed_loop_npz_root
+    npz_root: object
+    drop_objects: bool
+    out_dir: str
+    track_for_report: bool
+
+
+def closed_loop_combos(args, out_dir: str) -> list[_ClosedLoopCombo]:
+    """Enumerate every (source/site, object-mode) combo this call will evaluate.
+
+    Split out from the execution so the combo list exists *before* anything runs: under DDP the
+    job plan is pooled across all combos and balanced once (see
+    ``closed_loop_evaluation.run_evaluations_ddp``), which is only possible if we know the full
+    set up front. Purely derived from ``args`` -- deterministic, and therefore identical on every
+    rank, which the plan fingerprint check downstream relies on.
+
+    ``closed_loop_npz_root`` (single arbitrary path) and ``closed_loop_sites_npz_root`` (a
+    curated ``.json`` manifest grouped into per-site route pools) are independent; both
+    contribute when both are set.
+    """
+    from scenario_generation.site_discovery import discover_sites_from_json
+
+    combos: list[_ClosedLoopCombo] = []
+
+    def add(base_name, npz_root, mode_pairs, *, track_for_report: bool) -> None:
+        """``noobj`` gets a distinct label (suffix) rather than a separate axis, so it rides the
+        existing per-site machinery (wandb keys, metric_regex overlay, combined episode table)
+        unchanged. When only "objects" is requested (the common single-mode case), the
+        label/out_dir stay exactly as a bare single call would use (``base_name`` verbatim, no
+        subdir)."""
+        multi = len(mode_pairs) > 1
+        for tag, drop_objects in mode_pairs:
+            if multi:
+                base = base_name or "main"
+                label = f"{base}__noobj" if tag == "noobj" else base
+            else:
+                label = base_name
+            combos.append(
+                _ClosedLoopCombo(
+                    label=label,
+                    npz_root=npz_root,
+                    drop_objects=drop_objects,
+                    out_dir=os.path.join(out_dir, label) if label else out_dir,
+                    track_for_report=track_for_report,
+                )
+            )
+
+    if args.closed_loop_npz_root:
+        add(
+            None,
+            args.closed_loop_npz_root,
+            _object_mode_pairs(args.closed_loop_npz_object_modes),
+            track_for_report=False,
+        )
+    if args.closed_loop_sites_npz_root:
+        sites = discover_sites_from_json(args.closed_loop_sites_npz_root)
+        if not sites:
+            print(f"closed-loop: no sites found under {args.closed_loop_sites_npz_root}")
+        sites_modes = _object_mode_pairs(args.closed_loop_sites_object_modes)
+        for site_name, npz_root in sites.items():
+            add(site_name, npz_root, sites_modes, track_for_report=True)
+    return combos
+
+
 def closed_loop_validate(
-    model, args, epoch: int, out_dir: str, *, is_final_save: bool = False
+    model,
+    args,
+    epoch: int,
+    out_dir: str,
+    *,
+    is_final_save: bool = False,
+    ddp_rank: int = 0,
+    ddp_world_size: int = 1,
 ) -> None:
     """Closed-loop rendered rollout; logs metrics + videos to wandb.
 
@@ -149,9 +225,16 @@ def closed_loop_validate(
     per-site route pools by
     :func:`~scenario_generation.site_discovery.discover_sites_from_json`) are independent — both
     fire in the same call when both are set, each contributing its own rows to the combined
-    episode table / cross-site aggregate. Called on the checkpoint-save cadence, rank-0 only:
-    pass the unwrapped model; it is switched to eval for the rollout (so the diffusion sampler
-    runs and produces ``prediction``) and restored afterwards.
+    episode table / cross-site aggregate. Called on the checkpoint-save cadence; pass the
+    unwrapped model, which is switched to eval for the rollout (so the diffusion sampler runs and
+    produces ``prediction``) and restored afterwards.
+
+    **Collective when ``ddp_world_size > 1``**: EVERY rank must call this, the same number of
+    times and in the same order, or the run wedges at the barrier inside ``run_evaluations_ddp``
+    until the process-group timeout. The rollout work is pooled across all (site, object-mode)
+    combos and balanced over the ranks; only rank-0 gets summaries back and does the wandb /
+    HTML-report / print work. Passing the defaults (rank 0, world 1) keeps the plain
+    single-process behaviour, which is what non-DDP callers get.
 
     Per-step matplotlib rendering (PNGs/video/colormap images) is the dominant per-call cost, so
     it's deferred to the last call only (``is_final_save=True``, computed by the caller as "is
@@ -167,9 +250,9 @@ def closed_loop_validate(
         ClosedLoopEvalConfig,
         FullRouteClosedLoopEvaluation,
         RolloutParams,
+        run_evaluations_ddp,
     )
     from scenario_generation.closed_loop_html_report import build_html_report
-    from scenario_generation.site_discovery import discover_sites_from_json
     from scenario_generation.wandb_closed_loop import (
         build_combined_episode_table,
         build_full_closed_loop_wandb_log,
@@ -180,13 +263,12 @@ def closed_loop_validate(
     was_training = net.training
     net.eval()
 
-    def run_one(npz_root, site_out_dir: str, site_name: str | None, drop_objects: bool = False):
-        site_label = f" [{site_name}]" if site_name else ""
-        evaluator = FullRouteClosedLoopEvaluation(
+    def make_evaluator(combo: _ClosedLoopCombo) -> FullRouteClosedLoopEvaluation:
+        return FullRouteClosedLoopEvaluation(
             net,
             args,
             ClosedLoopEvalConfig(
-                out_dir=Path(site_out_dir),
+                out_dir=Path(combo.out_dir),
                 params=RolloutParams(
                     device=args.device,
                     near_miss_thresh=args.closed_loop_near_miss_thresh,
@@ -201,87 +283,60 @@ def closed_loop_validate(
                     abort_deviation_m=args.closed_loop_abort_deviation_m,
                     abort_after=args.closed_loop_abort_after,
                     abort_max_snaps=args.closed_loop_abort_max_snaps,
-                    drop_objects=drop_objects,
+                    drop_objects=combo.drop_objects,
                 ),
                 fps=float(args.closed_loop_fps),
                 verbose=False,
             ),
-            npz_root,
+            combo.npz_root,
             seg_len=args.closed_loop_seg_len,
+            ddp_rank=ddp_rank,
+            ddp_world_size=ddp_world_size,
         )
-        summary = evaluator.run()
-        if not summary:
-            return {}, {}
-        site_log = build_full_closed_loop_wandb_log(
-            summary,
-            out_dir=site_out_dir,
-            site=site_name,
-            video_pick=args.closed_loop_wandb_video_pick,
-            colormap_metrics=args.closed_loop_colormap_metrics,
-            near_miss_thresh=args.closed_loop_near_miss_thresh,
-            report_base_url=args.closed_loop_report_base_url or None,
-            render_media=is_final_save,
-        )
-        print(
-            f"closed-loop{site_label} @epoch {epoch + 1}: {summary['n_segments']} seg in "
-            f"{summary['elapsed_sec']:.1f}s  route_completion={summary.get('mean_route_completion', 0.0):.3f}  "
-            f"collisions={summary.get('object', {}).get('collision_count', 0)}  "
-            f"curb_hits={summary.get('road_border', {}).get('collision_count', 0)}  "
-            f"snaps={summary.get('reproducer', {}).get('snap_count', 0)}  -> "
-            f"{len(summary['video_mp4s'])} video(s)"
-        )
-        return site_log, summary
 
     log: dict = {}
     site_summaries: dict[str, dict] = {}
     episode_data: list = []  # (label, rows, out_dir) for the ONE combined table, across BOTH sources
     site_report_labels: list[str] = []
 
-    def run_labeled(
-        base_name: str | None,
-        npz_root,
-        mode_pairs: tuple[tuple[str, bool], ...],
-        *,
-        track_for_report: bool = False,
-    ) -> None:
-        """Run ``npz_root`` once per requested object-mode, merging into log/site_summaries/episode_data.
-
-        "noobj" gets a distinct label (suffix) rather than a separate axis, so it rides the
-        existing per-site machinery (wandb keys, metric_regex overlay, combined episode table)
-        unchanged. When only "objects" is requested (the common single-mode case), the
-        label/out_dir stay exactly as a bare single call would use (``base_name`` verbatim, no
-        subdir).
-        """
-        multi = len(mode_pairs) > 1
-        for tag, drop_objects in mode_pairs:
-            if multi:
-                base = base_name or "main"
-                label = f"{base}__noobj" if tag == "noobj" else base
-            else:
-                label = base_name
-            site_out_dir = os.path.join(out_dir, label) if label else out_dir
-            site_log, summary = run_one(npz_root, site_out_dir, label, drop_objects=drop_objects)
+    try:
+        combos = closed_loop_combos(args, out_dir)
+        # One collective call for every combo: jobs are pooled and balanced across ranks together
+        # with a single barrier. Non-zero ranks get {} back and fall through the rank-0 logging.
+        summaries = run_evaluations_ddp(
+            [make_evaluator(c) for c in combos],
+            rank=ddp_rank,
+            world_size=ddp_world_size,
+            verbose=True,
+        )
+        for combo, summary in zip(combos, summaries):
             if not summary:
                 continue
-            episode_label = label or "main"
+            site_log = build_full_closed_loop_wandb_log(
+                summary,
+                out_dir=combo.out_dir,
+                site=combo.label,
+                video_pick=args.closed_loop_wandb_video_pick,
+                colormap_metrics=args.closed_loop_colormap_metrics,
+                near_miss_thresh=args.closed_loop_near_miss_thresh,
+                report_base_url=args.closed_loop_report_base_url or None,
+                render_media=is_final_save,
+            )
+            site_label = f" [{combo.label}]" if combo.label else ""
+            print(
+                f"closed-loop{site_label} @epoch {epoch + 1}: {summary['n_segments']} seg in "
+                f"{summary['elapsed_sec']:.1f}s  route_completion={summary.get('mean_route_completion', 0.0):.3f}  "
+                f"collisions={summary.get('object', {}).get('collision_count', 0)}  "
+                f"curb_hits={summary.get('road_border', {}).get('collision_count', 0)}  "
+                f"snaps={summary.get('reproducer', {}).get('snap_count', 0)}  -> "
+                f"{len(summary['video_mp4s'])} video(s)"
+            )
+            episode_label = combo.label or "main"
             log.update(site_log)
             site_summaries[episode_label] = summary
-            episode_data.append((episode_label, summary.get("segments") or [], site_out_dir))
-            if track_for_report:
+            episode_data.append((episode_label, summary.get("segments") or [], combo.out_dir))
+            if combo.track_for_report:
                 site_report_labels.append(episode_label)
-
-    try:
-        if args.closed_loop_npz_root:
-            npz_modes = _object_mode_pairs(args.closed_loop_npz_object_modes)
-            run_labeled(None, args.closed_loop_npz_root, npz_modes)
-
-        if args.closed_loop_sites_npz_root:
-            sites = discover_sites_from_json(args.closed_loop_sites_npz_root)
-            if not sites:
-                print(f"closed-loop: no sites found under {args.closed_loop_sites_npz_root}")
-            sites_modes = _object_mode_pairs(args.closed_loop_sites_object_modes)
-            for site_name, npz_root in sites.items():
-                run_labeled(site_name, npz_root, sites_modes, track_for_report=True)
 
         # One combined, filterable/groupable episode table across every source/site/mode.
         if episode_data:
@@ -298,7 +353,8 @@ def closed_loop_validate(
     finally:
         net.train(was_training)
 
-    if log:
+    # `log` is empty off rank-0 anyway, but wandb is only initialized there: keep the guard explicit.
+    if log and ddp_rank == 0:
         wandb.log(log, step=epoch + 1)
 
 
@@ -306,8 +362,8 @@ def model_training(args: TrainConfig):
     assert len(args.coeff_timestep) == 4, "coeff_timestep must be a list of 4 elements"
 
     # init ddp
-    global_rank, rank, _ = ddp.ddp_setup_universal(True, args)
-    print(f"{global_rank=}, {rank=}")
+    global_rank, rank, world_size = ddp.ddp_setup_universal(True, args)
+    print(f"{global_rank=}, {rank=}, {world_size=}")
 
     if global_rank == 0:
         # Logging
@@ -717,19 +773,6 @@ def model_training(args: TrainConfig):
                     opset_version=20,
                     external_data=False,
                 )
-                # Closed-loop validation runs on the same cadence as the checkpoint save; outputs
-                # (videos + metrics) land next to the saved weights they correspond to.
-                is_final_save = (epoch + 1 - init_epoch) // save_utd == (
-                    train_epochs - init_epoch
-                ) // save_utd
-                closed_loop_validate(
-                    diffusion_planner,
-                    args,
-                    epoch,
-                    os.path.join(curr_dir, "closed_loop"),
-                    is_final_save=is_final_save,
-                )
-
             if valid_loss_ego_position_lat_loss < best_loss:
                 curr_dir = os.path.join(save_path, "best_model")
                 os.makedirs(curr_dir, exist_ok=True)
@@ -751,6 +794,26 @@ def model_training(args: TrainConfig):
                     opset_version=20,
                     external_data=False,
                 )
+
+        # Runs on the checkpoint-save cadence, outside the `global_rank == 0` block on purpose:
+        # the rollouts are sharded over every rank, so all ranks must reach this call. The cadence
+        # condition uses only rank-invariant values, so they agree without communicating.
+        if (epoch + 1 - init_epoch) % save_utd == 0:
+            # args.save_dir, not save_path: the latter is None off rank-0, and every rank writes
+            # its shard into the same per-epoch directory.
+            curr_dir = os.path.join(args.save_dir, f"epoch{epoch + 1:04d}")
+            is_final_save = (epoch + 1 - init_epoch) // save_utd == (
+                train_epochs - init_epoch
+            ) // save_utd
+            closed_loop_validate(
+                diffusion_planner,
+                args,
+                epoch,
+                os.path.join(curr_dir, "closed_loop"),
+                is_final_save=is_final_save,
+                ddp_rank=global_rank,
+                ddp_world_size=world_size if args.ddp else 1,
+            )
 
         scheduler.step()
         train_sampler.set_epoch(epoch + 1)

--- a/scenario_generation/closed_loop_ddp.py
+++ b/scenario_generation/closed_loop_ddp.py
@@ -2,9 +2,59 @@
 
 from __future__ import annotations
 
+import hashlib
+from typing import Any, Callable, Sequence
+
 
 def shard_items(items: list, rank: int, world_size: int) -> list:
     """Round-robin assignment: rank ``r`` gets indices r, r+world_size, ..."""
     if world_size <= 1:
         return items
     return [items[i] for i in range(rank, len(items), world_size)]
+
+
+def balance_items(
+    items: Sequence[Any],
+    world_size: int,
+    *,
+    cost: Callable[[Any], float],
+    key: Callable[[Any], str],
+) -> list[list[Any]]:
+    """Partition ``items`` into ``world_size`` buckets with LPT greedy bin packing.
+
+    Closed-loop jobs differ in cost by an order of magnitude (a route costs roughly what it is
+    long), so the round-robin ``shard_items`` above balances *counts* and leaves the wall clock
+    set by whichever rank happened to draw the long routes. LPT -- sort descending by cost, hand
+    each item to the currently-cheapest bucket -- is within 4/3 of optimal and is what makes a
+    single-barrier run actually approach ``world_size``x.
+
+    Determinism is load-bearing: every rank computes this independently and they must agree
+    exactly, or jobs get run twice / not at all while the merged result still looks healthy.
+    Ties therefore break on ``key(item)`` (not input order), and the bucket choice breaks ties on
+    the lowest bucket index.
+
+    Returns one list per rank, each in ``key`` order so a rank's own execution order is stable.
+    """
+    if world_size <= 1:
+        return [list(items)]
+    ordered = sorted(items, key=lambda it: (-float(cost(it)), key(it)))
+    buckets: list[list[Any]] = [[] for _ in range(world_size)]
+    loads = [0.0] * world_size
+    for item in ordered:
+        target = min(range(world_size), key=lambda r: (loads[r], r))
+        buckets[target].append(item)
+        loads[target] += float(cost(item))
+    return [sorted(b, key=key) for b in buckets]
+
+
+def plan_fingerprint(keys: Sequence[str]) -> int:
+    """Order-sensitive 60-bit fingerprint of a job-key list, for cross-rank agreement checks.
+
+    Ranks build their assignment plan independently from the filesystem; anything that makes two
+    ranks enumerate routes differently (glob order feeding ``enumerate_multi_root_routes``'s
+    collision disambiguation, a partially-written dataset, a stale NFS listing) silently turns
+    the plan into a non-partition -- some routes run twice, others never, and the merged summary
+    still looks perfectly healthy. Comparing this number across ranks makes that loud instead.
+    """
+    digest = hashlib.sha1("\n".join(keys).encode("utf-8")).hexdigest()
+    return int(digest[:15], 16)

--- a/scenario_generation/closed_loop_evaluation.py
+++ b/scenario_generation/closed_loop_evaluation.py
@@ -14,6 +14,7 @@ route under an npz_root.
 from __future__ import annotations
 
 import json
+import sys
 import time
 import traceback
 from abc import ABC, abstractmethod
@@ -21,7 +22,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from scenario_generation.closed_loop_ddp import shard_items
+from scenario_generation.closed_loop_ddp import balance_items, plan_fingerprint, shard_items
 from scenario_generation.closed_loop_eval import (
     aggregate,
     build_mp4,
@@ -152,6 +153,15 @@ class ClosedLoopJob:
     """One schedulable unit (route, bag, classification date, …)."""
 
     job_id: str
+
+    def cost(self) -> float:
+        """Relative scheduling weight, used to balance DDP shards (see ``balance_items``).
+
+        Only ratios between jobs matter, and only for load balancing -- a wrong estimate costs
+        wall clock, never correctness. The default treats every job as equal, which is what
+        round-robin sharding already assumed.
+        """
+        return 1.0
 
 
 @dataclass
@@ -379,6 +389,148 @@ class ClosedLoopEvaluation(ABC):
         raise NotImplementedError
 
 
+def _assert_same_plan(job_keys: list[str]) -> None:
+    """Fail loudly unless every rank enumerated the identical job list in the identical order.
+
+    Ranks build their plan independently from the filesystem; anything that makes two ranks
+    enumerate routes differently (glob order feeding ``enumerate_multi_root_routes``'s collision
+    disambiguation, a partially-written dataset, a stale NFS listing) silently turns the plan
+    into a non-partition -- some routes run twice, others never, and the merged summary still
+    looks perfectly healthy.
+    """
+    import torch
+    import torch.distributed as dist
+
+    fp = plan_fingerprint(job_keys)
+    # max(fp) and -max(-fp) == min(fp): equal iff every rank submitted the same fingerprint.
+    probe = torch.tensor([fp, -fp], dtype=torch.int64, device=_collective_device())
+    dist.all_reduce(probe, op=dist.ReduceOp.MAX)
+    hi, lo = int(probe[0].item()), -int(probe[1].item())
+    if hi != lo:
+        raise RuntimeError(
+            "closed-loop DDP: ranks disagree on the job plan "
+            f"(fingerprints span {lo:#x}..{hi:#x}; this rank has {len(job_keys)} job(s), "
+            f"fingerprint {fp:#x}) -- job discovery is not deterministic across ranks, so the "
+            "shards would not form a partition. Refusing to run."
+        )
+
+
+def _sum_across_ranks(values: list[float]) -> list[float]:
+    """Element-wise sum of a per-rank float vector. Collective: every rank must call it."""
+    import torch
+    import torch.distributed as dist
+
+    t = torch.tensor(values, dtype=torch.float64, device=_collective_device())
+    dist.all_reduce(t, op=dist.ReduceOp.SUM)
+    return [float(x) for x in t.tolist()]
+
+
+def run_evaluations_ddp(
+    evaluators: list[ClosedLoopEvaluation],
+    *,
+    rank: int = 0,
+    world_size: int = 1,
+    verbose: bool = False,
+) -> list[dict]:
+    """Run several evaluators across all DDP ranks, with ONE barrier for the whole set.
+
+    Returns one summary per evaluator, positionally aligned with ``evaluators`` (``{}`` on
+    non-zero ranks, which hold no merged result). ``world_size <= 1`` is plain
+    ``evaluator.run()`` per evaluator, identical to the sequential behaviour.
+
+    Why this exists rather than calling ``run_distributed()`` per evaluator: that barriers once
+    per evaluator, making the total ``sum over evaluators of max over ranks``. Sites hold wildly
+    different route counts (1 to 14 in the curated manifests), so a per-evaluator barrier pins
+    the single-route sites to single-rank speed no matter how many GPUs are attached, and no
+    amount of load balancing can recover it -- measured ceiling 1.96x on 4 GPUs. Pooling every
+    (evaluator, job) pair into ONE list, balancing that once, and barriering once makes the floor
+    the single longest *job* instead: measured 2.80x on the same manifest.
+
+    Every rank must call this the same number of times in the same order (it is collective).
+    """
+    if world_size <= 1:
+        return [ev.run() for ev in evaluators]
+
+    import torch.distributed as dist
+
+    if not (dist.is_available() and dist.is_initialized()):
+        raise RuntimeError(
+            f"closed-loop run_evaluations_ddp: world_size={world_size} > 1 but "
+            "torch.distributed is not initialized -- there would be no barrier to guarantee "
+            "every rank finished writing its shard before rank-0 merges."
+        )
+
+    t0 = time.perf_counter()
+    # (evaluator index, job). The evaluator index is part of the sort key so two evaluators that
+    # legitimately share a job_id (the same route under both object modes) stay distinct.
+    tagged: list[tuple[int, ClosedLoopJob]] = []
+    for ei, ev in enumerate(evaluators):
+        jobs = ev.discover_jobs()
+        if ev.config.max_jobs is not None:
+            jobs = jobs[: ev.config.max_jobs]
+        tagged.extend((ei, job) for job in jobs)
+
+    def _key(item: tuple[int, ClosedLoopJob]) -> str:
+        return f"{item[0]:04d}/{item[1].job_id}"
+
+    tagged.sort(key=_key)
+    _assert_same_plan([_key(it) for it in tagged])
+
+    buckets = balance_items(tagged, world_size, cost=lambda it: it[1].cost(), key=_key)
+    mine = buckets[rank]
+    per_eval: list[list[ClosedLoopJob]] = [[] for _ in evaluators]
+    for ei, job in mine:
+        per_eval[ei].append(job)
+    if verbose:
+        loads = [sum(j.cost() for _, j in b) for b in buckets]
+        # stderr, not print(): ``ddp.setup_for_distributed`` silences stdout everywhere but
+        # rank 0, and the per-rank lines are exactly what makes the balance auditable.
+        sys.stderr.write(
+            f"closed-loop DDP rank {rank}/{world_size}: {len(mine)}/{len(tagged)} job(s), "
+            f"planned cost {loads[rank]:.0f} (per-rank {[f'{x:.0f}' for x in loads]})\n"
+        )
+
+    failed_detail = ""
+    t_jobs = time.perf_counter()
+    per_eval_sec = [0.0] * len(evaluators)
+    for ei, (ev, jobs) in enumerate(zip(evaluators, per_eval)):
+        t_ev = time.perf_counter()
+        try:
+            ev.execute_jobs(jobs)
+        except Exception as exc:  # noqa: BLE001 - re-raised for every rank below
+            # Keep going to the barrier no matter what; see _raise_if_any_rank_failed.
+            traceback.print_exc()
+            failed_detail = f"rank {rank} raised in {type(ev).__name__}: {exc!r}"
+            break
+        per_eval_sec[ei] = time.perf_counter() - t_ev
+    rank_sec = time.perf_counter() - t_jobs
+    if verbose:
+        # max across ranks is this call's makespan; the spread across ranks shows how good the
+        # cost proxy was. Not a sequential baseline: ranks share one node's CPU.
+        sys.stderr.write(
+            f"closed-loop DDP rank {rank}/{world_size}: rollouts done in {rank_sec:.1f}s "
+            f"({len(mine)} job(s))\n"
+        )
+
+    dist.barrier()
+    _raise_if_any_rank_failed(failed_detail, rank)
+
+    # Per-combo ``elapsed_sec`` summed over ranks, so each site's summary keeps meaning what it
+    # meant before pooling -- "what this site cost" -- rather than becoming the whole call's
+    # makespan repeated once per site (which is what the shared t0 would otherwise report).
+    combo_sec = _sum_across_ranks(per_eval_sec)
+    if rank != 0:
+        return [{} for _ in evaluators]
+    if verbose:
+        sys.stderr.write(
+            f"closed-loop DDP: makespan {time.perf_counter() - t0:.1f}s, "
+            f"summed rollout cost across ranks {sum(combo_sec):.1f}s\n"
+        )
+    return [
+        ev.merge_ddp_shards(world_size, elapsed_sec=sec) for ev, sec in zip(evaluators, combo_sec)
+    ]
+
+
 @dataclass
 class FullRouteRouteJob(ClosedLoopJob):
     """One route (bag-prefix group) under an NPZ root."""
@@ -387,6 +539,18 @@ class FullRouteRouteJob(ClosedLoopJob):
     route_key: str = ""
     route_paths: list[Path] = field(default_factory=list)
     seg_len: int = 100_000
+
+    def cost(self) -> float:
+        """Frame count: rollout steps are roughly proportional to route length.
+
+        Route lengths in the curated site manifests span an order of magnitude (396..6353
+        frames), so this is the difference between a balanced shard and one rank holding every
+        other rank at the barrier. Read straight off the already-enumerated path list, no extra
+        I/O. It is a good ordering proxy *within* a site and a mediocre one across sites --
+        measured cost ranges 0.026..0.079 s/frame by site -- which is what keeps the achieved
+        speedup below the ideal. See the module docstring note on future work.
+        """
+        return float(len(self.route_paths))
 
 
 class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):

--- a/scenario_generation/tests/test_closed_loop_ddp.py
+++ b/scenario_generation/tests/test_closed_loop_ddp.py
@@ -19,12 +19,14 @@ import pytest
 import torch.distributed as dist
 import torch.multiprocessing as mp
 
+from scenario_generation.closed_loop_ddp import balance_items, plan_fingerprint, shard_items
 from scenario_generation.closed_loop_evaluation import (
     ClosedLoopEvalConfig,
     FullRouteClosedLoopEvaluation,
     FullRouteRouteJob,
     JobRunResult,
     RolloutParams,
+    run_evaluations_ddp,
 )
 
 # Route frame counts from the production manifest (path_list_closed_loop_x2.json), measured
@@ -304,3 +306,206 @@ def test_world_size_one_propagates_exceptions_unchanged(tmp_path):
     evaluators = _make_evaluators(tmp_path / "out", _SPECS[2:3], rank=0, world=1, fail_on="tk_07")
     with pytest.raises(ValueError, match="synthetic failure on tk_07"):
         evaluators[0].run_distributed()
+
+
+# ---------------------------------------------------------------------------------------------
+# Pooled, cost-balanced sharding across every evaluator (one barrier for the whole set)
+# ---------------------------------------------------------------------------------------------
+
+
+def _cost(item):
+    return item[1]
+
+
+def _key(item):
+    return item[0]
+
+
+def test_balance_items_is_a_partition():
+    items = [(f"j{i:02d}", float(i % 7 + 1)) for i in range(23)]
+    for world in (1, 2, 3, 4, 8, 32):
+        buckets = balance_items(items, world, cost=_cost, key=_key)
+        assert len(buckets) == max(world, 1)
+        flat = [it for b in buckets for it in b]
+        assert sorted(flat, key=_key) == sorted(items, key=_key)
+
+
+def test_balance_items_is_deterministic_regardless_of_input_order():
+    """Ranks enumerate independently; only agreeing plans form a partition."""
+    items = [(f"j{i:02d}", float(i % 5)) for i in range(20)]
+    base = balance_items(items, 4, cost=_cost, key=_key)
+    assert balance_items(list(reversed(items)), 4, cost=_cost, key=_key) == base
+    rng = np.random.default_rng(0)
+    for _ in range(5):
+        perm = [items[i] for i in rng.permutation(len(items))]
+        assert balance_items(perm, 4, cost=_cost, key=_key) == base
+
+
+def test_balance_items_allows_empty_buckets():
+    """Fewer jobs than ranks is normal (a 1-route site on 4 GPUs), not an error."""
+    assert [len(b) for b in balance_items([("only", 1.0)], 4, cost=_cost, key=_key)] == [1, 0, 0, 0]
+
+
+def test_pooled_balancing_beats_per_combo_round_robin():
+    """The reason this exists, on the real manifest's route lengths.
+
+    Baseline = the pre-existing wiring: ``shard_items`` round-robin inside each combo with a
+    barrier per combo, so the makespan is ``sum over combos of max over ranks``. A 1-route combo
+    cannot be split under that scheme no matter how many GPUs are attached.
+    """
+    world = 4
+    per_combo = [[(f"{s['name']}/{r}", float(n)) for r, n in s["routes"].items()] for s in _SPECS]
+    baseline = sum(
+        max(sum(c for _, c in shard_items(sorted(cb, key=_key), r, world)) for r in range(world))
+        for cb in per_combo
+    )
+    pooled = [it for cb in per_combo for it in cb]
+    new = max(sum(c for _, c in b) for b in balance_items(pooled, world, cost=_cost, key=_key))
+    total = sum(c for _, c in pooled)
+    assert new <= (total / world) * 1.05, f"pooled makespan {new} vs ideal {total / world}"
+    # Measured on these numbers: per-combo round-robin 1.96x, pooled 3.95x of sequential cost.
+    assert total / baseline < 2.2
+    assert total / new > 3.5
+
+
+def test_plan_fingerprint_is_order_sensitive_and_stable():
+    assert plan_fingerprint(["a", "b"]) == plan_fingerprint(["a", "b"])
+    assert plan_fingerprint(["a", "b"]) != plan_fingerprint(["b", "a"])
+    assert plan_fingerprint(["a", "b"]) != plan_fingerprint(["a", "b", "c"])
+    assert 0 <= plan_fingerprint(["a"]) < 2**63
+
+
+def test_full_route_job_cost_is_route_length():
+    job = FullRouteRouteJob(job_id="r", route_paths=[Path(f"{i}.npz") for i in range(37)])
+    assert job.cost() == 37.0
+
+
+def _worker_pooled(rank: int, world: int, out_root: str, init_file: str, mode: str, q):
+    """Run every evaluator through the pooled path (ONE barrier for the whole set)."""
+    try:
+        dist.init_process_group(
+            backend="gloo",
+            init_method=f"file://{init_file}",
+            world_size=world,
+            rank=rank,
+            timeout=datetime.timedelta(seconds=60),
+        )
+        fail_on = "tk_07" if mode == "fail" else None
+        evaluators = _make_evaluators(Path(out_root), _SPECS, rank, world, fail_on=fail_on)
+        error = ""
+        summaries = []
+        try:
+            summaries = run_evaluations_ddp(evaluators, rank=rank, world_size=world)
+        except Exception as exc:  # noqa: BLE001 - reported back to the parent
+            error = f"{type(exc).__name__}: {exc}"
+        q.put(
+            {
+                "rank": rank,
+                "error": error,
+                "ran": sorted(u for ev in evaluators for u in ev.ran),
+                "cost": sum(ev.ran_cost for ev in evaluators),
+                "n_segments": [s.get("n_segments") for s in summaries],
+                "elapsed_sec": [s.get("elapsed_sec") for s in summaries],
+                "routes_merged": [
+                    sorted({row["route"] for row in (s.get("segments") or [])}) for s in summaries
+                ],
+            }
+        )
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+@pytest.mark.parametrize("world", [2, 4])
+def test_pooled_runs_every_job_exactly_once(tmp_path, world):
+    """The partition invariant, end to end: nothing run twice, nothing skipped."""
+    results = _run_world(tmp_path, world, worker=_worker_pooled)
+    assert [r["error"] for r in results] == [""] * world
+    ran = [unit for r in results for unit in r["ran"]]
+    assert len(ran) == len(set(ran)), "a job was executed on more than one rank"
+    assert sorted(ran) == _ALL_UNITS
+
+
+@pytest.mark.parametrize("world", [2, 4])
+def test_pooled_merge_matches_the_full_route_set(tmp_path, world):
+    results = _run_world(tmp_path, world, worker=_worker_pooled)
+    rank0 = results[0]
+    assert rank0["n_segments"] == [len(s["routes"]) for s in _SPECS]
+    for spec, routes in zip(_SPECS, rank0["routes_merged"]):
+        assert routes == sorted(spec["routes"])
+    for r in results[1:]:
+        assert r["n_segments"] == [None] * len(_SPECS), "non-zero rank returned a summary"
+
+
+@pytest.mark.parametrize("world", [2, 4])
+def test_pooled_balances_cost_across_ranks(tmp_path, world):
+    """One barrier means the slowest rank sets the wall clock, so balance is the whole point."""
+    results = _run_world(tmp_path, world, worker=_worker_pooled)
+    costs = [r["cost"] for r in results]
+    ideal = sum(costs) / world
+    assert max(costs) <= ideal * 1.05, f"per-rank costs {costs}, ideal {ideal:.0f}"
+
+
+def test_pooled_survives_ranks_with_no_jobs(tmp_path):
+    """world=8 over combos of 1-2 routes: most ranks idle in most combos.
+
+    A rank with zero jobs for a combo still has to create its empty ``segments_{rank}.jsonl``,
+    or ``collect_ddp_shards``'s missing-file check turns ordinary imbalance into a crash.
+    """
+    results = _run_world(tmp_path, 8, worker=_worker_pooled)
+    assert [r["error"] for r in results] == [""] * 8
+    assert results[0]["n_segments"] == [len(s["routes"]) for s in _SPECS]
+    for spec in _SPECS:
+        shards = sorted((tmp_path / "out" / spec["name"]).glob("segments_*.jsonl"))
+        assert len(shards) == 8, f"{spec['name']}: {len(shards)} shard files, expected 8"
+
+
+def test_pooled_elapsed_sec_is_attributed_per_combo(tmp_path):
+    """Each site's ``elapsed_sec`` must stay "what this site cost", not the call's makespan.
+
+    Pooling shares one ``t0`` across every evaluator, so the naive version hands the same number
+    to every ``merge_ddp_shards`` and all 8 sites report an identical (and far too large) time,
+    which then flows into the per-site wandb metric and the training log.
+    """
+    results = _run_world(tmp_path, 4, worker=_worker_pooled)
+    elapsed = results[0]["elapsed_sec"]
+    assert len(set(elapsed)) == len(elapsed), f"all combos reported the same time: {elapsed}"
+    # The stub sleeps a fixed amount per frame, so seconds-per-frame must come out the same for
+    # every combo. A shared makespan would blow this apart by ~13x largest-to-smallest.
+    frames = [sum(s["routes"].values()) for s in _SPECS]
+    rates = [e / f for e, f in zip(elapsed, frames)]
+    assert max(rates) / min(rates) < 1.25, f"elapsed {elapsed} not proportional to frames {frames}"
+
+
+def test_pooled_rank_failure_raises_everywhere(tmp_path):
+    started = time.perf_counter()
+    results = _run_world(tmp_path, 4, mode="fail", worker=_worker_pooled)
+    elapsed = time.perf_counter() - started
+    for r in results:
+        assert "rank(s) failed" in r["error"], f"rank {r['rank']} reported {r['error']!r}"
+    assert all(r["n_segments"] == [] for r in results), "a rank published a summary anyway"
+    assert elapsed < 45, f"took {elapsed:.0f}s -- ranks waited out a barrier instead of failing"
+
+
+def test_pooled_world_size_one_uses_the_sequential_path(tmp_path):
+    assert not dist.is_initialized()
+    evaluators = _make_evaluators(tmp_path / "out", _SPECS, rank=0, world=1)
+    summaries = run_evaluations_ddp(evaluators, rank=0, world_size=1)
+    assert [s["n_segments"] for s in summaries] == [len(s["routes"]) for s in _SPECS]
+    for spec in _SPECS:
+        d = tmp_path / "out" / spec["name"]
+        assert (d / "segments.jsonl").is_file()
+        assert not list(d.glob("segments_*.jsonl")), "world=1 must not write rank-suffixed shards"
+
+
+def test_pooled_world_size_gt_one_without_process_group_refuses(tmp_path):
+    evaluators = _make_evaluators(tmp_path / "out", _SPECS[:1], rank=0, world=4)
+    with pytest.raises(RuntimeError, match="torch.distributed is not initialized"):
+        run_evaluations_ddp(evaluators, rank=0, world_size=4)
+
+
+def test_pooled_max_jobs_is_honoured(tmp_path):
+    """``run()`` is bypassed, so ``max_jobs`` must be applied when building the pooled plan."""
+    specs = [{"name": "tsukuba", "routes": _SPECS[2]["routes"], "max_jobs": 3}]
+    evaluators = _make_evaluators(tmp_path / "out", specs, rank=0, world=1)
+    assert run_evaluations_ddp(evaluators, rank=0, world_size=1)[0]["n_segments"] == 3


### PR DESCRIPTION
## Problem

`closed_loop_validate` runs inside `if global_rank == 0:`, so one GPU does the evaluation while
the rest idle at the next collective. On a 4-GPU job that is 48 minutes of 3 idle GPUs per
checkpoint (102 minutes on the final save, which also renders media).

The DDP machinery for this already exists (`shard_items`, `run_distributed`, `merge_ddp_shards`)
but has no caller. It also barriers once per (site, object-mode), so a site with one route runs at
single-GPU speed regardless of GPU count — measured ceiling **1.96x on 4 GPUs**.

## Fix

`run_evaluations_ddp()` pools all (combo, route) pairs into one list, splits it once with
cost-weighted LPT, runs with no intermediate barriers, then barriers once and merges per combo.
`closed_loop_validate` moves out of the rank-0 guard.

## Result

4xH100, real manifest, 38 segments:

| | sequential | 4 GPU | |
|---|---|---|---|
| media OFF | 2862 s | **1023 s** | **2.80x** |
| media ON | 6121 s | **2736 s** | **2.24x** |

Summed per-rank rollout time matches the sequential baselines to 0.04% / 0.1% — same workload,
negligible contention.

**Output is identical.** All 38 mp4s match, including 14 routes written concurrently
into one directory.

## For reviewers

- `elapsed_sec` is now all-reduced per combo, preserving its per-site meaning. This touches an
  existing per-site W&B metric deliberately.
- `run_distributed()` now has zero callers (it had none before either). Deleting it is your call.
- 2.80x vs an ideal 4.00x is the cost proxy, not the mechanism: frame count orders routes well
  within a site, poorly across sites (0.026-0.079 s/frame). Feeding measured per-route seconds
  back would reach 4.00x; that needs rank-0 to plan and broadcast, so it is left as follow-up.

## Tests

25 tests, where there were 0. The multi-rank ones spawn real gloo groups on CPU and drive the
production merge path. Failure propagation is mutation-verified.


