### PR TITLE
R2LPL: trust-region repair gate, unified Eq.26 selection, replay-memory seeding

### DIFF
--- a/rlvr/autoresearch/tools/build_repaired_targets.py
+++ b/rlvr/autoresearch/tools/build_repaired_targets.py
@@ -258,6 +258,11 @@ def _normalize_values(values: list[float]) -> list[float]:
 
 
 def _r2lpl_state_class(source_row: dict[str, Any]) -> str:
+    if "expert_disagreement" not in set(source_row.get("repair_labels", [])):
+        # Collision/road-border rows carry no measured log-deviation; they are
+        # off-log by construction (the realized rollout failed where the log did
+        # not) but not beyond salvage -> the paper's middle class.
+        return "recoverable"
     dev = float(source_row.get("expert_disagreement_max_dev", 0.0))
     if dev <= 1.0:
         return "near_log"
@@ -266,12 +271,22 @@ def _r2lpl_state_class(source_row: dict[str, Any]) -> str:
     return "far_offpolicy"
 
 
-def _r2lpl_weights(state_class: str) -> tuple[float, float]:
+def _r2lpl_weights(state_class: str) -> tuple[float, float, float]:
+    """Paper Eq. 26 weights (w_q rule, w_ref reference-path, w_E expert), matching the
+    reference implementation (R2LPL rollout_cl_generator.py): near-log leans on expert
+    consistency; recoverable/far lean on the rule score + route-path consistency."""
     if state_class == "near_log":
-        return 0.20, 0.80
+        return 0.10, 0.10, 0.80
     if state_class == "recoverable":
-        return 0.95, 0.05
-    return 1.00, 0.00
+        return 0.65, 0.30, 0.05
+    return 0.80, 0.20, 0.00
+
+
+# Reference-implementation near-log expert gate: candidates whose expert consistency
+# falls below max(best - margin, floor) are excluded from near-log selection (unless
+# that would exclude every survivor).
+_NEAR_LOG_EXPERT_MARGIN = 0.05
+_NEAR_LOG_EXPERT_MIN = 0.75
 
 
 def _apply_rear_end_collision_mode(rcfg, *, count_rear_end_collisions: bool) -> None:
@@ -527,6 +542,7 @@ def _best_safe_candidate(
     reference_traj: torch.Tensor | np.ndarray | None = None,
     morph_index: int | None = None,
     depart_index: int | None = None,
+    max_expert_dev_m: float | None = None,
 ) -> tuple[int | None, dict[str, Any]]:
     # Scripted candidates get a per-candidate outcome taxonomy in the meta
     # (selected / lost_selection / gate_rejected) keyed by their prefix.
@@ -553,6 +569,27 @@ def _best_safe_candidate(
             )
             accepted.append((violation_score, deviation_penalty, float(reward_row.total), idx))
 
+    # Trust-region gate: a gate-passing candidate that strays too far from the
+    # expert reference is a worse training target than no target at all — far
+    # off-policy targets measurably degrade closed-loop behavior when imitated.
+    if max_expert_dev_m is not None and accepted:
+        within = [item for item in accepted if item[1] <= max_expert_dev_m]
+        if not within:
+            meta = {
+                "reason": "no_candidate_within_trust_region",
+                "max_expert_dev_m": float(max_expert_dev_m),
+                "min_observed_dev_m": float(min(item[1] for item in accepted)),
+                # keep the unrepaired meta shape of the no_safe_candidate branch
+                "best_total": max(float(r.total) for r in reward_rows),
+                "best_sc_min_dist": max(
+                    float(getattr(r, "sc_min_dist", -99.0)) for r in reward_rows
+                ),
+            }
+            for prefix, _idx_s in scripted.items():
+                meta[f"{prefix}_outcome"] = "trust_region_rejected"
+            return None, meta
+        accepted = within
+
     accepted_indices = {item[3] for item in accepted}
     if not accepted:
         best_total = max(float(r.total) for r in reward_rows)
@@ -570,32 +607,47 @@ def _best_safe_candidate(
             )
         return None, meta
 
