### PR TITLE
feat(data_converter): generate override index when convert rosbags into npzs

### DIFF
--- a/cpp_tools/src/autoware_diffusion_planner_tools/CMakeLists.txt
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/CMakeLists.txt
@@ -43,6 +43,7 @@ ament_auto_add_executable(data_converter
   src/data_converter.cpp
   src/cli/converter_options.cpp
   src/conversion/data_converter.cpp
+  src/conversion/override_segments.cpp
   src/io/frame_writer.cpp
   src/io/bag_metadata.cpp
   src/io/npz_frame_writer.cpp
@@ -63,6 +64,7 @@ ament_auto_add_executable(parse_rosbag_for_directory_with_map_version
   src/parse_rosbag_for_directory_with_map_version.cpp
   src/cli/converter_options.cpp
   src/conversion/data_converter.cpp
+  src/conversion/override_segments.cpp
   src/io/frame_writer.cpp
   src/io/bag_metadata.cpp
   src/io/npz_frame_writer.cpp
@@ -78,6 +80,14 @@ ament_auto_add_executable(parse_rosbag_for_directory_with_map_version
 )
 target_include_directories(parse_rosbag_for_directory_with_map_version PRIVATE include src)
 target_link_libraries(parse_rosbag_for_directory_with_map_version yaml-cpp ZLIB::ZLIB Threads::Threads CLI11::CLI11 fmt::fmt)
+
+ament_auto_add_executable(override_interval_extractor
+  src/override_interval_extractor.cpp
+  src/conversion/override_segments.cpp
+  src/rosbag/parsed_bag_data.cpp
+)
+target_include_directories(override_interval_extractor PRIVATE include src)
+target_link_libraries(override_interval_extractor CLI11::CLI11)
 
 ament_auto_add_executable(inference_tool
   src/inference_tool.cpp

--- a/cpp_tools/src/autoware_diffusion_planner_tools/README.md
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/README.md
@@ -79,7 +79,9 @@ ros2 run autoware_diffusion_planner_tools data_converter \
 
 For an auto-driving rosbag, pass `--extract_override_segments` to also read
 control-mode messages and write `control_mode_4_intervals.json`. The converter
-does not infer the rosbag type from the output path.
+does not infer the rosbag type from the output path. The JSON includes
+`control_mode_sample_count` so consumers can distinguish an empty override list
+from a conversion that read no control-mode samples.
 
 `vector_map_path` is usually the Lanelet2 map file, for example
 `/path/to/map/lanelet2_map.osm`.

--- a/cpp_tools/src/autoware_diffusion_planner_tools/README.md
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/README.md
@@ -77,6 +77,10 @@ ros2 run autoware_diffusion_planner_tools data_converter \
   <save_dir>
 ```
 
+For an auto-driving rosbag, pass `--extract_override_segments` to also read
+control-mode messages and write `control_mode_4_intervals.json`. The converter
+does not infer the rosbag type from the output path.
+
 `vector_map_path` is usually the Lanelet2 map file, for example
 `/path/to/map/lanelet2_map.osm`.
 

--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/cli/converter_options.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/cli/converter_options.hpp
@@ -94,6 +94,11 @@ struct ConverterOptions
   // Mutually exclusive with sidecar_only (which writes no npz at all).
   bool pack_sequence;
 
+  // Extract control-mode 4 intervals and write control_mode_4_intervals.json.
+  // This is explicit because the output path does not reliably identify the
+  // source rosbag type.
+  bool extract_override_segments;
+
   // Build converter defaults shared by all converter entry points.
   static ConverterOptions default_converter_options();
 

--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/conversion/override_segments.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/conversion/override_segments.hpp
@@ -1,0 +1,24 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0.
+
+#ifndef CONVERSION__OVERRIDE_SEGMENTS_HPP_
+#define CONVERSION__OVERRIDE_SEGMENTS_HPP_
+
+#include "types/override_segment.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+struct ControlModeSample;
+
+std::vector<OverrideSegment> build_override_segments(
+  const std::vector<ControlModeSample> & control_modes);
+
+void save_override_segments_json(
+  const std::string & output_dir, const std::vector<OverrideSegment> & segments,
+  std::size_t control_mode_sample_count);
+
+#endif  // CONVERSION__OVERRIDE_SEGMENTS_HPP_

--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/rosbag/parsed_bag_data.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/rosbag/parsed_bag_data.hpp
@@ -37,6 +37,12 @@
 template <typename T>
 using TimedMsg = std::pair<int64_t, T>;
 
+struct ControlModeSample
+{
+  int64_t rosbag_time;
+  int32_t mode;
+};
+
 struct ParsedBagData
 {
   std::deque<TimedMsg<nav_msgs::msg::Odometry>> kinematic_states;
@@ -45,6 +51,7 @@ struct ParsedBagData
   std::deque<TimedMsg<autoware_vehicle_msgs::msg::TurnIndicatorsReport>> turn_indicators;
   std::vector<TimedMsg<autoware_planning_msgs::msg::LaneletRoute>> route_msgs;
   std::deque<TimedMsg<autoware_perception_msgs::msg::TrafficLightGroupArray>> traffic_signals;
+  std::vector<ControlModeSample> control_modes;
   timestamp_stats::TimestampStatsMap timestamp_stats_map;
 
   explicit ParsedBagData(const std::vector<std::string> & target_topics)
@@ -53,7 +60,8 @@ struct ParsedBagData
   }
 };
 
-ParsedBagData load_rosbag(const std::string & rosbag_path, int64_t limit);
+ParsedBagData load_rosbag(
+  const std::string & rosbag_path, int64_t limit, bool load_control_modes = false);
 
 // Returns std::nullopt if no topics are missing; otherwise returns SkippingInfo describing
 // which topics are missing.

--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/types/override_segment.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/types/override_segment.hpp
@@ -20,6 +20,7 @@
 struct OverrideSegment
 {
   int64_t start_timestamp_ns;
+  // Exclusive end boundary: [start_timestamp_ns, end_timestamp_ns).
   int64_t end_timestamp_ns;
 };
 

--- a/cpp_tools/src/autoware_diffusion_planner_tools/include/types/override_segment.hpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/include/types/override_segment.hpp
@@ -1,0 +1,26 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TYPES__OVERRIDE_SEGMENT_HPP_
+#define TYPES__OVERRIDE_SEGMENT_HPP_
+
+#include <cstdint>
+
+struct OverrideSegment
+{
+  int64_t start_timestamp_ns;
+  int64_t end_timestamp_ns;
+};
+
+#endif  // TYPES__OVERRIDE_SEGMENT_HPP_

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/cli/converter_options.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/cli/converter_options.cpp
@@ -111,6 +111,9 @@ void ConverterOptions::add_converter_options(CLI::App & app)
     "Write ONE npz and ONE json per sequence (frames stacked along a leading frame axis) "
     "instead of one file per frame. Forces write_skipped_npz on so the packed sequence is "
     "gap-free. Mutually exclusive with --sidecar_only.");
+  app.add_flag(
+    "--extract_override_segments", extract_override_segments,
+    "Read vehicle control-mode messages and write control_mode_4_intervals.json.");
 }
 
 std::string ConverterPaths::get_rosbag_dir_name() const
@@ -161,6 +164,7 @@ ConverterOptions ConverterOptions::default_converter_options()
   options.sidecar_only = false;
   // One file per frame by default; --pack_sequence packs a whole sequence into one npz/json.
   options.pack_sequence = false;
+  options.extract_override_segments = false;
   options.use_interpolation = static_cast<bool>(options.interpolation);
   return options;
 }

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/conversion/data_converter.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/conversion/data_converter.cpp
@@ -23,6 +23,7 @@
 #include "types/override_segment.hpp"
 
 #include <autoware/diffusion_planner/preprocessing/lane_segments.hpp>
+#include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_io/Io.h>
@@ -52,7 +53,9 @@ std::vector<OverrideSegment> build_override_segments(
   for (size_t index = 1; index < control_modes.size(); ++index) {
     const auto & sample = control_modes[index];
     if (sample.mode != current_mode) {
-      if (current_mode == 4) {
+      // Only MANUAL is treated as an override interval. DISENGAGED and
+      // partial-autonomy modes are treated as non-override modes.
+      if (current_mode == autoware_vehicle_msgs::msg::ControlModeReport::MANUAL) {
         // Use the first non-4 sample as the exclusive end boundary. This keeps
         // a single-sample override visible to half-open interval readers.
         segments.push_back({start_timestamp, sample.rosbag_time});
@@ -62,7 +65,7 @@ std::vector<OverrideSegment> build_override_segments(
     }
     previous_timestamp = sample.rosbag_time;
   }
-  if (current_mode == 4) {
+  if (current_mode == autoware_vehicle_msgs::msg::ControlModeReport::MANUAL) {
     segments.push_back({start_timestamp, previous_timestamp});
   }
   return segments;

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/conversion/data_converter.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/conversion/data_converter.cpp
@@ -67,9 +67,11 @@ std::vector<OverrideSegment> build_override_segments(
 }
 
 void save_override_segments_json(
-  const std::string & output_dir, const std::vector<OverrideSegment> & segments)
+  const std::string & output_dir, const std::vector<OverrideSegment> & segments,
+  const std::size_t control_mode_sample_count)
 {
   nlohmann::json payload;
+  payload["control_mode_sample_count"] = control_mode_sample_count;
   payload["override_segments"] = nlohmann::json::array();
   for (const auto & segment : segments) {
     payload["override_segments"].push_back(
@@ -111,7 +113,8 @@ int run_data_converter(const ConverterPaths & paths, const ConverterOptions & co
     converter.extract_override_segments ? build_override_segments(bag_data.control_modes)
                                         : std::vector<OverrideSegment>{};
   if (converter.extract_override_segments) {
-    save_override_segments_json(paths.save_dir, override_segments);
+    save_override_segments_json(
+      paths.save_dir, override_segments, bag_data.control_modes.size());
   }
 
   const auto missing_topics_skip = check_missing_topics(bag_data);

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/conversion/data_converter.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/conversion/data_converter.cpp
@@ -111,13 +111,6 @@ int run_data_converter(const ConverterPaths & paths, const ConverterOptions & co
 
   ParsedBagData bag_data = load_rosbag(
     paths.rosbag_path, converter.limit, converter.extract_override_segments);
-  const std::vector<OverrideSegment> override_segments =
-    converter.extract_override_segments ? build_override_segments(bag_data.control_modes)
-                                        : std::vector<OverrideSegment>{};
-  if (converter.extract_override_segments) {
-    save_override_segments_json(
-      paths.save_dir, override_segments, bag_data.control_modes.size());
-  }
 
   const auto missing_topics_skip = check_missing_topics(bag_data);
   if (missing_topics_skip) {
@@ -130,6 +123,12 @@ int run_data_converter(const ConverterPaths & paths, const ConverterOptions & co
       paths.save_dir, rosbag_dir_name, "missing_topics", 0, 0.0, 0, 0, missing_topics_skip.value(),
       bag_data.timestamp_stats_map, false, bag_metadata);
     return 0;
+  }
+
+  if (converter.extract_override_segments) {
+    save_override_segments_json(
+      paths.save_dir, build_override_segments(bag_data.control_modes),
+      bag_data.control_modes.size());
   }
 
   std::vector<SequenceData> sequences = build_sequences(bag_data, converter.search_nearest_route);

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/conversion/data_converter.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/conversion/data_converter.cpp
@@ -88,7 +88,7 @@ void save_override_segments_json(
   }
   std::filesystem::create_directories(output_dir);
   const std::filesystem::path output_path =
-    std::filesystem::path(output_dir) / "override_segments.json";
+    std::filesystem::path(output_dir) / "control_mode_4_intervals.json";
   std::ofstream output_file(output_path);
   if (!output_file.is_open()) {
     std::cerr << "Failed to open override segment output: " << output_path << std::endl;

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/conversion/data_converter.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/conversion/data_converter.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "conversion/data_converter.hpp"
+#include "conversion/override_segments.hpp"
 
 #include "io/bag_metadata.hpp"
 #include "io/frame_writer.hpp"
@@ -20,7 +21,6 @@
 #include "processing/frame_processor.hpp"
 #include "processing/sequence_builder.hpp"
 #include "rosbag/parsed_bag_data.hpp"
-#include "types/override_segment.hpp"
 
 #include <autoware/diffusion_planner/preprocessing/lane_segments.hpp>
 #include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
@@ -38,61 +38,6 @@
 
 namespace
 {
-
-std::vector<OverrideSegment> build_override_segments(
-  const std::vector<ControlModeSample> & control_modes)
-{
-  std::vector<OverrideSegment> segments;
-  if (control_modes.empty()) {
-    return segments;
-  }
-
-  int32_t current_mode = control_modes.front().mode;
-  int64_t start_timestamp = control_modes.front().rosbag_time;
-  int64_t previous_timestamp = control_modes.front().rosbag_time;
-  for (size_t index = 1; index < control_modes.size(); ++index) {
-    const auto & sample = control_modes[index];
-    if (sample.mode != current_mode) {
-      // Only MANUAL is treated as an override interval. DISENGAGED and
-      // partial-autonomy modes are treated as non-override modes.
-      if (current_mode == autoware_vehicle_msgs::msg::ControlModeReport::MANUAL) {
-        // Use the first non-4 sample as the exclusive end boundary. This keeps
-        // a single-sample override visible to half-open interval readers.
-        segments.push_back({start_timestamp, sample.rosbag_time});
-      }
-      current_mode = sample.mode;
-      start_timestamp = sample.rosbag_time;
-    }
-    previous_timestamp = sample.rosbag_time;
-  }
-  if (current_mode == autoware_vehicle_msgs::msg::ControlModeReport::MANUAL) {
-    segments.push_back({start_timestamp, previous_timestamp});
-  }
-  return segments;
-}
-
-void save_override_segments_json(
-  const std::string & output_dir, const std::vector<OverrideSegment> & segments,
-  const std::size_t control_mode_sample_count)
-{
-  nlohmann::json payload;
-  payload["control_mode_sample_count"] = control_mode_sample_count;
-  payload["override_segments"] = nlohmann::json::array();
-  for (const auto & segment : segments) {
-    payload["override_segments"].push_back(
-      {{"start_timestamp_ns", segment.start_timestamp_ns},
-       {"end_timestamp_ns", segment.end_timestamp_ns}});
-  }
-  std::filesystem::create_directories(output_dir);
-  const std::filesystem::path output_path =
-    std::filesystem::path(output_dir) / "control_mode_4_intervals.json";
-  std::ofstream output_file(output_path);
-  if (!output_file.is_open()) {
-    std::cerr << "Failed to open override segment output: " << output_path << std::endl;
-    return;
-  }
-  output_file << std::setw(2) << payload << std::endl;
-}
 
 }  // namespace
 

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/conversion/data_converter.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/conversion/data_converter.cpp
@@ -38,16 +38,6 @@
 namespace
 {
 
-bool is_auto_output_dir(const std::string & save_dir)
-{
-  for (const auto & component : std::filesystem::path(save_dir)) {
-    if (component == "auto") {
-      return true;
-    }
-  }
-  return false;
-}
-
 std::vector<OverrideSegment> build_override_segments(
   const std::vector<ControlModeSample> & control_modes)
 {
@@ -115,12 +105,12 @@ int run_data_converter(const ConverterPaths & paths, const ConverterOptions & co
   const std::string rosbag_dir_name = paths.get_rosbag_dir_name();
   const BagMetadata bag_metadata = load_bag_metadata(paths.rosbag_path);
 
-  const bool is_auto_rosbag = is_auto_output_dir(paths.save_dir);
-  ParsedBagData bag_data = load_rosbag(paths.rosbag_path, converter.limit, is_auto_rosbag);
+  ParsedBagData bag_data = load_rosbag(
+    paths.rosbag_path, converter.limit, converter.extract_override_segments);
   const std::vector<OverrideSegment> override_segments =
-    is_auto_rosbag ? build_override_segments(bag_data.control_modes)
-                   : std::vector<OverrideSegment>{};
-  if (is_auto_rosbag) {
+    converter.extract_override_segments ? build_override_segments(bag_data.control_modes)
+                                        : std::vector<OverrideSegment>{};
+  if (converter.extract_override_segments) {
     save_override_segments_json(paths.save_dir, override_segments);
   }
 

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/conversion/data_converter.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/conversion/data_converter.cpp
@@ -53,7 +53,9 @@ std::vector<OverrideSegment> build_override_segments(
     const auto & sample = control_modes[index];
     if (sample.mode != current_mode) {
       if (current_mode == 4) {
-        segments.push_back({start_timestamp, previous_timestamp});
+        // Use the first non-4 sample as the exclusive end boundary. This keeps
+        // a single-sample override visible to half-open interval readers.
+        segments.push_back({start_timestamp, sample.rosbag_time});
       }
       current_mode = sample.mode;
       start_timestamp = sample.rosbag_time;

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/conversion/data_converter.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/conversion/data_converter.cpp
@@ -20,16 +20,84 @@
 #include "processing/frame_processor.hpp"
 #include "processing/sequence_builder.hpp"
 #include "rosbag/parsed_bag_data.hpp"
+#include "types/override_segment.hpp"
 
 #include <autoware/diffusion_planner/preprocessing/lane_segments.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_io/Io.h>
 
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <memory>
 #include <string>
 #include <vector>
+
+namespace
+{
+
+bool is_auto_output_dir(const std::string & save_dir)
+{
+  for (const auto & component : std::filesystem::path(save_dir)) {
+    if (component == "auto") {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::vector<OverrideSegment> build_override_segments(
+  const std::vector<ControlModeSample> & control_modes)
+{
+  std::vector<OverrideSegment> segments;
+  if (control_modes.empty()) {
+    return segments;
+  }
+
+  int32_t current_mode = control_modes.front().mode;
+  int64_t start_timestamp = control_modes.front().rosbag_time;
+  int64_t previous_timestamp = control_modes.front().rosbag_time;
+  for (size_t index = 1; index < control_modes.size(); ++index) {
+    const auto & sample = control_modes[index];
+    if (sample.mode != current_mode) {
+      if (current_mode == 4) {
+        segments.push_back({start_timestamp, previous_timestamp});
+      }
+      current_mode = sample.mode;
+      start_timestamp = sample.rosbag_time;
+    }
+    previous_timestamp = sample.rosbag_time;
+  }
+  if (current_mode == 4) {
+    segments.push_back({start_timestamp, previous_timestamp});
+  }
+  return segments;
+}
+
+void save_override_segments_json(
+  const std::string & output_dir, const std::vector<OverrideSegment> & segments)
+{
+  nlohmann::json payload;
+  payload["override_segments"] = nlohmann::json::array();
+  for (const auto & segment : segments) {
+    payload["override_segments"].push_back(
+      {{"start_timestamp_ns", segment.start_timestamp_ns},
+       {"end_timestamp_ns", segment.end_timestamp_ns}});
+  }
+  std::filesystem::create_directories(output_dir);
+  const std::filesystem::path output_path =
+    std::filesystem::path(output_dir) / "override_segments.json";
+  std::ofstream output_file(output_path);
+  if (!output_file.is_open()) {
+    std::cerr << "Failed to open override segment output: " << output_path << std::endl;
+    return;
+  }
+  output_file << std::setw(2) << payload << std::endl;
+}
+
+}  // namespace
 
 int run_data_converter(const ConverterPaths & paths, const ConverterOptions & converter)
 {
@@ -47,7 +115,14 @@ int run_data_converter(const ConverterPaths & paths, const ConverterOptions & co
   const std::string rosbag_dir_name = paths.get_rosbag_dir_name();
   const BagMetadata bag_metadata = load_bag_metadata(paths.rosbag_path);
 
-  ParsedBagData bag_data = load_rosbag(paths.rosbag_path, converter.limit);
+  const bool is_auto_rosbag = is_auto_output_dir(paths.save_dir);
+  ParsedBagData bag_data = load_rosbag(paths.rosbag_path, converter.limit, is_auto_rosbag);
+  const std::vector<OverrideSegment> override_segments =
+    is_auto_rosbag ? build_override_segments(bag_data.control_modes)
+                   : std::vector<OverrideSegment>{};
+  if (is_auto_rosbag) {
+    save_override_segments_json(paths.save_dir, override_segments);
+  }
 
   const auto missing_topics_skip = check_missing_topics(bag_data);
   if (missing_topics_skip) {

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/conversion/override_segments.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/conversion/override_segments.cpp
@@ -1,0 +1,66 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0.
+
+#include "conversion/override_segments.hpp"
+
+#include "rosbag/parsed_bag_data.hpp"
+
+#include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
+
+#include "nlohmann/json.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <stdexcept>
+
+std::vector<OverrideSegment> build_override_segments(
+  const std::vector<ControlModeSample> & control_modes)
+{
+  std::vector<OverrideSegment> segments;
+  if (control_modes.empty()) {
+    return segments;
+  }
+
+  int32_t current_mode = control_modes.front().mode;
+  int64_t start_timestamp = control_modes.front().rosbag_time;
+  int64_t previous_timestamp = control_modes.front().rosbag_time;
+  for (size_t index = 1; index < control_modes.size(); ++index) {
+    const auto & sample = control_modes[index];
+    if (sample.mode != current_mode) {
+      if (current_mode == autoware_vehicle_msgs::msg::ControlModeReport::MANUAL) {
+        segments.push_back({start_timestamp, sample.rosbag_time});
+      }
+      current_mode = sample.mode;
+      start_timestamp = sample.rosbag_time;
+    }
+    previous_timestamp = sample.rosbag_time;
+  }
+  if (current_mode == autoware_vehicle_msgs::msg::ControlModeReport::MANUAL) {
+    segments.push_back({start_timestamp, previous_timestamp});
+  }
+  return segments;
+}
+
+void save_override_segments_json(
+  const std::string & output_dir, const std::vector<OverrideSegment> & segments,
+  const std::size_t control_mode_sample_count)
+{
+  nlohmann::json payload;
+  payload["control_mode_sample_count"] = control_mode_sample_count;
+  payload["override_segments"] = nlohmann::json::array();
+  for (const auto & segment : segments) {
+    payload["override_segments"].push_back(
+      {{"start_timestamp_ns", segment.start_timestamp_ns},
+       {"end_timestamp_ns", segment.end_timestamp_ns}});
+  }
+  std::filesystem::create_directories(output_dir);
+  const std::filesystem::path output_path =
+    std::filesystem::path(output_dir) / "control_mode_4_intervals.json";
+  std::ofstream output_file(output_path);
+  if (!output_file.is_open()) {
+    throw std::runtime_error("failed to open override segment output: " + output_path.string());
+  }
+  output_file << std::setw(2) << payload << std::endl;
+}

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/data_converter.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/data_converter.cpp
@@ -37,7 +37,7 @@ void print_options(const ConverterPaths & paths, const ConverterOptions & conver
     "Collision filter static_object_margin: {}, neighbor_margin: {}, road_border_margin: {}, "
     "collision_time_stride: {}\n"
     "Off-lane filter max_score: {}, offlane_time_stride: {}\n"
-    "Write skipped npz: {}, Sidecar only: {}, Pack sequence: {}\n"
+    "Write skipped npz: {}, Sidecar only: {}, Pack sequence: {}, Extract override segments: {}\n"
     "Red-light-run filter radius_m: {}, heading_tol_deg: {}\n"
     "Green-stop filter heading_tol_deg: {}, stay_radius_m: {}, speed_max_mps: {}, "
     "ahead_m: {}, lead_fwd_m: {}, lead_lat_m: {}\n",
@@ -47,7 +47,8 @@ void print_options(const ConverterPaths & paths, const ConverterOptions & conver
     converter.convert_red, converter.use_interpolation, converter.static_object_margin,
     converter.neighbor_margin, converter.road_border_margin, converter.collision_time_stride,
     converter.offlane_max_score, converter.offlane_time_stride, converter.write_skipped_npz,
-    converter.sidecar_only, converter.pack_sequence, converter.red_light_run_radius_m,
+    converter.sidecar_only, converter.pack_sequence, converter.extract_override_segments,
+    converter.red_light_run_radius_m,
     converter.red_light_run_heading_tol_deg, converter.green_stop_heading_tol_deg,
     converter.green_stop_stay_radius_m, converter.green_stop_speed_max_mps,
     converter.green_stop_ahead_m, converter.green_stop_lead_fwd_m, converter.green_stop_lead_lat_m);

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/override_interval_extractor.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/override_interval_extractor.cpp
@@ -1,0 +1,31 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0.
+
+#include "conversion/override_segments.hpp"
+#include "rosbag/parsed_bag_data.hpp"
+
+#include <CLI/CLI.hpp>
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+
+int main(int argc, char ** argv)
+{
+  std::string rosbag_path;
+  std::string output_dir;
+  int64_t limit = -1;
+  CLI::App app{"Extract control-mode override intervals without generating NPZ files"};
+  app.add_option("rosbag_path", rosbag_path, "Input ROSBag directory")->required();
+  app.add_option("output_dir", output_dir, "Output directory")->required();
+  app.add_option("--limit", limit, "Maximum number of ROSBag messages to read");
+  CLI11_PARSE(app, argc, argv);
+
+  const ParsedBagData bag_data = load_rosbag(rosbag_path, limit, true);
+  const auto segments = build_override_segments(bag_data.control_modes);
+  save_override_segments_json(output_dir, segments, bag_data.control_modes.size());
+  std::cout << "Extracted " << segments.size() << " override intervals from " << rosbag_path
+            << std::endl;
+  return 0;
+}

--- a/cpp_tools/src/autoware_diffusion_planner_tools/src/rosbag/parsed_bag_data.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/src/rosbag/parsed_bag_data.cpp
@@ -17,13 +17,17 @@
 #include "rosbag_parser.hpp"
 #include "utils/timestamp_utils.hpp"
 
+#include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
+
 #include <iostream>
 
-ParsedBagData load_rosbag(const std::string & rosbag_path, int64_t limit)
+ParsedBagData load_rosbag(
+  const std::string & rosbag_path, const int64_t limit, const bool load_control_modes)
 {
   using autoware_perception_msgs::msg::TrackedObjects;
   using autoware_perception_msgs::msg::TrafficLightGroupArray;
   using autoware_planning_msgs::msg::LaneletRoute;
+  using autoware_vehicle_msgs::msg::ControlModeReport;
   using autoware_vehicle_msgs::msg::TurnIndicatorsReport;
   using geometry_msgs::msg::AccelWithCovarianceStamped;
   using nav_msgs::msg::Odometry;
@@ -81,6 +85,10 @@ ParsedBagData load_rosbag(const std::string & rosbag_path, int64_t limit)
       data.timestamp_stats_map.add_timestamp(
         "/perception/traffic_light_recognition/traffic_signals",
         parse_timestamp(traffic_signal.stamp), rosbag_time);
+    } else if (load_control_modes && msg->topic_name == "/vehicle/status/control_mode") {
+      const ControlModeReport control_mode =
+        rosbag_parser.deserialize_message<ControlModeReport>(msg);
+      data.control_modes.push_back({rosbag_time, static_cast<int32_t>(control_mode.mode)});
     }
 
     parse_count++;
@@ -94,6 +102,9 @@ ParsedBagData load_rosbag(const std::string & rosbag_path, int64_t limit)
   std::cout << "Parsed " << data.route_msgs.size() << " route messages" << std::endl;
   std::cout << "Parsed " << data.turn_indicators.size() << " turn indicator messages" << std::endl;
   std::cout << "Parsed " << data.traffic_signals.size() << " traffic signal messages" << std::endl;
+  if (load_control_modes) {
+    std::cout << "Parsed " << data.control_modes.size() << " control mode messages" << std::endl;
+  }
 
   return data;
 }

--- a/cpp_tools/src/autoware_diffusion_planner_tools/test/test_converter_options.cpp
+++ b/cpp_tools/src/autoware_diffusion_planner_tools/test/test_converter_options.cpp
@@ -49,6 +49,7 @@ static ConverterOptions make_default_opts()
   o.write_skipped_npz = false;
   o.sidecar_only = false;
   o.pack_sequence = false;
+  o.extract_override_segments = false;
   return o;
 }
 
@@ -78,6 +79,7 @@ TEST(DefaultConverterOptionsTest, UsesSharedDefaults)
   EXPECT_FALSE(opts.write_skipped_npz);
   EXPECT_FALSE(opts.sidecar_only);   // full conversion (writes npz) by default
   EXPECT_FALSE(opts.pack_sequence);  // one file per frame by default
+  EXPECT_FALSE(opts.extract_override_segments);
 }
 
 TEST(NormalizeOptionsTest, PackSequenceForcesWriteSkippedNpz)

--- a/ros_scripts/parse_rosbag_by_cpp.py
+++ b/ros_scripts/parse_rosbag_by_cpp.py
@@ -1,6 +1,31 @@
 import argparse
+import json
 import subprocess
 from pathlib import Path
+
+
+def write_conversion_manifest(
+    path: Path,
+    results: list[dict],
+    converted_count: int,
+    skipped_count: int,
+    failed_count: int,
+):
+    path = path.resolve()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "records": results,
+                "converted_count": converted_count,
+                "skipped_count": skipped_count,
+                "failed_count": failed_count,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
 
 def parse_args() -> argparse.Namespace:

--- a/ros_scripts/parse_rosbag_by_cpp.py
+++ b/ros_scripts/parse_rosbag_by_cpp.py
@@ -27,6 +27,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--offlane_max_score", type=float, default=6.0)
     parser.add_argument("--offlane_time_stride", type=int, default=1)
     parser.add_argument("--write_skipped_npz", type=int, default=1)
+    parser.add_argument("--extract_override_segments", action="store_true")
     return parser.parse_args()
 
 
@@ -53,6 +54,7 @@ def main(
     offlane_max_score: float,
     offlane_time_stride: int,
     write_skipped_npz: int,
+    extract_override_segments: bool = False,
 ):
     # C++バイナリでrosbagを処理
     print("Running C++ binary to process rosbag...")
@@ -80,6 +82,8 @@ def main(
         f"--offlane_time_stride={offlane_time_stride}",
         f"--write_skipped_npz={write_skipped_npz}",
     ]
+    if extract_override_segments:
+        command.append("--extract_override_segments")
     print(" ".join(command))
     result = subprocess.run(
         command,

--- a/ros_scripts/parse_rosbag_for_directory.py
+++ b/ros_scripts/parse_rosbag_for_directory.py
@@ -1,14 +1,15 @@
 import argparse
-import json
 import logging
 import os
 import shutil
 import sys
 import time
+from collections import Counter
 from multiprocessing import Pool, cpu_count
 from pathlib import Path
 
 from parse_rosbag_by_cpp import main as parse_rosbag_main_cpp
+from parse_rosbag_by_cpp import write_conversion_manifest
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_CPP_BINARY = (
@@ -282,17 +283,10 @@ if __name__ == "__main__":
     with Pool(processes=num_workers) as pool:
         results = pool.map(process_single_bag, process_args)
 
-    converted_count = sum(
-        result.get("status") == "converted"
-        for result in results
-        if isinstance(result, dict)
-    )
-    skipped_count = sum(
-        result.get("status") == "skipped" for result in results if isinstance(result, dict)
-    )
-    failed_count = sum(
-        result.get("status") == "failed" for result in results if isinstance(result, dict)
-    )
+    status_counts = Counter(result["status"] for result in results)
+    converted_count = status_counts["converted"]
+    skipped_count = status_counts["skipped"]
+    failed_count = status_counts["failed"]
     logging.info(
         "Conversion summary: converted=%d, skipped=%d, failed=%d",
         converted_count,
@@ -301,20 +295,12 @@ if __name__ == "__main__":
     )
 
     if args.conversion_manifest_path is not None:
-        manifest_path = args.conversion_manifest_path.resolve()
-        manifest_path.parent.mkdir(parents=True, exist_ok=True)
-        manifest_path.write_text(
-            json.dumps(
-                {
-                    "records": results,
-                    "converted_count": converted_count,
-                    "skipped_count": skipped_count,
-                    "failed_count": failed_count,
-                },
-                indent=2,
-            )
-            + "\n",
-            encoding="utf-8",
+        write_conversion_manifest(
+            args.conversion_manifest_path,
+            results,
+            converted_count,
+            skipped_count,
+            failed_count,
         )
 
     elapsed_seconds = int(time.perf_counter() - start_time)

--- a/ros_scripts/parse_rosbag_for_directory.py
+++ b/ros_scripts/parse_rosbag_for_directory.py
@@ -104,11 +104,16 @@ def process_single_bag(args_tuple):
 
     save_dir = (save_root / proj_id / map_id / mode / date / time).resolve()
 
-    if save_dir.is_dir():
+    has_npz = save_dir.is_dir() and any(save_dir.rglob("*.npz"))
+    has_override_json = mode != "auto" or (
+        save_dir / "control_mode_4_intervals.json"
+    ).is_file()
+    if has_npz and has_override_json:
         logging.info(f"Already exists: {save_dir}")
         return {
             "status": "skipped",
             "mode": mode,
+            "reason": "already_exists",
             "bag_path": str(bag_path),
             "output_dir": str(save_dir),
         }

--- a/ros_scripts/parse_rosbag_for_directory.py
+++ b/ros_scripts/parse_rosbag_for_directory.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import shutil
+import sys
 import time
 from multiprocessing import Pool, cpu_count
 from pathlib import Path
@@ -252,6 +253,24 @@ if __name__ == "__main__":
     with Pool(processes=num_workers) as pool:
         results = pool.map(process_single_bag, process_args)
 
+    converted_count = sum(
+        result.get("status") == "converted"
+        for result in results
+        if isinstance(result, dict)
+    )
+    skipped_count = sum(
+        result.get("status") == "skipped" for result in results if isinstance(result, dict)
+    )
+    failed_count = sum(
+        result.get("status") == "failed" for result in results if isinstance(result, dict)
+    )
+    logging.info(
+        "Conversion summary: converted=%d, skipped=%d, failed=%d",
+        converted_count,
+        skipped_count,
+        failed_count,
+    )
+
     if args.conversion_manifest_path is not None:
         manifest_path = args.conversion_manifest_path.resolve()
         manifest_path.parent.mkdir(parents=True, exist_ok=True)
@@ -259,21 +278,9 @@ if __name__ == "__main__":
             json.dumps(
                 {
                     "records": results,
-                    "converted_count": sum(
-                        result.get("status") == "converted"
-                        for result in results
-                        if isinstance(result, dict)
-                    ),
-                    "skipped_count": sum(
-                        result.get("status") == "skipped"
-                        for result in results
-                        if isinstance(result, dict)
-                    ),
-                    "failed_count": sum(
-                        result.get("status") == "failed"
-                        for result in results
-                        if isinstance(result, dict)
-                    ),
+                    "converted_count": converted_count,
+                    "skipped_count": skipped_count,
+                    "failed_count": failed_count,
                 },
                 indent=2,
             )
@@ -290,3 +297,7 @@ if __name__ == "__main__":
 
     with open(save_root / "processing_time.txt", "w") as summary_file:
         summary_file.write(f"Total elapsed time: {time_str}\n")
+
+    if converted_count == 0 and failed_count > 0:
+        logging.error("No bags were converted successfully.")
+        sys.exit(1)

--- a/ros_scripts/parse_rosbag_for_directory.py
+++ b/ros_scripts/parse_rosbag_for_directory.py
@@ -90,7 +90,14 @@ def process_single_bag(args_tuple):
             f"Unexpected bag path layout for {bag_path}: expected "
             f"<proj_id>/<map_id>/<split>/<date>/<time>. Skipping."
         )
-        return {"status": "skipped", "bag_path": str(bag_path), "reason": "unexpected_layout"}
+        return {
+            "status": "skipped",
+            "mode": None,
+            "bag_path": str(bag_path),
+            "output_dir": None,
+            "reason": "unexpected_layout",
+            "error": None,
+        }
 
     # split が train/valid/auto のいずれでもない場合 (例: psim) は manual にフォールバック
     mode = SPLIT_TO_MODE.get(split, "manual")
@@ -116,6 +123,7 @@ def process_single_bag(args_tuple):
             "reason": "already_exists",
             "bag_path": str(bag_path),
             "output_dir": str(save_dir),
+            "error": None,
         }
 
     save_dir.mkdir(parents=True, exist_ok=True)
@@ -149,7 +157,14 @@ def process_single_bag(args_tuple):
     except Exception as e:
         error_msg = f"Error processing {bag_path}: {str(e)}"
         logging.error(error_msg)
-        return {"status": "failed", "mode": mode, "bag_path": str(bag_path), "error": str(e)}
+        return {
+            "status": "failed",
+            "mode": mode,
+            "bag_path": str(bag_path),
+            "output_dir": str(save_dir),
+            "reason": "conversion_failed",
+            "error": str(e),
+        }
 
     # The C++ converter writes the per-frame npz/json directly under save_dir but
     # emits the per-sequence route json into a nested "routes" subdir. Flatten it
@@ -165,7 +180,14 @@ def process_single_bag(args_tuple):
     except Exception as e:
         error_msg = f"Error flattening routes for {save_dir}: {str(e)}"
         logging.error(error_msg)
-        return {"status": "failed", "mode": mode, "bag_path": str(bag_path), "error": str(e)}
+        return {
+            "status": "failed",
+            "mode": mode,
+            "bag_path": str(bag_path),
+            "output_dir": str(save_dir),
+            "reason": "postprocess_failed",
+            "error": str(e),
+        }
 
     logging.info(f"Completed: {save_dir}")
     return {
@@ -173,6 +195,8 @@ def process_single_bag(args_tuple):
         "mode": mode,
         "bag_path": str(bag_path),
         "output_dir": str(save_dir),
+        "reason": None,
+        "error": None,
     }
 
 

--- a/ros_scripts/parse_rosbag_for_directory.py
+++ b/ros_scripts/parse_rosbag_for_directory.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import logging
 import os
 import shutil
@@ -41,6 +42,11 @@ def parse_args():
     parser.add_argument("--offlane_time_stride", type=int, default=1)
     parser.add_argument("--write_skipped_npz", type=int, default=1)
     parser.add_argument("--num_workers", type=int, default=os.cpu_count() // 2)
+    parser.add_argument(
+        "--conversion_manifest_path",
+        type=Path,
+        help="Write one record per attempted ROSBAG conversion as JSON.",
+    )
     return parser.parse_args()
 
 
@@ -83,7 +89,7 @@ def process_single_bag(args_tuple):
             f"Unexpected bag path layout for {bag_path}: expected "
             f"<proj_id>/<map_id>/<split>/<date>/<time>. Skipping."
         )
-        return f"Skipped (unexpected layout): {bag_path}"
+        return {"status": "skipped", "bag_path": str(bag_path), "reason": "unexpected_layout"}
 
     # split が train/valid/auto のいずれでもない場合 (例: psim) は manual にフォールバック
     mode = SPLIT_TO_MODE.get(split, "manual")
@@ -99,7 +105,12 @@ def process_single_bag(args_tuple):
 
     if save_dir.is_dir():
         logging.info(f"Already exists: {save_dir}")
-        return f"Skipped (already exists): {save_dir}"
+        return {
+            "status": "skipped",
+            "mode": mode,
+            "bag_path": str(bag_path),
+            "output_dir": str(save_dir),
+        }
 
     save_dir.mkdir(parents=True, exist_ok=True)
 
@@ -131,7 +142,7 @@ def process_single_bag(args_tuple):
     except Exception as e:
         error_msg = f"Error processing {bag_path}: {str(e)}"
         logging.error(error_msg)
-        return error_msg
+        return {"status": "failed", "mode": mode, "bag_path": str(bag_path), "error": str(e)}
 
     # The C++ converter writes the per-frame npz/json directly under save_dir but
     # emits the per-sequence route json into a nested "routes" subdir. Flatten it
@@ -147,9 +158,15 @@ def process_single_bag(args_tuple):
     except Exception as e:
         error_msg = f"Error flattening routes for {save_dir}: {str(e)}"
         logging.error(error_msg)
-        return error_msg
+        return {"status": "failed", "mode": mode, "bag_path": str(bag_path), "error": str(e)}
 
     logging.info(f"Completed: {save_dir}")
+    return {
+        "status": "converted",
+        "mode": mode,
+        "bag_path": str(bag_path),
+        "output_dir": str(save_dir),
+    }
 
 
 if __name__ == "__main__":
@@ -233,6 +250,35 @@ if __name__ == "__main__":
     # Process bags in parallel
     with Pool(processes=num_workers) as pool:
         results = pool.map(process_single_bag, process_args)
+
+    if args.conversion_manifest_path is not None:
+        manifest_path = args.conversion_manifest_path.resolve()
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(
+            json.dumps(
+                {
+                    "records": results,
+                    "converted_count": sum(
+                        result.get("status") == "converted"
+                        for result in results
+                        if isinstance(result, dict)
+                    ),
+                    "skipped_count": sum(
+                        result.get("status") == "skipped"
+                        for result in results
+                        if isinstance(result, dict)
+                    ),
+                    "failed_count": sum(
+                        result.get("status") == "failed"
+                        for result in results
+                        if isinstance(result, dict)
+                    ),
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
 
     elapsed_seconds = int(time.perf_counter() - start_time)
     hours = elapsed_seconds // 3600

--- a/ros_scripts/parse_rosbag_for_directory.py
+++ b/ros_scripts/parse_rosbag_for_directory.py
@@ -138,6 +138,7 @@ def process_single_bag(args_tuple):
             offlane_max_score=offlane_max_score,
             offlane_time_stride=offlane_time_stride,
             write_skipped_npz=write_skipped_npz,
+            extract_override_segments=(mode == "auto"),
         )
     except Exception as e:
         error_msg = f"Error processing {bag_path}: {str(e)}"

--- a/ros_scripts/parse_rosbag_for_directory_with_map_version.py
+++ b/ros_scripts/parse_rosbag_for_directory_with_map_version.py
@@ -172,6 +172,7 @@ def process_single_bag(args_tuple):
             offlane_max_score=offlane_max_score,
             offlane_time_stride=offlane_time_stride,
             write_skipped_npz=write_skipped_npz,
+            extract_override_segments=(mode == "auto"),
         )
         # Flatten the nested routes/ subdir emitted by the C++ converter so
         # save_dir does not end up with a redundant routes/routes level.

--- a/ros_scripts/parse_rosbag_for_directory_with_map_version.py
+++ b/ros_scripts/parse_rosbag_for_directory_with_map_version.py
@@ -39,6 +39,11 @@ def parse_args():
     parser.add_argument("--offlane_time_stride", type=int, default=1)
     parser.add_argument("--write_skipped_npz", type=int, default=1)
     parser.add_argument("--num_workers", type=int, default=os.cpu_count() // 2)
+    parser.add_argument(
+        "--conversion_manifest_path",
+        type=Path,
+        help="Write one record per attempted ROSBAG conversion as JSON.",
+    )
     return parser.parse_args()
 
 
@@ -130,17 +135,20 @@ def process_single_bag(args_tuple):
     # train/valid are human-driven -> manual, auto stays auto
     mode = "auto" if train_or_val == "auto" else "manual"
 
-    vector_map_path = _resolve_vector_map_path(bag_path)
-
     save_dir = (save_root / project_name / map_name / mode / date / time).resolve()
 
     if save_dir.is_dir():
         logging.info(f"Already exists: {save_dir}")
-        return f"Skipped (already exists): {save_dir}"
-
-    save_dir.mkdir(parents=True, exist_ok=True)
+        return {
+            "status": "skipped",
+            "mode": mode,
+            "bag_path": str(bag_path),
+            "output_dir": str(save_dir),
+        }
 
     try:
+        vector_map_path = _resolve_vector_map_path(bag_path)
+        save_dir.mkdir(parents=True, exist_ok=True)
         parse_rosbag_main_cpp(
             cpp_binary_path,
             rosbag_path=bag_path,
@@ -173,9 +181,16 @@ def process_single_bag(args_tuple):
                 shutil.move(str(entry), str(save_dir / entry.name))
             nested_routes.rmdir()
         logging.info(f"Completed: {save_dir}")
+        return {
+            "status": "converted",
+            "mode": mode,
+            "bag_path": str(bag_path),
+            "output_dir": str(save_dir),
+        }
     except Exception as e:
         error_msg = f"Error processing {bag_path}: {str(e)}"
         logging.error(error_msg)
+        return {"status": "failed", "mode": mode, "bag_path": str(bag_path), "error": str(e)}
 
 
 if __name__ == "__main__":
@@ -254,7 +269,36 @@ if __name__ == "__main__":
         )
 
     with Pool(processes=num_workers) as pool:
-        pool.map(process_single_bag, process_args)
+        results = pool.map(process_single_bag, process_args)
+
+    if args.conversion_manifest_path is not None:
+        manifest_path = args.conversion_manifest_path.resolve()
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(
+            json.dumps(
+                {
+                    "records": results,
+                    "converted_count": sum(
+                        result.get("status") == "converted"
+                        for result in results
+                        if isinstance(result, dict)
+                    ),
+                    "skipped_count": sum(
+                        result.get("status") == "skipped"
+                        for result in results
+                        if isinstance(result, dict)
+                    ),
+                    "failed_count": sum(
+                        result.get("status") == "failed"
+                        for result in results
+                        if isinstance(result, dict)
+                    ),
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
 
     elapsed_seconds = int(time.perf_counter() - start_time)
     hours = elapsed_seconds // 3600

--- a/ros_scripts/parse_rosbag_for_directory_with_map_version.py
+++ b/ros_scripts/parse_rosbag_for_directory_with_map_version.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import shutil
+import sys
 import time
 from multiprocessing import Pool, cpu_count
 from pathlib import Path
@@ -272,6 +273,24 @@ if __name__ == "__main__":
     with Pool(processes=num_workers) as pool:
         results = pool.map(process_single_bag, process_args)
 
+    converted_count = sum(
+        result.get("status") == "converted"
+        for result in results
+        if isinstance(result, dict)
+    )
+    skipped_count = sum(
+        result.get("status") == "skipped" for result in results if isinstance(result, dict)
+    )
+    failed_count = sum(
+        result.get("status") == "failed" for result in results if isinstance(result, dict)
+    )
+    logging.info(
+        "Conversion summary: converted=%d, skipped=%d, failed=%d",
+        converted_count,
+        skipped_count,
+        failed_count,
+    )
+
     if args.conversion_manifest_path is not None:
         manifest_path = args.conversion_manifest_path.resolve()
         manifest_path.parent.mkdir(parents=True, exist_ok=True)
@@ -279,21 +298,9 @@ if __name__ == "__main__":
             json.dumps(
                 {
                     "records": results,
-                    "converted_count": sum(
-                        result.get("status") == "converted"
-                        for result in results
-                        if isinstance(result, dict)
-                    ),
-                    "skipped_count": sum(
-                        result.get("status") == "skipped"
-                        for result in results
-                        if isinstance(result, dict)
-                    ),
-                    "failed_count": sum(
-                        result.get("status") == "failed"
-                        for result in results
-                        if isinstance(result, dict)
-                    ),
+                    "converted_count": converted_count,
+                    "skipped_count": skipped_count,
+                    "failed_count": failed_count,
                 },
                 indent=2,
             )
@@ -310,3 +317,7 @@ if __name__ == "__main__":
 
     with open(save_root / "processing_time.txt", "w") as summary_file:
         summary_file.write(f"Total elapsed time: {time_str}\n")
+
+    if converted_count == 0 and failed_count > 0:
+        logging.error("No bags were converted successfully.")
+        sys.exit(1)

--- a/ros_scripts/parse_rosbag_for_directory_with_map_version.py
+++ b/ros_scripts/parse_rosbag_for_directory_with_map_version.py
@@ -5,10 +5,12 @@ import os
 import shutil
 import sys
 import time
+from collections import Counter
 from multiprocessing import Pool, cpu_count
 from pathlib import Path
 
 from parse_rosbag_by_cpp import main as parse_rosbag_main_cpp
+from parse_rosbag_by_cpp import write_conversion_manifest
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_CPP_BINARY = (
@@ -288,17 +290,10 @@ if __name__ == "__main__":
     with Pool(processes=num_workers) as pool:
         results = pool.map(process_single_bag, process_args)
 
-    converted_count = sum(
-        result.get("status") == "converted"
-        for result in results
-        if isinstance(result, dict)
-    )
-    skipped_count = sum(
-        result.get("status") == "skipped" for result in results if isinstance(result, dict)
-    )
-    failed_count = sum(
-        result.get("status") == "failed" for result in results if isinstance(result, dict)
-    )
+    status_counts = Counter(result["status"] for result in results)
+    converted_count = status_counts["converted"]
+    skipped_count = status_counts["skipped"]
+    failed_count = status_counts["failed"]
     logging.info(
         "Conversion summary: converted=%d, skipped=%d, failed=%d",
         converted_count,
@@ -307,20 +302,12 @@ if __name__ == "__main__":
     )
 
     if args.conversion_manifest_path is not None:
-        manifest_path = args.conversion_manifest_path.resolve()
-        manifest_path.parent.mkdir(parents=True, exist_ok=True)
-        manifest_path.write_text(
-            json.dumps(
-                {
-                    "records": results,
-                    "converted_count": converted_count,
-                    "skipped_count": skipped_count,
-                    "failed_count": failed_count,
-                },
-                indent=2,
-            )
-            + "\n",
-            encoding="utf-8",
+        write_conversion_manifest(
+            args.conversion_manifest_path,
+            results,
+            converted_count,
+            skipped_count,
+            failed_count,
         )
 
     elapsed_seconds = int(time.perf_counter() - start_time)

--- a/ros_scripts/parse_rosbag_for_directory_with_map_version.py
+++ b/ros_scripts/parse_rosbag_for_directory_with_map_version.py
@@ -138,11 +138,16 @@ def process_single_bag(args_tuple):
 
     save_dir = (save_root / project_name / map_name / mode / date / time).resolve()
 
-    if save_dir.is_dir():
+    has_npz = save_dir.is_dir() and any(save_dir.rglob("*.npz"))
+    has_override_json = mode != "auto" or (
+        save_dir / "control_mode_4_intervals.json"
+    ).is_file()
+    if has_npz and has_override_json:
         logging.info(f"Already exists: {save_dir}")
         return {
             "status": "skipped",
             "mode": mode,
+            "reason": "already_exists",
             "bag_path": str(bag_path),
             "output_dir": str(save_dir),
         }

--- a/ros_scripts/parse_rosbag_for_directory_with_map_version.py
+++ b/ros_scripts/parse_rosbag_for_directory_with_map_version.py
@@ -150,6 +150,7 @@ def process_single_bag(args_tuple):
             "reason": "already_exists",
             "bag_path": str(bag_path),
             "output_dir": str(save_dir),
+            "error": None,
         }
 
     try:
@@ -193,11 +194,20 @@ def process_single_bag(args_tuple):
             "mode": mode,
             "bag_path": str(bag_path),
             "output_dir": str(save_dir),
+            "reason": None,
+            "error": None,
         }
     except Exception as e:
         error_msg = f"Error processing {bag_path}: {str(e)}"
         logging.error(error_msg)
-        return {"status": "failed", "mode": mode, "bag_path": str(bag_path), "error": str(e)}
+        return {
+            "status": "failed",
+            "mode": mode,
+            "bag_path": str(bag_path),
+            "output_dir": str(save_dir),
+            "reason": "conversion_failed",
+            "error": str(e),
+        }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request introduces enhancements to both the C++ and Python components for processing ROSBAG data, focusing on better handling and reporting of control mode information and conversion outcomes. The main highlights are the addition of control mode extraction and override segment detection for "auto" bags in the C++ pipeline, and improved manifest reporting for batch conversion scripts in Python.

**C++: Control Mode Extraction and Override Segment Handling**

* **Control mode extraction and override segment detection:**
  - Added a `ControlModeSample` struct and logic to extract `/vehicle/status/control_mode` messages from rosbags when processing "dp:auto" bags. These are used to build and save intervals (override segments) where the control mode is 4, outputting them as a JSON file (`control_mode_4_intervals.json`) in the output directory. 

**Python: Conversion Manifest Reporting**

* **Structured conversion manifest output:**
  - The batch conversion scripts (`parse_rosbag_for_directory.py` and `parse_rosbag_for_directory_with_map_version.py`) now accept a `--conversion_manifest_path` argument. They write a JSON manifest summarizing each bag's conversion status (converted/skipped/failed), with details such as mode, paths, and error messages when applicable. Aggregate counts for each outcome type are also included. This feature is neccesary to exctract override scenes only for rosbags which are added newly. 

**Other Improvements**

* Added utility functions for directory detection and override segment building in the C++ converter, and improved error handling and logging in Python scripts. 

These changes improve traceability of batch conversions and enable downstream use of control mode intervals for "auto" datasets.