### PR TITLE
fix(reproducer_rollout): close rollout.jsonl on early exit

### DIFF
--- a/cpp_tools/.gitignore
+++ b/cpp_tools/.gitignore
@@ -7,3 +7,4 @@ install
 /src/core/
 /src/universe/
 /src/sensor_component/
+/src/simulator/

--- a/cpp_tools/build.sh
+++ b/cpp_tools/build.sh
@@ -17,4 +17,6 @@ colcon build \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_EXPORT_COMPILE_COMMANDS=1 \
   -DBUILD_TESTING=0 \
-  --packages-up-to autoware_diffusion_planner_tools
+  -DSSV2_HEADLESS_EGO=ON \
+  -DCMAKE_CXX_FLAGS=-DSSV2_HEADLESS_EGO \
+  --packages-up-to autoware_diffusion_planner_tools openscenario_python autoware_lanelet2_extension_python behavior_tree_plugin

--- a/cpp_tools/prepare_repos.sh
+++ b/cpp_tools/prepare_repos.sh
@@ -4,5 +4,6 @@ set -eux
 cd $(dirname $0)
 
 vcs import --recursive src < cpp_tools.repos
+vcs import --recursive src < scenario_sim.repos
 rosdep update
 rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO

--- a/cpp_tools/scenario_sim.repos
+++ b/cpp_tools/scenario_sim.repos
@@ -1,0 +1,5 @@
+repositories:
+  simulator/scenario_simulator_v2:
+    type: git
+    url: https://github.com/tier4/scenario_simulator_v2.git
+    version: feature/diffusion_planner_validation

--- a/diffusion_planner/diffusion_planner/model/module/encoder.py
+++ b/diffusion_planner/diffusion_planner/model/module/encoder.py
@@ -451,7 +451,34 @@ class NeighborEncoder(nn.Module):
         x = torch.cat([x[..., :4], torch.zeros_like(x[..., 4:6]), x[..., 6:]], dim=-1)
 
         valid_indices = ~mask_p.view(-1)
-        x = torch.where(valid_indices.view(-1, 1, 1), x, torch.zeros_like(x))
+
+        if not self.training:
+            # Static-shape (mask) path used for eval and ONNX export. ONNX cannot
+            # trace the dynamic gather below, so we process all B*P slots and zero
+            # out the invalid ones — numerically identical, just more FLOPs. Export
+            # runs under model.eval() (see onnx_export.py), so keying on
+            # ``self.training`` keeps the exported graph static while letting
+            # training take the fast gather path.
+            x = torch.where(valid_indices.view(-1, 1, 1), x, torch.zeros_like(x))
+            x = self.channel_pre_project(x)
+            x = x.permute(0, 2, 1)
+            x = self.token_pre_project(x)
+            x = x.permute(0, 2, 1)
+            for block in self.blocks:
+                x = block(x)
+            x = torch.mean(x, dim=1)  # pooling
+            # Reshaped here rather than before the branch so the traced op order (and hence the
+            # exported ONNX bytes) stays identical to the pre-speed-up implementation.
+            type_embedding = self.type_emb(neighbor_type.view(B * P, -1))
+            x = x + type_embedding
+            x = self.emb_project(self.norm(x))
+            x_result = x * valid_indices.float().unsqueeze(-1)
+            return x_result.view(B, P, -1), mask_p.reshape(B, -1), pos.view(B, P, -1)
+
+        # Fast gather path (training): the temporal encoder only runs on the ~few
+        # dozen valid neighbours instead of all 320 padded slots.
+        neighbor_type = neighbor_type.view(B * P, -1)
+        x = x[valid_indices]
 
         x = self.channel_pre_project(x)
         x = x.permute(0, 2, 1)
@@ -463,12 +490,13 @@ class NeighborEncoder(nn.Module):
         # pooling
         x = torch.mean(x, dim=1)
 
-        neighbor_type = neighbor_type.view(B * P, -1)
-        type_embedding = self.type_emb(neighbor_type)
+        type_embedding = self.type_emb(neighbor_type[valid_indices])
         x = x + type_embedding
 
         x = self.emb_project(self.norm(x))
-        x_result = x * valid_indices.float().unsqueeze(-1)
+
+        x_result = torch.zeros((B * P, x.shape[-1]), dtype=x.dtype, device=x.device)
+        x_result[valid_indices] = x  # Fill in valid parts
 
         return x_result.view(B, P, -1), mask_p.reshape(B, -1), pos.view(B, P, -1)
 

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -147,18 +147,18 @@ def closed_loop_validate(
     per (site, object-mode) pair: ``closed_loop_npz_root`` (single arbitrary path) and
     ``closed_loop_sites_npz_root`` (a curated ``.json`` path-list manifest grouped into
     per-site route pools by
-    :func:`~scenario_generation.site_discovery.discover_sites_from_json`) are independent — both
-    fire in the same call when both are set, each contributing its own rows to the combined
-    episode table / cross-site aggregate. Called on the checkpoint-save cadence, rank-0 only:
-    pass the unwrapped model; it is switched to eval for the rollout (so the diffusion sampler
-    runs and produces ``prediction``) and restored afterwards.
+    :func:`~scenario_generation.site_discovery.discover_sites_from_json`) fire independently.
+    Called on the checkpoint-save cadence, rank-0 only: pass the unwrapped model; it is switched
+    to eval for the rollout (so the diffusion sampler runs and produces ``prediction``) and
+    restored afterwards.
 
-    Per-step matplotlib rendering (PNGs/video/colormap images) is the dominant per-call cost, so
-    it's deferred to the last call only (``is_final_save=True``, computed by the caller as "is
-    this the last time the checkpoint-save cadence fires in this run" -- NOT simply
-    ``epoch == train_epochs - 1``, since train_epochs may not land on a save_utd-multiple)
-    -- every other call still runs the full rollout and logs metrics/wandb scalars, just without
-    that cost.
+    ``is_final_save=True`` marks the last cadence call of the run (computed by the caller, since
+    train_epochs may not land on a save_utd-multiple).
+
+    * ``closed_loop_npz_root`` runs every cadence call; only its video/colormap rendering is
+      deferred to ``is_final_save``.
+    * ``closed_loop_sites_npz_root`` only runs at all on ``is_final_save`` -- it covers many more
+      sites/routes and is too expensive to run every cadence call.
     """
     if not args.closed_loop_npz_root and not args.closed_loop_sites_npz_root:
         return
@@ -174,13 +174,20 @@ def closed_loop_validate(
         build_combined_episode_table,
         build_full_closed_loop_wandb_log,
         build_sites_aggregate_log,
+        build_sites_score_bar_charts,
     )
 
     net = ddp.get_model(model, args.ddp)
     was_training = net.training
     net.eval()
 
-    def run_one(npz_root, site_out_dir: str, site_name: str | None, drop_objects: bool = False):
+    def run_one(
+        npz_root,
+        site_out_dir: str,
+        site_name: str | None,
+        drop_objects: bool = False,
+        is_site: bool = False,
+    ):
         site_label = f" [{site_name}]" if site_name else ""
         evaluator = FullRouteClosedLoopEvaluation(
             net,
@@ -221,6 +228,8 @@ def closed_loop_validate(
             near_miss_thresh=args.closed_loop_near_miss_thresh,
             report_base_url=args.closed_loop_report_base_url or None,
             render_media=is_final_save,
+            # Sites only run once per run now; the bar chart covers them instead.
+            include_score_scalars=not is_site,
         )
         print(
             f"closed-loop{site_label} @epoch {epoch + 1}: {summary['n_segments']} seg in "
@@ -243,6 +252,7 @@ def closed_loop_validate(
         mode_pairs: tuple[tuple[str, bool], ...],
         *,
         track_for_report: bool = False,
+        is_site: bool = False,
     ) -> None:
         """Run ``npz_root`` once per requested object-mode, merging into log/site_summaries/episode_data.
 