-    uses_r2lpl_conflict_selection = "expert_disagreement" in set(
-        source_row.get("repair_labels", [])
-    )
+    # Unified paper-style selection (R2LPL Eq. 26, reference implementation
+    # rollout_cl_generator.py): the SAME three-term score ranks survivors of
+    # EVERY mistake type. y = w_q * rule + w_ref * route-path consistency +
+    # w_E * expert consistency, weights by state class.
     scripted_r2lpl_scores: dict[str, float] = {}
-    if uses_r2lpl_conflict_selection:
-        rule_scores = _normalize_values([item[2] for item in accepted])
-        state_class = _r2lpl_state_class(source_row)
-        rule_weight, expert_weight = _r2lpl_weights(state_class)
-        ranked: list[tuple[float, float, float, int]] = []
-        for item, rule_score in zip(accepted, rule_scores, strict=True):
-            violation_score, deviation_penalty, _reward_total, idx = item
-            expert_score = math.exp(-max(deviation_penalty, 0.0) / 4.0)
-            r2lpl_score = rule_weight * rule_score + expert_weight * expert_score
-            for prefix, idx_s in scripted.items():
-                if idx == idx_s:
-                    scripted_r2lpl_scores[prefix] = float(r2lpl_score)
-            ranked.append((-r2lpl_score, violation_score, deviation_penalty, idx))
-        ranked.sort()
-        neg_r2lpl_score, violation_score, deviation_penalty, idx = ranked[0]
-        selected_r2lpl_score = -float(neg_r2lpl_score)
-        selected_state_class = state_class
-    else:
-        accepted.sort(key=lambda item: (item[0], item[1], item[3]))
-        violation_score, deviation_penalty, _reward_total, idx = accepted[0]
-        selected_r2lpl_score = None
-        selected_state_class = None
+    rule_scores = _normalize_values([item[2] for item in accepted])
+    # Route-path consistency: the reward's centerline component IS the
+    # route-reference-path adherence score (baselink mode), normalized across
+    # survivors like the rule score.
+    ref_scores = _normalize_values(
+        [float(getattr(reward_rows[item[3]], "centerline", 0.0)) for item in accepted]
+    )
+    state_class = _r2lpl_state_class(source_row)
+    rule_weight, ref_weight, expert_weight = _r2lpl_weights(state_class)
+    expert_scores = [math.exp(-max(item[1], 0.0) / 4.0) for item in accepted]
+    # Near-log expert gate (reference impl): drop survivors far below the most
+    # expert-consistent one, unless that would drop everyone.
+    gate_ok = [True] * len(accepted)
+    if state_class == "near_log" and expert_scores:
+        floor = max(max(expert_scores) - _NEAR_LOG_EXPERT_MARGIN, _NEAR_LOG_EXPERT_MIN)
+        gated = [score >= floor for score in expert_scores]
+        if any(gated):
+            gate_ok = gated
+    ranked: list[tuple[float, float, float, int]] = []
+    for item, rule_score, ref_score, expert_score, ok in zip(
+        accepted, rule_scores, ref_scores, expert_scores, gate_ok, strict=True
+    ):
+        violation_score, deviation_penalty, _reward_total, idx = item
+        r2lpl_score = (
+            rule_weight * rule_score + ref_weight * ref_score + expert_weight * expert_score
+        )
+        if not ok:
+            r2lpl_score = -1.0
+        for prefix, idx_s in scripted.items():
+            if idx == idx_s:
+                scripted_r2lpl_scores[prefix] = float(r2lpl_score)
+        ranked.append((-r2lpl_score, violation_score, deviation_penalty, idx))
+    ranked.sort()
+    neg_r2lpl_score, violation_score, deviation_penalty, idx = ranked[0]
+    selected_r2lpl_score = -float(neg_r2lpl_score)
+    selected_state_class = state_class
     reward_row = reward_rows[idx]
     label_row = candidate_rows[idx]
 
