### PR TITLE
perf: render PNGs on worker processes (render_pool)

### DIFF
--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -197,6 +197,7 @@ def closed_loop_validate(
                     unstick_radius_mult=args.closed_loop_unstick_radius_mult,
                     unstick_teleport_after=args.closed_loop_unstick_teleport_after,
                     draw_every=args.closed_loop_draw_every if is_final_save else None,
+                    draw_workers=args.closed_loop_draw_workers,
                     replan_interval=args.closed_loop_replan_interval,
                     abort_deviation_m=args.closed_loop_abort_deviation_m,
                     abort_after=args.closed_loop_abort_after,

--- a/diffusion_planner/diffusion_planner/train_config.py
+++ b/diffusion_planner/diffusion_planner/train_config.py
@@ -175,6 +175,8 @@ class TrainConfig:
     # route); 40 keeps per-epoch cost to ~tens of seconds. Lower it for higher-fidelity validation.
     closed_loop_replan_interval: int = 4
     closed_loop_draw_every: int = 4  # render 1 of every N steps (matplotlib is the dominant cost)
+    # draw on this many worker processes (minimum 1)
+    closed_loop_draw_workers: int = 4
     closed_loop_fps: int = 10
     closed_loop_near_miss_thresh: float = 0.5
     closed_loop_search_radius: float = 1.5

--- a/diffusion_planner/train_grpo_predictor.py
+++ b/diffusion_planner/train_grpo_predictor.py
@@ -375,6 +375,13 @@ def get_args():
         default=4,
         help="render 1 of every N steps (matplotlib render is the dominant cost)",
     )
+    parser.add_argument(
+        "--closed_loop_draw_workers",
+        type=int,
+        default=4,
+        help="render the PNGs on this many worker processes (minimum 1). Output is "
+        "byte-identical whatever the count; costs ~780 MB of RSS per worker",
+    )
     parser.add_argument("--closed_loop_fps", type=int, default=10)
     parser.add_argument("--closed_loop_near_miss_thresh", type=float, default=0.5)
     parser.add_argument("--closed_loop_search_radius", type=float, default=1.5)

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -288,6 +288,13 @@ def get_args(args_list=None):
         default=4,
         help="render 1 of every N steps (matplotlib render is the dominant cost)",
     )
+    parser.add_argument(
+        "--closed_loop_draw_workers",
+        type=int,
+        default=_train_config_default("closed_loop_draw_workers"),
+        help="render the PNGs on this many worker processes (minimum 1). Output is "
+        "byte-identical whatever the count; costs ~780 MB of RSS per worker",
+    )
     parser.add_argument("--closed_loop_fps", type=int, default=10)
     parser.add_argument("--closed_loop_near_miss_thresh", type=float, default=0.5)
     parser.add_argument("--closed_loop_search_radius", type=float, default=1.5)

--- a/diffusion_planner/valid_predictor_closed_loop.py
+++ b/diffusion_planner/valid_predictor_closed_loop.py
@@ -141,6 +141,13 @@ def parse_args() -> argparse.Namespace:
         "regardless, so the video also plays N x faster (shorter). For real-time use --fps 10/N",
     )
     p.add_argument(
+        "--draw_workers",
+        type=int,
+        default=4,
+        help="render the PNGs on this many worker processes (minimum 1). Output is "
+        "byte-identical whatever the count; costs ~780 MB of RSS per worker, per GPU shard",
+    )
+    p.add_argument(
         "--abort_deviation_m",
         type=float,
         default=0.0,
@@ -187,6 +194,7 @@ def _eval_knobs(args: argparse.Namespace) -> dict:
         fps=args.fps,
         replan_interval=args.replan_interval,
         draw_every=args.draw_every,
+        draw_workers=args.draw_workers,
         neighbor_history_mode="recorded",
         tracker_mode="perfect",
         strong_brake_mps2=args.strong_brake_mps2,

--- a/rlvr/autoresearch/tools/mine_collisions_reproducer.py
+++ b/rlvr/autoresearch/tools/mine_collisions_reproducer.py
@@ -430,8 +430,11 @@ def main() -> None:
 
     # Optionally render the top-N ranked hit segments to PNGs for inspection.
     if args.dump_hits > 0:
+        from scenario_generation.render_pool import render_pool
         from scenario_generation.reproducer_rollout import render_segment
 
+        # One pool for every hit: a spawned worker re-imports torch and matplotlib.
+        draw_pool = render_pool(4)
         render_root = args.out.with_suffix(".renders")
         render_root.mkdir(parents=True, exist_ok=True)
         model_title = _model_lora_title(args.model_path, args.lora_path)
@@ -476,11 +479,13 @@ def main() -> None:
                 view_half_m=args.view_half_m,
                 replan_interval=1,
                 draw_every=1,
+                draw_pool=draw_pool,
             )
             if args.render_webm:
                 webm = od / "hit_segment.webm"
                 _make_webm(od, webm, args.webm_fps)
                 print(f"    webm -> {webm}")
+        draw_pool.shutdown()
         print(f"rendered {args.dump_hits} hit segment(s) -> {render_root}")
 
 

