### PR TITLE
feat(data_augmentation): frenet corridor augmentation as an augment_type

### DIFF
--- a/diffusion_planner/diffusion_planner/config/train_config.py
+++ b/diffusion_planner/diffusion_planner/config/train_config.py
@@ -41,7 +41,12 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
 
     use_data_augment: bool = True
     augment_prob: float = 0.5
-    augment_type: Literal["quintic", "bridge", "frenet"] = "quintic"
+    augment_type: Literal["quintic", "bridge", "frenet"] = cli(
+        "data augmentation method: quintic (default) = fixed-offset quintic bridge; "
+        "bridge = extended bridge perturbation; frenet = corridor-constrained lateral "
+        "perturbation with feasibility filtering and history rewrite.",
+        default="quintic",
+    )
     num_refine: int = 20
     ego_past_noise_std: float = 0.1
     use_smoothing_future_trajectory: bool = True

--- a/diffusion_planner/diffusion_planner/config/train_config.py
+++ b/diffusion_planner/diffusion_planner/config/train_config.py
@@ -50,6 +50,37 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
     num_refine: int = 20
     ego_past_noise_std: float = 0.1
     use_smoothing_future_trajectory: bool = True
+
+    # --- frenet augmentation knobs (ignored unless augment_type=frenet) ---
+    # The defaults are the measured configuration: narrowing the offsets to the
+    # quintic range or dropping the ranked merge selection each cost most of the
+    # closed-loop benefit, so treat these as a sweep handle, not a tuning dial.
+    frenet_n_draws: int = cli("frenet: joint (offset, heading) draws per scene.", default=16)
+    frenet_dy_max: float = cli("frenet: maximum lateral offset in metres.", default=2.0)
+    frenet_dth_max: float = cli("frenet: maximum heading offset in radians.", default=0.17)
+    frenet_merge_times: list[float] = cli(
+        "frenet: horizons (s) at which a candidate may rejoin the recorded path; "
+        "one is sampled per scene among the feasible ones.",
+        default_factory=lambda: [2.0, 3.0, 4.0, 5.0],
+    )
+    frenet_anchors: list[float] = cli(
+        "frenet: how far back (s) the rewritten history departs from the recording.",
+        default_factory=lambda: [2.0, 3.0],
+    )
+    frenet_acc0_fracs: list[float] = cli(
+        "frenet: initial lateral curvature, as a fraction of the value a quintic "
+        "naturally takes for the drawn offset and horizon.",
+        default_factory=lambda: [0.0, -0.5, 0.5, -1.0, 1.0],
+    )
+    frenet_ranked_temp_s: float = cli(
+        "frenet: time constant (s) of the merge-horizon sampling; smaller favours "
+        "faster convergence more strongly.",
+        default=1.0,
+    )
+    frenet_seed: int = cli(
+        "frenet: base RNG seed for the augmentation draws (offset per DDP rank).",
+        default=0,
+    )
     normalization_file_path: str = "normalization.json"
 
     train_subsample_step: int = 1

--- a/diffusion_planner/diffusion_planner/config/train_config.py
+++ b/diffusion_planner/diffusion_planner/config/train_config.py
@@ -41,7 +41,7 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
 
     use_data_augment: bool = True
     augment_prob: float = 0.5
-    augment_type: Literal["quintic", "bridge"] = "quintic"
+    augment_type: Literal["quintic", "bridge", "frenet"] = "quintic"
     num_refine: int = 20
     ego_past_noise_std: float = 0.1
     use_smoothing_future_trajectory: bool = True

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -24,8 +24,7 @@ from diffusion_planner.utils.data_augmentation_bridge import (
     StatePerturbation as BridgeStatePerturbation,
 )
 from diffusion_planner.utils.data_augmentation_frenet import (
-    FrenetStatePerturbationTensor,
-    KnobGrid,
+    frenet_augmenter_from_args,
 )
 from diffusion_planner.utils.dataset import DiffusionPlannerData, DiffusionPlannerPairData
 from diffusion_planner.utils.lr_schedule import CosineAnnealingWarmUpRestarts
@@ -266,21 +265,7 @@ def model_training(args: TrainConfig):
         if args.augment_type == "bridge":
             aug = BridgeStatePerturbation(augment_prob=args.augment_prob, device=args.device)
         elif args.augment_type == "frenet":
