### PR TITLE
fix(r2lpl): drive closed-loop inference phases with EMA weights, not raw iterates

### DIFF
--- a/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
+++ b/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
@@ -997,6 +997,55 @@ def _args_json_for_model(model_path: Path) -> Path:
     raise FileNotFoundError(f"Could not find args.json next to {model_path}")
 
 
+_EMA_INFER_CACHE: dict[str, Path] = {}
+# Set in main() to <output_dir>/ema_infer_cache; used when the checkpoint's own
+# directory is not writable (e.g. a shared base model owned by another user).
+_EMA_INFER_FALLBACK_ROOT: Path | None = None
+
+
+def _ema_inference_model_path(model_path: Path | str) -> Path:
+    """Weights for closed-loop inference phases (mining / repair / guards).
+
+    Base-training checkpoints store the raw optimizer iterates under "model" and
+    the deployable EMA under "ema_state_dict"; simulate.load_model reads "model",
+    so handing the training checkpoint straight to an inference phase silently
+    drives the raw iterates. Extract the EMA once, next to the checkpoint, and
+    return that path. Checkpoints without an EMA pass through unchanged.
+    Training resume must keep the original checkpoint (it needs optimizer/EMA
+    state), so only inference call sites go through here.
+    """
+    import shutil
+
+    model_path = Path(model_path).resolve()
+    key = str(model_path)
+    if key in _EMA_INFER_CACHE:
+        return _EMA_INFER_CACHE[key]
+    ckpt = torch.load(model_path, map_location="cpu", weights_only=False)
+    if not (isinstance(ckpt, dict) and "ema_state_dict" in ckpt):
+        _EMA_INFER_CACHE[key] = model_path
+        return model_path
+    out_dir = model_path.parent / f"{model_path.stem}_ema_infer"
+    if not os.access(model_path.parent, os.W_OK):
+        if _EMA_INFER_FALLBACK_ROOT is None:
+            raise PermissionError(
+                f"cannot write EMA extraction next to read-only checkpoint {model_path} "
+                "and no fallback cache root is set"
+            )
+        digest = hashlib.sha1(key.encode()).hexdigest()[:12]
+        out_dir = _EMA_INFER_FALLBACK_ROOT / f"{model_path.stem}_{digest}_ema_infer"
+    out = out_dir / "best_model.pth"
+    if not out.exists():
+        out_dir.mkdir(parents=True, exist_ok=True)
+        state = {k.replace("module.", ""): v for k, v in ckpt["ema_state_dict"].items()}
+        tmp = out_dir / "best_model.pth.tmp"
+        torch.save({"model": state}, tmp)
+        tmp.replace(out)
+        shutil.copy2(_args_json_for_model(model_path), out_dir / "args.json")
+    print(f"[ema] closed-loop inference weights: {out} (EMA of {model_path})")
+    _EMA_INFER_CACHE[key] = out
+    return out
+
+
 def _checkpoint_epoch(model_path: Path) -> int:
     try:
         ckpt = torch.load(model_path, map_location="cpu", weights_only=False)
@@ -2755,6 +2804,8 @@ def main() -> None:
 
     out = Path(cfg["output_dir"]).resolve()
     out.mkdir(parents=True, exist_ok=True)
+    global _EMA_INFER_FALLBACK_ROOT
+    _EMA_INFER_FALLBACK_ROOT = out / "ema_infer_cache"
     model_path = Path(cfg["model_path"])
     previous_memory: Path | None = None
     checkpoint_policy = str(cfg.get("checkpoint_policy", "latest"))
@@ -2786,7 +2837,9 @@ def main() -> None:
                 )
         else:
             print("[round 0] guards on the starting model (reference row)")
