### PR TITLE
perf(closed_loop): cache track anchors across evaluations

### DIFF
--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -1018,6 +1018,42 @@ def _build_neighbor_interp(tl: RouteTimeline, lo: int, hi: int, eps: float = 0.1
     return interp
 
 
+# Track anchors depend only on the recorded data, not on the model or the epoch, yet
+# render_segment rebuilds them on every call that builds them -- one NPZ read per frame of the
+# whole route -- and closed_loop_validate re-evaluates the same routes in the same process.
+#
+# Unbounded on purpose, the same argument the per-map caches use: a process sees as many
+# (route, span) pairs as the suite has routes, not as many as it runs evaluations.
+#
+# No lock needed: the anchors are read-only downstream and the single call site runs before
+# render_segment starts its thread pool.
+_INTERP_ANCHOR_CACHE: dict[tuple, dict] = {}
+
+
+def _neighbor_interp_cached(tl: RouteTimeline, lo: int, hi: int, eps: float = 0.1) -> dict:
+    """``_build_neighbor_interp`` memoised per (route, span, sidecar, eps) for the process.
+
+    The sidecar path is part of the key because the same NPZ files paired with a different
+    sidecar directory report different track ids, and so yield different anchors.
+    """
+    key = (
+        str(tl.npz_paths[lo]),
+        str(tl.npz_paths[hi - 1]),
+        str(tl.sidecar_path(lo)),
+        hi - lo,  # the endpoints plus the count pin the file set: npz_paths is sorted
+        eps,
+    )
+    hit = _INTERP_ANCHOR_CACHE.get(key)
+    if hit is not None:
+        # counted so a profile shows the scan was skipped rather than silently missing
+        tl.timers.add("interp_build_cached", 0.0)
+        return hit
+    with tl.timers("interp_build"):
+        anchors = _build_neighbor_interp(tl, lo, hi, eps)
+    _INTERP_ANCHOR_CACHE[key] = anchors
+    return anchors
+
+
 def _interp_pose(anchors: tuple, idx: int) -> tuple[float, float, float]:
     """Linear world pose (x, y, heading) at recorded-frame ``idx`` from fresh anchors."""
     idxs, xy, hd = anchors
@@ -1478,7 +1514,7 @@ def render_segment(
     # every neighbor row is zeroed before _apply_neighbor_interp runs and that function skips
     # all-zero rows, so the anchors cannot be read.
     interp = (
-        _build_neighbor_interp(tl, start, min(end + 100, len(tl)))
+        _neighbor_interp_cached(tl, start, min(end + 100, len(tl)))
         if interpolate and neighbor_history_mode != "sim" and not drop_objects
         else {}
     )

--- a/scenario_generation/route_timeline.py
+++ b/scenario_generation/route_timeline.py
@@ -267,6 +267,10 @@ class RouteTimeline:
         """World ego pose [x, y, yaw] at recorded frame ``idx``."""
         return self.poses[idx]
 
+    def sidecar_path(self, idx: int) -> Path:
+        """The pose/track JSON this timeline resolved for recorded frame ``idx``."""
+        return self._sidecar_paths[idx]
+
     def neighbor_ids(self, idx: int) -> list[str]:
         """Per-neighbor track UUIDs (hex) for frame ``idx``, aligned to the
         neighbor_past slot order. Read from the sidecar's ``neighbor_ids`` field

--- a/scenario_generation/tests/test_interp_anchor_cache.py
+++ b/scenario_generation/tests/test_interp_anchor_cache.py
@@ -1,0 +1,140 @@
+"""The track-anchor cache is a pure memoisation of ``_build_neighbor_interp``: it must hit when
+the key repeats and miss whenever any part of the key differs."""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+from scenario_generation.reproducer_rollout import (
+    _INTERP_ANCHOR_CACHE,
+    _build_neighbor_interp,
+    _neighbor_interp_cached,
+)
+from scenario_generation.route_timeline import RouteTimeline
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    _INTERP_ANCHOR_CACHE.clear()
+    yield
+    _INTERP_ANCHOR_CACHE.clear()
+
+
+def _write_route(npz_dir, n: int, n_slots: int = 3):
+    # no sibling JSON, so the sidecar directory is what supplies the track ids
+    npz_dir.mkdir(parents=True, exist_ok=True)
+    paths = []
+    for i in range(n):
+        nb = np.zeros((n_slots, 31, 11), dtype=np.float32)
+        for s in range(n_slots):
+            nb[s, -1, 0] = 10.0 * s + i  # x advances every frame -> anchors are kept, not dropped
+            nb[s, -1, 1] = 2.0 * s
+            nb[s, -1, 2] = 1.0  # cos(heading)
+        p = npz_dir / f"f_{i:010d}.npz"
+        np.savez_compressed(p, neighbor_agents_past=nb, ego_shape=np.zeros(3, dtype=np.float32))
+        paths.append(p)
+    return paths
+
+
+def _write_sidecars(sidecar_dir, n: int, uuid_prefix: str, n_slots: int = 3):
+    sidecar_dir.mkdir(parents=True, exist_ok=True)
+    for i in range(n):
+        (sidecar_dir / f"f_{i:010d}.json").write_text(
+            json.dumps(
+                {
+                    "x": float(i),
+                    "y": 0.0,
+                    "z": 0.0,
+                    "qx": 0,
+                    "qy": 0,
+                    "qz": 0,
+                    "qw": 1,
+                    "neighbor_ids": [f"{uuid_prefix}{s}" for s in range(n_slots)],
+                }
+            )
+        )
+
+
+def _timeline(tmp_path, n=12, uuid_prefix="a", sidecar_name="sc_a"):
+    npz_dir = tmp_path / "npz"
+    paths = _write_route(npz_dir, n) if not npz_dir.exists() else sorted(npz_dir.glob("*.npz"))
+    sidecar_dir = tmp_path / sidecar_name
+    _write_sidecars(sidecar_dir, n, uuid_prefix)
+    return RouteTimeline(paths, sidecar_dir=sidecar_dir)
+
+
+def test_second_call_returns_the_cached_object_without_rebuilding(tmp_path):
+    tl = _timeline(tmp_path)
+    first = _neighbor_interp_cached(tl, 0, len(tl))
+    assert len(_INTERP_ANCHOR_CACHE) == 1
+
+    second = _neighbor_interp_cached(tl, 0, len(tl))
+    assert second is first  # the same object, not merely an equal one
+    assert len(_INTERP_ANCHOR_CACHE) == 1
+
+
+def test_cached_anchors_equal_a_direct_build(tmp_path):
+    tl = _timeline(tmp_path)
+    direct = _build_neighbor_interp(tl, 0, len(tl))
+    cached = _neighbor_interp_cached(tl, 0, len(tl))
+
+    assert set(cached) == set(direct)
+    for uuid, (idxs, xy, hd) in direct.items():
+        assert np.array_equal(cached[uuid][0], idxs)
+        assert np.array_equal(cached[uuid][1], xy)
+        assert np.array_equal(cached[uuid][2], hd)
+
+
+def test_a_fresh_timeline_over_the_same_files_still_hits(tmp_path):
+    tl_first = _timeline(tmp_path)
+    first = _neighbor_interp_cached(tl_first, 0, len(tl_first))
+
+    tl_again = _timeline(tmp_path)
+    assert tl_again is not tl_first
+    assert _neighbor_interp_cached(tl_again, 0, len(tl_again)) is first
+    assert len(_INTERP_ANCHOR_CACHE) == 1
+
+
+def test_a_different_span_of_one_route_does_not_share(tmp_path):
+    tl = _timeline(tmp_path)
+    whole = _neighbor_interp_cached(tl, 0, len(tl))
+    part = _neighbor_interp_cached(tl, 0, len(tl) - 2)
+
+    assert part is not whole
+    assert len(_INTERP_ANCHOR_CACHE) == 2
+
+
+def test_a_different_sidecar_dir_does_not_share(tmp_path):
+    """Same NPZ files, different sidecars -> different track ids -> different anchors."""
+    tl_a = _timeline(tmp_path, uuid_prefix="a", sidecar_name="sc_a")
+    anchors_a = _neighbor_interp_cached(tl_a, 0, len(tl_a))
+
+    tl_b = _timeline(tmp_path, uuid_prefix="b", sidecar_name="sc_b")
+    anchors_b = _neighbor_interp_cached(tl_b, 0, len(tl_b))
+
+    assert anchors_b is not anchors_a
+    assert len(_INTERP_ANCHOR_CACHE) == 2
+    assert set(anchors_a) == {"a0", "a1", "a2"}
+    assert set(anchors_b) == {"b0", "b1", "b2"}
+
+
+def test_eps_is_part_of_the_key(tmp_path):
+    tl = _timeline(tmp_path)
+    a = _neighbor_interp_cached(tl, 0, len(tl), eps=0.1)
+    b = _neighbor_interp_cached(tl, 0, len(tl), eps=5.0)
+    assert b is not a
+    assert len(_INTERP_ANCHOR_CACHE) == 2
+
+
+def test_a_hit_is_visible_in_the_timers(tmp_path):
+    tl = _timeline(tmp_path)
+    _neighbor_interp_cached(tl, 0, len(tl))
+    assert tl.timers.calls.get("interp_build") == 1
+    assert "interp_build_cached" not in tl.timers.calls
+
+    _neighbor_interp_cached(tl, 0, len(tl))
+    assert tl.timers.calls.get("interp_build") == 1  # not rebuilt
+    assert tl.timers.calls.get("interp_build_cached") == 1


### PR DESCRIPTION
## Problem

The per-track interpolation anchors are a function of the recorded route alone — not of the model
or the epoch. The training loop evaluates the same routes at every checkpoint and rebuilds them
every time. The scan is ~12% of a rollout.

## Fix

Cache them in-process, keyed by route paths and sidecar directory. Same pattern as the existing
per-map caches in `eval_cl_trajectory` and the pooled worker.

Memory is 4.15 MiB for a 2-route site (9,488 frames, 4,734 tracks), so the cache is unbounded:
the number of routes a process sees is the manifest size, not a function of steps.

## Result

Full workload, 1xH100, exclusive node: **-4.7% from the second evaluation onward**
(difference-in-differences against a no-cache arm, which cancels the per-arm offset).

Output is identical.

## Scope

This helps `train.py::closed_loop_validate` from its second call onward. It does **not** help
`run_all_sites_closed_loop.py`, which starts a subprocess per (site, mode) and evaluates each
route once. This is a per-evaluation stage saving, not "training gets N% faster".

## Tests

7 tests, mutation-verified — including that the sidecar path is part of the key (dropping it
fails the test, because the same npz read with a different sidecar yields different track IDs).

## Note

The added `interp_build` timer **nests** `timeline_load_*`, so summing all timers exceeds elapsed.

Top of a 3-PR stack that reduces the cost of the same scan from different angles:

- #333 ← `tier4-main`
- #340 ← #333
- **#341 (this PR)** ← #340

Merge bottom-up; review this PR's own commit only. Each PR's % figure was measured standalone
against `tier4-main`, not as an increment within the stack — #333 and #340 partly overlap with
this one. Independent of #337 — no shared files.
