### PR TITLE
feat(closed_loop): run sites_npz_root validation once per training run

### DIFF
--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -147,18 +147,18 @@ def closed_loop_validate(
     per (site, object-mode) pair: ``closed_loop_npz_root`` (single arbitrary path) and
     ``closed_loop_sites_npz_root`` (a curated ``.json`` path-list manifest grouped into
     per-site route pools by
-    :func:`~scenario_generation.site_discovery.discover_sites_from_json`) are independent — both
-    fire in the same call when both are set, each contributing its own rows to the combined
-    episode table / cross-site aggregate. Called on the checkpoint-save cadence, rank-0 only:
-    pass the unwrapped model; it is switched to eval for the rollout (so the diffusion sampler
-    runs and produces ``prediction``) and restored afterwards.
+    :func:`~scenario_generation.site_discovery.discover_sites_from_json`) fire independently.
+    Called on the checkpoint-save cadence, rank-0 only: pass the unwrapped model; it is switched
+    to eval for the rollout (so the diffusion sampler runs and produces ``prediction``) and
+    restored afterwards.
 
-    Per-step matplotlib rendering (PNGs/video/colormap images) is the dominant per-call cost, so
-    it's deferred to the last call only (``is_final_save=True``, computed by the caller as "is
-    this the last time the checkpoint-save cadence fires in this run" -- NOT simply
-    ``epoch == train_epochs - 1``, since train_epochs may not land on a save_utd-multiple)
-    -- every other call still runs the full rollout and logs metrics/wandb scalars, just without
-    that cost.
+    ``is_final_save=True`` marks the last cadence call of the run (computed by the caller, since
+    train_epochs may not land on a save_utd-multiple).
+
+    * ``closed_loop_npz_root`` runs every cadence call; only its video/colormap rendering is
+      deferred to ``is_final_save``.
+    * ``closed_loop_sites_npz_root`` only runs at all on ``is_final_save`` -- it covers many more
+      sites/routes and is too expensive to run every cadence call.
     """
     if not args.closed_loop_npz_root and not args.closed_loop_sites_npz_root:
         return
@@ -174,13 +174,20 @@ def closed_loop_validate(
         build_combined_episode_table,
         build_full_closed_loop_wandb_log,
         build_sites_aggregate_log,
+        build_sites_score_bar_charts,
     )
 
     net = ddp.get_model(model, args.ddp)
     was_training = net.training
     net.eval()
 
-    def run_one(npz_root, site_out_dir: str, site_name: str | None, drop_objects: bool = False):
+    def run_one(
+        npz_root,
+        site_out_dir: str,
+        site_name: str | None,
+        drop_objects: bool = False,
+        is_site: bool = False,
+    ):
         site_label = f" [{site_name}]" if site_name else ""
         evaluator = FullRouteClosedLoopEvaluation(
             net,
@@ -221,6 +228,8 @@ def closed_loop_validate(
             near_miss_thresh=args.closed_loop_near_miss_thresh,
             report_base_url=args.closed_loop_report_base_url or None,
             render_media=is_final_save,
+            # Sites only run once per run now; the bar chart covers them instead.
+            include_score_scalars=not is_site,
         )
         print(
             f"closed-loop{site_label} @epoch {epoch + 1}: {summary['n_segments']} seg in "
@@ -243,6 +252,7 @@ def closed_loop_validate(
         mode_pairs: tuple[tuple[str, bool], ...],
         *,
         track_for_report: bool = False,
+        is_site: bool = False,
     ) -> None:
         """Run ``npz_root`` once per requested object-mode, merging into log/site_summaries/episode_data.
 
