### PR TITLE
fix(wandb): read closed-loop cfg via attributes so a ClosedLoopConfig no longer crashes the upload

### DIFF
--- a/scenario_generation/tests/test_wandb_closed_loop.py
+++ b/scenario_generation/tests/test_wandb_closed_loop.py
@@ -1,0 +1,76 @@
+"""Regression tests for ``log_closed_loop_to_wandb``'s config handling.
+
+The callers (``run_all_groups_closed_loop.main`` and ``train.py``) pass a
+``ClosedLoopConfig`` dataclass, not a dict. Reading it with ``.get`` raised
+``AttributeError`` at the very end of a finished closed-loop run, which is the
+worst place to fail -- every metric was already computed by then.
+"""
+
+import sys
+from unittest import mock
+
+# Mock wandb module if not installed in local environment
+sys.modules.setdefault("wandb", mock.MagicMock())
+
+from diffusion_planner.config.closed_loop_config import ClosedLoopConfig
+
+from scenario_generation.wandb_closed_loop import log_closed_loop_to_wandb
+
+_NAMES = ["site/all"]
+_SUMMARIES = {"site/all": {"group": "all", "n_segments": 1, "total_steps": 10}}
+
+
+def test_dataclass_config_reaches_wandb_init():
+    """A ClosedLoopConfig must be read via attributes, not ``.get``."""
+    cfg = ClosedLoopConfig(wandb_project_name="proj-x", exp_name="run-y")
+    with mock.patch("scenario_generation.wandb_closed_loop.wandb") as wb:
+        log_closed_loop_to_wandb(cfg, _NAMES, _SUMMARIES, run=None)
+
+    assert wb.init.call_args.kwargs == {"project": "proj-x", "name": "run-y"}
+    assert wb.finish.called, "a run we opened ourselves must be finished"
+
+
+def test_mapping_config_still_supported():
+    """Older callers passed a plain dict; keep that path working."""
+    with mock.patch("scenario_generation.wandb_closed_loop.wandb") as wb:
+        log_closed_loop_to_wandb(
+            {"wandb_project_name": "p", "exp_name": "n"}, _NAMES, _SUMMARIES, run=None
+        )
+
+    assert wb.init.call_args.kwargs == {"project": "p", "name": "n"}
+
+
+def test_empty_project_name_skips_upload():
+    """``wandb_project_name`` is documented as "empty = disabled"."""
+    with mock.patch("scenario_generation.wandb_closed_loop.wandb") as wb:
+        log_closed_loop_to_wandb(ClosedLoopConfig(), _NAMES, _SUMMARIES, run=None)
+
+    assert not wb.init.called
+
+
+def test_none_config_skips_upload():
+    with mock.patch("scenario_generation.wandb_closed_loop.wandb") as wb:
+        log_closed_loop_to_wandb(None, _NAMES, _SUMMARIES, run=None)
+
+    assert not wb.init.called
+
+
+def test_supplied_run_logs_even_without_project_name():
+    """train.py hands us its own run; the project name is irrelevant then."""
+    run = mock.Mock()
+    with (
+        mock.patch("scenario_generation.wandb_closed_loop.log_metrics_tables") as tables,
+        mock.patch("scenario_generation.wandb_closed_loop.log_cross_run_charts") as charts,
+        mock.patch("scenario_generation.wandb_closed_loop.wandb") as wb,
+    ):
+        log_closed_loop_to_wandb(ClosedLoopConfig(), _NAMES, _SUMMARIES, run=run)
+
+    assert tables.called and charts.called
+    assert not wb.finish.called, "a caller-owned run must not be finished here"
+
+
+def test_empty_summaries_is_a_no_op():
+    with mock.patch("scenario_generation.wandb_closed_loop.wandb") as wb:
+        log_closed_loop_to_wandb(ClosedLoopConfig(wandb_project_name="p"), [], {}, run=None)
+
+    assert not wb.init.called