@@ -260,7 +270,9 @@ def closed_loop_validate(
             else:
                 label = base_name
             site_out_dir = os.path.join(out_dir, label) if label else out_dir
-            site_log, summary = run_one(npz_root, site_out_dir, label, drop_objects=drop_objects)
+            site_log, summary = run_one(
+                npz_root, site_out_dir, label, drop_objects=drop_objects, is_site=is_site
+            )
             if not summary:
                 continue
             episode_label = label or "main"
@@ -275,13 +287,15 @@ def closed_loop_validate(
             npz_modes = _object_mode_pairs(args.closed_loop_npz_object_modes)
             run_labeled(None, args.closed_loop_npz_root, npz_modes)
 
-        if args.closed_loop_sites_npz_root:
+        if args.closed_loop_sites_npz_root and is_final_save:
             sites = discover_sites_from_json(args.closed_loop_sites_npz_root)
             if not sites:
                 print(f"closed-loop: no sites found under {args.closed_loop_sites_npz_root}")
             sites_modes = _object_mode_pairs(args.closed_loop_sites_object_modes)
             for site_name, npz_root in sites.items():
-                run_labeled(site_name, npz_root, sites_modes, track_for_report=True)
+                run_labeled(
+                    site_name, npz_root, sites_modes, track_for_report=True, is_site=True
+                )
 
         # One combined, filterable/groupable episode table across every source/site/mode.
         if episode_data:
@@ -289,9 +303,10 @@ def closed_loop_validate(
         # Cross-source/site pooled rollup under closed_loop_overview/*.
         if len(site_summaries) > 1:
             log.update(build_sites_aggregate_log(site_summaries))
-        # Local HTML gallery, sites only (see site_report_labels above) -- only built on
-        # is_final_save, same as the media (videos/colormap images) it links to.
+        # Sites only (see site_report_labels above), only non-empty on is_final_save.
         if is_final_save and site_report_labels:
+            site_summaries_only = {label: site_summaries[label] for label in site_report_labels}
+            log.update(build_sites_score_bar_charts(site_summaries_only))
             report_path = build_html_report(out_dir, site_report_labels)
             if report_path:
                 print(f"closed-loop: wrote {report_path}")

--- a/diffusion_planner/diffusion_planner/train_epoch.py
+++ b/diffusion_planner/diffusion_planner/train_epoch.py
@@ -5,7 +5,7 @@ from tqdm import tqdm
 from diffusion_planner.model.module.decoder import compute_training_loss
 from diffusion_planner.utils import ddp
 from diffusion_planner.utils.data_augmentation import StatePerturbation
-from diffusion_planner.utils.train_utils import compute_grad_stats, get_epoch_mean_loss
+from diffusion_planner.utils.train_utils import get_epoch_mean_loss
 
 
 def heading_to_cos_sin(x):
@@ -81,10 +81,6 @@ def train_epoch(data_loader, model, optimizer, args, ema, aug: StatePerturbation
 
         # loss backward
         loss["loss"].backward()
-
-        # Gradient statistics (computed before clipping so that exploding
-        # gradients are not masked by clip_grad_norm_).
-        loss.update(compute_grad_stats(model.parameters()))
 
         nn.utils.clip_grad_norm_(model.parameters(), 5)
         optimizer.step()

--- a/diffusion_planner/diffusion_planner/utils/train_utils.py
+++ b/diffusion_planner/diffusion_planner/utils/train_utils.py
@@ -29,51 +29,6 @@ def set_seed(CUR_SEED):
     torch.backends.cudnn.benchmark = False
 
 
-def compute_grad_stats(parameters, prefix="grad"):
-    """
-    Compute global-gradient statistics (l1/l2/linf/mean/std) WITHOUT
-    materializing a single concatenated copy of every gradient.
-
-    torch.cat([...all grads...]) allocated one huge contiguous block at peak
-    memory (right after backward), which was a primary driver of caching-allocator
-    fragmentation. Here we accumulate the reductions per-parameter instead, and
-    sync to host only once (a single 5-element .tolist()).
-    """
-    l1 = sq = smax = ssum = None
-    n = 0
-    for p in parameters:
-        if p.grad is None:
-            continue
-        g = p.grad.detach()
-        a = g.abs()
-        g_l1 = a.sum()
-        g_sq = (g * g).sum()
-        g_max = a.max()
-        g_sum = g.sum()
-        l1 = g_l1 if l1 is None else l1 + g_l1
-        sq = g_sq if sq is None else sq + g_sq
-        smax = g_max if smax is None else torch.maximum(smax, g_max)
-        ssum = g_sum if ssum is None else ssum + g_sum
-        n += g.numel()
-
-    if n == 0:
-        return {}
-
-    mean = ssum / n
-    var = (sq / n - mean * mean).clamp_min(0)
-    # Single device->host sync for all five scalars.
-    l1_v, l2_v, linf_v, mean_v, std_v = torch.stack(
-        [l1, sq.sqrt(), smax, mean, var.sqrt()]
-    ).tolist()
-    return {
-        f"{prefix}/l1_norm": l1_v,
-        f"{prefix}/l2_norm": l2_v,
-        f"{prefix}/linf_norm": linf_v,
-        f"{prefix}/mean": mean_v,
-        f"{prefix}/std": std_v,
-    }
-
-
 def get_epoch_mean_loss(epoch_loss):
     epoch_mean_loss = {}
     for current_loss in epoch_loss:

--- a/diffusion_planner/tests/test_closed_loop_validate_cadence.py
+++ b/diffusion_planner/tests/test_closed_loop_validate_cadence.py
@@ -1,0 +1,148 @@
+"""Tests for closed-loop validation cadence in train.closed_loop_validate."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import diffusion_planner.train as train_module
+import pytest
+import scenario_generation.closed_loop_evaluation as closed_loop_evaluation
+import scenario_generation.closed_loop_html_report as closed_loop_html_report
+import scenario_generation.site_discovery as site_discovery
+import scenario_generation.wandb_closed_loop as wandb_closed_loop
+from diffusion_planner.train import closed_loop_validate
+
+
+def _make_args(**overrides):
+    """Minimal args namespace covering every closed_loop_* field the function reads."""
+    defaults = dict(
+        closed_loop_npz_root="single/route",
+        closed_loop_sites_npz_root="sites_manifest.json",
+        closed_loop_npz_object_modes=["objects"],
+        closed_loop_sites_object_modes=["objects"],
+        closed_loop_near_miss_thresh=0.5,
+        closed_loop_search_radius=1.5,
+        closed_loop_warmup_steps=0,
+        closed_loop_unstick_after=300,
+        closed_loop_unstick_advance_m=5.0,
+        closed_loop_unstick_radius_mult=10.0,
+        closed_loop_unstick_teleport_after=300,
+        closed_loop_draw_every=4,
+        closed_loop_replan_interval=4,
+        closed_loop_abort_deviation_m=50.0,
+        closed_loop_abort_after=30,
+        closed_loop_abort_max_snaps=0,
+        closed_loop_fps=10,
+        closed_loop_seg_len=100000,
+        closed_loop_wandb_video_pick="worst",
+        closed_loop_colormap_metrics=[],
+        closed_loop_report_base_url="",
+        device="cpu",
+        ddp=False,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+class _FakeEvaluator:
+    """Stand-in for FullRouteClosedLoopEvaluation; records the npz_root it was run on."""
+
+    calls: list = []
+
+    def __init__(self, net, args, cfg, npz_root, seg_len):
+        self.npz_root = npz_root
+
+    def run(self):
+        _FakeEvaluator.calls.append(self.npz_root)
+        return {
+            "n_segments": 1,
+            "elapsed_sec": 0.1,
+            "video_mp4s": [],
+            "segments": [],
+            "mean_route_completion": 1.0,
+        }
+
+
+def _fake_discover_sites(_path):
+    return {"site_a": "sites/site_a", "site_b": "sites/site_b"}
+
+
+wandb_log_calls: list = []
+
+
+def _fake_build_full_closed_loop_wandb_log(_summary, *, site=None, include_score_scalars=True, **_kw):
+    wandb_log_calls.append((site, include_score_scalars))
+    return {}
+
+
+@pytest.fixture(autouse=True)
+def _patched_dependencies(monkeypatch):
+    """Replace the heavy scenario_generation calls with recording fakes."""
+    _FakeEvaluator.calls = []
+    wandb_log_calls.clear()
+    monkeypatch.setattr(
+        closed_loop_evaluation, "FullRouteClosedLoopEvaluation", _FakeEvaluator
+    )
+    monkeypatch.setattr(site_discovery, "discover_sites_from_json", _fake_discover_sites)
+    monkeypatch.setattr(
+        wandb_closed_loop,
+        "build_full_closed_loop_wandb_log",
+        _fake_build_full_closed_loop_wandb_log,
+    )
+    monkeypatch.setattr(
+        wandb_closed_loop, "build_combined_episode_table", lambda *a, **k: None
+    )
+    monkeypatch.setattr(wandb_closed_loop, "build_sites_aggregate_log", lambda *a, **k: {})
+    monkeypatch.setattr(wandb_closed_loop, "build_sites_score_bar_charts", lambda *a, **k: {})
+    monkeypatch.setattr(closed_loop_html_report, "build_html_report", lambda *a, **k: None)
+    monkeypatch.setattr(train_module.wandb, "log", lambda *a, **k: None)
+    return _FakeEvaluator.calls
+
+
+def _fake_model():
+    model = MagicMock()
+    model.training = False
+    return model
+
+
+def test_sites_npz_root_skipped_on_non_final_save(_patched_dependencies, tmp_path):
+    """closed_loop_sites_npz_root must not run at all on a non-final cadence call."""
+    closed_loop_validate(
+        _fake_model(), _make_args(), epoch=0, out_dir=str(tmp_path), is_final_save=False
+    )
+
+    assert _patched_dependencies == ["single/route"]
+
+
+def test_sites_npz_root_runs_on_final_save(_patched_dependencies, tmp_path):
+    """closed_loop_sites_npz_root runs every discovered site once is_final_save fires."""
+    closed_loop_validate(
+        _fake_model(), _make_args(), epoch=0, out_dir=str(tmp_path), is_final_save=True
+    )
+
+    assert _patched_dependencies == ["single/route", "sites/site_a", "sites/site_b"]
+
+
+def test_closed_loop_npz_root_runs_regardless_of_is_final_save(_patched_dependencies, tmp_path):
+    """closed_loop_npz_root (not sites) is unaffected by is_final_save -- always fires."""
+    for is_final_save in (False, True):
+        _patched_dependencies.clear()
+        closed_loop_validate(
+            _fake_model(),
+            _make_args(),
+            epoch=0,
+            out_dir=str(tmp_path),
+            is_final_save=is_final_save,
+        )
+        assert "single/route" in _patched_dependencies
+
+
+def test_only_sites_skip_the_per_epoch_score_scalars(_patched_dependencies, tmp_path):
+    """main keeps its per-epoch score scalars; sites opt out (bar chart covers them instead)."""
+    closed_loop_validate(
+        _fake_model(), _make_args(), epoch=0, out_dir=str(tmp_path), is_final_save=True
+    )
+
+    calls = dict(wandb_log_calls)
+    assert calls[None] is True  # closed_loop_npz_root ("main") keeps its scalar trend
+    assert calls["site_a"] is False
+    assert calls["site_b"] is False

--- a/diffusion_planner/tests/test_scenario_centerline_metric.py
+++ b/diffusion_planner/tests/test_scenario_centerline_metric.py
@@ -1,8 +1,12 @@
-"""Tests for route-centerline distance, ADE, and FDE metrics."""
+"""Tests for route-centerline distance and lateral error metrics."""
 
 import torch
 
-from planner_metrics.centerline import compute_centerline_distance_batch, evaluate_centerline
+from planner_metrics.centerline import (
+    compute_centerline_distance_batch,
+    compute_centerline_error_components_batch,
+    evaluate_centerline,
+)
 
 
 def test_centerline_metric_projects_to_segments():
@@ -17,11 +21,26 @@ def test_centerline_metric_projects_to_segments():
         {"route_lanes": route_lanes},
     )
 
-    torch.testing.assert_allclose(distances, torch.tensor([[1.0, 2.0]]))
+    torch.testing.assert_close(distances, torch.tensor([[1.0, 2.0]]))
 
 
-def test_centerline_metric_returns_ade_and_fde_at_requested_horizon():
-    """Compute ADE/FDE using only the configured prediction horizon."""
+def test_centerline_metric_ignores_duplicate_point_segments():
+    """A duplicate centerline point must not report a spurious zero error."""
+    prediction = torch.tensor([[[10.0, 0.0]]])
+    route_lanes = torch.zeros((1, 3, 8))
+    route_lanes[0, :, 0] = torch.tensor([0.0, 0.0, 3.0])
+    route_lanes[0, :, 2] = 1.0
+
+    distances = compute_centerline_distance_batch(prediction, {"route_lanes": route_lanes})
+    components = compute_centerline_error_components_batch(prediction, {"route_lanes": route_lanes})
+
+    torch.testing.assert_close(distances, torch.tensor([[7.0]]))
+    torch.testing.assert_close(components["lateral_error_m"], torch.tensor([[0.0]]))
+    torch.testing.assert_close(components["longitudinal_error_m"], torch.tensor([[7.0]]))
+
+
+def test_centerline_metric_returns_lateral_errors_at_requested_horizon():
+    """Compute average/final lateral errors using the configured horizon."""
     prediction = torch.tensor([[[0.0, 1.0, 1.0, 0.0], [1.0, 2.0, 1.0, 0.0], [2.0, 3.0, 1.0, 0.0]]])
     # [batch, singleton context, lane, point, feature]
     route_lanes = torch.zeros((1, 1, 1, 4, 8))
@@ -34,5 +53,21 @@ def test_centerline_metric_returns_ade_and_fde_at_requested_horizon():
         {"horizon_seconds": 0.2},
     )
 
-    torch.testing.assert_allclose(values["ade_m"], torch.tensor([1.5]))
-    torch.testing.assert_allclose(values["fde_m"], torch.tensor([2.0]))
+    torch.testing.assert_close(values["average_lateral_error_m"], torch.tensor([1.5]))
+    torch.testing.assert_close(values["final_lateral_error_m"], torch.tensor([2.0]))
+
+
+def test_centerline_error_components_separate_endpoint_overshoot():
+    """Endpoint overshoot is longitudinal, not lateral, error."""
+    prediction = torch.tensor([[[4.0, 0.0], [5.0, 1.0]]])
+    route_lanes = torch.zeros((1, 2, 8))
+    route_lanes[0, :, 0] = torch.tensor([0.0, 3.0])
+    route_lanes[0, :, 2] = 1.0
+
+    values = compute_centerline_error_components_batch(
+        prediction,
+        {"route_lanes": route_lanes},
+    )
+
+    torch.testing.assert_close(values["lateral_error_m"], torch.tensor([[0.0, 1.0]]))
+    torch.testing.assert_close(values["longitudinal_error_m"], torch.tensor([[1.0, 2.0]]))

--- a/diffusion_planner/train_grpo_predictor.py
+++ b/diffusion_planner/train_grpo_predictor.py
@@ -336,7 +336,7 @@ def get_args():
         help="alternative/addition to --closed_loop_npz_root: a curated .json path-list manifest, "
         "grouped into per-site route pools by site_discovery.discover_sites_from_json and evaluated "
         "as independent sites (own npz_root each). Both may be set at once (each fires "
-        "independently).",
+        "independently). Only runs on the final save_utd cadence call of the run.",
     )
     parser.add_argument(
         "--closed_loop_npz_object_modes",

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -249,7 +249,7 @@ def get_args(args_list=None):
         help="alternative/addition to --closed_loop_npz_root: a curated .json path-list manifest, "
         "grouped into per-site route pools by site_discovery.discover_sites_from_json and evaluated "
         "as independent sites (own npz_root each). Both may be set at once (each fires "
-        "independently).",
+        "independently). Only runs on the final save_utd cadence call of the run.",
     )
     parser.add_argument(
         "--closed_loop_npz_object_modes",

--- a/planner_metrics/centerline.py
+++ b/planner_metrics/centerline.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import torch
 
 from planner_metrics.evaluation import MetricEvaluation
-from planner_metrics.geometry import _point_to_segments_min_dist
+from planner_metrics.geometry import (
+    _point_to_segments_error_components,
+    _point_to_segments_min_dist,
+)
 
 _PREDICTION_TIMESTEP_SECONDS = 0.1
+_CENTERLINE_SEGMENT_MIN_LENGTH = 1e-6
 
 
 def _centerline_segments(lanes: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
@@ -16,6 +20,8 @@ def _centerline_segments(lanes: torch.Tensor) -> tuple[torch.Tensor, torch.Tenso
     centerlines = lanes[..., :2]
     valid_points = lanes[..., :4].abs().sum(dim=-1) > 1e-6
     valid_segments = valid_points[:, :-1] & valid_points[:, 1:]
+    segment_lengths = (centerlines[:, 1:] - centerlines[:, :-1]).norm(dim=-1)
+    valid_segments &= segment_lengths > _CENTERLINE_SEGMENT_MIN_LENGTH
     if not valid_segments.any():
         raise ValueError("centerline metric found no valid route-centerline segments")
     return (
@@ -70,23 +76,80 @@ def compute_centerline_distance_batch(
 
 
 @torch.no_grad()
-def compute_centerline_ade_batch(
+def compute_centerline_error_components_batch(
     ego_trajs: torch.Tensor,
     data: dict[str, torch.Tensor],
     horizon_steps: int | None = None,
-) -> torch.Tensor:
-    """Return centerline ADE for each trajectory, shape ``(N,)``."""
-    return compute_centerline_distance_batch(ego_trajs, data, horizon_steps).mean(dim=1)
+) -> dict[str, torch.Tensor]:
+    """Return lateral and beyond-segment longitudinal errors per timestep.
+
+    Lateral error is measured against the selected centerline segment's
+    supporting line.  Thus longitudinal overshoot beyond a segment endpoint is
+    reported separately instead of being folded into lateral error.
+    """
+    if ego_trajs.ndim != 3 or ego_trajs.shape[-1] < 2:
+        raise ValueError(f"ego_trajs must have shape (N, T, D>=2), got {tuple(ego_trajs.shape)}")
+    if horizon_steps is None:
+        horizon_steps = ego_trajs.shape[1]
+    if not 1 <= horizon_steps <= ego_trajs.shape[1]:
+        raise ValueError(f"horizon_steps must be in [1, {ego_trajs.shape[1]}]")
+
+    lanes = data.get("route_lanes", data.get("lanes"))
+    if lanes is None:
+        raise ValueError("centerline metric requires route_lanes or lanes in data")
+    if lanes.ndim == 5:
+        if lanes.shape[1] != 1:
+            raise ValueError(
+                f"expected singleton route_lanes context axis, got {tuple(lanes.shape)}"
+            )
+        lanes = lanes[:, 0]
+    if lanes.ndim == 3:
+        lanes = lanes.unsqueeze(0)
+    if lanes.ndim != 4 or lanes.shape[0] not in (1, ego_trajs.shape[0]):
+        raise ValueError(
+            "lanes must have shape (S,P,D), (1,S,P,D), or (N,S,P,D); "
+            f"got {tuple(lanes.shape)} for N={ego_trajs.shape[0]}"
+        )
+
+    lateral_errors = []
+    longitudinal_errors = []
+    for index in range(ego_trajs.shape[0]):
+        scene_lanes = lanes[0 if lanes.shape[0] == 1 else index]
+        seg_p1, seg_p2 = _centerline_segments(scene_lanes)
+        points = ego_trajs[index, :horizon_steps, :2]
+        lateral, longitudinal = _point_to_segments_error_components(
+            points, seg_p1.to(points), seg_p2.to(points)
+        )
+        lateral_errors.append(lateral)
+        longitudinal_errors.append(longitudinal)
+    return {
+        "lateral_error_m": torch.stack(lateral_errors, dim=0),
+        "longitudinal_error_m": torch.stack(longitudinal_errors, dim=0),
+    }
 
 
 @torch.no_grad()
-def compute_centerline_fde_batch(
+def compute_centerline_average_lateral_error_batch(
     ego_trajs: torch.Tensor,
     data: dict[str, torch.Tensor],
     horizon_steps: int | None = None,
 ) -> torch.Tensor:
-    """Return centerline FDE for each trajectory, shape ``(N,)``."""
-    return compute_centerline_distance_batch(ego_trajs, data, horizon_steps)[:, -1]
+    """Return average lateral error for each trajectory, shape ``(N,)``."""
+    return compute_centerline_error_components_batch(ego_trajs, data, horizon_steps)[
+        "lateral_error_m"
+    ].mean(dim=1)
+
+
+@torch.no_grad()
+def compute_centerline_final_lateral_error_batch(
+    ego_trajs: torch.Tensor,
+    data: dict[str, torch.Tensor],
+    horizon_steps: int | None = None,
+) -> torch.Tensor:
+    """Return final lateral error for each trajectory, shape ``(N,)``."""
+    return compute_centerline_error_components_batch(ego_trajs, data, horizon_steps)[
+        "lateral_error_m"
+    ][:, -1]
 
 
 def evaluate_centerline(
@@ -94,16 +157,18 @@ def evaluate_centerline(
     data: dict[str, torch.Tensor],
     parameters: dict,
 ) -> dict[str, torch.Tensor]:
-    """Return per-trajectory centerline ADE/FDE using a configurable horizon."""
+    """Return average/final lateral error using a configurable horizon."""
     horizon_seconds = float(parameters.get("horizon_seconds", 8.0))
     if horizon_seconds <= 0:
         raise ValueError("centerline horizon_seconds must be positive")
     steps = min(int(round(horizon_seconds / _PREDICTION_TIMESTEP_SECONDS)), ego_trajs.shape[1])
     if steps < 1:
         raise ValueError("centerline horizon selects zero prediction steps")
+    components = compute_centerline_error_components_batch(ego_trajs, data, steps)
+    lateral_error = components["lateral_error_m"]
     return {
-        "ade_m": compute_centerline_ade_batch(ego_trajs, data, steps),
-        "fde_m": compute_centerline_fde_batch(ego_trajs, data, steps),
+        "average_lateral_error_m": lateral_error.mean(dim=1),
+        "final_lateral_error_m": lateral_error[:, -1],
     }
 
 
@@ -115,15 +180,16 @@ def evaluate_centerline_with_details(
     """Evaluate centerline metrics using the common open-loop result format.
 
     Centerline currently has no additional per-sample detail fields, so the
-    result contains only the ADE/FDE score tensors.
+    result contains only the average/final lateral error score tensors.
     """
     return MetricEvaluation(scores=evaluate_centerline(ego_trajs, data, parameters))
 
 
 __all__ = [
-    "compute_centerline_ade_batch",
+    "compute_centerline_average_lateral_error_batch",
     "compute_centerline_distance_batch",
-    "compute_centerline_fde_batch",
+    "compute_centerline_error_components_batch",
+    "compute_centerline_final_lateral_error_batch",
     "evaluate_centerline",
     "evaluate_centerline_with_details",
 ]

--- a/planner_metrics/geometry.py
+++ b/planner_metrics/geometry.py
@@ -723,6 +723,59 @@ def _point_to_segments_min_dist(
     return torch.cat(results)
 
 
+def _point_to_segments_error_components(
+    points: torch.Tensor,
+    seg_p1: torch.Tensor,
+    seg_p2: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return lateral and beyond-segment longitudinal errors per point.
+
+    The nearest segment is selected using the usual clamped point-to-segment
+    distance.  Once selected, lateral error is measured against the infinite
+    supporting line, rather than against a clamped endpoint.  This prevents a
+    point beyond a centerline endpoint from turning longitudinal overshoot into
+    lateral error.  Longitudinal error is the distance beyond the selected
+    segment's endpoint; it is zero while the perpendicular projection lies
+    inside the segment.
+
+    Returns:
+        ``(lateral_error, longitudinal_error)`` with shape ``(Q,)``.
+    """
+    Q = points.shape[0]
+    E = seg_p1.shape[0]
+    if E == 0:
+        raise ValueError("at least one segment is required")
+
+    _MAX_QE = 10_000_000
+    chunk_size = max(1, _MAX_QE // E)
+    lateral_results = []
+    longitudinal_results = []
+
+    for start in range(0, Q, chunk_size):
+        end = min(start + chunk_size, Q)
+        chunk = points[start:end]
+        seg = seg_p2 - seg_p1
+        seg_len2 = (seg**2).sum(-1).clamp(min=1e-10)
+        seg_len = seg_len2.sqrt()
+        diff = chunk[:, None, :] - seg_p1[None, :, :]
+        t_raw = (diff * seg[None, :, :]).sum(-1) / seg_len2[None, :]
+        t = t_raw.clamp(0, 1)
+        closest = seg_p1[None, :, :] + t[:, :, None] * seg[None, :, :]
+        distances = (chunk[:, None, :] - closest).norm(dim=-1)
+        nearest = distances.argmin(dim=1)
+        rows = torch.arange(chunk.shape[0], device=chunk.device)
+
+        nearest_seg = seg[nearest]
+        nearest_len = seg_len[nearest]
+        nearest_diff = diff[rows, nearest]
+        nearest_t_raw = t_raw[rows, nearest]
+        cross = nearest_seg[:, 0] * nearest_diff[:, 1] - nearest_seg[:, 1] * nearest_diff[:, 0]
+        lateral_results.append(cross.abs() / nearest_len)
+        longitudinal_results.append((nearest_t_raw - nearest_t_raw.clamp(0, 1)).abs() * nearest_len)
+
+    return torch.cat(lateral_results), torch.cat(longitudinal_results)
+
+
 def _points_inside_intersection_areas(
     points: torch.Tensor,
     polygons_tensor: torch.Tensor,

--- a/scenario_generation/closed_loop_evaluation.py
+++ b/scenario_generation/closed_loop_evaluation.py
@@ -30,6 +30,7 @@ from scenario_generation.closed_loop_eval import (
     segment_row_for_json,
     tdigest_sidecar_row,
 )
+from scenario_generation.inference_compile import compiled_for_inference
 from scenario_generation.perf_timer import Timers
 from scenario_generation.reproducer_rollout import render_segment
 from scenario_generation.route_timeline import RouteTimeline
@@ -167,7 +168,8 @@ class ClosedLoopEvaluation(ABC):
                 f"{len(jobs)} job(s) -> {[j.job_id for j in jobs]}"
             )
 
-        result = self.execute_jobs(jobs)
+        with compiled_for_inference(self.model):
+            result = self.execute_jobs(jobs)
         elapsed_sec = time.perf_counter() - t0
 
         if self.ddp_world_size > 1:

--- a/scenario_generation/inference_compile.py
+++ b/scenario_generation/inference_compile.py
@@ -1,0 +1,81 @@
+"""``torch.compile`` for the closed-loop evaluation forward pass.
+
+``nn.MultiheadAttention`` takes a fused fastpath in eval mode that dynamo cannot trace, so a
+compiled model always runs the decomposed path instead. Both are correct; they round differently
+in the last float32 bit, and a closed loop feeds that difference back into its own next input.
+Closed-loop metrics therefore shift once. No backend choice avoids this -- it is structural.
+
+``cudagraphs`` replays the same kernels in the same order and was the faster of the two
+candidates on a real rollout. Inductor generates its own reductions and was no faster.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+class _CloneEncoderOutput(torch.nn.Module):
+    """Clone the encoder's output so the DiT's next cudagraph replay cannot overwrite it.
+
+    The encoding is computed once per inference and read by every DPM-solver step, but a
+    cudagraph-managed output buffer belongs to the graph that produced it and is reused on the
+    next replay.
+    """
+
+    def __init__(self, inner: torch.nn.Module) -> None:
+        super().__init__()
+        self.inner = inner
+
+    def forward(self, *args, **kwargs):
+        return self.inner(*args, **kwargs).clone()
+
+
+@contextlib.contextmanager
+def compiled_for_inference(model):
+    """Compile the encoder and the DiT for the duration, then put the model back as it was.
+
+    Scoped rather than permanent because the training loop hands over its LIVE model: compiling
+    in place would leave ``model.encoder`` wrapped and rename the decoder's parameter keys
+    (``_orig_mod.`` prefixes), which would then land in the next checkpoint.
+
+    The fastpath switch is entered here rather than left to the caller because compilation is
+    lazy and the flag is not in dynamo's guard set: setting it afterwards would leave the graph
+    traced under the old value while reading back as changed.
+
+    Callers must run inference under ``no_grad`` -- an output carrying an autograd graph drops
+    compile off the CUDA-graph fast path silently -- and call :func:`mark_inference_step` once
+    per inference.
+    """
+    encoder = getattr(model, "encoder", None)
+    decoder = getattr(model, "decoder", None)
+    dit = getattr(decoder, "dit", None)
+    if not isinstance(encoder, torch.nn.Module) or not isinstance(dit, torch.nn.Module):
+        # e.g. the ONNX adapter from simulate.load_onnx_model, which runs its own runtime.
+        logger.info("%s has nothing to compile; running it as-is.", type(model).__name__)
+        yield model
+        return
+
+    fastpath = torch.backends.mha.get_fastpath_enabled()
+    torch.backends.mha.set_fastpath_enabled(False)
+    model.encoder = _CloneEncoderOutput(torch.compile(encoder, backend="cudagraphs"))
+    decoder.dit = torch.compile(dit, backend="cudagraphs")
+    try:
+        yield model
+    finally:
+        model.encoder = encoder
+        decoder.dit = dit
+        torch.backends.mha.set_fastpath_enabled(fastpath)
+
+
+def mark_inference_step() -> None:
+    """Open a new cudagraph step.
+
+    Unconditional on purpose: the rollout should not have to know whether the model it was handed
+    is compiled, and skipping it on a compiled model corrupts the replayed buffers.
+    """
+    torch.compiler.cudagraph_mark_step_begin()

--- a/scenario_generation/metrics/tdigest.py
+++ b/scenario_generation/metrics/tdigest.py
@@ -6,12 +6,38 @@ and query an approximate percentile — without retaining the raw series.
 
 from __future__ import annotations
 
+import random
+from contextlib import contextmanager
+
 import numpy as np
 from tdigest import TDigest
 
 # In-memory metric key; stripped from human-readable segments.jsonl and written to
 # a ``tdigests*.jsonl`` sidecar for multi-GPU clearance-p5 merge.
 TDIGEST_KEY = "_tdigest"
+
+# Arbitrary, but must never change: the percentile a digest reports depends on it.
+_RNG_SEED = 20260731
+
+
+@contextmanager
+def _deterministic_rng():
+    """Pin the global ``random`` state so that identical samples give an identical digest.
+
+    ``tdigest`` 0.5.x draws from the global ``random`` module while building and compressing,
+    so without this the same input lands on different centroids and reports a different
+    percentile. The previous state is restored, so other users of ``random`` are unaffected.
+
+    Not reentrant: concurrent digest builds would interleave the save/seed/restore and both
+    lose determinism. Both call sites are on the main thread; moving one into a worker needs a
+    lock here first.
+    """
+    state = random.getstate()
+    random.seed(_RNG_SEED)
+    try:
+        yield
+    finally:
+        random.setstate(state)
 
 
 def is_tdigest_key(key: str) -> bool:
@@ -24,18 +50,24 @@ def tdigest_dict_from_values(values: np.ndarray) -> dict | None:
     finite = finite[np.isfinite(finite)]
     if finite.size == 0:
         return None
-    digest = TDigest()
-    digest.batch_update(finite.tolist())
-    digest.compress()
-    return digest.to_dict()
+    with _deterministic_rng():
+        digest = TDigest()
+        digest.batch_update(finite.tolist())
+        digest.compress()
+        return digest.to_dict()
 
 
 def merged_percentile(digest_dicts: list[dict], percentile: float) -> float:
-    """Merge serialized digests and return an approximate percentile in ``[0, 100]``."""
+    """Merge serialized digests and return an approximate percentile in ``[0, 100]``.
+
+    Order-dependent: t-digest merging is not associative, so a caller pooling shards must feed
+    them in a stable order.
+    """
     if not digest_dicts:
         return float("inf")
-    digest = TDigest()
-    for d in digest_dicts:
-        digest.update_from_dict(d)
-    digest.compress()
-    return float(digest.percentile(float(percentile)))
+    with _deterministic_rng():
+        digest = TDigest()
+        for d in digest_dicts:
+            digest.update_from_dict(d)
+        digest.compress()
+        return float(digest.percentile(float(percentile)))

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -31,6 +31,7 @@ from diffusion_planner.dimensions import INPUT_T, POSE_DIM
 
 from planner_metrics.scene_format import future_to_4col
 from scenario_generation.danger_event_selection import OnlineEventSelector
+from scenario_generation.inference_compile import mark_inference_step
 from scenario_generation.metrics import (
     score_object_step,
     score_object_step_batched,
@@ -1660,6 +1661,8 @@ def render_segment(
         override = None
         if plan_world is None or offset == 0:
             data = _to_torch_batch([np_dict], model_args, device)
+            # No-op unless the model was compiled with cudagraphs; one inference is one step.
+            mark_inference_step()
             _, outputs = model(data)
             pred = outputs["prediction"][0, 0].cpu().numpy()
             plan_world = _ego_pred_to_world(
@@ -1968,6 +1971,9 @@ def run_segments_batched(
                                 else:
                                     nxt = s.cursor.max_idx_reached + 1
                                 pool.submit(s.tl.prefetch, range(nxt, nxt + prefetch_ahead))
+                        # No-op unless the model was compiled with cudagraphs; one inference is
+                        # one step.
+                        mark_inference_step()
                         _, outputs = model(data)
                         preds = outputs["prediction"][:, 0].cpu().numpy()  # (B,80,4)
                         # Model's predicted turn indicator per segment, decoded with the SAME

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -1525,210 +1525,209 @@ def render_segment(
     # looks near the goal in the PNG but `dist_goal` never drops below `goal_reach_m` because the
     # goal is the recorded GT end pose `poses[end-1]`, which a diverging closed-loop ego may never
     # reach). One JSONL line per step + a start header + a terminated line, next to the PNGs.
-    dbg = open(out_dir / "rollout.jsonl", "w", buffering=1)
-    dbg.write(
-        json.dumps(
-            {
-                "event": "start",
-                "start_frame_id": _frame_id(tl, start),
-                "end_frame_id": _frame_id(tl, max(start, end - 1)),
-                "start_route_index": int(start),
-                "end_route_index": int(end),
-                "goal_frame_id": _frame_id(tl, max(start, end - 1)),
-                "goal_idx": int(end - 1),
-                "goal": [float(s.goal_xy[0]), float(s.goal_xy[1])],
-                "goal_reach_m": float(s.goal_reach_m),
-                "max_steps": int(cap),
-                "unstick_after": int(s.unstick_after),
-                "len_tl": int(len(tl)),
-            }
-        )
-        + "\n"
-    )
-    while not s.done:
-        k = s.k
-        pre = _pre_step(s)
-        if pre is None:
-            dbg.write(
-                json.dumps(
-                    {
-                        "event": "terminated",
-                        "k": k,
-                        "reason": s.terminated,
-                        "ego": [float(s.live_pose[0]), float(s.live_pose[1])],
-                        "dist_goal": float(np.linalg.norm(s.live_pose[:2] - s.goal_xy)),
-                        "max_idx_reached": int(s.cursor.max_idx_reached),
-                        "snap_count": int(s.snap_count),
-                    }
-                )
-                + "\n"
-            )
-            break
-        np_dict, neighbors_live, idx, slot_uuids, _wbu = pre
-
-        if drop_objects:
-            # Empty-world ablation: no other traffic (dynamic neighbors + static objects), map
-            # kept. Zeroing makes every neighbor/static slot fail its validity mask, so the model
-            # sees an empty scene, the PNG/video render empty, and scoring finds nothing to hit
-            # (clearance inf, collision 0) — consistent across model input, draw, and scoring.
-            np_dict["neighbor_agents_past"] = np.zeros_like(np_dict["neighbor_agents_past"])
-            if "static_objects" in np_dict:
-                np_dict["static_objects"] = np.zeros_like(np_dict["static_objects"])
-            neighbors_live = np.zeros_like(neighbors_live)
-
-        # Early-abort: check BEFORE the (expensive) model replan call, using the deviation from
-        # last step's advance — an already-diverged segment skips inference too instead of just
-        # cutting the render short. GT deviation is measured against the recorded pose at the
-        # cursor's current frame (same `idx` the goal/progress checks use).
-        gt_deviation_m = float(np.linalg.norm(s.live_pose[:2] - tl.poses[idx, :2]))
-        s.gt_dev_sum += gt_deviation_m
-        s.gt_dev_count += 1
-        if abort_deviation_m > 0 and gt_deviation_m > abort_deviation_m:
-            deviation_streak += 1
-        else:
-            deviation_streak = 0
-        if (abort_deviation_m > 0 and deviation_streak >= abort_after) or (
-            abort_max_snaps > 0 and s.snap_count >= abort_max_snaps
-        ):
-            s.terminated, s.done = "diverged", True
-            dbg.write(
-                json.dumps(
-                    {
-                        "event": "diverged",
-                        "k": k,
-                        "gt_deviation_m": round(gt_deviation_m, 3),
-                        "deviation_streak": int(deviation_streak),
-                        "snap_count": int(s.snap_count),
-                    }
-                )
-                + "\n"
-            )
-            break
-
-        # Neighbor positions are interpolation-smoothed (if enabled) before scoring/drawing, same
-        # as the un-cached-plan path below — scoring on raw (freeze-then-jump) recorded positions
-        # would make clearance/collision noisier than what's actually rendered.
-        nids = slot_uuids or (tl.neighbor_ids(idx) if (color_by_uuid or interpolate) else None)
-        if interpolate and nids and interp:
-            _apply_neighbor_interp(np_dict, nids, s.live_pose, idx, interp)
-
-        # Scored here (before the replan/draw below) so this step's clearance/collision/
-        # road-border-distance are available for the per-step trace line right below — used by
-        # trajectory_colormap.py to color the rendered path by risk.
-        _score_into(s, neighbors_live, device, timers, np_dict)
-
-        # Logged with the SAME live_pose the goal test in _pre_step just used (the ego only moves
-        # in _advance_step below), so `dist_goal < goal_reach_m` here == the termination condition.
+    with open(out_dir / "rollout.jsonl", "w", buffering=1) as dbg:
         dbg.write(
             json.dumps(
                 {
-                    "k": k,
-                    "ego": [round(float(s.live_pose[0]), 3), round(float(s.live_pose[1]), 3)],
-                    "yaw": round(float(s.live_pose[2]), 4),
-                    "dist_goal": round(float(np.linalg.norm(s.live_pose[:2] - s.goal_xy)), 3),
-                    "speed": round(float(s.dyn.speed), 3),
-                    "rec_frame_id": _frame_id(tl, idx),
-                    "rec_idx": int(idx),
-                    "max_idx_reached": int(s.cursor.max_idx_reached),
-                    "stuck": int(s.stuck),
-                    "ego_stuck": int(s.ego_stuck),
-                    # Cursor's own state (normal/repeat) + the rollout's escalation counts
-                    # (an expand/teleport this tick shows as a *_count delta on the next line).
-                    "state": s.cursor.state,
-                    "state_run_steps": int(s.cursor.state_run_steps),
-                    "expand_count": int(s.expand_count),
-                    "snap_count": int(s.snap_count),
-                    "clearance_m": round(float(s.clearances[k]), 4)
-                    if np.isfinite(s.clearances[k])
-                    else None,
-                    "collision": bool(s.collisions[k]),
-                    "rb_dist_m": round(float(s.rb_dists[k]), 4)
-                    if np.isfinite(s.rb_dists[k])
-                    else None,
-                    "red_light_violation": bool(s.red_light[k]),
-                    "gt_deviation_m": round(gt_deviation_m, 3),
+                    "event": "start",
+                    "start_frame_id": _frame_id(tl, start),
+                    "end_frame_id": _frame_id(tl, max(start, end - 1)),
+                    "start_route_index": int(start),
+                    "end_route_index": int(end),
+                    "goal_frame_id": _frame_id(tl, max(start, end - 1)),
+                    "goal_idx": int(end - 1),
+                    "goal": [float(s.goal_xy[0]), float(s.goal_xy[1])],
+                    "goal_reach_m": float(s.goal_reach_m),
+                    "max_steps": int(cap),
+                    "unstick_after": int(s.unstick_after),
+                    "len_tl": int(len(tl)),
                 }
             )
             + "\n"
         )
-        # Re-plan every `replan_interval` steps. On a replan step (offset 0) run the model and
-        # drive the ego with the tracker exactly as the per-step rollout does (so replan_interval=1
-        # is identical to the baseline). On the in-between steps execute the cached plan open-loop:
-        # PerfectTracker only targets ref[0] in the current heading and cannot follow a multi-step
-        # plan (it diverges), so the ego is placed directly on the plan's predicted world pose at
-        # `offset` (steps since the last inference). The ego still single-steps at 10 Hz.
-        offset = k % replan_interval
-        override = None
-        if plan_world is None or offset == 0:
-            data = _to_torch_batch([np_dict], model_args, device)
-            # No-op unless the model was compiled with cudagraphs; one inference is one step.
-            mark_inference_step()
-            _, outputs = model(data)
-            pred = outputs["prediction"][0, 0].cpu().numpy()
-            plan_world = _ego_pred_to_world(
-                pred[:, :2], pred[:, 2:4], s.live_pose[0], s.live_pose[1], s.live_pose[2]
+        while not s.done:
+            k = s.k
+            pre = _pre_step(s)
+            if pre is None:
+                dbg.write(
+                    json.dumps(
+                        {
+                            "event": "terminated",
+                            "k": k,
+                            "reason": s.terminated,
+                            "ego": [float(s.live_pose[0]), float(s.live_pose[1])],
+                            "dist_goal": float(np.linalg.norm(s.live_pose[:2] - s.goal_xy)),
+                            "max_idx_reached": int(s.cursor.max_idx_reached),
+                            "snap_count": int(s.snap_count),
+                        }
+                    )
+                    + "\n"
+                )
+                break
+            np_dict, neighbors_live, idx, slot_uuids, _wbu = pre
+
+            if drop_objects:
+                # Empty-world ablation: no other traffic (dynamic neighbors + static objects), map
+                # kept. Zeroing makes every neighbor/static slot fail its validity mask, so the model
+                # sees an empty scene, the PNG/video render empty, and scoring finds nothing to hit
+                # (clearance inf, collision 0) — consistent across model input, draw, and scoring.
+                np_dict["neighbor_agents_past"] = np.zeros_like(np_dict["neighbor_agents_past"])
+                if "static_objects" in np_dict:
+                    np_dict["static_objects"] = np.zeros_like(np_dict["static_objects"])
+                neighbors_live = np.zeros_like(neighbors_live)
+
+            # Early-abort: check BEFORE the (expensive) model replan call, using the deviation from
+            # last step's advance — an already-diverged segment skips inference too instead of just
+            # cutting the render short. GT deviation is measured against the recorded pose at the
+            # cursor's current frame (same `idx` the goal/progress checks use).
+            gt_deviation_m = float(np.linalg.norm(s.live_pose[:2] - tl.poses[idx, :2]))
+            s.gt_dev_sum += gt_deviation_m
+            s.gt_dev_count += 1
+            if abort_deviation_m > 0 and gt_deviation_m > abort_deviation_m:
+                deviation_streak += 1
+            else:
+                deviation_streak = 0
+            if (abort_deviation_m > 0 and deviation_streak >= abort_after) or (
+                abort_max_snaps > 0 and s.snap_count >= abort_max_snaps
+            ):
+                s.terminated, s.done = "diverged", True
+                dbg.write(
+                    json.dumps(
+                        {
+                            "event": "diverged",
+                            "k": k,
+                            "gt_deviation_m": round(gt_deviation_m, 3),
+                            "deviation_streak": int(deviation_streak),
+                            "snap_count": int(s.snap_count),
+                        }
+                    )
+                    + "\n"
+                )
+                break
+
+            # Neighbor positions are interpolation-smoothed (if enabled) before scoring/drawing, same
+            # as the un-cached-plan path below — scoring on raw (freeze-then-jump) recorded positions
+            # would make clearance/collision noisier than what's actually rendered.
+            nids = slot_uuids or (tl.neighbor_ids(idx) if (color_by_uuid or interpolate) else None)
+            if interpolate and nids and interp:
+                _apply_neighbor_interp(np_dict, nids, s.live_pose, idx, interp)
+
+            # Scored here (before the replan/draw below) so this step's clearance/collision/
+            # road-border-distance are available for the per-step trace line right below — used by
+            # trajectory_colormap.py to color the rendered path by risk.
+            _score_into(s, neighbors_live, device, timers, np_dict)
+
+            # Logged with the SAME live_pose the goal test in _pre_step just used (the ego only moves
+            # in _advance_step below), so `dist_goal < goal_reach_m` here == the termination condition.
+            dbg.write(
+                json.dumps(
+                    {
+                        "k": k,
+                        "ego": [round(float(s.live_pose[0]), 3), round(float(s.live_pose[1]), 3)],
+                        "yaw": round(float(s.live_pose[2]), 4),
+                        "dist_goal": round(float(np.linalg.norm(s.live_pose[:2] - s.goal_xy)), 3),
+                        "speed": round(float(s.dyn.speed), 3),
+                        "rec_frame_id": _frame_id(tl, idx),
+                        "rec_idx": int(idx),
+                        "max_idx_reached": int(s.cursor.max_idx_reached),
+                        "stuck": int(s.stuck),
+                        "ego_stuck": int(s.ego_stuck),
+                        # Cursor's own state (normal/repeat) + the rollout's escalation counts
+                        # (an expand/teleport this tick shows as a *_count delta on the next line).
+                        "state": s.cursor.state,
+                        "state_run_steps": int(s.cursor.state_run_steps),
+                        "expand_count": int(s.expand_count),
+                        "snap_count": int(s.snap_count),
+                        "clearance_m": round(float(s.clearances[k]), 4)
+                        if np.isfinite(s.clearances[k])
+                        else None,
+                        "collision": bool(s.collisions[k]),
+                        "rb_dist_m": round(float(s.rb_dists[k]), 4)
+                        if np.isfinite(s.rb_dists[k])
+                        else None,
+                        "red_light_violation": bool(s.red_light[k]),
+                        "gt_deviation_m": round(gt_deviation_m, 3),
+                    }
+                )
+                + "\n"
             )
-            pred_cur = pred  # fresh plan: drawn + tracked in the current ego frame
-            _feed_turn_indicator(s, outputs)
-        else:
-            # Clamp so a `replan_interval` longer than the horizon holds the final plan pose.
-            off = min(offset, len(plan_world[0]) - 1)
-            tx, ty, th = (
-                float(plan_world[0][off, 0]),
-                float(plan_world[0][off, 1]),
-                float(plan_world[1][off]),
-            )
-            spd = float(np.hypot(tx - s.live_pose[0], ty - s.live_pose[1]) / DT)
-            override = (np.array([tx, ty, th], dtype=np.float64), spd)
-            pred_cur = _world_plan_to_ego(
-                plan_world[0][off:],
-                plan_world[1][off:],
-                s.live_pose[0],
-                s.live_pose[1],
-                s.live_pose[2],
-            )
-            # No fresh inference this step: hold the last decoded turn indicator so the
-            # 10 Hz turn_indicators history keeps scrolling with the same signal.
-            _hold_turn_indicator(s)
-        # Complete perfect tracking (tracker_mode="perfect"): the replan step would otherwise run
-        # PerfectTracker.track, which advances the plan's *distance* along the CURRENT heading and
-        # snaps heading to the reference only AFTERWARD — so on any curve the ego drifts off the
-        # predicted point. Instead place the ego DIRECTLY on the first predicted world pose, exactly
-        # as the in-between steps already do for the cached plan (the "faithful perfect tracking" the
-        # override path implements). Every step then lands on the predicted polyline point.
-        if tracker_mode == "perfect" and override is None:
-            tx, ty, th = (
-                float(plan_world[0][0, 0]),
-                float(plan_world[0][0, 1]),
-                float(plan_world[1][0]),
-            )
-            spd = float(np.hypot(tx - s.live_pose[0], ty - s.live_pose[1]) / DT)
-            override = (np.array([tx, ty, th], dtype=np.float64), spd)
-        if (
-            draw_every is not None
-            and (window is None or (window[0] <= k <= window[1]))
-            and k % draw_every == 0
-        ):
-            _draw_step(
-                np_dict,
-                pred_cur,
-                s.ego_shape,
-                out_dir / f"{k:05d}.png",
-                neighbor_ids=nids if color_by_uuid else None,
-                step=k,
-                total=cap,
-                title_prefix=title_prefix,
-                distance_label_offset_m=distance_label_offset_m,
-                view_half_m=view_half_m,
-            )
-        snaps_before = s.snap_count
-        _advance_step(s, pred_cur, idx, device, timers, override=override)
-        if s.snap_count > snaps_before:
-            # An unstick teleport just moved the ego; the cached plan is pinned to the PRE-snap
-            # world location, so executing it next step would drag the ego right back. Invalidate
-            # it to force a fresh inference at the snapped pose (else the snap never sticks).
-            plan_world = None
-    dbg.close()
+            # Re-plan every `replan_interval` steps. On a replan step (offset 0) run the model and
+            # drive the ego with the tracker exactly as the per-step rollout does (so replan_interval=1
+            # is identical to the baseline). On the in-between steps execute the cached plan open-loop:
+            # PerfectTracker only targets ref[0] in the current heading and cannot follow a multi-step
+            # plan (it diverges), so the ego is placed directly on the plan's predicted world pose at
+            # `offset` (steps since the last inference). The ego still single-steps at 10 Hz.
+            offset = k % replan_interval
+            override = None
+            if plan_world is None or offset == 0:
+                data = _to_torch_batch([np_dict], model_args, device)
+                # No-op unless the model was compiled with cudagraphs; one inference is one step.
+                mark_inference_step()
+                _, outputs = model(data)
+                pred = outputs["prediction"][0, 0].cpu().numpy()
+                plan_world = _ego_pred_to_world(
+                    pred[:, :2], pred[:, 2:4], s.live_pose[0], s.live_pose[1], s.live_pose[2]
+                )
+                pred_cur = pred  # fresh plan: drawn + tracked in the current ego frame
+                _feed_turn_indicator(s, outputs)
+            else:
+                # Clamp so a `replan_interval` longer than the horizon holds the final plan pose.
+                off = min(offset, len(plan_world[0]) - 1)
+                tx, ty, th = (
+                    float(plan_world[0][off, 0]),
+                    float(plan_world[0][off, 1]),
+                    float(plan_world[1][off]),
+                )
+                spd = float(np.hypot(tx - s.live_pose[0], ty - s.live_pose[1]) / DT)
+                override = (np.array([tx, ty, th], dtype=np.float64), spd)
+                pred_cur = _world_plan_to_ego(
+                    plan_world[0][off:],
+                    plan_world[1][off:],
+                    s.live_pose[0],
+                    s.live_pose[1],
+                    s.live_pose[2],
+                )
+                # No fresh inference this step: hold the last decoded turn indicator so the
+                # 10 Hz turn_indicators history keeps scrolling with the same signal.
+                _hold_turn_indicator(s)
+            # Complete perfect tracking (tracker_mode="perfect"): the replan step would otherwise run
+            # PerfectTracker.track, which advances the plan's *distance* along the CURRENT heading and
+            # snaps heading to the reference only AFTERWARD — so on any curve the ego drifts off the
+            # predicted point. Instead place the ego DIRECTLY on the first predicted world pose, exactly
+            # as the in-between steps already do for the cached plan (the "faithful perfect tracking" the
+            # override path implements). Every step then lands on the predicted polyline point.
+            if tracker_mode == "perfect" and override is None:
+                tx, ty, th = (
+                    float(plan_world[0][0, 0]),
+                    float(plan_world[0][0, 1]),
+                    float(plan_world[1][0]),
+                )
+                spd = float(np.hypot(tx - s.live_pose[0], ty - s.live_pose[1]) / DT)
+                override = (np.array([tx, ty, th], dtype=np.float64), spd)
+            if (
+                draw_every is not None
+                and (window is None or (window[0] <= k <= window[1]))
+                and k % draw_every == 0
+            ):
+                _draw_step(
+                    np_dict,
+                    pred_cur,
+                    s.ego_shape,
+                    out_dir / f"{k:05d}.png",
+                    neighbor_ids=nids if color_by_uuid else None,
+                    step=k,
+                    total=cap,
+                    title_prefix=title_prefix,
+                    distance_label_offset_m=distance_label_offset_m,
+                    view_half_m=view_half_m,
+                )
+            snaps_before = s.snap_count
+            _advance_step(s, pred_cur, idx, device, timers, override=override)
+            if s.snap_count > snaps_before:
+                # An unstick teleport just moved the ego; the cached plan is pinned to the PRE-snap
+                # world location, so executing it next step would drag the ego right back. Invalidate
+                # it to force a fresh inference at the snapped pose (else the snap never sticks).
+                plan_world = None
     return _finalize(s)
 
 

--- a/scenario_generation/tests/test_inference_compile.py
+++ b/scenario_generation/tests/test_inference_compile.py
@@ -1,0 +1,52 @@
+"""Smoke tests for scenario_generation.inference_compile.
+
+The compiled forward itself needs a GPU, so what is worth pinning here is the scoping: the
+training loop hands over its live model, and a wrapper left behind would rename the decoder's
+parameter keys in the next checkpoint.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from scenario_generation.inference_compile import compiled_for_inference, mark_inference_step
+
+
+class _Decoder(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.dit = nn.Linear(4, 4)
+
+
+class _Model(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.encoder = nn.Linear(4, 4)
+        self.decoder = _Decoder()
+
+
+def test_model_and_fastpath_are_restored_on_exit():
+    model = _Model()
+    encoder, dit = model.encoder, model.decoder.dit
+    fastpath = torch.backends.mha.get_fastpath_enabled()
+
+    with compiled_for_inference(model):
+        assert model.encoder is not encoder
+        assert not torch.backends.mha.get_fastpath_enabled()
+
+    assert model.encoder is encoder
+    assert model.decoder.dit is dit
+    assert torch.backends.mha.get_fastpath_enabled() == fastpath
+    assert set(model.state_dict()) == set(_Model().state_dict())
+
+
+def test_a_model_with_nothing_to_compile_passes_through():
+    """The ONNX adapter runs its own runtime and has no encoder/dit to hand to dynamo."""
+    model = object()
+    with compiled_for_inference(model) as handed_back:
+        assert handed_back is model
+
+
+def test_mark_inference_step_is_safe_without_a_compiled_model():
+    mark_inference_step()

--- a/scenario_generation/tests/test_tdigest_determinism.py
+++ b/scenario_generation/tests/test_tdigest_determinism.py
@@ -1,0 +1,129 @@
+"""The t-digest wrappers must be reproducible: ``clearance_p5_m`` is derived from them, and the
+underlying ``tdigest`` package draws from the global ``random`` module.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+
+import numpy as np
+
+from scenario_generation.metrics.tdigest import (
+    merged_percentile,
+    tdigest_dict_from_values,
+)
+
+
+def _samples(n: int = 5108, seed: int = 0) -> np.ndarray:
+    """A clearance-like series: same size and shape as one closed-loop segment."""
+    rng = np.random.default_rng(seed)
+    return np.abs(rng.normal(5.0, 3.0, n))
+
+
+def test_digest_from_identical_values_is_identical():
+    values = _samples()
+    first = tdigest_dict_from_values(values)
+    for _ in range(7):
+        assert tdigest_dict_from_values(values) == first
+
+
+def test_percentile_from_identical_values_is_identical():
+    values = _samples()
+    got = {merged_percentile([tdigest_dict_from_values(values)], 5.0) for _ in range(8)}
+    assert len(got) == 1, f"clearance-p5 is not reproducible: {sorted(got)}"
+
+
+def test_merge_of_several_digests_is_identical():
+    """The DDP path merges one digest per shard; that merge must be reproducible too."""
+    values = _samples()
+    shards = [tdigest_dict_from_values(values[i::4]) for i in range(4)]
+    got = {merged_percentile(shards, 5.0) for _ in range(8)}
+    assert len(got) == 1, f"merged clearance-p5 is not reproducible: {sorted(got)}"
+
+
+def test_percentile_still_approximates_the_true_value():
+    """Pinning the RNG must not have pinned it to a *wrong* answer."""
+    values = _samples()
+    got = merged_percentile([tdigest_dict_from_values(values)], 5.0)
+    assert abs(got - float(np.percentile(values, 5.0))) < 0.01
+
+
+def test_global_random_state_is_not_disturbed():
+    values = _samples(n=512)
+
+    random.seed(123)
+    expected = [random.random() for _ in range(3)]
+
+    random.seed(123)
+    tdigest_dict_from_values(values)
+    merged_percentile([tdigest_dict_from_values(values)], 5.0)
+    got = [random.random() for _ in range(3)]
+
+    assert got == expected
+
+
+def test_empty_input_still_returns_none_and_inf():
+    assert tdigest_dict_from_values(np.array([])) is None
+    assert tdigest_dict_from_values(np.array([np.nan, np.inf])) is None
+    assert merged_percentile([], 5.0) == float("inf")
+
+
+def _shard_files(out_dir, n_shards: int = 4, n_routes_per_shard: int = 3):
+    """Write per-rank segments_*/tdigests_* pairs the way a DDP run does."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    rng = np.random.default_rng(7)
+    for rank in range(n_shards):
+        seg_lines, dig_lines = [], []
+        for j in range(n_routes_per_shard):
+            route = f"route_{rank}_{j}"
+            vals = np.abs(rng.normal(5.0, 3.0, 400))
+            digest = tdigest_dict_from_values(vals)
+            seg_lines.append(
+                json.dumps(
+                    {
+                        "route": route,
+                        "object": {
+                            "clearance_min_m": float(vals.min()),
+                            "clearance_mean_m": float(vals.mean()),
+                            "clearance_p5_m": float(np.percentile(vals, 5)),
+                            "clearance_finite_steps": int(vals.size),
+                            "miss_thresh_m": 0.5,
+                            "collision_steps": 0,
+                            "collision_count": 0,
+                            "miss_steps": 0,
+                            "miss_count": 0,
+                        },
+                    }
+                )
+            )
+            dig_lines.append(json.dumps({"route": route, "object": digest}))
+        (out_dir / f"segments_{rank}.jsonl").write_text("\n".join(seg_lines) + "\n")
+        (out_dir / f"tdigests_{rank}.jsonl").write_text("\n".join(dig_lines) + "\n")
+
+
+def test_shard_merge_reload_gives_the_same_p5(tmp_path):
+    from scenario_generation.closed_loop_eval import load_segment_rows_with_tdigests
+    from scenario_generation.metrics.tdigest import TDIGEST_KEY
+
+    out_dir = tmp_path / "run"
+    _shard_files(out_dir)
+
+    def p5_from_disk() -> float:
+        rows = load_segment_rows_with_tdigests(out_dir)
+        digests = [r["object"][TDIGEST_KEY] for r in rows]
+        return merged_percentile(digests, 5.0)
+
+    got = {p5_from_disk() for _ in range(5)}
+    assert len(got) == 1, f"merged shard p5 is not reproducible: {sorted(got)}"
+
+
+def test_shard_rows_load_in_a_deterministic_order(tmp_path):
+    from scenario_generation.closed_loop_eval import load_segment_rows_with_tdigests
+
+    out_dir = tmp_path / "run"
+    _shard_files(out_dir)
+    order = [r["route"] for r in load_segment_rows_with_tdigests(out_dir)]
+    for _ in range(4):
+        assert [r["route"] for r in load_segment_rows_with_tdigests(out_dir)] == order
+    assert order == sorted(order), "shard files must be walked in sorted() order"

--- a/scenario_generation/tests/test_wandb_closed_loop.py
+++ b/scenario_generation/tests/test_wandb_closed_loop.py
@@ -1,0 +1,84 @@
+"""Unit tests for wandb_closed_loop's per-site bar-chart builder."""
+
+from __future__ import annotations
+
+from scenario_generation.wandb_closed_loop import (
+    build_full_closed_loop_wandb_log,
+    build_sites_score_bar_charts,
+)
+
+
+def _summary(collisions=0, curb_hits=0, snaps=0, red_light=0, strong_brake=0, completion=1.0):
+    return {
+        "mean_route_completion": completion,
+        "object": {"collision_count": collisions},
+        "road_border": {"collision_count": curb_hits},
+        "reproducer": {"snap_count": snaps},
+        "red_light_violation": {"count": red_light},
+        "strong_brake": {"count": strong_brake},
+    }
+
+
+def test_build_sites_score_bar_charts_one_chart_per_metric_with_all_sites():
+    """Every SCORE_KEY gets its own chart; each chart has one bar per site."""
+    summaries = {
+        "site_a": _summary(collisions=2, curb_hits=1),
+        "site_b": _summary(collisions=0, curb_hits=3),
+    }
+
+    log = build_sites_score_bar_charts(summaries)
+
+    assert set(log.keys()) == {
+        "closed_loop_scores_bar/mean_route_completion",
+        "closed_loop_scores_bar/total_curb_hits",
+        "closed_loop_scores_bar/total_snaps",
+        "closed_loop_scores_bar/total_red_light_violations",
+        "closed_loop_scores_bar/total_strong_brakes",
+        "closed_loop_scores_bar/total_collision_events",
+    }
+    curb_hits_rows = log["closed_loop_scores_bar/total_curb_hits"].table.data
+    assert dict(curb_hits_rows) == {"site_a": 1, "site_b": 3}
+    collision_rows = log["closed_loop_scores_bar/total_collision_events"].table.data
+    assert dict(collision_rows) == {"site_a": 2, "site_b": 0}
+
+
+def test_build_sites_score_bar_charts_excludes_noobj_from_collision_events():
+    """The empty-world ablation (__noobj) is always a meaningless 0 for collision events."""
+    summaries = {
+        "site_a": _summary(collisions=2),
+        "site_a__noobj": _summary(collisions=0),
+    }
+
+    log = build_sites_score_bar_charts(summaries)
+
+    collision_rows = dict(log["closed_loop_scores_bar/total_collision_events"].table.data)
+    assert collision_rows == {"site_a": 2}
+    # Comparison keys (not objects-only) still include the noobj label.
+    completion_rows = dict(log["closed_loop_scores_bar/mean_route_completion"].table.data)
+    assert set(completion_rows) == {"site_a", "site_a__noobj"}
+
+
+def test_build_sites_score_bar_charts_empty_summaries_returns_empty_log():
+    assert build_sites_score_bar_charts({}) == {}
+
+
+def test_include_score_scalars_false_omits_per_site_score_keys():
+    """Sites that only run once per training run skip the (now single-point) scalar trend."""
+    log = build_full_closed_loop_wandb_log(
+        _summary(collisions=1, curb_hits=2),
+        site="site_a",
+        render_media=False,
+        include_score_scalars=False,
+    )
+
+    assert not any(key.startswith("closed_loop_scores/") for key in log)
+
+
+def test_include_score_scalars_true_by_default_keeps_per_site_score_keys():
+    """main (closed_loop_npz_root) still runs every cadence call -- its trend stays intact."""
+    log = build_full_closed_loop_wandb_log(
+        _summary(collisions=1, curb_hits=2), site="main", render_media=False
+    )
+
+    assert log["closed_loop_scores/total_collision_events/main"] == 1
+    assert log["closed_loop_scores/total_curb_hits/main"] == 2

--- a/scenario_generation/wandb_closed_loop.py
+++ b/scenario_generation/wandb_closed_loop.py
@@ -9,7 +9,9 @@ import wandb
 
 from scenario_generation.closed_loop_score_keys import (
     COMPARISON_OVERVIEW_SUM_KEYS,
+    COMPARISON_SCORE_KEYS,
     OBJECTS_ONLY_OVERVIEW_SUM_KEYS,
+    OBJECTS_ONLY_SCORE_KEYS,
     SCORE_KEYS,
     extract_score,
 )
@@ -179,6 +181,35 @@ def build_sites_aggregate_log(summaries: dict[str, dict]) -> dict:
     return {k: v for k, v in log.items() if _wandb_scalar(v) or isinstance(v, int)}
 
 
+def build_sites_score_bar_charts(summaries: dict[str, dict]) -> dict:
+    """Per-metric bar chart comparing every site side-by-side, under ``closed_loop_scores_bar/``.
+
+    Sites now only run once per training run, so a per-site score line chart would just be one
+    isolated point; a bar chart across sites fits a one-shot comparison better. ``summaries`` is
+    keyed by site label, sites only (not the ``closed_loop_npz_root`` "main" entry).
+    """
+    log: dict = {}
+    if not summaries:
+        return log
+
+    def _bar(key: str, labels: list[str]) -> None:
+        table = wandb.Table(columns=["site", key])
+        for label in labels:
+            val = extract_score(summaries[label], key)
+            if _wandb_scalar(val):
+                table.add_data(label, val)
+        if table.data:
+            log[f"closed_loop_scores_bar/{key}"] = wandb.plot.bar(table, "site", key, title=key)
+
+    all_labels = list(summaries.keys())
+    objects_labels = [label for label in all_labels if not _is_noobj_label(label)]
+    for key in COMPARISON_SCORE_KEYS:
+        _bar(key, all_labels)
+    for key in OBJECTS_ONLY_SCORE_KEYS:
+        _bar(key, objects_labels)
+    return log
+
+
 def _site_label(site: str | None) -> str:
     """W&B-key-safe site token; ``None`` (single-npz_root mode) -> ``"main"``."""
     return (site or "main").replace("/", "_")
@@ -194,6 +225,7 @@ def build_full_closed_loop_wandb_log(
     near_miss_thresh: float = 0.5,
     report_base_url: str | None = None,
     render_media: bool = True,
+    include_score_scalars: bool = True,
 ) -> dict:
     """Per-site full-route closed-loop wandb payload, keyed into role-based sections so the
     workspace stays navigable (one collapsible section each) instead of one flat ``closed_loop``
@@ -210,15 +242,20 @@ def build_full_closed_loop_wandb_log(
     unaffected) -- for a caller that already skipped rendering (e.g. train.py's RolloutParams
     ``draw=False`` on most epochs), so there's no colormap image to render from anyway.
 
+    ``include_score_scalars=False`` skips the ``closed_loop_scores/{metric}/{site}`` block --
+    for a site that only runs once per run, where :func:`build_sites_score_bar_charts` is the
+    better fit instead.
+
     The per-episode table is built once across ALL sites by :func:`build_combined_episode_table`
     at the caller (so it's a single filterable/groupable panel), not here.
     """
     label = _site_label(site)
     log: dict = {}
-    for key in SCORE_KEYS:
-        val = extract_score(summary, key)
-        if _wandb_scalar(val):
-            log[f"closed_loop_scores/{key}/{label}"] = val
+    if include_score_scalars:
+        for key in SCORE_KEYS:
+            val = extract_score(summary, key)
+            if _wandb_scalar(val):
+                log[f"closed_loop_scores/{key}/{label}"] = val
 
     rows = summary.get("segments") or []
     rep = pick_representative_row(rows, mode=video_pick)


### PR DESCRIPTION
## Why

`render_segment` closed `rollout.jsonl` only after the step loop returned, so an exception inside
the loop left the handle open for as long as the traceback kept the frame alive.

## What

Open it with a `with` block. The loop body is re-indented and otherwise untouched — `git diff -w`
is two lines:

```
-    dbg = open(out_dir / "rollout.jsonl", "w", buffering=1)
+    with open(out_dir / "rollout.jsonl", "w", buffering=1) as dbg:
...
-    dbg.close()
```

Checked once by making `_pre_step` raise: the file object is open before the change, closed
after. Not kept as a test — `with` closing the file is a language guarantee.

`scenario_generation/tests`: 228 passed. The two `test_map_cache.py` failures reproduce on
`tier4-main` unchanged.

## Stack

#334 ← this ← `perf/render-pool`. Merge bottom-up.