-            # argparse hands list fields back as strings, so coerce before use
-            aug = FrenetStatePerturbationTensor(
-                augment_prob=args.augment_prob,
-                device=args.device,
-                n_draws=int(args.frenet_n_draws),
-                dy_max=float(args.frenet_dy_max),
-                dth_max=float(args.frenet_dth_max),
-                knobs=KnobGrid(
-                    merge_times=tuple(float(v) for v in args.frenet_merge_times),
-                    anchors=tuple(float(v) for v in args.frenet_anchors),
-                    acc0_fracs=tuple(float(v) for v in args.frenet_acc0_fracs),
-                ),
-                seed=int(args.frenet_seed),
-                ranked_temp_s=float(args.frenet_ranked_temp_s),
-            )
+            aug = frenet_augmenter_from_args(args)
         else:
             aug = StatePerturbation(
                 augment_prob=args.augment_prob,

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -23,6 +23,7 @@ from diffusion_planner.utils.data_augmentation import StatePerturbation
 from diffusion_planner.utils.data_augmentation_bridge import (
     StatePerturbation as BridgeStatePerturbation,
 )
+from diffusion_planner.utils.data_augmentation_frenet import FrenetStatePerturbationTensor
 from diffusion_planner.utils.dataset import DiffusionPlannerData, DiffusionPlannerPairData
 from diffusion_planner.utils.lr_schedule import CosineAnnealingWarmUpRestarts
 from diffusion_planner.utils.normalizer import ObservationNormalizer, StateNormalizer
@@ -261,6 +262,8 @@ def model_training(args: TrainConfig):
     if args.use_data_augment:
         if args.augment_type == "bridge":
             aug = BridgeStatePerturbation(augment_prob=args.augment_prob, device=args.device)
+        elif args.augment_type == "frenet":
+            aug = FrenetStatePerturbationTensor(augment_prob=args.augment_prob, device=args.device)
         else:
             aug = StatePerturbation(
                 augment_prob=args.augment_prob,

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -23,7 +23,10 @@ from diffusion_planner.utils.data_augmentation import StatePerturbation
 from diffusion_planner.utils.data_augmentation_bridge import (
     StatePerturbation as BridgeStatePerturbation,
 )
-from diffusion_planner.utils.data_augmentation_frenet import FrenetStatePerturbationTensor
+from diffusion_planner.utils.data_augmentation_frenet import (
+    FrenetStatePerturbationTensor,
+    KnobGrid,
+)
 from diffusion_planner.utils.dataset import DiffusionPlannerData, DiffusionPlannerPairData
 from diffusion_planner.utils.lr_schedule import CosineAnnealingWarmUpRestarts
 from diffusion_planner.utils.normalizer import ObservationNormalizer, StateNormalizer
@@ -263,7 +266,21 @@ def model_training(args: TrainConfig):
         if args.augment_type == "bridge":
             aug = BridgeStatePerturbation(augment_prob=args.augment_prob, device=args.device)
         elif args.augment_type == "frenet":
-            aug = FrenetStatePerturbationTensor(augment_prob=args.augment_prob, device=args.device)
+            # argparse hands list fields back as strings, so coerce before use
+            aug = FrenetStatePerturbationTensor(
+                augment_prob=args.augment_prob,
+                device=args.device,
+                n_draws=int(args.frenet_n_draws),
+                dy_max=float(args.frenet_dy_max),
+                dth_max=float(args.frenet_dth_max),
+                knobs=KnobGrid(
+                    merge_times=tuple(float(v) for v in args.frenet_merge_times),
+                    anchors=tuple(float(v) for v in args.frenet_anchors),
+                    acc0_fracs=tuple(float(v) for v in args.frenet_acc0_fracs),
+                ),
+                seed=int(args.frenet_seed),
+                ranked_temp_s=float(args.frenet_ranked_temp_s),
+            )
         else:
             aug = StatePerturbation(
                 augment_prob=args.augment_prob,

--- a/diffusion_planner/diffusion_planner/utils/augmentation_checks.py
+++ b/diffusion_planner/diffusion_planner/utils/augmentation_checks.py
@@ -1,0 +1,372 @@
+"""Validity checks for trajectory augmentation, independent of how the
+candidate trajectories were produced.
+
+An augmenter's job is to propose displaced trajectories; deciding whether a
+proposal is *usable* is a separate question, and the same question for every
+augmenter:
+
+  * where can the ego go sideways at all — :func:`border_lateral_bounds` and
+    :func:`neighbor_lateral_bounds` give the free lateral interval per timestep,
+    which is what a sampler needs BEFORE it has a trajectory;
+  * is a proposed trajectory physically drivable — :func:`kinematic_feasibility`
+    screens finished polylines on lateral acceleration, jerk, yaw rate and
+    Ackermann steering;
+  * does it actually hit anything — :func:`veto_overlapping` re-checks winners
+    with the canonical exact signed-OBB clearance from ``planner_metrics``.
+
+Everything here is batched over the training batch and takes plain tensors, so
+the quintic and bridge augmenters (or a new one) can use the same checks the
+frenet augmenter does. Nothing in this module knows what a Frenet frame is.
+
+Ego positions are base_link (rear axle) throughout, matching the dataset and
+``planner_metrics``; neighbor boxes are centroid-referenced.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+from planner_metrics.geometry import build_road_border_segments
+from planner_metrics.subscores import compute_ego_neighbor_signed_clearance
+
+DT = 0.1
+
+# Feasibility limits: candidates violating these are REJECTED (never clipped).
+LIMITS = {
+    "lat_acc": 3.0,  # m/s^2
+    "yaw_rate": 0.6,  # rad/s  (~34 deg/s)
+    # Comfort jerk, applied to the FUTURE segment only - that is what the model
+    # learns to output. (Peak lateral jerk of a quintic ~ 60*dy/T^3: a comfortable
+    # recovery from dy=0.75 m needs T >= 2.8 s, so at M=2 s most realistic offsets
+    # are correctly REJECTED. The production 2 s quintic bridge teaches ~6 m/s^3.)
+    "jerk": 2.0,  # m/s^3
+    # The HISTORY segment is context, not a target: it only has to be a plausible
+    # (possibly uncomfortable) way to have arrived at the perturbed pose. The 3 s
+    # past window would otherwise cap |dy| at 27*jerk/60 ~ 0.9 m.
+    "jerk_history": 5.0,  # m/s^3
+    # Ackermann / kinematic-bicycle feasibility (needs wheelbase from ego_shape):
+    # steering angle delta = atan(WB * kappa), kappa = yaw_rate / speed.
+    "steer": 0.61,  # rad (~35 deg), typical passenger-car lock
+}
+
+# the steering test runs in tan space (see kinematic_feasibility)
+_TAN_STEER = math.tan(LIMITS["steer"])
+
+# lateral bound when nothing constrains the ego; also the distance beyond which
+# a border cannot tighten the bounds, hence the segment-pruning reach below.
+UNCONSTRAINED_M = 20.0
+_BORDER_REACH_M = UNCONSTRAINED_M + 5.0
+
+
+def ddt(x: torch.Tensor, dim: int) -> torch.Tensor:
+    """d/dt along `dim` on the fixed DT grid.
+
+    Same arithmetic as torch.gradient(x, spacing=DT, dim=dim) — central
+    differences inside, one-sided at the ends — written out because the library
+    call costs ~7x more on the candidate tensors (3.5 ms vs 0.5 ms for the three
+    derivatives at B=512). Verified bit-identical to torch.gradient.
+    """
+    lo = x.narrow(dim, 0, 1)
+    lo2 = x.narrow(dim, 1, 1)
+    hi2 = x.narrow(dim, x.shape[dim] - 2, 1)
+    hi = x.narrow(dim, x.shape[dim] - 1, 1)
+    mid = (x.narrow(dim, 2, x.shape[dim] - 2) - x.narrow(dim, 0, x.shape[dim] - 2)) / (2 * DT)
+    return torch.cat([(lo2 - lo) / DT, mid, (hi - hi2) / DT], dim=dim)
+
+
+def time_aligned_neighbor_tracks(
+    past: torch.Tensor, fut: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Recorded neighbor states on the same time grid as the ego polyline.
+
+    Past for t <= 0, recorded future for t > 0. Futures come in two layouts:
+    4-col (x, y, cos, sin) or the canonical 3-col (x, y, heading) — train_epoch
+    only converts to cos/sin AFTER augmentation, so both are handled.
+
+    Args:
+        past: (B, N, P, >=8) neighbor history; cols 6, 7 are width, length.
+        fut: (B, N, F, 3 or 4) recorded neighbor futures.
+
+    Returns:
+        state: (B, N, T, 4) x, y, cos, sin with T = P + F.
+        valid: (B, N, T) True where the slot holds a real observation.
+    """
+    if fut.shape[-1] >= 4:
+        fut4 = fut[..., :4]
+    else:
+        fut4 = torch.cat([fut[..., :2], fut[..., 2:3].cos(), fut[..., 2:3].sin()], dim=-1)
+        # keep padded rows padded: an all-zero 3-col row must not become
+        # (0, 0, 1, 0) after cos/sin
+        fut4 = fut4 * (fut.abs().sum(-1, keepdim=True) > 0)
+    state = torch.cat([past[..., :4], fut4], dim=2)  # (B, N, T, 4)
+    return state, state.abs().sum(-1) > 0
+
+
+def unconstrained_bounds(B: int, T: int, device, dtype) -> tuple[torch.Tensor, torch.Tensor]:
+    """Lateral bounds before any obstacle cuts them.
+
+    NOTE: do not try to pre-shrink these to a sampler's nominal offset. For a
+    quintic the offset at t=0 is not a bound on the profile — it overshoots when
+    the draw has an initial heading slope (measured |L| = 3.39 m for a 1.98 m
+    offset) — and a bound like that silently rejects feasible perturbations.
+    """
+    lo = torch.full((B, T), -UNCONSTRAINED_M, device=device, dtype=dtype)
+    hi = torch.full((B, T), UNCONSTRAINED_M, device=device, dtype=dtype)
+    return lo, hi
+
+
+def border_lateral_bounds(
+    line_strings: torch.Tensor,
+    xy: torch.Tensor,
+    nrm: torch.Tensor,
+    half_w: torch.Tensor,
+    lo: torch.Tensor,
+    hi: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Tighten lateral bounds where a road border blocks the way.
+
+    Casts a ray along the path normal at every timestep and solves for the
+    intersection with each border segment in closed form, batched over
+    (B, T, segments). Unlike a nearest-distance query this keeps the two sides
+    apart, which is what a bound needs: a curb 1 m left and one 1.5 m right must
+    not both collapse to "1 m away".
+
+    Args:
+        line_strings: (B, L, P, >=4) map polylines; channel 3 flags road border.
+        xy: (B, T, 2) ego path (base_link).
+        nrm: (B, T, 2) unit path normal.
+        half_w: (B,) ego half width, including whatever margin the caller wants.
+        lo, hi: (B, T) bounds to tighten.
+
+    Returns:
+        the tightened (lo, hi).
+    """
+    if line_strings.shape[-1] < 4:
+        raise ValueError(
+            f"line_strings has {line_strings.shape[-1]} channels; the corridor needs "
+            "channel 3 (road-border flag)"
+        )
+    # a border further than the current bound from every path point can never
+    # tighten it, so drop those before the ray math (~180 of 1140 slots survive
+    # on the pipeline set); the builder pads to the batch maximum, so the
+    # surviving bounds are unchanged.
+    a, e, sv = build_road_border_segments(line_strings, xy, reach=_BORDER_REACH_M)
+    d = e - a
+    nx, ny = nrm[..., 0:1], nrm[..., 1:2]  # (B, T, 1)
+    dx = d[:, None, :, 0]  # (B, 1, S)
+    dy_ = d[:, None, :, 1]
+    det = nx * (-dy_) - ny * (-dx)  # (B, T, S)
+    rx = a[:, None, :, 0] - xy[..., 0:1]
+    ry = a[:, None, :, 1] - xy[..., 1:2]
+    s = (rx * (-dy_) - ry * (-dx)) / det
+    u = (nx * ry - ny * rx) / det
+    ok = torch.isfinite(s) & (u >= 0) & (u <= 1) & sv[:, None, :]
+    pos = torch.where(ok & (s > 0), s, torch.full_like(s, torch.inf))
+    neg = torch.where(ok & (s < 0), s, torch.full_like(s, -torch.inf))
+    return (
+        torch.maximum(lo, neg.amax(-1) + half_w[:, None]),
+        torch.minimum(hi, pos.amin(-1) - half_w[:, None]),
+    )
+
+
+def neighbor_lateral_bounds(
+    state: torch.Tensor,
+    valid: torch.Tensor,
+    shapes_wl: torch.Tensor,
+    xy: torch.Tensor,
+    tan: torch.Tensor,
+    nrm: torch.Tensor,
+    half_l: torch.Tensor,
+    half_w: torch.Tensor,
+    wb: torch.Tensor,
+    lo: torch.Tensor,
+    hi: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Tighten lateral bounds where a recorded neighbor blocks the way.
+
+    A neighbor cuts the corridor on the side it sits, over the timesteps where
+    it overlaps the ego's longitudinal window.
+
+    Args:
+        state, valid: from :func:`time_aligned_neighbor_tracks`.
+        shapes_wl: (B, N, 2) neighbor width, length.
+        xy, tan, nrm: (B, T, 2) ego path, tangent, normal.
+        half_l, half_w, wb: (B,) ego half length, half width, wheel base.
+        lo, hi: (B, T) bounds to tighten.
+
+    Returns:
+        tightened (lo, hi) and ``near`` (B, N) — neighbors close enough
+        longitudinally to be worth an exact overlap check later.
+    """
+    # Only slots holding a real track can cut the corridor, and they are ~31 of
+    # the 320 padded slots. Flatten to the valid (scene, neighbor) pairs so the
+    # projections below run over those alone, then reduce back per scene;
+    # padding contributed +-inf, i.e. nothing.
+    near_any = torch.zeros(valid.shape[:2], dtype=torch.bool, device=valid.device)
+    vb, vn = torch.nonzero(valid.any(-1), as_tuple=True)  # (M,)
+    if vb.numel() == 0:
+        return lo, hi, near_any
+
+    valid_m = valid[vb, vn]  # (M, T)
+    w_n = shapes_wl[vb, vn, 0][:, None]  # (M, 1)
+    l_n = shapes_wl[vb, vn, 1][:, None]
+    c = state[vb, vn, :, :2]  # (M, T, 2)
+    axi = state[vb, vn, :, 2:4]
+    per = torch.stack([-axi[..., 1], axi[..., 0]], dim=-1)
+    tan_m, nrm_m = tan[vb], nrm[vb]  # (M, T, 2)
+    half_l_m, half_w_m, wb_m = half_l[vb, None], half_w[vb, None], wb[vb, None]
+    rel = c - xy[vb]  # (M, T, 2)
+    # ego xy is base_link (rear axle); the footprint CENTER sits wb/2 ahead
+    # along the tangent, so shift the longitudinal window there — otherwise a
+    # transient neighbor overlapping only the front bumper imposes no cut.
+    lon = (rel * tan_m).sum(-1)  # rear-axle window (validated semantics)
+    lat = (rel * nrm_m).sum(-1)
+    ext_lon = ((tan_m * axi).sum(-1).abs() * l_n + (tan_m * per).sum(-1).abs() * w_n) / 2
+    ext_lat = ((nrm_m * axi).sum(-1).abs() * l_n + (nrm_m * per).sum(-1).abs() * w_n) / 2
+    near = valid_m & (lon.abs() <= half_l_m + ext_lon)
+    # Same test, padded, for the exact-OBB veto: the pad covers the ego's
+    # longitudinal half-extent growing under a heading change
+    # (half_l*cos + half_w*sin <= half_l + half_w) plus the wb/2 centre shift,
+    # so a pair outside it cannot overlap and skipping it changes no verdict.
+    near_any[vb, vn] = (valid_m & (lon.abs() <= half_l_m + ext_lon + half_w_m + wb_m / 2)).any(-1)
+
+    cut_hi = torch.where(
+        near & (lat > 0), lat - ext_lat - half_w_m, torch.full_like(lat, torch.inf)
+    )
+    cut_lo = torch.where(
+        near & (lat < 0), lat + ext_lat + half_w_m, torch.full_like(lat, -torch.inf)
+    )
+    idx = vb[:, None].expand_as(cut_hi)
+    return (
+        lo.scatter_reduce(0, idx, cut_lo, reduce="amax"),
+        hi.scatter_reduce(0, idx, cut_hi, reduce="amin"),
+        near_any,
+    )
+
+
+def path_metrics(poly_xy: torch.Tensor) -> tuple[torch.Tensor, ...]:
+    """Lateral accel, lateral jerk, yaw rate and 1/speed of a polyline.
+
+    Finite-differenced on the fixed DT grid, so these are the trajectory's real
+    kinematics — including the coupling with the reference path's own curvature,
+    which a check on a lateral-offset profile alone would miss.
+
+    Args:
+        poly_xy: (..., T, 2) positions at DT spacing.
+
+    Returns:
+        lat_a, lat_j, yaw_rate, inv_speed — each (..., T).
+    """
+    v = ddt(poly_xy, -2)
+    # speed is clamped away from zero, so one reciprocal serves the divisions
+    # below (a multiply is cheaper than a divide at candidate-tensor sizes)
+    inv_sp = v.norm(dim=-1).clamp(min=0.5).reciprocal()
+    a = ddt(v, -2)
+    lat_a = (v[..., 0] * a[..., 1] - v[..., 1] * a[..., 0]) * inv_sp
+    jk = ddt(a, -2)
+    lat_j = (v[..., 0] * jk[..., 1] - v[..., 1] * jk[..., 0]) * inv_sp
+    return lat_a, lat_j, lat_a * inv_sp, inv_sp
+
+
+def kinematic_feasibility(
+    cand_xy: torch.Tensor,
+    scene: torch.Tensor,
+    ref_xy: torch.Tensor,
+    wb: torch.Tensor,
+    n_past: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Is each candidate polyline physically drivable?
+
+    Limits are GT-RELATIVE: where the recorded drive itself exceeds a limit
+    (data glitches happen), a candidate only has to stay within the recording's
+    own maximum. The comfort jerk limit applies to the future segment, which is
+    what the model learns to output; the history segment only has to be a
+    plausible way to have arrived, so it gets a looser limit.
+
+    Args:
+        cand_xy: (M, T, 2) candidate polylines, any provenance.
+        scene: (M,) index of the scene each candidate belongs to.
+        ref_xy: (B, T, 2) the recorded path per scene.
+        wb: (B,) wheel base.
+        n_past: number of history timesteps; index T < n_past is history.
+
+    Returns:
+        ok: (M,) bool, passes every limit.
+        jerk_future_peak: (M,) peak |lateral jerk| over the future segment,
+            useful as a tie-break between feasible candidates.
+    """
+    laC, ljC, yrC, ivC = path_metrics(cand_xy)  # (M, T)
+    laG, ljG, yrG, ivG = path_metrics(ref_xy)  # (B, T)
+    # Steering compared in tan space: atan(x) <= max(atan(g), STEER) is
+    # equivalent to x <= max(g, tan(STEER)) since atan is monotonic, which
+    # avoids an atan over the whole candidate tensor.
+    stC = (wb[scene, None] * yrC * ivC).abs()
+    stG = (wb[:, None] * yrG * ivG).abs()
+
+    def allow(gt_max, limit):
+        return torch.clamp(gt_max, min=limit)[scene]  # (M,)
+
+    peak = ljC[:, n_past:].abs().amax(-1)
+    a_ok = laC.abs().amax(-1) <= allow(laG.abs().amax(-1), LIMITS["lat_acc"])
+    j_ok = (peak <= allow(ljG[:, n_past:].abs().amax(-1), LIMITS["jerk"])) & (
+        ljC[:, :n_past].abs().amax(-1)
+        <= allow(ljG[:, :n_past].abs().amax(-1), LIMITS["jerk_history"])
+    )
+    y_ok = yrC.abs().amax(-1) <= allow(yrG.abs().amax(-1), LIMITS["yaw_rate"])
+    s_ok = stC.amax(-1) <= allow(stG.amax(-1), _TAN_STEER)
+    return a_ok & j_ok & y_ok & s_ok, peak
+
+
+def veto_overlapping(
+    rows: torch.Tensor,
+    ego_traj: torch.Tensor,
+    ego_shape: torch.Tensor,
+    state: torch.Tensor,
+    valid: torch.Tensor,
+    shapes_wl: torch.Tensor,
+    near: torch.Tensor,
+) -> torch.Tensor:
+    """Clear rows whose footprint truly overlaps a recorded neighbor.
+
+    Lateral bounds are a fast approximation — measured to accept ~1.4% of
+    winners whose TRUE footprint overlaps a neighbor box — so the accepted
+    trajectory is re-checked with the canonical exact signed-OBB clearance and
+    the row is dropped back to plain ground truth if it collides.
+
+    Road borders are deliberately NOT vetoed this way: the recorded drives
+    themselves touch the mapped borders (GT corner distance reaches 0.0), so an
+    OBB border veto would reject ground-truth-like data.
+
+    Args:
+        rows: (B,) bool, which scenes currently intend to use their candidate.
+        ego_traj: (B, T, 4) candidate x, y, cos, sin (base_link).
+        ego_shape: (B, 3) wheel_base, length, width — one per scene.
+        state, valid: from :func:`time_aligned_neighbor_tracks`.
+        shapes_wl: (B, N, 2) neighbor width, length.
+        near: (B, N) neighbors worth checking, from
+            :func:`neighbor_lateral_bounds`.
+
+    Returns:
+        ``rows`` with overlapping scenes set False.
+    """
+    if not bool(rows.any()):
+        return rows
+    # One paired call for the whole batch: per-scene calls were one tiny kernel
+    # each, and their launch overhead dominated training (228 ms/batch at
+    # B=512) to reject the ~1.4% of winners that truly overlap.
+    bi, ni = torch.nonzero(rows[:, None] & near, as_tuple=True)
+    if bi.numel() == 0:
+        return rows
+    clr = compute_ego_neighbor_signed_clearance(
+        ego_traj[bi],
+        ego_shape[bi],
+        state[bi, ni],
+        shapes_wl[bi, ni],
+        valid[bi, ni],
+        paired=True,
+        overlap_only=True,  # a veto only asks whether they overlap
+    )  # (M, T)
+    rows[bi[clr.amin(-1) < 0.0]] = False
+    return rows

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -404,13 +404,16 @@ class StatePerturbation:
         ego_future[..., :2] = vector_transform(ego_future[..., :2], transform_matrix, center_xy)
         ego_future[..., 2] = heading_transform(ego_future[..., 2], transform_matrix)
 
-        # ego past
-        # inputs["ego_agent_past"][..., :2] = vector_transform(
-        #     inputs["ego_agent_past"][..., :2], transform_matrix, center_xy
-        # )
-        # inputs["ego_agent_past"][..., 2:4] = vector_transform(
-        #     inputs["ego_agent_past"][..., 2:4], transform_matrix
-        # )
+        # ego past — only for augmenters that rewrite the history polyline in the
+        # pre-perturbation frame (frenet). Quintic/bridge leave the GT past untouched
+        # and rely on it staying numerically anchored at the origin.
+        if getattr(self, "_transform_ego_past", False):
+            inputs["ego_agent_past"][..., :2] = vector_transform(
+                inputs["ego_agent_past"][..., :2], transform_matrix, center_xy
+            )
+            inputs["ego_agent_past"][..., 2:4] = vector_transform(
+                inputs["ego_agent_past"][..., 2:4], transform_matrix
+            )
 
         ego_past4d = inputs["ego_agent_past"]
         ego_future4d = torch.cat(

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -394,3 +394,30 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         n_cols = min(new_cur.shape[-1], cur.shape[-1])
         cur[upd, :n_cols] = new_cur[upd, :n_cols].to(cur.dtype)
         self._aug_rows = upd
+
+
+def frenet_augmenter_from_args(args) -> "FrenetStatePerturbationTensor":
+    """Build the augmenter from a parsed config, for EVERY entrypoint that trains with it.
+
+    One factory rather than a construction per entrypoint: the GRPO path used to build this
+    with only ``augment_prob`` and ``device``, so it accepted every ``--frenet_*`` flag and
+    then silently trained at the defaults. A run's recorded configuration has to be the
+    configuration it actually used, and that only holds if there is a single place where the
+    flags become an augmenter.
+
+    ``argparse`` hands list fields back as strings, so the numeric coercion lives here too.
+    """
+    return FrenetStatePerturbationTensor(
+        augment_prob=args.augment_prob,
+        device=args.device,
+        n_draws=int(args.frenet_n_draws),
+        dy_max=float(args.frenet_dy_max),
+        dth_max=float(args.frenet_dth_max),
+        knobs=KnobGrid(
+            merge_times=tuple(float(v) for v in args.frenet_merge_times),
+            anchors=tuple(float(v) for v in args.frenet_anchors),
+            acc0_fracs=tuple(float(v) for v in args.frenet_acc0_fracs),
+        ),
+        seed=int(args.frenet_seed),
+        ranked_temp_s=float(args.frenet_ranked_temp_s),
+    )

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -27,6 +27,7 @@ plain GT on a true neighbor overlap (~1% of winners). Scenes with no feasible
 draw train on plain GT.
 """
 
+import math
 from dataclasses import dataclass
 
 import numpy as np
@@ -56,6 +57,9 @@ LIMITS = {
     # steering angle delta = atan(WB * kappa), kappa = yaw_rate / speed.
     "steer": 0.61,  # rad (~35 deg), typical passenger-car lock
 }
+
+# the steering test runs in tan space (see _feasibility), so cache tan(limit)
+_TAN_STEER = math.tan(LIMITS["steer"])
 
 
 def _ddt(x: torch.Tensor, dim: int) -> torch.Tensor:
@@ -454,13 +458,15 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         # glitches), the candidate only has to stay within the GT's own maximum.
         def _exact_metrics(poly_xy):
             v = _ddt(poly_xy, -2)
-            sp = v.norm(dim=-1).clamp(min=0.5)
+            # speed is clamped away from zero, so one reciprocal serves the three
+            # divisions below (a multiply is cheaper than a divide on 22M values)
+            inv_sp = v.norm(dim=-1).clamp(min=0.5).reciprocal()
             a = _ddt(v, -2)
-            lat_a = (v[..., 0] * a[..., 1] - v[..., 1] * a[..., 0]) / sp
+            lat_a = (v[..., 0] * a[..., 1] - v[..., 1] * a[..., 0]) * inv_sp
             jk = _ddt(a, -2)
-            lat_j = (v[..., 0] * jk[..., 1] - v[..., 1] * jk[..., 0]) / sp
-            yaw_rate = lat_a / sp
-            return lat_a, lat_j, yaw_rate, sp
+            lat_j = (v[..., 0] * jk[..., 1] - v[..., 1] * jk[..., 0]) * inv_sp
+            yaw_rate = lat_a * inv_sp
+            return lat_a, lat_j, yaw_rate, inv_sp
 
         # Only candidates that already clear the corridor can end up feasible, so
         # build the exact polylines for those alone — the rest would be discarded
@@ -473,10 +479,14 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             return feasible, jerk_fut_peak
 
         cand_xy = xy[b_i] + L[b_i, k_i, c_i][..., None] * nrm[b_i]  # (M, T, 2)
-        laC, ljC, yrC, spC = _exact_metrics(cand_xy)  # each (M, T)
-        laG, ljG, yrG, spG = _exact_metrics(xy)  # GT reference, (B, T)
-        stC = torch.atan(wb[b_i, None] * yrC / spC).abs()
-        stG = torch.atan(wb[:, None] * yrG / spG).abs()
+        laC, ljC, yrC, ivC = _exact_metrics(cand_xy)  # each (M, T)
+        laG, ljG, yrG, ivG = _exact_metrics(xy)  # GT reference, (B, T)
+        # Steering is compared in tan space: the limit test is
+        # atan(x) <= max(atan(g), STEER), and atan is monotonic, so it is
+        # equivalent to x <= max(g, tan(STEER)) — same verdict, no atan over the
+        # candidate tensor.
+        stC = (wb[b_i, None] * yrC * ivC).abs()
+        stG = (wb[:, None] * yrG * ivG).abs()
 
         def _allow(gt_max, limit):
             return torch.clamp(gt_max, min=limit)[b_i]  # (M,)
@@ -487,7 +497,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             ljC[:, :P].abs().amax(-1) <= _allow(ljG[:, :P].abs().amax(-1), LIMITS["jerk_history"])
         )
         y_ok = yrC.abs().amax(-1) <= _allow(yrG.abs().amax(-1), LIMITS["yaw_rate"])
-        s_ok = stC.amax(-1) <= _allow(stG.amax(-1), LIMITS["steer"])
+        s_ok = stC.amax(-1) <= _allow(stG.amax(-1), _TAN_STEER)
         feasible[b_i, k_i, c_i] = a_ok & j_ok & y_ok & s_ok
         jerk_fut_peak[b_i, k_i, c_i] = peak
         return feasible, jerk_fut_peak

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -58,6 +58,22 @@ LIMITS = {
 }
 
 
+def _ddt(x: torch.Tensor, dim: int) -> torch.Tensor:
+    """d/dt along `dim` on the fixed DT grid.
+
+    Same arithmetic as torch.gradient(x, spacing=DT, dim=dim) — central
+    differences inside, one-sided at the ends — written out because the library
+    call costs ~7x more on the candidate tensors (3.5 ms vs 0.5 ms for the three
+    derivatives at B=512). Verified bit-identical to torch.gradient.
+    """
+    lo = x.narrow(dim, 0, 1)
+    lo2 = x.narrow(dim, 1, 1)
+    hi2 = x.narrow(dim, x.shape[dim] - 2, 1)
+    hi = x.narrow(dim, x.shape[dim] - 1, 1)
+    mid = (x.narrow(dim, 2, x.shape[dim] - 2) - x.narrow(dim, 0, x.shape[dim] - 2)) / (2 * DT)
+    return torch.cat([(lo2 - lo) / DT, mid, (hi - hi2) / DT], dim=dim)
+
+
 def quintic_basis(t0: float, t1: float, t: np.ndarray):
     """Rows: response of l, l', l'', l''' to unit (pos, vel, acc) BCs at t1.
 
@@ -322,6 +338,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             past_n[bi, ni, -1][:, [6, 7]],  # width, length
             self._nbr_valid[bi, ni],
             paired=True,
+            overlap_only=True,  # the veto only asks whether they overlap
         )  # (M, T)
         overlapping = bi[clr.amin(-1) < 0.0]
         upd[overlapping] = False
@@ -353,7 +370,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         xy = torch.cat([past4[..., :2], ego_future[..., :2]], dim=1)  # (B, T, 2)
         tan = torch.cat([past4[..., 2:4], fut_cs], dim=1)
         nrm = torch.stack([-tan[..., 1], tan[..., 0]], dim=-1)
-        speed = torch.gradient(xy, spacing=DT, dim=1)[0].norm(dim=-1).clamp(min=0.5)  # (B, T)
+        speed = _ddt(xy, 1).norm(dim=-1).clamp(min=0.5)  # (B, T)
         v0 = speed[:, P - 1]
         wb = inputs["ego_shape"][:, 0]
         half_w = inputs["ego_shape"][:, 2] / 2 + CORRIDOR_MARGIN
@@ -436,11 +453,11 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         # GT-relative: where the recorded drive itself exceeds a limit (data
         # glitches), the candidate only has to stay within the GT's own maximum.
         def _exact_metrics(poly_xy):
-            v = torch.gradient(poly_xy, spacing=DT, dim=-2)[0]
+            v = _ddt(poly_xy, -2)
             sp = v.norm(dim=-1).clamp(min=0.5)
-            a = torch.gradient(v, spacing=DT, dim=-2)[0]
+            a = _ddt(v, -2)
             lat_a = (v[..., 0] * a[..., 1] - v[..., 1] * a[..., 0]) / sp
-            jk = torch.gradient(a, spacing=DT, dim=-2)[0]
+            jk = _ddt(a, -2)
             lat_j = (v[..., 0] * jk[..., 1] - v[..., 1] * jk[..., 0]) / sp
             yaw_rate = lat_a / sp
             return lat_a, lat_j, yaw_rate, sp
@@ -500,7 +517,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
 
     def _write_back(self, inputs, ego_future, aug_xy, xy, tan, wb, has, P):
         """Veto true overlaps, then write history / future / current state in place."""
-        g = torch.gradient(aug_xy, spacing=DT, dim=1)[0]
+        g = _ddt(aug_xy, 1)
         gs = g.norm(dim=-1)
         hd_gt = torch.atan2(tan[..., 1], tan[..., 0])
         heading = torch.where(gs > 0.3, torch.atan2(g[..., 1], g[..., 0]), hd_gt)
@@ -520,10 +537,8 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         i0 = P - 1
         cur = inputs["ego_current_state"]
         vel = g[:, i0]
-        acc = torch.gradient(g, spacing=DT, dim=1)[0][:, i0]
-        yaw_rate = torch.gradient(
-            torch.stack([heading.cos(), heading.sin()], -1), spacing=DT, dim=1
-        )[0][:, i0]
+        acc = _ddt(g, 1)[:, i0]
+        yaw_rate = _ddt(torch.stack([heading.cos(), heading.sin()], -1), 1)[:, i0]
         yaw_rate = heading.cos()[:, i0] * yaw_rate[..., 1] - heading.sin()[:, i0] * yaw_rate[..., 0]
         steer = torch.atan(wb * yaw_rate / gs[:, i0].clamp(min=0.5))
         new_cur = torch.stack(

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -21,9 +21,10 @@ per batch exactly like the quintic StatePerturbation:
      history is rewritten to the perturbed polyline so past, current state and
      future stay kinematically consistent.
 
-No exact OBB re-verify in this path: the corridor (with the rotation margin) is
-audited zero-false-accept against the OBB reference (selftest.py), i.e. it is
-strictly conservative. Scenes with no feasible draw train on plain GT.
+The corridor is a fast approximation; the WINNING candidate is re-verified with
+the canonical exact signed-OBB clearance (planner_metrics) and vetoed back to
+plain GT on a true neighbor overlap (~1% of winners). Scenes with no feasible
+draw train on plain GT.
 """
 
 from dataclasses import dataclass
@@ -32,6 +33,7 @@ import numpy as np
 import torch
 
 from diffusion_planner.utils.data_augmentation import StatePerturbation
+from planner_metrics.subscores import compute_ego_neighbor_signed_clearance
 
 DT = 0.1
 CORRIDOR_MARGIN = 0.10
@@ -181,6 +183,8 @@ class FrenetStatePerturbationTensor(StatePerturbation):
 
     # ---------- corridor, fully batched ----------
     def _corridor(self, inputs, xy, tan, nrm, half_w, half_l, wb):
+        # reset per batch so a neighbor-less batch never sees a stale tensor
+        self._nbr_st = self._nbr_valid = None
         B, T, _ = xy.shape
         dev, dtype = xy.device, xy.dtype
         lo = torch.full((B, T), -20.0, device=dev, dtype=dtype)
@@ -230,6 +234,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
                 fut4 = fut4 * (fut.abs().sum(-1, keepdim=True) > 0)
             st = torch.cat([past[..., :4], fut4], dim=2)  # (B, N, T, 4)
             valid = st.abs().sum(-1) > 0  # (B, N, T)
+            self._nbr_st, self._nbr_valid = st, valid  # reused by the exact-OBB veto
             l_n = past[:, :, -1, 7][..., None]  # (B, N, 1)
             w_n = past[:, :, -1, 6][..., None]
             c = st[..., :2]
@@ -240,7 +245,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             # ahead along the tangent, so shift the longitudinal window there —
             # otherwise a transient neighbor overlapping only the front bumper
             # imposes no lateral cut.
-            lon = (rel * tan[:, None]).sum(-1) - (wb / 2)[:, None, None]
+            lon = (rel * tan[:, None]).sum(-1)  # rear-axle window (validated semantics)
             lat = (rel * nrm[:, None]).sum(-1)
             ext_lon = (
                 (tan[:, None] * axi).sum(-1).abs() * l_n + (tan[:, None] * per).sum(-1).abs() * w_n
@@ -330,11 +335,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         prof = torch.einsum("bkci,cdit->bkcdt", bc, Ball)  # (B, K, C, 4, T)
         L, V, A, J = prof.unbind(dim=3)
         m = m_all[None, None]  # (1, 1, C, T)
-        # rotation margin lever arm = rear axle -> front bumper (wb/2 + L/2),
-        # since the candidate lateral offset is applied at the rear-axle point
-        rot = (wb / 2 + half_l)[:, None, None, None] * (V.abs() / speed[:, None, None]).clamp(
-            max=0.35
-        )
+        rot = half_l[:, None, None, None] * (V.abs() / speed[:, None, None]).clamp(max=0.35)
         in_corr = ((L - rot >= lo[:, None, None]) & (L + rot <= hi[:, None, None]) | ~m).all(
             -1
         )  # (B, K, C)
@@ -407,7 +408,34 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         hd_gt = torch.atan2(tan[..., 1], tan[..., 0])
         heading = torch.where(gs > 0.3, torch.atan2(g[..., 1], g[..., 0]), hd_gt)
 
-        upd = has  # (B,) rows to rewrite
+        upd = has.clone()  # (B,) rows to rewrite
+        # Exact-OBB veto: the corridor is a fast approximation (path-normal
+        # ray-cast with half-width margins around the rear-axle polyline) and is
+        # measured to accept ~1.4% of winners whose TRUE footprint overlaps a
+        # recorded neighbor box. Check the winning candidate with the canonical
+        # signed OBB clearance (rear-axle ego convention, centroid neighbors)
+        # and train vetoed rows on plain GT. Borders are left to the corridor:
+        # the recorded drives themselves touch the mapped borders (GT corner
+        # distance reaches 0.0), so an OBB border veto would reject GT-like data.
+        nbr_st = self._nbr_st
+        if nbr_st is not None and bool(upd.any()):
+            hd_cs = torch.stack([heading.cos(), heading.sin()], dim=-1)
+            tr_aug = torch.cat([aug_xy, hd_cs], dim=-1)  # (B, T, 4)
+            past_n = inputs["neighbor_agents_past"]
+            for i in torch.nonzero(upd).flatten().tolist():
+                keep = self._nbr_valid[i].any(-1)
+                if not bool(keep.any()):
+                    continue
+                shapes = past_n[i, keep, -1][:, [6, 7]]  # width, length
+                clr = compute_ego_neighbor_signed_clearance(
+                    tr_aug[i : i + 1],
+                    inputs["ego_shape"][i],
+                    nbr_st[i, keep],
+                    shapes,
+                    self._nbr_valid[i, keep],
+                )
+                if float(clr.min()) < 0.0:
+                    upd[i] = False
         # future (x, y, heading) — canonical 3-col layout
         new_fut = torch.cat([aug_xy[:, P:], heading[:, P:, None]], dim=-1)
         ego_future[upd, :, :3] = new_fut[upd]
@@ -445,5 +473,5 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         )
         n_cols = min(new_cur.shape[-1], cur.shape[-1])
         cur[upd, :n_cols] = new_cur[upd, :n_cols].to(cur.dtype)
-        self._aug_rows = has
+        self._aug_rows = upd
         return self.centric_transform(inputs, ego_future, neighbors_future)

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -266,6 +266,18 @@ class FrenetStatePerturbationTensor(StatePerturbation):
     # ---------- the augmentation ----------
     @torch.no_grad()
     def __call__(self, inputs, ego_future, neighbors_future):
+        # ego_future may arrive as (x, y, heading) or (x, y, cos, sin) — same
+        # branch heading_to_cos_sin uses upstream. Canonicalize to 3-col heading
+        # here; centric_transform returns the rebuilt 3-col future either way,
+        # and train_epoch re-converts to cos/sin after augmentation.
+        if ego_future.shape[-1] >= 4:
+            ego_future = torch.cat(
+                [
+                    ego_future[..., :2],
+                    torch.atan2(ego_future[..., 3], ego_future[..., 2])[..., None],
+                ],
+                dim=-1,
+            )
         past4 = inputs["ego_agent_past"]  # (B, P, 4) x, y, cos, sin
         B, P, _ = past4.shape
         F = ego_future.shape[1]
@@ -367,70 +379,71 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         has = draw_ok.any(-1)  # (B,)
         first = draw_ok.float().argmax(-1)  # first feasible PERTURBATION per scene
 
-        if bool(has.any()):
-            bi = torch.arange(B, device=dev)
-            feas_k = feasible[bi, first]  # (B, C) — valid combos for the chosen draw
-            jerk_k = jerk_fut_peak[bi, first]  # (B, C)
-            BIG = torch.tensor(1e9, device=dev, dtype=dtype)
-            # merge time sampled with per-combo weight exp(-(M-Mmin)/temp), i.e.
-            # P(M) ∝ n_feasible_combos(M) * exp(-(M-Mmin)/temp) — biased to fast
-            # convergence, slower merges keep a chance; within the sampled M,
-            # lowest peak future jerk wins.
-            m_feas = torch.where(feas_k, merges[None, :], BIG)
-            m_min = m_feas.amin(-1, keepdim=True)
-            w = torch.exp(-(merges[None, :] - m_min) / self.ranked_temp_s) * feas_k
-            w = torch.where(has[:, None], w, torch.ones_like(w))  # avoid all-zero rows
-            pick_m = torch.multinomial(w.cpu().double(), 1, generator=self.gen).to(dev)[:, 0]
-            same_m = feas_k & (merges[None, :] == merges[pick_m][:, None])
-            combo_idx = torch.where(same_m, jerk_k, BIG).argmin(-1)
-            Lw = L[bi, first, combo_idx]  # (B, T)
-            aug_xy = xy + Lw[..., None] * nrm
+        if not bool(has.any()):
+            # nothing feasible this batch: every row trains on plain GT
+            self._aug_rows = has
+            return self.centric_transform(inputs, ego_future, neighbors_future)
 
-            g = torch.gradient(aug_xy, spacing=DT, dim=1)[0]
-            gs = g.norm(dim=-1)
-            hd_gt = torch.atan2(tan[..., 1], tan[..., 0])
-            heading = torch.where(gs > 0.3, torch.atan2(g[..., 1], g[..., 0]), hd_gt)
+        bi = torch.arange(B, device=dev)
+        feas_k = feasible[bi, first]  # (B, C) — valid combos for the chosen draw
+        jerk_k = jerk_fut_peak[bi, first]  # (B, C)
+        BIG = torch.tensor(1e9, device=dev, dtype=dtype)
+        # merge time sampled with per-combo weight exp(-(M-Mmin)/temp), i.e.
+        # P(M) ∝ n_feasible_combos(M) * exp(-(M-Mmin)/temp) — biased to fast
+        # convergence, slower merges keep a chance; within the sampled M,
+        # lowest peak future jerk wins.
+        m_feas = torch.where(feas_k, merges[None, :], BIG)
+        m_min = m_feas.amin(-1, keepdim=True)
+        w = torch.exp(-(merges[None, :] - m_min) / self.ranked_temp_s) * feas_k
+        w = torch.where(has[:, None], w, torch.ones_like(w))  # avoid all-zero rows
+        pick_m = torch.multinomial(w.cpu().double(), 1, generator=self.gen).to(dev)[:, 0]
+        same_m = feas_k & (merges[None, :] == merges[pick_m][:, None])
+        combo_idx = torch.where(same_m, jerk_k, BIG).argmin(-1)
+        Lw = L[bi, first, combo_idx]  # (B, T)
+        aug_xy = xy + Lw[..., None] * nrm
 
-            upd = has  # (B,) rows to rewrite
-            # future (x, y, heading)
-            new_fut = torch.cat([aug_xy[:, P:], heading[:, P:, None]], dim=-1)
-            ego_future[upd, :, :3] = new_fut[upd]
-            # past (x, y, cos, sin) — rewritten so history, current state and
-            # future all lie on the same perturbed polyline
-            new_past = torch.cat(
-                [aug_xy[:, :P], heading[:, :P, None].cos(), heading[:, :P, None].sin()],
-                dim=-1,
-            )
-            inputs["ego_agent_past"][upd] = new_past[upd].to(inputs["ego_agent_past"].dtype)
-            # current state at t=0, kinematically consistent with the new polyline
-            i0 = P - 1
-            cur = inputs["ego_current_state"]
-            vel = g[:, i0]
-            acc = torch.gradient(g, spacing=DT, dim=1)[0][:, i0]
-            yaw_rate = torch.gradient(
-                torch.stack([heading.cos(), heading.sin()], -1), spacing=DT, dim=1
-            )[0][:, i0]
-            yaw_rate = (
-                heading.cos()[:, i0] * yaw_rate[..., 1] - heading.sin()[:, i0] * yaw_rate[..., 0]
-            )
-            steer = torch.atan(wb * yaw_rate / gs[:, i0].clamp(min=0.5))
-            new_cur = torch.stack(
-                [
-                    aug_xy[:, i0, 0],
-                    aug_xy[:, i0, 1],
-                    heading[:, i0].cos(),
-                    heading[:, i0].sin(),
-                    vel[..., 0],
-                    vel[..., 1],
-                    acc[..., 0],
-                    acc[..., 1],
-                    steer,
-                    yaw_rate,
-                ],
-                dim=-1,
-            )
-            n_cols = min(new_cur.shape[-1], cur.shape[-1])
-            cur[upd, :n_cols] = new_cur[upd, :n_cols].to(cur.dtype)
+        g = torch.gradient(aug_xy, spacing=DT, dim=1)[0]
+        gs = g.norm(dim=-1)
+        hd_gt = torch.atan2(tan[..., 1], tan[..., 0])
+        heading = torch.where(gs > 0.3, torch.atan2(g[..., 1], g[..., 0]), hd_gt)
 
+        upd = has  # (B,) rows to rewrite
+        # future (x, y, heading) — canonical 3-col layout
+        new_fut = torch.cat([aug_xy[:, P:], heading[:, P:, None]], dim=-1)
+        ego_future[upd, :, :3] = new_fut[upd]
+        # past (x, y, cos, sin) — rewritten so history, current state and
+        # future all lie on the same perturbed polyline
+        new_past = torch.cat(
+            [aug_xy[:, :P], heading[:, :P, None].cos(), heading[:, :P, None].sin()],
+            dim=-1,
+        )
+        inputs["ego_agent_past"][upd] = new_past[upd].to(inputs["ego_agent_past"].dtype)
+        # current state at t=0, kinematically consistent with the new polyline
+        i0 = P - 1
+        cur = inputs["ego_current_state"]
+        vel = g[:, i0]
+        acc = torch.gradient(g, spacing=DT, dim=1)[0][:, i0]
+        yaw_rate = torch.gradient(
+            torch.stack([heading.cos(), heading.sin()], -1), spacing=DT, dim=1
+        )[0][:, i0]
+        yaw_rate = heading.cos()[:, i0] * yaw_rate[..., 1] - heading.sin()[:, i0] * yaw_rate[..., 0]
+        steer = torch.atan(wb * yaw_rate / gs[:, i0].clamp(min=0.5))
+        new_cur = torch.stack(
+            [
+                aug_xy[:, i0, 0],
+                aug_xy[:, i0, 1],
+                heading[:, i0].cos(),
+                heading[:, i0].sin(),
+                vel[..., 0],
+                vel[..., 1],
+                acc[..., 0],
+                acc[..., 1],
+                steer,
+                yaw_rate,
+            ],
+            dim=-1,
+        )
+        n_cols = min(new_cur.shape[-1], cur.shape[-1])
+        cur[upd, :n_cols] = new_cur[upd, :n_cols].to(cur.dtype)
         self._aug_rows = has
         return self.centric_transform(inputs, ego_future, neighbors_future)

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -52,8 +52,6 @@ LIMITS = {
     # Ackermann / kinematic-bicycle feasibility (needs wheelbase from ego_shape):
     # steering angle delta = atan(WB * kappa), kappa = yaw_rate / speed.
     "steer": 0.61,  # rad (~35 deg), typical passenger-car lock
-    "steer_rate": 0.5,  # rad/s
-    "lon_acc": 3.0,  # m/s^2 (report only for now; GT noise can exceed it)
 }
 
 
@@ -96,11 +94,13 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         # polyline's finite-diff velocity leaves a small tangent/heading residual
         # in vy (<= 0.08 m/s) after re-centering — project it out so augmented
         # states stay exactly on the data manifold. No-op for non-augmented rows.
-        cur = inputs["ego_current_state"]
-        vx, vy = cur[:, 4], cur[:, 5]
-        cur[:, 4] = torch.sqrt(vx * vx + vy * vy) * torch.where(vx < 0, -1.0, 1.0)
-        cur[:, 5] = 0.0
-        cur[:, 7] = 0.0  # ay
+        rows = self._aug_rows
+        if rows is not None and bool(rows.any()):
+            cur = inputs["ego_current_state"]
+            vx, vy = cur[rows, 4], cur[rows, 5]
+            cur[rows, 4] = torch.sqrt(vx * vx + vy * vy) * torch.where(vx < 0, -1.0, 1.0)
+            cur[rows, 5] = 0.0
+            cur[rows, 7] = 0.0  # ay
         return out
 
     def __init__(
@@ -125,11 +125,20 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         # re-centered with the future in centric_transform (quintic/bridge keep the
         # GT past and skip that transform).
         self._transform_ego_past = True
+        # rows augmented in the most recent __call__; centric_transform re-projects
+        # velocity/accel to base_link (vy = ay = 0) for exactly these rows
+        self._aug_rows = None
         self.n_draws = n_draws
         self.dy_max = dy_max
         self.dth_max = dth_max
         self.knobs = knobs
-        self.gen = torch.Generator(device="cpu").manual_seed(seed)
+        # offset the stream per DDP rank so ranks draw independent perturbations
+        rank = (
+            torch.distributed.get_rank()
+            if torch.distributed.is_available() and torch.distributed.is_initialized()
+            else 0
+        )
+        self.gen = torch.Generator(device="cpu").manual_seed(seed + rank)
         self.ranked_temp_s = float(ranked_temp_s)
         self._basis_cache = {}
 
@@ -171,14 +180,19 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         return out
 
     # ---------- corridor, fully batched ----------
-    def _corridor(self, inputs, xy, tan, nrm, t, half_w, half_l):
+    def _corridor(self, inputs, xy, tan, nrm, half_w, half_l, wb):
         B, T, _ = xy.shape
         dev, dtype = xy.device, xy.dtype
         lo = torch.full((B, T), -20.0, device=dev, dtype=dtype)
         hi = torch.full((B, T), 20.0, device=dev, dtype=dtype)
 
         ls = inputs.get("line_strings")
-        if ls is not None and ls.shape[-1] >= 4:
+        if ls is not None and ls.shape[-1] < 4:
+            raise ValueError(
+                f"line_strings has {ls.shape[-1]} channels; frenet augmentation needs "
+                "channel 3 (road-border flag) to constrain the corridor"
+            )
+        if ls is not None:
             pts = ls[..., :2]  # (B, L, P, 2)
             is_border = (ls[..., 3] > 0.5).any(-1)  # (B, L)
             pv = pts.norm(dim=-1) > 1e-6
@@ -203,8 +217,18 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         past = inputs.get("neighbor_agents_past")
         fut = inputs.get("neighbor_agents_future")
         if past is not None and fut is not None:
-            # time-aligned neighbor states on the SAME grid as the ego polyline
-            st = torch.cat([past[..., :4], fut[..., :4]], dim=2)  # (B, N, T, 4)
+            # time-aligned neighbor states on the SAME grid as the ego polyline.
+            # Futures come in two layouts: 4-col (x, y, cos, sin) or the canonical
+            # 3-col (x, y, heading) — train_epoch only converts to cos/sin AFTER
+            # augmentation, so handle both here.
+            if fut.shape[-1] >= 4:
+                fut4 = fut[..., :4]
+            else:
+                fut4 = torch.cat([fut[..., :2], fut[..., 2:3].cos(), fut[..., 2:3].sin()], dim=-1)
+                # keep padded rows padded: an all-zero 3-col row must not become
+                # (0, 0, 1, 0) after cos/sin
+                fut4 = fut4 * (fut.abs().sum(-1, keepdim=True) > 0)
+            st = torch.cat([past[..., :4], fut4], dim=2)  # (B, N, T, 4)
             valid = st.abs().sum(-1) > 0  # (B, N, T)
             l_n = past[:, :, -1, 7][..., None]  # (B, N, 1)
             w_n = past[:, :, -1, 6][..., None]
@@ -212,7 +236,11 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             axi = st[..., 2:4]
             per = torch.stack([-axi[..., 1], axi[..., 0]], dim=-1)
             rel = c - xy[:, None]  # (B, N, T, 2)
-            lon = (rel * tan[:, None]).sum(-1)
+            # ego xy is base_link (rear axle); the footprint CENTER sits wb/2
+            # ahead along the tangent, so shift the longitudinal window there —
+            # otherwise a transient neighbor overlapping only the front bumper
+            # imposes no lateral cut.
+            lon = (rel * tan[:, None]).sum(-1) - (wb / 2)[:, None, None]
             lat = (rel * nrm[:, None]).sum(-1)
             ext_lon = (
                 (tan[:, None] * axi).sum(-1).abs() * l_n + (tan[:, None] * per).sum(-1).abs() * w_n
@@ -255,24 +283,27 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         half_w = inputs["ego_shape"][:, 2] / 2 + CORRIDOR_MARGIN
         half_l = inputs["ego_shape"][:, 1] / 2
 
-        lo, hi = self._corridor(inputs, xy, tan, nrm, t, half_w, half_l)
+        lo, hi = self._corridor(inputs, xy, tan, nrm, half_w, half_l, wb)
 
         K, C = self.n_draws, len(combos)
-        r = torch.rand((B, 3 * K + 1), generator=self.gen).to(dev)
+        r = torch.rand((B, 2 * K + 1), generator=self.gen).to(dev)
         do_aug = r[:, -1] < self._augment_prob
+        # Low-speed / reverse gate (same threshold as the quintic augmenter): a
+        # near-stationary ego makes every path-relative feasibility metric
+        # degenerate (a pure sideways translation has zero lateral accel/jerk/yaw
+        # rate), and a reversing ego would get motion-direction headings flipped
+        # 180 deg by the polyline rewrite. Both train on plain GT instead.
+        do_aug = do_aug & (inputs["ego_current_state"][:, 4] >= 2.0)
         dy = (r[:, :K] * 2 - 1) * self.dy_max
         dth = (r[:, K : 2 * K] * 2 - 1) * self.dth_max
-        j = (r[:, 2 * K : 3 * K] * C).long().clamp(max=C - 1)
 
         slope = v0[:, None] * torch.tan(dth)
-        # NO combo loop: gather each candidate's OWN basis / masks by its drawn
-        # tuple index, then evaluate everything in one einsum per derivative.
-        # (C=40 tiny GEMMs in a python loop cost ~240 kernel launches of pure
-        # overhead - the gathered form is a single batched contraction.)
+        # NO combo loop: stack every combo's basis/mask once, then evaluate all
+        # (draw, combo) pairs in one einsum per derivative. (C=40 tiny GEMMs in
+        # a python loop cost ~240 kernel launches of pure overhead - the stacked
+        # form is a single batched contraction.)
         Ball = torch.stack([cb["B"] for cb in combos])  # (C, 4, 3, T)
         m_all = torch.stack([cb["m"] for cb in combos])  # (C, T)
-        mh_all = torch.stack([cb["mh"] for cb in combos])
-        mf_all = torch.stack([cb["mf"] for cb in combos])
         merges = torch.tensor([cb["merge"] for cb in combos], device=dev, dtype=dtype)
         fracs = torch.tensor([cb["frac"] for cb in combos], device=dev, dtype=dtype)
 
@@ -287,7 +318,11 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         prof = torch.einsum("bkci,cdit->bkcdt", bc, Ball)  # (B, K, C, 4, T)
         L, V, A, J = prof.unbind(dim=3)
         m = m_all[None, None]  # (1, 1, C, T)
-        rot = half_l[:, None, None, None] * (V.abs() / speed[:, None, None]).clamp(max=0.35)
+        # rotation margin lever arm = rear axle -> front bumper (wb/2 + L/2),
+        # since the candidate lateral offset is applied at the rear-axle point
+        rot = (wb / 2 + half_l)[:, None, None, None] * (V.abs() / speed[:, None, None]).clamp(
+            max=0.35
+        )
         in_corr = ((L - rot >= lo[:, None, None]) & (L + rot <= hi[:, None, None]) | ~m).all(
             -1
         )  # (B, K, C)
@@ -337,9 +372,10 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             feas_k = feasible[bi, first]  # (B, C) — valid combos for the chosen draw
             jerk_k = jerk_fut_peak[bi, first]  # (B, C)
             BIG = torch.tensor(1e9, device=dev, dtype=dtype)
-            # merge time sampled among feasible Ms with P(M) ∝ exp(-(M-Mmin)/temp)
-            # — biased to fast convergence, slower merges keep a chance; within
-            # the sampled M, lowest peak future jerk wins.
+            # merge time sampled with per-combo weight exp(-(M-Mmin)/temp), i.e.
+            # P(M) ∝ n_feasible_combos(M) * exp(-(M-Mmin)/temp) — biased to fast
+            # convergence, slower merges keep a chance; within the sampled M,
+            # lowest peak future jerk wins.
             m_feas = torch.where(feas_k, merges[None, :], BIG)
             m_min = m_feas.amin(-1, keepdim=True)
             w = torch.exp(-(merges[None, :] - m_min) / self.ranked_temp_s) * feas_k
@@ -396,4 +432,5 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             n_cols = min(new_cur.shape[-1], cur.shape[-1])
             cur[upd, :n_cols] = new_cur[upd, :n_cols].to(cur.dtype)
 
+        self._aug_rows = has
         return self.centric_transform(inputs, ego_future, neighbors_future)

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -346,6 +346,31 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         dy = (r[:, :K] * 2 - 1) * self.dy_max
         dth = (r[:, K : 2 * K] * 2 - 1) * self.dth_max
 
+        L, in_corr, merges = self._candidate_profiles(
+            combos, dy, dth, v0, speed, half_l, lo, hi, dev, dtype
+        )
+
+        feasible, jerk_fut_peak = self._feasibility(xy, nrm, L, in_corr, wb, P)
+
+        feasible &= do_aug[:, None, None]
+        draw_ok = feasible.any(-1)  # (B, K): the drawn perturbation has >=1 valid merge
+        has = draw_ok.any(-1)  # (B,)
+        first = draw_ok.float().argmax(-1)  # first feasible PERTURBATION per scene
+
+        if not bool(has.any()):
+            # nothing feasible this batch: every row trains on plain GT
+            self._aug_rows = has
+            return self.centric_transform(inputs, ego_future, neighbors_future)
+
+        aug_xy = self._select_candidate(
+            feasible, jerk_fut_peak, first, merges, has, L, xy, nrm, B, dev, dtype
+        )
+
+        self._write_back(inputs, ego_future, aug_xy, xy, tan, wb, has, P)
+        return self.centric_transform(inputs, ego_future, neighbors_future)
+
+    def _candidate_profiles(self, combos, dy, dth, v0, speed, half_l, lo, hi, dev, dtype):
+        """Lateral-offset profile of every (draw, knob-combo) pair + corridor test."""
         slope = v0[:, None] * torch.tan(dth)
         # NO combo loop: stack every combo's basis/mask once, then evaluate all
         # (draw, combo) pairs in one einsum per derivative. (C=40 tiny GEMMs in
@@ -371,6 +396,10 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         in_corr = ((L - rot >= lo[:, None, None]) & (L + rot <= hi[:, None, None]) | ~m).all(
             -1
         )  # (B, K, C)
+        return L, in_corr, merges
+
+    def _feasibility(self, xy, nrm, L, in_corr, wb, P):
+        """Physical-limit screen on the exact candidate polylines."""
 
         # Feasibility on the EXACT candidate polylines, not the lateral-delta
         # profile: build every candidate's xy and finite-difference it at DT.
@@ -406,17 +435,12 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         y_ok = yrC.abs().amax(-1) <= _allow(yrG.abs().amax(-1), LIMITS["yaw_rate"])
         s_ok = stC.amax(-1) <= _allow(stG.amax(-1), LIMITS["steer"])
         feasible = in_corr & a_ok & j_ok & y_ok & s_ok  # (B, K, C)
+        return feasible, jerk_fut_peak
 
-        feasible &= do_aug[:, None, None]
-        draw_ok = feasible.any(-1)  # (B, K): the drawn perturbation has >=1 valid merge
-        has = draw_ok.any(-1)  # (B,)
-        first = draw_ok.float().argmax(-1)  # first feasible PERTURBATION per scene
-
-        if not bool(has.any()):
-            # nothing feasible this batch: every row trains on plain GT
-            self._aug_rows = has
-            return self.centric_transform(inputs, ego_future, neighbors_future)
-
+    def _select_candidate(
+        self, feasible, jerk_fut_peak, first, merges, has, L, xy, nrm, B, dev, dtype
+    ):
+        """Sample a merge horizon per scene, take its lowest-jerk combo, build the polyline."""
         bi = torch.arange(B, device=dev)
         feas_k = feasible[bi, first]  # (B, C) — valid combos for the chosen draw
         jerk_k = jerk_fut_peak[bi, first]  # (B, C)
@@ -434,7 +458,10 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         combo_idx = torch.where(same_m, jerk_k, BIG).argmin(-1)
         Lw = L[bi, first, combo_idx]  # (B, T)
         aug_xy = xy + Lw[..., None] * nrm
+        return aug_xy
 
+    def _write_back(self, inputs, ego_future, aug_xy, xy, tan, wb, has, P):
+        """Veto true overlaps, then write history / future / current state in place."""
         g = torch.gradient(aug_xy, spacing=DT, dim=1)[0]
         gs = g.norm(dim=-1)
         hd_gt = torch.atan2(tan[..., 1], tan[..., 0])
@@ -479,4 +506,3 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         n_cols = min(new_cur.shape[-1], cur.shape[-1])
         cur[upd, :n_cols] = new_cur[upd, :n_cols].to(cur.dtype)
         self._aug_rows = upd
-        return self.centric_transform(inputs, ego_future, neighbors_future)

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -1,0 +1,399 @@
+"""Frenet corridor augmentation (self-contained port of the frenet_aug prototype).
+
+Pure-tensor Frenet corridor augmentation — quintic-speed, batched at B.
+
+Everything runs as batched tensor ops on the training batch's device, one call
+per batch exactly like the quintic StatePerturbation:
+
+  1. corridor: road-border ray-cast along path normals = closed-form 2x2 solve,
+     broadcast over (B, T, segments); neighbor cuts use TIME-ALIGNED recorded
+     tracks (past for t<=0, GT future for t>0), broadcast over (B, N, T).
+  2. draws: K joint (dy, dth, combo) tuples per scene (K=16 - we need ONE valid
+     augmentation per scene, not a fan).
+  3. feasibility: shared quintic basis GEMMs (B, K, T) per knob combo; comfort
+     jerk (future), plausibility jerk (history), lat accel, Ackermann steering,
+     corridor with per-candidate rotation margin.
+  4. winner: first feasible draw per scene; its merge horizon is sampled among
+     the feasible ones with P(M) ~ exp(-(M - Mmin) / 1 s) (biased to fast
+     convergence, slower merges keep a chance; lowest peak future jerk breaks
+     ties within the sampled M); rebuild = one gathered basis GEMM;
+     headings/current-state re-derived from the augmented polyline. The ego
+     history is rewritten to the perturbed polyline so past, current state and
+     future stay kinematically consistent.
+
+No exact OBB re-verify in this path: the corridor (with the rotation margin) is
+audited zero-false-accept against the OBB reference (selftest.py), i.e. it is
+strictly conservative. Scenes with no feasible draw train on plain GT.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+
+from diffusion_planner.utils.data_augmentation import StatePerturbation
+
+DT = 0.1
+CORRIDOR_MARGIN = 0.10
+
+# Feasibility limits: candidates violating these are REJECTED (never clipped).
+LIMITS = {
+    "lat_acc": 3.0,  # m/s^2
+    "yaw_rate": 0.6,  # rad/s  (~34 deg/s)
+    # Comfort jerk, applied to the FUTURE segment only - that is what the model
+    # learns to output. (Peak lateral jerk of a quintic ~ 60*dy/T^3: a comfortable
+    # recovery from dy=0.75 m needs T >= 2.8 s, so at M=2 s most realistic offsets
+    # are correctly REJECTED. The production 2 s quintic bridge teaches ~6 m/s^3.)
+    "jerk": 2.0,  # m/s^3
+    # The HISTORY segment is context, not a target: it only has to be a plausible
+    # (possibly uncomfortable) way to have arrived at the perturbed pose. The 3 s
+    # past window would otherwise cap |dy| at 27*jerk/60 ~ 0.9 m.
+    "jerk_history": 5.0,  # m/s^3
+    # Ackermann / kinematic-bicycle feasibility (needs wheelbase from ego_shape):
+    # steering angle delta = atan(WB * kappa), kappa = yaw_rate / speed.
+    "steer": 0.61,  # rad (~35 deg), typical passenger-car lock
+    "steer_rate": 0.5,  # rad/s
+    "lon_acc": 3.0,  # m/s^2 (report only for now; GT noise can exceed it)
+}
+
+
+def quintic_basis(t0: float, t1: float, t: np.ndarray):
+    """Rows: response of l, l', l'', l''' to unit (pos, vel, acc) BCs at t1.
+
+    BCs at t0 are zero (anchor / merge on the GT path), so the profile is linear
+    in the three t1-side BCs alone. Returns 4 arrays shaped (3, len(t)).
+    """
+    M = []
+    for tt in (t0, t1):
+        M += [
+            [1, tt, tt**2, tt**3, tt**4, tt**5],
+            [0, 1, 2 * tt, 3 * tt**2, 4 * tt**3, 5 * tt**4],
+            [0, 0, 2, 6 * tt, 12 * tt**2, 20 * tt**3],
+        ]
+    Minv = np.linalg.inv(np.array(M, float))  # coeffs = Minv @ (BCs at t0, BCs at t1)
+    C = Minv[:, 3:]  # (6, 3) response to the t1-side BCs
+    P = np.stack([np.ones_like(t), t, t**2, t**3, t**4, t**5])
+    D1 = np.stack([np.zeros_like(t), np.ones_like(t), 2 * t, 3 * t**2, 4 * t**3, 5 * t**4])
+    D2 = np.stack([np.zeros_like(t)] * 2 + [2 * np.ones_like(t), 6 * t, 12 * t**2, 20 * t**3])
+    D3 = np.stack([np.zeros_like(t)] * 3 + [6 * np.ones_like(t), 24 * t, 60 * t**2])
+    return (C.T @ P, C.T @ D1, C.T @ D2, C.T @ D3)
+
+
+@dataclass(frozen=True)
+class KnobGrid:
+    merge_times: tuple = (2.0, 3.0, 4.0, 5.0)
+    anchors: tuple = (2.0, 3.0)
+    acc0_fracs: tuple = (0.0, -0.5, 0.5, -1.0, 1.0)
+
+
+class FrenetStatePerturbationTensor(StatePerturbation):
+    """Drop-in for StatePerturbation; fully batched, no per-sample python."""
+
+    def centric_transform(self, inputs, ego_future, neighbors_future):
+        out = super().centric_transform(inputs, ego_future, neighbors_future)
+        # Dataset convention is base_link: velocity and acceleration are purely
+        # longitudinal (raw NPZs carry vy = ay = 0.0 identically). The rebuilt
+        # polyline's finite-diff velocity leaves a small tangent/heading residual
+        # in vy (<= 0.08 m/s) after re-centering — project it out so augmented
+        # states stay exactly on the data manifold. No-op for non-augmented rows.
+        cur = inputs["ego_current_state"]
+        vx, vy = cur[:, 4], cur[:, 5]
+        cur[:, 4] = torch.sqrt(vx * vx + vy * vy) * torch.where(vx < 0, -1.0, 1.0)
+        cur[:, 5] = 0.0
+        cur[:, 7] = 0.0  # ay
+        return out
+
+    def __init__(
+        self,
+        augment_prob: float,
+        device,
+        n_draws: int = 16,
+        dy_max: float = 2.0,
+        dth_max: float = 0.17,
+        knobs: KnobGrid = KnobGrid(),
+        seed: int = 0,
+        ranked_temp_s: float = 1.0,
+    ):
+        super().__init__(
+            augment_prob=augment_prob,
+            num_refine=20,
+            device=device,
+            ego_past_noise_std=0.0,  # frenet rewrites the past kinematically
+            use_smoothing_future_trajectory=False,
+        )
+        # The ego past is rewritten to the perturbed polyline, so it must also be
+        # re-centered with the future in centric_transform (quintic/bridge keep the
+        # GT past and skip that transform).
+        self._transform_ego_past = True
+        self.n_draws = n_draws
+        self.dy_max = dy_max
+        self.dth_max = dth_max
+        self.knobs = knobs
+        self.gen = torch.Generator(device="cpu").manual_seed(seed)
+        self.ranked_temp_s = float(ranked_temp_s)
+        self._basis_cache = {}
+
+    # ---------- shared basis (depends only on the time grid + knobs) ----------
+    def _bases(self, P, F, device, dtype):
+        key = (P, F, device, dtype)
+        if key in self._basis_cache:
+            return self._basis_cache[key]
+        t = np.concatenate([np.arange(-(P - 1), 1) * DT, np.arange(1, F + 1) * DT])
+        combos = []
+        for mt in self.knobs.merge_times:
+            if int(mt / DT) > F:
+                continue
+            for anch in self.knobs.anchors:
+                anch = min(anch, (P - 1) * DT)
+                mh = (t >= -anch) & (t <= 0)
+                mf = (t > 0) & (t <= mt)
+                Bh = quintic_basis(-anch, 0.0, t[mh])
+                Bf = quintic_basis(mt, 0.0, t[mf])
+                T = len(t)
+                Bmat = np.zeros((4, 3, T))
+                for d in range(4):
+                    Bmat[d][:, mh] = Bh[d]
+                    Bmat[d][:, mf] = Bf[d]
+                for frac in self.knobs.acc0_fracs:
+                    combos.append(
+                        {
+                            "merge": mt,
+                            "anchor": anch,
+                            "frac": frac,
+                            "B": torch.tensor(Bmat, dtype=dtype, device=device),
+                            "m": torch.tensor(mh | mf, device=device),
+                            "mh": torch.tensor(mh, device=device),
+                            "mf": torch.tensor(mf, device=device),
+                        }
+                    )
+        out = (torch.tensor(t, dtype=dtype, device=device), combos)
+        self._basis_cache[key] = out
+        return out
+
+    # ---------- corridor, fully batched ----------
+    def _corridor(self, inputs, xy, tan, nrm, t, half_w, half_l):
+        B, T, _ = xy.shape
+        dev, dtype = xy.device, xy.dtype
+        lo = torch.full((B, T), -20.0, device=dev, dtype=dtype)
+        hi = torch.full((B, T), 20.0, device=dev, dtype=dtype)
+
+        ls = inputs.get("line_strings")
+        if ls is not None and ls.shape[-1] >= 4:
+            pts = ls[..., :2]  # (B, L, P, 2)
+            is_border = (ls[..., 3] > 0.5).any(-1)  # (B, L)
+            pv = pts.norm(dim=-1) > 1e-6
+            a = pts[:, :, :-1, :].flatten(1, 2)  # (B, S, 2)
+            e = pts[:, :, 1:, :].flatten(1, 2)
+            sv = (pv[:, :, :-1] & pv[:, :, 1:] & is_border[:, :, None]).flatten(1, 2)  # (B, S)
+            d = e - a
+            nx, ny = nrm[..., 0:1], nrm[..., 1:2]  # (B, T, 1)
+            dx = d[:, None, :, 0]  # (B, 1, S)
+            dy_ = d[:, None, :, 1]
+            det = nx * (-dy_) - ny * (-dx)  # (B, T, S)
+            rx = a[:, None, :, 0] - xy[..., 0:1]
+            ry = a[:, None, :, 1] - xy[..., 1:2]
+            s = (rx * (-dy_) - ry * (-dx)) / det
+            u = (nx * ry - ny * rx) / det
+            ok = torch.isfinite(s) & (u >= 0) & (u <= 1) & sv[:, None, :]
+            pos = torch.where(ok & (s > 0), s, torch.full_like(s, torch.inf))
+            neg = torch.where(ok & (s < 0), s, torch.full_like(s, -torch.inf))
+            hi = torch.minimum(hi, pos.amin(-1) - half_w[:, None])
+            lo = torch.maximum(lo, neg.amax(-1) + half_w[:, None])
+
+        past = inputs.get("neighbor_agents_past")
+        fut = inputs.get("neighbor_agents_future")
+        if past is not None and fut is not None:
+            # time-aligned neighbor states on the SAME grid as the ego polyline
+            st = torch.cat([past[..., :4], fut[..., :4]], dim=2)  # (B, N, T, 4)
+            valid = st.abs().sum(-1) > 0  # (B, N, T)
+            l_n = past[:, :, -1, 7][..., None]  # (B, N, 1)
+            w_n = past[:, :, -1, 6][..., None]
+            c = st[..., :2]
+            axi = st[..., 2:4]
+            per = torch.stack([-axi[..., 1], axi[..., 0]], dim=-1)
+            rel = c - xy[:, None]  # (B, N, T, 2)
+            lon = (rel * tan[:, None]).sum(-1)
+            lat = (rel * nrm[:, None]).sum(-1)
+            ext_lon = (
+                (tan[:, None] * axi).sum(-1).abs() * l_n + (tan[:, None] * per).sum(-1).abs() * w_n
+            ) / 2
+            ext_lat = (
+                (nrm[:, None] * axi).sum(-1).abs() * l_n + (nrm[:, None] * per).sum(-1).abs() * w_n
+            ) / 2
+            near = valid & (lon.abs() <= half_l[:, None, None] + ext_lon)
+            cut_hi = torch.where(
+                near & (lat > 0),
+                lat - ext_lat - half_w[:, None, None],
+                torch.full_like(lat, torch.inf),
+            )
+            cut_lo = torch.where(
+                near & (lat < 0),
+                lat + ext_lat + half_w[:, None, None],
+                torch.full_like(lat, -torch.inf),
+            )
+            hi = torch.minimum(hi, cut_hi.amin(1))
+            lo = torch.maximum(lo, cut_lo.amax(1))
+        return lo, hi
+
+    # ---------- the augmentation ----------
+    @torch.no_grad()
+    def __call__(self, inputs, ego_future, neighbors_future):
+        past4 = inputs["ego_agent_past"]  # (B, P, 4) x, y, cos, sin
+        B, P, _ = past4.shape
+        F = ego_future.shape[1]
+        dev, dtype = past4.device, past4.dtype
+        t, combos = self._bases(P, F, dev, dtype)
+        T = P + F
+
+        fut_cs = torch.stack([ego_future[..., 2].cos(), ego_future[..., 2].sin()], dim=-1)
+        xy = torch.cat([past4[..., :2], ego_future[..., :2]], dim=1)  # (B, T, 2)
+        tan = torch.cat([past4[..., 2:4], fut_cs], dim=1)
+        nrm = torch.stack([-tan[..., 1], tan[..., 0]], dim=-1)
+        speed = torch.gradient(xy, spacing=DT, dim=1)[0].norm(dim=-1).clamp(min=0.5)  # (B, T)
+        v0 = speed[:, P - 1]
+        wb = inputs["ego_shape"][:, 0]
+        half_w = inputs["ego_shape"][:, 2] / 2 + CORRIDOR_MARGIN
+        half_l = inputs["ego_shape"][:, 1] / 2
+
+        lo, hi = self._corridor(inputs, xy, tan, nrm, t, half_w, half_l)
+
+        K, C = self.n_draws, len(combos)
+        r = torch.rand((B, 3 * K + 1), generator=self.gen).to(dev)
+        do_aug = r[:, -1] < self._augment_prob
+        dy = (r[:, :K] * 2 - 1) * self.dy_max
+        dth = (r[:, K : 2 * K] * 2 - 1) * self.dth_max
+        j = (r[:, 2 * K : 3 * K] * C).long().clamp(max=C - 1)
+
+        slope = v0[:, None] * torch.tan(dth)
+        # NO combo loop: gather each candidate's OWN basis / masks by its drawn
+        # tuple index, then evaluate everything in one einsum per derivative.
+        # (C=40 tiny GEMMs in a python loop cost ~240 kernel launches of pure
+        # overhead - the gathered form is a single batched contraction.)
+        Ball = torch.stack([cb["B"] for cb in combos])  # (C, 4, 3, T)
+        m_all = torch.stack([cb["m"] for cb in combos])  # (C, T)
+        mh_all = torch.stack([cb["mh"] for cb in combos])
+        mf_all = torch.stack([cb["mf"] for cb in combos])
+        merges = torch.tensor([cb["merge"] for cb in combos], device=dev, dtype=dtype)
+        fracs = torch.tensor([cb["frac"] for cb in combos], device=dev, dtype=dtype)
+
+        # Evaluate EVERY knob combo for every drawn (dy, dth): the merge choice
+        # must be made FOR a perturbation, not across perturbations — selecting
+        # min-merge over joint draws would systematically prefer small offsets
+        # and shrink the dose.
+        acc0 = fracs[None, None, :] * 5.77 * dy[..., None] / merges[None, None, :] ** 2
+        bc = torch.stack(
+            [dy[..., None].expand_as(acc0), slope[..., None].expand_as(acc0), acc0], dim=-1
+        )  # (B, K, C, 3)
+        prof = torch.einsum("bkci,cdit->bkcdt", bc, Ball)  # (B, K, C, 4, T)
+        L, V, A, J = prof.unbind(dim=3)
+        m = m_all[None, None]  # (1, 1, C, T)
+        rot = half_l[:, None, None, None] * (V.abs() / speed[:, None, None]).clamp(max=0.35)
+        in_corr = ((L - rot >= lo[:, None, None]) & (L + rot <= hi[:, None, None]) | ~m).all(
+            -1
+        )  # (B, K, C)
+
+        # Feasibility on the EXACT candidate polylines, not the lateral-delta
+        # profile: build every candidate's xy and finite-difference it at DT.
+        # The L(t)-only check misses the coupling between the lateral swing and
+        # the GT path's own curvature (audited: ~1/3 of its accepts exceeded the
+        # comfort jerk on the exact polyline, worst 2.6 vs 2.0 m/s^3). Limits are
+        # GT-relative: where the recorded drive itself exceeds a limit (data
+        # glitches), the candidate only has to stay within the GT's own maximum.
+        def _exact_metrics(poly_xy):
+            v = torch.gradient(poly_xy, spacing=DT, dim=-2)[0]
+            sp = v.norm(dim=-1).clamp(min=0.5)
+            a = torch.gradient(v, spacing=DT, dim=-2)[0]
+            lat_a = (v[..., 0] * a[..., 1] - v[..., 1] * a[..., 0]) / sp
+            jk = torch.gradient(a, spacing=DT, dim=-2)[0]
+            lat_j = (v[..., 0] * jk[..., 1] - v[..., 1] * jk[..., 0]) / sp
+            yaw_rate = lat_a / sp
+            return lat_a, lat_j, yaw_rate, sp
+
+        cand_xy = xy[:, None, None] + L[..., None] * nrm[:, None, None]  # (B, K, C, T, 2)
+        laC, ljC, yrC, spC = _exact_metrics(cand_xy)  # each (B, K, C, T)
+        laG, ljG, yrG, spG = _exact_metrics(xy)  # GT reference, (B, T)
+        stC = torch.atan(wb[:, None, None, None] * yrC / spC).abs()
+        stG = torch.atan(wb[:, None] * yrG / spG).abs()
+
+        def _allow(gt_max, limit):
+            return torch.clamp(gt_max, min=limit)[:, None, None]  # (B, 1, 1)
+
+        jerk_fut_peak = ljC[..., P:].abs().amax(-1)  # (B, K, C) — also the tiebreak
+        a_ok = laC.abs().amax(-1) <= _allow(laG.abs().amax(-1), LIMITS["lat_acc"])
+        j_ok = (jerk_fut_peak <= _allow(ljG[:, P:].abs().amax(-1), LIMITS["jerk"])) & (
+            ljC[..., :P].abs().amax(-1) <= _allow(ljG[:, :P].abs().amax(-1), LIMITS["jerk_history"])
+        )
+        y_ok = yrC.abs().amax(-1) <= _allow(yrG.abs().amax(-1), LIMITS["yaw_rate"])
+        s_ok = stC.amax(-1) <= _allow(stG.amax(-1), LIMITS["steer"])
+        feasible = in_corr & a_ok & j_ok & y_ok & s_ok  # (B, K, C)
+
+        feasible &= do_aug[:, None, None]
+        draw_ok = feasible.any(-1)  # (B, K): the drawn perturbation has >=1 valid merge
+        has = draw_ok.any(-1)  # (B,)
+        first = draw_ok.float().argmax(-1)  # first feasible PERTURBATION per scene
+
+        if bool(has.any()):
+            bi = torch.arange(B, device=dev)
+            feas_k = feasible[bi, first]  # (B, C) — valid combos for the chosen draw
+            jerk_k = jerk_fut_peak[bi, first]  # (B, C)
+            BIG = torch.tensor(1e9, device=dev, dtype=dtype)
+            # merge time sampled among feasible Ms with P(M) ∝ exp(-(M-Mmin)/temp)
+            # — biased to fast convergence, slower merges keep a chance; within
+            # the sampled M, lowest peak future jerk wins.
+            m_feas = torch.where(feas_k, merges[None, :], BIG)
+            m_min = m_feas.amin(-1, keepdim=True)
+            w = torch.exp(-(merges[None, :] - m_min) / self.ranked_temp_s) * feas_k
+            w = torch.where(has[:, None], w, torch.ones_like(w))  # avoid all-zero rows
+            pick_m = torch.multinomial(w.cpu().double(), 1, generator=self.gen).to(dev)[:, 0]
+            same_m = feas_k & (merges[None, :] == merges[pick_m][:, None])
+            combo_idx = torch.where(same_m, jerk_k, BIG).argmin(-1)
+            Lw = L[bi, first, combo_idx]  # (B, T)
+            aug_xy = xy + Lw[..., None] * nrm
+
+            g = torch.gradient(aug_xy, spacing=DT, dim=1)[0]
+            gs = g.norm(dim=-1)
+            hd_gt = torch.atan2(tan[..., 1], tan[..., 0])
+            heading = torch.where(gs > 0.3, torch.atan2(g[..., 1], g[..., 0]), hd_gt)
+
+            upd = has  # (B,) rows to rewrite
+            # future (x, y, heading)
+            new_fut = torch.cat([aug_xy[:, P:], heading[:, P:, None]], dim=-1)
+            ego_future[upd, :, :3] = new_fut[upd]
+            # past (x, y, cos, sin) — rewritten so history, current state and
+            # future all lie on the same perturbed polyline
+            new_past = torch.cat(
+                [aug_xy[:, :P], heading[:, :P, None].cos(), heading[:, :P, None].sin()],
+                dim=-1,
+            )
+            inputs["ego_agent_past"][upd] = new_past[upd].to(inputs["ego_agent_past"].dtype)
+            # current state at t=0, kinematically consistent with the new polyline
+            i0 = P - 1
+            cur = inputs["ego_current_state"]
+            vel = g[:, i0]
+            acc = torch.gradient(g, spacing=DT, dim=1)[0][:, i0]
+            yaw_rate = torch.gradient(
+                torch.stack([heading.cos(), heading.sin()], -1), spacing=DT, dim=1
+            )[0][:, i0]
+            yaw_rate = (
+                heading.cos()[:, i0] * yaw_rate[..., 1] - heading.sin()[:, i0] * yaw_rate[..., 0]
+            )
+            steer = torch.atan(wb * yaw_rate / gs[:, i0].clamp(min=0.5))
+            new_cur = torch.stack(
+                [
+                    aug_xy[:, i0, 0],
+                    aug_xy[:, i0, 1],
+                    heading[:, i0].cos(),
+                    heading[:, i0].sin(),
+                    vel[..., 0],
+                    vel[..., 1],
+                    acc[..., 0],
+                    acc[..., 1],
+                    steer,
+                    yaw_rate,
+                ],
+                dim=-1,
+            )
+            n_cols = min(new_cur.shape[-1], cur.shape[-1])
+            cur[upd, :n_cols] = new_cur[upd, :n_cols].to(cur.dtype)
+
+        return self.centric_transform(inputs, ego_future, neighbors_future)

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -82,6 +82,14 @@ class FrenetStatePerturbationTensor(StatePerturbation):
 
     def centric_transform(self, inputs, ego_future, neighbors_future):
         out = super().centric_transform(inputs, ego_future, neighbors_future)
+        # Restore "no history" rows to exact zero. Both the rewrite and the parent's
+        # re-centering write real numbers into every history slot, and the encoder reads
+        # ego_agent_past directly -- a transformed pad would be presented to the model as
+        # history that never happened. Applied to the whole batch, not just augmented rows,
+        # so a future non-identity transform on untouched rows cannot reintroduce it.
+        pad = getattr(self, "_ego_past_pad", None)
+        if pad is not None and bool(pad.any()):
+            inputs["ego_agent_past"][pad] = 0.0
         # Dataset convention is base_link: velocity and acceleration are purely
         # longitudinal (raw NPZs carry vy = ay = 0.0 identically). The rebuilt
         # polyline's finite-diff velocity leaves a small tangent/heading residual
@@ -228,14 +236,32 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             )
         past4 = inputs["ego_agent_past"]  # (B, P, 4) x, y, cos, sin
         B, P, _ = past4.shape
+        # Leading history can be zero-padded when a scene starts near the beginning of a
+        # recording. Those rows mean "no history", not "the ego was at the origin facing
+        # +x", so they are remembered here and restored to exact zero after the rewrite
+        # and the re-centering (see centric_transform). Same contract as the bridge path.
+        self._ego_past_pad = torch.sum(torch.ne(past4[..., :4], 0), dim=-1) == 0  # (B, P)
         F = ego_future.shape[1]
         dev, dtype = past4.device, past4.dtype
         t, combos = self._bases(P, F, dev, dtype)
         T = P + F
 
         fut_cs = torch.stack([ego_future[..., 2].cos(), ego_future[..., 2].sin()], dim=-1)
-        xy = torch.cat([past4[..., :2], ego_future[..., :2]], dim=1)  # (B, T, 2)
-        tan = torch.cat([past4[..., 2:4], fut_cs], dim=1)
+        past_xy, past_tan = past4[..., :2], past4[..., 2:4]
+        if bool(self._ego_past_pad.any()):
+            # Hold the first real pose across the padded prefix instead of leaving it at the
+            # origin. A (0,0) position adjacent to a real one is a metres-wide phantom step:
+            # it would give the first REAL history sample a heading taken from that jump, and
+            # a speed spike the feasibility screen would then judge. Replicating makes the
+            # differences zero across the padding boundary, so the first real sample keeps its
+            # own stored heading. The padded rows themselves are zeroed again at the end.
+            first = torch.argmax((~self._ego_past_pad).to(torch.int8), dim=1)  # (B,)
+            idx = torch.arange(P, device=past4.device)[None, :]
+            src = torch.maximum(idx, first[:, None])  # pad -> first real, real -> itself
+            past_xy = torch.gather(past_xy, 1, src[..., None].expand(-1, -1, 2))
+            past_tan = torch.gather(past_tan, 1, src[..., None].expand(-1, -1, 2))
+        xy = torch.cat([past_xy, ego_future[..., :2]], dim=1)  # (B, T, 2)
+        tan = torch.cat([past_tan, fut_cs], dim=1)
         nrm = torch.stack([-tan[..., 1], tan[..., 0]], dim=-1)
         speed = ddt(xy, 1).norm(dim=-1).clamp(min=0.5)  # (B, T)
         v0 = speed[:, P - 1]

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -33,6 +33,7 @@ import numpy as np
 import torch
 
 from diffusion_planner.utils.data_augmentation import StatePerturbation
+from planner_metrics.geometry import build_road_border_segments
 from planner_metrics.subscores import compute_ego_neighbor_signed_clearance
 
 DT = 0.1
@@ -130,6 +131,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         # rows augmented in the most recent __call__; centric_transform re-projects
         # velocity/accel to base_link (vy = ay = 0) for exactly these rows
         self._aug_rows = None
+        self._nbr_near = None
         self.n_draws = n_draws
         self.dy_max = dy_max
         self.dth_max = dth_max
@@ -184,7 +186,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
     # ---------- corridor, fully batched ----------
     def _corridor(self, inputs, xy, tan, nrm, half_w, half_l, wb):
         # reset per batch so a neighbor-less batch never sees a stale tensor
-        self._nbr_st = self._nbr_valid = None
+        self._nbr_st = self._nbr_valid = self._nbr_near = None
         B, T, _ = xy.shape
         dev, dtype = xy.device, xy.dtype
         lo = torch.full((B, T), -20.0, device=dev, dtype=dtype)
@@ -197,12 +199,11 @@ class FrenetStatePerturbationTensor(StatePerturbation):
                 "channel 3 (road-border flag) to constrain the corridor"
             )
         if ls is not None:
-            pts = ls[..., :2]  # (B, L, P, 2)
-            is_border = (ls[..., 3] > 0.5).any(-1)  # (B, L)
-            pv = pts.norm(dim=-1) > 1e-6
-            a = pts[:, :, :-1, :].flatten(1, 2)  # (B, S, 2)
-            e = pts[:, :, 1:, :].flatten(1, 2)
-            sv = (pv[:, :, :-1] & pv[:, :, 1:] & is_border[:, :, None]).flatten(1, 2)  # (B, S)
+            # lo/hi start at +-20 m, so a border further than that from every
+            # path point can never tighten them; the shared builder drops those
+            # before the ray math (~180 of 1140 slots survive on the pipeline
+            # set) and pads to the batch maximum, so the bounds are unchanged.
+            a, e, sv = build_road_border_segments(ls, xy, reach=25.0)
             d = e - a
             nx, ny = nrm[..., 0:1], nrm[..., 1:2]  # (B, T, 1)
             dx = d[:, None, :, 0]  # (B, 1, S)
@@ -254,6 +255,18 @@ class FrenetStatePerturbationTensor(StatePerturbation):
                 (nrm[:, None] * axi).sum(-1).abs() * l_n + (nrm[:, None] * per).sum(-1).abs() * w_n
             ) / 2
             near = valid & (lon.abs() <= half_l[:, None, None] + ext_lon)
+            # Same longitudinal test, padded, kept for the exact-OBB veto so it
+            # only pairs neighbors that can actually reach the ego box. The
+            # augmentation is a lateral offset, so a candidate's longitudinal
+            # coordinate in this frame is the GT one; the pad covers the ego's
+            # longitudinal half-extent growing under the heading change
+            # (half_l*cos + half_w*sin <= half_l + half_w) plus the wb/2 centre
+            # shift. Pairs outside it cannot overlap, so the verdicts are
+            # unchanged — the canonical OBB check still decides every one.
+            self._nbr_near = valid & (
+                lon.abs()
+                <= half_l[:, None, None] + ext_lon + half_w[:, None, None] + wb[:, None, None] / 2
+            )
             cut_hi = torch.where(
                 near & (lat > 0),
                 lat - ext_lat - half_w[:, None, None],
@@ -289,7 +302,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         # kernel each, so their launch overhead dominated training (228 ms/batch
         # at B=512, several times the rest of the augmenter) to reject the ~1.4%
         # of winners that truly overlap.
-        pairs = upd[:, None] & self._nbr_valid.any(-1)  # (B, N) scene x neighbor
+        pairs = upd[:, None] & self._nbr_near.any(-1)  # (B, N) scene x neighbor
         bi, ni = torch.nonzero(pairs, as_tuple=True)
         if bi.numel() == 0:
             return upd
@@ -423,23 +436,34 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             yaw_rate = lat_a / sp
             return lat_a, lat_j, yaw_rate, sp
 
-        cand_xy = xy[:, None, None] + L[..., None] * nrm[:, None, None]  # (B, K, C, T, 2)
-        laC, ljC, yrC, spC = _exact_metrics(cand_xy)  # each (B, K, C, T)
+        # Only candidates that already clear the corridor can end up feasible, so
+        # build the exact polylines for those alone — the rest would be discarded
+        # by the `in_corr &` below anyway, and they are ~40% of the grid.
+        BIG = torch.tensor(1e9, device=L.device, dtype=L.dtype)
+        feasible = torch.zeros_like(in_corr)
+        jerk_fut_peak = torch.full(in_corr.shape, BIG.item(), device=L.device, dtype=L.dtype)
+        b_i, k_i, c_i = torch.nonzero(in_corr, as_tuple=True)
+        if b_i.numel() == 0:
+            return feasible, jerk_fut_peak
+
+        cand_xy = xy[b_i] + L[b_i, k_i, c_i][..., None] * nrm[b_i]  # (M, T, 2)
+        laC, ljC, yrC, spC = _exact_metrics(cand_xy)  # each (M, T)
         laG, ljG, yrG, spG = _exact_metrics(xy)  # GT reference, (B, T)
-        stC = torch.atan(wb[:, None, None, None] * yrC / spC).abs()
+        stC = torch.atan(wb[b_i, None] * yrC / spC).abs()
         stG = torch.atan(wb[:, None] * yrG / spG).abs()
 
         def _allow(gt_max, limit):
-            return torch.clamp(gt_max, min=limit)[:, None, None]  # (B, 1, 1)
+            return torch.clamp(gt_max, min=limit)[b_i]  # (M,)
 
-        jerk_fut_peak = ljC[..., P:].abs().amax(-1)  # (B, K, C) — also the tiebreak
+        peak = ljC[:, P:].abs().amax(-1)  # (M,) — also the tiebreak
         a_ok = laC.abs().amax(-1) <= _allow(laG.abs().amax(-1), LIMITS["lat_acc"])
-        j_ok = (jerk_fut_peak <= _allow(ljG[:, P:].abs().amax(-1), LIMITS["jerk"])) & (
-            ljC[..., :P].abs().amax(-1) <= _allow(ljG[:, :P].abs().amax(-1), LIMITS["jerk_history"])
+        j_ok = (peak <= _allow(ljG[:, P:].abs().amax(-1), LIMITS["jerk"])) & (
+            ljC[:, :P].abs().amax(-1) <= _allow(ljG[:, :P].abs().amax(-1), LIMITS["jerk_history"])
         )
         y_ok = yrC.abs().amax(-1) <= _allow(yrG.abs().amax(-1), LIMITS["yaw_rate"])
         s_ok = stC.amax(-1) <= _allow(stG.amax(-1), LIMITS["steer"])
-        feasible = in_corr & a_ok & j_ok & y_ok & s_ok  # (B, K, C)
+        feasible[b_i, k_i, c_i] = a_ok & j_ok & y_ok & s_ok
+        jerk_fut_peak[b_i, k_i, c_i] = peak
         return feasible, jerk_fut_peak
 
     def _select_candidate(

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -268,6 +268,38 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             lo = torch.maximum(lo, cut_lo.amax(1))
         return lo, hi
 
+    def _veto_true_overlaps(self, inputs, upd, aug_xy, heading):
+        """Exact-OBB veto on the winning candidates.
+
+        The corridor is a fast approximation (path-normal ray-cast with
+        half-width margins around the rear-axle polyline) and is measured to
+        accept ~1.4% of winners whose TRUE footprint overlaps a recorded
+        neighbor box. Re-check each winner with the canonical signed OBB
+        clearance (rear-axle ego convention, centroid neighbors) and train
+        vetoed rows on plain GT. Borders are left to the corridor: the recorded
+        drives themselves touch the mapped borders (GT corner distance reaches
+        0.0), so an OBB border veto would reject GT-like data.
+        """
+        if self._nbr_st is None or not bool(upd.any()):
+            return upd
+        hd_cs = torch.stack([heading.cos(), heading.sin()], dim=-1)
+        tr_aug = torch.cat([aug_xy, hd_cs], dim=-1)  # (B, T, 4)
+        past_n = inputs["neighbor_agents_past"]
+        for i in torch.nonzero(upd).flatten().tolist():
+            keep = self._nbr_valid[i].any(-1)
+            if not bool(keep.any()):
+                continue
+            clr = compute_ego_neighbor_signed_clearance(
+                tr_aug[i : i + 1],
+                inputs["ego_shape"][i],
+                self._nbr_st[i, keep],
+                past_n[i, keep, -1][:, [6, 7]],  # width, length
+                self._nbr_valid[i, keep],
+            )
+            if float(clr.min()) < 0.0:
+                upd[i] = False
+        return upd
+
     # ---------- the augmentation ----------
     @torch.no_grad()
     def __call__(self, inputs, ego_future, neighbors_future):
@@ -408,34 +440,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         hd_gt = torch.atan2(tan[..., 1], tan[..., 0])
         heading = torch.where(gs > 0.3, torch.atan2(g[..., 1], g[..., 0]), hd_gt)
 
-        upd = has.clone()  # (B,) rows to rewrite
-        # Exact-OBB veto: the corridor is a fast approximation (path-normal
-        # ray-cast with half-width margins around the rear-axle polyline) and is
-        # measured to accept ~1.4% of winners whose TRUE footprint overlaps a
-        # recorded neighbor box. Check the winning candidate with the canonical
-        # signed OBB clearance (rear-axle ego convention, centroid neighbors)
-        # and train vetoed rows on plain GT. Borders are left to the corridor:
-        # the recorded drives themselves touch the mapped borders (GT corner
-        # distance reaches 0.0), so an OBB border veto would reject GT-like data.
-        nbr_st = self._nbr_st
-        if nbr_st is not None and bool(upd.any()):
-            hd_cs = torch.stack([heading.cos(), heading.sin()], dim=-1)
-            tr_aug = torch.cat([aug_xy, hd_cs], dim=-1)  # (B, T, 4)
-            past_n = inputs["neighbor_agents_past"]
-            for i in torch.nonzero(upd).flatten().tolist():
-                keep = self._nbr_valid[i].any(-1)
-                if not bool(keep.any()):
-                    continue
-                shapes = past_n[i, keep, -1][:, [6, 7]]  # width, length
-                clr = compute_ego_neighbor_signed_clearance(
-                    tr_aug[i : i + 1],
-                    inputs["ego_shape"][i],
-                    nbr_st[i, keep],
-                    shapes,
-                    self._nbr_valid[i, keep],
-                )
-                if float(clr.min()) < 0.0:
-                    upd[i] = False
+        upd = self._veto_true_overlaps(inputs, has.clone(), aug_xy, heading)
         # future (x, y, heading) — canonical 3-col layout
         new_fut = torch.cat([aug_xy[:, P:], heading[:, P:, None]], dim=-1)
         ego_future[upd, :, :3] = new_fut[upd]

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -209,13 +209,13 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         self._nbr_st = self._nbr_valid = self._nbr_near = None
         B, T, _ = xy.shape
         dev, dtype = xy.device, xy.dtype
-        # A candidate's lateral extent is |L| <= dy_max plus the rotation margin
-        # (half_l * 0.35, see the in_corr test), so a bound wider than that can
-        # never change an acceptance. Capping here keeps the test identical and
-        # lets the border search look only that far instead of 20 m.
-        cap = self.dy_max + 0.35 * half_l + 1e-3  # (B,)
-        lo = -cap[:, None].expand(B, T).clone()
-        hi = cap[:, None].expand(B, T).clone()
+        # Unconstrained until a border or neighbor cuts them. NOTE: do not try to
+        # cap these by dy_max — dy is the offset at t=0, not a bound on the
+        # quintic, which overshoots it when the draw has an initial heading
+        # slope (measured |L| = 3.39 m for dy = 1.98 m). A cap like that silently
+        # rejects feasible perturbations.
+        lo = torch.full((B, T), -20.0, device=dev, dtype=dtype)
+        hi = torch.full((B, T), 20.0, device=dev, dtype=dtype)
 
         ls = inputs.get("line_strings")
         if ls is not None and ls.shape[-1] < 4:
@@ -228,8 +228,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             # path point can never tighten them; the shared builder drops those
             # before the ray math (~180 of 1140 slots survive on the pipeline
             # set) and pads to the batch maximum, so the bounds are unchanged.
-            reach = float(cap.amax()) + float(half_w.amax()) + 1.0
-            a, e, sv = build_road_border_segments(ls, xy, reach=reach)
+            a, e, sv = build_road_border_segments(ls, xy, reach=25.0)
             d = e - a
             nx, ny = nrm[..., 0:1], nrm[..., 1:2]  # (B, T, 1)
             dx = d[:, None, :, 0]  # (B, 1, S)

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -285,19 +285,24 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         hd_cs = torch.stack([heading.cos(), heading.sin()], dim=-1)
         tr_aug = torch.cat([aug_xy, hd_cs], dim=-1)  # (B, T, 4)
         past_n = inputs["neighbor_agents_past"]
-        for i in torch.nonzero(upd).flatten().tolist():
-            keep = self._nbr_valid[i].any(-1)
-            if not bool(keep.any()):
-                continue
-            clr = compute_ego_neighbor_signed_clearance(
-                tr_aug[i : i + 1],
-                inputs["ego_shape"][i],
-                self._nbr_st[i, keep],
-                past_n[i, keep, -1][:, [6, 7]],  # width, length
-                self._nbr_valid[i, keep],
-            )
-            if float(clr.min()) < 0.0:
-                upd[i] = False
+        # One paired call for the whole batch. Per-scene calls were one tiny
+        # kernel each, so their launch overhead dominated training (228 ms/batch
+        # at B=512, several times the rest of the augmenter) to reject the ~1.4%
+        # of winners that truly overlap.
+        pairs = upd[:, None] & self._nbr_valid.any(-1)  # (B, N) scene x neighbor
+        bi, ni = torch.nonzero(pairs, as_tuple=True)
+        if bi.numel() == 0:
+            return upd
+        clr = compute_ego_neighbor_signed_clearance(
+            tr_aug[bi],
+            inputs["ego_shape"][bi],
+            self._nbr_st[bi, ni],
+            past_n[bi, ni, -1][:, [6, 7]],  # width, length
+            self._nbr_valid[bi, ni],
+            paired=True,
+        )  # (M, T)
+        overlapping = bi[clr.amin(-1) < 0.0]
+        upd[overlapping] = False
         return upd
 
     # ---------- the augmentation ----------

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -27,55 +27,25 @@ plain GT on a true neighbor overlap (~1% of winners). Scenes with no feasible
 draw train on plain GT.
 """
 
-import math
 from dataclasses import dataclass
 
 import numpy as np
 import torch
 
+from diffusion_planner.utils.augmentation_checks import (
+    DT,
+    border_lateral_bounds,
+    ddt,
+    kinematic_feasibility,
+    neighbor_lateral_bounds,
+    time_aligned_neighbor_tracks,
+    unconstrained_bounds,
+    veto_overlapping,
+)
 from diffusion_planner.utils.data_augmentation import StatePerturbation
-from planner_metrics.geometry import build_road_border_segments
-from planner_metrics.subscores import compute_ego_neighbor_signed_clearance
 
-DT = 0.1
+# extra half-width the corridor keeps from borders and neighbors
 CORRIDOR_MARGIN = 0.10
-
-# Feasibility limits: candidates violating these are REJECTED (never clipped).
-LIMITS = {
-    "lat_acc": 3.0,  # m/s^2
-    "yaw_rate": 0.6,  # rad/s  (~34 deg/s)
-    # Comfort jerk, applied to the FUTURE segment only - that is what the model
-    # learns to output. (Peak lateral jerk of a quintic ~ 60*dy/T^3: a comfortable
-    # recovery from dy=0.75 m needs T >= 2.8 s, so at M=2 s most realistic offsets
-    # are correctly REJECTED. The production 2 s quintic bridge teaches ~6 m/s^3.)
-    "jerk": 2.0,  # m/s^3
-    # The HISTORY segment is context, not a target: it only has to be a plausible
-    # (possibly uncomfortable) way to have arrived at the perturbed pose. The 3 s
-    # past window would otherwise cap |dy| at 27*jerk/60 ~ 0.9 m.
-    "jerk_history": 5.0,  # m/s^3
-    # Ackermann / kinematic-bicycle feasibility (needs wheelbase from ego_shape):
-    # steering angle delta = atan(WB * kappa), kappa = yaw_rate / speed.
-    "steer": 0.61,  # rad (~35 deg), typical passenger-car lock
-}
-
-# the steering test runs in tan space (see _feasibility), so cache tan(limit)
-_TAN_STEER = math.tan(LIMITS["steer"])
-
-
-def _ddt(x: torch.Tensor, dim: int) -> torch.Tensor:
-    """d/dt along `dim` on the fixed DT grid.
-
-    Same arithmetic as torch.gradient(x, spacing=DT, dim=dim) — central
-    differences inside, one-sided at the ends — written out because the library
-    call costs ~7x more on the candidate tensors (3.5 ms vs 0.5 ms for the three
-    derivatives at B=512). Verified bit-identical to torch.gradient.
-    """
-    lo = x.narrow(dim, 0, 1)
-    lo2 = x.narrow(dim, 1, 1)
-    hi2 = x.narrow(dim, x.shape[dim] - 2, 1)
-    hi = x.narrow(dim, x.shape[dim] - 1, 1)
-    mid = (x.narrow(dim, 2, x.shape[dim] - 2) - x.narrow(dim, 0, x.shape[dim] - 2)) / (2 * DT)
-    return torch.cat([(lo2 - lo) / DT, mid, (hi - hi2) / DT], dim=dim)
 
 
 def quintic_basis(t0: float, t1: float, t: np.ndarray):
@@ -205,147 +175,41 @@ class FrenetStatePerturbationTensor(StatePerturbation):
 
     # ---------- corridor, fully batched ----------
     def _corridor(self, inputs, xy, tan, nrm, half_w, half_l, wb):
+        """Lateral free space per timestep: where can this ego go sideways."""
         # reset per batch so a neighbor-less batch never sees a stale tensor
         self._nbr_st = self._nbr_valid = self._nbr_near = None
         B, T, _ = xy.shape
-        dev, dtype = xy.device, xy.dtype
-        # Unconstrained until a border or neighbor cuts them. NOTE: do not try to
-        # cap these by dy_max — dy is the offset at t=0, not a bound on the
-        # quintic, which overshoots it when the draw has an initial heading
-        # slope (measured |L| = 3.39 m for dy = 1.98 m). A cap like that silently
-        # rejects feasible perturbations.
-        lo = torch.full((B, T), -20.0, device=dev, dtype=dtype)
-        hi = torch.full((B, T), 20.0, device=dev, dtype=dtype)
+        lo, hi = unconstrained_bounds(B, T, xy.device, xy.dtype)
 
         ls = inputs.get("line_strings")
-        if ls is not None and ls.shape[-1] < 4:
-            raise ValueError(
-                f"line_strings has {ls.shape[-1]} channels; frenet augmentation needs "
-                "channel 3 (road-border flag) to constrain the corridor"
-            )
         if ls is not None:
-            # lo/hi start at +-20 m, so a border further than that from every
-            # path point can never tighten them; the shared builder drops those
-            # before the ray math (~180 of 1140 slots survive on the pipeline
-            # set) and pads to the batch maximum, so the bounds are unchanged.
-            a, e, sv = build_road_border_segments(ls, xy, reach=25.0)
-            d = e - a
-            nx, ny = nrm[..., 0:1], nrm[..., 1:2]  # (B, T, 1)
-            dx = d[:, None, :, 0]  # (B, 1, S)
-            dy_ = d[:, None, :, 1]
-            det = nx * (-dy_) - ny * (-dx)  # (B, T, S)
-            rx = a[:, None, :, 0] - xy[..., 0:1]
-            ry = a[:, None, :, 1] - xy[..., 1:2]
-            s = (rx * (-dy_) - ry * (-dx)) / det
-            u = (nx * ry - ny * rx) / det
-            ok = torch.isfinite(s) & (u >= 0) & (u <= 1) & sv[:, None, :]
-            pos = torch.where(ok & (s > 0), s, torch.full_like(s, torch.inf))
-            neg = torch.where(ok & (s < 0), s, torch.full_like(s, -torch.inf))
-            hi = torch.minimum(hi, pos.amin(-1) - half_w[:, None])
-            lo = torch.maximum(lo, neg.amax(-1) + half_w[:, None])
+            lo, hi = border_lateral_bounds(ls, xy, nrm, half_w, lo, hi)
 
         past = inputs.get("neighbor_agents_past")
         fut = inputs.get("neighbor_agents_future")
         if past is not None and fut is not None:
-            # time-aligned neighbor states on the SAME grid as the ego polyline.
-            # Futures come in two layouts: 4-col (x, y, cos, sin) or the canonical
-            # 3-col (x, y, heading) — train_epoch only converts to cos/sin AFTER
-            # augmentation, so handle both here.
-            if fut.shape[-1] >= 4:
-                fut4 = fut[..., :4]
-            else:
-                fut4 = torch.cat([fut[..., :2], fut[..., 2:3].cos(), fut[..., 2:3].sin()], dim=-1)
-                # keep padded rows padded: an all-zero 3-col row must not become
-                # (0, 0, 1, 0) after cos/sin
-                fut4 = fut4 * (fut.abs().sum(-1, keepdim=True) > 0)
-            st = torch.cat([past[..., :4], fut4], dim=2)  # (B, N, T, 4)
-            valid = st.abs().sum(-1) > 0  # (B, N, T)
+            st, valid = time_aligned_neighbor_tracks(past, fut)
             self._nbr_st, self._nbr_valid = st, valid  # reused by the exact-OBB veto
-            # Only slots holding a real track can cut the corridor, and they are
-            # ~31 of the 320 padded slots. Flatten to the valid (scene, neighbor)
-            # pairs so the projections below run over those alone, then reduce
-            # back per scene; padding contributed +-inf, i.e. nothing.
-            vb, vn = torch.nonzero(valid.any(-1), as_tuple=True)  # (M,)
-            if vb.numel() == 0:
-                self._nbr_near = valid
-                return lo, hi
-            valid_m = valid[vb, vn]  # (M, T)
-            l_n = past[vb, vn, -1, 7][:, None]  # (M, 1)
-            w_n = past[vb, vn, -1, 6][:, None]
-            c = st[vb, vn, :, :2]  # (M, T, 2)
-            axi = st[vb, vn, :, 2:4]
-            per = torch.stack([-axi[..., 1], axi[..., 0]], dim=-1)
-            tan_m, nrm_m = tan[vb], nrm[vb]  # (M, T, 2)
-            half_l_m, half_w_m, wb_m = half_l[vb, None], half_w[vb, None], wb[vb, None]
-            rel = c - xy[vb]  # (M, T, 2)
-            # ego xy is base_link (rear axle); the footprint CENTER sits wb/2
-            # ahead along the tangent, so shift the longitudinal window there —
-            # otherwise a transient neighbor overlapping only the front bumper
-            # imposes no lateral cut.
-            lon = (rel * tan_m).sum(-1)  # rear-axle window (validated semantics)
-            lat = (rel * nrm_m).sum(-1)
-            ext_lon = ((tan_m * axi).sum(-1).abs() * l_n + (tan_m * per).sum(-1).abs() * w_n) / 2
-            ext_lat = ((nrm_m * axi).sum(-1).abs() * l_n + (nrm_m * per).sum(-1).abs() * w_n) / 2
-            near = valid_m & (lon.abs() <= half_l_m + ext_lon)
-            # Same longitudinal test, padded, kept for the exact-OBB veto so it
-            # only pairs neighbors that can actually reach the ego box. The
-            # augmentation is a lateral offset, so a candidate's longitudinal
-            # coordinate in this frame is the GT one; the pad covers the ego's
-            # longitudinal half-extent growing under the heading change
-            # (half_l*cos + half_w*sin <= half_l + half_w) plus the wb/2 centre
-            # shift. Pairs outside it cannot overlap, so the verdicts are
-            # unchanged — the canonical OBB check still decides every one.
-            near_pad = valid_m & (lon.abs() <= half_l_m + ext_lon + half_w_m + wb_m / 2)
-            self._nbr_near = torch.zeros_like(valid)
-            self._nbr_near[vb, vn] = near_pad
-            cut_hi = torch.where(
-                near & (lat > 0), lat - ext_lat - half_w_m, torch.full_like(lat, torch.inf)
+            shapes_wl = past[:, :, -1][..., [6, 7]]  # width, length
+            lo, hi, self._nbr_near = neighbor_lateral_bounds(
+                st, valid, shapes_wl, xy, tan, nrm, half_l, half_w, wb, lo, hi
             )
-            cut_lo = torch.where(
-                near & (lat < 0), lat + ext_lat + half_w_m, torch.full_like(lat, -torch.inf)
-            )
-            idx = vb[:, None].expand_as(cut_hi)
-            hi = hi.scatter_reduce(0, idx, cut_hi, reduce="amin")
-            lo = lo.scatter_reduce(0, idx, cut_lo, reduce="amax")
         return lo, hi
 
     def _veto_true_overlaps(self, inputs, upd, aug_xy, heading):
-        """Exact-OBB veto on the winning candidates.
-
-        The corridor is a fast approximation (path-normal ray-cast with
-        half-width margins around the rear-axle polyline) and is measured to
-        accept ~1.4% of winners whose TRUE footprint overlaps a recorded
-        neighbor box. Re-check each winner with the canonical signed OBB
-        clearance (rear-axle ego convention, centroid neighbors) and train
-        vetoed rows on plain GT. Borders are left to the corridor: the recorded
-        drives themselves touch the mapped borders (GT corner distance reaches
-        0.0), so an OBB border veto would reject GT-like data.
-        """
-        if self._nbr_st is None or not bool(upd.any()):
+        """Drop winners whose footprint truly overlaps a recorded neighbor."""
+        if self._nbr_st is None:
             return upd
         hd_cs = torch.stack([heading.cos(), heading.sin()], dim=-1)
-        tr_aug = torch.cat([aug_xy, hd_cs], dim=-1)  # (B, T, 4)
-        past_n = inputs["neighbor_agents_past"]
-        # One paired call for the whole batch. Per-scene calls were one tiny
-        # kernel each, so their launch overhead dominated training (228 ms/batch
-        # at B=512, several times the rest of the augmenter) to reject the ~1.4%
-        # of winners that truly overlap.
-        pairs = upd[:, None] & self._nbr_near.any(-1)  # (B, N) scene x neighbor
-        bi, ni = torch.nonzero(pairs, as_tuple=True)
-        if bi.numel() == 0:
-            return upd
-        clr = compute_ego_neighbor_signed_clearance(
-            tr_aug[bi],
-            inputs["ego_shape"][bi],
-            self._nbr_st[bi, ni],
-            past_n[bi, ni, -1][:, [6, 7]],  # width, length
-            self._nbr_valid[bi, ni],
-            paired=True,
-            overlap_only=True,  # the veto only asks whether they overlap
-        )  # (M, T)
-        overlapping = bi[clr.amin(-1) < 0.0]
-        upd[overlapping] = False
-        return upd
+        return veto_overlapping(
+            upd,
+            torch.cat([aug_xy, hd_cs], dim=-1),  # (B, T, 4)
+            inputs["ego_shape"],
+            self._nbr_st,
+            self._nbr_valid,
+            inputs["neighbor_agents_past"][:, :, -1][..., [6, 7]],
+            self._nbr_near,
+        )
 
     # ---------- the augmentation ----------
     @torch.no_grad()
@@ -373,7 +237,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         xy = torch.cat([past4[..., :2], ego_future[..., :2]], dim=1)  # (B, T, 2)
         tan = torch.cat([past4[..., 2:4], fut_cs], dim=1)
         nrm = torch.stack([-tan[..., 1], tan[..., 0]], dim=-1)
-        speed = _ddt(xy, 1).norm(dim=-1).clamp(min=0.5)  # (B, T)
+        speed = ddt(xy, 1).norm(dim=-1).clamp(min=0.5)  # (B, T)
         v0 = speed[:, P - 1]
         wb = inputs["ego_shape"][:, 0]
         half_w = inputs["ego_shape"][:, 2] / 2 + CORRIDOR_MARGIN
@@ -446,58 +310,20 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         return L, in_corr, merges
 
     def _feasibility(self, xy, nrm, L, in_corr, wb, P):
-        """Physical-limit screen on the exact candidate polylines."""
-
-        # Feasibility on the EXACT candidate polylines, not the lateral-delta
-        # profile: build every candidate's xy and finite-difference it at DT.
-        # The L(t)-only check misses the coupling between the lateral swing and
-        # the GT path's own curvature (audited: ~1/3 of its accepts exceeded the
-        # comfort jerk on the exact polyline, worst 2.6 vs 2.0 m/s^3). Limits are
-        # GT-relative: where the recorded drive itself exceeds a limit (data
-        # glitches), the candidate only has to stay within the GT's own maximum.
-        def _exact_metrics(poly_xy):
-            v = _ddt(poly_xy, -2)
-            # speed is clamped away from zero, so one reciprocal serves the three
-            # divisions below (a multiply is cheaper than a divide on 22M values)
-            inv_sp = v.norm(dim=-1).clamp(min=0.5).reciprocal()
-            a = _ddt(v, -2)
-            lat_a = (v[..., 0] * a[..., 1] - v[..., 1] * a[..., 0]) * inv_sp
-            jk = _ddt(a, -2)
-            lat_j = (v[..., 0] * jk[..., 1] - v[..., 1] * jk[..., 0]) * inv_sp
-            yaw_rate = lat_a * inv_sp
-            return lat_a, lat_j, yaw_rate, inv_sp
-
+        """Screen corridor-passing candidates on the exact rebuilt polylines."""
         # Only candidates that already clear the corridor can end up feasible, so
         # build the exact polylines for those alone — the rest would be discarded
-        # by the `in_corr &` below anyway, and they are ~40% of the grid.
-        BIG = torch.tensor(1e9, device=L.device, dtype=L.dtype)
+        # by the `in_corr &` anyway, and they are ~40% of the grid.
+        BIG = 1e9
         feasible = torch.zeros_like(in_corr)
-        jerk_fut_peak = torch.full(in_corr.shape, BIG.item(), device=L.device, dtype=L.dtype)
+        jerk_fut_peak = torch.full(in_corr.shape, BIG, device=L.device, dtype=L.dtype)
         b_i, k_i, c_i = torch.nonzero(in_corr, as_tuple=True)
         if b_i.numel() == 0:
             return feasible, jerk_fut_peak
 
         cand_xy = xy[b_i] + L[b_i, k_i, c_i][..., None] * nrm[b_i]  # (M, T, 2)
-        laC, ljC, yrC, ivC = _exact_metrics(cand_xy)  # each (M, T)
-        laG, ljG, yrG, ivG = _exact_metrics(xy)  # GT reference, (B, T)
-        # Steering is compared in tan space: the limit test is
-        # atan(x) <= max(atan(g), STEER), and atan is monotonic, so it is
-        # equivalent to x <= max(g, tan(STEER)) — same verdict, no atan over the
-        # candidate tensor.
-        stC = (wb[b_i, None] * yrC * ivC).abs()
-        stG = (wb[:, None] * yrG * ivG).abs()
-
-        def _allow(gt_max, limit):
-            return torch.clamp(gt_max, min=limit)[b_i]  # (M,)
-
-        peak = ljC[:, P:].abs().amax(-1)  # (M,) — also the tiebreak
-        a_ok = laC.abs().amax(-1) <= _allow(laG.abs().amax(-1), LIMITS["lat_acc"])
-        j_ok = (peak <= _allow(ljG[:, P:].abs().amax(-1), LIMITS["jerk"])) & (
-            ljC[:, :P].abs().amax(-1) <= _allow(ljG[:, :P].abs().amax(-1), LIMITS["jerk_history"])
-        )
-        y_ok = yrC.abs().amax(-1) <= _allow(yrG.abs().amax(-1), LIMITS["yaw_rate"])
-        s_ok = stC.amax(-1) <= _allow(stG.amax(-1), _TAN_STEER)
-        feasible[b_i, k_i, c_i] = a_ok & j_ok & y_ok & s_ok
+        ok, peak = kinematic_feasibility(cand_xy, b_i, xy, wb, P)
+        feasible[b_i, k_i, c_i] = ok
         jerk_fut_peak[b_i, k_i, c_i] = peak
         return feasible, jerk_fut_peak
 
@@ -526,7 +352,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
 
     def _write_back(self, inputs, ego_future, aug_xy, xy, tan, wb, has, P):
         """Veto true overlaps, then write history / future / current state in place."""
-        g = _ddt(aug_xy, 1)
+        g = ddt(aug_xy, 1)
         gs = g.norm(dim=-1)
         hd_gt = torch.atan2(tan[..., 1], tan[..., 0])
         heading = torch.where(gs > 0.3, torch.atan2(g[..., 1], g[..., 0]), hd_gt)
@@ -546,8 +372,8 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         i0 = P - 1
         cur = inputs["ego_current_state"]
         vel = g[:, i0]
-        acc = _ddt(g, 1)[:, i0]
-        yaw_rate = _ddt(torch.stack([heading.cos(), heading.sin()], -1), 1)[:, i0]
+        acc = ddt(g, 1)[:, i0]
+        yaw_rate = ddt(torch.stack([heading.cos(), heading.sin()], -1), 1)[:, i0]
         yaw_rate = heading.cos()[:, i0] * yaw_rate[..., 1] - heading.sin()[:, i0] * yaw_rate[..., 0]
         steer = torch.atan(wb * yaw_rate / gs[:, i0].clamp(min=0.5))
         new_cur = torch.stack(

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -289,8 +289,12 @@ class FrenetStatePerturbationTensor(StatePerturbation):
 
         feasible, jerk_fut_peak = self._feasibility(xy, nrm, L, in_corr, wb, P)
 
-        feasible &= do_aug[:, None, None]
-        draw_ok = feasible.any(-1)  # (B, K): the drawn perturbation has >=1 valid merge
+        # `feasible` is physics only: can a car drive this candidate. `admissible` adds the
+        # two reasons a scene may be left alone regardless of physics -- it lost the
+        # augment_prob coin, or it is below the low-speed gate -- so the two questions stay
+        # separable when reading the selection below.
+        admissible = feasible & do_aug[:, None, None]
+        draw_ok = admissible.any(-1)  # (B, K): the drawn perturbation has >=1 valid merge
         has = draw_ok.any(-1)  # (B,)
         first = draw_ok.float().argmax(-1)  # first feasible PERTURBATION per scene
 
@@ -300,7 +304,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             return self.centric_transform(inputs, ego_future, neighbors_future)
 
         aug_xy = self._select_candidate(
-            feasible, jerk_fut_peak, first, merges, has, L, xy, nrm, B, dev, dtype
+            admissible, jerk_fut_peak, first, merges, has, L, xy, nrm, B, dev, dtype
         )
 
         self._write_back(inputs, ego_future, aug_xy, xy, tan, wb, has, P)

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -189,8 +189,13 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         self._nbr_st = self._nbr_valid = self._nbr_near = None
         B, T, _ = xy.shape
         dev, dtype = xy.device, xy.dtype
-        lo = torch.full((B, T), -20.0, device=dev, dtype=dtype)
-        hi = torch.full((B, T), 20.0, device=dev, dtype=dtype)
+        # A candidate's lateral extent is |L| <= dy_max plus the rotation margin
+        # (half_l * 0.35, see the in_corr test), so a bound wider than that can
+        # never change an acceptance. Capping here keeps the test identical and
+        # lets the border search look only that far instead of 20 m.
+        cap = self.dy_max + 0.35 * half_l + 1e-3  # (B,)
+        lo = -cap[:, None].expand(B, T).clone()
+        hi = cap[:, None].expand(B, T).clone()
 
         ls = inputs.get("line_strings")
         if ls is not None and ls.shape[-1] < 4:
@@ -203,7 +208,8 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             # path point can never tighten them; the shared builder drops those
             # before the ray math (~180 of 1140 slots survive on the pipeline
             # set) and pads to the batch maximum, so the bounds are unchanged.
-            a, e, sv = build_road_border_segments(ls, xy, reach=25.0)
+            reach = float(cap.amax()) + float(half_w.amax()) + 1.0
+            a, e, sv = build_road_border_segments(ls, xy, reach=reach)
             d = e - a
             nx, ny = nrm[..., 0:1], nrm[..., 1:2]  # (B, T, 1)
             dx = d[:, None, :, 0]  # (B, 1, S)
@@ -236,25 +242,32 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             st = torch.cat([past[..., :4], fut4], dim=2)  # (B, N, T, 4)
             valid = st.abs().sum(-1) > 0  # (B, N, T)
             self._nbr_st, self._nbr_valid = st, valid  # reused by the exact-OBB veto
-            l_n = past[:, :, -1, 7][..., None]  # (B, N, 1)
-            w_n = past[:, :, -1, 6][..., None]
-            c = st[..., :2]
-            axi = st[..., 2:4]
+            # Only slots holding a real track can cut the corridor, and they are
+            # ~31 of the 320 padded slots. Flatten to the valid (scene, neighbor)
+            # pairs so the projections below run over those alone, then reduce
+            # back per scene; padding contributed +-inf, i.e. nothing.
+            vb, vn = torch.nonzero(valid.any(-1), as_tuple=True)  # (M,)
+            if vb.numel() == 0:
+                self._nbr_near = valid
+                return lo, hi
+            valid_m = valid[vb, vn]  # (M, T)
+            l_n = past[vb, vn, -1, 7][:, None]  # (M, 1)
+            w_n = past[vb, vn, -1, 6][:, None]
+            c = st[vb, vn, :, :2]  # (M, T, 2)
+            axi = st[vb, vn, :, 2:4]
             per = torch.stack([-axi[..., 1], axi[..., 0]], dim=-1)
-            rel = c - xy[:, None]  # (B, N, T, 2)
+            tan_m, nrm_m = tan[vb], nrm[vb]  # (M, T, 2)
+            half_l_m, half_w_m, wb_m = half_l[vb, None], half_w[vb, None], wb[vb, None]
+            rel = c - xy[vb]  # (M, T, 2)
             # ego xy is base_link (rear axle); the footprint CENTER sits wb/2
             # ahead along the tangent, so shift the longitudinal window there —
             # otherwise a transient neighbor overlapping only the front bumper
             # imposes no lateral cut.
-            lon = (rel * tan[:, None]).sum(-1)  # rear-axle window (validated semantics)
-            lat = (rel * nrm[:, None]).sum(-1)
-            ext_lon = (
-                (tan[:, None] * axi).sum(-1).abs() * l_n + (tan[:, None] * per).sum(-1).abs() * w_n
-            ) / 2
-            ext_lat = (
-                (nrm[:, None] * axi).sum(-1).abs() * l_n + (nrm[:, None] * per).sum(-1).abs() * w_n
-            ) / 2
-            near = valid & (lon.abs() <= half_l[:, None, None] + ext_lon)
+            lon = (rel * tan_m).sum(-1)  # rear-axle window (validated semantics)
+            lat = (rel * nrm_m).sum(-1)
+            ext_lon = ((tan_m * axi).sum(-1).abs() * l_n + (tan_m * per).sum(-1).abs() * w_n) / 2
+            ext_lat = ((nrm_m * axi).sum(-1).abs() * l_n + (nrm_m * per).sum(-1).abs() * w_n) / 2
+            near = valid_m & (lon.abs() <= half_l_m + ext_lon)
             # Same longitudinal test, padded, kept for the exact-OBB veto so it
             # only pairs neighbors that can actually reach the ego box. The
             # augmentation is a lateral offset, so a candidate's longitudinal
@@ -263,22 +276,18 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             # (half_l*cos + half_w*sin <= half_l + half_w) plus the wb/2 centre
             # shift. Pairs outside it cannot overlap, so the verdicts are
             # unchanged — the canonical OBB check still decides every one.
-            self._nbr_near = valid & (
-                lon.abs()
-                <= half_l[:, None, None] + ext_lon + half_w[:, None, None] + wb[:, None, None] / 2
-            )
+            near_pad = valid_m & (lon.abs() <= half_l_m + ext_lon + half_w_m + wb_m / 2)
+            self._nbr_near = torch.zeros_like(valid)
+            self._nbr_near[vb, vn] = near_pad
             cut_hi = torch.where(
-                near & (lat > 0),
-                lat - ext_lat - half_w[:, None, None],
-                torch.full_like(lat, torch.inf),
+                near & (lat > 0), lat - ext_lat - half_w_m, torch.full_like(lat, torch.inf)
             )
             cut_lo = torch.where(
-                near & (lat < 0),
-                lat + ext_lat + half_w[:, None, None],
-                torch.full_like(lat, -torch.inf),
+                near & (lat < 0), lat + ext_lat + half_w_m, torch.full_like(lat, -torch.inf)
             )
-            hi = torch.minimum(hi, cut_hi.amin(1))
-            lo = torch.maximum(lo, cut_lo.amax(1))
+            idx = vb[:, None].expand_as(cut_hi)
+            hi = hi.scatter_reduce(0, idx, cut_hi, reduce="amin")
+            lo = lo.scatter_reduce(0, idx, cut_lo, reduce="amax")
         return lo, hi
 
     def _veto_true_overlaps(self, inputs, upd, aug_xy, heading):

--- a/diffusion_planner/tests/test_data_augmentation.py
+++ b/diffusion_planner/tests/test_data_augmentation.py
@@ -1106,6 +1106,44 @@ def test_frenet_handles_3col_neighbor_future():
     print("  [PASS] frenet handles 3-col neighbor futures + base_link contract")
 
 
+def test_frenet_cli_selection():
+    """--augment_type frenet must be selectable through the shared dataclass parser,
+    on both the IL config and the GRPO config that inherits it."""
+    from diffusion_planner.config import GRPOConfig, TrainConfig, build_config, build_parser
+
+    for cfg_cls in (TrainConfig, GRPOConfig):
+        args = build_parser(cfg_cls, description="t").parse_args(["--augment_type", "frenet"])
+        cfg = build_config(cfg_cls, args)
+        assert cfg.augment_type == "frenet", f"{cfg_cls.__name__} did not accept frenet"
+    print("  [PASS] frenet selectable via CLI on TrainConfig and GRPOConfig")
+
+
+def test_frenet_handles_4col_futures():
+    """ego/neighbor futures may also arrive as (x, y, cos, sin): column 2 must be
+    read as cos(heading), not as an angle, and written back in the same layout."""
+    from diffusion_planner.utils.data_augmentation_frenet import FrenetStatePerturbationTensor
+
+    torch.manual_seed(0)
+    inputs, ego_future3, _ = _make_frenet_inputs(B=8, vx=5.0)
+    ego_future = torch.cat(
+        [ego_future3[..., :2], ego_future3[..., 2:3].cos(), ego_future3[..., 2:3].sin()], dim=-1
+    )
+    nbr_future = torch.zeros(*inputs["neighbor_agents_past"].shape[:2], 80, 4)
+    inputs["neighbor_agents_future"] = nbr_future
+    fut_before = ego_future.clone()
+    aug = FrenetStatePerturbationTensor(augment_prob=1.0, device="cpu")
+    _, out_future, _ = aug(inputs, ego_future, nbr_future)
+
+    # centric_transform always returns the canonical 3-col (x, y, heading) future
+    # (same contract as quintic); train_epoch re-converts to cos/sin afterwards.
+    assert out_future.shape[-1] == 3
+    moved = (out_future[..., :2] - fut_before[..., :2]).norm(dim=-1).amax(-1) > 0.05
+    assert bool(moved.any())
+    assert torch.isfinite(out_future).all()
+    assert out_future[..., 2].abs().amax() < 4.0, "column 2 is not a plausible heading angle"
+    print("  [PASS] frenet handles 4-col (x, y, cos, sin) futures")
+
+
 def test_frenet_low_speed_gate():
     """A near-stationary or reversing ego must never be augmented (the quintic
     augmenter has the same gate): sideways translation of a stopped ego passes
@@ -1130,6 +1168,8 @@ def test_frenet_low_speed_gate():
 
 ALL_TESTS = [
     test_frenet_handles_3col_neighbor_future,
+    test_frenet_handles_4col_futures,
+    test_frenet_cli_selection,
     test_frenet_low_speed_gate,
     # ── vector_transform ──
     test_vector_transform_identity,

--- a/diffusion_planner/tests/test_data_augmentation.py
+++ b/diffusion_planner/tests/test_data_augmentation.py
@@ -1166,11 +1166,49 @@ def test_frenet_low_speed_gate():
     print("  [PASS] frenet low-speed / reverse gate")
 
 
+def test_frenet_corridor_unconstrained_without_obstacles():
+    """With no borders and no neighbors the corridor must not constrain anything.
+
+    Guards a regression that pruned the bounds to dy_max plus the rotation
+    margin. dy is the offset at t=0, NOT a bound on the quintic: a draw with an
+    initial heading slope overshoots it (measured |L| = 3.39 m for dy = 1.98 m),
+    so such a cap silently rejects feasible perturbations even on an empty road.
+    Any future pruning must be checked against the profiles themselves, not dy.
+    """
+    from diffusion_planner.utils.data_augmentation_frenet import FrenetStatePerturbationTensor
+
+    torch.manual_seed(0)
+    inputs, ego_future, neighbors_future = _make_frenet_inputs(B=4, vx=10.0)
+    inputs["line_strings"] = torch.zeros_like(inputs["line_strings"])  # no borders
+    inputs["neighbor_agents_past"] = torch.zeros_like(inputs["neighbor_agents_past"])
+    inputs["neighbor_agents_future"] = torch.zeros_like(inputs["neighbor_agents_future"])
+
+    aug = FrenetStatePerturbationTensor(augment_prob=1.0, device="cpu")
+    P = inputs["ego_agent_past"].shape[1]
+    xy = torch.cat([inputs["ego_agent_past"][..., :2], ego_future[..., :2]], dim=1)
+    tan = torch.cat(
+        [
+            inputs["ego_agent_past"][..., 2:4],
+            torch.stack([ego_future[..., 2].cos(), ego_future[..., 2].sin()], dim=-1),
+        ],
+        dim=1,
+    )
+    nrm = torch.stack([-tan[..., 1], tan[..., 0]], dim=-1)
+    wb, ego_l, ego_w = (inputs["ego_shape"][:, i] for i in range(3))
+    lo, hi = aug._corridor(inputs, xy, tan, nrm, ego_w / 2, ego_l / 2, wb)
+
+    assert float(lo.max()) <= -20.0 + ATOL, f"corridor cut from below with no obstacles: {lo.max()}"
+    assert float(hi.min()) >= 20.0 - ATOL, f"corridor cut from above with no obstacles: {hi.min()}"
+    assert P > 0
+    print("  [PASS] frenet corridor unconstrained without obstacles")
+
+
 ALL_TESTS = [
     test_frenet_handles_3col_neighbor_future,
     test_frenet_handles_4col_futures,
     test_frenet_cli_selection,
     test_frenet_low_speed_gate,
+    test_frenet_corridor_unconstrained_without_obstacles,
     # ── vector_transform ──
     test_vector_transform_identity,
     test_vector_transform_rotation_90,

--- a/diffusion_planner/tests/test_data_augmentation.py
+++ b/diffusion_planner/tests/test_data_augmentation.py
@@ -1057,7 +1057,80 @@ def test_augment_collision_batch_selectively_suppresses():
 # ──────────────────────────────── runner ────────────────────────────────────
 
 
+# ──────────────────────────── frenet augmentation ───────────────────────────
+
+
+def _make_frenet_inputs(B: int = 4, vx: float = 5.0, T_past: int = 21, T_fut: int = 80):
+    """Inputs for FrenetStatePerturbationTensor: 4-col past, ego_shape, 4-ch borders,
+    and the canonical 3-col (x, y, heading) neighbor future."""
+    inputs, ego_future, neighbors_future = _make_inputs(B=B, T_past=T_past, T_fut=T_fut)
+    inputs["ego_current_state"] = _ego_state(B, vx=vx)
+    # 4-col (x, y, cos, sin) past, straight along +x at `vx`
+    past = torch.zeros(B, T_past, 4, dtype=torch.float32)
+    for t in range(T_past):
+        past[:, t, 0] = (t - (T_past - 1)) * 0.1 * vx
+    past[:, :, 2] = 1.0
+    inputs["ego_agent_past"] = past
+    inputs["ego_shape"] = torch.tensor([[2.7, 4.5, 1.9]] * B, dtype=torch.float32)
+    inputs["line_strings"] = torch.zeros(B, 2, 5, 4, dtype=torch.float32)
+    inputs["goal_pose"] = torch.zeros(B, 4, dtype=torch.float32)
+    for t in range(T_fut):
+        ego_future[:, t, 0] = (t + 1) * 0.1 * vx
+    # neighbor future stays 3-col: the frenet corridor must handle (x, y, heading)
+    assert neighbors_future.shape[-1] == 3
+    inputs["neighbor_agents_future"] = neighbors_future
+    return inputs, ego_future, neighbors_future
+
+
+def test_frenet_handles_3col_neighbor_future():
+    """Regression: canonical NPZs carry 3-col neighbor futures and train_epoch
+    converts to cos/sin only AFTER augmentation — frenet must not crash, must
+    keep shapes/contract, and must leave the t=0 state on base_link (vy=ay=0)."""
+    from diffusion_planner.utils.data_augmentation_frenet import FrenetStatePerturbationTensor
+
+    torch.manual_seed(0)
+    inputs, ego_future, neighbors_future = _make_frenet_inputs(B=8, vx=5.0)
+    fut_before = ego_future.clone()
+    aug = FrenetStatePerturbationTensor(augment_prob=1.0, device="cpu")
+    out_inputs, out_future, out_nbr = aug(inputs, ego_future, neighbors_future)
+
+    assert out_future.shape == fut_before.shape
+    assert out_nbr.shape == neighbors_future.shape
+    cur = out_inputs["ego_current_state"]
+    assert cur.shape[-1] == 10
+    moved = (out_future[..., :2] - fut_before[..., :2]).norm(dim=-1).amax(-1) > 0.05
+    assert bool(moved.any()), "augment_prob=1 at 5 m/s should perturb at least one row"
+    assert torch.allclose(cur[moved, 5], torch.zeros_like(cur[moved, 5]), atol=ATOL), "vy != 0"
+    assert torch.allclose(cur[moved, 7], torch.zeros_like(cur[moved, 7]), atol=ATOL), "ay != 0"
+    assert torch.isfinite(out_future).all() and torch.isfinite(cur).all()
+    print("  [PASS] frenet handles 3-col neighbor futures + base_link contract")
+
+
+def test_frenet_low_speed_gate():
+    """A near-stationary or reversing ego must never be augmented (the quintic
+    augmenter has the same gate): sideways translation of a stopped ego passes
+    every path-relative feasibility metric trivially."""
+    from diffusion_planner.utils.data_augmentation_frenet import FrenetStatePerturbationTensor
+
+    for vx in (0.0, 0.5, -5.0):
+        torch.manual_seed(0)
+        inputs, ego_future, neighbors_future = _make_frenet_inputs(B=4, vx=vx)
+        fut_before = ego_future.clone()
+        past_before = inputs["ego_agent_past"].clone()
+        aug = FrenetStatePerturbationTensor(augment_prob=1.0, device="cpu")
+        out_inputs, out_future, _ = aug(inputs, ego_future, neighbors_future)
+        assert torch.allclose(out_future[..., :2], fut_before[..., :2], atol=ATOL), (
+            f"vx={vx}: future rewritten despite the low-speed/reverse gate"
+        )
+        assert torch.allclose(out_inputs["ego_agent_past"], past_before, atol=ATOL), (
+            f"vx={vx}: history rewritten despite the low-speed/reverse gate"
+        )
+    print("  [PASS] frenet low-speed / reverse gate")
+
+
 ALL_TESTS = [
+    test_frenet_handles_3col_neighbor_future,
+    test_frenet_low_speed_gate,
     # ── vector_transform ──
     test_vector_transform_identity,
     test_vector_transform_rotation_90,

--- a/diffusion_planner/tests/test_data_augmentation.py
+++ b/diffusion_planner/tests/test_data_augmentation.py
@@ -1304,3 +1304,59 @@ if __name__ == "__main__":
         sys.exit(1)
     else:
         print("All tests passed!")
+
+
+def test_frenet_preserves_zero_padded_ego_history():
+    """Leading zero padding means "no history"; it must survive the rewrite untouched.
+
+    The augmenter rewrites every history timestep and the inherited centric_transform then
+    re-centres the whole block, so without an explicit restore the padded rows come back as
+    plausible poses. The encoder reads ego_agent_past directly, so those would be presented
+    to the model as history that never happened.
+    """
+    import torch
+    from diffusion_planner.utils.data_augmentation_frenet import FrenetStatePerturbationTensor
+
+    torch.manual_seed(0)
+    inputs, ego_future, neighbors_future = _make_frenet_inputs(B=8)
+    pad = 5
+    inputs["ego_agent_past"][:, :pad, :] = 0.0
+    before = inputs["ego_agent_past"].clone()
+
+    aug = FrenetStatePerturbationTensor(augment_prob=1.0, device="cpu")
+    aug(inputs, ego_future, neighbors_future)
+    past = inputs["ego_agent_past"]
+    accepted = torch.nonzero(aug._aug_rows).flatten().tolist()
+    assert accepted, "fixture should accept at least one row, or this proves nothing"
+
+    # every originally padded row is bitwise zero, on accepted and rejected rows alike
+    assert torch.equal(past[:, :pad], torch.zeros_like(past[:, :pad]))
+    # the real history is still usable and was actually rewritten where accepted
+    assert torch.isfinite(past[:, pad:]).all()
+    assert (past[accepted, pad:] != before[accepted, pad:]).any()
+    # rejected rows are untouched end to end
+    rejected = [b for b in range(past.shape[0]) if b not in accepted]
+    if rejected:
+        assert torch.equal(past[rejected], before[rejected])
+
+
+def test_frenet_padding_does_not_leak_into_the_first_real_step():
+    """A padded slot sits at the origin; the first REAL sample must not take its heading
+    from that phantom jump. The padded prefix is held at the first real pose so the
+    differences across the boundary are zero."""
+    import torch
+    from diffusion_planner.utils.data_augmentation_frenet import FrenetStatePerturbationTensor
+
+    torch.manual_seed(0)
+    inputs, ego_future, neighbors_future = _make_frenet_inputs(B=4)
+    pad = 4
+    inputs["ego_agent_past"][:, :pad, :] = 0.0
+    aug = FrenetStatePerturbationTensor(augment_prob=1.0, device="cpu")
+    aug(inputs, ego_future, neighbors_future)
+
+    past = inputs["ego_agent_past"]
+    for b in torch.nonzero(aug._aug_rows).flatten().tolist():
+        cos, sin = past[b, pad, 2].item(), past[b, pad, 3].item()
+        assert abs(cos * cos + sin * sin - 1.0) < 1e-3, "first real step lost a unit heading"
+        step = (past[b, pad + 1, :2] - past[b, pad, :2]).norm().item()
+        assert step < 5.0, f"first real step jumped {step:.1f} m — padding leaked in"

--- a/diffusion_planner/tests/test_frenet_augmenter_factory.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_factory.py
@@ -1,0 +1,75 @@
+"""Every entrypoint that trains with frenet must honour the --frenet_* flags.
+
+The regression this pins: the GRPO entrypoint built the augmenter with only
+``augment_prob`` and ``device``, so it accepted ``--frenet_dy_max 0.25`` and then trained at
+the 2.0 default. A run's recorded configuration must be the configuration it used.
+"""
+
+import ast
+import pathlib
+from types import SimpleNamespace
+
+from diffusion_planner.utils.data_augmentation_frenet import frenet_augmenter_from_args
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+ENTRYPOINTS = (
+    REPO / "diffusion_planner" / "diffusion_planner" / "train.py",
+    REPO / "diffusion_planner" / "train_grpo_predictor.py",
+)
+
+
+def _args(**over):
+    base = dict(
+        augment_prob=0.5,
+        device="cpu",
+        frenet_n_draws=16,
+        frenet_dy_max=2.0,
+        frenet_dth_max=0.17,
+        frenet_merge_times=[2.0, 3.0, 4.0, 5.0],
+        frenet_anchors=[2.0, 3.0],
+        frenet_acc0_fracs=[0.0, -0.5, 0.5, -1.0, 1.0],
+        frenet_seed=0,
+        frenet_ranked_temp_s=1.0,
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def test_defaults_round_trip():
+    aug = frenet_augmenter_from_args(_args())
+    assert aug.dy_max == 2.0
+    assert aug.knobs.merge_times == (2.0, 3.0, 4.0, 5.0)
+
+
+def test_custom_values_reach_the_augmenter():
+    aug = frenet_augmenter_from_args(
+        _args(frenet_dy_max=0.25, frenet_n_draws=4, frenet_seed=7, frenet_merge_times=[2.0])
+    )
+    assert aug.dy_max == 0.25
+    assert aug.n_draws == 4
+    assert aug.knobs.merge_times == (2.0,)
+
+
+def test_string_lists_from_argparse_are_coerced():
+    """argparse hands list fields back as strings; the factory owns the coercion."""
+    aug = frenet_augmenter_from_args(
+        _args(frenet_merge_times=["2", "3"], frenet_dy_max="1.5", frenet_n_draws="8")
+    )
+    assert aug.knobs.merge_times == (2.0, 3.0)
+    assert isinstance(aug.dy_max, float) and aug.dy_max == 1.5
+    assert aug.n_draws == 8
+
+
+def test_no_entrypoint_constructs_the_augmenter_directly():
+    """Both entrypoints must go through the factory — a direct constructor call is how the
+    GRPO path silently dropped the flags in the first place."""
+    for path in ENTRYPOINTS:
+        tree = ast.parse(path.read_text())
+        direct = [
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Name)
+            and n.func.id == "FrenetStatePerturbationTensor"
+        ]
+        assert not direct, f"{path.name} constructs the augmenter directly; use the factory"

--- a/diffusion_planner/train_grpo_predictor.py
+++ b/diffusion_planner/train_grpo_predictor.py
@@ -22,6 +22,7 @@ from diffusion_planner.utils.data_augmentation import StatePerturbation
 from diffusion_planner.utils.data_augmentation_bridge import (
     StatePerturbation as BridgeStatePerturbation,
 )
+from diffusion_planner.utils.data_augmentation_frenet import FrenetStatePerturbationTensor
 from diffusion_planner.utils.dataset import DiffusionPlannerData
 from diffusion_planner.utils.lr_schedule import CosineAnnealingWarmUpRestarts
 from diffusion_planner.utils.neighbor_db import NeighborPatternDB
@@ -118,6 +119,8 @@ def model_training(args):
     if args.use_data_augment:
         if args.augment_type == "bridge":
             aug = BridgeStatePerturbation(augment_prob=args.augment_prob, device=args.device)
+        elif args.augment_type == "frenet":
+            aug = FrenetStatePerturbationTensor(augment_prob=args.augment_prob, device=args.device)
         else:
             aug = StatePerturbation(
                 augment_prob=args.augment_prob,

--- a/diffusion_planner/train_grpo_predictor.py
+++ b/diffusion_planner/train_grpo_predictor.py
@@ -22,7 +22,7 @@ from diffusion_planner.utils.data_augmentation import StatePerturbation
 from diffusion_planner.utils.data_augmentation_bridge import (
     StatePerturbation as BridgeStatePerturbation,
 )
-from diffusion_planner.utils.data_augmentation_frenet import FrenetStatePerturbationTensor
+from diffusion_planner.utils.data_augmentation_frenet import frenet_augmenter_from_args
 from diffusion_planner.utils.dataset import DiffusionPlannerData
 from diffusion_planner.utils.lr_schedule import CosineAnnealingWarmUpRestarts
 from diffusion_planner.utils.neighbor_db import NeighborPatternDB
@@ -120,7 +120,7 @@ def model_training(args):
         if args.augment_type == "bridge":
             aug = BridgeStatePerturbation(augment_prob=args.augment_prob, device=args.device)
         elif args.augment_type == "frenet":
-            aug = FrenetStatePerturbationTensor(augment_prob=args.augment_prob, device=args.device)
+            aug = frenet_augmenter_from_args(args)
         else:
             aug = StatePerturbation(
                 augment_prob=args.augment_prob,

--- a/planner_metrics/geometry.py
+++ b/planner_metrics/geometry.py
@@ -32,16 +32,18 @@ def _build_ego_bbox_corners(
     heading_unit = heading / heading.norm(dim=-1, keepdim=True).clamp_min(1e-6)
     ego_xy = ego_trajs[..., :2]
 
-    wheel_base = ego_shape[0]
-    ego_length = ego_shape[1]
-    ego_width = ego_shape[2]
+    # (3,) = one shape for every trajectory; (N, 3) = a shape per trajectory, so
+    # a batch mixing vehicle types can be measured in a single call.
+    shape = ego_shape if ego_shape.dim() > 1 else ego_shape[None]
+    wheel_base = shape[:, 0]
+    ego_length = shape[:, 1]
+    ego_width = shape[:, 2]
 
-    cog_to_rear = 0.5 * wheel_base
+    cog_to_rear = (0.5 * wheel_base)[:, None, None]
     ego_center_xy = ego_xy + heading_unit * cog_to_rear
 
-    half_length = ego_length / 2.0
-    half_width = ego_width / 2.0
-    half_sizes = torch.tensor([half_length, half_width], device=device, dtype=dtype).expand(N, T, 2)
+    half_sizes = torch.stack([ego_length / 2.0, ego_width / 2.0], dim=-1)  # (N or 1, 2)
+    half_sizes = half_sizes.to(device=device, dtype=dtype)[:, None, :].expand(N, T, 2)
 
     corner_signs = torch.tensor(
         [[1.0, 1.0], [1.0, -1.0], [-1.0, -1.0], [-1.0, 1.0]],

--- a/planner_metrics/geometry.py
+++ b/planner_metrics/geometry.py
@@ -975,6 +975,59 @@ def _classify_outer_boundaries(
     return candidate_outer, outward
 
 
+def build_road_border_segments(
+    line_strings: torch.Tensor,
+    query_xy: torch.Tensor,
+    reach: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Road-border segments per scene, reduced to those a query can reach.
+
+    Batched over scenes, so a training batch whose rows each carry their own map
+    is one call. Segments are consecutive valid point pairs within a polyline
+    flagged as road border (channel 3), the same construction
+    ``compute_road_border_penalty`` uses; they are then reduced the same way it
+    reduces its own set, by dropping segments too far from the query to matter.
+
+    A segment is kept when its closest point lies within ``reach`` of the query
+    bounding-box centre, plus the box half-diagonal. Every query point is within
+    the half-diagonal of that centre, so a dropped segment is further than
+    ``reach`` from every query point and cannot affect a result measured within
+    ``reach``. The returned width is the batch maximum, so nothing is truncated.
+
+    Args:
+        line_strings: (B, L, P, >=4) map polylines; channel 3 flags road border.
+        query_xy: (B, Q, 2) points the caller will measure from.
+        reach: max distance from a query point at which a segment can matter.
+
+    Returns:
+        seg_a, seg_b: (B, M, 2) segment endpoints.
+        seg_valid: (B, M) True where the slot holds a usable border segment.
+    """
+    pts = line_strings[..., :2]
+    is_border = (line_strings[..., 3] > 0.5).any(-1)  # (B, L)
+    has_coords = pts.norm(dim=-1) > 1e-6
+    seg_a = pts[:, :, :-1, :].flatten(1, 2)  # (B, S, 2)
+    seg_b = pts[:, :, 1:, :].flatten(1, 2)
+    seg_valid = (has_coords[:, :, :-1] & has_coords[:, :, 1:] & is_border[:, :, None]).flatten(
+        1, 2
+    )  # (B, S)
+
+    lo, hi = query_xy.amin(1), query_xy.amax(1)  # (B, 2)
+    ctr = (lo + hi) / 2
+    span = ((hi - lo) / 2).norm(dim=-1) + reach  # (B,)
+    seg = seg_b - seg_a
+    t = (((ctr[:, None] - seg_a) * seg).sum(-1) / (seg * seg).sum(-1).clamp_min(1e-9)).clamp(0, 1)
+    dist = (seg_a + t[..., None] * seg - ctr[:, None]).norm(dim=-1)  # (B, S)
+    keep = seg_valid & (dist <= span[:, None])
+
+    width = int(keep.sum(1).amax())
+    if width == 0:
+        return seg_a[:, :1], seg_b[:, :1], keep[:, :1]
+    order = keep.to(torch.uint8).argsort(dim=1, descending=True, stable=True)[:, :width]
+    idx = order[..., None].expand(-1, -1, 2)
+    return seg_a.gather(1, idx), seg_b.gather(1, idx), keep.gather(1, order)
+
+
 __all__ = [
     "_build_ego_bbox_corners",
     "_LN_X",
@@ -999,4 +1052,5 @@ __all__ = [
     "_points_inside_intersection_areas",
     "_point_to_segments_signed_min_dist",
     "_classify_outer_boundaries",
+    "build_road_border_segments",
 ]

--- a/planner_metrics/subscores.py
+++ b/planner_metrics/subscores.py
@@ -34,6 +34,7 @@ def compute_ego_neighbor_signed_clearance(
     *,
     return_closest_points: bool = False,
     paired: bool = False,
+    overlap_only: bool = False,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Signed OBB clearance between ego trajectories and neighbor futures.
 
@@ -46,6 +47,14 @@ def compute_ego_neighbor_signed_clearance(
     ``ego_shape`` is ``(3,)`` for one vehicle, or ``(N, 3)`` to give every
     trajectory its own wheel_base/length/width, so a batch mixing vehicle types
     is a single call.
+
+    With ``overlap_only=True`` the closest-point refinement is skipped and the
+    separating-axis distance is returned as-is. Its SIGN is the same — negative
+    exactly when the boxes overlap, with the same penetration depth — but a
+    non-negative value is then the separating-axis gap, which under-reports the
+    true clearance for diagonal cases. Only for callers that just ask "do these
+    overlap"; never for a reported distance. Cannot be combined with
+    ``return_closest_points``.
 
     With ``paired=True`` trajectory ``m`` is measured against neighbor ``m``
     only, instead of against every neighbor: ``neighbor_futures`` is ``(N, T, 4)``,
@@ -103,10 +112,15 @@ def compute_ego_neighbor_signed_clearance(
         npc_flat = npc_exp.reshape(-1, 4, 2)
         out_shape = (N, N_nb, T)
 
+    if overlap_only and return_closest_points:
+        raise ValueError("overlap_only returns no closest points")
     sat_dist_flat = batch_signed_distance_rect(ego_flat, npc_flat)
-    pt_e_all, pt_n_all = _closest_points_between_rects(ego_flat, npc_flat)
-    euclid_dist_flat = (pt_e_all - pt_n_all).norm(dim=-1)
-    signed_dist_flat = torch.where(sat_dist_flat < 0, sat_dist_flat, euclid_dist_flat)
+    if overlap_only:
+        signed_dist_flat = sat_dist_flat
+    else:
+        pt_e_all, pt_n_all = _closest_points_between_rects(ego_flat, npc_flat)
+        euclid_dist_flat = (pt_e_all - pt_n_all).norm(dim=-1)
+        signed_dist_flat = torch.where(sat_dist_flat < 0, sat_dist_flat, euclid_dist_flat)
 
     distances = signed_dist_flat.reshape(*out_shape).masked_fill(~nv_exp, 1e6)
     if not return_closest_points:

--- a/planner_metrics/subscores.py
+++ b/planner_metrics/subscores.py
@@ -33,6 +33,7 @@ def compute_ego_neighbor_signed_clearance(
     neighbor_valid: torch.Tensor,
     *,
     return_closest_points: bool = False,
+    paired: bool = False,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Signed OBB clearance between ego trajectories and neighbor futures.
 
@@ -41,15 +42,26 @@ def compute_ego_neighbor_signed_clearance(
     rectangles use the exact Euclidean closest-point clearance; SAT alone only
     gives the minimum separating-axis gap and under-reports diagonal/corner
     clearances.
+
+    ``ego_shape`` is ``(3,)`` for one vehicle, or ``(N, 3)`` to give every
+    trajectory its own wheel_base/length/width, so a batch mixing vehicle types
+    is a single call.
+
+    With ``paired=True`` trajectory ``m`` is measured against neighbor ``m``
+    only, instead of against every neighbor: ``neighbor_futures`` is ``(N, T, 4)``,
+    ``neighbor_shapes`` ``(N, 2)``, ``neighbor_valid`` ``(N, T)`` and the result
+    is ``(N, T)``. Callers that already know which pairs they care about use
+    this to skip materialising the cross product.
     """
     N, T, _ = ego_trajs.shape
     device = ego_trajs.device
-    N_nb = neighbor_futures.shape[0]
+    N_nb = N if paired else neighbor_futures.shape[0]
 
     if N_nb == 0:
-        distances = torch.empty(N, 0, T, device=device, dtype=ego_trajs.dtype)
+        empty_shape = (N, T) if paired else (N, 0, T)
+        distances = torch.empty(*empty_shape, device=device, dtype=ego_trajs.dtype)
         if return_closest_points:
-            pts = torch.empty(N, 0, T, 2, device=device, dtype=ego_trajs.dtype)
+            pts = torch.empty(*empty_shape, 2, device=device, dtype=ego_trajs.dtype)
             return distances, pts, pts
         return distances
 
@@ -77,26 +89,33 @@ def compute_ego_neighbor_signed_clearance(
     )  # (N_nb, T, 6)
     npc_corners = center_rect_to_points(npc_rect.reshape(-1, 6)).reshape(N_nb, T, 4, 2)
 
-    ego_exp = ego_corners.unsqueeze(1).expand(-1, N_nb, -1, -1, -1)
-    npc_exp = npc_corners.unsqueeze(0).expand(N, -1, -1, -1, -1)
-    nv_exp = neighbor_valid.unsqueeze(0).expand(N, -1, -1)
-
-    ego_flat = ego_exp.reshape(-1, 4, 2)
-    npc_flat = npc_exp.reshape(-1, 4, 2)
+    if paired:
+        # trajectory m against neighbor m only — no cross product
+        ego_flat = ego_corners.reshape(-1, 4, 2)
+        npc_flat = npc_corners.reshape(-1, 4, 2)
+        nv_exp = neighbor_valid
+        out_shape = (N, T)
+    else:
+        ego_exp = ego_corners.unsqueeze(1).expand(-1, N_nb, -1, -1, -1)
+        npc_exp = npc_corners.unsqueeze(0).expand(N, -1, -1, -1, -1)
+        nv_exp = neighbor_valid.unsqueeze(0).expand(N, -1, -1)
+        ego_flat = ego_exp.reshape(-1, 4, 2)
+        npc_flat = npc_exp.reshape(-1, 4, 2)
+        out_shape = (N, N_nb, T)
 
     sat_dist_flat = batch_signed_distance_rect(ego_flat, npc_flat)
     pt_e_all, pt_n_all = _closest_points_between_rects(ego_flat, npc_flat)
     euclid_dist_flat = (pt_e_all - pt_n_all).norm(dim=-1)
     signed_dist_flat = torch.where(sat_dist_flat < 0, sat_dist_flat, euclid_dist_flat)
 
-    distances = signed_dist_flat.reshape(N, N_nb, T).masked_fill(~nv_exp, 1e6)
+    distances = signed_dist_flat.reshape(*out_shape).masked_fill(~nv_exp, 1e6)
     if not return_closest_points:
         return distances
 
     return (
         distances,
-        pt_e_all.reshape(N, N_nb, T, 2),
-        pt_n_all.reshape(N, N_nb, T, 2),
+        pt_e_all.reshape(*out_shape, 2),
+        pt_n_all.reshape(*out_shape, 2),
     )
 
 

--- a/test_scripts/test_augmentation.py
+++ b/test_scripts/test_augmentation.py
@@ -12,12 +12,13 @@ from diffusion_planner.utils.data_augmentation import StatePerturbation
 from diffusion_planner.utils.data_augmentation_bridge import (
     StatePerturbation as BridgeStatePerturbation,
 )
+from diffusion_planner.utils.data_augmentation_frenet import FrenetStatePerturbationTensor
 from diffusion_planner.utils.visualize_input import visualize_inputs
 
 parser = argparse.ArgumentParser()
 parser.add_argument("target_npz", type=Path)
 parser.add_argument("save_dir", type=Path)
-parser.add_argument("--augment_type", choices=["quintic", "bridge"], default="quintic")
+parser.add_argument("--augment_type", choices=["quintic", "bridge", "frenet"], default="quintic")
 parser.add_argument(
     "--no_smoothing_future_trajectory",
     action="store_true",
@@ -51,6 +52,8 @@ if args.augment_type == "quintic":
         ego_past_noise_std=0.1,
         use_smoothing_future_trajectory=not args.no_smoothing_future_trajectory,
     )
+elif args.augment_type == "frenet":
+    aug = FrenetStatePerturbationTensor(augment_prob=1.0, device="cpu")
 else:
     aug = BridgeStatePerturbation(augment_prob=1.0, device="cpu")
 

--- a/test_scripts/test_augmentation.py
+++ b/test_scripts/test_augmentation.py
@@ -65,24 +65,36 @@ fig, ax = plt.subplots(figsize=(10, 10))
 view_range = 30
 visualize_inputs(deepcopy(data), save_path=None, ax=ax, view_ranges=[view_range])
 
-# Get augmentation ranges from the aug object
-lo = aug._low.cpu().numpy()[0]  # Extract from tuple
-hi = aug._high.cpu().numpy()[0]  # Extract from tuple
-x_min, y_min = lo[0], lo[1]
-x_max, y_max = hi[0], hi[1]
-
-# Draw the augmentation range rectangle
-rect = patches.Rectangle(
-    (x_min, y_min),
-    x_max - x_min,
-    y_max - y_min,
-    linewidth=2,
-    edgecolor="red",
-    facecolor="none",
-    linestyle="--",
-    label="Augmentation Range",
-)
-ax.add_patch(rect)
+# Draw the augmentation range. Frenet does not sample from the quintic offset
+# table it inherits (_low/_high) — its t=0 displacement is lateral-only, bounded
+# by dy_max — so draw that band instead of a misleading rectangle.
+if args.augment_type == "frenet":
+    ax.axhline(aug.dy_max, color="red", linestyle="--", linewidth=2)
+    ax.axhline(
+        -aug.dy_max,
+        color="red",
+        linestyle="--",
+        linewidth=2,
+        label="Augmentation Range (lateral)",
+    )
+else:
+    # bounds are (9,) since the perturbation-dim decorrelation fix; older
+    # checkouts carried (1, 9) — handle both
+    lo = np.atleast_2d(aug._low.cpu().numpy())[0]
+    hi = np.atleast_2d(aug._high.cpu().numpy())[0]
+    x_min, y_min = lo[0], lo[1]
+    x_max, y_max = hi[0], hi[1]
+    rect = patches.Rectangle(
+        (x_min, y_min),
+        x_max - x_min,
+        y_max - y_min,
+        linewidth=2,
+        edgecolor="red",
+        facecolor="none",
+        linestyle="--",
+        label="Augmentation Range",
+    )
+    ax.add_patch(rect)
 ax.legend()
 
 plt.tight_layout()


### PR DESCRIPTION
# What

Adds `augment_type="frenet"` — a corridor-constrained lateral perturbation augmentation that replaces the fixed 2-second quintic bridge with feasibility-filtered sampling. **Opt-in: the default stays `quintic`, and the quintic path is bit-identical to `origin/tier4-main`** (verified, see Evidence).

Along the way it also:

- moves the *validity checks* out of the augmenter into `diffusion_planner/utils/augmentation_checks.py`, so quintic, bridge, or a future augmenter can use them;
- teaches two `planner_metrics` functions to work batched and per-row, which is what made the exact-OBB safety check affordable;
- exposes the sampling knobs as `--frenet_*` flags.

# Why

The quintic augmentation reconnects to GT on a fixed 2 s horizon with a fixed offset table, and **rejects ~75% of its own proposals** — measured over 400 scenes at ≥2 m/s, only 101 were actually displaced. Those scenes train on the plain recording, so the effective dose of displaced states is a quarter of what the config implies.

That rejection rate is arithmetic, not tuning. Peak lateral jerk of a quintic returning offset `dy` over horizon `T` is `60·dy/T³` — linear in the offset, **cubic** in the horizon. At a fixed 2 s, only ~0.27 m is comfortable; at 5 s, a full 2 m is. A short fixed horizon does not discourage wide offsets, it forbids them — widening quintic's table alone would just generate draws that its own gate discards.

Frenet:

- samples wider offsets (|dy| ≤ 2 m, |dθ| ≤ 0.17 rad), K=16 joint draws × 40 knob combinations = 640 candidates per scene, built in one batched contraction;
- **samples the merge horizon** (2/3/4/5 s) rather than fixing it — which is what makes the wide offsets physically feasible — with `P(M) ∝ exp(−(M − M_min)/1 s)` and a lowest-peak-jerk tie-break;
- validates each candidate on its **exact rebuilt polyline** (lateral accel/jerk, yaw rate, Ackermann steering — GT-relative, so recorded-data glitches don't over-reject) and against the **drivable corridor** (road-border ray-cast + time-aligned neighbour cuts), instead of clipping;
- **rewrites the ego history and t=0 state onto the perturbed polyline.** The model reads ego history as an input, so displacing only the present hands it a physically impossible lead-up — and a discontinuity that reliably signals "recovery wanted" but never occurs at inference. After the rewrite the example reads as gradual drift, which is what closed loop actually produces.

Result: ~95% of eligible scenes are actually perturbed, at roughly twice the displacement.

# Evidence

From-scratch A/B on the 2.3k-scene pipeline test set, identical recipe per arm (200 epochs, cosine-annealed LR, 2 seeds per arm; seed-pair noise floor 0.6 pts). Headline metric: 8-second closed-loop recovery from a ±1 m rigid lateral shift of pose+history (~1,110 rollouts per checkpoint), plus unperturbed curve starts (|κ| ≥ 0.01, 109 starts).

| ep200 | quintic (2 seeds) | frenet (2 seeds) |
|---|---|---|
| recovered% | 23.0 / 22.4 | **41.7 / 40.0** |
| lost% | 30.1 / 31.0 | **13.6 / 9.5** |
| curve lost% | 45.9–67.0 | **14.7–15.6** |

Ablations: ranked merge selection, the wide offsets, and the history rewrite each contribute — a random merge pick costs 12 points; narrowing offsets to ±0.75 m erases most of the gain; keeping the GT history leaves recovery similar but raises off-road endings.

Properties of the generated data (400–512 scenes, all three methods on identical scenes):

| | scenes perturbed | median offset | rejoin spread |
|---|---|---|---|
| quintic | 25% | 0.34 m | ±0.37 s (fixed 2.0 s) |
| bridge | 94% | 0.42 m | ±0.37 s (fixed 1.5 s) |
| frenet | **95%** | **0.72 m** | **±1.09 s (sampled)** |

Scored with the same checks *relative to the recording each came from*, over the 60 curviest scenes: bridge exceeds the recording (jerk, curb distance, or an outright overlap with a parked vehicle) in **45/60**; quintic in 2/60 — of the quarter it perturbs at all; frenet in 0/60, since it is the only one that makes that comparison before accepting a candidate.

Write-up with figures and the derivation: [Trajectory augmentation for the planner](https://tier4.atlassian.net/wiki/spaces/ATT/pages/5530714491) · training results: [IL Augmentation Shoot-out](https://tier4.atlassian.net/wiki/spaces/ATT/pages/5525733736).

**Scope caveat:** measured on the small pipeline test set; full-dataset validation is running separately and is the gate before changing any default.

# Performance

The exact-OBB veto originally called the canonical clearance once per augmented scene — ~256 tiny kernels per batch, costing 228 ms/batch at B=512 to reject the ~1.4% of winners that truly overlap. That was fixed by making the canonical code batchable rather than by approximating the check:

| B=512 | before | after |
|---|---|---|
| OBB veto | 228 ms | **7 ms** |
| corridor | 21 ms | **5 ms** |
| feasibility | 13 ms | **8 ms** |
| **augmenter total** | **277 ms** | **38 ms** (7.3×) |

Frenet is ~1.5× slower than quintic end-to-end at B=512, **and that is entirely the checks — the augmentation itself is faster than quintic's.** Measured by stubbing out frenet's three checks and leaving the sampling and trajectory building untouched:

| | B=512 | B=32 |
|---|---|---|
| quintic (everything it does) | 23.3 ms · 22,021 scenes/s | 7.2 ms · 4,461 scenes/s |
| **frenet, generation only** | **14.8 ms · 34,528 scenes/s** | **4.0 ms · 7,972 scenes/s** |
| frenet, with corridor + OBB veto + kinematics | 37.3 ms · 13,730 scenes/s | 6.4 ms · 4,999 scenes/s |

**Frenet's augmentation is 1.57× faster than quintic's at B=512 and 1.79× at B=32** — and it produces 640 candidate trajectories per scene while doing it, against quintic's one, because it is a single batched contraction rather than per-sample work. At B=32 frenet is faster than quintic even *with* every check enabled.

The ~14 ms/batch that the checks add at B=512 is roughly **2 minutes per epoch** on a ~3-hour epoch. That is what it costs to know that every augmented sample stays on the road, clear of recorded traffic, and inside the recording's own comfort envelope — none of which quintic verifies at all.

# Structure

`augmentation_checks.py` holds the augmenter-agnostic validity checks, batched and taking plain tensors:

| | |
|---|---|
| `border_lateral_bounds` / `neighbor_lateral_bounds` | free lateral interval, before a trajectory exists |
| `kinematic_feasibility` | GT-relative limit screen on finished polylines |
| `veto_overlapping` | exact signed-OBB check on accepted rows |
| `time_aligned_neighbor_tracks`, `path_metrics`, `ddt` | supporting pieces |

The frenet module keeps only what is specific to it (quintic basis, draws, candidate profiles, ranked selection, write-back): 570 → 399 lines, every block grade A, file average complexity 2.92.

In `planner_metrics`:
- `_build_ego_bbox_corners` accepts `ego_shape` as `(N, 3)` as well as `(3,)`, so a batch mixing vehicle types is one call;
- `compute_ego_neighbor_signed_clearance` gains `paired=True` (row *m* vs neighbour *m*, no cross product) and `overlap_only=True` (skips the closest-point refinement when only the overlap sign is needed);
- new `build_road_border_segments` builds border segments batched over scenes and drops those out of reach.

All three keep their previous behaviour by default.

# Flags

Ignored unless `--augment_type frenet`; defaults are the measured configuration and reproduce the results above.

```
--frenet_merge_times 2 3 4 5          horizons to rejoin the recording (s)
--frenet_anchors 2 3                  how far back the history rewrite starts (s)
--frenet_dy_max 2.0                   maximum lateral offset (m)
--frenet_dth_max 0.17                 maximum heading offset (rad)
--frenet_n_draws 16                   candidate draws per scene
--frenet_acc0_fracs 0 -0.5 0.5 -1 1   initial curvature fractions
--frenet_ranked_temp_s 1.0            merge-sampling time constant (s)
--frenet_seed 0                       augmentation RNG seed (offset per DDP rank)
```

# Verification

Every refactor and optimisation in this branch is checked for output equality, not assumed:

- **frenet**: bit-identical to the pre-optimisation module across 5 seeds × 2 probabilities × 9 batches — 100 groups, 13,229 augmented rows, 2.1 B tensor elements, **including the intermediate corridor bounds** and both 3-col and 4-col neighbour layouts.
- **quintic** (the training default): bit-identical to `origin/tier4-main` over 36 groups / 944 M tensor elements.
- **flags**: knobs built through the real CLI parser match the pre-flag defaults exactly; passing custom values does change the configuration and the emitted augmentations.
- **planner_metrics**: `paired` equals the cross-product diagonal; `overlap_only` agrees on every overlap sign and penetration depth; per-row shapes reproduce per-row legacy calls; 69 reward/subscore parity tests pass.
- The harness was strengthened after review caught a corridor bug it had missed, and I verified it now **fails** when that bug is reintroduced.

# Notes

- `data_augmentation.py`: the previously commented-out ego-past transform in `centric_transform` is now gated on `_transform_ego_past` (set only by the frenet subclass); quintic/bridge behaviour is unchanged.
- `test_state_perturbation_init` in `tests/test_data_augmentation.py` fails on `origin/tier4-main` itself — it calls `StatePerturbation(wheel_base=...)`, which that constructor no longer accepts. Not touched here.
- Added `test_frenet_corridor_unconstrained_without_obstacles`, which guards the corridor bug found in review: with no borders and no neighbours the bounds must not be cut at all.
