### PR TITLE
feat: write tags into closed loop test results

### DIFF
--- a/diffusion_planner/run_all_groups_closed_loop.py
+++ b/diffusion_planner/run_all_groups_closed_loop.py
@@ -24,6 +24,7 @@ from diffusion_planner.config.closed_loop_config import (
 from diffusion_planner.config.config_cli import build_config, build_parser, resolve_paths
 from diffusion_planner.config.config_utils import save_config
 from diffusion_planner.utils import ddp
+from tag_toolkit.store import TagStore
 
 from scenario_generation.wandb_closed_loop import (
     log_closed_loop_to_wandb,
@@ -34,11 +35,11 @@ def resolve_closed_loop_inputs(
     inputs: str | list[str],
     modes: list[str] | None = None,
 ) -> list[dict]:
-    """Resolve input paths to a list of ``{"name", "groups", "mode"}`` entries.
+    """Resolve input paths to a list of ``{"name", "groups", "mode", "tag_store"}`` entries.
 
-    Each entry in ``inputs`` produces ONE entry in the output list — duplicate
-    paths are allowed and kept as separate entries (same JSON may legitimately
-    need to run under multiple modes, e.g. ``sites.json objects sites.json noobj``).
+    ``tag_store`` is built via ``TagStore.from_source``: if a same-named ``.tags.db``
+    exists next to the input it is loaded; otherwise an in-memory index is built.
+    The caller holds this store for the lifetime of the evaluation.
 
     ``modes`` is zipped positionally with the *input list* (1-to-1):
 
@@ -48,7 +49,7 @@ def resolve_closed_loop_inputs(
 
     Return shape:
 
-        [{"name": "sites", "groups": {"all": [...]}, "mode": "objects"}, ...]
+        [{"name": "sites", "groups": {"all": [...]}, "mode": "objects", "tag_store": TagStore}, ...]
     """
     if isinstance(inputs, str):
         inputs = [inputs]
@@ -73,6 +74,7 @@ def resolve_closed_loop_inputs(
 
         if p.is_dir():
             groups.setdefault("all", []).append(str(p))
+            tag_store = TagStore.from_source(str(p))
 
         elif p.suffix == ".json":
             with open(p, "r") as f:
@@ -83,12 +85,13 @@ def resolve_closed_loop_inputs(
                     groups.setdefault(group_name, []).extend(str(Path(item)) for item in paths)
             elif isinstance(data, list):
                 groups.setdefault("all", []).extend(str(Path(item)) for item in data)
+            tag_store = TagStore.from_source(str(p))
 
         else:
             print(f"Warning: {input_path} has unsupported extension, skipping", file=sys.stderr)
             continue
 
-        entries.append({"name": p.stem if p.suffix else p.name, "groups": groups, "mode": mode})
+        entries.append({"name": p.stem if p.suffix else p.name, "groups": groups, "mode": mode, "tag_store": tag_store})
 
     return entries
 
@@ -102,6 +105,7 @@ def run_one_group(
     mode: str | None = None,
     render_media: bool = True,
     pass_condition: ClosedLoopPassCondition | None = None,
+    tag_store=None,
 ) -> None:
     """Run closed-loop evaluation for a single group; writes ``summary.json`` + ``segments.jsonl``
     under ``out_dir``. Wandb logging is left to the caller.
@@ -186,6 +190,7 @@ def run_one_group(
         seg_len=cfg.closed_loop_seg_len,
         ddp_rank=ddp_rank,
         ddp_world_size=ddp_world_size,
+        tag_store=tag_store,
     )
 
     evaluator.run_distributed()
@@ -367,6 +372,8 @@ def run_closed_loop_main(
         json_out_dir = out_root / json_label
         json_out_dir.mkdir(parents=True, exist_ok=True)
 
+        tag_store = entry.get("tag_store")
+
         for group_name, npz_paths in groups.items():
             mode_out_dir = json_out_dir / group_name
             summary_key = _make_summary_key(json_label, group_name)
@@ -381,6 +388,7 @@ def run_closed_loop_main(
                 mode=mode,
                 render_media=render_media,
                 pass_condition=group_condition,
+                tag_store=tag_store,
             )
 
         written_json_labels.add(json_label)

--- a/scenario_generation/closed_loop_eval.py
+++ b/scenario_generation/closed_loop_eval.py
@@ -28,6 +28,9 @@ from scenario_generation.render_pool import render_pool
 from scenario_generation.reproducer_rollout import render_segment
 from scenario_generation.route_timeline import RouteTimeline, group_routes
 
+from tag_toolkit import TagStore
+
+
 _DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 # Clearance t-digests live in a sidecar ``tdigests.jsonl`` / ``tdigests_{rank}.jsonl``
@@ -552,6 +555,8 @@ def run_closed_loop_eval(
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
+    tag_store = TagStore.from_source(Path(npz_root), save=True)
+
     # npz_root is either one directory tree, a JSON path list of route dirs, or an
     # already-resolved list of roots -- enumerate_multi_root_routes merges them all,
     # disambiguating any bag-prefix key that collides across roots and remembering the source
@@ -618,9 +623,8 @@ def run_closed_loop_eval(
                 timeline_progress_mode="pose",
             )
             row = {"route": key, **metrics}
-            # Human-readable segments.jsonl (no _tdigest blobs). Digests go to a sidecar so
-            # multi-GPU parents can still merge approximate global clearance p5.
-            fout.write(json.dumps(segment_row_for_json(metrics, route=key), default=float) + "\n")
+
+            fout.write(json.dumps(segment_row_for_json(metrics, route=key, tags=tag_store.tags_of(scope=routes[key], granularity="route")), default=float) + "\n")
             fout.flush()
             side = tdigest_sidecar_row(row)
             if side is not None:

--- a/scenario_generation/closed_loop_eval.py
+++ b/scenario_generation/closed_loop_eval.py
@@ -28,9 +28,6 @@ from scenario_generation.render_pool import render_pool
 from scenario_generation.reproducer_rollout import render_segment
 from scenario_generation.route_timeline import RouteTimeline, group_routes
 
-from tag_toolkit import TagStore
-
-
 _DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 # Clearance t-digests live in a sidecar ``tdigests.jsonl`` / ``tdigests_{rank}.jsonl``
@@ -555,8 +552,6 @@ def run_closed_loop_eval(
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    tag_store = TagStore.from_source(Path(npz_root), save=True)
-
     # npz_root is either one directory tree, a JSON path list of route dirs, or an
     # already-resolved list of roots -- enumerate_multi_root_routes merges them all,
     # disambiguating any bag-prefix key that collides across roots and remembering the source
@@ -623,8 +618,9 @@ def run_closed_loop_eval(
                 timeline_progress_mode="pose",
             )
             row = {"route": key, **metrics}
-
-            fout.write(json.dumps(segment_row_for_json(metrics, route=key, tags=tag_store.tags_of(scope=routes[key], granularity="route")), default=float) + "\n")
+            # Human-readable segments.jsonl (no _tdigest blobs). Digests go to a sidecar so
+            # multi-GPU parents can still merge approximate global clearance p5.
+            fout.write(json.dumps(segment_row_for_json(metrics, route=key), default=float) + "\n")
             fout.flush()
             side = tdigest_sidecar_row(row)
             if side is not None:

--- a/scenario_generation/closed_loop_evaluation.py
+++ b/scenario_generation/closed_loop_evaluation.py
@@ -31,6 +31,7 @@ from scenario_generation.closed_loop_eval import (
     segment_row_for_json,
     tdigest_sidecar_row,
 )
+from tag_toolkit import TagStore
 from scenario_generation.inference_compile import compiled_for_inference
 from scenario_generation.perf_timer import Timers
 from scenario_generation.render_pool import render_pool
@@ -390,6 +391,7 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
         seg_len: int,
         ddp_rank: int,
         ddp_world_size: int,
+        tag_store=None,
     ) -> None:
         super().__init__(
             model,
@@ -400,6 +402,7 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
         )
         self.npz_root = npz_root
         self.seg_len = seg_len
+        self.tag_store = tag_store
 
     @classmethod
     def from_checkpoint(
@@ -411,6 +414,7 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
         seg_len: int,
         ddp_rank: int,
         ddp_world_size: int,
+        tag_store=None,
     ) -> FullRouteClosedLoopEvaluation:
         model, model_args = cls.load_model_pair(model_path, config.params.device)
         return cls(
@@ -421,6 +425,7 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
             seg_len=seg_len,
             ddp_rank=ddp_rank,
             ddp_world_size=ddp_world_size,
+            tag_store=tag_store,
         )
 
     def discover_jobs(self) -> list[FullRouteRouteJob]:
@@ -494,6 +499,8 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
             row = {"route": job.route_key, **metrics}
             if self.config.pass_condition is not None:
                 row["passed"] = evaluate_segment_pass(row, self.config.pass_condition)
+            if self.tag_store:
+                row["tags"] = self.tag_store.tags_of(scope=job.route_paths, granularity="route")
             if segments_file is not None:
                 # Human-readable segments.jsonl never carries the raw _tdigest blobs; those go to
                 # the sidecar so a later DDP merge (or a re-load of this run) can still pool an

--- a/tag_toolkit/README.md
+++ b/tag_toolkit/README.md
@@ -41,20 +41,20 @@ routes = store.query("split:auto")  # instant
 ### 2. Index mode (fast for large datasets)
 
 For large datasets, build a SQLite index once and load it for repeated
-queries. The output path should end in `.db` (or `.sqlite` / `.tags.db`)
-— `TagStore` recognises those suffixes and reopens the file as a
+queries. The output path should end in `.tags.db`
+— `TagStore` recognises that suffix and reopens the file as a
 database.
 
 ```python
 from tag_toolkit import TagStore
 
-TagStore.build_index("/path/to/dataset", "/path/to/tags.db")
-store = TagStore("/path/to/tags.db")
+TagStore.build_index("/path/to/dataset", "/path/to/tags.tags.db")
+store = TagStore("/path/to/tags.tags.db")
 routes = store.query("split:auto")
 ```
 
 Note: `add_tags` and friends update the in-memory index immediately, but
-they do **not** rewrite the saved `.db` file. To refresh the on-disk
+they do **not** rewrite the saved `.tags.db` file. To refresh the on-disk
 index after on-the-fly mutations, run `build_index` again (with the same
 source).
 
@@ -108,10 +108,10 @@ print(f"Found {len(routes)} routes")
 from tag_toolkit import TagStore
 
 # Build once (slow)
-TagStore.build_index("/path/to/large_dataset", "/path/to/tags.db")
+TagStore.build_index("/path/to/large_dataset", "/path/to/tags.tags.db")
 
 # Load from index (fast, repeated use)
-store = TagStore("/path/to/tags.db")
+store = TagStore("/path/to/tags.tags.db")
 routes = store.query("split:auto")
 ```
 
@@ -120,7 +120,7 @@ routes = store.query("split:auto")
 ```python
 from tag_toolkit import TagStore
 
-store = TagStore("/path/to/tags.db")
+store = TagStore("/path/to/tags.tags.db")
 
 # Tag every frame in the index — the typical "label the whole dataset" case.
 result = store.add_tags(["override_metric:centerline"])
@@ -157,7 +157,7 @@ each call. The SQLite WAL keeps the index consistent; the on-disk
 sidecars are still flushed before each call returns.
 
 ```python
-store = TagStore("/path/to/tags.db")
+store = TagStore("/path/to/tags.tags.db")
 
 for route in store.route_paths():
     store.add_tags(["site:foo"], scope=route, sync=False)
@@ -168,7 +168,7 @@ for route in store.route_paths():
 ```python
 from tag_toolkit import TagStore, format_buckets
 
-store = TagStore("/path/to/tags.db")
+store = TagStore("/path/to/tags.tags.db")
 buckets = store.group_by(["site", "split"])
 print(format_buckets(buckets, ["site", "split"]))
 print(buckets[0].members[:2])  # route list in this bucket
@@ -188,7 +188,7 @@ TOTAL                                          3
 ### 6. Replace and remove
 
 ```python
-store = TagStore("/path/to/tags.db")
+store = TagStore("/path/to/tags.tags.db")
 
 # Add
 store.add_tags(["lateral:turn"])

--- a/tag_toolkit/__init__.py
+++ b/tag_toolkit/__init__.py
@@ -4,7 +4,7 @@ Quick start::
 
     # Open or create a SQLite index
     from tag_toolkit import TagStore
-    store = TagStore("/path/to/dataset.db")   # persisted
+    store = TagStore("/path/to/dataset.tags.db")   # persisted
     # or:
     store = TagStore("/path/to/dataset/")     # in-memory, mutations stay in memory
 

--- a/tag_toolkit/docs/api.md
+++ b/tag_toolkit/docs/api.md
@@ -57,13 +57,13 @@ TagStore(source=None) -> TagStore
 Construct from one of:
 
 - `None` (default) — empty in-memory store. Open it with `rebuild_index(source)` later.
-- A `.db` / `.sqlite` / `.tags.db` file — opens or creates that SQLite DB. All operations are persisted.
+- A `.tags.db` file — opens or creates that SQLite DB. All operations are persisted.
 - Anything else (a directory, a path-list JSON, a list of paths, or a single `.npz`) — in-memory index seeded from that source. Mutations stay in memory; call `export_index(path)` to persist.
 
 Concurrent writers are serialized by an internal `RLock`; readers are lock-free.
 
 ```python
-store = TagStore("/data/dataset.db")                  # persisted
+store = TagStore("/data/dataset.tags.db")                  # persisted
 store = TagStore("/data/routes/")                      # in-memory, seeded
 store = TagStore("/data/close_loop_path_list.json")    # in-memory, seeded
 store = TagStore()                                     # empty; call rebuild_index() later
@@ -137,23 +137,23 @@ a `TagStore` backed by that file. Equivalent to
 `store = TagStore(); store.rebuild_index(source); store.export_index(output)`.
 
 ```python
-store = TagStore.build_index("/data/routes/", "/data/index.db")
+store = TagStore.build_index("/data/routes/", "/data/index.tags.db")
 ```
 
 The CLI wrapper at `scripts/tag_management/build_index.py` exposes the same
 flow without writing Python. It is the fast-path entry point for large
 datasets whose downstream tools (`scripts/tag_usage/export_dataset.py`,
-etc.) accept a pre-built `.db`:
+etc.) accept a pre-built `.tags.db`:
 
 ```bash
-python scripts/tag_management/build_index.py /data/routes/ -o /data/index.db
-python scripts/tag_management/build_index.py /data/routes/ -o /data/index.db --force
+python scripts/tag_management/build_index.py /data/routes/ -o /data/index.tags.db
+python scripts/tag_management/build_index.py /data/routes/ -o /data/index.tags.db --force
 ```
 
 | Flag | Meaning |
 |---|---|
 | `source` (positional) | Same shape as `TagStore`: directory, path-list `.json` / `.json.zst`, single `.npz`, or a sequence of those. |
-| `--output` / `-o` (required) | Destination `.db` / `.sqlite` / `.tags.db` path. Parent dirs are auto-created. |
+| `--output` / `-o` (required) | Destination `.tags.db` path. Parent dirs are auto-created. |
 | `--force` | Overwrite `--output` if it already exists. Default is fail-fast. |
 
 Exit codes: `0` on success; `1` if the source is missing, the output suffix is

--- a/tag_toolkit/docs/design.md
+++ b/tag_toolkit/docs/design.md
@@ -20,7 +20,7 @@ pre-filters). For wholesale changes, use `rebuild_index`.
 the set, they never extend it. A path that isn't in the index never
 becomes "visible" through `scope`.
 
-For large or repeated use, prefer a pre-built `.db` index file. The
+For large or repeated use, prefer a pre-built `.tags.db` index file. The
 on-init directory scan reads every sidecar on disk; the loaded index
 skips that.
 
@@ -153,7 +153,7 @@ subsequent query.
 | When set | Once, at `TagStore(source)` | Every query / mutate call |
 | Effect | Defines the **authoritative frame set** | Narrows the **operation** to a subset |
 | Can extend the frame set? | Yes — scanning discovers frames on disk | **No** — unknown paths are silently dropped |
-| Disk cost | One-time scan or `.db` load | None for indexed paths; one `expand_source` fallback per non-indexed path |
+| Disk cost | One-time scan or `.tags.db` load | None for indexed paths; one `expand_source` fallback per non-indexed path |
 | Mutability | Frozen for the lifetime of the store | Re-evaluated per call |
 
 `source` answers "what does this store see?". `scope` answers "of what

--- a/tag_toolkit/docs/usage.md
+++ b/tag_toolkit/docs/usage.md
@@ -3,7 +3,7 @@
 Tags for Diffusion Planner data live on each NPZ's sidecar JSON (`<stem>.json`
 next to `<stem>.npz`). `tag_toolkit` reads and writes the `tags` field, and
 queries at **route** or **frame** granularity. For large datasets, build the
-index once with `TagStore.build_index` and load the resulting `.db` file
+index once with `TagStore.build_index` and load the resulting `.tags.db` file
 thereafter.
 
 Scope resolution rules live in [design.md](design.md).
@@ -90,7 +90,7 @@ skipped silently.
 | `source`               | Behavior                                           |
 | ---------------------- | -------------------------------------------------- |
 | `None`                 | Empty in-memory store                              |
-| `"/path/to/index.db"`  | Open pre-built SQLite index                        |
+| `"/path/to/index.tags.db"`  | Open pre-built SQLite index                        |
 | `"/path/to/dataset"`   | Scan directory recursively for NPZ + sidecar pairs |
 | `"/path/to/list.json"` | Scan paths listed in the JSON file                 |
 | `[path1, path2, ...]`  | Scan multiple sources                              |
@@ -99,20 +99,20 @@ skipped silently.
 ```python
 store = TagStore()                       # empty
 store = TagStore("/path/to/dataset")     # scan on init
-store = TagStore("/path/to/index.db")    # open pre-built index
+store = TagStore("/path/to/index.tags.db")    # open pre-built index
 ```
 
-`TagStore` recognises `.db`, `.sqlite`, and `.tags.db` as SQLite index
+`TagStore` recognises `.tags.db` as SQLite index
 extensions on init.
 
 ### `TagStore.build_index(source, output)`
 
 Scan `source`, build the in-memory index, and persist it to `output`
-(typically a `.db` file) via `VACUUM INTO`. Returns a `TagStore` backed
+(typically a `.tags.db` file) via `VACUUM INTO`. Returns a `TagStore` backed
 by the file at `output`.
 
 ```python
-store = TagStore.build_index("/path/to/dataset", "/path/to/tags.db")
+store = TagStore.build_index("/path/to/dataset", "/path/to/tags.tags.db")
 ```
 
 ### Scope

--- a/tag_toolkit/scripts/README.md
+++ b/tag_toolkit/scripts/README.md
@@ -8,8 +8,8 @@ docstring. This README is a one-line index.
 
 | Script | Purpose |
 |---|---|
-| [`incremental_index.py`](tag_management/incremental_index.py) | Append new frames to an existing `.db` index without rescanning old frames; pre-filters duplicates via the `frames` PK. |
-| [`build_index.py`](tag_management/build_index.py) | CLI wrapper around `TagStore.build_index`: build a `.db` index from a directory / path-list / single `.npz` and write it to `--output` (fails fast if it already exists; pass `--force` to overwrite). |
+| [`incremental_index.py`](tag_management/incremental_index.py) | Append new frames to an existing `.tags.db` index without rescanning old frames; pre-filters duplicates via the `frames` PK. |
+| [`build_index.py`](tag_management/build_index.py) | CLI wrapper around `TagStore.build_index`: build a `.tags.db` index from a directory / path-list / single `.npz` and write it to `--output` (fails fast if it already exists; pass `--force` to overwrite). |
 | [`write_route_tags_from_csv.py`](tag_management/write_route_tags_from_csv.py) | Apply route-level tags from a CSV column-to-dimension mapping (e.g. `devops_site`, `devops_override_label`) to one dataset tree, batched `sync=False`. |
 | [`write_path_tags.py`](tag_management/write_path_tags.py) | Walk one dataset tree, infer `site:*` / `split:*` / `project:*` / `vehicle:*` tags from the directory layout; supports optional `split_labels.json` and `project_vehicle_map.json`. |
 

--- a/tag_toolkit/scripts/tag_management/build_index.py
+++ b/tag_toolkit/scripts/tag_management/build_index.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Build a TagStore SQLite index (.db) from a dataset source on the CLI.
+"""Build a TagStore SQLite index (.tags.db) from a dataset source on the CLI.
 
 This is a thin wrapper around ``TagStore.build_index(source, output)``;
 it exists so the index can be materialised without writing Python code.
@@ -8,8 +8,8 @@ A pre-built index is the fast path for downstream tools such as
 
 Usage::
 
-    python build_index.py /path/to/dataset -o /data/tags.db
-    python build_index.py /path/to/dataset -o /data/tags.db --force
+    python build_index.py /path/to/dataset -o /data/tags.tags.db
+    python build_index.py /path/to/dataset -o /data/tags.tags.db --force
 """
 
 from __future__ import annotations
@@ -25,7 +25,7 @@ if _TAG_TOOLKIT_PARENT.exists():
 
 from tag_toolkit import TagStore
 
-_DB_SUFFIXES = (".db", ".sqlite", ".tags.db")
+_DB_SUFFIXES = (".tags.db",)
 
 
 def parse_args() -> argparse.Namespace:
@@ -48,7 +48,7 @@ def parse_args() -> argparse.Namespace:
         "-o",
         type=Path,
         required=True,
-        help=("Output .db path. Must end in one of: " + ", ".join(_DB_SUFFIXES) + "."),
+        help=("Output .tags.db path. Must end in one of: " + ", ".join(_DB_SUFFIXES) + "."),
     )
     parser.add_argument(
         "--force",

--- a/tag_toolkit/scripts/tag_management/incremental_index.py
+++ b/tag_toolkit/scripts/tag_management/incremental_index.py
@@ -7,8 +7,8 @@ never read, never re-tagged, never re-validated.
 
 Usage::
 
-    python incremental_index.py existing.db /path/to/dataset
-    python incremental_index.py existing.db /path/to/dataset --output new.db
+    python incremental_index.py existing.tags.db /path/to/dataset
+    python incremental_index.py existing.tags.db /path/to/dataset --output new.tags.db
 """
 
 from __future__ import annotations
@@ -67,7 +67,7 @@ def _merge(
     triggers WAL mode, which checkpoints back to the main file on close).
     """
     with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_path = Path(tmpdir) / "merged.db"
+        tmp_path = Path(tmpdir) / "merged.tags.db"
         shutil.copy2(old_index_path, tmp_path)
         store = TagStore(str(tmp_path))
         try:
@@ -138,7 +138,7 @@ def main() -> int:
     parser.add_argument(
         "old_index",
         type=Path,
-        help="path to the existing SQLite index file (.db, .sqlite, or .tags.db)",
+        help="path to the existing SQLite index file (.tags.db)",
     )
     parser.add_argument(
         "new_source",

--- a/tag_toolkit/scripts/tag_management/write_route_tags_from_csv.py
+++ b/tag_toolkit/scripts/tag_management/write_route_tags_from_csv.py
@@ -14,7 +14,7 @@ Usage::
         /path/to/mapping.csv \\
         --match-col t4_dataset_id \\
         --tag-dimensions devops_site devops_override_label \\
-        [--output-index /path/to/output.db]
+        [--output-index /path/to/output.tags.db]
 
 All file writes are batched (per-file fsync deferred) and synced once at
 the end for maximum performance.
@@ -337,8 +337,8 @@ def parse_args() -> argparse.Namespace:
         help=(
             "TagToolkit source (see tag_toolkit.source): a directory, a "
             "path-list .json / .json.zst, a single .npz, a sequence of "
-            "those, or a pre-built TagStore SQLite index (*.db / *.sqlite "
-            "/ *.tags.db). The form is auto-detected; a database index is "
+            "those, or a pre-built TagStore SQLite index (*.tags.db). "
+            "The form is auto-detected; a database index is "
             "the fast path for large datasets."
         ),
     )
@@ -370,7 +370,7 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         default=None,
         dest="output_index",
-        help="Output path for the .db index file (optional)",
+        help="Output path for the .tags.db index file (optional)",
     )
     return parser.parse_args()
 

--- a/tag_toolkit/scripts/tag_usage/export_dataset.py
+++ b/tag_toolkit/scripts/tag_usage/export_dataset.py
@@ -19,7 +19,7 @@ Usage::
         --query "devops_override_label:b" --mode close_loop --dimension devops_override_label
 
     # Use a pre-built SQLite index for faster startup on large datasets
-    python export_dataset.py /data/tags.db --output /data/out \\
+    python export_dataset.py /data/tags.tags.db --output /data/out \\
         --mode close_loop --dimension devops_override_label
 
 Modes
@@ -293,8 +293,8 @@ def main():
         help=(
             "TagToolkit source (see tag_toolkit.source): a directory, a "
             "path-list .json / .json.zst, a single .npz, a sequence of "
-            "those, or a pre-built TagStore SQLite index (*.db / *.sqlite "
-            "/ *.tags.db). The form is auto-detected; a database index is "
+            "those, or a pre-built TagStore SQLite index (*.tags.db). "
+            "The form is auto-detected; a database index is "
             "the fast path for large datasets."
         ),
     )

