### PR TITLE
R2LPL two-sided teacher: release bands, take-off pools, trainer override channel

### DIFF
--- a/diffusion_planner/diffusion_planner/config/train_config.py
+++ b/diffusion_planner/diffusion_planner/config/train_config.py
@@ -46,12 +46,8 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
     ego_past_noise_std: float = 0.1
     use_smoothing_future_trajectory: bool = True
     normalization_file_path: str = "normalization.json"
-    # Programmatic override channel for launch wrappers (e.g. the R2LPL round
-    # runner): most TrainConfig fields are deliberately not CLI-exposed, but a
-    # wrapper still has to SET them per run — silently training a fine-tune at
-    # the from-scratch defaults (learning_rate 1e-4, warm_up_epoch 5, ...) is
-    # exactly the failure this channel prevents. Points at a JSON object whose
-    # keys must be TrainConfig field names; unknown keys fail loudly.
+    # Override channel for launch wrappers: JSON object of non-CLI TrainConfig
+    # fields; unknown keys fail loudly (see train_predictor.apply_overrides_json).
     train_overrides_json: str = cli(
         "JSON object of TrainConfig field overrides applied after CLI parsing",
         path=True,

--- a/diffusion_planner/diffusion_planner/config/train_config.py
+++ b/diffusion_planner/diffusion_planner/config/train_config.py
@@ -46,6 +46,17 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
     ego_past_noise_std: float = 0.1
     use_smoothing_future_trajectory: bool = True
     normalization_file_path: str = "normalization.json"
+    # Programmatic override channel for launch wrappers (e.g. the R2LPL round
+    # runner): most TrainConfig fields are deliberately not CLI-exposed, but a
+    # wrapper still has to SET them per run — silently training a fine-tune at
+    # the from-scratch defaults (learning_rate 1e-4, warm_up_epoch 5, ...) is
+    # exactly the failure this channel prevents. Points at a JSON object whose
+    # keys must be TrainConfig field names; unknown keys fail loudly.
+    train_overrides_json: str = cli(
+        "JSON object of TrainConfig field overrides applied after CLI parsing",
+        path=True,
+        default="",
+    )
 
     train_subsample_step: int = 1
 

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -10,14 +10,39 @@ All flags are declared on :class:`diffusion_planner.config.TrainConfig` with
 ``cli(...)`` and mirrored on train_run.py.
 """
 
+import dataclasses
+import json
+
 from diffusion_planner.config import TrainConfig, build_config, build_parser
 from diffusion_planner.train import model_training
 from diffusion_planner.utils.normalizer import ObservationNormalizer, StateNormalizer
 
 
+def apply_overrides_json(cfg: TrainConfig, overrides_path: str) -> TrainConfig:
+    """Apply a JSON object of field overrides onto a built config.
+
+    Unknown keys fail loudly: a typo or a field renamed upstream must not
+    silently fall back to the default (the caller believes it set the value).
+    """
+    if not overrides_path:
+        return cfg
+    with open(overrides_path) as f:
+        overrides = json.load(f)
+    if not isinstance(overrides, dict):
+        raise ValueError(f"{overrides_path} must contain a JSON object")
+    known = {f.name for f in dataclasses.fields(TrainConfig)}
+    unknown = sorted(set(overrides) - known)
+    if unknown:
+        raise ValueError(f"{overrides_path} sets keys that are not TrainConfig fields: {unknown}")
+    for key, value in overrides.items():
+        setattr(cfg, key, value)
+    return cfg
+
+
 def main() -> None:
     args = build_parser(TrainConfig, description=__doc__).parse_args()
     cfg = build_config(TrainConfig, args)
+    cfg = apply_overrides_json(cfg, cfg.train_overrides_json)
     cfg.state_normalizer = StateNormalizer.from_json(cfg)
     cfg.observation_normalizer = ObservationNormalizer.from_json(cfg)
     model_training(cfg)

--- a/diffusion_planner/train_predictor.py
+++ b/diffusion_planner/train_predictor.py
@@ -30,11 +30,30 @@ def apply_overrides_json(cfg: TrainConfig, overrides_path: str) -> TrainConfig:
         overrides = json.load(f)
     if not isinstance(overrides, dict):
         raise ValueError(f"{overrides_path} must contain a JSON object")
-    known = {f.name for f in dataclasses.fields(TrainConfig)}
-    unknown = sorted(set(overrides) - known)
+    all_fields = {f.name: f for f in dataclasses.fields(TrainConfig)}
+    unknown = sorted(set(overrides) - set(all_fields))
     if unknown:
         raise ValueError(f"{overrides_path} sets keys that are not TrainConfig fields: {unknown}")
+    cli_exposed = sorted(k for k in overrides if all_fields[k].metadata.get("cli"))
+    if cli_exposed:
+        raise ValueError(
+            f"{overrides_path} sets CLI-exposed fields {cli_exposed}; pass those as "
+            "command-line flags — a file value would silently shadow the flag"
+        )
+    # JSON cannot express every annotation, but the scalar cases cover the
+    # dangerous silent coercions ('false' is a truthy str; 4.0 is not an int).
+    scalar = {"bool": bool, "int": int, "float": (int, float), "str": str}
     for key, value in overrides.items():
+        field_type = all_fields[key].type
+        annotation = getattr(field_type, "__name__", str(field_type))
+        expected = scalar.get(annotation)
+        if expected is not None and not isinstance(value, expected):
+            raise ValueError(
+                f"{overrides_path}: {key} expects {annotation}, "
+                f"got {type(value).__name__} ({value!r})"
+            )
+        if annotation != "bool" and isinstance(value, bool):
+            raise ValueError(f"{overrides_path}: {key} expects {annotation}, got bool")
         setattr(cfg, key, value)
     return cfg
 

--- a/rlvr/autoresearch/README_r2lpl_lifelong.md
+++ b/rlvr/autoresearch/README_r2lpl_lifelong.md
@@ -526,8 +526,13 @@ argument and the stages fail loudly on unreadable inputs.
 The `takeoff` stage keeps stopped-input frames whose route lane shows GREEN
 and whose recorded future genuinely departs (threshold required — creeps are
 rejected on purpose): the go-decision evidence that failure-window corpora
-under-represent. Feed its output to `training.anchor.takeoff_scene_list` /
-`takeoff_fraction` (set together; `waits_fraction + takeoff_fraction < 1`).
+under-represent. Departure distance is measured over the valid
+(non-zero-padded) future waypoints only, so a truncated future cannot count the
+phantom jump back to the origin as travel. Feed its output to
+`training.anchor.takeoff_scene_list` / `takeoff_fraction` (set together;
+`waits_fraction + takeoff_fraction < 1`). Stratum quotas are floored when the
+anchor slice is drawn, so the normal slice the fraction sum promises survives
+even tiny anchor budgets.
 `build_resume_benchmark.py` selects quasi-stationary-at-t0 scenes whose
 recorded ego resumes mid-horizon — the take-off decision benchmark.
 `prep_ddp_ema.py` rewrites checkpoint keys with the ``module.`` prefix so EMA
@@ -563,11 +568,13 @@ through the chunk manifest (required — scene-list-only mining carries no
 provenance), walks `post_window_s` seconds past the offense at `stride_s`, and
 keeps a frame by traffic-light alignment: route-lane RED (and not also green)
 frames teach patience unconditionally; GREEN/no-TL frames are kept only when the recorded future
-travels at least `min_takeoff_travel_m` (a genuine release — keeping creeps
-would re-teach the bias). The kept rows are sampled to `ratio` x the round's
+travels at least `min_takeoff_travel_m` over its valid (non-zero-padded)
+waypoints (a genuine release — keeping creeps would re-teach the bias). The kept rows are sampled to `ratio` x the round's
 focus count and unioned into the training list as ordinary recorded scenes:
 nothing is generated, relabeled, or removed from the repaired set. All knobs
-are required; base_sft backend only.
+are required; base_sft backend only. `post_window_s` must convert to at least
+one frame at `frame_hz` — a sub-frame window is rejected at startup instead of
+silently degenerating the band to the offense frame itself.
 
 ## Hard-Example Signal (`target_gt_disagreement`)
 

--- a/rlvr/autoresearch/README_r2lpl_lifelong.md
+++ b/rlvr/autoresearch/README_r2lpl_lifelong.md
@@ -523,6 +523,11 @@ list as chainable stages (seeded subsample, moving filter, stop-go waits via
 `build_patience_benchmark --out_pool`, per-log frame dedup, `is_skipped` audit,
 route-arc region exclusion). Every output-changing threshold is a required
 argument and the stages fail loudly on unreadable inputs.
+The `takeoff` stage keeps stopped-input frames whose route lane shows GREEN
+and whose recorded future genuinely departs (threshold required — creeps are
+rejected on purpose): the go-decision evidence that failure-window corpora
+under-represent. Feed its output to `training.anchor.takeoff_scene_list` /
+`takeoff_fraction` (set together; `waits_fraction + takeoff_fraction < 1`).
 `build_resume_benchmark.py` selects quasi-stationary-at-t0 scenes whose
 recorded ego resumes mid-horizon — the take-off decision benchmark.
 `prep_ddp_ema.py` rewrites checkpoint keys with the ``module.`` prefix so EMA
@@ -533,6 +538,36 @@ reward total when the width fields are absent (repaired rows), and
 ``label_quotas`` keys accept the ``label/reason`` form (e.g.
 ``expert_disagreement/model_lagging_expert``) so per-reason teacher classes can
 be reserved separately from the umbrella label.
+
+## Release Bands (`release_bands`) — the two-sided teacher
+
+Mining carves credit windows that end at the offense, so every repaired target
+teaches the entry into a braking manoeuvre and never its resolution — the
+recorded release lies just past the window edge. A corpus built only from
+those windows is systematically deceleration-flavoured, and each additional
+training epoch absorbs more of that bias into the EMA (visible as a monotone
+per-epoch erosion of take-off response at heavily-mined geometries, while red
+compliance persists). The `release_bands` block pairs every mined event with
+recorded frames from its own post-offense band:
+
+```json
+"release_bands": {
+  "post_window_s": 10.0, "stride_s": 0.5,
+  "min_takeoff_travel_m": 10.0, "frame_hz": 10,
+  "ratio": 1.0, "seed": 0, "workers": 12
+}
+```
+
+Per round, `build_release_bands.py` resolves each event to its source sequence
+through the chunk manifest (required — scene-list-only mining carries no
+provenance), walks `post_window_s` seconds past the offense at `stride_s`, and
+keeps a frame by traffic-light alignment: route-lane RED frames teach patience
+unconditionally; GREEN/no-TL frames are kept only when the recorded future
+travels at least `min_takeoff_travel_m` (a genuine release — keeping creeps
+would re-teach the bias). The kept rows are sampled to `ratio` x the round's
+focus count and unioned into the training list as ordinary recorded scenes:
+nothing is generated, relabeled, or removed from the repaired set. All knobs
+are required; base_sft backend only.
 
 ## Hard-Example Signal (`target_gt_disagreement`)
 

--- a/rlvr/autoresearch/README_r2lpl_lifelong.md
+++ b/rlvr/autoresearch/README_r2lpl_lifelong.md
@@ -561,8 +561,8 @@ recorded frames from its own post-offense band:
 Per round, `build_release_bands.py` resolves each event to its source sequence
 through the chunk manifest (required — scene-list-only mining carries no
 provenance), walks `post_window_s` seconds past the offense at `stride_s`, and
-keeps a frame by traffic-light alignment: route-lane RED frames teach patience
-unconditionally; GREEN/no-TL frames are kept only when the recorded future
+keeps a frame by traffic-light alignment: route-lane RED (and not also green)
+frames teach patience unconditionally; GREEN/no-TL frames are kept only when the recorded future
 travels at least `min_takeoff_travel_m` (a genuine release — keeping creeps
 would re-teach the bias). The kept rows are sampled to `ratio` x the round's
 focus count and unioned into the training list as ordinary recorded scenes:

--- a/rlvr/autoresearch/tools/build_r2lpl_pools.py
+++ b/rlvr/autoresearch/tools/build_r2lpl_pools.py
@@ -134,6 +134,69 @@ def _moving_filter(paths: list[str], thresh: float, workers: int) -> tuple[list[
     return keep, unreadable
 
 
+_TL_SLICE = slice(8, 13)  # route_lanes TL one-hot [green, yellow, red, white, none]
+
+
+def _takeoff_worker(args: tuple[str, int, float, float]) -> tuple[str, bool] | None:
+    path, recent_steps, max_recent_travel_m, min_future_travel_m = args
+    try:
+        with np.load(path) as d:
+            past = d["ego_agent_past"][:, :2]
+            recent = float(
+                np.linalg.norm(np.diff(past[-(recent_steps + 1) :], axis=0), axis=1).sum()
+            )
+            if recent >= max_recent_travel_m:
+                return (path, False)
+            rl = d["route_lanes"]
+            valid = np.abs(rl).sum(axis=(1, 2)) > 0
+            if not valid.any():
+                return (path, False)
+            onehot = rl[valid][:, 0, _TL_SLICE]
+            hot = onehot.max(axis=1) > 0
+            if not bool((hot & (onehot.argmax(axis=1) == 0)).any()):  # 0 = green
+                return (path, False)
+            fut = d["ego_agent_future"][:, :2]
+            travel = float(np.linalg.norm(np.diff(fut, axis=0), axis=1).sum())
+    except Exception:
+        return None
+    return (path, travel >= min_future_travel_m)
+
+
+def cmd_takeoff(args: argparse.Namespace) -> None:
+    """Green take-off pool: stopped input + route-lane GREEN + genuinely departing future.
+
+    These are the frames where the recorded driver commits to GO at a signal —
+    the decision the failure-window corpus systematically under-teaches. The
+    departure threshold must reject creeps: a slow roll-forward re-teaches the
+    deceleration bias instead of cancelling it.
+    """
+    paths = _read_list(args.scene_list)
+    keep: list[str] = []
+    unreadable = 0
+    jobs = (
+        (p, args.recent_past_steps, args.max_recent_travel_m, args.min_future_travel_m)
+        for p in paths
+    )
+    with ProcessPoolExecutor(max_workers=args.workers) as ex:
+        for result in ex.map(_takeoff_worker, jobs, chunksize=256):
+            if result is None:
+                unreadable += 1
+            elif result[1]:
+                keep.append(result[0])
+    if paths and not keep:
+        raise RuntimeError(
+            f"takeoff filter kept 0 of {len(paths)} scenes ({unreadable} unreadable) — "
+            "wrong dataset root, a corpus without route-lane TL states, or thresholds "
+            "no recorded departure satisfies"
+        )
+    print(
+        f"[takeoff] kept {len(keep)}/{len(paths)} "
+        f"(recent < {args.max_recent_travel_m} m over {args.recent_past_steps} steps, "
+        f"route green, future >= {args.min_future_travel_m} m; {unreadable} unreadable)"
+    )
+    _write_list(keep, args.out)
+
+
 def cmd_stopgo(args: argparse.Namespace) -> None:
     pool = _read_list(args.stop_pool)
     keep, unreadable = _moving_filter(pool, args.min_end_displacement_m, args.workers)
@@ -292,6 +355,17 @@ def main(argv: list[str] | None = None) -> None:
     p.add_argument("--workers", type=int, required=True)
     p.add_argument("--out", type=Path, required=True)
     p.set_defaults(func=cmd_moving)
+
+    p = sub.add_parser(
+        "takeoff", help="stopped-input + route-green + departing-future pool (release evidence)"
+    )
+    p.add_argument("--scene_list", type=Path, required=True)
+    p.add_argument("--recent_past_steps", type=int, required=True)
+    p.add_argument("--max_recent_travel_m", type=float, required=True)
+    p.add_argument("--min_future_travel_m", type=float, required=True)
+    p.add_argument("--workers", type=int, required=True)
+    p.add_argument("--out", type=Path, required=True)
+    p.set_defaults(func=cmd_takeoff)
 
     p = sub.add_parser("stopgo", help="moving filter over a stop-events pool (+ optional union)")
     p.add_argument(

--- a/rlvr/autoresearch/tools/build_r2lpl_pools.py
+++ b/rlvr/autoresearch/tools/build_r2lpl_pools.py
@@ -137,7 +137,10 @@ def _moving_filter(paths: list[str], thresh: float, workers: int) -> tuple[list[
 
 
 def _takeoff_worker(args: tuple[str, int, float, float]) -> tuple[str, bool] | None:
-    from rlvr.autoresearch.tools.build_release_bands import _route_tl_state
+    from rlvr.autoresearch.tools.build_release_bands import (
+        _route_tl_state,
+        valid_future_pathlen,
+    )
 
     path, recent_steps, max_recent_travel_m, min_future_travel_m = args
     try:
@@ -151,8 +154,7 @@ def _takeoff_worker(args: tuple[str, int, float, float]) -> tuple[str, bool] | N
             green, _red = _route_tl_state(d)
             if not green:
                 return (path, False)
-            fut = d["ego_agent_future"][:, :2]
-            travel = float(np.linalg.norm(np.diff(fut, axis=0), axis=1).sum())
+            travel = valid_future_pathlen(d["ego_agent_future"])
     except Exception:
         return None
     return (path, travel >= min_future_travel_m)

--- a/rlvr/autoresearch/tools/build_r2lpl_pools.py
+++ b/rlvr/autoresearch/tools/build_r2lpl_pools.py
@@ -13,6 +13,8 @@ ad-hoc job scripts. Stages (each a subcommand, chainable via files):
   arc-region   build a route-region point set from full drives in a route cache
                (arc-length window along the driven path)
   arc-exclude  drop scenes whose recorded pose lies within radius of a region
+  takeoff      stopped-input + route-green + departing-future pool (release
+               evidence; see build_release_bands for the per-event variant)
 
 Every threshold is an explicit required argument — there are no defaults for
 values that change the output, so a config cannot silently drift from the
@@ -134,10 +136,9 @@ def _moving_filter(paths: list[str], thresh: float, workers: int) -> tuple[list[
     return keep, unreadable
 
 
-_TL_SLICE = slice(8, 13)  # route_lanes TL one-hot [green, yellow, red, white, none]
-
-
 def _takeoff_worker(args: tuple[str, int, float, float]) -> tuple[str, bool] | None:
+    from rlvr.autoresearch.tools.build_release_bands import _route_tl_state
+
     path, recent_steps, max_recent_travel_m, min_future_travel_m = args
     try:
         with np.load(path) as d:
@@ -147,13 +148,8 @@ def _takeoff_worker(args: tuple[str, int, float, float]) -> tuple[str, bool] | N
             )
             if recent >= max_recent_travel_m:
                 return (path, False)
-            rl = d["route_lanes"]
-            valid = np.abs(rl).sum(axis=(1, 2)) > 0
-            if not valid.any():
-                return (path, False)
-            onehot = rl[valid][:, 0, _TL_SLICE]
-            hot = onehot.max(axis=1) > 0
-            if not bool((hot & (onehot.argmax(axis=1) == 0)).any()):  # 0 = green
+            green, _red = _route_tl_state(d)
+            if not green:
                 return (path, False)
             fut = d["ego_agent_future"][:, :2]
             travel = float(np.linalg.norm(np.diff(fut, axis=0), axis=1).sum())

--- a/rlvr/autoresearch/tools/build_r2lpl_pools.py
+++ b/rlvr/autoresearch/tools/build_r2lpl_pools.py
@@ -15,6 +15,8 @@ ad-hoc job scripts. Stages (each a subcommand, chainable via files):
   arc-exclude  drop scenes whose recorded pose lies within radius of a region
   takeoff      stopped-input + route-green + departing-future pool (release
                evidence; see build_release_bands for the per-event variant)
+  ego-dims     platform slice: keep scenes whose ego_shape wheelbase exceeds
+               a threshold (geometry-sensitive pools must not mix platforms)
 
 Every threshold is an explicit required argument — there are no defaults for
 values that change the output, so a config cannot silently drift from the
@@ -195,6 +197,47 @@ def cmd_takeoff(args: argparse.Namespace) -> None:
     _write_list(keep, args.out)
 
 
+def _ego_dims_worker(args: tuple[str, float]) -> tuple[str, bool] | None:
+    path, min_wheelbase_m = args
+    try:
+        with np.load(path) as d:
+            wheelbase = float(np.asarray(d["ego_shape"]).reshape(-1)[0])
+    except Exception:
+        return None
+    return (path, wheelbase > min_wheelbase_m)
+
+
+def cmd_ego_dims(args: argparse.Namespace) -> None:
+    """Platform slice by recorded ego dimensions (``ego_shape[0]`` = wheelbase).
+
+    Mixed catalogs interleave platforms, and geometry-sensitive slices
+    (take-off pools, anchors) must not mix them: a row recorded by a smaller
+    vehicle is geometrically invalid for a larger one. Strictly-greater
+    comparison, so the threshold sits BETWEEN the platform wheelbases.
+    """
+    paths = _read_list(args.scene_list)
+    keep: list[str] = []
+    unreadable = 0
+    jobs = ((p, args.min_wheelbase_m) for p in paths)
+    with ProcessPoolExecutor(max_workers=args.workers) as ex:
+        for result in ex.map(_ego_dims_worker, jobs, chunksize=256):
+            if result is None:
+                unreadable += 1
+            elif result[1]:
+                keep.append(result[0])
+    if paths and not keep:
+        raise RuntimeError(
+            f"ego-dims filter kept 0 of {len(paths)} scenes ({unreadable} unreadable) — "
+            "wrong dataset root, NPZs without ego_shape, or a threshold above every "
+            "platform in the catalog"
+        )
+    print(
+        f"[ego-dims] kept {len(keep)}/{len(paths)} "
+        f"(wheelbase > {args.min_wheelbase_m} m; {unreadable} unreadable)"
+    )
+    _write_list(keep, args.out)
+
+
 def cmd_stopgo(args: argparse.Namespace) -> None:
     pool = _read_list(args.stop_pool)
     keep, unreadable = _moving_filter(pool, args.min_end_displacement_m, args.workers)
@@ -364,6 +407,13 @@ def main(argv: list[str] | None = None) -> None:
     p.add_argument("--workers", type=int, required=True)
     p.add_argument("--out", type=Path, required=True)
     p.set_defaults(func=cmd_takeoff)
+
+    p = sub.add_parser("ego-dims", help="keep scenes whose ego_shape wheelbase exceeds a threshold")
+    p.add_argument("--scene_list", type=Path, required=True)
+    p.add_argument("--min_wheelbase_m", type=float, required=True)
+    p.add_argument("--workers", type=int, required=True)
+    p.add_argument("--out", type=Path, required=True)
+    p.set_defaults(func=cmd_ego_dims)
 
     p = sub.add_parser("stopgo", help="moving filter over a stop-events pool (+ optional union)")
     p.add_argument(

--- a/rlvr/autoresearch/tools/build_release_bands.py
+++ b/rlvr/autoresearch/tools/build_release_bands.py
@@ -89,7 +89,19 @@ def _sequence_index(scene_path: str) -> dict[int, str]:
     return idx
 
 
-def _pathlen(xy: np.ndarray) -> float:
+def valid_future_pathlen(future: np.ndarray) -> float:
+    """Arc length over the VALID waypoints of a zero-padded ego future.
+
+    ``ego_agent_future`` zero-pads invalid steps; a padded row sits at the
+    origin, so summing raw diffs adds a phantom jump back to (0, 0) that can
+    turn a short truncated motion into an apparent long departure. Mask with
+    the canonical non-zero-waypoint rule (see add_distractor_neighbors_npz)
+    before measuring.
+    """
+    xy = future[:, :2]
+    xy = xy[np.abs(xy).sum(axis=1) > 1e-6]
+    if len(xy) < 2:
+        return 0.0
     return float(np.linalg.norm(np.diff(xy, axis=0), axis=1).sum())
 
 
@@ -129,7 +141,7 @@ def _band_worker(
                     if red and not green:
                         out.append(p)
                         continue
-                    fut = _pathlen(d["ego_agent_future"][:, :2])
+                    fut = valid_future_pathlen(d["ego_agent_future"])
             except Exception:
                 continue
             if fut >= min_takeoff_m:
@@ -194,6 +206,12 @@ def build_release_bands(
         )
 
     post_frames = int(round(post_window_s * frame_hz))
+    if post_frames < 1:
+        raise ValueError(
+            f"post_window_s={post_window_s} at frame_hz={frame_hz} rounds to zero "
+            "post-offense frames — the band would degenerate to the offense frame "
+            "itself, silently disabling the two-sided teacher"
+        )
     stride_frames = max(1, int(round(stride_s * frame_hz)))
     jobs = [
         (manifest[key], sorted(frames), post_frames, stride_frames, min_takeoff_travel_m)

--- a/rlvr/autoresearch/tools/build_release_bands.py
+++ b/rlvr/autoresearch/tools/build_release_bands.py
@@ -111,6 +111,29 @@ def _band_worker(
     return out
 
 
+def _load_chunk_manifest(chunk_manifest: Path) -> dict[str, str]:
+    manifest: dict[str, str] = {}
+    with open(chunk_manifest) as fh:
+        for line in fh:
+            row = json.loads(line)
+            manifest[str(row["chunk_key"])] = str(row["start_scene_path"])
+    if not manifest:
+        raise ValueError(f"{chunk_manifest} is empty")
+    return manifest
+
+
+def _load_event_offenses(credit_windows: Path) -> dict[str, set[int]]:
+    events: dict[str, set[int]] = {}
+    with open(credit_windows) as fh:
+        for line in fh:
+            row = json.loads(line)
+            key = _chunk_key_of_event(str(row["event_key"]))
+            events.setdefault(key, set()).add(int(row["offense_frame_id"]))
+    if not events:
+        raise ValueError(f"{credit_windows} contains no event rows")
+    return events
+
+
 def build_release_bands(
     credit_windows: Path,
     chunk_manifest: Path,
@@ -129,22 +152,8 @@ def build_release_bands(
     if workers < 1:
         raise ValueError(f"workers must be >= 1: {workers}")
 
-    manifest: dict[str, str] = {}
-    with open(chunk_manifest) as fh:
-        for line in fh:
-            row = json.loads(line)
-            manifest[str(row["chunk_key"])] = str(row["start_scene_path"])
-    if not manifest:
-        raise ValueError(f"{chunk_manifest} is empty")
-
-    events: dict[str, set[int]] = {}
-    with open(credit_windows) as fh:
-        for line in fh:
-            row = json.loads(line)
-            key = _chunk_key_of_event(str(row["event_key"]))
-            events.setdefault(key, set()).add(int(row["offense_frame_id"]))
-    if not events:
-        raise ValueError(f"{credit_windows} contains no event rows")
+    manifest = _load_chunk_manifest(chunk_manifest)
+    events = _load_event_offenses(credit_windows)
     unmatched = sorted(k for k in events if k not in manifest)
     if unmatched:
         raise ValueError(

--- a/rlvr/autoresearch/tools/build_release_bands.py
+++ b/rlvr/autoresearch/tools/build_release_bands.py
@@ -33,39 +33,60 @@ from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 
 import numpy as np
+from diffusion_planner.dimensions import (
+    TRAFFIC_LIGHT_GREEN,
+    TRAFFIC_LIGHT_NO_TRAFFIC_LIGHT,
+    TRAFFIC_LIGHT_RED,
+)
 
-# route_lanes feature columns 8..12 carry the traffic-light one-hot
+# route_lanes feature columns carry the traffic-light one-hot
 # [green, yellow, red, white, none] (diffusion_planner.dimensions).
-_TL_SLICE = slice(8, 13)
+_TL_SLICE = slice(TRAFFIC_LIGHT_GREEN, TRAFFIC_LIGHT_NO_TRAFFIC_LIGHT + 1)
 _TL_GREEN = 0
-_TL_RED = 2
+_TL_RED = TRAFFIC_LIGHT_RED - TRAFFIC_LIGHT_GREEN
 
-_FRAME_RE = re.compile(r"_(\d+)\.npz$")
+_FRAME_RE = re.compile(r"^(.*)_(\d+)\.npz$")
 
 
 def _chunk_key_of_event(event_key: str) -> str:
     """``<chunk_key>_<idx>_<step>_danger_<label>`` -> ``<chunk_key>``.
 
     Chunk keys themselves contain underscores (log names do), so strip the
-    known suffixes from the right instead of splitting from the left.
+    known suffixes from the right instead of splitting from the left. Keys
+    without the ``_danger_`` marker (other credit-window producers use other
+    forms) are rejected loudly rather than mis-stripped.
     """
-    stem = event_key.rsplit("_danger_", 1)[0]
+    stem, marker, _label = event_key.rpartition("_danger_")
+    if not marker:
+        raise ValueError(
+            f"unsupported event_key format (expected ..._danger_<label>): {event_key!r}"
+        )
     parts = stem.split("_")
     if len(parts) < 3:
         raise ValueError(f"unparseable event_key: {event_key!r}")
     return "_".join(parts[:-2])
 
 
-def _sequence_index(scene_path: str) -> tuple[str, dict[int, str]]:
+def _sequence_index(scene_path: str) -> dict[int, str]:
+    """frame -> path for the frames of the SAME LOG as ``scene_path``.
+
+    A dataset directory may hold several logs with overlapping frame numbers;
+    log identity is (directory, filename prefix), matching the convention in
+    the pool/mining tools. Indexing by frame alone would silently mix logs.
+    """
     d = os.path.dirname(scene_path)
+    m = _FRAME_RE.match(os.path.basename(scene_path))
+    if m is None:
+        raise ValueError(f"scene filename carries no frame index: {scene_path}")
+    prefix = m.group(1)
     idx: dict[int, str] = {}
     for f in os.listdir(d):
-        m = _FRAME_RE.search(f)
-        if m and f.endswith(".npz"):
-            idx[int(m.group(1))] = os.path.join(d, f)
+        m = _FRAME_RE.match(f)
+        if m and m.group(1) == prefix:
+            idx[int(m.group(2))] = os.path.join(d, f)
     if not idx:
-        raise ValueError(f"no frame-indexed .npz files next to {scene_path}")
-    return d, idx
+        raise ValueError(f"no frames of log {prefix!r} next to {scene_path}")
+    return idx
 
 
 def _pathlen(xy: np.ndarray) -> float:
@@ -89,14 +110,19 @@ def _band_worker(
     args: tuple[str, list[int], int, int, float],
 ) -> list[str]:
     start_scene_path, offense_frames, post_frames, stride_frames, min_takeoff_m = args
-    _, idx = _sequence_index(start_scene_path)
-    last_frame = max(idx)
+    idx = _sequence_index(start_scene_path)
+    frames = sorted(idx)
     out: list[str] = []
     for f0 in offense_frames:
-        for f in range(f0, min(f0 + post_frames, last_frame) + 1, stride_frames):
-            p = idx.get(f)
-            if p is None:
+        # Walk the frames that actually exist (catalogs may be stored at a
+        # frame step > 1) and thin them to the requested stride by frame id.
+        band = [f for f in frames if f0 <= f <= f0 + post_frames]
+        kept_until = None
+        for f in band:
+            if kept_until is not None and f < kept_until:
                 continue
+            kept_until = f + stride_frames
+            p = idx[f]
             try:
                 with np.load(p) as d:
                     green, red = _route_tl_state(d)
@@ -128,7 +154,13 @@ def _load_event_offenses(credit_windows: Path) -> dict[str, set[int]]:
         for line in fh:
             row = json.loads(line)
             key = _chunk_key_of_event(str(row["event_key"]))
-            events.setdefault(key, set()).add(int(row["offense_frame_id"]))
+            offense = row.get("offense_frame_id")
+            if offense is None:
+                raise ValueError(
+                    f"{credit_windows}: event {row.get('event_key')!r} carries no "
+                    "offense_frame_id — cannot locate its post-offense band"
+                )
+            events.setdefault(key, set()).add(int(offense))
     if not events:
         raise ValueError(f"{credit_windows} contains no event rows")
     return events
@@ -172,6 +204,13 @@ def build_release_bands(
         for result in ex.map(_band_worker, jobs, chunksize=8):
             rows.update(result)
     kept = sorted(rows)
+    if not kept:
+        raise RuntimeError(
+            f"release-band extraction kept 0 rows from {len(events)} event chunks — "
+            "wrong frame_hz for this catalog, a mis-strided sequence layout, or "
+            "frames missing route_lanes/ego_agent_future; refusing to silently "
+            "disable the two-sided teacher"
+        )
     out.parent.mkdir(parents=True, exist_ok=True)
     tmp = out.with_suffix(f".tmp{os.getpid()}")
     tmp.write_text(json.dumps(kept))

--- a/rlvr/autoresearch/tools/build_release_bands.py
+++ b/rlvr/autoresearch/tools/build_release_bands.py
@@ -118,6 +118,24 @@ def _route_tl_state(d: np.lib.npyio.NpzFile) -> tuple[bool, bool]:
     return green, red
 
 
+def _frame_is_band_row(path: str, min_takeoff_m: float) -> bool:
+    """Keep a frame as red-hold patience or a genuine recorded departure.
+
+    RED-and-not-green frames are patience evidence regardless of motion;
+    everything else must show a real recorded departure over its valid
+    waypoints — keeping creeps would re-teach the deceleration bias.
+    """
+    try:
+        with np.load(path) as d:
+            green, red = _route_tl_state(d)
+            if red and not green:
+                return True
+            fut = valid_future_pathlen(d["ego_agent_future"])
+    except Exception:
+        return False
+    return fut >= min_takeoff_m
+
+
 def _band_worker(
     args: tuple[str, list[int], int, int, float],
 ) -> list[str]:
@@ -135,16 +153,7 @@ def _band_worker(
                 continue
             kept_until = f + stride_frames
             p = idx[f]
-            try:
-                with np.load(p) as d:
-                    green, red = _route_tl_state(d)
-                    if red and not green:
-                        out.append(p)
-                        continue
-                    fut = valid_future_pathlen(d["ego_agent_future"])
-            except Exception:
-                continue
-            if fut >= min_takeoff_m:
+            if _frame_is_band_row(p, min_takeoff_m):
                 out.append(p)
     return out
 
@@ -178,6 +187,32 @@ def _load_event_offenses(credit_windows: Path) -> dict[str, set[int]]:
     return events
 
 
+def _validate_band_params(
+    post_window_s: float,
+    stride_s: float,
+    min_takeoff_travel_m: float,
+    frame_hz: float,
+    workers: int,
+) -> None:
+    if post_window_s <= 0 or stride_s <= 0 or frame_hz <= 0:
+        raise ValueError("post_window_s, stride_s and frame_hz must be > 0")
+    if min_takeoff_travel_m <= 0:
+        raise ValueError(f"min_takeoff_travel_m must be > 0: {min_takeoff_travel_m}")
+    if workers < 1:
+        raise ValueError(f"workers must be >= 1: {workers}")
+
+
+def _validated_post_frames(post_window_s: float, frame_hz: float) -> int:
+    post_frames = int(round(post_window_s * frame_hz))
+    if post_frames < 1:
+        raise ValueError(
+            f"post_window_s={post_window_s} at frame_hz={frame_hz} rounds to zero "
+            "post-offense frames — the band would degenerate to the offense frame "
+            "itself, silently disabling the two-sided teacher"
+        )
+    return post_frames
+
+
 def build_release_bands(
     credit_windows: Path,
     chunk_manifest: Path,
@@ -189,12 +224,7 @@ def build_release_bands(
     frame_hz: float,
     workers: int,
 ) -> list[str]:
-    if post_window_s <= 0 or stride_s <= 0 or frame_hz <= 0:
-        raise ValueError("post_window_s, stride_s and frame_hz must be > 0")
-    if min_takeoff_travel_m <= 0:
-        raise ValueError(f"min_takeoff_travel_m must be > 0: {min_takeoff_travel_m}")
-    if workers < 1:
-        raise ValueError(f"workers must be >= 1: {workers}")
+    _validate_band_params(post_window_s, stride_s, min_takeoff_travel_m, frame_hz, workers)
 
     manifest = _load_chunk_manifest(chunk_manifest)
     events = _load_event_offenses(credit_windows)
@@ -205,13 +235,7 @@ def build_release_bands(
             f"{chunk_manifest} (first: {unmatched[0]!r}) — wrong manifest for this run?"
         )
 
-    post_frames = int(round(post_window_s * frame_hz))
-    if post_frames < 1:
-        raise ValueError(
-            f"post_window_s={post_window_s} at frame_hz={frame_hz} rounds to zero "
-            "post-offense frames — the band would degenerate to the offense frame "
-            "itself, silently disabling the two-sided teacher"
-        )
+    post_frames = _validated_post_frames(post_window_s, frame_hz)
     stride_frames = max(1, int(round(stride_s * frame_hz)))
     jobs = [
         (manifest[key], sorted(frames), post_frames, stride_frames, min_takeoff_travel_m)

--- a/rlvr/autoresearch/tools/build_release_bands.py
+++ b/rlvr/autoresearch/tools/build_release_bands.py
@@ -1,0 +1,201 @@
+"""Extract post-event RELEASE BANDS for every mined R2LPL event.
+
+The mining/repair pipeline carves credit windows that END at (or before) the
+offense, so every repaired target teaches the entry into a braking manoeuvre
+and never its resolution — the recorded driver's release/re-acceleration lies
+just past the window edge in the source logs. A corpus built only from those
+windows is systematically deceleration-biased, and post-training on it erodes
+take-off behaviour a little more every epoch. Pairing each event's credit
+window with frames from the SAME event's post-offense band restores the other
+half of the manoeuvre, using recorded futures only — nothing is generated,
+relabeled, or filtered out of the repaired set itself.
+
+For each event row in a mining run's credit_windows.jsonl, this tool locates
+the source sequence via the chunk manifest, then walks recorded frames from
+the offense forward through ``--post_window_s`` seconds at ``--stride_s``
+spacing. Traffic-light alignment decides what each frame may teach:
+
+  * route lane RED (and not green)  -> keep unconditionally (patience);
+  * route lane GREEN or no route TL -> keep only when the recorded future
+    travels at least ``--min_takeoff_travel_m`` (a genuine release — a creep
+    would re-teach the bias this tool exists to cancel).
+
+Every threshold is required; the tool fails loudly on unmatched chunk keys.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+
+import numpy as np
+
+# route_lanes feature columns 8..12 carry the traffic-light one-hot
+# [green, yellow, red, white, none] (diffusion_planner.dimensions).
+_TL_SLICE = slice(8, 13)
+_TL_GREEN = 0
+_TL_RED = 2
+
+_FRAME_RE = re.compile(r"_(\d+)\.npz$")
+
+
+def _chunk_key_of_event(event_key: str) -> str:
+    """``<chunk_key>_<idx>_<step>_danger_<label>`` -> ``<chunk_key>``.
+
+    Chunk keys themselves contain underscores (log names do), so strip the
+    known suffixes from the right instead of splitting from the left.
+    """
+    stem = event_key.rsplit("_danger_", 1)[0]
+    parts = stem.split("_")
+    if len(parts) < 3:
+        raise ValueError(f"unparseable event_key: {event_key!r}")
+    return "_".join(parts[:-2])
+
+
+def _sequence_index(scene_path: str) -> tuple[str, dict[int, str]]:
+    d = os.path.dirname(scene_path)
+    idx: dict[int, str] = {}
+    for f in os.listdir(d):
+        m = _FRAME_RE.search(f)
+        if m and f.endswith(".npz"):
+            idx[int(m.group(1))] = os.path.join(d, f)
+    if not idx:
+        raise ValueError(f"no frame-indexed .npz files next to {scene_path}")
+    return d, idx
+
+
+def _pathlen(xy: np.ndarray) -> float:
+    return float(np.linalg.norm(np.diff(xy, axis=0), axis=1).sum())
+
+
+def _route_tl_state(d: np.lib.npyio.NpzFile) -> tuple[bool, bool]:
+    rl = d["route_lanes"]
+    valid = np.abs(rl).sum(axis=(1, 2)) > 0
+    if not valid.any():
+        return False, False
+    onehot = rl[valid][:, 0, _TL_SLICE]
+    hot = onehot.max(axis=1) > 0
+    cls = onehot.argmax(axis=1)
+    green = bool((hot & (cls == _TL_GREEN)).any())
+    red = bool((hot & (cls == _TL_RED)).any())
+    return green, red
+
+
+def _band_worker(
+    args: tuple[str, list[int], int, int, float],
+) -> list[str]:
+    start_scene_path, offense_frames, post_frames, stride_frames, min_takeoff_m = args
+    _, idx = _sequence_index(start_scene_path)
+    last_frame = max(idx)
+    out: list[str] = []
+    for f0 in offense_frames:
+        for f in range(f0, min(f0 + post_frames, last_frame) + 1, stride_frames):
+            p = idx.get(f)
+            if p is None:
+                continue
+            try:
+                with np.load(p) as d:
+                    green, red = _route_tl_state(d)
+                    if red and not green:
+                        out.append(p)
+                        continue
+                    fut = _pathlen(d["ego_agent_future"][:, :2])
+            except Exception:
+                continue
+            if fut >= min_takeoff_m:
+                out.append(p)
+    return out
+
+
+def build_release_bands(
+    credit_windows: Path,
+    chunk_manifest: Path,
+    out: Path,
+    *,
+    post_window_s: float,
+    stride_s: float,
+    min_takeoff_travel_m: float,
+    frame_hz: float,
+    workers: int,
+) -> list[str]:
+    if post_window_s <= 0 or stride_s <= 0 or frame_hz <= 0:
+        raise ValueError("post_window_s, stride_s and frame_hz must be > 0")
+    if min_takeoff_travel_m <= 0:
+        raise ValueError(f"min_takeoff_travel_m must be > 0: {min_takeoff_travel_m}")
+    if workers < 1:
+        raise ValueError(f"workers must be >= 1: {workers}")
+
+    manifest: dict[str, str] = {}
+    with open(chunk_manifest) as fh:
+        for line in fh:
+            row = json.loads(line)
+            manifest[str(row["chunk_key"])] = str(row["start_scene_path"])
+    if not manifest:
+        raise ValueError(f"{chunk_manifest} is empty")
+
+    events: dict[str, set[int]] = {}
+    with open(credit_windows) as fh:
+        for line in fh:
+            row = json.loads(line)
+            key = _chunk_key_of_event(str(row["event_key"]))
+            events.setdefault(key, set()).add(int(row["offense_frame_id"]))
+    if not events:
+        raise ValueError(f"{credit_windows} contains no event rows")
+    unmatched = sorted(k for k in events if k not in manifest)
+    if unmatched:
+        raise ValueError(
+            f"{len(unmatched)}/{len(events)} event chunk keys are absent from "
+            f"{chunk_manifest} (first: {unmatched[0]!r}) — wrong manifest for this run?"
+        )
+
+    post_frames = int(round(post_window_s * frame_hz))
+    stride_frames = max(1, int(round(stride_s * frame_hz)))
+    jobs = [
+        (manifest[key], sorted(frames), post_frames, stride_frames, min_takeoff_travel_m)
+        for key, frames in sorted(events.items())
+    ]
+    rows: set[str] = set()
+    with ProcessPoolExecutor(max_workers=workers) as ex:
+        for result in ex.map(_band_worker, jobs, chunksize=8):
+            rows.update(result)
+    kept = sorted(rows)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out.with_suffix(f".tmp{os.getpid()}")
+    tmp.write_text(json.dumps(kept))
+    tmp.replace(out)
+    print(
+        f"[release-bands] {len(kept)} band rows from {len(events)} event chunks "
+        f"(window {post_window_s}s, stride {stride_s}s, takeoff >= {min_takeoff_travel_m} m)"
+    )
+    return kept
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--credit_windows", type=Path, required=True)
+    parser.add_argument("--chunk_manifest", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--post_window_s", type=float, required=True)
+    parser.add_argument("--stride_s", type=float, required=True)
+    parser.add_argument("--min_takeoff_travel_m", type=float, required=True)
+    parser.add_argument("--frame_hz", type=float, required=True)
+    parser.add_argument("--workers", type=int, required=True)
+    args = parser.parse_args(argv)
+    build_release_bands(
+        args.credit_windows,
+        args.chunk_manifest,
+        args.out,
+        post_window_s=args.post_window_s,
+        stride_s=args.stride_s,
+        min_takeoff_travel_m=args.min_takeoff_travel_m,
+        frame_hz=args.frame_hz,
+        workers=args.workers,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
+++ b/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
@@ -1187,8 +1187,11 @@ def _anchor_slice_paths(
     Config (``training.anchor`` in the workflow JSON): ``scene_list`` +
     ``ratio`` are required when the section is present (fail loudly, no silent
     defaults); ``waits_scene_list``/``waits_fraction`` must be given together;
-    ``seed`` (default 0) is offset by the round index so each round redraws
-    reproducibly.
+    ``takeoff_scene_list``/``takeoff_fraction`` (also set together) stratify a
+    green take-off slice into the anchors — the release-side evidence that the
+    failure-window corpus under-represents (build with
+    ``build_r2lpl_pools takeoff``); ``seed`` (default 0) is offset by the round
+    index so each round redraws reproducibly.
     """
     if not anchor_cfg:
         return []
@@ -1202,6 +1205,21 @@ def _anchor_slice_paths(
     waits_fraction = anchor_cfg.get("waits_fraction")
     if (waits_list is None) != (waits_fraction is None):
         raise ValueError("training.anchor.waits_scene_list and waits_fraction must be set together")
+    takeoff_list = anchor_cfg.get("takeoff_scene_list")
+    takeoff_fraction = anchor_cfg.get("takeoff_fraction")
+    if (takeoff_list is None) != (takeoff_fraction is None):
+        raise ValueError(
+            "training.anchor.takeoff_scene_list and takeoff_fraction must be set together"
+        )
+    if (
+        waits_fraction is not None
+        and takeoff_fraction is not None
+        and float(waits_fraction) + float(takeoff_fraction) >= 1.0
+    ):
+        raise ValueError(
+            "training.anchor waits_fraction + takeoff_fraction must leave room for the "
+            f"normal slice (< 1.0): {waits_fraction} + {takeoff_fraction}"
+        )
 
     import math as _math
     import random as _random
@@ -1229,6 +1247,16 @@ def _anchor_slice_paths(
             raise ValueError(f"training.anchor.waits_scene_list is empty: {waits_list}")
         n_waits = int(round(frac * n_anchor))
         picked.extend(_sample(waits_pool, n_waits))
+    if takeoff_list is not None:
+        frac = float(takeoff_fraction)
+        if not 0.0 < frac < 1.0:
+            raise ValueError(f"training.anchor.takeoff_fraction must be in (0, 1): {frac}")
+        takeoff_pool = [str(p) for p in _read_json_list(Path(takeoff_list))]
+        if not takeoff_pool:
+            raise ValueError(f"training.anchor.takeoff_scene_list is empty: {takeoff_list}")
+        already = set(picked)
+        n_takeoff = int(round(frac * n_anchor))
+        picked.extend(_sample([p for p in takeoff_pool if p not in already], n_takeoff))
     picked_set = set(picked)
     picked.extend(_sample([p for p in normal_pool if p not in picked_set], n_anchor - len(picked)))
     return picked
@@ -1535,6 +1563,88 @@ def _validate_repair_generation_config(cfg: dict[str, Any]) -> None:
             f"repair variant {variant_name!r} needs K >= {min_k} "
             f"(det + {min_k - 1} fixed slots), got K={k}"
         )
+
+
+_RELEASE_BANDS_REQUIRED = (
+    "post_window_s",
+    "stride_s",
+    "min_takeoff_travel_m",
+    "frame_hz",
+    "ratio",
+    "seed",
+    "workers",
+)
+
+
+def _validate_release_bands_config(cfg: dict[str, Any]) -> None:
+    """Fail at STARTUP on release_bands misconfiguration.
+
+    The block extends each round's training corpus with post-offense recorded
+    frames from the SAME events the repair phase mined (see
+    build_release_bands): pairing every failure window with its recorded
+    resolution keeps the corpus from being one-sidedly deceleration-flavoured.
+    All knobs are required — no silent defaults.
+    """
+    bands_cfg = cfg.get("release_bands")
+    if "release_bands" in cfg and not bands_cfg:
+        raise ValueError(
+            "config has an empty 'release_bands' section; remove it or fill in "
+            f"{list(_RELEASE_BANDS_REQUIRED)}"
+        )
+    if not bands_cfg:
+        return
+    missing = [k for k in _RELEASE_BANDS_REQUIRED if bands_cfg.get(k) is None]
+    if missing:
+        raise ValueError(f"release_bands is missing required fields: {missing}")
+    if float(bands_cfg["ratio"]) <= 0.0:
+        raise ValueError(f"release_bands.ratio must be > 0: {bands_cfg['ratio']}")
+    if str(cfg.get("training_backend", "base_sft")) != "base_sft":
+        raise ValueError(
+            "release_bands is only wired into the base_sft training backend; "
+            f"got training_backend={cfg.get('training_backend')!r}"
+        )
+    mining = cfg.get("perception_mining") or {}
+    if not (mining.get("chunk_manifest") or cfg.get("chunk_manifest")):
+        raise ValueError(
+            "release_bands requires a chunk manifest (event -> source sequence "
+            "provenance); scene_list-only mining cannot locate post-offense frames"
+        )
+
+
+def _release_band_paths(
+    cfg: dict[str, Any],
+    credit_jsonl: Path,
+    rdir: Path,
+    round_idx: int,
+    n_focus: int,
+) -> list[str]:
+    """Extract + sample this round's release bands (see build_release_bands)."""
+    bands_cfg = cfg.get("release_bands")
+    if not bands_cfg:
+        return []
+    from rlvr.autoresearch.tools.build_release_bands import build_release_bands
+
+    mining = cfg.get("perception_mining") or {}
+    manifest = mining.get("chunk_manifest") or cfg.get("chunk_manifest")
+    out_json = rdir / f"round_{round_idx}_release_bands.json"
+    rows = build_release_bands(
+        credit_jsonl,
+        Path(str(manifest)),
+        out_json,
+        post_window_s=float(bands_cfg["post_window_s"]),
+        stride_s=float(bands_cfg["stride_s"]),
+        min_takeoff_travel_m=float(bands_cfg["min_takeoff_travel_m"]),
+        frame_hz=float(bands_cfg["frame_hz"]),
+        workers=int(bands_cfg["workers"]),
+    )
+    n_keep = int(round(float(bands_cfg["ratio"]) * n_focus))
+    if len(rows) > n_keep:
+        import random as _random
+
+        rng = _random.Random(int(bands_cfg["seed"]) + round_idx)
+        rows = sorted(rng.sample(rows, n_keep))
+        _write_json(out_json, rows)
+    return [str(r) for r in rows]
 
 
 def _validate_guards_config(cfg: dict[str, Any]) -> None:
@@ -2985,6 +3095,7 @@ def main() -> None:
 
     cfg = _load_config(args.config) if args.config else _config_from_cli_args(args)
     _validate_anchor_config(cfg)
+    _validate_release_bands_config(cfg)
     _validate_guards_config(cfg)
     _validate_repair_generation_config(cfg)
     _validate_normal_scene_list_config(cfg)
@@ -3200,9 +3311,17 @@ def main() -> None:
             # just replaced. Point it at the spliced list instead.
             replay_json = rdir / f"round_{round_idx}_replay_scenes_refreshed.json"
             _write_json(replay_json, replay_paths)
-        anchor_paths = _anchor_slice_paths(
-            cfg.get("anchor"), len(set(repaired_paths) | set(replay_paths)), round_idx
-        )
+        n_focus = len(set(repaired_paths) | set(replay_paths))
+        band_paths = _release_band_paths(cfg, credit_jsonl, rdir, round_idx, n_focus)
+        if band_paths:
+            band_paths = _ensure_4col_neighbor_futures(
+                band_paths, rdir.parent / "release_bands_4col"
+            )
+            print(
+                f"[round {round_idx}] release bands: {len(band_paths)} recorded "
+                f"post-offense rows paired with {n_focus} focus scenes"
+            )
+        anchor_paths = _anchor_slice_paths(cfg.get("anchor"), n_focus, round_idx)
         if anchor_paths:
             # Campaign-level cache dir: the anchor pool is largely the same
             # scenes every round, so convert once per campaign, not per round.
@@ -3213,7 +3332,9 @@ def main() -> None:
                 f"[round {round_idx}] anchor slice: {len(anchor_paths)} real scenes "
                 f"({len(repaired_paths)} repaired + {len(replay_paths)} replay)"
             )
-        _union_scene_lists(repaired_paths, [*replay_paths, *anchor_paths], train_input_list)
+        _union_scene_lists(
+            repaired_paths, [*replay_paths, *band_paths, *anchor_paths], train_input_list
+        )
         if bool(cfg.get("validate_on_repaired_targets", False)):
             cfg["val_scenes"] = str(train_input_list)
 

--- a/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
+++ b/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
@@ -2297,9 +2297,8 @@ def _base_train_invocation(
         str(total_epochs),
         "--resume_model_path",
         str(model_path),
-        "--normalization_file_path",
-        normalization_path,
     ]
+    overrides.setdefault("normalization_file_path", normalization_path)
 
     passthrough = (
         "train_subsample_step",
@@ -2375,9 +2374,37 @@ def _base_train_invocation(
         merged["batch_size"] = max(1, min(int(merged["batch_size"]), train_scene_count))
     if "warm_up_epoch" in merged:
         merged["warm_up_epoch"] = max(0, min(int(merged["warm_up_epoch"]), total_epochs))
+    # The trainer's CLI deliberately exposes only cli()-marked TrainConfig
+    # fields; every other knob is handed over via --train_overrides_json (the
+    # trainer fails loudly on keys that are not TrainConfig fields, so a rename
+    # upstream surfaces here instead of silently training at defaults).
+    from diffusion_planner.config import TrainConfig as _TrainConfig
+    from diffusion_planner.config import cli_fields as _cli_fields
+
+    cli_exposed = {f.name for f in _cli_fields(_TrainConfig)}
+    overrides_payload: dict[str, Any] = {}
     for key in passthrough:
-        if key in merged:
+        if key not in merged:
+            continue
+        if key in cli_exposed:
             _append_train_arg(cmd, key, merged[key])
+        elif merged[key] is not None:
+            overrides_payload[key] = merged[key]
+    for key, value in merged.items():
+        if key in passthrough or value is None:
+            continue
+        if key in cli_exposed:
+            _append_train_arg(cmd, key, value)
+        else:
+            overrides_payload[key] = value
+    if "train_overrides_json" not in cli_exposed:
+        raise RuntimeError(
+            "train_predictor's TrainConfig lacks the train_overrides_json channel; "
+            "cannot pass non-CLI training knobs (learning_rate, ema_decay, ...)"
+        )
+    overrides_file = save_dir / "train_overrides.json"
+    overrides_file.write_text(json.dumps(overrides_payload, indent=2, sort_keys=True))
+    cmd.extend(["--train_overrides_json", str(overrides_file)])
 
     env = dict(os.environ)
     repo_root = Path(__file__).resolve().parents[3]

--- a/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
+++ b/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
@@ -1259,8 +1259,12 @@ def _anchor_slice_paths(
     if not normal_pool:
         raise ValueError(f"training.anchor.scene_list is empty: {anchor_cfg['scene_list']}")
     picked: list[str] = []
+    # Floor each special stratum: independent rounding could consume the whole
+    # budget on tiny n_anchor (e.g. 0.4+0.4 with n_anchor=2 rounds to 1+1),
+    # eliminating the normal slice the fraction-sum validation promised.
+    # With sum(fractions) < 1, the floors sum to at most n_anchor - 1.
     for pool, frac in strata:
-        n_slice = int(round(frac * n_anchor))
+        n_slice = int(_math.floor(frac * n_anchor))
         already = set(picked)
         picked.extend(_sample([p for p in pool if p not in already], n_slice))
     picked_set = set(picked)
@@ -1612,6 +1616,12 @@ def _validate_release_bands_config(cfg: dict[str, Any]) -> None:
             raise ValueError(f"release_bands.{key} must be > 0: {bands_cfg[key]}")
     if int(bands_cfg["workers"]) < 1:
         raise ValueError(f"release_bands.workers must be >= 1: {bands_cfg['workers']}")
+    if int(round(float(bands_cfg["post_window_s"]) * float(bands_cfg["frame_hz"]))) < 1:
+        raise ValueError(
+            f"release_bands.post_window_s={bands_cfg['post_window_s']} at "
+            f"frame_hz={bands_cfg['frame_hz']} rounds to zero post-offense frames — "
+            "the band would degenerate to the offense frame itself"
+        )
     if str(cfg.get("training_backend", "base_sft")) != "base_sft":
         raise ValueError(
             "release_bands is only wired into the base_sft training backend; "

--- a/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
+++ b/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
@@ -1201,6 +1201,30 @@ def _anchor_stratum(anchor_cfg: dict[str, Any], name: str) -> tuple[list[str], f
     return pool, frac
 
 
+def _validated_anchor_strata(
+    anchor_cfg: dict[str, Any],
+) -> tuple[float, list[tuple[list[str], float]]]:
+    """Validate ``training.anchor`` and resolve its special strata (fail loudly)."""
+    missing = [key for key in ("scene_list", "ratio") if not anchor_cfg.get(key)]
+    if missing:
+        raise ValueError(f"training.anchor is missing required fields: {missing}")
+    ratio = float(anchor_cfg["ratio"])
+    if ratio <= 0.0:
+        raise ValueError(f"training.anchor.ratio must be > 0: {ratio}")
+    strata = [
+        stratum
+        for name in ("waits", "takeoff")
+        if (stratum := _anchor_stratum(anchor_cfg, name)) is not None
+    ]
+    fractions = [frac for _, frac in strata]
+    if len(fractions) > 1 and sum(fractions) >= 1.0:
+        raise ValueError(
+            "training.anchor waits_fraction + takeoff_fraction must leave room for the "
+            f"normal slice (< 1.0): {fractions}"
+        )
+    return ratio, strata
+
+
 def _anchor_slice_paths(
     anchor_cfg: dict[str, Any] | None, n_focus: int, round_idx: int
 ) -> list[str]:
@@ -1224,23 +1248,7 @@ def _anchor_slice_paths(
     """
     if not anchor_cfg:
         return []
-    missing = [key for key in ("scene_list", "ratio") if not anchor_cfg.get(key)]
-    if missing:
-        raise ValueError(f"training.anchor is missing required fields: {missing}")
-    ratio = float(anchor_cfg["ratio"])
-    if ratio <= 0.0:
-        raise ValueError(f"training.anchor.ratio must be > 0: {ratio}")
-    strata = [
-        stratum
-        for name in ("waits", "takeoff")
-        if (stratum := _anchor_stratum(anchor_cfg, name)) is not None
-    ]
-    fractions = [frac for _, frac in strata]
-    if len(fractions) > 1 and sum(fractions) >= 1.0:
-        raise ValueError(
-            "training.anchor waits_fraction + takeoff_fraction must leave room for the "
-            f"normal slice (< 1.0): {fractions}"
-        )
+    ratio, strata = _validated_anchor_strata(anchor_cfg)
 
     import math as _math
     import random as _random
@@ -1608,6 +1616,24 @@ def _validate_release_bands_config(cfg: dict[str, Any]) -> None:
         )
     if not bands_cfg:
         return
+    _validate_release_bands_knobs(bands_cfg)
+    if str(cfg.get("training_backend", "base_sft")) != "base_sft":
+        raise ValueError(
+            "release_bands is only wired into the base_sft training backend; "
+            f"got training_backend={cfg.get('training_backend')!r}"
+        )
+    manifest = _release_bands_manifest(cfg)
+    if manifest is None:
+        raise ValueError(
+            "release_bands requires a chunk manifest (event -> source sequence "
+            "provenance); scene_list-only mining cannot locate post-offense frames"
+        )
+    if not Path(manifest).is_file():
+        raise ValueError(f"release_bands chunk manifest does not exist: {manifest}")
+
+
+def _validate_release_bands_knobs(bands_cfg: dict[str, Any]) -> None:
+    """Per-knob checks for a non-empty release_bands section (fail loudly)."""
     missing = [k for k in _RELEASE_BANDS_REQUIRED if bands_cfg.get(k) is None]
     if missing:
         raise ValueError(f"release_bands is missing required fields: {missing}")
@@ -1622,19 +1648,6 @@ def _validate_release_bands_config(cfg: dict[str, Any]) -> None:
             f"frame_hz={bands_cfg['frame_hz']} rounds to zero post-offense frames — "
             "the band would degenerate to the offense frame itself"
         )
-    if str(cfg.get("training_backend", "base_sft")) != "base_sft":
-        raise ValueError(
-            "release_bands is only wired into the base_sft training backend; "
-            f"got training_backend={cfg.get('training_backend')!r}"
-        )
-    manifest = _release_bands_manifest(cfg)
-    if manifest is None:
-        raise ValueError(
-            "release_bands requires a chunk manifest (event -> source sequence "
-            "provenance); scene_list-only mining cannot locate post-offense frames"
-        )
-    if not Path(manifest).is_file():
-        raise ValueError(f"release_bands chunk manifest does not exist: {manifest}")
 
 
 def _release_bands_manifest(cfg: dict[str, Any]) -> str | None:

--- a/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
+++ b/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
@@ -1177,6 +1177,30 @@ def _union_scene_lists(current_scenes: list[str], replay_scenes: list[str], out_
     _write_json(out_path, merged)
 
 
+def _anchor_stratum(anchor_cfg: dict[str, Any], name: str) -> tuple[list[str], float] | None:
+    """Resolve one stratified anchor slice (``<name>_scene_list``/``<name>_fraction``).
+
+    Both keys must be given together; the fraction must sit in (0, 1); the
+    referenced list must be non-empty. Returns (pool, fraction) or None when
+    the stratum is not configured.
+    """
+    list_key = f"{name}_scene_list"
+    frac_key = f"{name}_fraction"
+    scene_list = anchor_cfg.get(list_key)
+    fraction = anchor_cfg.get(frac_key)
+    if (scene_list is None) != (fraction is None):
+        raise ValueError(f"training.anchor.{list_key} and {frac_key} must be set together")
+    if scene_list is None:
+        return None
+    frac = float(fraction)
+    if not 0.0 < frac < 1.0:
+        raise ValueError(f"training.anchor.{frac_key} must be in (0, 1): {frac}")
+    pool = [str(p) for p in _read_json_list(Path(scene_list))]
+    if not pool:
+        raise ValueError(f"training.anchor.{list_key} is empty: {scene_list}")
+    return pool, frac
+
+
 def _anchor_slice_paths(
     anchor_cfg: dict[str, Any] | None, n_focus: int, round_idx: int
 ) -> list[str]:
@@ -1206,24 +1230,16 @@ def _anchor_slice_paths(
     ratio = float(anchor_cfg["ratio"])
     if ratio <= 0.0:
         raise ValueError(f"training.anchor.ratio must be > 0: {ratio}")
-    waits_list = anchor_cfg.get("waits_scene_list")
-    waits_fraction = anchor_cfg.get("waits_fraction")
-    if (waits_list is None) != (waits_fraction is None):
-        raise ValueError("training.anchor.waits_scene_list and waits_fraction must be set together")
-    takeoff_list = anchor_cfg.get("takeoff_scene_list")
-    takeoff_fraction = anchor_cfg.get("takeoff_fraction")
-    if (takeoff_list is None) != (takeoff_fraction is None):
-        raise ValueError(
-            "training.anchor.takeoff_scene_list and takeoff_fraction must be set together"
-        )
-    if (
-        waits_fraction is not None
-        and takeoff_fraction is not None
-        and float(waits_fraction) + float(takeoff_fraction) >= 1.0
-    ):
+    strata = [
+        stratum
+        for name in ("waits", "takeoff")
+        if (stratum := _anchor_stratum(anchor_cfg, name)) is not None
+    ]
+    fractions = [frac for _, frac in strata]
+    if len(fractions) > 1 and sum(fractions) >= 1.0:
         raise ValueError(
             "training.anchor waits_fraction + takeoff_fraction must leave room for the "
-            f"normal slice (< 1.0): {waits_fraction} + {takeoff_fraction}"
+            f"normal slice (< 1.0): {fractions}"
         )
 
     import math as _math
@@ -1243,25 +1259,10 @@ def _anchor_slice_paths(
     if not normal_pool:
         raise ValueError(f"training.anchor.scene_list is empty: {anchor_cfg['scene_list']}")
     picked: list[str] = []
-    if waits_list is not None:
-        frac = float(waits_fraction)
-        if not 0.0 < frac < 1.0:
-            raise ValueError(f"training.anchor.waits_fraction must be in (0, 1): {frac}")
-        waits_pool = [str(p) for p in _read_json_list(Path(waits_list))]
-        if not waits_pool:
-            raise ValueError(f"training.anchor.waits_scene_list is empty: {waits_list}")
-        n_waits = int(round(frac * n_anchor))
-        picked.extend(_sample(waits_pool, n_waits))
-    if takeoff_list is not None:
-        frac = float(takeoff_fraction)
-        if not 0.0 < frac < 1.0:
-            raise ValueError(f"training.anchor.takeoff_fraction must be in (0, 1): {frac}")
-        takeoff_pool = [str(p) for p in _read_json_list(Path(takeoff_list))]
-        if not takeoff_pool:
-            raise ValueError(f"training.anchor.takeoff_scene_list is empty: {takeoff_list}")
+    for pool, frac in strata:
+        n_slice = int(round(frac * n_anchor))
         already = set(picked)
-        n_takeoff = int(round(frac * n_anchor))
-        picked.extend(_sample([p for p in takeoff_pool if p not in already], n_takeoff))
+        picked.extend(_sample([p for p in pool if p not in already], n_slice))
     picked_set = set(picked)
     picked.extend(_sample([p for p in normal_pool if p not in picked_set], n_anchor - len(picked)))
     return picked
@@ -2225,6 +2226,44 @@ def _repair_refresh_chunk_targets(
     return targets
 
 
+def _emit_train_args(
+    cmd: list[str],
+    merged: dict[str, Any],
+    passthrough: tuple[str, ...],
+    save_dir: Path,
+) -> None:
+    """Split training knobs between CLI flags and the overrides file.
+
+    The trainer's CLI deliberately exposes only ``cli()``-marked TrainConfig
+    fields; every other knob is handed over via ``--train_overrides_json``
+    (the trainer fails loudly on keys that are not TrainConfig fields, so a
+    rename upstream surfaces here instead of silently training at defaults).
+    Keys are emitted in passthrough order first for stable, diffable commands.
+    """
+    from diffusion_planner.config import TrainConfig as _TrainConfig
+    from diffusion_planner.config import cli_fields as _cli_fields
+
+    cli_exposed = {f.name for f in _cli_fields(_TrainConfig)}
+    if "train_overrides_json" not in cli_exposed:
+        raise RuntimeError(
+            "train_predictor's TrainConfig lacks the train_overrides_json channel; "
+            "cannot pass non-CLI training knobs (learning_rate, ema_decay, ...)"
+        )
+    ordered = [*passthrough, *[k for k in merged if k not in passthrough]]
+    overrides_payload: dict[str, Any] = {}
+    for key in ordered:
+        value = merged.get(key)
+        if value is None:
+            continue
+        if key in cli_exposed:
+            _append_train_arg(cmd, key, value)
+        else:
+            overrides_payload[key] = value
+    overrides_file = save_dir / "train_overrides.json"
+    overrides_file.write_text(json.dumps(overrides_payload, indent=2, sort_keys=True))
+    cmd.extend(["--train_overrides_json", str(overrides_file)])
+
+
 def _base_train_invocation(
     cfg: dict[str, Any],
     *,
@@ -2374,37 +2413,7 @@ def _base_train_invocation(
         merged["batch_size"] = max(1, min(int(merged["batch_size"]), train_scene_count))
     if "warm_up_epoch" in merged:
         merged["warm_up_epoch"] = max(0, min(int(merged["warm_up_epoch"]), total_epochs))
-    # The trainer's CLI deliberately exposes only cli()-marked TrainConfig
-    # fields; every other knob is handed over via --train_overrides_json (the
-    # trainer fails loudly on keys that are not TrainConfig fields, so a rename
-    # upstream surfaces here instead of silently training at defaults).
-    from diffusion_planner.config import TrainConfig as _TrainConfig
-    from diffusion_planner.config import cli_fields as _cli_fields
-
-    cli_exposed = {f.name for f in _cli_fields(_TrainConfig)}
-    overrides_payload: dict[str, Any] = {}
-    for key in passthrough:
-        if key not in merged:
-            continue
-        if key in cli_exposed:
-            _append_train_arg(cmd, key, merged[key])
-        elif merged[key] is not None:
-            overrides_payload[key] = merged[key]
-    for key, value in merged.items():
-        if key in passthrough or value is None:
-            continue
-        if key in cli_exposed:
-            _append_train_arg(cmd, key, value)
-        else:
-            overrides_payload[key] = value
-    if "train_overrides_json" not in cli_exposed:
-        raise RuntimeError(
-            "train_predictor's TrainConfig lacks the train_overrides_json channel; "
-            "cannot pass non-CLI training knobs (learning_rate, ema_decay, ...)"
-        )
-    overrides_file = save_dir / "train_overrides.json"
-    overrides_file.write_text(json.dumps(overrides_payload, indent=2, sort_keys=True))
-    cmd.extend(["--train_overrides_json", str(overrides_file)])
+    _emit_train_args(cmd, merged, passthrough, save_dir)
 
     env = dict(os.environ)
     repo_root = Path(__file__).resolve().parents[3]

--- a/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
+++ b/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
@@ -556,8 +556,8 @@ def _config_from_workflow_contract(contract: dict[str, Any]) -> dict[str, Any]:
         "count_rear_end_collisions": _workflow_count_rear_end_collisions(judgement),
         "realized_reward": bool(workflow.get("realized_reward", False)),
         **(
-            {"release_bands": dict(workflow["release_bands"])}
-            if workflow.get("release_bands")
+            {"release_bands": dict(workflow["release_bands"] or {})}
+            if "release_bands" in workflow
             else {}
         ),
         "final_round_mining": bool(
@@ -1501,12 +1501,17 @@ def _validate_anchor_config(cfg: dict[str, Any]) -> None:
         raise ValueError(f"training.anchor is missing required fields: {missing}")
     if float(anchor_cfg["ratio"]) <= 0.0:
         raise ValueError(f"training.anchor.ratio must be > 0: {anchor_cfg['ratio']}")
-    if (anchor_cfg.get("waits_scene_list") is None) != (anchor_cfg.get("waits_fraction") is None):
-        raise ValueError("training.anchor.waits_scene_list and waits_fraction must be set together")
-    waits_fraction = anchor_cfg.get("waits_fraction")
-    if waits_fraction is not None and not 0.0 < float(waits_fraction) < 1.0:
-        raise ValueError(f"training.anchor.waits_fraction must be in (0, 1): {waits_fraction}")
-    for key in ("scene_list", "waits_scene_list"):
+    fractions: list[float] = []
+    for name in ("waits", "takeoff"):
+        stratum = _anchor_stratum(anchor_cfg, name)  # pairing/range/emptiness
+        if stratum is not None:
+            fractions.append(stratum[1])
+    if len(fractions) > 1 and sum(fractions) >= 1.0:
+        raise ValueError(
+            "training.anchor waits_fraction + takeoff_fraction must leave room for the "
+            f"normal slice (< 1.0): {fractions}"
+        )
+    for key in ("scene_list", "waits_scene_list", "takeoff_scene_list"):
         value = anchor_cfg.get(key)
         if value is None:
             continue
@@ -1602,19 +1607,29 @@ def _validate_release_bands_config(cfg: dict[str, Any]) -> None:
     missing = [k for k in _RELEASE_BANDS_REQUIRED if bands_cfg.get(k) is None]
     if missing:
         raise ValueError(f"release_bands is missing required fields: {missing}")
-    if float(bands_cfg["ratio"]) <= 0.0:
-        raise ValueError(f"release_bands.ratio must be > 0: {bands_cfg['ratio']}")
+    for key in ("post_window_s", "stride_s", "min_takeoff_travel_m", "frame_hz", "ratio"):
+        if float(bands_cfg[key]) <= 0.0:
+            raise ValueError(f"release_bands.{key} must be > 0: {bands_cfg[key]}")
+    if int(bands_cfg["workers"]) < 1:
+        raise ValueError(f"release_bands.workers must be >= 1: {bands_cfg['workers']}")
     if str(cfg.get("training_backend", "base_sft")) != "base_sft":
         raise ValueError(
             "release_bands is only wired into the base_sft training backend; "
             f"got training_backend={cfg.get('training_backend')!r}"
         )
-    mining = cfg.get("perception_mining") or {}
-    if not (mining.get("chunk_manifest") or cfg.get("chunk_manifest")):
+    manifest = _release_bands_manifest(cfg)
+    if manifest is None:
         raise ValueError(
             "release_bands requires a chunk manifest (event -> source sequence "
             "provenance); scene_list-only mining cannot locate post-offense frames"
         )
+    if not Path(manifest).is_file():
+        raise ValueError(f"release_bands chunk manifest does not exist: {manifest}")
+
+
+def _release_bands_manifest(cfg: dict[str, Any]) -> str | None:
+    mining = cfg.get("perception_mining") or {}
+    return mining.get("chunk_manifest") or cfg.get("chunk_manifest")
 
 
 def _release_band_paths(
@@ -1630,8 +1645,7 @@ def _release_band_paths(
         return []
     from rlvr.autoresearch.tools.build_release_bands import build_release_bands
 
-    mining = cfg.get("perception_mining") or {}
-    manifest = mining.get("chunk_manifest") or cfg.get("chunk_manifest")
+    manifest = _release_bands_manifest(cfg)
     out_json = rdir / f"round_{round_idx}_release_bands.json"
     rows = build_release_bands(
         credit_jsonl,
@@ -1643,14 +1657,16 @@ def _release_band_paths(
         frame_hz=float(bands_cfg["frame_hz"]),
         workers=int(bands_cfg["workers"]),
     )
-    n_keep = int(round(float(bands_cfg["ratio"]) * n_focus))
+    # Never round a configured feature down to nothing: tiny rounds keep at
+    # least one band row per event corpus rather than silently disabling it.
+    n_keep = max(1, int(round(float(bands_cfg["ratio"]) * n_focus)))
     if len(rows) > n_keep:
         import random as _random
 
         rng = _random.Random(int(bands_cfg["seed"]) + round_idx)
         rows = sorted(rng.sample(rows, n_keep))
         _write_json(out_json, rows)
-    return [str(r) for r in rows]
+    return rows
 
 
 def _validate_guards_config(cfg: dict[str, Any]) -> None:
@@ -2244,6 +2260,22 @@ def _emit_train_args(
     from diffusion_planner.config import cli_fields as _cli_fields
 
     cli_exposed = {f.name for f in _cli_fields(_TrainConfig)}
+    reserved = {
+        "exp_name",
+        "save_dir",
+        "train_set_list",
+        "valid_set_list",
+        "train_epochs",
+        "resume_model_path",
+        "train_overrides_json",
+    }
+    clashing = sorted(reserved & set(merged))
+    if clashing:
+        raise ValueError(
+            f"train_args must not set runner-owned keys {clashing}: the round runner "
+            "computes these (cumulative epochs, per-round scene list, warm-start "
+            "checkpoint) and a duplicate flag would override them argparse-last-wins"
+        )
     if "train_overrides_json" not in cli_exposed:
         raise RuntimeError(
             "train_predictor's TrainConfig lacks the train_overrides_json channel; "

--- a/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
+++ b/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
@@ -555,6 +555,11 @@ def _config_from_workflow_contract(contract: dict[str, Any]) -> dict[str, Any]:
         "validate_on_repaired_targets": bool(workflow.get("validate_on_repaired_targets", False)),
         "count_rear_end_collisions": _workflow_count_rear_end_collisions(judgement),
         "realized_reward": bool(workflow.get("realized_reward", False)),
+        **(
+            {"release_bands": dict(workflow["release_bands"])}
+            if workflow.get("release_bands")
+            else {}
+        ),
         "final_round_mining": bool(
             workflow.get("final_round_mining", workflow.get("realized_reward", False))
         ),

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -1358,6 +1358,159 @@ def test_anchor_slice_paths_ratio_and_waits_stratification(tmp_path):
         )
 
 
+def test_anchor_slice_paths_takeoff_stratification(tmp_path):
+    normal = [f"/tmp/normal_{i}.npz" for i in range(100)]
+    waits = [f"/tmp/waits_{i}.npz" for i in range(50)]
+    takeoff = [f"/tmp/takeoff_{i}.npz" for i in range(50)]
+    normal_json = tmp_path / "normal.json"
+    waits_json = tmp_path / "waits.json"
+    takeoff_json = tmp_path / "takeoff.json"
+    normal_json.write_text(json.dumps(normal))
+    waits_json.write_text(json.dumps(waits))
+    takeoff_json.write_text(json.dumps(takeoff))
+
+    cfg = {
+        "scene_list": str(normal_json),
+        "ratio": 2.0,
+        "waits_scene_list": str(waits_json),
+        "waits_fraction": 0.3,
+        "takeoff_scene_list": str(takeoff_json),
+        "takeoff_fraction": 0.2,
+        "seed": 3,
+    }
+    picked = round_runner._anchor_slice_paths(cfg, n_focus=10, round_idx=1)
+    assert len(picked) == 20
+    assert sum(1 for p in picked if "waits_" in p) == 6  # round(0.3 * 20)
+    assert sum(1 for p in picked if "takeoff_" in p) == 4  # round(0.2 * 20)
+    assert len(set(picked)) == len(picked)
+
+    # loud on partial config and on fractions that leave no normal slice
+    with pytest.raises(ValueError):
+        round_runner._anchor_slice_paths(
+            {"scene_list": str(normal_json), "ratio": 1.0, "takeoff_fraction": 0.2}, 10, 1
+        )
+    with pytest.raises(ValueError):
+        round_runner._anchor_slice_paths(
+            {
+                "scene_list": str(normal_json),
+                "ratio": 1.0,
+                "waits_scene_list": str(waits_json),
+                "waits_fraction": 0.6,
+                "takeoff_scene_list": str(takeoff_json),
+                "takeoff_fraction": 0.4,
+            },
+            10,
+            1,
+        )
+
+
+def test_validate_release_bands_config_requires_all_knobs():
+    base = {
+        "training_backend": "base_sft",
+        "perception_mining": {"chunk_manifest": "/tmp/manifest.jsonl"},
+    }
+    # absent section is fine; empty section is loud
+    round_runner._validate_release_bands_config(dict(base))
+    with pytest.raises(ValueError):
+        round_runner._validate_release_bands_config({**base, "release_bands": {}})
+    full = {
+        "post_window_s": 10.0,
+        "stride_s": 0.5,
+        "min_takeoff_travel_m": 10.0,
+        "frame_hz": 10.0,
+        "ratio": 1.0,
+        "seed": 0,
+        "workers": 4,
+    }
+    round_runner._validate_release_bands_config({**base, "release_bands": dict(full)})
+    for key in full:
+        broken = {k: v for k, v in full.items() if k != key}
+        with pytest.raises(ValueError):
+            round_runner._validate_release_bands_config({**base, "release_bands": broken})
+    # a chunk manifest is mandatory provenance
+    with pytest.raises(ValueError):
+        round_runner._validate_release_bands_config(
+            {"training_backend": "base_sft", "release_bands": dict(full)}
+        )
+
+
+def _release_band_fixture(tmp_path, *, tl_state: str, future_travel_m: float, frame: int):
+    """One frame NPZ with a route-lane TL one-hot and a straight-line future."""
+    seq = tmp_path / "seq"
+    seq.mkdir(exist_ok=True)
+    onehot = {"green": 8, "red": 10}[tl_state]
+    route = np.zeros((2, 20, 33), dtype=np.float32)
+    route[0, :, 0] = 1.0  # mark the lane valid
+    route[0, 0, onehot] = 1.0
+    step = future_travel_m / 79.0
+    future = np.zeros((80, 3), dtype=np.float32)
+    future[:, 0] = np.arange(80, dtype=np.float32) * step
+    path = seq / f"scene_{frame:016d}.npz"
+    np.savez(
+        path,
+        ego_agent_past=np.zeros((31, 3), dtype=np.float32),
+        ego_agent_future=future,
+        route_lanes=route,
+    )
+    return path
+
+
+def test_build_release_bands_tl_alignment(tmp_path):
+    from rlvr.autoresearch.tools.build_release_bands import build_release_bands
+
+    start = _release_band_fixture(tmp_path, tl_state="red", future_travel_m=0.0, frame=100)
+    _release_band_fixture(tmp_path, tl_state="green", future_travel_m=2.0, frame=110)  # creep
+    kept_go = _release_band_fixture(tmp_path, tl_state="green", future_travel_m=20.0, frame=120)
+
+    manifest = tmp_path / "manifest.jsonl"
+    manifest.write_text(
+        json.dumps({"chunk_key": "g000_logA_00000000", "start_scene_path": str(start)}) + "\n"
+    )
+    credit = tmp_path / "credit.jsonl"
+    credit.write_text(
+        json.dumps(
+            {
+                "event_key": "g000_logA_00000000_0_16_danger_expert_disagreement",
+                "offense_frame_id": 100,
+            }
+        )
+        + "\n"
+    )
+    out = tmp_path / "bands.json"
+    rows = build_release_bands(
+        credit,
+        manifest,
+        out,
+        post_window_s=3.0,
+        stride_s=1.0,
+        min_takeoff_travel_m=10.0,
+        frame_hz=10.0,
+        workers=1,
+    )
+    # red frame kept (patience), green take-off kept (release), green creep dropped
+    assert str(start) in rows
+    assert str(kept_go) in rows
+    assert len(rows) == 2
+    assert json.loads(out.read_text()) == rows
+
+    # unmatched chunk keys fail loudly
+    bad_credit = tmp_path / "bad_credit.jsonl"
+    bad_credit.write_text(
+        json.dumps({"event_key": "g999_other_00000000_0_1_danger_x", "offense_frame_id": 1}) + "\n"
+    )
+    with pytest.raises(ValueError):
+        build_release_bands(
+            bad_credit,
+            manifest,
+            tmp_path / "x.json",
+            post_window_s=1.0,
+            stride_s=1.0,
+            min_takeoff_travel_m=10.0,
+            frame_hz=10.0,
+            workers=1,
+        )
+
+
 def test_round_runner_checkpoint_policy_prefers_latest_lora(tmp_path):
     run_dir = tmp_path / "run"
     run_dir.mkdir()

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -1404,6 +1404,51 @@ def test_anchor_slice_paths_takeoff_stratification(tmp_path):
         )
 
 
+def test_workflow_contract_carries_release_bands(tmp_path):
+    """The contract builder must not silently drop the release_bands block —
+    a dropped block disables the extraction with no error (dark-lever class)."""
+    scene_list = tmp_path / "scenes.json"
+    scene_list.write_text("[]")
+    bands = {
+        "post_window_s": 10.0,
+        "stride_s": 0.5,
+        "min_takeoff_travel_m": 10.0,
+        "frame_hz": 10,
+        "ratio": 1.0,
+        "seed": 0,
+        "workers": 2,
+    }
+    workflow = tmp_path / "workflow.json"
+    workflow.write_text(
+        json.dumps(
+            {
+                "judgement": {
+                    "reward_config": "/tmp/reward.json",
+                    "threshold_config": "/tmp/thresholds.json",
+                    "credit_window_config": "/tmp/credit.json",
+                    "enabled_labels": ["moving_collision"],
+                },
+                "repair_generation": {"ego_shape": "from_npz", "min_margin": 0.3},
+                "replay_memory": {"capacity": 200},
+                "training": {"val_scenes": "/tmp/valid.json"},
+                "release_bands": bands,
+            }
+        )
+    )
+    training = tmp_path / "training.json"
+    training.write_text(json.dumps({"backend": "base_sft", "train_args": {}}))
+    cfg = round_runner._config_from_workflow_contract(
+        {
+            "model_path": "/tmp/model.pth",
+            "scene_list": str(scene_list),
+            "workflow_config": str(workflow),
+            "training_config": str(training),
+            "output_dir": str(tmp_path / "auto_research" / "out"),
+        }
+    )
+    assert cfg.get("release_bands") == bands
+
+
 def test_validate_release_bands_config_requires_all_knobs():
     base = {
         "training_backend": "base_sft",

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -1404,6 +1404,73 @@ def test_anchor_slice_paths_takeoff_stratification(tmp_path):
         )
 
 
+def test_base_train_invocation_uses_override_channel(tmp_path):
+    """Non-CLI training knobs must travel via --train_overrides_json: the slim
+    trainer CLI rejects them as flags, and training a fine-tune at TrainConfig
+    defaults (learning_rate 1e-4 vs an intended 5e-6) is a silent disaster."""
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (model_dir / "best_model.pth").write_bytes(b"x")
+    (model_dir / "args.json").write_text(
+        json.dumps({"learning_rate": 1e-4, "batch_size": 64, "seed": 3407, "ddp": True})
+    )
+    train_list = tmp_path / "train.json"
+    train_list.write_text(json.dumps([str(tmp_path / f"s{i}.npz") for i in range(4)]))
+    training_cfg = tmp_path / "training.json"
+    training_cfg.write_text(
+        json.dumps(
+            {
+                "backend": "base_sft",
+                "train_args": {"learning_rate": 5e-6, "warm_up_epoch": 0},
+            }
+        )
+    )
+    cfg = {
+        "training_config": str(training_cfg),
+        "val_scenes": "/tmp/val.json",
+        "epochs_per_round": 1,
+        "gpu_ids": [0],
+    }
+    rdir = tmp_path / "round"
+    rdir.mkdir()
+    cmd, next_model, _cwd, _env = round_runner._base_train_invocation(
+        cfg,
+        model_path=model_dir / "best_model.pth",
+        train_list=train_list,
+        rdir=rdir,
+        round_idx=1,
+    )
+    joined = " ".join(cmd)
+    assert "--learning_rate" not in joined
+    assert "--train_overrides_json" in joined
+    overrides_file = Path(cmd[cmd.index("--train_overrides_json") + 1])
+    payload = json.loads(overrides_file.read_text())
+    assert payload["learning_rate"] == 5e-6
+    assert payload["warm_up_epoch"] == 0
+    assert "normalization_file_path" in payload
+    # CLI-exposed knobs stay flags
+    assert "--batch_size" in joined
+
+
+def test_trainer_applies_and_rejects_overrides(tmp_path):
+    import importlib
+
+    tp = importlib.import_module("train_predictor")
+    from diffusion_planner.config import TrainConfig
+
+    cfg = TrainConfig(train_set_list="", valid_set_list="")
+    good = tmp_path / "ok.json"
+    good.write_text(json.dumps({"learning_rate": 5e-6, "warm_up_epoch": 0}))
+    cfg = tp.apply_overrides_json(cfg, str(good))
+    assert cfg.learning_rate == 5e-6
+    assert cfg.warm_up_epoch == 0
+
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps({"learning_rte": 5e-6}))
+    with pytest.raises(ValueError):
+        tp.apply_overrides_json(cfg, str(bad))
+
+
 def test_workflow_contract_carries_release_bands(tmp_path):
     """The contract builder must not silently drop the release_bands block —
     a dropped block disables the extraction with no error (dark-lever class)."""

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -1470,6 +1470,80 @@ def test_trainer_applies_and_rejects_overrides(tmp_path):
     with pytest.raises(ValueError):
         tp.apply_overrides_json(cfg, str(bad))
 
+    # CLI-exposed fields must go through flags, not the file
+    clash = tmp_path / "clash.json"
+    clash.write_text(json.dumps({"batch_size": 8}))
+    with pytest.raises(ValueError):
+        tp.apply_overrides_json(cfg, str(clash))
+
+    # silent-coercion guards: truthy-string bool and float-for-int
+    for payload in ({"use_ema": "false"}, {"num_workers": 4.0}, {"seed": True}):
+        f = tmp_path / "typ.json"
+        f.write_text(json.dumps(payload))
+        with pytest.raises(ValueError):
+            tp.apply_overrides_json(cfg, str(f))
+
+
+def test_release_band_paths_ratio_sampling_and_rewrite(tmp_path, monkeypatch):
+    """Runner-side wiring: ratio subsample, seed+round offset, out_json rewrite,
+    and the manifest fallback to the top-level cfg key."""
+    rows = [str(tmp_path / f"band_{i}.npz") for i in range(10)]
+
+    def _fake_build(credit, manifest, out, **kw):
+        out.write_text(json.dumps(rows))
+        return list(rows)
+
+    import rlvr.autoresearch.tools.build_release_bands as brb
+
+    monkeypatch.setattr(brb, "build_release_bands", _fake_build)
+    cfg = {
+        "release_bands": {
+            "post_window_s": 10.0,
+            "stride_s": 0.5,
+            "min_takeoff_travel_m": 10.0,
+            "frame_hz": 10,
+            "ratio": 0.5,
+            "seed": 0,
+            "workers": 1,
+        },
+        "chunk_manifest": "/tmp/manifest.jsonl",
+    }
+    rdir = tmp_path / "round"
+    rdir.mkdir()
+    credit = rdir / "credit.jsonl"
+    credit.write_text("{}")
+    picked = round_runner._release_band_paths(cfg, credit, rdir, round_idx=1, n_focus=8)
+    assert len(picked) == 4  # round(0.5 * 8)
+    out_json = rdir / "round_1_release_bands.json"
+    assert json.loads(out_json.read_text()) == picked  # rewrite matches selection
+    # seeded + round-offset: same round reproduces, next round redraws
+    again = round_runner._release_band_paths(cfg, credit, rdir, round_idx=1, n_focus=8)
+    assert again == picked
+    other = round_runner._release_band_paths(cfg, credit, rdir, round_idx=2, n_focus=8)
+    assert other != picked
+    # tiny rounds keep at least one row instead of silently disabling the feature
+    one = round_runner._release_band_paths(cfg, credit, rdir, round_idx=1, n_focus=1)
+    assert len(one) == 1
+
+
+def test_emit_train_args_rejects_runner_owned_keys(tmp_path):
+    cmd: list[str] = []
+    with pytest.raises(ValueError):
+        round_runner._emit_train_args(
+            cmd, {"train_epochs": 80, "learning_rate": 5e-6}, ("learning_rate",), tmp_path
+        )
+
+
+def test_takeoff_worker_tl_and_creep_alignment(tmp_path):
+    from rlvr.autoresearch.tools.build_r2lpl_pools import _takeoff_worker
+
+    go = _release_band_fixture(tmp_path, tl_state="green", future_travel_m=20.0, frame=1)
+    creep = _release_band_fixture(tmp_path, tl_state="green", future_travel_m=2.0, frame=2)
+    red = _release_band_fixture(tmp_path, tl_state="red", future_travel_m=20.0, frame=3)
+    assert _takeoff_worker((str(go), 10, 0.5, 10.0)) == (str(go), True)
+    assert _takeoff_worker((str(creep), 10, 0.5, 10.0)) == (str(creep), False)
+    assert _takeoff_worker((str(red), 10, 0.5, 10.0)) == (str(red), False)
+
 
 def test_workflow_contract_carries_release_bands(tmp_path):
     """The contract builder must not silently drop the release_bands block —
@@ -1516,10 +1590,12 @@ def test_workflow_contract_carries_release_bands(tmp_path):
     assert cfg.get("release_bands") == bands
 
 
-def test_validate_release_bands_config_requires_all_knobs():
+def test_validate_release_bands_config_requires_all_knobs(tmp_path):
+    manifest = tmp_path / "manifest.jsonl"
+    manifest.write_text("{}")
     base = {
         "training_backend": "base_sft",
-        "perception_mining": {"chunk_manifest": "/tmp/manifest.jsonl"},
+        "perception_mining": {"chunk_manifest": str(manifest)},
     }
     # absent section is fine; empty section is loud
     round_runner._validate_release_bands_config(dict(base))

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -3651,8 +3651,10 @@ def test_base_train_invocation_uses_cumulative_epochs_and_train_predictor(tmp_pa
     assert cmd[cmd.index("--train_epochs") + 1] == "7"
     assert cmd[cmd.index("--batch_size") + 1] == "2"
     # ema_decay must survive the train_args passthrough — 0.999 is too slow
-    # to absorb behavior changes within a short per-round fine-tune.
-    assert cmd[cmd.index("--ema_decay") + 1] == "0.996"
+    # to absorb behavior changes within a short per-round fine-tune. It is not
+    # CLI-exposed, so it travels via the overrides channel.
+    overrides_file = Path(cmd[cmd.index("--train_overrides_json") + 1])
+    assert json.loads(overrides_file.read_text())["ema_decay"] == 0.996
 
 
 def test_torchrun_subprocess_cleanup_removes_stale_file_store(tmp_path, monkeypatch):

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -1545,6 +1545,137 @@ def test_takeoff_worker_tl_and_creep_alignment(tmp_path):
     assert _takeoff_worker((str(red), 10, 0.5, 10.0)) == (str(red), False)
 
 
+def test_future_pathlen_masks_zero_padding(tmp_path):
+    """A short valid motion followed by zero padding must NOT count the phantom
+    jump back to the origin as travel — in both the band builder and the
+    take-off filter (they share valid_future_pathlen)."""
+    from rlvr.autoresearch.tools.build_r2lpl_pools import _takeoff_worker
+    from rlvr.autoresearch.tools.build_release_bands import valid_future_pathlen
+
+    # 2 m of real motion, then 80-10 padded rows: raw diffs would report ~4 m
+    # (2 m out + 2 m phantom return); the masked length must stay ~2 m.
+    fut = np.zeros((80, 3), dtype=np.float32)
+    fut[:10, 0] = np.linspace(0.5, 2.5, 10, dtype=np.float32)
+    assert valid_future_pathlen(fut) == pytest.approx(2.0, abs=1e-4)
+
+    padded_creep = _release_band_fixture(
+        tmp_path, tl_state="green", future_travel_m=20.0, frame=5, valid_steps=10
+    )
+    # raw length ~2.3 m valid + ~2.3 m phantom jump: must be rejected at 4 m
+    assert _takeoff_worker((str(padded_creep), 10, 0.5, 4.0)) == (str(padded_creep), False)
+
+    from rlvr.autoresearch.tools.build_release_bands import build_release_bands
+
+    start = _release_band_fixture(tmp_path, tl_state="red", future_travel_m=0.0, frame=200)
+    manifest = tmp_path / "pad_manifest.jsonl"
+    manifest.write_text(
+        json.dumps({"chunk_key": "g001_logB_00000000", "start_scene_path": str(start)}) + "\n"
+    )
+    credit = tmp_path / "pad_credit.jsonl"
+    credit.write_text(
+        json.dumps(
+            {
+                "event_key": "g001_logB_00000000_0_16_danger_expert_disagreement",
+                "offense_frame_id": 200,
+            }
+        )
+        + "\n"
+    )
+    _release_band_fixture(
+        tmp_path, tl_state="green", future_travel_m=20.0, frame=210, valid_steps=10
+    )
+    rows = build_release_bands(
+        credit,
+        manifest,
+        tmp_path / "pad_bands.json",
+        post_window_s=2.0,
+        stride_s=1.0,
+        min_takeoff_travel_m=4.0,
+        frame_hz=10.0,
+        workers=1,
+    )
+    # only the red patience frame survives; the padded green pseudo-departure is out
+    assert rows == [str(start)]
+
+
+def test_build_release_bands_rejects_subframe_window(tmp_path):
+    """post_window_s that rounds to zero frames must fail loudly, not silently
+    degenerate the two-sided corpus to offense frames only."""
+    from rlvr.autoresearch.tools.build_release_bands import build_release_bands
+
+    start = _release_band_fixture(tmp_path, tl_state="red", future_travel_m=0.0, frame=300)
+    manifest = tmp_path / "sub_manifest.jsonl"
+    manifest.write_text(
+        json.dumps({"chunk_key": "g002_logC_00000000", "start_scene_path": str(start)}) + "\n"
+    )
+    credit = tmp_path / "sub_credit.jsonl"
+    credit.write_text(
+        json.dumps(
+            {
+                "event_key": "g002_logC_00000000_0_16_danger_expert_disagreement",
+                "offense_frame_id": 300,
+            }
+        )
+        + "\n"
+    )
+    with pytest.raises(ValueError, match="zero post-offense frames"):
+        build_release_bands(
+            credit,
+            manifest,
+            tmp_path / "sub_bands.json",
+            post_window_s=0.01,
+            stride_s=1.0,
+            min_takeoff_travel_m=4.0,
+            frame_hz=10.0,
+            workers=1,
+        )
+
+    # the startup validator must reject the same configuration
+    with pytest.raises(ValueError, match="zero post-offense frames"):
+        round_runner._validate_release_bands_config(
+            {
+                "training_backend": "base_sft",
+                "chunk_manifest": str(manifest),
+                "release_bands": {
+                    "post_window_s": 0.01,
+                    "stride_s": 1.0,
+                    "min_takeoff_travel_m": 4.0,
+                    "frame_hz": 10,
+                    "ratio": 1.0,
+                    "seed": 0,
+                    "workers": 1,
+                },
+            }
+        )
+
+
+def test_anchor_slice_paths_small_budget_keeps_normal_slice(tmp_path):
+    """Independent per-stratum rounding must not consume the whole anchor
+    budget: fractions summing to 0.8 with n_anchor=2 previously rounded to
+    1 + 1 and produced zero normal anchors despite passing validation."""
+    normal = [f"/tmp/normal_{i}.npz" for i in range(10)]
+    waits = [f"/tmp/waits_{i}.npz" for i in range(10)]
+    takeoff = [f"/tmp/takeoff_{i}.npz" for i in range(10)]
+    normal_json = tmp_path / "normal.json"
+    waits_json = tmp_path / "waits.json"
+    takeoff_json = tmp_path / "takeoff.json"
+    normal_json.write_text(json.dumps(normal))
+    waits_json.write_text(json.dumps(waits))
+    takeoff_json.write_text(json.dumps(takeoff))
+    cfg = {
+        "scene_list": str(normal_json),
+        "ratio": 1.0,
+        "waits_scene_list": str(waits_json),
+        "waits_fraction": 0.4,
+        "takeoff_scene_list": str(takeoff_json),
+        "takeoff_fraction": 0.4,
+        "seed": 0,
+    }
+    picked = round_runner._anchor_slice_paths(cfg, n_focus=2, round_idx=1)
+    assert len(picked) == 2
+    assert any("normal_" in p for p in picked)
+
+
 def test_workflow_contract_carries_release_bands(tmp_path):
     """The contract builder must not silently drop the release_bands block —
     a dropped block disables the extraction with no error (dark-lever class)."""
@@ -1622,8 +1753,13 @@ def test_validate_release_bands_config_requires_all_knobs(tmp_path):
         )
 
 
-def _release_band_fixture(tmp_path, *, tl_state: str, future_travel_m: float, frame: int):
-    """One frame NPZ with a route-lane TL one-hot and a straight-line future."""
+def _release_band_fixture(
+    tmp_path, *, tl_state: str, future_travel_m: float, frame: int, valid_steps: int = 80
+):
+    """One frame NPZ with a route-lane TL one-hot and a straight-line future.
+
+    ``valid_steps`` < 80 zero-pads the tail, reproducing a truncated future.
+    """
     seq = tmp_path / "seq"
     seq.mkdir(exist_ok=True)
     onehot = {"green": 8, "red": 10}[tl_state]
@@ -1633,6 +1769,7 @@ def _release_band_fixture(tmp_path, *, tl_state: str, future_travel_m: float, fr
     step = future_travel_m / 79.0
     future = np.zeros((80, 3), dtype=np.float32)
     future[:, 0] = np.arange(80, dtype=np.float32) * step
+    future[valid_steps:] = 0.0
     path = seq / f"scene_{frame:016d}.npz"
     np.savez(
         path,

--- a/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
+++ b/rlvr/autoresearch/tools/test_r2lpl_lifelong_replay.py
@@ -6333,3 +6333,58 @@ def test_direct_config_rejects_removed_knobs(tmp_path):
     path.write_text(_json.dumps(cfg))
     with pytest.raises(ValueError, match="state_class_mode"):
         round_runner._load_config(path)
+
+
+def test_ego_dims_filter_splits_platforms(tmp_path):
+    import json as _json
+
+    from rlvr.autoresearch.tools.build_r2lpl_pools import _ego_dims_worker
+    from rlvr.autoresearch.tools.build_r2lpl_pools import main as pools_main
+
+    def scene(name, wheelbase):
+        p = tmp_path / name
+        np.savez(p, ego_shape=np.array([wheelbase, 7.24, 2.29], dtype=np.float32))
+        return str(p)
+
+    big = scene("big.npz", 4.76)
+    small = scene("small.npz", 2.79)
+    no_shape = tmp_path / "no_shape.npz"
+    np.savez(no_shape, ego_agent_future=np.zeros((80, 3), dtype=np.float32))
+
+    assert _ego_dims_worker((big, 4.0)) == (big, True)
+    assert _ego_dims_worker((small, 4.0)) == (small, False)
+    assert _ego_dims_worker((str(no_shape), 4.0)) is None  # unreadable, not a crash
+
+    scene_list = tmp_path / "pool.json"
+    scene_list.write_text(_json.dumps([big, small, str(no_shape)]))
+    out = tmp_path / "j6_only.json"
+    pools_main(
+        [
+            "ego-dims",
+            "--scene_list",
+            str(scene_list),
+            "--min_wheelbase_m",
+            "4.0",
+            "--workers",
+            "1",
+            "--out",
+            str(out),
+        ]
+    )
+    assert _json.loads(out.read_text()) == [big]
+
+    # a threshold no platform clears must fail loudly, never emit an empty pool
+    with pytest.raises(RuntimeError, match="ego-dims filter kept 0"):
+        pools_main(
+            [
+                "ego-dims",
+                "--scene_list",
+                str(scene_list),
+                "--min_wheelbase_m",
+                "99.0",
+                "--workers",
+                "1",
+                "--out",
+                str(tmp_path / "never.json"),
+            ]
+        )


### PR DESCRIPTION
## What

Bakes the "two-sided teacher" data treatment into the R2LPL lifelong workflow, and restores wrapper-driven training on tier4-main:

1. **`rlvr/autoresearch/tools/build_release_bands.py`** (new): for every mined event, extract recorded **post-offense release-band** frames from the source sequence via chunk-manifest provenance, kept by traffic-light alignment — route-lane RED (and not also green) frames teach patience unconditionally; GREEN/no-TL frames are kept only when the recorded future genuinely departs (threshold required — creeps are rejected on purpose). Frames are indexed by (directory, filename-prefix) log identity and the band walk follows the frames that actually exist, so step>1 catalogs work.
2. **`release_bands` workflow block** in `run_lifelong_r2lpl_rounds`: per round, extract bands from the round's own `credit_windows.jsonl`, sample them at a configured ratio to the focus count, and union them into the training list. All knobs required, validated at startup (ranges, manifest existence, base_sft-only); the workflow contract carries the block through (empty block rejected loudly).
3. **`build_r2lpl_pools takeoff`** (new stage): stopped-input + route-lane-green + genuinely-departing-future pool; stratified into the anchor slice via `training.anchor.takeoff_scene_list`/`takeoff_fraction` (validated with the waits stratum: paired keys, (0,1) range, fraction sum < 1, list existence — all at startup).
4. **`TrainConfig.train_overrides_json`** (the only `diffusion_planner/` change, +36 lines, additive): the CLI consolidation left most TrainConfig fields without command-line handles, but launch wrappers must still SET them per run — a warm-started fine-tune silently training at the from-scratch defaults (e.g. `learning_rate` 1e-4 instead of an intended 5e-6) is the failure this prevents. One `cli()` field pointing at a JSON of overrides; unknown keys, CLI-shadowing keys, and scalar type mismatches (`"false"` as a truthy string bool, float-for-int) all fail loudly. The round runner emits `cli()`-exposed knobs as flags (introspected, not hardcoded) and everything else through `train_overrides.json` written next to the round's checkpoints; `train_args` attempting to set runner-owned keys (`train_epochs`, scene lists, resume checkpoint) is rejected instead of silently overriding computed values.

## Why

Mining carves credit windows that end at the offense, so every repaired target teaches the entry into a braking manoeuvre and never its resolution. A corpus of one-sided windows is systematically deceleration-flavoured, and each training epoch absorbs more of the bias — observed as a monotone per-epoch erosion of take-off response at heavily-mined geometries while stop compliance persists. A controlled run with the repaired slice removed (all else identical) eliminated the erosion, isolating the cause to window geometry. Pairing each event's window with frames from the same event's recorded post-offense band cancels the bias at the source: extended training then holds/improves the take-off response instead of eroding it, while retaining the repaired corpus's reward value. Nothing is generated, relabeled, or filtered out of the repaired set.

## Impact on existing users

- **IL training: byte-identical.** `train_overrides_json` defaults to `""` → strict no-op; the `train_run.py` relaunch path (`to_command_line`) omits default-valued flags, so existing command lines/logs don't change. Verified by running the IL parse→build→relaunch path with no new flag.
- **R2LPL configs without `release_bands`/`takeoff_*`: unchanged** (blocks are opt-in; absent = disabled, empty = loud error).
- Note: without commit 4, `run_lifelong_r2lpl_rounds` base_sft training cannot launch against this repo's trainer at all (the runner passes flags the consolidated CLI no longer accepts) — this PR is also the fix for that.

## Validation

- 178 tests green (`test_r2lpl_lifelong_replay.py`), including: extractor TL/creep alignment on synthetic sequences, unmatched-chunk-key and zero-row loud failures, contract carriage, anchor stratum validation (pairing/range/sum), ratio-sampling + seed-offset + rewrite wiring, reserved-key rejection, override type/CLI-shadow rejections.
- Extraction equivalence: the tool reproduces a previously hand-built release-band set **exactly** (set-identical rows) from the same credit windows + manifest.
- End-to-end 1-round workflow smoke (mine → repair → auto-extract → sample → union → 1-epoch base_sft train → checkpoint) passed with the block enabled.
- Cyclomatic complexity audit (radon): all touched functions ≤ C; the two runner functions this PR grew were refactored back to/below their previous grades (`_base_train_invocation` C14→C12, `_anchor_slice_paths` C16→C19 with the new stratum, helpers A/B).
- Two independent review passes; all findings addressed in dedicated commits.