--- a/scenario_generation/closed_loop_eval.py
+++ b/scenario_generation/closed_loop_eval.py
@@ -23,6 +23,7 @@ import numpy as np
 
 from scenario_generation.metrics.tdigest import TDIGEST_KEY, is_tdigest_key, merged_percentile
 from scenario_generation.perf_timer import Timers
+from scenario_generation.render_pool import render_pool
 from scenario_generation.reproducer_rollout import render_segment
 from scenario_generation.route_timeline import RouteTimeline, group_routes
 
@@ -460,6 +461,7 @@ def run_closed_loop_eval(
     abort_after: int = 30,
     abort_max_snaps: int = 0,
     drop_objects: bool = False,
+    draw_workers: int = 1,
 ) -> dict:
     """Render closed-loop rollouts over every route under ``npz_root`` and aggregate metrics.
 
@@ -508,6 +510,8 @@ def run_closed_loop_eval(
     digests_name = "tdigests.jsonl" if shard is None else f"tdigests_{shard[0]}.jsonl"
     fout = open(out_dir / segments_name, "w")
     fdigest = open(out_dir / digests_name, "w")
+    # One pool for every route: a spawned worker re-imports torch and matplotlib.
+    draw_pool = render_pool(draw_workers)
     try:
         for ri, key in enumerate(route_keys):
             tl = RouteTimeline(routes[key], sidecar_dir=route_sidecar_dir[key], timers=timers)
@@ -538,6 +542,7 @@ def run_closed_loop_eval(
                 abort_after=abort_after,
                 abort_max_snaps=abort_max_snaps,
                 drop_objects=drop_objects,
+                draw_pool=draw_pool,
             )
             row = {"route": key, **metrics}
             # Human-readable segments.jsonl (no _tdigest blobs). Digests go to a sidecar so
@@ -574,6 +579,7 @@ def run_closed_loop_eval(
     finally:
         fout.close()
         fdigest.close()
+        draw_pool.shutdown()
 
     # In-memory ``rows`` still carry digests for this process's aggregate.
     summary = aggregate(rows, near_miss_thresh, strong_brake_mps2=strong_brake_mps2)

--- a/scenario_generation/closed_loop_evaluation.py
+++ b/scenario_generation/closed_loop_evaluation.py
@@ -31,6 +31,7 @@ from scenario_generation.closed_loop_eval import (
     tdigest_sidecar_row,
 )
 from scenario_generation.perf_timer import Timers
+from scenario_generation.render_pool import render_pool
 from scenario_generation.reproducer_rollout import render_segment
 from scenario_generation.route_timeline import RouteTimeline
 
@@ -53,6 +54,8 @@ class RolloutParams:
     # train.py, most epochs) skip the dominant per-epoch cost and only pay it on the one call
     # that actually needs media (e.g. the final epoch).
     draw_every: int | None = 8
+    # Not a render_kwarg: the runner opens the pool and passes it down.
+    draw_workers: int = 1
     replan_interval: int = 10
     tracker_mode: str = "mpc"
     neighbor_history_mode: str = "recorded"
@@ -412,10 +415,14 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
         with (
             segments_path.open("w", encoding="utf-8") as fout,
             digests_path.open("w", encoding="utf-8") as fdigest,
+            # One pool for every segment: a spawned worker re-imports torch and matplotlib.
+            render_pool(self.config.params.draw_workers) as draw_pool,
         ):
             for ri, job in enumerate(jobs):
                 assert isinstance(job, FullRouteRouteJob)
-                partial = self.run_job(job, segments_file=fout, digest_file=fdigest)
+                partial = self.run_job(
+                    job, segments_file=fout, digest_file=fdigest, draw_pool=draw_pool
+                )
                 merged.rows.extend(partial.rows)
                 merged.video_mp4s.extend(partial.video_mp4s)
                 merged.extras["route_keys"].append(job.route_key)
@@ -428,6 +435,7 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
         *,
         segments_file=None,
         digest_file=None,
+        draw_pool=None,
     ) -> JobRunResult:
         assert isinstance(job, FullRouteRouteJob)
         params = self.config.params
@@ -446,6 +454,7 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
                 end,
                 png_dir,
                 **params.render_kwargs(),
+                draw_pool=draw_pool,
             )
             row = {"route": job.route_key, **metrics}
             if segments_file is not None:

--- a/scenario_generation/render_pool.py
+++ b/scenario_generation/render_pool.py
@@ -1,0 +1,34 @@
+"""The pool that renders per-step figures.
+
+Matplotlib builds each figure in Python, so the GIL serialises a thread pool; worker processes
+each hold their own interpreter and overlap for real.
+
+Callers must be spawn-safe: an importable callable, picklable arguments, a
+``if __name__ == "__main__":`` guard, and no mutation of what was submitted.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+from concurrent.futures import Executor, ProcessPoolExecutor
+
+
+def _pin_worker_threads() -> None:
+    # torch sizes its intra-op pool from the machine's core count, so N workers each grab N_cores
+    # threads and thrash.
+    import torch
+
+    torch.set_num_threads(1)
+
+
+def render_pool(workers: int = 1) -> Executor:
+    """A pool of ``workers`` renderers; anything below 1 is one worker.
+
+    Spawn, not fork: the caller may hold a CUDA context. Workers start on the first submit, so a
+    run that draws nothing spawns nothing. Each worker costs ~780 MB of RSS.
+    """
+    return ProcessPoolExecutor(
+        max_workers=max(1, workers),
+        mp_context=multiprocessing.get_context("spawn"),
+        initializer=_pin_worker_threads,
+    )

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -55,7 +55,6 @@ import math
 import os
 import random
 import zlib
