### PR TITLE
perf(closed_loop): skip the track-anchor scan when objects are dropped

### DIFF
--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -1474,10 +1474,12 @@ def render_segment(
     )
     # Build per-track interpolation anchors over the frames this render visits.
     # The cursor maps sim steps to recorded frames in ~[start, end]; a small
-    # margin covers any overrun without scanning the whole route.
+    # margin covers any overrun without scanning the whole route. Skipped under drop_objects:
+    # every neighbor row is zeroed before _apply_neighbor_interp runs and that function skips
+    # all-zero rows, so the anchors cannot be read.
     interp = (
         _build_neighbor_interp(tl, start, min(end + 100, len(tl)))
-        if interpolate and neighbor_history_mode != "sim"
+        if interpolate and neighbor_history_mode != "sim" and not drop_objects
         else {}
     )
     plan_world = None  # cached (world_xy(T,2), world_h(T,)) from the most recent inference

--- a/scenario_generation/tests/test_reproducer_noobj_interp.py
+++ b/scenario_generation/tests/test_reproducer_noobj_interp.py
@@ -1,0 +1,63 @@
+"""The invariant that makes ``render_segment`` safe to skip the track-anchor scan under
+``drop_objects``: ``_apply_neighbor_interp`` leaves all-zero neighbor rows alone."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from scenario_generation.reproducer_rollout import _apply_neighbor_interp
+
+
+def _anchors_that_would_move_everything(uuids: list[str]) -> dict:
+    return {
+        u: (
+            np.array([0, 100]),
+            np.array([[1000.0, 1000.0], [2000.0, 2000.0]]),
+            np.array([0.5, 1.5]),
+        )
+        for u in uuids
+    }
+
+
+def _np_dict(n_slots: int = 4, *, zeroed: bool) -> dict:
+    nb = np.zeros((1, n_slots, 31, 11), dtype=np.float64)
+    if not zeroed:
+        # a non-zero among the first six columns is what makes a row "present"
+        nb[0, :, -1, 0] = 3.0
+        nb[0, :, -1, 1] = 4.0
+        nb[0, :, -1, 2] = 1.0
+    return {"neighbor_agents_past": nb}
+
+
+def test_apply_is_a_noop_on_zeroed_neighbors():
+    uuids = [f"track{i}" for i in range(4)]
+    d = _np_dict(zeroed=True)
+    before = d["neighbor_agents_past"].copy()
+
+    _apply_neighbor_interp(
+        d, uuids, np.array([0.0, 0.0, 0.0]), 50, _anchors_that_would_move_everything(uuids)
+    )
+
+    assert np.array_equal(d["neighbor_agents_past"], before)
+
+
+def test_apply_does_move_present_neighbors():
+    uuids = [f"track{i}" for i in range(4)]
+    d = _np_dict(zeroed=False)
+    before = d["neighbor_agents_past"].copy()
+
+    _apply_neighbor_interp(
+        d, uuids, np.array([0.0, 0.0, 0.0]), 50, _anchors_that_would_move_everything(uuids)
+    )
+
+    assert not np.array_equal(d["neighbor_agents_past"], before)
+
+
+def test_empty_anchor_dict_is_a_noop():
+    uuids = [f"track{i}" for i in range(4)]
+    d = _np_dict(zeroed=False)
+    before = d["neighbor_agents_past"].copy()
+
+    _apply_neighbor_interp(d, uuids, np.array([0.0, 0.0, 0.0]), 50, {})
+
+    assert np.array_equal(d["neighbor_agents_past"], before)


### PR DESCRIPTION
## Problem

`render_segment` builds per-track interpolation anchors by scanning every frame of the route.
Under `drop_objects` it then zeroes every neighbour row **before** applying them, and
`_apply_neighbor_interp` skips all-zero rows — so the scan's result is never read.

Four of the eight (site, object-mode) combinations run with `drop_objects`.

## Fix

Skip the scan when `drop_objects` is set.

## Result

Full workload, 1xH100, exclusive node: **-6.8% on the noobj combos**, -2.1% over all 8.
The pooled figure is at the noise floor (cross-arm noise +/-2-3%); the noobj number is the claim.

Output is identical.

## Tests

3 tests, mutation-verified.

## Note

Middle of a 3-PR stack that reduces the cost of the same scan from different angles:

- #333 ← `tier4-main`
- **#340 (this PR)** ← #333
- #341 ← #340

Merge bottom-up; review this PR's own commit only. Each PR's % figure was measured standalone
against `tier4-main`, not as an increment within the stack — #333 and #341 partly overlap with
this one.