@@ -260,7 +270,9 @@ def closed_loop_validate(
             else:
                 label = base_name
             site_out_dir = os.path.join(out_dir, label) if label else out_dir
-            site_log, summary = run_one(npz_root, site_out_dir, label, drop_objects=drop_objects)
+            site_log, summary = run_one(
+                npz_root, site_out_dir, label, drop_objects=drop_objects, is_site=is_site
+            )
             if not summary:
                 continue
             episode_label = label or "main"
@@ -275,13 +287,15 @@ def closed_loop_validate(
             npz_modes = _object_mode_pairs(args.closed_loop_npz_object_modes)
             run_labeled(None, args.closed_loop_npz_root, npz_modes)
 
-        if args.closed_loop_sites_npz_root:
+        if args.closed_loop_sites_npz_root and is_final_save:
             sites = discover_sites_from_json(args.closed_loop_sites_npz_root)
             if not sites:
                 print(f"closed-loop: no sites found under {args.closed_loop_sites_npz_root}")
             sites_modes = _object_mode_pairs(args.closed_loop_sites_object_modes)
             for site_name, npz_root in sites.items():
-                run_labeled(site_name, npz_root, sites_modes, track_for_report=True)
+                run_labeled(
+                    site_name, npz_root, sites_modes, track_for_report=True, is_site=True
+                )
 
         # One combined, filterable/groupable episode table across every source/site/mode.
         if episode_data:
@@ -289,9 +303,10 @@ def closed_loop_validate(
         # Cross-source/site pooled rollup under closed_loop_overview/*.
         if len(site_summaries) > 1:
             log.update(build_sites_aggregate_log(site_summaries))
-        # Local HTML gallery, sites only (see site_report_labels above) -- only built on
-        # is_final_save, same as the media (videos/colormap images) it links to.
+        # Sites only (see site_report_labels above), only non-empty on is_final_save.
         if is_final_save and site_report_labels:
+            site_summaries_only = {label: site_summaries[label] for label in site_report_labels}
+            log.update(build_sites_score_bar_charts(site_summaries_only))
             report_path = build_html_report(out_dir, site_report_labels)
             if report_path:
                 print(f"closed-loop: wrote {report_path}")

--- a/diffusion_planner/tests/test_closed_loop_validate_cadence.py
+++ b/diffusion_planner/tests/test_closed_loop_validate_cadence.py
@@ -1,0 +1,148 @@
+"""Tests for closed-loop validation cadence in train.closed_loop_validate."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import diffusion_planner.train as train_module
+import pytest
+import scenario_generation.closed_loop_evaluation as closed_loop_evaluation
+import scenario_generation.closed_loop_html_report as closed_loop_html_report
+import scenario_generation.site_discovery as site_discovery
+import scenario_generation.wandb_closed_loop as wandb_closed_loop
+from diffusion_planner.train import closed_loop_validate
+
+
+def _make_args(**overrides):
+    """Minimal args namespace covering every closed_loop_* field the function reads."""
+    defaults = dict(
+        closed_loop_npz_root="single/route",
+        closed_loop_sites_npz_root="sites_manifest.json",
+        closed_loop_npz_object_modes=["objects"],
+        closed_loop_sites_object_modes=["objects"],
+        closed_loop_near_miss_thresh=0.5,
+        closed_loop_search_radius=1.5,
+        closed_loop_warmup_steps=0,
+        closed_loop_unstick_after=300,
+        closed_loop_unstick_advance_m=5.0,
+        closed_loop_unstick_radius_mult=10.0,
+        closed_loop_unstick_teleport_after=300,
+        closed_loop_draw_every=4,
+        closed_loop_replan_interval=4,
+        closed_loop_abort_deviation_m=50.0,
+        closed_loop_abort_after=30,
+        closed_loop_abort_max_snaps=0,
+        closed_loop_fps=10,
+        closed_loop_seg_len=100000,
+        closed_loop_wandb_video_pick="worst",
+        closed_loop_colormap_metrics=[],
+        closed_loop_report_base_url="",
+        device="cpu",
+        ddp=False,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+class _FakeEvaluator:
+    """Stand-in for FullRouteClosedLoopEvaluation; records the npz_root it was run on."""
+
+    calls: list = []
+
+    def __init__(self, net, args, cfg, npz_root, seg_len):
+        self.npz_root = npz_root
+
+    def run(self):
+        _FakeEvaluator.calls.append(self.npz_root)
+        return {
+            "n_segments": 1,
+            "elapsed_sec": 0.1,
+            "video_mp4s": [],
+            "segments": [],
+            "mean_route_completion": 1.0,
+        }
+
+
+def _fake_discover_sites(_path):
+    return {"site_a": "sites/site_a", "site_b": "sites/site_b"}
+
+
+wandb_log_calls: list = []
+
+
+def _fake_build_full_closed_loop_wandb_log(_summary, *, site=None, include_score_scalars=True, **_kw):
+    wandb_log_calls.append((site, include_score_scalars))
+    return {}
+
+
+@pytest.fixture(autouse=True)
+def _patched_dependencies(monkeypatch):
+    """Replace the heavy scenario_generation calls with recording fakes."""
+    _FakeEvaluator.calls = []
+    wandb_log_calls.clear()
+    monkeypatch.setattr(
+        closed_loop_evaluation, "FullRouteClosedLoopEvaluation", _FakeEvaluator
+    )
+    monkeypatch.setattr(site_discovery, "discover_sites_from_json", _fake_discover_sites)
+    monkeypatch.setattr(
+        wandb_closed_loop,
+        "build_full_closed_loop_wandb_log",
+        _fake_build_full_closed_loop_wandb_log,
+    )
+    monkeypatch.setattr(
+        wandb_closed_loop, "build_combined_episode_table", lambda *a, **k: None
+    )
+    monkeypatch.setattr(wandb_closed_loop, "build_sites_aggregate_log", lambda *a, **k: {})
+    monkeypatch.setattr(wandb_closed_loop, "build_sites_score_bar_charts", lambda *a, **k: {})
+    monkeypatch.setattr(closed_loop_html_report, "build_html_report", lambda *a, **k: None)
+    monkeypatch.setattr(train_module.wandb, "log", lambda *a, **k: None)
+    return _FakeEvaluator.calls
+
+
+def _fake_model():
+    model = MagicMock()
+    model.training = False
+    return model
+
+
+def test_sites_npz_root_skipped_on_non_final_save(_patched_dependencies, tmp_path):
+    """closed_loop_sites_npz_root must not run at all on a non-final cadence call."""
+    closed_loop_validate(
+        _fake_model(), _make_args(), epoch=0, out_dir=str(tmp_path), is_final_save=False
+    )
+
+    assert _patched_dependencies == ["single/route"]
+
+
+def test_sites_npz_root_runs_on_final_save(_patched_dependencies, tmp_path):
+    """closed_loop_sites_npz_root runs every discovered site once is_final_save fires."""
+    closed_loop_validate(
+        _fake_model(), _make_args(), epoch=0, out_dir=str(tmp_path), is_final_save=True
+    )
+
+    assert _patched_dependencies == ["single/route", "sites/site_a", "sites/site_b"]
+
+
+def test_closed_loop_npz_root_runs_regardless_of_is_final_save(_patched_dependencies, tmp_path):
+    """closed_loop_npz_root (not sites) is unaffected by is_final_save -- always fires."""
+    for is_final_save in (False, True):
+        _patched_dependencies.clear()
+        closed_loop_validate(
+            _fake_model(),
+            _make_args(),
+            epoch=0,
+            out_dir=str(tmp_path),
+            is_final_save=is_final_save,
+        )
+        assert "single/route" in _patched_dependencies
+
+
+def test_only_sites_skip_the_per_epoch_score_scalars(_patched_dependencies, tmp_path):
+    """main keeps its per-epoch score scalars; sites opt out (bar chart covers them instead)."""
+    closed_loop_validate(
+        _fake_model(), _make_args(), epoch=0, out_dir=str(tmp_path), is_final_save=True
+    )
+
+    calls = dict(wandb_log_calls)
+    assert calls[None] is True  # closed_loop_npz_root ("main") keeps its scalar trend
+    assert calls["site_a"] is False
+    assert calls["site_b"] is False

--- a/diffusion_planner/train_grpo_predictor.py
+++ b/diffusion_planner/train_grpo_predictor.py
@@ -336,7 +336,7 @@ def get_args():
         help="alternative/addition to --closed_loop_npz_root: a curated .json path-list manifest, "
         "grouped into per-site route pools by site_discovery.discover_sites_from_json and evaluated "
         "as independent sites (own npz_root each). Both may be set at once (each fires "
-        "independently).",
+        "independently). Only runs on the final save_utd cadence call of the run.",
     )
     parser.add_argument(
         "--closed_loop_npz_object_modes",

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -249,7 +249,7 @@ def get_args(args_list=None):
         help="alternative/addition to --closed_loop_npz_root: a curated .json path-list manifest, "
         "grouped into per-site route pools by site_discovery.discover_sites_from_json and evaluated "
         "as independent sites (own npz_root each). Both may be set at once (each fires "
-        "independently).",
+        "independently). Only runs on the final save_utd cadence call of the run.",
     )
     parser.add_argument(
         "--closed_loop_npz_object_modes",

--- a/scenario_generation/tests/test_wandb_closed_loop.py
+++ b/scenario_generation/tests/test_wandb_closed_loop.py
@@ -1,0 +1,84 @@
+"""Unit tests for wandb_closed_loop's per-site bar-chart builder."""
+
+from __future__ import annotations
+
+from scenario_generation.wandb_closed_loop import (
+    build_full_closed_loop_wandb_log,
+    build_sites_score_bar_charts,
+)
+
+
+def _summary(collisions=0, curb_hits=0, snaps=0, red_light=0, strong_brake=0, completion=1.0):
+    return {
+        "mean_route_completion": completion,
+        "object": {"collision_count": collisions},
+        "road_border": {"collision_count": curb_hits},
+        "reproducer": {"snap_count": snaps},
+        "red_light_violation": {"count": red_light},
+        "strong_brake": {"count": strong_brake},
+    }
+
+
+def test_build_sites_score_bar_charts_one_chart_per_metric_with_all_sites():
+    """Every SCORE_KEY gets its own chart; each chart has one bar per site."""
+    summaries = {
+        "site_a": _summary(collisions=2, curb_hits=1),
+        "site_b": _summary(collisions=0, curb_hits=3),
+    }
+
+    log = build_sites_score_bar_charts(summaries)
+
+    assert set(log.keys()) == {
+        "closed_loop_scores_bar/mean_route_completion",
+        "closed_loop_scores_bar/total_curb_hits",
+        "closed_loop_scores_bar/total_snaps",
+        "closed_loop_scores_bar/total_red_light_violations",
+        "closed_loop_scores_bar/total_strong_brakes",
+        "closed_loop_scores_bar/total_collision_events",
+    }
+    curb_hits_rows = log["closed_loop_scores_bar/total_curb_hits"].table.data
+    assert dict(curb_hits_rows) == {"site_a": 1, "site_b": 3}
+    collision_rows = log["closed_loop_scores_bar/total_collision_events"].table.data
+    assert dict(collision_rows) == {"site_a": 2, "site_b": 0}
+
+
+def test_build_sites_score_bar_charts_excludes_noobj_from_collision_events():
+    """The empty-world ablation (__noobj) is always a meaningless 0 for collision events."""
+    summaries = {
+        "site_a": _summary(collisions=2),
+        "site_a__noobj": _summary(collisions=0),
+    }
+
+    log = build_sites_score_bar_charts(summaries)
+
+    collision_rows = dict(log["closed_loop_scores_bar/total_collision_events"].table.data)
+    assert collision_rows == {"site_a": 2}
+    # Comparison keys (not objects-only) still include the noobj label.
+    completion_rows = dict(log["closed_loop_scores_bar/mean_route_completion"].table.data)
+    assert set(completion_rows) == {"site_a", "site_a__noobj"}
+
+
+def test_build_sites_score_bar_charts_empty_summaries_returns_empty_log():
+    assert build_sites_score_bar_charts({}) == {}
+
+
+def test_include_score_scalars_false_omits_per_site_score_keys():
+    """Sites that only run once per training run skip the (now single-point) scalar trend."""
+    log = build_full_closed_loop_wandb_log(
+        _summary(collisions=1, curb_hits=2),
+        site="site_a",
+        render_media=False,
+        include_score_scalars=False,
+    )
+
+    assert not any(key.startswith("closed_loop_scores/") for key in log)
+
+
+def test_include_score_scalars_true_by_default_keeps_per_site_score_keys():
+    """main (closed_loop_npz_root) still runs every cadence call -- its trend stays intact."""
+    log = build_full_closed_loop_wandb_log(
+        _summary(collisions=1, curb_hits=2), site="main", render_media=False
+    )
+
+    assert log["closed_loop_scores/total_collision_events/main"] == 1
+    assert log["closed_loop_scores/total_curb_hits/main"] == 2

--- a/scenario_generation/wandb_closed_loop.py
+++ b/scenario_generation/wandb_closed_loop.py
@@ -9,7 +9,9 @@ import wandb
 
 from scenario_generation.closed_loop_score_keys import (
     COMPARISON_OVERVIEW_SUM_KEYS,
+    COMPARISON_SCORE_KEYS,
     OBJECTS_ONLY_OVERVIEW_SUM_KEYS,
+    OBJECTS_ONLY_SCORE_KEYS,
     SCORE_KEYS,
     extract_score,
 )
@@ -179,6 +181,35 @@ def build_sites_aggregate_log(summaries: dict[str, dict]) -> dict:
     return {k: v for k, v in log.items() if _wandb_scalar(v) or isinstance(v, int)}
 
 
+def build_sites_score_bar_charts(summaries: dict[str, dict]) -> dict:
+    """Per-metric bar chart comparing every site side-by-side, under ``closed_loop_scores_bar/``.
+
+    Sites now only run once per training run, so a per-site score line chart would just be one
+    isolated point; a bar chart across sites fits a one-shot comparison better. ``summaries`` is
+    keyed by site label, sites only (not the ``closed_loop_npz_root`` "main" entry).
+    """
+    log: dict = {}
+    if not summaries:
+        return log
+
+    def _bar(key: str, labels: list[str]) -> None:
+        table = wandb.Table(columns=["site", key])
+        for label in labels:
+            val = extract_score(summaries[label], key)
+            if _wandb_scalar(val):
+                table.add_data(label, val)
+        if table.data:
+            log[f"closed_loop_scores_bar/{key}"] = wandb.plot.bar(table, "site", key, title=key)
+
+    all_labels = list(summaries.keys())
+    objects_labels = [label for label in all_labels if not _is_noobj_label(label)]
+    for key in COMPARISON_SCORE_KEYS:
+        _bar(key, all_labels)
+    for key in OBJECTS_ONLY_SCORE_KEYS:
+        _bar(key, objects_labels)
+    return log
+
+
 def _site_label(site: str | None) -> str:
     """W&B-key-safe site token; ``None`` (single-npz_root mode) -> ``"main"``."""
     return (site or "main").replace("/", "_")
@@ -194,6 +225,7 @@ def build_full_closed_loop_wandb_log(
     near_miss_thresh: float = 0.5,
     report_base_url: str | None = None,
     render_media: bool = True,
+    include_score_scalars: bool = True,
 ) -> dict:
     """Per-site full-route closed-loop wandb payload, keyed into role-based sections so the
     workspace stays navigable (one collapsible section each) instead of one flat ``closed_loop``
@@ -210,15 +242,20 @@ def build_full_closed_loop_wandb_log(
     unaffected) -- for a caller that already skipped rendering (e.g. train.py's RolloutParams
     ``draw=False`` on most epochs), so there's no colormap image to render from anyway.
 
+    ``include_score_scalars=False`` skips the ``closed_loop_scores/{metric}/{site}`` block --
+    for a site that only runs once per run, where :func:`build_sites_score_bar_charts` is the
+    better fit instead.
+
     The per-episode table is built once across ALL sites by :func:`build_combined_episode_table`
     at the caller (so it's a single filterable/groupable panel), not here.
     """
     label = _site_label(site)
     log: dict = {}
-    for key in SCORE_KEYS:
-        val = extract_score(summary, key)
-        if _wandb_scalar(val):
-            log[f"closed_loop_scores/{key}/{label}"] = val
+    if include_score_scalars:
+        for key in SCORE_KEYS:
+            val = extract_score(summary, key)
+            if _wandb_scalar(val):
+                log[f"closed_loop_scores/{key}/{label}"] = val
 
     rows = summary.get("segments") or []
     rep = pick_representative_row(rows, mode=video_pick)


### PR DESCRIPTION
# Summary
  - closed_loop_sites_npz_root validation used to run in full on every save_utd cadence call; now it only runs on is_final_save
  (closed_loop_npz_root is unaffected, still runs every call)
  - Since sites now validate only once per run, per-site score line charts would show a single isolated point. Replaced with a
  closed_loop_scores_bar/* chart comparing all sites side-by-side

 # Test 

  - [x] Added diffusion_planner/tests/test_closed_loop_validate_cadence.py
  - [x] Added scenario_generation/tests/test_wandb_closed_loop.py
  - [x] Verified locally on GPU (resume + 1 epoch) that the bar chart renders correctly in wandb