-from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -93,6 +92,7 @@ from scenario_generation.gui.lanelet_scene_builder import (
     _obb_collides,
     _obb_corners,
 )
+from scenario_generation.render_pool import render_pool
 from scenario_generation.route import Route
 from scenario_generation.scene_context import Agent, AgentType, SceneContext
 from scenario_generation.simulate import (
@@ -2450,7 +2450,10 @@ def run_route_replay(
         )
 
     # --- Main loop. ---
-    with ThreadPoolExecutor(max_workers=4, thread_name_prefix="save") as save_pool:
+    # save_step_figure builds its figure in Python, which the GIL serialises across threads, so
+    # the saves go to worker processes (see render_pool). REPLAY_SAVE_WORKERS trades RSS for
+    # throughput.
+    with render_pool(int(os.environ.get("REPLAY_SAVE_WORKERS", "4"))) as save_pool:
         pending_saves: list = []
         for step in range(spawn_config.max_steps):
             # Keep NPC manager's sim time in sync for TL writes on spawn.

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 import json
 import math
 import time
+from concurrent.futures import Executor
+from contextlib import nullcontext
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -41,6 +43,7 @@ from scenario_generation.metrics import (
 from scenario_generation.metrics.tdigest import TDIGEST_KEY, tdigest_dict_from_values
 from scenario_generation.perception_reproducer import PerceptionReproducer
 from scenario_generation.perf_timer import Timers
+from scenario_generation.render_pool import render_pool
 from scenario_generation.route_timeline import RouteTimeline
 from scenario_generation.simulate import decode_turn_indicator, resolve_keep_turn_indicator
 from scenario_generation.tensor_converter import _heading_to_cos_sin
@@ -1411,6 +1414,7 @@ def render_segment(
     abort_after: int = 30,
     abort_max_snaps: int = 0,
     drop_objects: bool = False,
+    draw_pool: Executor | None = None,
 ) -> dict:
     """Re-run one segment with per-step PNG rendering (live-ego frame).
 
@@ -1431,6 +1435,10 @@ def render_segment(
     ``draw_every=None`` skips the per-step render entirely (no PNGs at all) -- scoring/
     ``rollout.jsonl`` (and anything downstream that reads it, e.g. trajectory-colormap images)
     are unaffected, only the video/PNG artifacts disappear.
+
+    ``draw_pool`` (see ``render_pool``): the workers the PNGs are rendered on. The step loop
+    hands the arrays off and waits once, at the end of the segment. Pass one to share workers
+    across segments; ``None`` opens a one-worker pool for this segment.
 
     Runs until the ego reaches the segment end (within ``goal_reach_m``) or the
     step cap (``max_steps``, default 3*(end-start) — the only timeout). Unstick is
@@ -1520,11 +1528,16 @@ def render_segment(
     )
     plan_world = None  # cached (world_xy(T,2), world_h(T,)) from the most recent inference
     deviation_streak = 0  # consecutive steps the live ego has been > abort_deviation_m from GT
+    pending: list = []
     # Per-step termination diagnostics: lets you see WHY a segment keeps running (e.g. the ego
     # looks near the goal in the PNG but `dist_goal` never drops below `goal_reach_m` because the
     # goal is the recorded GT end pose `poses[end-1]`, which a diverging closed-loop ego may never
     # reach). One JSONL line per step + a start header + a terminated line, next to the PNGs.
-    with open(out_dir / "rollout.jsonl", "w", buffering=1) as dbg:
+    with (
+        open(out_dir / "rollout.jsonl", "w", buffering=1) as dbg,
+        # Only a pool opened here gets shut down.
+        nullcontext(draw_pool) if draw_pool is not None else render_pool(1) as draw,
+    ):
         dbg.write(
             json.dumps(
                 {
@@ -1706,17 +1719,20 @@ def render_segment(
                 and (window is None or (window[0] <= k <= window[1]))
                 and k % draw_every == 0
             ):
-                _draw_step(
-                    np_dict,
-                    pred_cur,
-                    s.ego_shape,
-                    out_dir / f"{k:05d}.png",
-                    neighbor_ids=nids if color_by_uuid else None,
-                    step=k,
-                    total=cap,
-                    title_prefix=title_prefix,
-                    distance_label_offset_m=distance_label_offset_m,
-                    view_half_m=view_half_m,
+                pending.append(
+                    draw.submit(
+                        _draw_step,
+                        np_dict,
+                        pred_cur,
+                        s.ego_shape,
+                        out_dir / f"{k:05d}.png",
+                        neighbor_ids=nids if color_by_uuid else None,
+                        step=k,
+                        total=cap,
+                        title_prefix=title_prefix,
+                        distance_label_offset_m=distance_label_offset_m,
+                        view_half_m=view_half_m,
+                    )
                 )
             snaps_before = s.snap_count
             _advance_step(s, pred_cur, idx, device, timers, override=override)
@@ -1725,6 +1741,10 @@ def render_segment(
                 # world location, so executing it next step would drag the ego right back. Invalidate
                 # it to force a fresh inference at the snapped pose (else the snap never sticks).
                 plan_world = None
+    # Every PNG must be on disk before the caller globs the directory for ffmpeg, and a worker
+    # exception only surfaces here.
+    for f in pending:
+        f.result()
     return _finalize(s)
 
 

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -1524,208 +1524,207 @@ def render_segment(
     # looks near the goal in the PNG but `dist_goal` never drops below `goal_reach_m` because the
     # goal is the recorded GT end pose `poses[end-1]`, which a diverging closed-loop ego may never
     # reach). One JSONL line per step + a start header + a terminated line, next to the PNGs.
-    dbg = open(out_dir / "rollout.jsonl", "w", buffering=1)
-    dbg.write(
-        json.dumps(
-            {
-                "event": "start",
-                "start_frame_id": _frame_id(tl, start),
-                "end_frame_id": _frame_id(tl, max(start, end - 1)),
-                "start_route_index": int(start),
-                "end_route_index": int(end),
-                "goal_frame_id": _frame_id(tl, max(start, end - 1)),
-                "goal_idx": int(end - 1),
-                "goal": [float(s.goal_xy[0]), float(s.goal_xy[1])],
-                "goal_reach_m": float(s.goal_reach_m),
-                "max_steps": int(cap),
-                "unstick_after": int(s.unstick_after),
-                "len_tl": int(len(tl)),
-            }
-        )
-        + "\n"
-    )
-    while not s.done:
-        k = s.k
-        pre = _pre_step(s)
-        if pre is None:
-            dbg.write(
-                json.dumps(
-                    {
-                        "event": "terminated",
-                        "k": k,
-                        "reason": s.terminated,
-                        "ego": [float(s.live_pose[0]), float(s.live_pose[1])],
-                        "dist_goal": float(np.linalg.norm(s.live_pose[:2] - s.goal_xy)),
-                        "max_idx_reached": int(s.cursor.max_idx_reached),
-                        "snap_count": int(s.snap_count),
-                    }
-                )
-                + "\n"
-            )
-            break
-        np_dict, neighbors_live, idx, slot_uuids, _wbu = pre
-
-        if drop_objects:
-            # Empty-world ablation: no other traffic (dynamic neighbors + static objects), map
-            # kept. Zeroing makes every neighbor/static slot fail its validity mask, so the model
-            # sees an empty scene, the PNG/video render empty, and scoring finds nothing to hit
-            # (clearance inf, collision 0) — consistent across model input, draw, and scoring.
-            np_dict["neighbor_agents_past"] = np.zeros_like(np_dict["neighbor_agents_past"])
-            if "static_objects" in np_dict:
-                np_dict["static_objects"] = np.zeros_like(np_dict["static_objects"])
-            neighbors_live = np.zeros_like(neighbors_live)
-
-        # Early-abort: check BEFORE the (expensive) model replan call, using the deviation from
-        # last step's advance — an already-diverged segment skips inference too instead of just
-        # cutting the render short. GT deviation is measured against the recorded pose at the
-        # cursor's current frame (same `idx` the goal/progress checks use).
-        gt_deviation_m = float(np.linalg.norm(s.live_pose[:2] - tl.poses[idx, :2]))
-        s.gt_dev_sum += gt_deviation_m
-        s.gt_dev_count += 1
-        if abort_deviation_m > 0 and gt_deviation_m > abort_deviation_m:
-            deviation_streak += 1
-        else:
-            deviation_streak = 0
-        if (abort_deviation_m > 0 and deviation_streak >= abort_after) or (
-            abort_max_snaps > 0 and s.snap_count >= abort_max_snaps
-        ):
-            s.terminated, s.done = "diverged", True
-            dbg.write(
-                json.dumps(
-                    {
-                        "event": "diverged",
-                        "k": k,
-                        "gt_deviation_m": round(gt_deviation_m, 3),
-                        "deviation_streak": int(deviation_streak),
-                        "snap_count": int(s.snap_count),
-                    }
-                )
-                + "\n"
-            )
-            break
-
-        # Neighbor positions are interpolation-smoothed (if enabled) before scoring/drawing, same
-        # as the un-cached-plan path below — scoring on raw (freeze-then-jump) recorded positions
-        # would make clearance/collision noisier than what's actually rendered.
-        nids = slot_uuids or (tl.neighbor_ids(idx) if (color_by_uuid or interpolate) else None)
-        if interpolate and nids and interp:
-            _apply_neighbor_interp(np_dict, nids, s.live_pose, idx, interp)
-
-        # Scored here (before the replan/draw below) so this step's clearance/collision/
-        # road-border-distance are available for the per-step trace line right below — used by
-        # trajectory_colormap.py to color the rendered path by risk.
-        _score_into(s, neighbors_live, device, timers, np_dict)
-
-        # Logged with the SAME live_pose the goal test in _pre_step just used (the ego only moves
-        # in _advance_step below), so `dist_goal < goal_reach_m` here == the termination condition.
+    with open(out_dir / "rollout.jsonl", "w", buffering=1) as dbg:
         dbg.write(
             json.dumps(
                 {
-                    "k": k,
-                    "ego": [round(float(s.live_pose[0]), 3), round(float(s.live_pose[1]), 3)],
-                    "yaw": round(float(s.live_pose[2]), 4),
-                    "dist_goal": round(float(np.linalg.norm(s.live_pose[:2] - s.goal_xy)), 3),
-                    "speed": round(float(s.dyn.speed), 3),
-                    "rec_frame_id": _frame_id(tl, idx),
-                    "rec_idx": int(idx),
-                    "max_idx_reached": int(s.cursor.max_idx_reached),
-                    "stuck": int(s.stuck),
-                    "ego_stuck": int(s.ego_stuck),
-                    # Cursor's own state (normal/repeat) + the rollout's escalation counts
-                    # (an expand/teleport this tick shows as a *_count delta on the next line).
-                    "state": s.cursor.state,
-                    "state_run_steps": int(s.cursor.state_run_steps),
-                    "expand_count": int(s.expand_count),
-                    "snap_count": int(s.snap_count),
-                    "clearance_m": round(float(s.clearances[k]), 4)
-                    if np.isfinite(s.clearances[k])
-                    else None,
-                    "collision": bool(s.collisions[k]),
-                    "rb_dist_m": round(float(s.rb_dists[k]), 4)
-                    if np.isfinite(s.rb_dists[k])
-                    else None,
-                    "red_light_violation": bool(s.red_light[k]),
-                    "gt_deviation_m": round(gt_deviation_m, 3),
+                    "event": "start",
+                    "start_frame_id": _frame_id(tl, start),
+                    "end_frame_id": _frame_id(tl, max(start, end - 1)),
+                    "start_route_index": int(start),
+                    "end_route_index": int(end),
+                    "goal_frame_id": _frame_id(tl, max(start, end - 1)),
+                    "goal_idx": int(end - 1),
+                    "goal": [float(s.goal_xy[0]), float(s.goal_xy[1])],
+                    "goal_reach_m": float(s.goal_reach_m),
+                    "max_steps": int(cap),
+                    "unstick_after": int(s.unstick_after),
+                    "len_tl": int(len(tl)),
                 }
             )
             + "\n"
         )
-        # Re-plan every `replan_interval` steps. On a replan step (offset 0) run the model and
-        # drive the ego with the tracker exactly as the per-step rollout does (so replan_interval=1
-        # is identical to the baseline). On the in-between steps execute the cached plan open-loop:
-        # PerfectTracker only targets ref[0] in the current heading and cannot follow a multi-step
-        # plan (it diverges), so the ego is placed directly on the plan's predicted world pose at
-        # `offset` (steps since the last inference). The ego still single-steps at 10 Hz.
-        offset = k % replan_interval
-        override = None
-        if plan_world is None or offset == 0:
-            data = _to_torch_batch([np_dict], model_args, device)
-            _, outputs = model(data)
-            pred = outputs["prediction"][0, 0].cpu().numpy()
-            plan_world = _ego_pred_to_world(
-                pred[:, :2], pred[:, 2:4], s.live_pose[0], s.live_pose[1], s.live_pose[2]
+        while not s.done:
+            k = s.k
+            pre = _pre_step(s)
+            if pre is None:
+                dbg.write(
+                    json.dumps(
+                        {
+                            "event": "terminated",
+                            "k": k,
+                            "reason": s.terminated,
+                            "ego": [float(s.live_pose[0]), float(s.live_pose[1])],
+                            "dist_goal": float(np.linalg.norm(s.live_pose[:2] - s.goal_xy)),
+                            "max_idx_reached": int(s.cursor.max_idx_reached),
+                            "snap_count": int(s.snap_count),
+                        }
+                    )
+                    + "\n"
+                )
+                break
+            np_dict, neighbors_live, idx, slot_uuids, _wbu = pre
+
+            if drop_objects:
+                # Empty-world ablation: no other traffic (dynamic neighbors + static objects), map
+                # kept. Zeroing makes every neighbor/static slot fail its validity mask, so the model
+                # sees an empty scene, the PNG/video render empty, and scoring finds nothing to hit
+                # (clearance inf, collision 0) — consistent across model input, draw, and scoring.
+                np_dict["neighbor_agents_past"] = np.zeros_like(np_dict["neighbor_agents_past"])
+                if "static_objects" in np_dict:
+                    np_dict["static_objects"] = np.zeros_like(np_dict["static_objects"])
+                neighbors_live = np.zeros_like(neighbors_live)
+
+            # Early-abort: check BEFORE the (expensive) model replan call, using the deviation from
+            # last step's advance — an already-diverged segment skips inference too instead of just
+            # cutting the render short. GT deviation is measured against the recorded pose at the
+            # cursor's current frame (same `idx` the goal/progress checks use).
+            gt_deviation_m = float(np.linalg.norm(s.live_pose[:2] - tl.poses[idx, :2]))
+            s.gt_dev_sum += gt_deviation_m
+            s.gt_dev_count += 1
+            if abort_deviation_m > 0 and gt_deviation_m > abort_deviation_m:
+                deviation_streak += 1
+            else:
+                deviation_streak = 0
+            if (abort_deviation_m > 0 and deviation_streak >= abort_after) or (
+                abort_max_snaps > 0 and s.snap_count >= abort_max_snaps
+            ):
+                s.terminated, s.done = "diverged", True
+                dbg.write(
+                    json.dumps(
+                        {
+                            "event": "diverged",
+                            "k": k,
+                            "gt_deviation_m": round(gt_deviation_m, 3),
+                            "deviation_streak": int(deviation_streak),
+                            "snap_count": int(s.snap_count),
+                        }
+                    )
+                    + "\n"
+                )
+                break
+
+            # Neighbor positions are interpolation-smoothed (if enabled) before scoring/drawing, same
+            # as the un-cached-plan path below — scoring on raw (freeze-then-jump) recorded positions
+            # would make clearance/collision noisier than what's actually rendered.
+            nids = slot_uuids or (tl.neighbor_ids(idx) if (color_by_uuid or interpolate) else None)
+            if interpolate and nids and interp:
+                _apply_neighbor_interp(np_dict, nids, s.live_pose, idx, interp)
+
+            # Scored here (before the replan/draw below) so this step's clearance/collision/
+            # road-border-distance are available for the per-step trace line right below — used by
+            # trajectory_colormap.py to color the rendered path by risk.
+            _score_into(s, neighbors_live, device, timers, np_dict)
+
+            # Logged with the SAME live_pose the goal test in _pre_step just used (the ego only moves
+            # in _advance_step below), so `dist_goal < goal_reach_m` here == the termination condition.
+            dbg.write(
+                json.dumps(
+                    {
+                        "k": k,
+                        "ego": [round(float(s.live_pose[0]), 3), round(float(s.live_pose[1]), 3)],
+                        "yaw": round(float(s.live_pose[2]), 4),
+                        "dist_goal": round(float(np.linalg.norm(s.live_pose[:2] - s.goal_xy)), 3),
+                        "speed": round(float(s.dyn.speed), 3),
+                        "rec_frame_id": _frame_id(tl, idx),
+                        "rec_idx": int(idx),
+                        "max_idx_reached": int(s.cursor.max_idx_reached),
+                        "stuck": int(s.stuck),
+                        "ego_stuck": int(s.ego_stuck),
+                        # Cursor's own state (normal/repeat) + the rollout's escalation counts
+                        # (an expand/teleport this tick shows as a *_count delta on the next line).
+                        "state": s.cursor.state,
+                        "state_run_steps": int(s.cursor.state_run_steps),
+                        "expand_count": int(s.expand_count),
+                        "snap_count": int(s.snap_count),
+                        "clearance_m": round(float(s.clearances[k]), 4)
+                        if np.isfinite(s.clearances[k])
+                        else None,
+                        "collision": bool(s.collisions[k]),
+                        "rb_dist_m": round(float(s.rb_dists[k]), 4)
+                        if np.isfinite(s.rb_dists[k])
+                        else None,
+                        "red_light_violation": bool(s.red_light[k]),
+                        "gt_deviation_m": round(gt_deviation_m, 3),
+                    }
+                )
+                + "\n"
             )
-            pred_cur = pred  # fresh plan: drawn + tracked in the current ego frame
-            _feed_turn_indicator(s, outputs)
-        else:
-            # Clamp so a `replan_interval` longer than the horizon holds the final plan pose.
-            off = min(offset, len(plan_world[0]) - 1)
-            tx, ty, th = (
-                float(plan_world[0][off, 0]),
-                float(plan_world[0][off, 1]),
-                float(plan_world[1][off]),
-            )
-            spd = float(np.hypot(tx - s.live_pose[0], ty - s.live_pose[1]) / DT)
-            override = (np.array([tx, ty, th], dtype=np.float64), spd)
-            pred_cur = _world_plan_to_ego(
-                plan_world[0][off:],
-                plan_world[1][off:],
-                s.live_pose[0],
-                s.live_pose[1],
-                s.live_pose[2],
-            )
-            # No fresh inference this step: hold the last decoded turn indicator so the
-            # 10 Hz turn_indicators history keeps scrolling with the same signal.
-            _hold_turn_indicator(s)
-        # Complete perfect tracking (tracker_mode="perfect"): the replan step would otherwise run
-        # PerfectTracker.track, which advances the plan's *distance* along the CURRENT heading and
-        # snaps heading to the reference only AFTERWARD — so on any curve the ego drifts off the
-        # predicted point. Instead place the ego DIRECTLY on the first predicted world pose, exactly
-        # as the in-between steps already do for the cached plan (the "faithful perfect tracking" the
-        # override path implements). Every step then lands on the predicted polyline point.
-        if tracker_mode == "perfect" and override is None:
-            tx, ty, th = (
-                float(plan_world[0][0, 0]),
-                float(plan_world[0][0, 1]),
-                float(plan_world[1][0]),
-            )
-            spd = float(np.hypot(tx - s.live_pose[0], ty - s.live_pose[1]) / DT)
-            override = (np.array([tx, ty, th], dtype=np.float64), spd)
-        if (
-            draw_every is not None
-            and (window is None or (window[0] <= k <= window[1]))
-            and k % draw_every == 0
-        ):
-            _draw_step(
-                np_dict,
-                pred_cur,
-                s.ego_shape,
-                out_dir / f"{k:05d}.png",
-                neighbor_ids=nids if color_by_uuid else None,
-                step=k,
-                total=cap,
-                title_prefix=title_prefix,
-                distance_label_offset_m=distance_label_offset_m,
-                view_half_m=view_half_m,
-            )
-        snaps_before = s.snap_count
-        _advance_step(s, pred_cur, idx, device, timers, override=override)
-        if s.snap_count > snaps_before:
-            # An unstick teleport just moved the ego; the cached plan is pinned to the PRE-snap
-            # world location, so executing it next step would drag the ego right back. Invalidate
-            # it to force a fresh inference at the snapped pose (else the snap never sticks).
-            plan_world = None
-    dbg.close()
+            # Re-plan every `replan_interval` steps. On a replan step (offset 0) run the model and
+            # drive the ego with the tracker exactly as the per-step rollout does (so replan_interval=1
+            # is identical to the baseline). On the in-between steps execute the cached plan open-loop:
+            # PerfectTracker only targets ref[0] in the current heading and cannot follow a multi-step
+            # plan (it diverges), so the ego is placed directly on the plan's predicted world pose at
+            # `offset` (steps since the last inference). The ego still single-steps at 10 Hz.
+            offset = k % replan_interval
+            override = None
+            if plan_world is None or offset == 0:
+                data = _to_torch_batch([np_dict], model_args, device)
+                _, outputs = model(data)
+                pred = outputs["prediction"][0, 0].cpu().numpy()
+                plan_world = _ego_pred_to_world(
+                    pred[:, :2], pred[:, 2:4], s.live_pose[0], s.live_pose[1], s.live_pose[2]
+                )
+                pred_cur = pred  # fresh plan: drawn + tracked in the current ego frame
+                _feed_turn_indicator(s, outputs)
+            else:
+                # Clamp so a `replan_interval` longer than the horizon holds the final plan pose.
+                off = min(offset, len(plan_world[0]) - 1)
+                tx, ty, th = (
+                    float(plan_world[0][off, 0]),
+                    float(plan_world[0][off, 1]),
+                    float(plan_world[1][off]),
+                )
+                spd = float(np.hypot(tx - s.live_pose[0], ty - s.live_pose[1]) / DT)
+                override = (np.array([tx, ty, th], dtype=np.float64), spd)
+                pred_cur = _world_plan_to_ego(
+                    plan_world[0][off:],
+                    plan_world[1][off:],
+                    s.live_pose[0],
+                    s.live_pose[1],
+                    s.live_pose[2],
+                )
+                # No fresh inference this step: hold the last decoded turn indicator so the
+                # 10 Hz turn_indicators history keeps scrolling with the same signal.
+                _hold_turn_indicator(s)
+            # Complete perfect tracking (tracker_mode="perfect"): the replan step would otherwise run
+            # PerfectTracker.track, which advances the plan's *distance* along the CURRENT heading and
+            # snaps heading to the reference only AFTERWARD — so on any curve the ego drifts off the
+            # predicted point. Instead place the ego DIRECTLY on the first predicted world pose, exactly
+            # as the in-between steps already do for the cached plan (the "faithful perfect tracking" the
+            # override path implements). Every step then lands on the predicted polyline point.
+            if tracker_mode == "perfect" and override is None:
+                tx, ty, th = (
+                    float(plan_world[0][0, 0]),
+                    float(plan_world[0][0, 1]),
+                    float(plan_world[1][0]),
+                )
+                spd = float(np.hypot(tx - s.live_pose[0], ty - s.live_pose[1]) / DT)
+                override = (np.array([tx, ty, th], dtype=np.float64), spd)
+            if (
+                draw_every is not None
+                and (window is None or (window[0] <= k <= window[1]))
+                and k % draw_every == 0
+            ):
+                _draw_step(
+                    np_dict,
+                    pred_cur,
+                    s.ego_shape,
+                    out_dir / f"{k:05d}.png",
+                    neighbor_ids=nids if color_by_uuid else None,
+                    step=k,
+                    total=cap,
+                    title_prefix=title_prefix,
+                    distance_label_offset_m=distance_label_offset_m,
+                    view_half_m=view_half_m,
+                )
+            snaps_before = s.snap_count
+            _advance_step(s, pred_cur, idx, device, timers, override=override)
+            if s.snap_count > snaps_before:
+                # An unstick teleport just moved the ego; the cached plan is pinned to the PRE-snap
+                # world location, so executing it next step would drag the ego right back. Invalidate
+                # it to force a fresh inference at the snapped pose (else the snap never sticks).
+                plan_world = None
     return _finalize(s)
 
 

--- a/scenario_generation/tests/test_render_pool.py
+++ b/scenario_generation/tests/test_render_pool.py
@@ -1,0 +1,48 @@
+"""PNG bytes must not depend on the number of render workers.
+
+The neighbours are renamed to hex track UUIDs so the colour lookup takes its hashed branch, which
+is the part that can differ between processes.
+"""
+
+import hashlib
+from pathlib import Path
+
+import numpy as np
+
+from scenario_generation.render_pool import render_pool
+from scenario_generation.reproducer_rollout import _draw_step
+
+FIXTURE = Path(__file__).parent / "test_data" / "fixture_scene.npz"
+N_FRAMES = 6
+
+
+def _render(tmp_path, workers: int) -> list[str]:
+    frame = dict(np.load(FIXTURE))
+    np_dict = {k: v[None] for k, v in frame.items()}  # _draw_step indexes [0]
+    uuids = [f"{0xA3F91C2E + i * 0x1111:08x}" for i in range(len(frame["neighbor_agents_past"]))]
+    out_dir = tmp_path / f"workers{workers}"
+    out_dir.mkdir()
+    with render_pool(workers) as pool:
+        pending = [
+            pool.submit(
+                _draw_step,
+                np_dict,
+                np.zeros((8, 4), dtype=np.float32),
+                frame["ego_shape"],
+                out_dir / f"{k:05d}.png",
+                neighbor_ids=uuids,
+                step=k,
+                total=N_FRAMES,
+            )
+            for k in range(N_FRAMES)
+        ]
+        for f in pending:
+            f.result()
+    pngs = sorted(out_dir.glob("*.png"))
+    assert len(pngs) == N_FRAMES, "nothing was drawn, so this proves nothing"
+    return [hashlib.sha256(p.read_bytes()).hexdigest() for p in pngs]
+
+
+def test_png_bytes_are_independent_of_worker_count(tmp_path):
+    """3 workers over 6 frames, so a per-worker difference cannot hide in one process."""
+    assert _render(tmp_path, 3) == _render(tmp_path, 1)


### PR DESCRIPTION
## Problem

PNG rendering dominates a media-on closed-loop evaluation — 214 ms/frame against ~15 ms for a
rollout step — and is CPU-bound Python, so a thread pool cannot overlap it.

The same pattern had already been written three times in this repo without being shared:
`replay.py` / `simulate.py` (`save_pool`), `reproducer_rollout`, `render_npz_dir`.

## Fix

`scenario_generation/render_pool.py` — 39 lines, one function:

```python
def render_pool(workers: int = 1) -> Executor:
    return ProcessPoolExecutor(
        max_workers=max(1, workers),
        mp_context=multiprocessing.get_context("spawn"),
        initializer=_pin_worker_threads,  # torch.set_num_threads(1), or N workers thrash
    )
```

There is no in-process path and no lifecycle object. `Executor.__exit__` already does
`shutdown(wait=True)`, and `ProcessPoolExecutor` under spawn already starts workers on the first
`submit` — a run that draws nothing spawns nothing. The caller keeps its own list of futures,
which is only needed to re-raise what a worker raised (`shutdown(wait=True)` waits but discards
exceptions).

Spawn, not fork: the caller holds a CUDA context. Since every frame is now drawn in a worker,
**every caller that draws must be spawn-safe** — an importable callable, picklable arguments,
and a `if __name__ == "__main__":` guard. Every entry point that reaches this is already guarded.

Two call sites move onto it:

**`render_segment(draw_pool=...)`** — submits each frame, waits once per segment. Pass a pool and
an evaluation run reuses one set of workers instead of re-spawning them (and re-importing torch +
matplotlib) per route; pass nothing and the segment opens a one-worker pool of its own. Wired as
`closed_loop_draw_workers` (train config + both training CLIs) and `--draw_workers`
(`valid_predictor_closed_loop.py`), defaulting to 4.

**`run_route_replay`** — its 4 save threads are replaced by 4 processes.

## Result

`replay.py`, measured locally on the fixture scene (33 agents, 140 lanes), 40 frames, against
saving in the calling process:

| road-border polylines | submit payload | 4 threads (before) | 4 processes (after) |
|---|---|---|---|
| 0 | 0.36 MB | 1.42x | 1.20x |
| 200 | 0.63 MB | 1.12x | **1.77x** |
| 1000 | 1.57 MB | **0.99x** | **3.04x** |

The heavier the figure, the less the threads buy; at the size a real lanelet map produces they
buy nothing at all. Processes win despite pickling a 1.6 MB payload per frame — which is also
why this PR does not add an `initargs` path for the static overlays yet.

That measurement is why `render_pool` has no thread mode.

## Tests

One test: `test_render_pool.py` asserts PNG bytes do not depend on the worker count (3 workers vs
1 over 6 frames, hex UUID track ids so the palette lookup takes its hashed branch). That is the
property that can silently regress as the draw path changes — it already did once, which is #334.

Everything else was checked by measurement rather than kept as a test, because it is a property
of the runtime rather than of this code:

- a pool nothing is submitted to starts no workers — `ProcessPoolExecutor.submit` →
  `_adjust_process_count`; constructing one and never submitting leaves just the ~12 MB
  resource_tracker (cited in the `render_pool` docstring, since it is why there is no laziness of
  our own),
- `render_segment` end to end on a 30-frame route: `draw_every=None` → 0 PNGs and 0 child
  processes; `draw_every=1` → 25 PNGs, pool shut down on exit,
- a worker exception reaches `.result()` rather than being swallowed,
- `replay.py`'s save path is byte-identical between the threaded and the pooled path, with route
  + border overlays and a metrics overlay. Not a test only because the repo has no replay-scene
  fixture; `_draw_step`'s fixture is what the kept test uses.

`scenario_generation/tests`: 229 passed. The two `test_map_cache.py` failures reproduce on
`tier4-main` unchanged.

## Stack

`#334` ← `#351` ← **this**. Merge bottom-up. #351 carries the `with`-block re-indent that keeps
this PR's diff readable; #334 makes agent colours process-independent, without which pooled
rendering flickers.