### PR TITLE
feat(closed-loop viz): show reproducer ego on per-step PNGs and video

### DIFF
--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -1510,11 +1510,15 @@ def save_step_figure(
     road_border_polylines: list[np.ndarray] | None = None,
     metrics: dict | None = None,
     extra_ego_trajectories: list[tuple[np.ndarray, str, str]] | None = None,
+    reproducer_ego: tuple[float, float, float] | None = None,
 ) -> None:
     """Render + save the overview PNG for a single replay step.
 
     Viewport is fixed to ``±view_half_m`` metres around the ego, so lane
     borders stay visible and NPC detail remains readable at every step.
+
+    ``reproducer_ego``: optional ``(x, y, heading)`` in the live-ego frame for the
+    recorded cursor ego, drawn as a hollow outline in ``_EGO_COLOR``.
     """
     from matplotlib.figure import Figure
 
@@ -1688,6 +1692,36 @@ def save_step_figure(
                 width=agent.width,
                 wheelbase=agent.wheelbase if is_ego else None,
             )
+
+    # 3a) Hollow reproducer ego (recorded cursor pose in the live-ego frame).
+    # Same color as live ego, outline-only, so divergence from the closed-loop ego is visible.
+    if reproducer_ego is not None:
+        rx, ry, rh = float(reproducer_ego[0]), float(reproducer_ego[1]), float(reproducer_ego[2])
+        draw_agent_box(
+            ax,
+            rx,
+            ry,
+            rh,
+            ego.length,
+            ego.width,
+            _EGO_COLOR,
+            alpha=0.9,
+            lw=2.0,
+            zorder=23,
+            wheelbase=ego.wheelbase,
+            filled=False,
+        )
+        ax.annotate(
+            "reproducer",
+            (rx, ry),
+            fontsize=6,
+            color=_EGO_COLOR,
+            ha="center",
+            va="top",
+            xytext=(0, -8),
+            textcoords="offset points",
+            zorder=24,
+        )
 
     # 3b) Extra ego-frame trajectories (e.g. GT vs model output side by side).
     # Each entry: (traj[T, >=4] with x, y, cos, sin in the CURRENT ego frame,

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -1322,6 +1322,7 @@ def _draw_step(
     distance_label_offset_m: float = 1.2,
     view_half_m: float = 50.0,
     extra_ego_trajectories: list[tuple[np.ndarray, str, str]] | None = None,
+    reproducer_ego: tuple[float, float, float] | None = None,
 ):
     """Save a PNG of one reproducer step with the EXACT perfect-tracker sim renderer.
 
@@ -1335,6 +1336,9 @@ def _draw_step(
     ``neighbor_ids``: per-slot track UUIDs from the sidecar. When given, neighbor
     agents are renamed to their UUID so the sim's own ``_stable_color`` keeps one
     color per track across frames (vs the flickering distance-sorted slot colors).
+
+    ``reproducer_ego``: optional ``(x, y, heading)`` of the recorded cursor ego in
+    the live-ego frame, drawn as a hollow outline matching the live ego color.
     """
     from pathlib import Path
 
@@ -1370,6 +1374,7 @@ def _draw_step(
         route_polylines=_polylines_from_tensor(data["route_lanes"]),
         road_border_polylines=_polylines_from_tensor(data["line_strings"], border_only=True),
         extra_ego_trajectories=extra_ego_trajectories,
+        reproducer_ego=reproducer_ego,
     )
 
 
@@ -1706,6 +1711,7 @@ def render_segment(
             and (window is None or (window[0] <= k <= window[1]))
             and k % draw_every == 0
         ):
+            repro_xyh = _world_pose_to_ego(tl.poses[idx], s.live_pose)
             _draw_step(
                 np_dict,
                 pred_cur,
@@ -1717,6 +1723,7 @@ def render_segment(
                 title_prefix=title_prefix,
                 distance_label_offset_m=distance_label_offset_m,
                 view_half_m=view_half_m,
+                reproducer_ego=repro_xyh,
             )
         snaps_before = s.snap_count
         _advance_step(s, pred_cur, idx, device, timers, override=override)

--- a/scenario_generation/visualize.py
+++ b/scenario_generation/visualize.py
@@ -147,12 +147,16 @@ def draw_agent_box(
     lw=1.5,
     zorder=10,
     wheelbase: float | None = None,
+    filled: bool = True,
 ):
     """Draw an oriented bounding box for an agent.
 
     When ``wheelbase`` is provided, (x, y) is treated as rear-axle midpoint
     (ego convention). When None, (x, y) is the bbox centroid (neighbor
     convention from the perception pipeline).
+
+    ``filled=False`` draws an outline-only (hollow) box: face is transparent,
+    ``alpha`` applies to the edge only.
     """
     if wheelbase is not None:
         rear_overhang = (length - wheelbase) / 2
@@ -165,7 +169,7 @@ def draw_agent_box(
         width,
         lw=lw,
         ec=color,
-        fc=color,
+        fc=color if filled else "none",
         alpha=alpha,
         zorder=zorder,
         transform=t_rot,


### PR DESCRIPTION
## Summary

Outline-only `reproducer_ego` rendered next to the solid live-ego box, in
the same blue, so cursor lag/repeat is visible at a glance.

Defaults are backwards compatible (`None` / `True`).

## Why

Extracted from #288. The Plotly route-metrics map portion of that change
is intentionally left out of this PR — this one is just the per-step
PNG ego reproducer, so it can land independently and be reviewed
in isolation.

## Test plan

- [x] `git diff origin/tier4-main..HEAD` is the intended 3-file,
      +46/-1 change.
- [x] `replay.save_step_figure(...)` with no `reproducer_ego` kwarg
      still renders the original solid-only ego (default `None`,
      `filled=True` path unchanged).
- [x] Closed-loop override run with `reproducer_ego` threaded through
      shows the hollow box in the same blue, offset behind the live
      ego, with the small label.
<img width="816" height="798" alt="image" src="https://github.com/user-attachments/assets/dfefd244-cc85-46da-9069-bd60082790bb" />


Made with [Cursor](https://cursor.com)