-            reference_metrics = _run_guard_phase(cfg, model_path, gdir0, gpu_ids0, tag="round_000")
+            reference_metrics = _run_guard_phase(
+                cfg, _ema_inference_model_path(model_path), gdir0, gpu_ids0, tag="round_000"
+            )
     guard_rows: list[tuple[int, dict[str, Any]]] = []
     training_backend = str(cfg.get("training_backend", "base_sft"))
     if training_backend != "base_sft" and not isinstance(
@@ -2844,10 +2897,11 @@ def main() -> None:
             _print_dry_run_plan(cfg, model_path, rdir, gpu_ids, memory_cmd, round_idx)
             continue
 
+        infer_model = _ema_inference_model_path(model_path)
         print(f"[round {round_idx}] perception_mine")
-        phase_times["perception_mine"] = _run_mining_phase(cfg, model_path, rdir, gpu_ids)
+        phase_times["perception_mine"] = _run_mining_phase(cfg, infer_model, rdir, gpu_ids)
         print(f"[round {round_idx}] repair")
-        phase_times["repair"] = _run_repair_phase(cfg, model_path, rdir, gpu_ids)
+        phase_times["repair"] = _run_repair_phase(cfg, infer_model, rdir, gpu_ids)
         print(f"[round {round_idx}] memory: {' '.join(memory_cmd)}")
         phase_times["memory"] = _run(memory_cmd, rdir / "memory.log")
 
@@ -2924,7 +2978,11 @@ def main() -> None:
             print(f"[round {round_idx}] guards")
             t0 = time.perf_counter()
             guard_metrics = _run_guard_phase(
-                cfg, model_path, rdir / "guards", gpu_ids, tag=f"round_{round_idx:03d}"
+                cfg,
+                _ema_inference_model_path(model_path),
+                rdir / "guards",
+                gpu_ids,
+                tag=f"round_{round_idx:03d}",
             )
             phase_times["guards"] = time.perf_counter() - t0
             guard_rows.append((round_idx, guard_metrics))
@@ -2954,7 +3012,9 @@ def main() -> None:
         fdir = out / "final_round_mine"
         fdir.mkdir(parents=True, exist_ok=True)
         print(f"[final] mining residual problems + realized reward with {model_path}")
-        _run_mining_phase(cfg, model_path, fdir, _gpu_ids_from_config(cfg))
+        _run_mining_phase(
+            cfg, _ema_inference_model_path(model_path), fdir, _gpu_ids_from_config(cfg)
+        )
         fsum = _load_json(fdir / "perception_direct_summary.json")
         # Represent the final-round mine in the operator-facing summary contract, not
         # just stdout: the last round's checkpoint has no successor mine, so this is the

--- a/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
+++ b/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
@@ -997,10 +997,17 @@ def _args_json_for_model(model_path: Path) -> Path:
     raise FileNotFoundError(f"Could not find args.json next to {model_path}")
 
 
-_EMA_INFER_CACHE: dict[str, Path] = {}
+# In-memory cache: source pathname -> (source stamp, resolved inference path).
+_EMA_INFER_CACHE: dict[str, tuple[dict[str, Any], Path]] = {}
 # Set in main() to <output_dir>/ema_infer_cache; used when the checkpoint's own
 # directory is not writable (e.g. a shared base model owned by another user).
 _EMA_INFER_FALLBACK_ROOT: Path | None = None
+_EMA_INFER_STAMP_NAME = "source_stamp.json"
+
+
+def _ema_source_stamp(model_path: Path) -> dict[str, Any]:
+    st = model_path.stat()
+    return {"source": str(model_path), "size": st.st_size, "mtime_ns": st.st_mtime_ns}
 
 
 def _ema_inference_model_path(model_path: Path | str) -> Path:
@@ -1009,20 +1016,28 @@ def _ema_inference_model_path(model_path: Path | str) -> Path:
     Base-training checkpoints store the raw optimizer iterates under "model" and
     the deployable EMA under "ema_state_dict"; simulate.load_model reads "model",
     so handing the training checkpoint straight to an inference phase silently
-    drives the raw iterates. Extract the EMA once, next to the checkpoint, and
-    return that path. Checkpoints without an EMA pass through unchanged.
-    Training resume must keep the original checkpoint (it needs optimizer/EMA
-    state), so only inference call sites go through here.
+    drives the raw iterates. Extract the EMA once per source-checkpoint version
+    and return the extraction's path. Checkpoints without an EMA pass through
+    unchanged. Training resume must keep the original checkpoint (it needs
+    optimizer/EMA state), so only inference call sites go through here.
+
+    The cache (in-memory and on-disk) is validated against the source file's
+    size+mtime stamp, because chunked base-SFT overwrites the same latest.pth
+    between calls; the extraction dir is staged fully (weights, args.json,
+    stamp) and published with an atomic rename so a partial dir is never
+    visible as a cache hit.
     """
     import shutil
 
     model_path = Path(model_path).resolve()
     key = str(model_path)
-    if key in _EMA_INFER_CACHE:
-        return _EMA_INFER_CACHE[key]
+    stamp = _ema_source_stamp(model_path)
+    cached = _EMA_INFER_CACHE.get(key)
+    if cached is not None and cached[0] == stamp:
+        return cached[1]
     ckpt = torch.load(model_path, map_location="cpu", weights_only=False)
     if not (isinstance(ckpt, dict) and "ema_state_dict" in ckpt):
-        _EMA_INFER_CACHE[key] = model_path
+        _EMA_INFER_CACHE[key] = (stamp, model_path)
         return model_path
     out_dir = model_path.parent / f"{model_path.stem}_ema_infer"
     if not os.access(model_path.parent, os.W_OK):
@@ -1034,15 +1049,30 @@ def _ema_inference_model_path(model_path: Path | str) -> Path:
         digest = hashlib.sha1(key.encode()).hexdigest()[:12]
         out_dir = _EMA_INFER_FALLBACK_ROOT / f"{model_path.stem}_{digest}_ema_infer"
     out = out_dir / "best_model.pth"
-    if not out.exists():
-        out_dir.mkdir(parents=True, exist_ok=True)
+    stamp_path = out_dir / _EMA_INFER_STAMP_NAME
+    disk_valid = False
+    if out.exists() and (out_dir / "args.json").exists() and stamp_path.exists():
+        try:
+            disk_valid = json.loads(stamp_path.read_text()) == stamp
+        except (OSError, json.JSONDecodeError):
+            disk_valid = False
+    if not disk_valid:
+        # Stage the complete extraction in a sibling temp dir, then publish it
+        # with a single rename: a crash mid-extraction leaves only temp litter,
+        # never a half-populated cache dir.
         state = {k.replace("module.", ""): v for k, v in ckpt["ema_state_dict"].items()}
-        tmp = out_dir / "best_model.pth.tmp"
-        torch.save({"model": state}, tmp)
-        tmp.replace(out)
-        shutil.copy2(_args_json_for_model(model_path), out_dir / "args.json")
+        staging = out_dir.parent / f".{out_dir.name}.staging{os.getpid()}"
+        if staging.exists():
+            shutil.rmtree(staging)
+        staging.mkdir(parents=True)
+        torch.save({"model": state}, staging / "best_model.pth")
+        shutil.copy2(_args_json_for_model(model_path), staging / "args.json")
+        (staging / _EMA_INFER_STAMP_NAME).write_text(json.dumps(stamp))
+        if out_dir.exists():
+            shutil.rmtree(out_dir)
+        os.rename(staging, out_dir)
     print(f"[ema] closed-loop inference weights: {out} (EMA of {model_path})")
-    _EMA_INFER_CACHE[key] = out
+    _EMA_INFER_CACHE[key] = (stamp, out)
     return out
 
 
@@ -2595,7 +2625,12 @@ def _run_base_sft_training(
         if cycle == last_cycle:
             break
         newly, refresh_elapsed = _refresh_repair(
-            cfg, current_model, rdir, scope=scope, cycle=cycle, gpu_ids=gpu_ids
+            cfg,
+            _ema_inference_model_path(current_model),
+            rdir,
+            scope=scope,
+            cycle=cycle,
+            gpu_ids=gpu_ids,
         )
         total_elapsed += refresh_elapsed
         if newly:

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -4603,6 +4603,17 @@ def test_main_runs_report_only_guards_per_round(tmp_path, monkeypatch):
         guarded.append((tag, str(model_path)))
         return {"tag": tag, "model_path": str(model_path), **guard_metric_seq.pop(0)}
 
+    ema_routed: list[str] = []
+
+    def fake_ema(path):
+        # Pass-through recorder: the fake checkpoints are not real torch files,
+        # so extraction itself is covered by the dedicated unit tests; here we
+        # assert the WIRING — closed-loop inference models go through the
+        # extractor, training warm-starts keep the raw checkpoint.
+        ema_routed.append(str(path))
+        return Path(path)
+
+    monkeypatch.setattr(round_runner, "_ema_inference_model_path", fake_ema)
     monkeypatch.setattr(round_runner, "_run_mining_phase", fake_mining)
     monkeypatch.setattr(round_runner, "_run_repair_phase", fake_repair)
     monkeypatch.setattr(round_runner, "_run", fake_run)
@@ -4622,6 +4633,10 @@ def test_main_runs_report_only_guards_per_round(tmp_path, monkeypatch):
     # checkpoints always advance; each round mines with the previous checkpoint
     assert train_warm_starts == [str(initial_model), round1_ckpt]
     assert mining_calls == [str(initial_model), round1_ckpt]
+    # every closed-loop inference model (guards + mining) was routed through
+    # the EMA extractor
+    assert set(mining_calls) <= set(ema_routed)
+    assert {p for _, p in guarded} <= set(ema_routed)
     round1 = json.loads((out_dir / "r2lpl_round_001" / "round_summary.json").read_text())
     round2 = json.loads((out_dir / "r2lpl_round_002" / "round_summary.json").read_text())
     assert round1["guards"]["tag"] == "round_001"
@@ -5388,3 +5403,48 @@ def test_ema_inference_model_path_read_only_dir_uses_fallback(tmp_path, monkeypa
         assert float(torch.load(out, weights_only=False)["model"]["w"].sum()) == 2.0
     finally:
         ro.chmod(0o700)
+
+
+def test_ema_inference_model_path_refreshes_when_source_checkpoint_changes(tmp_path, monkeypatch):
+    """Chunked base-SFT overwrites the same latest.pth; both the in-memory and
+    on-disk caches must be invalidated by the source stamp, and a half-written
+    extraction dir must never be honored as a cache hit."""
+    monkeypatch.setattr(round_runner, "_EMA_INFER_CACHE", {})
+    monkeypatch.setattr(round_runner, "_EMA_INFER_FALLBACK_ROOT", tmp_path / "cache")
+    ckpt_dir = tmp_path / "base_train"
+    ckpt_dir.mkdir()
+    (ckpt_dir / "args.json").write_text("{}")
+    ckpt = ckpt_dir / "latest.pth"
+
+    def save(v: float) -> None:
+        torch.save(
+            {"model": {"w": torch.zeros(1)}, "ema_state_dict": {"w": torch.full((1,), v)}},
+            ckpt,
+        )
+
+    save(1.0)
+    out = round_runner._ema_inference_model_path(ckpt)
+    assert float(torch.load(out, weights_only=False)["model"]["w"]) == 1.0
+
+    save(2.0)
+    os.utime(ckpt, ns=(ckpt.stat().st_atime_ns, ckpt.stat().st_mtime_ns + 1_000_000))
+    out2 = round_runner._ema_inference_model_path(ckpt)
+    assert float(torch.load(out2, weights_only=False)["model"]["w"]) == 2.0, (
+        "overwritten checkpoint must refresh the extraction"
+    )
+
+    # fresh process (empty in-memory cache) trusts a stamped complete dir ...
+    round_runner._EMA_INFER_CACHE.clear()
+    assert (
+        float(
+            torch.load(round_runner._ema_inference_model_path(ckpt), weights_only=False)["model"][
+                "w"
+            ]
+        )
+        == 2.0
+    )
+    # ... but a partial dir (weights present, args.json missing) is rebuilt
+    round_runner._EMA_INFER_CACHE.clear()
+    (out2.parent / "args.json").unlink()
+    out3 = round_runner._ema_inference_model_path(ckpt)
+    assert (out3.parent / "args.json").exists(), "partial cache dir must be rebuilt"

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -5331,3 +5331,60 @@ def test_realized_reward_scorer_buffers_cleared_after_finalize(monkeypatch):
         _, n_second = finalize()  # no new data
         assert n_first > 0
         assert n_second == n_first, "second finalize must not re-score cleared buffers"
+
+
+def test_ema_inference_model_path_extracts_ema_and_passes_through(tmp_path, monkeypatch):
+    """Closed-loop phases must drive the deployable EMA, never the raw iterates.
+
+    A training checkpoint (has ema_state_dict) is extracted to a sibling dir as a
+    {"model": ema} checkpoint; an inference-only checkpoint passes through; a
+    read-only checkpoint dir falls back to the campaign cache root.
+    """
+    monkeypatch.setattr(round_runner, "_EMA_INFER_CACHE", {})
+    monkeypatch.setattr(round_runner, "_EMA_INFER_FALLBACK_ROOT", tmp_path / "cache")
+
+    ckpt_dir = tmp_path / "base_train"
+    ckpt_dir.mkdir()
+    (ckpt_dir / "args.json").write_text("{}")
+    ckpt = ckpt_dir / "latest.pth"
+    torch.save(
+        {
+            "model": {"module.layer.weight": torch.zeros(2)},
+            "ema_state_dict": {"module.layer.weight": torch.ones(2)},
+            "optimizer": {},
+        },
+        ckpt,
+    )
+    out = round_runner._ema_inference_model_path(ckpt)
+    assert out != ckpt.resolve()
+    loaded = torch.load(out, weights_only=False)
+    assert set(loaded) == {"model"}
+    assert "layer.weight" in loaded["model"], "module. prefix must be stripped"
+    assert float(loaded["model"]["layer.weight"].sum()) == 2.0, "must be the EMA weights"
+    assert (out.parent / "args.json").exists(), "args.json must sit next to the extraction"
+    assert round_runner._ema_inference_model_path(ckpt) == out, "cached + idempotent"
+
+    plain = tmp_path / "best_model.pth"
+    torch.save({"model": {"layer.weight": torch.ones(2)}}, plain)
+    assert round_runner._ema_inference_model_path(plain) == plain.resolve()
+
+
+def test_ema_inference_model_path_read_only_dir_uses_fallback(tmp_path, monkeypatch):
+    monkeypatch.setattr(round_runner, "_EMA_INFER_CACHE", {})
+    ro = tmp_path / "shared"
+    ro.mkdir()
+    (ro / "args.json").write_text("{}")
+    ckpt = ro / "best_model.pth"
+    torch.save({"model": {"w": torch.zeros(2)}, "ema_state_dict": {"w": torch.ones(2)}}, ckpt)
+    ro.chmod(0o500)
+    try:
+        monkeypatch.setattr(round_runner, "_EMA_INFER_FALLBACK_ROOT", None)
+        with pytest.raises(PermissionError):
+            round_runner._ema_inference_model_path(ckpt)
+        round_runner._EMA_INFER_CACHE.clear()
+        monkeypatch.setattr(round_runner, "_EMA_INFER_FALLBACK_ROOT", tmp_path / "cache")
+        out = round_runner._ema_inference_model_path(ckpt)
+        assert str(out).startswith(str(tmp_path / "cache"))
+        assert float(torch.load(out, weights_only=False)["model"]["w"].sum()) == 2.0
+    finally:
+        ro.chmod(0o700)


### PR DESCRIPTION
## Problem

`run_lifelong_r2lpl_rounds` hands the training checkpoint (`latest.pth`) directly to every closed-loop inference phase — mining, repair-candidate generation, and the guard probes. `scenario_generation.simulate.load_model` loads `ckpt["model"]`, which for base-training checkpoints is the **raw optimizer iterates**, not the deployable EMA (`ema_state_dict`, timm ModelEma decay 0.999). After a short training round the raw weights are noisy optimizer state that the EMA has not yet absorbed, so guard metrics and mined failure events measure a model nobody would deploy. Observed in a live lifelong run as a large spurious jump in guard collision events immediately after an otherwise-clean round.

## Fix

- New `_ema_inference_model_path()`: if the checkpoint contains `ema_state_dict`, extract it once as a `{"model": ema}` checkpoint in a sibling `<stem>_ema_infer/` dir (atomic write, `args.json` copied alongside so downstream loaders find it). Checkpoints without an EMA pass through unchanged. When the checkpoint's directory is not writable (shared base models), extraction falls back to `<output_dir>/ema_infer_cache/`; with no fallback root set it fails loudly.
- Wired into all five inference call sites: round-0 reference guards, per-round mining, repair generation, per-round guards, and the final-round mine.
- Training resume is untouched — it correctly keeps the full checkpoint (model + EMA + optimizer + scheduler).
- Logs `[ema] closed-loop inference weights: ...` at each use so runs are auditable.

## Tests

Two new unit tests in `test_r2lpl_lifelong_replay.py`: EMA extraction (module-prefix stripping, `{"model"}`-only payload, args.json placement, cache idempotency, passthrough for inference-only checkpoints) and the read-only-dir fallback (PermissionError without a fallback root, cache-root extraction with one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)