### PR TITLE
feat: add closed loop vehicle type labeling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ wandb/
 .vscode/
 *.egg-info
 control_panel/_dev_presets.py
+
+# project->vehicle mapping for closed-loop eval (--project_vehicle_map /
+# --closed_loop_project_vehicle_map): supplied at runtime, not tracked here.
+*project_vehicle_map*.json

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -147,7 +147,8 @@ def closed_loop_validate(
     per (site, object-mode) pair: ``closed_loop_npz_root`` (single arbitrary path) and
     ``closed_loop_sites_npz_root`` (a curated ``.json`` path-list manifest grouped into
     per-site route pools by
-    :func:`~scenario_generation.site_discovery.discover_sites_from_json`) are independent — both
+    :func:`~scenario_generation.site_discovery.discover_sites_with_vehicles_from_json`)
+    are independent — both
     fire in the same call when both are set, each contributing its own rows to the combined
     episode table / cross-site aggregate. Called on the checkpoint-save cadence, rank-0 only:
     pass the unwrapped model; it is switched to eval for the rollout (so the diffusion sampler

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -169,7 +169,7 @@ def closed_loop_validate(
         RolloutParams,
     )
     from scenario_generation.closed_loop_html_report import build_html_report
-    from scenario_generation.site_discovery import discover_sites_from_json
+    from scenario_generation.site_discovery import discover_sites_with_vehicles_from_json
     from scenario_generation.wandb_closed_loop import (
         build_combined_episode_table,
         build_full_closed_loop_wandb_log,
@@ -234,8 +234,9 @@ def closed_loop_validate(
 
     log: dict = {}
     site_summaries: dict[str, dict] = {}
-    episode_data: list = []  # (label, rows, out_dir) for the ONE combined table, across BOTH sources
+    episode_data: list = []  # (label, rows, out_dir, vehicle_type) for the ONE combined table
     site_report_labels: list[str] = []
+    site_vehicle_types: dict[str, str] = {}
 
     def run_labeled(
         base_name: str | None,
@@ -243,6 +244,7 @@ def closed_loop_validate(
         mode_pairs: tuple[tuple[str, bool], ...],
         *,
         track_for_report: bool = False,
+        vehicle_type: str | None = None,
     ) -> None:
         """Run ``npz_root`` once per requested object-mode, merging into log/site_summaries/episode_data.
 
@@ -266,9 +268,13 @@ def closed_loop_validate(
             episode_label = label or "main"
             log.update(site_log)
             site_summaries[episode_label] = summary
-            episode_data.append((episode_label, summary.get("segments") or [], site_out_dir))
+            episode_data.append(
+                (episode_label, summary.get("segments") or [], site_out_dir, vehicle_type)
+            )
             if track_for_report:
                 site_report_labels.append(episode_label)
+            if vehicle_type:
+                site_vehicle_types[episode_label] = vehicle_type
 
     try:
         if args.closed_loop_npz_root:
@@ -276,23 +282,38 @@ def closed_loop_validate(
             run_labeled(None, args.closed_loop_npz_root, npz_modes)
 
         if args.closed_loop_sites_npz_root:
-            sites = discover_sites_from_json(args.closed_loop_sites_npz_root)
+            project_vehicle_map = None
+            if args.closed_loop_project_vehicle_map:
+                project_vehicle_map = json.loads(
+                    Path(args.closed_loop_project_vehicle_map).read_text()
+                )
+            sites = discover_sites_with_vehicles_from_json(
+                args.closed_loop_sites_npz_root, project_vehicle_map
+            )
             if not sites:
                 print(f"closed-loop: no sites found under {args.closed_loop_sites_npz_root}")
             sites_modes = _object_mode_pairs(args.closed_loop_sites_object_modes)
-            for site_name, npz_root in sites.items():
-                run_labeled(site_name, npz_root, sites_modes, track_for_report=True)
+            for site_name, info in sites.items():
+                run_labeled(
+                    site_name,
+                    info["npz_roots"],
+                    sites_modes,
+                    track_for_report=True,
+                    vehicle_type=info["vehicle_type"],
+                )
 
         # One combined, filterable/groupable episode table across every source/site/mode.
         if episode_data:
             log["closed_loop_episodes/all"] = build_combined_episode_table(episode_data)
         # Cross-source/site pooled rollup under closed_loop_overview/*.
         if len(site_summaries) > 1:
-            log.update(build_sites_aggregate_log(site_summaries))
+            log.update(build_sites_aggregate_log(site_summaries, site_vehicle_types))
         # Local HTML gallery, sites only (see site_report_labels above) -- only built on
         # is_final_save, same as the media (videos/colormap images) it links to.
         if is_final_save and site_report_labels:
-            report_path = build_html_report(out_dir, site_report_labels)
+            report_path = build_html_report(
+                out_dir, site_report_labels, site_vehicle_types=site_vehicle_types
+            )
             if report_path:
                 print(f"closed-loop: wrote {report_path}")
     finally:

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -157,10 +157,10 @@ class TrainConfig:
     #
     # ``closed_loop_sites_npz_root`` is an alternative/addition to ``closed_loop_npz_root`` for
     # multi-site validation: a curated .json path-list manifest, grouped into per-site route pools
-    # by scenario_generation.site_discovery.discover_sites_from_json and evaluated as independent
-    # npz_roots, wandb-logged under "closed_loop_scores/<metric>/<site_name>". Both may be set at
-    # once — each fires independently and contributes its own rows to the combined episode table /
-    # cross-site aggregate.
+    # by scenario_generation.site_discovery.discover_sites_with_vehicles_from_json and evaluated
+    # as independent npz_roots, wandb-logged under "closed_loop_scores/<metric>/<site_name>".
+    # Both may be set at once — each fires independently and contributes its own rows to the
+    # combined episode table / cross-site aggregate.
     # ---------------------------------------------------------
     closed_loop_npz_root: str = ""
     closed_loop_sites_npz_root: str = ""

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -164,6 +164,9 @@ class TrainConfig:
     # ---------------------------------------------------------
     closed_loop_npz_root: str = ""
     closed_loop_sites_npz_root: str = ""
+    # optional JSON file of {project_code_name: vehicle_type_label} for labeling
+    # closed_loop_sites_npz_root sites by vehicle type. Empty = no labeling.
+    closed_loop_project_vehicle_map: str = ""
     # Object-mode ablation per source: "objects"=normal, "noobj"=empty-world (no dynamic/static
     # objects, map kept — isolates "reacts badly to traffic" from "can't follow the
     # route/map"). npz_root defaults to objects-only (usually a single curated scene);

--- a/diffusion_planner/run_all_sites_closed_loop.py
+++ b/diffusion_planner/run_all_sites_closed_loop.py
@@ -1,7 +1,7 @@
 """Run ``valid_predictor_closed_loop.py`` once per site in a curated JSON manifest.
 
 ``--sites_npz_root`` is a curated ``.json`` path-list file (the same format as
-``--npz_root``'s JSON-list convention, e.g. ``path_list_closed_loop_x2.json``) --
+``--npz_root``'s JSON-list convention, e.g. ``path_list_closed_loop.json``) --
 entries are grouped into per-site route pools by
 ``site_discovery.discover_sites_with_vehicles_from_json``. A "site" is the path
 component immediately before the first recognized split dir
@@ -23,7 +23,7 @@ vehicle_type were used for which site name, for downstream reporting.
 Example::
 
     python diffusion_planner/run_all_sites_closed_loop.py \\
-        --sites_npz_root /media/.../path_list_closed_loop_x2.json \\
+        --sites_npz_root /media/.../path_list_closed_loop.json \\
         --model_path /media/.../best_model.pth \\
         --out_root /media/.../cl_results/all_sites \\
         --near_miss_thresh 0.3 --replan_interval 10 --draw_every 8

--- a/diffusion_planner/run_all_sites_closed_loop.py
+++ b/diffusion_planner/run_all_sites_closed_loop.py
@@ -5,7 +5,7 @@
 entries are grouped into per-site route pools by
 ``site_discovery.discover_sites_with_vehicles_from_json``. A "site" is the path
 component immediately before the first recognized split dir
- in each entry, matching the existing
+(``valid``/``manual``/``auto``) in each entry, matching the existing
 ``{project}/{area_map_id}_{area_map_name}/{split}/...``. Each site's routes are never
 grouped across sites — this avoids the cross-directory filename-collision failure
 mode of pointing --npz_root at a shared parent that mixes multiple sites' npz

--- a/diffusion_planner/run_all_sites_closed_loop.py
+++ b/diffusion_planner/run_all_sites_closed_loop.py
@@ -5,9 +5,8 @@
 entries are grouped into per-site route pools by
 ``site_discovery.discover_sites_with_vehicles_from_json``. A "site" is the path
 component immediately before the first recognized split dir
-(``valid``/``manual``/``auto``) in each entry, matching the existing
-``{project}/{area_map_id}_{area_map_name}/{split}/...`` layout convention (e.g.
-``x2_dev/2231_odaiba_shinagawa_copied_from_xx1``). Each site's routes are never
+ in each entry, matching the existing
+``{project}/{area_map_id}_{area_map_name}/{split}/...``. Each site's routes are never
 grouped across sites — this avoids the cross-directory filename-collision failure
 mode of pointing --npz_root at a shared parent that mixes multiple sites' npz
 together.

--- a/diffusion_planner/run_all_sites_closed_loop.py
+++ b/diffusion_planner/run_all_sites_closed_loop.py
@@ -49,7 +49,7 @@ def parse_args() -> argparse.Namespace:
         required=True,
         type=Path,
         help="curated .json path-list manifest, grouped into per-site route pools by "
-        "site_discovery.discover_sites_from_json",
+        "site_discovery.discover_sites_with_vehicles_from_json",
     )
     parser.add_argument("--model_path", required=True, type=Path)
     parser.add_argument("--out_root", required=True, type=Path)

--- a/diffusion_planner/run_all_sites_closed_loop.py
+++ b/diffusion_planner/run_all_sites_closed_loop.py
@@ -13,7 +13,8 @@ together.
 
 If ``--project_vehicle_map`` is given (a JSON file of ``{project_code_name:
 vehicle_type_label}``), each site also gets a ``vehicle_type`` label for
-reporting/filtering -- it doesn't change what gets simulated.
+reporting/filtering -- it doesn't change what gets simulated. Without it sites are
+left unlabelled, and ``--only_vehicle_types`` has nothing to filter on.
 
 Per-site outputs land in ``<out_root>/<site_name>/`` (summary.json,
 segments.jsonl, videos), exactly as a standalone single-site run would
@@ -64,8 +65,8 @@ def parse_args() -> argparse.Namespace:
         "--only_vehicle_types",
         nargs="*",
         default=None,
-        help="run only sites whose resolved vehicle type (see --project_vehicle_map) is in "
-        "this list",
+        help="run only sites whose resolved vehicle type is in this list. Requires "
+        "--project_vehicle_map: without it sites carry no vehicle label at all",
     )
     parser.add_argument(
         "--object_modes",
@@ -164,6 +165,14 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
+    if args.only_vehicle_types and not args.project_vehicle_map:
+        # Without a map no site carries a vehicle label, so the filter would drop everything
+        # and report it as "no sites found" -- say what actually went wrong instead.
+        print(
+            "--only_vehicle_types requires --project_vehicle_map (sites are unlabelled without it)",
+            file=sys.stderr,
+        )
+        return 2
     project_vehicle_map = None
     if args.project_vehicle_map:
         project_vehicle_map = json.loads(args.project_vehicle_map.read_text())

--- a/diffusion_planner/run_all_sites_closed_loop.py
+++ b/diffusion_planner/run_all_sites_closed_loop.py
@@ -3,19 +3,23 @@
 ``--sites_npz_root`` is a curated ``.json`` path-list file (the same format as
 ``--npz_root``'s JSON-list convention, e.g. ``path_list_closed_loop_x2.json``) --
 entries are grouped into per-site route pools by
-``site_discovery.discover_sites_from_json``. A "site" is the path component
-immediately before the first recognized split dir (``valid``/``manual``/``auto``)
-in each entry, matching the existing
+``site_discovery.discover_sites_with_vehicles_from_json``. A "site" is the path
+component immediately before the first recognized split dir
+(``valid``/``manual``/``auto``) in each entry, matching the existing
 ``{project}/{area_map_id}_{area_map_name}/{split}/...`` layout convention (e.g.
 ``x2_dev/2231_odaiba_shinagawa_copied_from_xx1``). Each site's routes are never
 grouped across sites — this avoids the cross-directory filename-collision failure
 mode of pointing --npz_root at a shared parent that mixes multiple sites' npz
 together.
 
+If ``--project_vehicle_map`` is given (a JSON file of ``{project_code_name:
+vehicle_type_label}``), each site also gets a ``vehicle_type`` label for
+reporting/filtering -- it doesn't change what gets simulated.
+
 Per-site outputs land in ``<out_root>/<site_name>/`` (summary.json,
 segments.jsonl, videos), exactly as a standalone single-site run would
-produce. A ``sites_summary.json`` at ``<out_root>`` records which npz_root was
-used for which site name, for downstream reporting.
+produce. A ``sites_summary.json`` at ``<out_root>`` records which npz_root and
+vehicle_type were used for which site name, for downstream reporting.
 
 Example::
 
@@ -35,7 +39,7 @@ import sys
 from pathlib import Path
 
 from scenario_generation.closed_loop_html_report import build_html_report
-from scenario_generation.site_discovery import discover_sites_from_json
+from scenario_generation.site_discovery import discover_sites_with_vehicles_from_json
 
 
 def parse_args() -> argparse.Namespace:
@@ -50,6 +54,20 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--model_path", required=True, type=Path)
     parser.add_argument("--out_root", required=True, type=Path)
     parser.add_argument("--only_sites", nargs="*", default=None, help="run only these site names")
+    parser.add_argument(
+        "--project_vehicle_map",
+        type=Path,
+        default=None,
+        help="optional JSON file of {project_code_name: vehicle_type_label} for "
+        "labeling/filtering sites by vehicle type",
+    )
+    parser.add_argument(
+        "--only_vehicle_types",
+        nargs="*",
+        default=None,
+        help="run only sites whose resolved vehicle type (see --project_vehicle_map) is in "
+        "this list",
+    )
     parser.add_argument(
         "--object_modes",
         nargs="+",
@@ -147,9 +165,18 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    sites = discover_sites_from_json(args.sites_npz_root)
+    project_vehicle_map = None
+    if args.project_vehicle_map:
+        project_vehicle_map = json.loads(args.project_vehicle_map.read_text())
+    sites = discover_sites_with_vehicles_from_json(args.sites_npz_root, project_vehicle_map)
     if args.only_sites:
-        sites = {name: root for name, root in sites.items() if name in args.only_sites}
+        sites = {name: info for name, info in sites.items() if name in args.only_sites}
+    if args.only_vehicle_types:
+        sites = {
+            name: info
+            for name, info in sites.items()
+            if info["vehicle_type"] in args.only_vehicle_types
+        }
     if not sites:
         print(f"No sites with npz found under {args.sites_npz_root}", file=sys.stderr)
         return 1
@@ -157,7 +184,9 @@ def main() -> int:
     cli_path = Path(__file__).resolve().parent / "valid_predictor_closed_loop.py"
     args.out_root.mkdir(parents=True, exist_ok=True)
     results: dict[str, dict] = {}
-    for site_name, npz_root in sites.items():
+    for site_name, info in sites.items():
+        npz_root = info["npz_roots"]
+        vehicle_type = info["vehicle_type"]
         for mode in args.object_modes:
             # "noobj" gets a distinct site label (suffix) rather than a separate axis — this
             # lets it ride the existing per-site machinery (HTML rows/cards, W&B per-site keys,
@@ -171,7 +200,10 @@ def main() -> int:
             # resolve_npz_roots already reads for a single --npz_root).
             npz_root_arg = site_out_dir / "npz_roots.json"
             npz_root_arg.write_text(json.dumps([str(p) for p in npz_root]))
-            print(f"=== [{label}] npz_root={npz_root} -> out_dir={site_out_dir} ===")
+            print(
+                f"=== [{label}] vehicle_type={vehicle_type} npz_root={npz_root} "
+                f"-> out_dir={site_out_dir} ==="
+            )
             cmd = [
                 sys.executable,
                 str(cli_path),
@@ -199,6 +231,7 @@ def main() -> int:
             summary_path = site_out_dir / "summary.json"
             results[label] = {
                 "npz_root": [str(p) for p in npz_root],
+                "vehicle_type": vehicle_type,
                 "out_dir": str(site_out_dir),
                 "error": str(error) if error else None,
                 "summary": json.loads(summary_path.read_text()) if summary_path.is_file() else None,
@@ -217,7 +250,7 @@ def main() -> int:
         s = r["summary"] or {}
         obj = s.get("object") or {}
         print(
-            f"  {site_name}: n_routes={s.get('n_routes')} "
+            f"  {site_name} [{r.get('vehicle_type')}]: n_routes={s.get('n_routes')} "
             f"collision_segment_rate={obj.get('collision_segment_rate')} "
             f"near_miss_segment_rate={obj.get('miss_segment_rate')}"
         )
@@ -225,6 +258,7 @@ def main() -> int:
     # All site names with a summary (from THIS run's `merged`, so a targeted --only_sites
     # re-run's report still covers every previously-completed site, not just the ones just run).
     all_site_names = sorted(name for name, r in merged.items() if r.get("summary") is not None)
+    site_vehicle_types = {name: r.get("vehicle_type") for name, r in merged.items()}
     report_path = None
     if not args.no_report and all_site_names:
         report_path = build_html_report(
@@ -233,6 +267,7 @@ def main() -> int:
             title="Per-Site Closed-Loop Evaluation",
             subtitle=f"sites_npz_root={args.sites_npz_root}",
             colormap_metrics=tuple(args.report_colormap_metrics),
+            site_vehicle_types=site_vehicle_types,
         )
         if report_path:
             print(f"Wrote {report_path}")
@@ -267,12 +302,14 @@ def _log_to_wandb(
     try:
         log: dict = {}
         site_summaries: dict[str, dict] = {}
-        episode_data: list = []  # (site, rows, out_dir) for the ONE combined table
+        site_vehicle_types: dict[str, str] = {}
+        episode_data: list = []  # (site, rows, out_dir, vehicle_type) for the ONE combined table
         for site_name in site_names:
             r = merged.get(site_name) or {}
             summary = r.get("summary")
             if not summary:
                 continue
+            vehicle_type = r.get("vehicle_type")
             site_out_dir = r.get("out_dir") or str(args.out_root / site_name)
             segments_path = Path(site_out_dir) / "segments.jsonl"
             rows = []
@@ -293,11 +330,13 @@ def _log_to_wandb(
                 )
             )
             site_summaries[site_name] = summary_with_rows
-            episode_data.append((site_name, rows, site_out_dir))
+            if vehicle_type:
+                site_vehicle_types[site_name] = vehicle_type
+            episode_data.append((site_name, rows, site_out_dir, vehicle_type))
         if episode_data:
             log["closed_loop_episodes/all"] = build_combined_episode_table(episode_data)
         if len(site_summaries) > 1:
-            log.update(build_sites_aggregate_log(site_summaries))
+            log.update(build_sites_aggregate_log(site_summaries, site_vehicle_types))
         if report_path is not None:
             log["closed_loop_links/report"] = resolve_report_link(
                 args.out_root, args.report_base_url

--- a/diffusion_planner/tests/test_closed_loop_args.py
+++ b/diffusion_planner/tests/test_closed_loop_args.py
@@ -1,0 +1,135 @@
+"""closed_loop_validate is shared by two entrypoints, so every arg it reads must exist on both.
+
+``train_predictor.py`` hands it a :class:`TrainConfig` dataclass, while
+``train_grpo_predictor.py`` hands it the raw ``argparse.Namespace`` from its own
+``get_args()``. A ``TrainConfig`` field added without the matching GRPO flag therefore
+raises ``AttributeError`` at the first checkpoint-save epoch -- inside the
+``if global_rank == 0:`` block, so rank 0 dies while the other ranks wait on the next
+epoch's ``torch.distributed.barrier()`` until the NCCL timeout.
+
+The source is read with ``ast`` rather than imported: ``train_grpo_predictor`` pulls in
+torch/timm/wandb, which these tests do not need.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_GRPO_PY = _REPO_ROOT / "diffusion_planner" / "train_grpo_predictor.py"
+_TRAIN_PY = _REPO_ROOT / "diffusion_planner" / "diffusion_planner" / "train.py"
+
+
+def _grpo_arg_dests() -> set[str]:
+    """Every attribute ``train_grpo_predictor.get_args()`` puts on its Namespace."""
+    tree = ast.parse(_GRPO_PY.read_text(encoding="utf-8"))
+    get_args = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "get_args"
+    )
+    dests: set[str] = set()
+    for node in ast.walk(get_args):
+        is_add_argument = (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "add_argument"
+        )
+        if not is_add_argument:
+            continue
+        explicit = [kw.value for kw in node.keywords if kw.arg == "dest"]
+        if explicit and isinstance(explicit[0], ast.Constant):
+            dests.add(explicit[0].value)
+            continue
+        for arg in node.args:
+            if isinstance(arg, ast.Constant) and str(arg.value).startswith("--"):
+                dests.add(str(arg.value)[2:].replace("-", "_"))
+                break
+    return dests
+
+
+def _args_attrs_read_by(func_name: str, path: Path) -> set[str]:
+    """Attributes read as ``args.<name>`` inside ``func_name`` (nested functions included)."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    func = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == func_name
+    )
+    return {
+        node.attr
+        for node in ast.walk(func)
+        if isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "args"
+    }
+
+
+def _sites_guard_source() -> str:
+    """The verbatim ``if args.closed_loop_sites_npz_root:`` block of ``closed_loop_validate``.
+
+    Located by content rather than line number so the test survives edits above it.
+    """
+    source = _TRAIN_PY.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    validate = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "closed_loop_validate"
+    )
+    guard = next(
+        node
+        for node in ast.walk(validate)
+        if isinstance(node, ast.If)
+        and isinstance(node.test, ast.Attribute)
+        and node.test.attr == "closed_loop_sites_npz_root"
+    )
+    segment = ast.get_source_segment(source, guard)
+    assert segment, "could not recover the source of the sites guard"
+    return segment
+
+
+def test_grpo_parser_defines_the_sites_flag():
+    """Precondition: per-site closed-loop eval is a supported GRPO option, not a dead flag."""
+    assert "closed_loop_sites_npz_root" in _grpo_arg_dests()
+
+
+def test_grpo_parser_defines_every_arg_closed_loop_validate_reads():
+    """Both callers of ``closed_loop_validate`` must satisfy every attribute it reads.
+
+    Compares name sets rather than a fixed list, so a ``TrainConfig`` field added in future
+    without the matching GRPO flag fails here instead of at someone's first save epoch.
+    """
+    missing = sorted(_args_attrs_read_by("closed_loop_validate", _TRAIN_PY) - _grpo_arg_dests())
+    assert not missing, f"read by closed_loop_validate but absent from get_args: {missing}"
+
+
+def test_sites_guard_runs_on_a_grpo_namespace(tmp_path: Path):
+    """Run ``closed_loop_validate``'s site-discovery guard against a GRPO-shaped Namespace.
+
+    The block's own source text is executed, with its collaborators stubbed, so the test
+    tracks train.py rather than a paraphrase of it.
+    """
+    path_list = tmp_path / "path_list.json"
+    path_list.write_text(json.dumps([str(tmp_path / "proj_a" / "site_1" / "manual")]))
+
+    args = argparse.Namespace(**dict.fromkeys(_grpo_arg_dests(), ""))
+    args.closed_loop_sites_npz_root = str(path_list)
+
+    namespace = {
+        "args": args,
+        "json": json,
+        "Path": Path,
+        "discover_sites_with_vehicles_from_json": lambda *a, **k: {},
+        "_object_mode_pairs": lambda modes: (("objects", False),),
+        "run_labeled": lambda *a, **k: None,
+    }
+    try:
+        exec(compile(_sites_guard_source(), "<train.py sites guard>", "exec"), namespace)
+    except AttributeError as exc:
+        pytest.fail(f"guard is not runnable on a GRPO Namespace: {exc}")

--- a/diffusion_planner/train_grpo_predictor.py
+++ b/diffusion_planner/train_grpo_predictor.py
@@ -334,9 +334,9 @@ def get_args():
         type=str,
         default="",
         help="alternative/addition to --closed_loop_npz_root: a curated .json path-list manifest, "
-        "grouped into per-site route pools by site_discovery.discover_sites_from_json and evaluated "
-        "as independent sites (own npz_root each). Both may be set at once (each fires "
-        "independently).",
+        "grouped into per-site route pools by "
+        "site_discovery.discover_sites_with_vehicles_from_json and evaluated as independent "
+        "sites (own npz_root each). Both may be set at once (each fires independently).",
     )
     parser.add_argument(
         "--closed_loop_npz_object_modes",

--- a/diffusion_planner/train_grpo_predictor.py
+++ b/diffusion_planner/train_grpo_predictor.py
@@ -339,6 +339,13 @@ def get_args():
         "sites (own npz_root each). Both may be set at once (each fires independently).",
     )
     parser.add_argument(
+        "--closed_loop_project_vehicle_map",
+        type=str,
+        default="",
+        help="optional JSON file of {project_code_name: vehicle_type_label} for labeling "
+        "--closed_loop_sites_npz_root sites by vehicle type. Empty = no labeling.",
+    )
+    parser.add_argument(
         "--closed_loop_npz_object_modes",
         nargs="+",
         choices=("objects", "noobj"),

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -252,6 +252,13 @@ def get_args(args_list=None):
         "independently).",
     )
     parser.add_argument(
+        "--closed_loop_project_vehicle_map",
+        type=str,
+        default=_train_config_default("closed_loop_project_vehicle_map"),
+        help="optional JSON file of {project_code_name: vehicle_type_label} for labeling "
+        "--closed_loop_sites_npz_root sites by vehicle type. Empty = no labeling.",
+    )
+    parser.add_argument(
         "--closed_loop_npz_object_modes",
         nargs="+",
         choices=("objects", "noobj"),

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -247,9 +247,9 @@ def get_args(args_list=None):
         type=str,
         default="",
         help="alternative/addition to --closed_loop_npz_root: a curated .json path-list manifest, "
-        "grouped into per-site route pools by site_discovery.discover_sites_from_json and evaluated "
-        "as independent sites (own npz_root each). Both may be set at once (each fires "
-        "independently).",
+        "grouped into per-site route pools by "
+        "site_discovery.discover_sites_with_vehicles_from_json and evaluated as independent "
+        "sites (own npz_root each). Both may be set at once (each fires independently).",
     )
     parser.add_argument(
         "--closed_loop_project_vehicle_map",

--- a/diffusion_planner/train_run.py
+++ b/diffusion_planner/train_run.py
@@ -60,9 +60,9 @@ def parse_args() -> argparse.Namespace:
         "--closed_loop_sites_npz_root",
         default="",
         help="optional: a curated .json path-list manifest, grouped into per-site route pools by "
-        "site_discovery.discover_sites_from_json and evaluated as independent sites (objects + "
-        "no-objects ablation by default). May be set together with --closed_loop_npz_root (each "
-        "fires independently). Empty = disabled.",
+        "site_discovery.discover_sites_with_vehicles_from_json and evaluated as independent "
+        "sites (objects + no-objects ablation by default). May be set together with "
+        "--closed_loop_npz_root (each fires independently). Empty = disabled.",
     )
     p.add_argument(
         "--closed_loop_project_vehicle_map",

--- a/diffusion_planner/train_run.py
+++ b/diffusion_planner/train_run.py
@@ -65,6 +65,12 @@ def parse_args() -> argparse.Namespace:
         "fires independently). Empty = disabled.",
     )
     p.add_argument(
+        "--closed_loop_project_vehicle_map",
+        default="",
+        help="optional JSON file of {project_code_name: vehicle_type_label} for labeling "
+        "--closed_loop_sites_npz_root sites by vehicle type. Empty = no labeling.",
+    )
+    p.add_argument(
         "--enable_temporal_stability_eval",
         type=boolean,
         default=_train_config_default("enable_temporal_stability_eval"),
@@ -145,6 +151,10 @@ def main() -> None:
         "--closed_loop_sites_npz_root",
         str(Path(args.closed_loop_sites_npz_root).resolve())
         if args.closed_loop_sites_npz_root
+        else "",
+        "--closed_loop_project_vehicle_map",
+        str(Path(args.closed_loop_project_vehicle_map).resolve())
+        if args.closed_loop_project_vehicle_map
         else "",
         "--enable_temporal_stability_eval",
         str(args.enable_temporal_stability_eval),

--- a/scenario_generation/closed_loop_eval.py
+++ b/scenario_generation/closed_loop_eval.py
@@ -62,7 +62,8 @@ def resolve_npz_roots(npz_root) -> list[Path]:
     The input is a single directory tree of NPZ frames (globbed recursively), a ``.json`` file
     holding a list of such directory paths (one route dir per entry) -- the same "path list"
     form as ``--train_set_list`` / ``--valid_set_list`` -- or an already-resolved list of paths
-    (e.g. from ``site_discovery.discover_sites_from_json``, which does its own per-site
+    (e.g. one site's ``npz_roots`` from
+    ``site_discovery.discover_sites_with_vehicles_from_json``, which does its own per-site
     grouping). A directory is returned as a one-element list; a JSON list or a pre-resolved
     list is returned verbatim (each entry a ``Path``).
     """

--- a/scenario_generation/closed_loop_html_report.py
+++ b/scenario_generation/closed_loop_html_report.py
@@ -28,11 +28,24 @@ _DEFAULT_METRIC = "clearance"
 _PALETTE = ["#1a73e8", "#d68a1f", "#8a4ad6", "#2a8a6d", "#d63a3a", "#2aa5d6"]
 
 
+def _vehicle_type_for_site(site_name: str, site_vehicle_types: dict[str, str] | None) -> str:
+    """Look up a site's vehicle type, stripping the ``__noobj`` suffix if present."""
+    if not site_vehicle_types:
+        return ""
+    if site_name in site_vehicle_types:
+        return site_vehicle_types[site_name] or ""
+    if site_name.endswith("__noobj"):
+        base = site_name[: -len("__noobj")]
+        return site_vehicle_types.get(base) or ""
+    return ""
+
+
 def collect_site_data(
     out_root: str | Path,
     site_names: list[str],
     *,
     colormap_metrics: tuple[str, ...] = METRIC_CHOICES,
+    site_vehicle_types: dict[str, str] | None = None,
 ) -> tuple[list[dict], list[dict]]:
     """Read each site's ``summary.json`` + ``segments.jsonl`` into (items, summaries) for
     :func:`build_html_report`. ``items`` is one dict per episode (with a resolved, relative
@@ -40,6 +53,9 @@ def collect_site_data(
     path}`` — one rendered image per metric in ``colormap_metrics`` that actually produced
     something, so the report's per-card dropdown can switch between them); ``summaries`` is
     one aggregate dict per site.
+
+    ``site_vehicle_types`` (``{site_label: vehicle_type}``, optional) adds a ``vehicle_type``
+    field to every item/summary.
     """
     out_root = Path(out_root)
     items: list[dict[str, Any]] = []
@@ -53,9 +69,11 @@ def collect_site_data(
         s = json.loads(summary_path.read_text(encoding="utf-8"))
         near_miss_thresh = s.get("near_miss_thresh", 0.5)
         strong_brake_mps2 = s.get("strong_brake", {}).get("thresh_mps2", -2.5)
+        vehicle_type = _vehicle_type_for_site(site_name, site_vehicle_types)
         summaries.append(
             {
                 "site": site_name,
+                "vehicle_type": vehicle_type,
                 "n_segments": s.get("n_segments", 0),
                 "total_steps": s.get("total_steps", 0),
                 "route_completion": s.get("mean_route_completion", 0.0),
@@ -112,6 +130,7 @@ def collect_site_data(
                 items.append(
                     {
                         "site": site_name,
+                        "vehicle_type": vehicle_type,
                         "route": r["route"],
                         "segment": f"[{start},{end}]",
                         "n_steps_run": r.get("n_steps_run", 0),
@@ -142,6 +161,7 @@ def build_html_report(
     subtitle: str = "",
     report_filename: str = "report.html",
     colormap_metrics: tuple[str, ...] = METRIC_CHOICES,
+    site_vehicle_types: dict[str, str] | None = None,
 ) -> Path | None:
     """Write the self-contained gallery HTML to ``<out_root>/<report_filename>``.
 
@@ -150,9 +170,17 @@ def build_html_report(
     trajectory colormap image rendered (default: all of them) — each episode card shows
     one image at a time with a dropdown to switch between the metrics that rendered for
     it, see :mod:`scenario_generation.trajectory_colormap`.
+
+    ``site_vehicle_types`` (``{site_label: vehicle_type}``, optional) adds a vehicle-type
+    filter/column to the report.
     """
     out_root = Path(out_root)
-    items, summaries = collect_site_data(out_root, site_names, colormap_metrics=colormap_metrics)
+    items, summaries = collect_site_data(
+        out_root,
+        site_names,
+        colormap_metrics=colormap_metrics,
+        site_vehicle_types=site_vehicle_types,
+    )
     if not summaries:
         return None
 

--- a/scenario_generation/closed_loop_report_template.html
+++ b/scenario_generation/closed_loop_report_template.html
@@ -43,13 +43,14 @@
 
 <h2>Per-Site Summary</h2>
 <table id="summaryTable">
-<tr><th>Site</th><th>segments</th><th>Route Completion</th><th>Collisions</th><th>Curb Hits</th><th>Stuck (snaps)</th><th>Red Light</th><th>Strong Brake</th><th>Diverged</th></tr>
+<tr><th>Site</th><th>Vehicle</th><th>segments</th><th>Route Completion</th><th>Collisions</th><th>Curb Hits</th><th>Stuck (snaps)</th><th>Red Light</th><th>Strong Brake</th><th>Diverged</th></tr>
 </table>
 
 <h2>Episodes</h2>
 <div class="controls">
   <input type="text" id="search" placeholder="Search by route">
   <select id="siteFilter"><option value="">Site: All</option></select>
+  <select id="vehicleFilter"><option value="">Vehicle: All</option></select>
   <select id="sortSel">
     <option value="default">Sort: Default</option>
     <option value="completion_asc">Route Completion (worst first)</option>
@@ -68,13 +69,17 @@ const PALETTE = __PALETTE_JSON__;
 const DEFAULT_METRIC = __DEFAULT_METRIC_JSON__;
 const siteColor = {};
 [...new Set(ITEMS.map(i => i.site))].sort().forEach((s, i) => { siteColor[s] = PALETTE[i % PALETTE.length]; });
+const vehicleColor = {};
+[...new Set(ITEMS.map(i => i.vehicle_type).filter(Boolean))].sort().forEach((v, i) => { vehicleColor[v] = PALETTE[(i+2) % PALETTE.length]; });
 
 const summaryTable = document.getElementById('summaryTable');
 for (const s of SUMMARY) {
   const tr = document.createElement('tr');
   const c = siteColor[s.site] || '#888';
+  const vc = vehicleColor[s.vehicle_type] || 'var(--muted)';
   tr.innerHTML = `
     <td style="color:${c};font-weight:700">${s.site}</td>
+    <td style="color:${vc}">${s.vehicle_type || ''}</td>
     <td>${s.n_segments}</td>
     <td>${(s.route_completion*100).toFixed(0)}%</td>
     <td>${s.total_collision_events}</td>
@@ -91,6 +96,11 @@ const siteFilter = document.getElementById('siteFilter');
   const o = document.createElement('option'); o.value = s; o.textContent = s; siteFilter.appendChild(o);
 });
 
+const vehicleFilter = document.getElementById('vehicleFilter');
+[...new Set(ITEMS.map(i => i.vehicle_type).filter(Boolean))].sort().forEach(v => {
+  const o = document.createElement('option'); o.value = v; o.textContent = v; vehicleFilter.appendChild(o);
+});
+
 const grid = document.getElementById('grid');
 const searchEl = document.getElementById('search');
 const sortEl = document.getElementById('sortSel');
@@ -105,6 +115,7 @@ function card(item) {
   const redLight = item.n_red_light_violations || 0, brakes = item.n_strong_brakes || 0;
   const completion = ((item.route_completion || 0)*100).toFixed(0)+'%';
   const c = siteColor[item.site] || '#888';
+  const vc = vehicleColor[item.vehicle_type] || '#888';
   const videoTag = item.video_path
     ? `<video controls muted preload="metadata" src="${item.video_path}"></video>`
     : `<div style="padding:40px;text-align:center;color:var(--muted);">video missing</div>`;
@@ -127,6 +138,7 @@ function card(item) {
     <div class="meta">
       <div class="title">${item.route}</div>
       <span class="tag" style="background:${c}">${item.site}</span>
+      ${item.vehicle_type ? `<span class="tag" style="background:${vc}">${item.vehicle_type}</span>` : ''}
       <span class="tag" style="background:#888">${item.segment}</span>
       <div class="metrics">
         <span>Route completion: <b>${completion}</b></span>
@@ -152,9 +164,10 @@ function card(item) {
 function render() {
   const q = searchEl.value.trim().toLowerCase();
   const s = siteFilter.value;
+  const v = vehicleFilter.value;
   let filtered = ITEMS.filter(i => {
-    const hay = `${i.route} ${i.site}`.toLowerCase();
-    return (!q || hay.includes(q)) && (!s || i.site === s);
+    const hay = `${i.route} ${i.site} ${i.vehicle_type || ''}`.toLowerCase();
+    return (!q || hay.includes(q)) && (!s || i.site === s) && (!v || i.vehicle_type === v);
   });
   const mode = sortEl.value;
   if (mode === 'collision_desc') filtered.sort((a,b) => (b.n_collision_events||0)-(a.n_collision_events||0));
@@ -165,7 +178,7 @@ function render() {
   countEl.textContent = `${filtered.length} / ${ITEMS.length} episodes`;
 }
 
-[searchEl,siteFilter,sortEl].forEach(el => el.addEventListener(el===searchEl?'input':'change', render));
+[searchEl,siteFilter,vehicleFilter,sortEl].forEach(el => el.addEventListener(el===searchEl?'input':'change', render));
 render();
 </script>
 </body>

--- a/scenario_generation/site_discovery.py
+++ b/scenario_generation/site_discovery.py
@@ -52,8 +52,13 @@ def discover_sites_with_vehicles_from_json(
 ) -> dict[str, dict]:
     """Like :func:`discover_sites_from_json`, but also resolves each site's ``project`` and,
     via ``project_vehicle_map`` (``{project_code_name: vehicle_type_label}``), its
-    ``vehicle_type``. Falls back to the raw project name if the map is omitted or missing
-    an entry.
+    ``vehicle_type``.
+
+    With no map at all, ``vehicle_type`` is left ``""`` -- a project is a data-collection
+    campaign name and not a vehicle model, so labelling sites with it would report something
+    the caller never asked for. Only a project missing from a map that *was* supplied falls
+    back to the raw project name, with a warning. Downstream consumers already treat ``""``
+    as "unlabelled" (the report hides the column, the W&B rollup omits the per-vehicle keys).
 
     Returns ``{site_key: {"npz_roots": [Path, ...], "vehicle_type": str, "project": str}}``.
 
@@ -63,6 +68,7 @@ def discover_sites_with_vehicles_from_json(
     was seen first. If one site name appears under N projects, all N are kept as separate
     entries (``f"{project}__{site}"``) instead of merging their routes.
     """
+    labelling = project_vehicle_map is not None
     project_vehicle_map = project_vehicle_map or {}
     entries = json.loads(Path(json_path).read_text())
 
@@ -80,8 +86,10 @@ def discover_sites_with_vehicles_from_json(
                 project = parts[i - 2] if i >= 2 else "unknown"
                 vehicle_type = project_vehicle_map.get(project)
                 if vehicle_type is None:
-                    vehicle_type = project
-                    if project_vehicle_map:
+                    # No map -> unlabelled. Map supplied but this project is not in it ->
+                    # fall back to the project name so the site is still distinguishable.
+                    vehicle_type = project if labelling else ""
+                    if labelling:
                         unmapped_projects.add(project)
                 parsed.append((site, project, vehicle_type, path))
                 break

--- a/scenario_generation/site_discovery.py
+++ b/scenario_generation/site_discovery.py
@@ -12,11 +12,17 @@ routes that happen to share a bag-name prefix.
 ``split`` is ``valid`` for the label-based downloader's original layout, or ``manual``/``auto``
 for the PR253 ros_scripts reorg (train/valid -> manual, auto stays auto) — both conventions
 coexist across existing datasets, so all three are checked.
+
+The path component one level above the site is the ``project`` -- a data-collection
+campaign name, not a vehicle model (several projects can share one vehicle). This module
+has no built-in project->vehicle mapping; pass one via ``project_vehicle_map`` in
+:func:`discover_sites_with_vehicles_from_json` if needed.
 """
 
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 _SPLIT_DIR_NAMES = ("valid", "manual", "auto")
@@ -30,14 +36,56 @@ def discover_sites_from_json(json_path: str | Path) -> dict[str, list[Path]]:
     dir (see ``_SPLIT_DIR_NAMES``) in each entry. Entries with no recognized split dir are
     skipped. Multiple entries resolving to the same site (e.g. several curated
     date/time roots under one site) are merged into that site's list of roots.
+
+    Thin wrapper around :func:`discover_sites_with_vehicles_from_json` for callers that
+    don't need vehicle type.
     """
+    sites = discover_sites_with_vehicles_from_json(json_path)
+    return {name: info["npz_roots"] for name, info in sites.items()}
+
+
+def discover_sites_with_vehicles_from_json(
+    json_path: str | Path,
+    project_vehicle_map: dict[str, str] | None = None,
+) -> dict[str, dict]:
+    """Like :func:`discover_sites_from_json`, but also resolves each site's ``project`` and,
+    via ``project_vehicle_map`` (``{project_code_name: vehicle_type_label}``), its
+    ``vehicle_type``. Falls back to the raw project name if the map is omitted or missing
+    an entry.
+
+    Returns ``{site_key: {"npz_roots": [Path, ...], "vehicle_type": str, "project": str}}``.
+    If one site name appears under two vehicle types, both are kept as separate entries
+    (``f"{vehicle_type}__{site}"``) instead of merging their routes.
+    """
+    project_vehicle_map = project_vehicle_map or {}
     entries = json.loads(Path(json_path).read_text())
-    sites: dict[str, list[Path]] = {}
+    sites: dict[str, dict] = {}
     for entry in entries:
         path = Path(entry)
         parts = path.parts
         for i, part in enumerate(parts):
             if i > 0 and part in _SPLIT_DIR_NAMES:
-                sites.setdefault(parts[i - 1], []).append(path)
+                site = parts[i - 1]
+                project = parts[i - 2] if i >= 2 else "unknown"
+                vehicle_type = project_vehicle_map.get(project)
+                if vehicle_type is None:
+                    vehicle_type = project
+                    if project_vehicle_map:
+                        print(f"unrecognized project {project!r}, using it as vehicle_type", file=sys.stderr)
+
+                key = site
+                existing = sites.get(key)
+                if existing is not None and existing["vehicle_type"] != vehicle_type:
+                    print(f"site {site!r} has two vehicle types, splitting", file=sys.stderr)
+                    sites[f"{existing['vehicle_type']}__{site}"] = sites.pop(key)
+                    key = f"{vehicle_type}__{site}"
+                elif f"{vehicle_type}__{site}" in sites:
+                    key = f"{vehicle_type}__{site}"
+
+                info = sites.setdefault(
+                    key,
+                    {"npz_roots": [], "vehicle_type": vehicle_type, "project": project},
+                )
+                info["npz_roots"].append(path)
                 break
     return sites

--- a/scenario_generation/site_discovery.py
+++ b/scenario_generation/site_discovery.py
@@ -66,8 +66,11 @@ def discover_sites_with_vehicles_from_json(
     project_vehicle_map = project_vehicle_map or {}
     entries = json.loads(Path(json_path).read_text())
 
-    # Pass 1: resolve (site, project, vehicle_type) per entry.
+    # Pass 1: resolve (site, project, vehicle_type) per entry. Projects missing from the map
+    # are collected rather than warned about here -- a curated manifest holds one entry per
+    # route dir, so warning inline would repeat the same line thousands of times.
     parsed: list[tuple[str, str, str, Path]] = []
+    unmapped_projects: set[str] = set()
     for entry in entries:
         path = Path(entry)
         parts = path.parts
@@ -79,12 +82,14 @@ def discover_sites_with_vehicles_from_json(
                 if vehicle_type is None:
                     vehicle_type = project
                     if project_vehicle_map:
-                        print(
-                            f"unrecognized project {project!r}, using it as vehicle_type",
-                            file=sys.stderr,
-                        )
+                        unmapped_projects.add(project)
                 parsed.append((site, project, vehicle_type, path))
                 break
+    if unmapped_projects:
+        print(
+            f"unrecognized project(s) {sorted(unmapped_projects)}, using them as vehicle_type",
+            file=sys.stderr,
+        )
 
     # Pass 2: group by site, then by project -- never by vehicle_type, since several projects
     # can map to one vehicle and pooling their roots would put both projects' routes under a

--- a/scenario_generation/site_discovery.py
+++ b/scenario_generation/site_discovery.py
@@ -2,9 +2,8 @@
 
 A "site" is inferred from the path component immediately before the first recognized split
 dir (``_SPLIT_DIR_NAMES``) in each JSON entry, following the existing
-``{project}/{area_map_id}_{area_map_name}/{split}/...`` layout convention (e.g.
-``x2_dev/2231_odaiba_shinagawa_copied_from_xx1``). Each site's routes are evaluated
-independently — callers must never merge multiple sites' npz under one
+``{project}/{area_map_id}_{area_map_name}/{split}/...`` layout convention. Each site's routes
+are evaluated independently — callers must never merge multiple sites' npz under one
 ``--npz_root``/``rglob``, since route grouping is filename-only and ignores directory
 structure (see route_timeline.route_prefix); mixing sites risks silently merging unrelated
 routes that happen to share a bag-name prefix.
@@ -16,7 +15,9 @@ coexist across existing datasets, so all three are checked.
 The path component one level above the site is the ``project`` -- a data-collection
 campaign name, not a vehicle model (several projects can share one vehicle). This module
 has no built-in project->vehicle mapping; pass one via ``project_vehicle_map`` in
-:func:`discover_sites_with_vehicles_from_json` if needed.
+:func:`discover_sites_with_vehicles_from_json` if needed. The JSON file it is loaded from is
+supplied at runtime and is not tracked in this repository (``*project_vehicle_map*.json`` is
+gitignored).
 """
 
 from __future__ import annotations
@@ -30,7 +31,7 @@ _SPLIT_DIR_NAMES = ("valid", "manual", "auto")
 
 def discover_sites_from_json(json_path: str | Path) -> dict[str, list[Path]]:
     """Group a curated flat JSON path list (the ``--closed_loop_npz_root`` JSON-list
-    convention, e.g. ``path_list_closed_loop_x2.json``) into per-site npz roots.
+    convention, e.g. ``path_list_closed_loop.json``) into per-site npz roots.
 
     Site name is the path component immediately before the first recognized split
     dir (see ``_SPLIT_DIR_NAMES``) in each entry. Entries with no recognized split dir are

--- a/scenario_generation/site_discovery.py
+++ b/scenario_generation/site_discovery.py
@@ -54,12 +54,14 @@ def discover_sites_with_vehicles_from_json(
     an entry.
 
     Returns ``{site_key: {"npz_roots": [Path, ...], "vehicle_type": str, "project": str}}``.
-    If one site name appears under two vehicle types, both are kept as separate entries
-    (``f"{vehicle_type}__{site}"``) instead of merging their routes.
+    If one site name appears under N different vehicle types, all N are kept as separate
+    entries (``f"{vehicle_type}__{site}"``) instead of merging their routes.
     """
     project_vehicle_map = project_vehicle_map or {}
     entries = json.loads(Path(json_path).read_text())
-    sites: dict[str, dict] = {}
+
+    # Pass 1: resolve (site, project, vehicle_type) per entry.
+    parsed: list[tuple[str, str, str, Path]] = []
     for entry in entries:
         path = Path(entry)
         parts = path.parts
@@ -71,21 +73,29 @@ def discover_sites_with_vehicles_from_json(
                 if vehicle_type is None:
                     vehicle_type = project
                     if project_vehicle_map:
-                        print(f"unrecognized project {project!r}, using it as vehicle_type", file=sys.stderr)
-
-                key = site
-                existing = sites.get(key)
-                if existing is not None and existing["vehicle_type"] != vehicle_type:
-                    print(f"site {site!r} has two vehicle types, splitting", file=sys.stderr)
-                    sites[f"{existing['vehicle_type']}__{site}"] = sites.pop(key)
-                    key = f"{vehicle_type}__{site}"
-                elif f"{vehicle_type}__{site}" in sites:
-                    key = f"{vehicle_type}__{site}"
-
-                info = sites.setdefault(
-                    key,
-                    {"npz_roots": [], "vehicle_type": vehicle_type, "project": project},
-                )
-                info["npz_roots"].append(path)
+                        print(
+                            f"unrecognized project {project!r}, using it as vehicle_type",
+                            file=sys.stderr,
+                        )
+                parsed.append((site, project, vehicle_type, path))
                 break
+
+    # Pass 2: group by site, then by vehicle_type, so a collision between any number of
+    # vehicle types is seen in full before deciding site keys.
+    by_site: dict[str, dict[str, dict]] = {}
+    for site, project, vehicle_type, path in parsed:
+        group = by_site.setdefault(site, {}).setdefault(
+            vehicle_type, {"npz_roots": [], "project": project}
+        )
+        group["npz_roots"].append(path)
+
+    sites: dict[str, dict] = {}
+    for site, groups in by_site.items():
+        if len(groups) == 1:
+            (vehicle_type, group) = next(iter(groups.items()))
+            sites[site] = {**group, "vehicle_type": vehicle_type}
+        else:
+            print(f"site {site!r} spans vehicle types {sorted(groups)}, splitting", file=sys.stderr)
+            for vehicle_type, group in groups.items():
+                sites[f"{vehicle_type}__{site}"] = {**group, "vehicle_type": vehicle_type}
     return sites

--- a/scenario_generation/site_discovery.py
+++ b/scenario_generation/site_discovery.py
@@ -34,11 +34,11 @@ def discover_sites_from_json(json_path: str | Path) -> dict[str, list[Path]]:
 
     Site name is the path component immediately before the first recognized split
     dir (see ``_SPLIT_DIR_NAMES``) in each entry. Entries with no recognized split dir are
-    skipped. Multiple entries resolving to the same site (e.g. several curated
-    date/time roots under one site) are merged into that site's list of roots.
+    skipped. Merged only within the same project; a site name shared across two projects
+    stays split (see :func:`discover_sites_with_vehicles_from_json`).
 
-    Thin wrapper around :func:`discover_sites_with_vehicles_from_json` for callers that
-    don't need vehicle type.
+    Thin wrapper around :func:`discover_sites_with_vehicles_from_json` that drops the
+    vehicle_type/project info.
     """
     sites = discover_sites_with_vehicles_from_json(json_path)
     return {name: info["npz_roots"] for name, info in sites.items()}

--- a/scenario_generation/site_discovery.py
+++ b/scenario_generation/site_discovery.py
@@ -35,8 +35,9 @@ def discover_sites_from_json(json_path: str | Path) -> dict[str, list[Path]]:
 
     Site name is the path component immediately before the first recognized split
     dir (see ``_SPLIT_DIR_NAMES``) in each entry. Entries with no recognized split dir are
-    skipped. Merged only within the same project; a site name shared across two projects
-    stays split (see :func:`discover_sites_with_vehicles_from_json`).
+    skipped. Grouping is keyed on ``(project, site)`` -- never on vehicle type -- so entries
+    merge only within one project and a site name shared across two projects stays split
+    (see :func:`discover_sites_with_vehicles_from_json`).
 
     Thin wrapper around :func:`discover_sites_with_vehicles_from_json` that drops the
     vehicle_type/project info.
@@ -55,8 +56,12 @@ def discover_sites_with_vehicles_from_json(
     an entry.
 
     Returns ``{site_key: {"npz_roots": [Path, ...], "vehicle_type": str, "project": str}}``.
-    If one site name appears under N different vehicle types, all N are kept as separate
-    entries (``f"{vehicle_type}__{site}"``) instead of merging their routes.
+
+    Grouping is keyed on ``(project, site)``; ``vehicle_type`` is a label only and never
+    merges roots. Several projects can share one vehicle, so keying on the vehicle would pool
+    two projects' routes under one site key and leave ``project`` describing only whichever
+    was seen first. If one site name appears under N projects, all N are kept as separate
+    entries (``f"{project}__{site}"``) instead of merging their routes.
     """
     project_vehicle_map = project_vehicle_map or {}
     entries = json.loads(Path(json_path).read_text())
@@ -81,22 +86,23 @@ def discover_sites_with_vehicles_from_json(
                 parsed.append((site, project, vehicle_type, path))
                 break
 
-    # Pass 2: group by site, then by vehicle_type, so a collision between any number of
-    # vehicle types is seen in full before deciding site keys.
+    # Pass 2: group by site, then by project -- never by vehicle_type, since several projects
+    # can map to one vehicle and pooling their roots would put both projects' routes under a
+    # single ``project``. Grouping in two steps (rather than straight on the pair) means a
+    # collision between any number of projects is seen in full before deciding site keys.
     by_site: dict[str, dict[str, dict]] = {}
     for site, project, vehicle_type, path in parsed:
         group = by_site.setdefault(site, {}).setdefault(
-            vehicle_type, {"npz_roots": [], "project": project}
+            project, {"npz_roots": [], "project": project, "vehicle_type": vehicle_type}
         )
         group["npz_roots"].append(path)
 
     sites: dict[str, dict] = {}
     for site, groups in by_site.items():
         if len(groups) == 1:
-            (vehicle_type, group) = next(iter(groups.items()))
-            sites[site] = {**group, "vehicle_type": vehicle_type}
+            sites[site] = next(iter(groups.values()))
         else:
-            print(f"site {site!r} spans vehicle types {sorted(groups)}, splitting", file=sys.stderr)
-            for vehicle_type, group in groups.items():
-                sites[f"{vehicle_type}__{site}"] = {**group, "vehicle_type": vehicle_type}
+            print(f"site {site!r} spans projects {sorted(groups)}, splitting", file=sys.stderr)
+            for project, group in groups.items():
+                sites[f"{project}__{site}"] = group
     return sites

--- a/scenario_generation/tests/test_closed_loop_html_report.py
+++ b/scenario_generation/tests/test_closed_loop_html_report.py
@@ -1,0 +1,64 @@
+"""Unit tests for the closed-loop HTML report's vehicle_type field/filter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scenario_generation.closed_loop_html_report import build_html_report, collect_site_data
+
+_MINIMAL_SUMMARY = {"n_segments": 1, "mean_route_completion": 0.9}
+_MINIMAL_SEGMENT = {
+    "segment": [0, 1],
+    "route": "route_0",
+    "n_steps_run": 1,
+    "terminated": "completed",
+    "route_completion": 0.9,
+    "progress_m": 1.0,
+}
+
+
+def _make_site(out_root: Path, site_name: str) -> None:
+    d = out_root / site_name
+    d.mkdir(parents=True)
+    (d / "summary.json").write_text(json.dumps(_MINIMAL_SUMMARY))
+    (d / "segments.jsonl").write_text(json.dumps(_MINIMAL_SEGMENT) + "\n")
+
+
+def test_collect_site_data_adds_vehicle_type(tmp_path: Path):
+    _make_site(tmp_path, "site_a")
+    items, summaries = collect_site_data(
+        tmp_path, ["site_a"], site_vehicle_types={"site_a": "vehicle_x"}
+    )
+    assert summaries[0]["vehicle_type"] == "vehicle_x"
+    assert items[0]["vehicle_type"] == "vehicle_x"
+
+
+def test_collect_site_data_without_map_is_empty_string(tmp_path: Path):
+    _make_site(tmp_path, "site_a")
+    items, summaries = collect_site_data(tmp_path, ["site_a"])
+    assert summaries[0]["vehicle_type"] == ""
+    assert items[0]["vehicle_type"] == ""
+
+
+def test_noobj_label_resolves_base_site_vehicle_type(tmp_path: Path):
+    _make_site(tmp_path, "site_a__noobj")
+    items, summaries = collect_site_data(
+        tmp_path, ["site_a__noobj"], site_vehicle_types={"site_a": "vehicle_x"}
+    )
+    assert summaries[0]["vehicle_type"] == "vehicle_x"
+    assert items[0]["vehicle_type"] == "vehicle_x"
+
+
+def test_build_html_report_embeds_vehicle_filter(tmp_path: Path):
+    _make_site(tmp_path, "site_a")
+    _make_site(tmp_path, "site_b")
+    report_path = build_html_report(
+        tmp_path,
+        ["site_a", "site_b"],
+        site_vehicle_types={"site_a": "vehicle_x", "site_b": "vehicle_y"},
+    )
+    html = report_path.read_text(encoding="utf-8")
+    assert 'id="vehicleFilter"' in html
+    assert '"vehicle_type": "vehicle_x"' in html
+    assert '"vehicle_type": "vehicle_y"' in html

--- a/scenario_generation/tests/test_site_discovery.py
+++ b/scenario_generation/tests/test_site_discovery.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
+
+import pytest
 
 from scenario_generation.site_discovery import (
     discover_sites_from_json,
@@ -12,6 +15,8 @@ from scenario_generation.site_discovery import (
 
 # Layout: <root>/<project>/<area_map>/<split>/<date>/<time>
 ROOT = "/data"
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _write_list(tmp_path: Path, entries: list[str]) -> Path:
@@ -91,3 +96,29 @@ def test_legacy_wrapper_returns_only_npz_roots(tmp_path: Path):
     full = discover_sites_with_vehicles_from_json(path)
     assert set(legacy) == set(full)
     assert all(legacy[name] == full[name]["npz_roots"] for name in legacy)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "project_vehicle_map.json",
+        "closed_loop_project_vehicle_map.json",
+    ],
+)
+def test_project_vehicle_map_file_is_gitignored(filename: str):
+    """The ``project_vehicle_map`` JSON is supplied at runtime, so it must stay untracked.
+
+    Covers both ways the ``*project_vehicle_map*.json`` glob is reached: the bare name and a
+    prefixed one.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "check-ignore", "-q", filename],
+            cwd=_REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:  # pragma: no cover - git is expected in dev/CI
+        pytest.skip("git not available")
+    assert result.returncode == 0, f"{filename} is not ignored (rc={result.returncode})"

--- a/scenario_generation/tests/test_site_discovery.py
+++ b/scenario_generation/tests/test_site_discovery.py
@@ -58,6 +58,31 @@ def test_falls_back_to_project_name_when_missing_from_map(tmp_path: Path, capsys
     assert "proj_unknown" in capsys.readouterr().err
 
 
+def test_unmapped_projects_are_warned_about_once_not_once_per_entry(tmp_path: Path, capsys):
+    """One line per run naming every unmapped project, not one line per manifest entry.
+
+    A curated manifest holds one entry per route dir, so warning inline would bury the rest
+    of the training log. Mirrors the site-collision warning, which is already per-site.
+    """
+    entries = [
+        f"{ROOT}/{project}/{site}/manual/2026-01-{day:02d}/10-00-00"
+        for project, site in (("proj_unmapped_a", "site_a"), ("proj_unmapped_b", "site_b"))
+        for day in range(1, 26)
+    ]
+    path = _write_list(tmp_path, entries)
+    discover_sites_with_vehicles_from_json(path, {"proj_a": "vehicle_x"})
+    err = capsys.readouterr().err
+    assert err.count("unrecognized project") == 1, f"{len(entries)} entries produced: {err}"
+    assert "proj_unmapped_a" in err and "proj_unmapped_b" in err
+
+
+def test_no_warning_when_no_map_is_given(tmp_path: Path, capsys):
+    """Without a map there is nothing to be unrecognized against, so stay quiet."""
+    path = _write_list(tmp_path, [f"{ROOT}/proj_a/site_1/manual/2026-01-01/10-00-00"])
+    discover_sites_with_vehicles_from_json(path)
+    assert "unrecognized project" not in capsys.readouterr().err
+
+
 def test_splits_site_name_collision_across_projects(tmp_path: Path, capsys):
     entries = [
         f"{ROOT}/proj_a/site_1/manual/2026-01-01/10-00-00",

--- a/scenario_generation/tests/test_site_discovery.py
+++ b/scenario_generation/tests/test_site_discovery.py
@@ -35,7 +35,7 @@ def test_groups_multiple_roots_under_one_site(tmp_path: Path):
     assert set(sites) == {"site_1"}
     assert len(sites["site_1"]["npz_roots"]) == 2
     assert sites["site_1"]["project"] == "proj_a"
-    assert sites["site_1"]["vehicle_type"] == "proj_a"  # no map -> falls back to project name
+    assert sites["site_1"]["vehicle_type"] == ""  # no map -> unlabelled
 
 
 def test_resolves_vehicle_type_from_map(tmp_path: Path):

--- a/scenario_generation/tests/test_site_discovery.py
+++ b/scenario_generation/tests/test_site_discovery.py
@@ -67,6 +67,20 @@ def test_splits_site_name_collision_across_vehicle_types(tmp_path: Path, capsys)
     assert "site_1" in capsys.readouterr().err
 
 
+def test_splits_three_way_vehicle_type_collision(tmp_path: Path, capsys):
+    entries = [
+        f"{ROOT}/proj_a/site_1/manual/2026-01-01/10-00-00",
+        f"{ROOT}/proj_b/site_1/manual/2026-01-01/10-00-00",
+        f"{ROOT}/proj_c/site_1/manual/2026-01-01/10-00-00",
+    ]
+    path = _write_list(tmp_path, entries)
+    vehicle_map = {"proj_a": "vehicle_x", "proj_b": "vehicle_y", "proj_c": "vehicle_z"}
+    sites = discover_sites_with_vehicles_from_json(path, vehicle_map)
+    assert set(sites) == {"vehicle_x__site_1", "vehicle_y__site_1", "vehicle_z__site_1"}
+    assert sites["vehicle_z__site_1"]["project"] == "proj_c"
+    assert "site_1" not in sites  # the bare site name must not silently reappear
+
+
 def test_legacy_wrapper_returns_only_npz_roots(tmp_path: Path):
     entries = [
         f"{ROOT}/proj_a/site_1/manual/2026-01-01/10-00-00",

--- a/scenario_generation/tests/test_site_discovery.py
+++ b/scenario_generation/tests/test_site_discovery.py
@@ -1,0 +1,79 @@
+"""Unit tests for site_discovery's site/vehicle-type resolution."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scenario_generation.site_discovery import (
+    discover_sites_from_json,
+    discover_sites_with_vehicles_from_json,
+)
+
+# Layout: <root>/<project>/<area_map>/<split>/<date>/<time>
+ROOT = "/data"
+
+
+def _write_list(tmp_path: Path, entries: list[str]) -> Path:
+    p = tmp_path / "path_list.json"
+    p.write_text(json.dumps(entries))
+    return p
+
+
+def test_groups_multiple_roots_under_one_site(tmp_path: Path):
+    entries = [
+        f"{ROOT}/proj_a/site_1/manual/2026-01-01/10-00-00",
+        f"{ROOT}/proj_a/site_1/manual/2026-01-02/11-00-00",
+    ]
+    path = _write_list(tmp_path, entries)
+    sites = discover_sites_with_vehicles_from_json(path)
+    assert set(sites) == {"site_1"}
+    assert len(sites["site_1"]["npz_roots"]) == 2
+    assert sites["site_1"]["project"] == "proj_a"
+    assert sites["site_1"]["vehicle_type"] == "proj_a"  # no map -> falls back to project name
+
+
+def test_resolves_vehicle_type_from_map(tmp_path: Path):
+    entries = [
+        f"{ROOT}/proj_a/site_1/manual/2026-01-01/10-00-00",
+        f"{ROOT}/proj_b/site_2/manual/2026-01-01/10-00-00",
+    ]
+    path = _write_list(tmp_path, entries)
+    vehicle_map = {"proj_a": "vehicle_x", "proj_b": "vehicle_x"}
+    sites = discover_sites_with_vehicles_from_json(path, vehicle_map)
+    assert sites["site_1"]["vehicle_type"] == "vehicle_x"
+    assert sites["site_2"]["vehicle_type"] == "vehicle_x"
+
+
+def test_falls_back_to_project_name_when_missing_from_map(tmp_path: Path, capsys):
+    entries = [f"{ROOT}/proj_unknown/site_1/manual/2026-01-01/10-00-00"]
+    path = _write_list(tmp_path, entries)
+    sites = discover_sites_with_vehicles_from_json(path, {"proj_a": "vehicle_x"})
+    assert sites["site_1"]["vehicle_type"] == "proj_unknown"
+    assert "proj_unknown" in capsys.readouterr().err
+
+
+def test_splits_site_name_collision_across_vehicle_types(tmp_path: Path, capsys):
+    entries = [
+        f"{ROOT}/proj_a/site_1/manual/2026-01-01/10-00-00",
+        f"{ROOT}/proj_b/site_1/manual/2026-01-01/10-00-00",
+    ]
+    path = _write_list(tmp_path, entries)
+    vehicle_map = {"proj_a": "vehicle_x", "proj_b": "vehicle_y"}
+    sites = discover_sites_with_vehicles_from_json(path, vehicle_map)
+    assert set(sites) == {"vehicle_x__site_1", "vehicle_y__site_1"}
+    assert sites["vehicle_x__site_1"]["project"] == "proj_a"
+    assert sites["vehicle_y__site_1"]["project"] == "proj_b"
+    assert "site_1" in capsys.readouterr().err
+
+
+def test_legacy_wrapper_returns_only_npz_roots(tmp_path: Path):
+    entries = [
+        f"{ROOT}/proj_a/site_1/manual/2026-01-01/10-00-00",
+        f"{ROOT}/proj_b/site_2/manual/2026-01-01/10-00-00",
+    ]
+    path = _write_list(tmp_path, entries)
+    legacy = discover_sites_from_json(path)
+    full = discover_sites_with_vehicles_from_json(path)
+    assert set(legacy) == set(full)
+    assert all(legacy[name] == full[name]["npz_roots"] for name in legacy)

--- a/scenario_generation/tests/test_site_discovery.py
+++ b/scenario_generation/tests/test_site_discovery.py
@@ -58,7 +58,7 @@ def test_falls_back_to_project_name_when_missing_from_map(tmp_path: Path, capsys
     assert "proj_unknown" in capsys.readouterr().err
 
 
-def test_splits_site_name_collision_across_vehicle_types(tmp_path: Path, capsys):
+def test_splits_site_name_collision_across_projects(tmp_path: Path, capsys):
     entries = [
         f"{ROOT}/proj_a/site_1/manual/2026-01-01/10-00-00",
         f"{ROOT}/proj_b/site_1/manual/2026-01-01/10-00-00",
@@ -66,13 +66,15 @@ def test_splits_site_name_collision_across_vehicle_types(tmp_path: Path, capsys)
     path = _write_list(tmp_path, entries)
     vehicle_map = {"proj_a": "vehicle_x", "proj_b": "vehicle_y"}
     sites = discover_sites_with_vehicles_from_json(path, vehicle_map)
-    assert set(sites) == {"vehicle_x__site_1", "vehicle_y__site_1"}
-    assert sites["vehicle_x__site_1"]["project"] == "proj_a"
-    assert sites["vehicle_y__site_1"]["project"] == "proj_b"
+    assert set(sites) == {"proj_a__site_1", "proj_b__site_1"}
+    assert sites["proj_a__site_1"]["project"] == "proj_a"
+    assert sites["proj_b__site_1"]["project"] == "proj_b"
+    assert sites["proj_a__site_1"]["vehicle_type"] == "vehicle_x"
+    assert sites["proj_b__site_1"]["vehicle_type"] == "vehicle_y"
     assert "site_1" in capsys.readouterr().err
 
 
-def test_splits_three_way_vehicle_type_collision(tmp_path: Path, capsys):
+def test_splits_three_way_project_collision(tmp_path: Path, capsys):
     entries = [
         f"{ROOT}/proj_a/site_1/manual/2026-01-01/10-00-00",
         f"{ROOT}/proj_b/site_1/manual/2026-01-01/10-00-00",
@@ -81,9 +83,47 @@ def test_splits_three_way_vehicle_type_collision(tmp_path: Path, capsys):
     path = _write_list(tmp_path, entries)
     vehicle_map = {"proj_a": "vehicle_x", "proj_b": "vehicle_y", "proj_c": "vehicle_z"}
     sites = discover_sites_with_vehicles_from_json(path, vehicle_map)
-    assert set(sites) == {"vehicle_x__site_1", "vehicle_y__site_1", "vehicle_z__site_1"}
-    assert sites["vehicle_z__site_1"]["project"] == "proj_c"
+    assert set(sites) == {"proj_a__site_1", "proj_b__site_1", "proj_c__site_1"}
+    assert sites["proj_c__site_1"]["project"] == "proj_c"
     assert "site_1" not in sites  # the bare site name must not silently reappear
+
+
+def test_splits_site_name_collision_even_when_projects_share_a_vehicle(tmp_path: Path, capsys):
+    """Grouping is keyed on ``(project, site)``, so one vehicle over two projects still splits.
+
+    Keying on the vehicle would pool both projects' roots under a single site key, which is
+    what the module docstring warns about: route grouping is filename-only, and the reported
+    ``project`` could then describe only whichever project happened to be seen first.
+    """
+    entries = [
+        f"{ROOT}/proj_a/site_1/manual/2026-01-01/10-00-00",
+        f"{ROOT}/proj_b/site_1/manual/2026-01-01/10-00-00",
+    ]
+    path = _write_list(tmp_path, entries)
+    vehicle_map = {"proj_a": "vehicle_x", "proj_b": "vehicle_x"}  # one vehicle, two projects
+    sites = discover_sites_with_vehicles_from_json(path, vehicle_map)
+    assert set(sites) == {"proj_a__site_1", "proj_b__site_1"}
+    assert all(info["vehicle_type"] == "vehicle_x" for info in sites.values())
+    assert "site_1" in capsys.readouterr().err
+
+
+def test_project_describes_every_npz_root_of_its_site(tmp_path: Path):
+    """A site's ``project`` must hold for all of its roots; it is recorded in sites_summary.json."""
+    entries = [
+        f"{ROOT}/proj_a/site_1/manual/2026-01-01/10-00-00",
+        f"{ROOT}/proj_a/site_1/manual/2026-01-02/11-00-00",
+        f"{ROOT}/proj_b/site_1/manual/2026-01-01/10-00-00",
+    ]
+    path = _write_list(tmp_path, entries)
+    sites = discover_sites_with_vehicles_from_json(
+        path, {"proj_a": "vehicle_x", "proj_b": "vehicle_x"}
+    )
+    for site_key, info in sites.items():
+        # <root>/<project>/<site>/<split>/<date>/<time> -- project is 5 components up
+        roots_from = {root.parts[-5] for root in info["npz_roots"]}
+        assert roots_from == {info["project"]}, (
+            f"{site_key}: project={info['project']!r} but roots come from {sorted(roots_from)}"
+        )
 
 
 def test_legacy_wrapper_returns_only_npz_roots(tmp_path: Path):

--- a/scenario_generation/tests/test_wandb_closed_loop.py
+++ b/scenario_generation/tests/test_wandb_closed_loop.py
@@ -1,0 +1,54 @@
+"""Unit tests for wandb_closed_loop's vehicle_type column and per-vehicle rollup."""
+
+from __future__ import annotations
+
+from scenario_generation.wandb_closed_loop import (
+    EPISODE_TABLE_COLUMNS,
+    build_combined_episode_table,
+    build_sites_aggregate_log,
+)
+
+_ROW = {"segment": [0, 1], "route": "route_0", "n_steps_run": 1, "route_completion": 0.9}
+
+
+def test_episode_table_has_vehicle_type_column():
+    assert "vehicle_type" in EPISODE_TABLE_COLUMNS
+
+
+def test_combined_episode_table_fills_vehicle_type():
+    table = build_combined_episode_table([("site_a", [_ROW], None, "vehicle_x")])
+    vehicle_col = EPISODE_TABLE_COLUMNS.index("vehicle_type")
+    assert table.data[0][vehicle_col] == "vehicle_x"
+
+
+def test_combined_episode_table_backward_compatible_without_vehicle_type():
+    table = build_combined_episode_table([("site_a", [_ROW], None)])
+    vehicle_col = EPISODE_TABLE_COLUMNS.index("vehicle_type")
+    assert table.data[0][vehicle_col] == ""
+
+
+def test_sites_aggregate_log_adds_per_vehicle_rollup():
+    summaries = {
+        "site_a": {"n_segments": 1, "mean_route_completion": 0.9},
+        "site_b": {"n_segments": 1, "mean_route_completion": 0.5},
+    }
+    site_vehicle_types = {"site_a": "vehicle_x", "site_b": "vehicle_y"}
+    log = build_sites_aggregate_log(summaries, site_vehicle_types)
+    assert log["closed_loop_overview_by_vehicle/vehicle_x/n_sites"] == 1
+    assert log["closed_loop_overview_by_vehicle/vehicle_y/n_sites"] == 1
+    assert log["closed_loop_overview/n_sites"] == 2
+
+
+def test_sites_aggregate_log_without_vehicle_types_has_no_per_vehicle_keys():
+    summaries = {"site_a": {"n_segments": 1, "mean_route_completion": 0.9}}
+    log = build_sites_aggregate_log(summaries)
+    assert not any(k.startswith("closed_loop_overview_by_vehicle/") for k in log)
+
+
+def test_noobj_label_shares_base_site_vehicle_type_in_rollup():
+    summaries = {
+        "site_a": {"n_segments": 1, "mean_route_completion": 0.9},
+        "site_a__noobj": {"n_segments": 1, "mean_route_completion": 1.0},
+    }
+    log = build_sites_aggregate_log(summaries, {"site_a": "vehicle_x"})
+    assert log["closed_loop_overview_by_vehicle/vehicle_x/n_sites"] == 2

--- a/scenario_generation/tests/test_wandb_closed_loop.py
+++ b/scenario_generation/tests/test_wandb_closed_loop.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
+from scenario_generation.site_discovery import discover_sites_with_vehicles_from_json
 from scenario_generation.wandb_closed_loop import (
     EPISODE_TABLE_COLUMNS,
     build_combined_episode_table,
@@ -52,3 +56,33 @@ def test_noobj_label_shares_base_site_vehicle_type_in_rollup():
     }
     log = build_sites_aggregate_log(summaries, {"site_a": "vehicle_x"})
     assert log["closed_loop_overview_by_vehicle/vehicle_x/n_sites"] == 2
+
+
+def test_no_project_vehicle_map_produces_no_per_vehicle_rollup(tmp_path: Path):
+    """Driven through the real caller shape: no map in, no per-vehicle W&B keys out.
+
+    ``test_sites_aggregate_log_without_vehicle_types_has_no_per_vehicle_keys`` above omits
+    ``site_vehicle_types`` entirely, which the production callers never do -- they build it
+    from ``discover_sites_with_vehicles_from_json`` (see ``closed_loop_validate`` in train.py
+    and ``_log_to_wandb`` in run_all_sites_closed_loop.py). Unlike the HTML report, these key
+    names cannot be corrected after a run has logged them.
+    """
+    path_list = tmp_path / "path_list.json"
+    path_list.write_text(
+        json.dumps(
+            [
+                "/data/proj_a/site_1/manual/2026-01-01/10-00-00",
+                "/data/proj_b/site_2/manual/2026-01-01/10-00-00",
+            ]
+        )
+    )
+    sites = discover_sites_with_vehicles_from_json(path_list)  # no --project_vehicle_map
+    site_vehicle_types = {
+        name: info["vehicle_type"] for name, info in sites.items() if info["vehicle_type"]
+    }
+    summaries = {name: {"n_segments": 1, "mean_route_completion": 0.9} for name in sites}
+
+    log = build_sites_aggregate_log(summaries, site_vehicle_types)
+    per_vehicle = sorted(k for k in log if k.startswith("closed_loop_overview_by_vehicle/"))
+    assert not per_vehicle, f"per-vehicle rollup logged without a map: {per_vehicle[:4]}"
+    assert log["closed_loop_overview/n_sites"] == 2  # the overall rollup is unaffected

--- a/scenario_generation/wandb_closed_loop.py
+++ b/scenario_generation/wandb_closed_loop.py
@@ -74,6 +74,7 @@ def pick_representative_row(rows: list[dict], mode: str = "worst") -> dict | Non
 
 EPISODE_TABLE_COLUMNS = [
     "site",
+    "vehicle_type",
     "route",
     "segment",
     "n_steps_run",
@@ -89,13 +90,20 @@ EPISODE_TABLE_COLUMNS = [
 ]
 
 
-def _episode_row(table: wandb.Table, site: str, r: dict, out_dir: str | Path | None) -> None:
+def _episode_row(
+    table: wandb.Table,
+    site: str,
+    r: dict,
+    out_dir: str | Path | None,
+    vehicle_type: str | None = None,
+) -> None:
     seg = r.get("segment")
     seg_str = f"[{seg[0]},{seg[1]}]" if seg else ""
     video_path = str(_segment_paths(out_dir, r)[1]) if out_dir is not None else ""
     comp = r.get("route_completion")
     table.add_data(
         site,
+        vehicle_type or "",
         r.get("route", ""),
         seg_str,
         int(r.get("n_steps_run", 0)),
@@ -112,17 +120,19 @@ def _episode_row(table: wandb.Table, site: str, r: dict, out_dir: str | Path | N
 
 
 def build_combined_episode_table(
-    site_episodes: list[tuple[str, list[dict], str | Path | None]],
+    site_episodes: list[tuple[str, list[dict], str | Path | None]]
+    | list[tuple[str, list[dict], str | Path | None, str | None]],
 ) -> wandb.Table:
-    """ONE episode table across every site (``site`` column filled per row), so the W&B UI's
-    native sort/filter/group-by works across the whole run — group by ``site``, sort by
-    ``n_collision_events`` desc, etc. — in a single interactive panel instead of one table
-    per site. ``site_episodes`` is ``[(site_name, rows, out_dir), ...]``.
+    """ONE episode table across every site, so the W&B UI's native sort/filter/group-by
+    works across the whole run in a single panel. ``site_episodes`` is
+    ``[(site_name, rows, out_dir), ...]``, optionally with a 4th ``vehicle_type`` element.
     """
     table = wandb.Table(columns=EPISODE_TABLE_COLUMNS)
-    for site, rows, out_dir in site_episodes:
+    for entry in site_episodes:
+        site, rows, out_dir, *rest = entry
+        vehicle_type = rest[0] if rest else None
         for r in rows:
-            _episode_row(table, site, r, out_dir)
+            _episode_row(table, site, r, out_dir, vehicle_type)
     return table
 
 
@@ -140,7 +150,32 @@ def resolve_report_link(out_dir: str | Path, report_base_url: str | None = None)
     return str(out_dir.resolve())
 
 
-def build_sites_aggregate_log(summaries: dict[str, dict]) -> dict:
+def _aggregate_rollup(prefix: str, values: list[dict], objects_values: list[dict]) -> dict:
+    """Rollup under ``{prefix}/...``, shared by the overall and per-vehicle logs."""
+    log: dict = {}
+    n_sites = len(values)
+    total_segments = sum(int(s.get("n_segments", 0)) for s in values)
+
+    log[f"{prefix}/n_sites"] = n_sites
+    log[f"{prefix}/n_segments"] = total_segments
+
+    comp_num = sum(
+        float(s.get("mean_route_completion", 0.0)) * int(s.get("n_segments", 0)) for s in values
+    )
+    log[f"{prefix}/route_completion"] = comp_num / total_segments if total_segments else 0.0
+
+    for key in COMPARISON_OVERVIEW_SUM_KEYS:
+        log[f"{prefix}/{key}"] = sum(int(extract_score(s, key) or 0) for s in values)
+    for key in OBJECTS_ONLY_OVERVIEW_SUM_KEYS:
+        log[f"{prefix}/{key}"] = sum(int(extract_score(s, key) or 0) for s in objects_values)
+
+    return log
+
+
+def build_sites_aggregate_log(
+    summaries: dict[str, dict],
+    site_vehicle_types: dict[str, str] | None = None,
+) -> dict:
     """Cross-site rollup under ``closed_loop_overview/`` (the at-a-glance block): the segment-
     weighted mean route-completion (so long routes aren't under-weighted), plus the plain
     cross-site SUM of each event count. Deliberately just the small non-saturating set — no
@@ -150,31 +185,33 @@ def build_sites_aggregate_log(summaries: dict[str, dict]) -> dict:
     collision-style sums (``OBJECTS_ONLY_OVERVIEW_SUM_KEYS``), since those are 0 by
     construction in the empty-world ablation and would just dilute the objects-mode number
     with zeros.
+
+    If ``site_vehicle_types`` (``{site_label: vehicle_type}``) is given, the same rollup is
+    also computed per vehicle type under ``closed_loop_overview_by_vehicle/{vehicle_type}/...``.
     """
     log: dict = {}
     if not summaries:
         return log
     values = list(summaries.values())
     objects_values = [s for label, s in summaries.items() if not _is_noobj_label(label)]
-    n_sites = len(values)
-    total_segments = sum(int(s.get("n_segments", 0)) for s in values)
+    log.update(_aggregate_rollup("closed_loop_overview", values, objects_values))
 
-    log["closed_loop_overview/n_sites"] = n_sites
-    log["closed_loop_overview/n_segments"] = total_segments
-
-    comp_num = sum(
-        float(s.get("mean_route_completion", 0.0)) * int(s.get("n_segments", 0)) for s in values
-    )
-    log["closed_loop_overview/route_completion"] = (
-        comp_num / total_segments if total_segments else 0.0
-    )
-
-    for key in COMPARISON_OVERVIEW_SUM_KEYS:
-        log[f"closed_loop_overview/{key}"] = sum(int(extract_score(s, key) or 0) for s in values)
-    for key in OBJECTS_ONLY_OVERVIEW_SUM_KEYS:
-        log[f"closed_loop_overview/{key}"] = sum(
-            int(extract_score(s, key) or 0) for s in objects_values
-        )
+    if site_vehicle_types:
+        by_vehicle: dict[str, list[str]] = {}
+        for label in summaries:
+            base_label = label[: -len("__noobj")] if _is_noobj_label(label) else label
+            vehicle_type = site_vehicle_types.get(base_label) or site_vehicle_types.get(label)
+            if vehicle_type is None:
+                continue
+            by_vehicle.setdefault(vehicle_type, []).append(label)
+        for vehicle_type, labels in by_vehicle.items():
+            v_values = [summaries[label] for label in labels]
+            v_objects_values = [summaries[label] for label in labels if not _is_noobj_label(label)]
+            log.update(
+                _aggregate_rollup(
+                    f"closed_loop_overview_by_vehicle/{vehicle_type}", v_values, v_objects_values
+                )
+            )
 
     return {k: v for k, v in log.items() if _wandb_scalar(v) or isinstance(v, int)}
 


### PR DESCRIPTION
  ## Summary

  Adds vehicle-type labeling to closed-loop evaluation, alongside the existing per-site grouping.

  - `site_discovery`: resolves vehicle type from the project path component via `--project_vehicle_map`
  - `run_all_sites_closed_loop.py`: adds `--project_vehicle_map` / `--only_vehicle_types`
  - HTML report and W&B log get a vehicle_type column, filter, and per-vehicle rollup

  Simulation itself (each route's ego_shape) is unchanged — this is labeling/reporting only.

  ## Test

  - Added 15 unit tests, all passing
  - Ran the existing `scenario_generation/tests/` suite, no regressions
  - Ran `run_all_sites_closed_loop.py` locally on real data and confirmed vehicle_type resolves correctly