--- a/scenario_generation/wandb_closed_loop.py
+++ b/scenario_generation/wandb_closed_loop.py
@@ -29,9 +29,9 @@ Prerequisites:
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 
 import wandb
-
 from scenario_generation.closed_loop_score_keys import extract_score
 
 # (display column name, source key in a per-group summary dict)
@@ -631,8 +631,22 @@ def log_cross_run_charts(
         print(f"wandb: logged Closed-Loop-{json_label}/cross_run_chart")
 
 
+def _cfg_field(cfg: object | None, field: str) -> str:
+    """Read ``field`` off a config that may be a dataclass, a mapping, or ``None``.
+
+    ``run_all_groups_closed_loop`` and ``train.py`` both hand us a
+    ``ClosedLoopConfig`` dataclass, while older callers passed a plain dict, so
+    read through both rather than assuming ``.get``.
+    """
+    if cfg is None:
+        return ""
+    if isinstance(cfg, Mapping):
+        return cfg.get(field) or ""
+    return getattr(cfg, field, "") or ""
+
+
 def log_closed_loop_to_wandb(
-    cfg: "dict | None",
+    cfg: "object | dict | None",
     group_names: list[str],
     group_summaries: dict[str, dict],
     run: "wandb.sdk.wandb_run.Run | None" = None,
@@ -643,8 +657,9 @@ def log_closed_loop_to_wandb(
     Sets up W&B Custom Chart presets for cross-run comparison.
 
     Args:
-        cfg: Config dict with ``wandb_project_name`` and ``exp_name`` fields.
-             If None, uses defaults.
+        cfg: ``ClosedLoopConfig`` (or a dict) carrying ``wandb_project_name`` and
+             ``exp_name``. If None, or if ``wandb_project_name`` is empty and no
+             ``run`` was supplied, the upload is skipped.
         group_names: List of group keys.
         group_summaries: Dict mapping group key -> summary dict.
         run: W&B run instance. If None, starts a new one.
@@ -653,9 +668,15 @@ def log_closed_loop_to_wandb(
         return
 
     if run is None:
-        project = (cfg or {}).get("wandb_project_name") or None
-        name = (cfg or {}).get("exp_name") or None
-        run = wandb.init(project=project, name=name)
+        project = _cfg_field(cfg, "wandb_project_name")
+        if not project:
+            # ``wandb_project_name`` is documented as "empty = disabled". Without this
+            # guard we would wandb.init(project=None) and either create a run in the
+            # default project or block on a missing API key -- after the evaluation
+            # has already finished, which is the worst possible place to fail.
+            print("wandb: wandb_project_name is empty, skipping closed-loop upload")
+            return
+        run = wandb.init(project=project, name=_cfg_field(cfg, "exp_name") or None)
         own_run = True
     else:
         own_run = False


### PR DESCRIPTION
## What

`log_closed_loop_to_wandb` read its `cfg` with `.get()`, but every caller passes a `ClosedLoopConfig` dataclass. Standalone `run_all_groups_closed_loop.py` runs therefore died with `AttributeError: 'ClosedLoopConfig' object has no attribute 'get'` — after the whole evaluation had already finished.

Also fixed: an empty `wandb_project_name` is documented as "disabled", but the code still called `wandb.init(project=None)`. It now skips the upload instead.

## Impact

- `run_all_groups_closed_loop.py` (standalone): crashed at the very last step, so ~5 h of closed-loop results never reached W&B. Hit on Slurm jobs 6870-6872.
- `train.py`: unaffected. It passes `wandb_run=wandb.run`, so the `cfg` branch is skipped.

## Why it was missed

`test_closed_loop_cli.py` monkeypatches `log_closed_loop_to_wandb` to a no-op, so the real function was never exercised. Added `scenario_generation/tests/test_wandb_closed_loop.py` (6 cases) covering dataclass / dict / None configs and empty vs. set project names.

Verified by replaying a finished 34-group run through the fixed path and confirming the tables and charts land in W&B.