@@ -727,6 +779,7 @@ def build_repaired_targets(
     count_rear_end_collisions: bool,
     allow_empty: bool = False,
     target_gt_disagreement_thresh: float = 2.0,
+    max_expert_dev_m: float | None = None,
     repair_expert_gt_candidate: bool = True,
     repair_expert_reference: bool = True,
     expert_morph_w_max: float = 1.0,
@@ -869,10 +922,18 @@ def build_repaired_targets(
                 scoring_data = _expert_reference_scoring_data(
                     data, scene_path=str(row["scene_path"])
                 )
-                reference_traj = _future_to_4col(data["ego_expert_future"].detach().cpu().numpy())
             else:
                 scoring_data = data
-                reference_traj = _future_to_4col(data["ego_agent_future"].detach().cpu().numpy())
+            # Unified paper-style selection: the expert-consistency term references
+            # the LOGGED EXPERT future for EVERY mistake type (Eq. 26); the mined
+            # window scenes always carry it. Fail loudly if a corpus does not.
+            if "ego_expert_future" not in data:
+                raise ValueError(
+                    f"{row['scene_path']}: mined scene lacks 'ego_expert_future' — "
+                    "the unified R2LPL selection requires the logged expert future "
+                    "for every repaired row (re-mine with a reproducer that saves it)."
+                )
+            reference_traj = _future_to_4col(data["ego_expert_future"].detach().cpu().numpy())
 
             # The classifier above already ran the full subscore geometry
             # (OBB clearance / road border / lane / centerline) on this exact
@@ -1000,6 +1061,7 @@ def build_repaired_targets(
                     reference_traj=reference_traj,
                     morph_index=morph_index if morph_added else None,
                     depart_index=depart_index if depart_added else None,
+                    max_expert_dev_m=max_expert_dev_m,
                 )
             morph_selected = bool(morph_added and best_idx == morph_index)
             depart_selected = bool(depart_added and best_idx == depart_index)
@@ -1142,6 +1204,14 @@ def main() -> None:
         "which target_gt_disagreement is flagged (R2LPL hard-example signal).",
     )
     ap.add_argument(
+        "--max_expert_dev_m",
+        type=float,
+        default=None,
+        help="trust-region gate: reject gate-passing candidates whose mean-L2 deviation from "
+        "the expert reference exceeds this (m); scenes with no candidate inside the region "
+        "are dropped to unrepaired. Off when omitted.",
+    )
+    ap.add_argument(
         "--repair_expert_gt_candidate",
         dest="repair_expert_gt_candidate",
         action="store_true",
@@ -1248,6 +1318,7 @@ def main() -> None:
         count_rear_end_collisions=bool(args.count_rear_end_collisions),
         allow_empty=bool(args.allow_empty),
         target_gt_disagreement_thresh=float(args.target_gt_disagreement_thresh),
+        max_expert_dev_m=(None if args.max_expert_dev_m is None else float(args.max_expert_dev_m)),
         repair_expert_gt_candidate=bool(args.repair_expert_gt_candidate),
         repair_expert_reference=bool(args.repair_expert_reference),
         expert_morph_w_max=float(args.expert_morph_w_max),

--- a/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
+++ b/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
@@ -334,6 +334,8 @@ def _config_from_workflow_contract(contract: dict[str, Any]) -> dict[str, Any]:
     }
     if repair.get("prototypes_path"):
         repair_cfg["prototypes_path"] = str(repair["prototypes_path"])
+    if repair.get("max_expert_dev_m") is not None:
+        repair_cfg["max_expert_dev_m"] = float(repair["max_expert_dev_m"])
     if repair.get("enable_depart_morph"):
         repair_cfg["enable_depart_morph"] = bool(repair["enable_depart_morph"])
     missing_repair = [k for k in ("ego_shape", "min_margin") if not repair_cfg.get(k)]
@@ -438,6 +440,7 @@ def _config_from_workflow_contract(contract: dict[str, Any]) -> dict[str, Any]:
         "reward_config": str(reward_config),
         "threshold_config": str(threshold_config),
         "credit_window_config": str(credit_window_config),
+        "initial_replay_memory": workflow.get("initial_replay_memory"),
         "replay_memory": {
             "capacity": _required_replay_capacity(replay),
             "alpha": float(_first_non_null(replay.get("alpha"), 0.5)),
@@ -1835,6 +1838,8 @@ def _repair_cmd(
         cmd.append("--enable_depart_morph")
     if repair_cfg.get("prototypes_path"):
         cmd.extend(["--prototypes_path", str(repair_cfg["prototypes_path"])])
+    if repair_cfg.get("max_expert_dev_m") is not None:
+        cmd.extend(["--max_expert_dev_m", str(repair_cfg["max_expert_dev_m"])])
     if cfg.get("repair_labels"):
         cmd.extend(["--labels", ",".join(cfg["repair_labels"])])
     if bool(cfg.get("enable_conflict_detector", False)):
@@ -2756,7 +2761,16 @@ def main() -> None:
     out = Path(cfg["output_dir"]).resolve()
     out.mkdir(parents=True, exist_ok=True)
     model_path = Path(cfg["model_path"])
+    # Cross-campaign lifelong continuity: seed round 1's replay-memory union from a
+    # previous campaign's memory JSON so chained single-round jobs keep retraining
+    # earlier repairs. Absent/None -> fresh memory (single-campaign behavior).
     previous_memory: Path | None = None
+    initial_memory = cfg.get("initial_replay_memory")
+    if initial_memory:
+        initial_memory = Path(initial_memory)
+        if not initial_memory.is_file():
+            raise ValueError(f"initial_replay_memory does not exist: {initial_memory}")
+        previous_memory = initial_memory
     checkpoint_policy = str(cfg.get("checkpoint_policy", "latest"))
     guards_cfg = cfg.get("guards")
     reference_metrics: dict[str, Any] | None = None

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -2558,57 +2558,83 @@ def test_seed_state_tracker_mode_selects_mpc():
     assert state.tracker.__class__.__name__ == "MPCTracker"
 
 
-def test_repair_candidate_selector_breaks_ties_by_lower_deviation():
+def _clean_reward_row(total: float, centerline: float = 0.0) -> SimpleNamespace:
+    return SimpleNamespace(
+        total=total,
+        centerline=centerline,
+        collision_step=None,
+        rb_crossing=False,
+        lane_crossing=False,
+        static_crossing=False,
+        kinematic_violated=False,
+        sc_min_dist=1.0,
+        rb_min_dist=1.0,
+    )
+
+
+_SELECTOR_CANDIDATE_ROWS = [
+    {"moving_collision_step": None, "expert_disagreement": False, "labels": ["clean"]},
+    {"moving_collision_step": None, "expert_disagreement": False, "labels": ["clean"]},
+]
+_SELECTOR_CANDIDATE_TRAJS = [
+    torch.tensor([[0.0, 0.0, 1.0, 0.0], [0.1, 0.0, 1.0, 0.0]], dtype=torch.float32),
+    torch.tensor([[5.0, 0.0, 1.0, 0.0], [5.1, 0.0, 1.0, 0.0]], dtype=torch.float32),
+]
+_SELECTOR_REFERENCE = torch.tensor(
+    [[0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 1.0, 0.0]], dtype=torch.float32
+)
+
+
+def test_repair_candidate_selector_unified_recoverable_prefers_rule_score():
+    # Paper Eq. 26, unified across mistake types: a collision/road-border row is a
+    # "recoverable" state (0.65 rule / 0.30 ref / 0.05 expert), so the higher-reward
+    # candidate wins even though the lower-reward one sits nearer the expert.
     source_row = {"repair_labels": ["road_border_crossing"]}
-    candidate_rows = [
-        {"moving_collision_step": None, "expert_disagreement": False, "labels": ["clean"]},
-        {"moving_collision_step": None, "expert_disagreement": False, "labels": ["clean"]},
-    ]
-    reward_rows = [
-        SimpleNamespace(
-            total=1.0,
-            collision_step=None,
-            rb_crossing=False,
-            lane_crossing=False,
-            static_crossing=False,
-            kinematic_violated=False,
-            sc_min_dist=1.0,
-            rb_min_dist=1.0,
-        ),
-        SimpleNamespace(
-            total=10.0,
-            collision_step=None,
-            rb_crossing=False,
-            lane_crossing=False,
-            static_crossing=False,
-            kinematic_violated=False,
-            sc_min_dist=1.0,
-            rb_min_dist=1.0,
-        ),
-    ]
-    candidate_trajs = [
-        torch.tensor([[0.0, 0.0, 1.0, 0.0], [0.1, 0.0, 1.0, 0.0]], dtype=torch.float32),
-        torch.tensor([[5.0, 0.0, 1.0, 0.0], [5.1, 0.0, 1.0, 0.0]], dtype=torch.float32),
-    ]
-    reference_traj = torch.tensor([[0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 1.0, 0.0]], dtype=torch.float32)
+    reward_rows = [_clean_reward_row(total=1.0), _clean_reward_row(total=10.0)]
 
     idx, meta = _best_safe_candidate(
         source_row,
-        candidate_rows,
+        _SELECTOR_CANDIDATE_ROWS,
         reward_rows,
         min_static_margin=0.3,
         target_gt_disagreement_thresh=2.0,
-        candidate_trajs=candidate_trajs,
-        reference_traj=reference_traj,
+        candidate_trajs=_SELECTOR_CANDIDATE_TRAJS,
+        reference_traj=_SELECTOR_REFERENCE,
     )
 
-    assert idx == 0
-    assert meta["selected_deviation_penalty"] < 1.0
+    assert idx == 1
+    assert meta["selected_r2lpl_state_class"] == "recoverable"
+    assert meta["selected_r2lpl_score"] > 0.0
     # R2LPL hard-example signal is emitted alongside the deviation penalty and is
     # distinct from realized expert_disagreement.
     assert meta["target_gt_disagreement_mean_l2"] == meta["selected_deviation_penalty"]
     assert meta["target_gt_disagreement_max_l2"] >= meta["target_gt_disagreement_mean_l2"]
     assert isinstance(meta["target_gt_disagreement"], bool)
+
+
+def test_repair_candidate_selector_unified_near_log_prefers_expert():
+    # Near-log conflict states weight expert consistency 0.80 and gate out
+    # candidates far below the most expert-consistent one, so the expert-nearest
+    # candidate wins despite a lower reward total.
+    source_row = {
+        "repair_labels": ["expert_disagreement"],
+        "expert_disagreement_max_dev": 0.5,
+    }
+    reward_rows = [_clean_reward_row(total=1.0), _clean_reward_row(total=10.0)]
+
+    idx, meta = _best_safe_candidate(
+        source_row,
+        _SELECTOR_CANDIDATE_ROWS,
+        reward_rows,
+        min_static_margin=0.3,
+        target_gt_disagreement_thresh=2.0,
+        candidate_trajs=_SELECTOR_CANDIDATE_TRAJS,
+        reference_traj=_SELECTOR_REFERENCE,
+    )
+
+    assert idx == 0
+    assert meta["selected_r2lpl_state_class"] == "near_log"
+    assert meta["selected_deviation_penalty"] < 1.0
 
 
 def test_t0_dirty_source_discards_whole_event_window(monkeypatch):
@@ -3128,12 +3154,14 @@ def test_build_repaired_targets_preserves_simulated_context(monkeypatch, tmp_pat
         lanes_has_speed_limit=sim_lanes_has_speed_limit,
         turn_indicators=sim_turn_indicators,
         ego_agent_future=np.full((80, 4), -5.0, dtype=np.float32),
+        ego_expert_future=np.full((80, 4), -5.0, dtype=np.float32),
         origin=np.asarray("sim"),
     )
 
     data = {
         "ego_shape": torch.tensor(sim_ego_shape[None], dtype=torch.float32),
         "ego_agent_future": torch.zeros((80, 4), dtype=torch.float32),
+        "ego_expert_future": torch.zeros((80, 4), dtype=torch.float32),
     }
     selected = torch.zeros((80, 4), dtype=torch.float32)
     selected[:, 0] = torch.arange(80, dtype=torch.float32)
@@ -5331,3 +5359,138 @@ def test_realized_reward_scorer_buffers_cleared_after_finalize(monkeypatch):
         _, n_second = finalize()  # no new data
         assert n_first > 0
         assert n_second == n_first, "second finalize must not re-score cleared buffers"
+
+
+def test_repair_candidate_selector_trust_region_gate_filters_far_candidates():
+    # A gate-passing candidate beyond max_expert_dev_m must not be selectable even
+    # when its rule score would win the Eq. 26 ranking (campaign finding: imitating
+    # far off-policy winners degrades closed-loop behavior).
+    source_row = {"repair_labels": ["road_border_crossing"]}
+    reward_rows = [_clean_reward_row(total=1.0), _clean_reward_row(total=10.0)]
+
+    idx, meta = _best_safe_candidate(
+        source_row,
+        _SELECTOR_CANDIDATE_ROWS,
+        reward_rows,
+        min_static_margin=0.3,
+        target_gt_disagreement_thresh=2.0,
+        candidate_trajs=_SELECTOR_CANDIDATE_TRAJS,
+        reference_traj=_SELECTOR_REFERENCE,
+        max_expert_dev_m=4.0,
+    )
+
+    # Without the gate the recoverable weights pick the far high-reward candidate
+    # (see test_repair_candidate_selector_unified_recoverable_prefers_rule_score);
+    # the gate removes it, leaving the near one.
+    assert idx == 0
+    assert meta["selected_deviation_penalty"] <= 4.0
+
+
+def test_repair_candidate_selector_trust_region_rejection_meta_shape():
+    # When no candidate sits inside the trust region the scene must drop to
+    # unrepaired with the SAME meta shape as the no_safe_candidate branch: the
+    # unrepaired logger formats meta["best_total"]/meta["best_sc_min_dist"]
+    # unconditionally (a missing key crashed link 3 of the 2026-08 campaign).
+    source_row = {"repair_labels": ["road_border_crossing"]}
+    reward_rows = [_clean_reward_row(total=1.0), _clean_reward_row(total=10.0)]
+
+    idx, meta = _best_safe_candidate(
+        source_row,
+        _SELECTOR_CANDIDATE_ROWS,
+        reward_rows,
+        min_static_margin=0.3,
+        target_gt_disagreement_thresh=2.0,
+        candidate_trajs=_SELECTOR_CANDIDATE_TRAJS,
+        reference_traj=_SELECTOR_REFERENCE,
+        max_expert_dev_m=0.01,
+    )
+
+    assert idx is None
+    assert meta["reason"] == "no_candidate_within_trust_region"
+    assert meta["max_expert_dev_m"] == 0.01
+    assert meta["min_observed_dev_m"] > 0.01
+    assert isinstance(meta["best_total"], float)
+    assert isinstance(meta["best_sc_min_dist"], float)
+    # the exact consumer expression in the unrepaired logger must not raise
+    assert f"{meta['best_total']:.1f} {meta['best_sc_min_dist']:.2f}"
+
+
+def test_workflow_contract_forwards_max_expert_dev_m_to_repair_cmd(tmp_path):
+    """Regression pin: the contract whitelist silently dropped
+    repair_generation.max_expert_dev_m, so a configured trust-region gate never
+    reached the build_repaired_targets subprocess (link 2, 2026-08 campaign)."""
+    scene_list = tmp_path / "scenes.json"
+    scene_list.write_text("[]")
+    training = tmp_path / "training.json"
+    training.write_text(json.dumps({"backend": "base_sft", "train_args": {}}))
+    workflow = tmp_path / "workflow.json"
+    workflow.write_text(
+        json.dumps(
+            {
+                "judgement": {
+                    "reward_config": "/tmp/reward.json",
+                    "threshold_config": "/tmp/thresholds.json",
+                    "credit_window_config": "/tmp/credit.json",
+                    "enabled_labels": ["moving_collision"],
+                },
+                "repair_generation": {
+                    "ego_shape": "2.7,4.3,1.7",
+                    "min_margin": 0.3,
+                    "max_expert_dev_m": 4.0,
+                },
+                "replay_memory": {"capacity": 200},
+                "training": {"val_scenes": "/tmp/valid.json"},
+            }
+        )
+    )
+    cfg = round_runner._config_from_workflow_contract(
+        {
+            "model_path": "/tmp/model.pth",
+            "scene_list": str(scene_list),
+            "workflow_config": str(workflow),
+            "training_config": str(training),
+            "output_dir": str(tmp_path / "auto_research" / "out"),
+        }
+    )
+    assert cfg["repair_config"]["max_expert_dev_m"] == 4.0
+    cmd = round_runner._repair_cmd(
+        cfg, tmp_path / "model.pth", tmp_path / "credit.jsonl", tmp_path / "round"
+    )
+    assert cmd[cmd.index("--max_expert_dev_m") + 1] == "4.0"
+
+
+def test_workflow_contract_passes_initial_replay_memory_through(tmp_path):
+    scene_list = tmp_path / "scenes.json"
+    scene_list.write_text("[]")
+    training = tmp_path / "training.json"
+    training.write_text(json.dumps({"backend": "base_sft", "train_args": {}}))
+    seed = tmp_path / "prev_memory.json"
+    seed.write_text("[]")
+    base_workflow = {
+        "judgement": {
+            "reward_config": "/tmp/reward.json",
+            "threshold_config": "/tmp/thresholds.json",
+            "credit_window_config": "/tmp/credit.json",
+            "enabled_labels": ["moving_collision"],
+        },
+        "repair_generation": {"ego_shape": "2.7,4.3,1.7", "min_margin": 0.3},
+        "replay_memory": {"capacity": 200},
+        "training": {"val_scenes": "/tmp/valid.json"},
+        "initial_replay_memory": str(seed),
+    }
+    workflow = tmp_path / "workflow.json"
+    workflow.write_text(json.dumps(base_workflow))
+    contract = {
+        "model_path": "/tmp/model.pth",
+        "scene_list": str(scene_list),
+        "workflow_config": str(workflow),
+        "training_config": str(training),
+        "output_dir": str(tmp_path / "auto_research" / "out"),
+    }
+    cfg = round_runner._config_from_workflow_contract(contract)
+    assert cfg["initial_replay_memory"] == str(seed)
+
+    del base_workflow["initial_replay_memory"]
+    workflow.write_text(json.dumps(base_workflow))
+    cfg = round_runner._config_from_workflow_contract(contract)
+    assert cfg["initial_replay_memory"] is None


### PR DESCRIPTION
## What

Three fixes/features for the R2LPL lifelong loop, validated during a multi-link lifelong campaign:

1. **Trust-region repair gate** (`build_repaired_targets --max_expert_dev_m`, off by default): candidates that pass all safety gates but sit farther than this from the logged expert reference are rejected as training targets. Imitating far off-policy gate-passers measurably degraded closed-loop behavior; gating them (4.0 m in our runs) recovered it. Scenes with no in-region candidate drop to `*_unrepaired.json` with reason `no_candidate_within_trust_region`, keeping the meta shape the unrepaired logger formats (a mismatched shape crashed a live run on the first rejection — regression-tested now).

2. **Unified Eq. 26 selection**: the paper's three-term score (rule score / route-path consistency / expert consistency, weighted by state class) now ranks survivors of **every** mistake type, not only `expert_disagreement` rows, matching the reference implementation. Adds the near-log expert gate and a `recoverable` state class for collision/road-border rows. The expert-consistency reference is always the logged expert future; corpora lacking `ego_expert_future` fail loudly.

3. **`initial_replay_memory`** (workflow key, optional): seeds round 1's replay-memory union from a previous campaign's memory JSON, so chained single-round jobs keep retraining earlier repairs. Also fixes the workflow-contract whitelist silently dropping `max_expert_dev_m` (a configured gate never reached the repair subprocess — the regression pin asserts the flag lands on the actual command line).

## Tests

`test_r2lpl_lifelong_replay.py`: gate filtering, rejection-meta shape (including the exact consumer f-string), both contract pass-throughs, unified-selection behavior for recoverable vs near-log classes. Full file: 158 passed; the one failure (`test_round_runner_cli_dry_run_uses_multiple_visible_gpus_or_skips`) is pre-existing on tier4-main (fixture lacks the now-required `replay_memory.capacity`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)