### PR TITLE
fix(replay): pass save_step_figure args by keyword in run_route_replay

### DIFF
--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -2759,11 +2759,11 @@ def run_route_replay(
                         step,
                         spawn_config.max_steps,
                         route_polylines,
-                        _VIEW_HALF_M,
-                        _route_vis_ll_ids,
-                        step * 0.1,
-                        road_border_polylines,
-                        overlay_metrics,
+                        view_half_m=_VIEW_HALF_M,
+                        route_lanelet_ids=_route_vis_ll_ids,
+                        sim_time=step * 0.1,
+                        road_border_polylines=road_border_polylines,
+                        metrics=overlay_metrics,
                     )
                 )
 


### PR DESCRIPTION
## Problem
`run_route_replay` (the direct `scenario_generation.replay` route-sim path) submits `save_step_figure` with **positional** args. PR #167 (2026-06-29) inserted `title_prefix` and `distance_label_offset_m` into the `save_step_figure` signature **between `route_polylines` and `view_half_m`** without updating this call. Every positional arg after `route_polylines` shifted by two:

| passed value | intended param | actually landed in |
|---|---|---|
| `_VIEW_HALF_M` | view_half_m | title_prefix |
| `_route_vis_ll_ids` (list) | route_lanelet_ids | **distance_label_offset_m** (float) |
| `step * 0.1` | sim_time | view_half_m |
| `road_border_polylines` | road_border_polylines | route_lanelet_ids |
| `overlay_metrics` | metrics | sim_time |

A list ends up in the `distance_label_offset_m` float slot, so the road-border distance label render does `float * list` → `TypeError: can't multiply sequence by non-int`, crashing every rendered step.

The other two callers (`reproducer_rollout.py`, `render_npz_dir.py`) already pass these by keyword and are unaffected — which is why the perception reproducer renders fine and only the direct route-sim path was broken.

## Fix
Pass the post-`route_polylines` args by keyword, matching the other callers.

## Verification
- `ruff` + `ruff format` pass.
- Ran `scenario_generation.replay` on the miraikan→teleport route: renders per-step PNGs + `clearance_log.json`, completes cleanly (previously crashed at step 0).