--- a/tag_toolkit/source.py
+++ b/tag_toolkit/source.py
@@ -132,8 +132,31 @@ def _expand_spec(path_s: str) -> list[Path]:
 def _expand_path_list_file(path: Path) -> list[Path]:
     """Expand a path-list JSON file."""
     data = load_json(path)
+    if not data:
+        return []
+
+    # Handle dict format: {"group_name": ["/route/path1", "/route/path2"], ...}
+    # Each value is typically a route directory (or list of route dirs);
+    # _expand_spec handles both directories (recursive *.npz) and direct npz paths.
+    if isinstance(data, dict):
+        out: list[Path] = []
+        seen: set[str] = set()
+        for group_paths in data.values():
+            if not isinstance(group_paths, list):
+                continue
+            for item in group_paths:
+                if not isinstance(item, str):
+                    continue
+                for npz in _expand_spec(os.path.expanduser(item)):
+                    key = str(npz)
+                    if key not in seen:
+                        seen.add(key)
+                        out.append(npz)
+        return out
+
+    # Handle list format: ["path1.npz", "path2.npz", ...]
     if not isinstance(data, list):
-        raise ValueError(f"path list must be a JSON array: {path}")
+        raise ValueError(f"path list must be a JSON array or dict: {path}")
     if not data:
         return []
     for entry in data:
@@ -145,8 +168,8 @@ def _expand_path_list_file(path: Path) -> list[Path]:
         return _dedupe_npz_strings([os.path.abspath(os.path.expanduser(entry)) for entry in data])
 
     # Mixed / closed-loop lists may contain route directories — expand those only.
-    out: list[Path] = []
-    seen: set[str] = set()
+    out = []
+    seen = set()
     for item in data:
         for npz in _expand_spec(os.path.expanduser(item)):
             key = str(npz)

--- a/tag_toolkit/store/__init__.py
+++ b/tag_toolkit/store/__init__.py
@@ -3,7 +3,7 @@
 Tags travel with each NPZ's sidecar JSON. The store scans a source,
 builds a SQLite index, and exposes query / mutation on top of that index.
 
-If ``source`` is a ``.db`` / ``.sqlite`` / ``.tags.db`` file the SQLite
+If ``source`` is a ``.tags.db`` file the SQLite
 index is opened there and all operations are persisted. Otherwise the
 index lives in memory; mutations stay in memory and can be exported to a
 file with ``store.export_index(path)``.
@@ -70,7 +70,7 @@ class TagStore(_QueryMixin, _MutateMixin, _IndexMixin):
     """SQLite-backed store for tags on NPZ sidecar files.
 
     Construct from one of:
-      - a ``.db`` / ``.sqlite`` / ``.tags.db`` file: opens/creates that
+      - a ``.tags.db`` file: opens/creates that
         SQLite database; all operations are persisted
       - a directory, path-list JSON, list of paths, or single ``.npz``:
         creates an in-memory SQLite index; mutations stay in memory;

--- a/tag_toolkit/store/_db.py
+++ b/tag_toolkit/store/_db.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-_DB_SUFFIXES = (".db", ".sqlite", ".tags.db")
+_DB_SUFFIXES = (".tags.db",)
 
 # ---------------------------------------------------------------------------
 # SQLite schema

--- a/tag_toolkit/store/_index.py
+++ b/tag_toolkit/store/_index.py
@@ -22,6 +22,40 @@ _BATCH_SIZE = 100_000
 class _IndexMixin:
     """Mixin providing index management methods for TagStore."""
 
+    @staticmethod
+    def from_source(source: str | Path, *, save: bool = False, force_rebuild: bool = False) -> "TagStore":
+        """Load a TagStore for *source*, auto-building the index from sidecars.
+
+        By default this is read-only and in-memory: it tries to open a same-named
+        ``.tags.db`` next to *source*, and only scans sidecars when one is missing.
+
+        Args:
+            source: Path to the source (JSON path list, route directory, etc.).
+            save: When True, persist a freshly built index to ``<source>.tags.db``.
+                No-op if the index was loaded from disk (i.e. ``save`` only triggers
+                a write when the index actually had to be rebuilt).
+            force_rebuild: If True, rebuild from source even when a
+                ``.tags.db`` already exists. In that case ``save`` controls
+                whether the rebuilt index is written back to disk.
+        """
+        from . import TagStore
+
+        source = Path(source).resolve()
+        db_path = source.parent / f"{source.stem}.tags.db"
+
+        if db_path.exists() and not force_rebuild:
+            return TagStore(db_path)
+
+        store = TagStore()
+        store.rebuild_index(source)
+
+        if not save:
+            return store
+
+        store.export_index(db_path)
+        print(f"[TagStore] Index saved to {db_path}")
+        return TagStore(db_path)
+
     def rebuild_index(
         self,
         source: str | Path | Sequence[str | Path],

--- a/tag_toolkit/tests/test_store.py
+++ b/tag_toolkit/tests/test_store.py
@@ -197,8 +197,8 @@ def test_scan_mode_direct_directory(sample: Path) -> None:
 
 
 def test_index_mode_from_file(tmp_path: Path, sample: Path) -> None:
-    """TagStore can load from a .db index file (SQLite format)."""
-    index_file = tmp_path / "index.db"
+    """TagStore can load from a .tags.db index file (SQLite format)."""
+    index_file = tmp_path / "index.tags.db"
     TagStore.build_index(sample, index_file)
 
     # Load from index file
@@ -811,7 +811,7 @@ def test_source_property(sample: Path) -> None:
 
 def test_build_index_returns_index_store(sample: Path, tmp_path: Path) -> None:
     """build_index returns a TagStore with in-memory index."""
-    index_file = tmp_path / "index.db"
+    index_file = tmp_path / "index.tags.db"
     store = TagStore.build_index(sample, index_file)
 
     assert isinstance(store, TagStore)
@@ -831,8 +831,8 @@ def test_scan_path_list_json(tmp_path: Path, sample: Path) -> None:
 
 
 def test_index_file_loaded_from_pickle(tmp_path: Path, sample: Path) -> None:
-    """Passing a .db file loads the SQLite index directly without scanning."""
-    index_file = tmp_path / "index.db"
+    """Passing a .tags.db file loads the SQLite index directly without scanning."""
+    index_file = tmp_path / "index.tags.db"
     TagStore.build_index(sample, index_file)
 
     store = TagStore(index_file)
@@ -848,7 +848,7 @@ def test_build_index_from_multiple_sources(tmp_path: Path) -> None:
     _frame(a, "a1", ["split:train"])
     _frame(b, "b1", ["split:eval"])
 
-    index_file = tmp_path / "index.db"
+    index_file = tmp_path / "index.tags.db"
     store = TagStore.build_index([a, b], index_file)
     assert len(store.npz_paths()) == 2
     assert len(store.query("split:train")) == 1
@@ -857,7 +857,7 @@ def test_build_index_from_multiple_sources(tmp_path: Path) -> None:
 
 def test_index_roundtrip_paths_are_absolute(sample: Path, tmp_path: Path) -> None:
     """Index saves and loads with absolute paths."""
-    index_file = tmp_path / "index.db"
+    index_file = tmp_path / "index.tags.db"
     TagStore.build_index(sample, index_file)
 
     store = TagStore(index_file)
@@ -867,8 +867,8 @@ def test_index_roundtrip_paths_are_absolute(sample: Path, tmp_path: Path) -> Non
 
 
 def test_index_load_rejects_non_index_payload(tmp_path: Path) -> None:
-    """Loading a .db file that is not a valid SQLite database raises."""
-    index_file = tmp_path / "bad_index.db"
+    """Loading a .tags.db file that is not a valid SQLite database raises."""
+    index_file = tmp_path / "bad_index.tags.db"
     index_file.write_text("this is not a sqlite database")
 
     with pytest.raises(sqlite3.DatabaseError, match="file is not a database"):
@@ -1597,7 +1597,7 @@ def test_concurrent_add_tags_does_not_corrupt(tmp_path: Path) -> None:
     bag.mkdir(parents=True)
     frame_paths = [_frame(bag, f"frame{i:08d}") for i in range(8)]
 
-    db_path = tmp_path / "index.db"
+    db_path = tmp_path / "index.tags.db"
 
     # Populate the DB file directly so concurrent workers can use it
     tmp_conn = sqlite3.connect(str(db_path))
@@ -1932,7 +1932,7 @@ def test_append_frames_accumulates_tag_counts(sample: Path, tmp_path: Path) -> N
     from tag_toolkit import TagStore
 
     aomi_route = sample / "proj_a" / "xxxx_site_a" / "auto" / "2026-06-23" / "10-55-13" / "routes"
-    db_path = tmp_path / "index.db"
+    db_path = tmp_path / "index.tags.db"
     store = TagStore.build_index(aomi_route, db_path)
 
     route_path = str(store.route_paths()[0])
@@ -1964,7 +1964,7 @@ def test_append_frames_then_remove_tags_still_works(sample: Path, tmp_path: Path
     from tag_toolkit import TagStore
 
     aomi_route = sample / "proj_a" / "xxxx_site_a" / "auto" / "2026-06-23" / "10-55-13" / "routes"
-    db_path = tmp_path / "index.db"
+    db_path = tmp_path / "index.tags.db"
     store = TagStore.build_index(aomi_route, db_path)
     route_path = str(store.route_paths()[0])
 


### PR DESCRIPTION
## Summary

This PR does two things:

1. **Unify TagStore database suffix to `.tags.db`** — Simplified `_DB_SUFFIXES` from `(".db", ".sqlite", ".tags.db")` to only support `(".tags.db")`, making database file naming more consistent and clear.

2. **Support writing tags to closed-loop test results** — Modified `run_all_groups_closed_loop.py` and `FullRouteClosedLoopEvaluation` to load tags from `TagStore` during evaluation and write them to `segments.jsonl`.

## Changes

- `tag_toolkit/store/_db.py`: Unified suffix to `.tags.db`
- `tag_toolkit/store/_index.py`: Added `from_source()` static method to auto-load or build index from source path
- `diffusion_planner/run_all_groups_closed_loop.py`: Integrated `TagStore`, building a tag store for each input in `resolve_closed_loop_inputs()` and passing it to `run_one_group()`
- `scenario_generation/closed_loop_evaluation.py`: Added `tag_store` parameter to `FullRouteClosedLoopEvaluation` and wrote tags to segment rows

## Example Output

After running a closed test, e.g. `lane_change/segments.jsonl` including tags:

```json
{
  "route": "2623728a-d174-4e57-bdcf-44b4d74a9cc4_0_00000000",
  "segment": [0, 366],
  "n_steps_run": 222,
  "terminated": "goal",
  "route_completion": 0.6383561643835617,
  "mean_gt_deviation_m": 1.0904254485676064,
  "progress_m": 148.76500066925533,
  "object": {...},
  "road_border": {...},
  "red_light_violation": {...},
  "strong_brake": {...},
  "reproducer": {...},
  "tags": [
    "devops_location:odaiba_fune_t_junc",
    "devops_override_label:lane_change",
    "devops_site:odaiba"
  ]
}
```

The `tags` field now contains the route labels (location, override label type, site, etc.) for each segment.