### PR TITLE
feat(eval): closed-loop recovery and signed in-cut route evals

### DIFF
--- a/rlvr/autoresearch/tools/eval_incut_route.py
+++ b/rlvr/autoresearch/tools/eval_incut_route.py
@@ -1,0 +1,266 @@
+"""Signed in-cut eval: does the model cut the inside of bends?
+
+Same rollout driver and scoring as :mod:`eval_recovery_route` -- closed loop,
+perfect tracker, replan every step -- but it additionally records the **signed**
+lateral offset per step and the **signed curvature** of each start window, so a
+directional bias toward the inside of a bend becomes measurable. The recovery
+harness alone cannot see it: it reports ``|ego_lat| / side_hw``, which is
+identical for an in-cut of 0.4 m and an out-swing of 0.4 m. Measuring the
+absolute offset and calling it in-cut invalidated a whole earlier round.
+
+Sign convention (defined and unit-tested in
+:mod:`rlvr.autoresearch.tools.incut_geometry`): ``incut_m > 0`` means the ego sits
+toward the **inside** of the bend, i.e. cutting the corner.
+
+The default ``--offsets 0`` is unperturbed on purpose: the question is the
+model's natural line through a bend, and a typical in-cut is ~0.25 m, so a 1 m
+injected displacement would swamp it. Pair with ``--min_kappa`` to keep only
+curved windows -- ``0.01`` is a <=100 m radius bend, ``0.02`` a <=50 m one.
+Curve starts are a small minority of a mostly-straight route, so check how many
+survive the filter before trusting a per-turn-direction split, and always report
+left and right turns separately: a plain left/right bias would otherwise read as
+in-cut on whichever direction the route happens to favour.
+
+This tool also records the realized world pose per step, so any other metric can
+be recomputed from the output JSON afterwards. An earlier round stored no pose and
+its results could not be re-analysed once the metric turned out to be the wrong
+one.
+
+Usage:
+    python -m rlvr.autoresearch.tools.eval_incut_route \\
+        --models base:/path/base.pth treated:/path/treated.pth \\
+        --npz_root <dir with the recorded route NPZ + sidecars> \\
+        --drop_objects --start_stride 4 --offsets 0 --min_kappa 0.01 \\
+        --out_json out/incut.json
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+
+import planner_metrics.subscores as subscores
+from rlvr.autoresearch.tools.eval_centerline_metrics import lat_offset_and_naive_score
+from rlvr.autoresearch.tools.eval_recovery_route import (
+    _OFFSET,
+    _offset_ego_state,
+    add_common_args,
+    candidate_starts,
+    centerline_inputs,
+    collect_usage,
+    drive_rollout,
+    expand_offsets,
+    in_process_draw_pool,
+    open_routes,
+    route_distance_m,
+    summarize_rollout,
+)
+from rlvr.autoresearch.tools.incut_geometry import (
+    incut_from_signed_lat,
+    signed_curvature_from_poses,
+)
+from scenario_generation import reproducer_rollout
+from scenario_generation.route_timeline import RouteTimeline
+from scenario_generation.simulate import load_model
+
+_CL_SCORES: dict[int, float] = {}
+_ROUTE_DIST: dict[int, float] = {}
+_SIGNED_LAT: dict[int, float] = {}
+_POSES: list[np.ndarray] = []
+
+_ORIG_PRE_STEP = reproducer_rollout._pre_step
+
+
+def _scoring_draw_step(np_dict, pred, ego_shape, path, step=0, **kwargs):
+    """Record the unsigned score (comparable with the recovery eval) AND the signed offset."""
+    data, ego_traj = centerline_inputs(np_dict)
+    shape_t = torch.as_tensor(np.asarray(ego_shape), dtype=torch.float32)
+    score = subscores.compute_centerline_score_batch(ego_traj, shape_t, data, usage_mode="baselink")
+    k = int(step)
+    _CL_SCORES[k] = float(score[0])
+    _ROUTE_DIST[k] = route_distance_m(data)
+
+    # signed offset, in the scorer's own convention (+ = left of the route direction)
+    ego_half_w = float(np.asarray(ego_shape).reshape(-1)[-1]) / 2.0
+    lat = lat_offset_and_naive_score(ego_traj[0], data, ego_half_w, usage_mode="baselink")
+    _SIGNED_LAT[k] = (
+        float("nan")
+        if lat is None
+        else float(np.asarray(lat["signed_lat_offset_m"]).reshape(-1)[0])
+    )
+
+
+def _pre_step_record_pose(s, gpu_transform: bool = False):
+    """Record the realized world pose each step; otherwise the driver is untouched."""
+    pre = _ORIG_PRE_STEP(s, gpu_transform)
+    if pre is None:
+        return None
+    if getattr(s, "live_pose", None) is not None:
+        _POSES.append(np.asarray(s.live_pose, dtype=float).copy())
+    return pre
+
+
+def curve_starts(tl: RouteTimeline, args) -> list[tuple[int, float]]:
+    """``(start, signed curvature)`` for the starts whose window is curved enough.
+
+    ``--min_kappa 0`` keeps straights too, and a straight window has no inside, so its
+    in-cut is NaN rather than a zero that would dilute a curve-only average.
+    """
+    out = []
+    for i in candidate_starts(tl, args):
+        kappa = signed_curvature_from_poses(tl.poses[i : i + args.steps])
+        if abs(kappa) >= args.min_kappa:
+            out.append((i, float(kappa)))
+    return out
+
+
+def incut_block(signed_lat: np.ndarray, route_dist: np.ndarray, kappa: float) -> dict:
+    """In-cut statistics for one rollout, gated on the pose being near the route."""
+    near = route_dist <= 5.0
+    incut = incut_from_signed_lat(signed_lat, kappa)
+    fin = incut[near][np.isfinite(incut[near])] if near.any() else np.array([])
+    tail = incut[-10:][near[-10:]]
+    fin_tail = tail[np.isfinite(tail)]
+    return dict(
+        # + = toward the inside of the bend (cutting the corner)
+        incut_mean_m=float(fin.mean()) if fin.size else None,
+        incut_settle_m=float(fin_tail.mean()) if fin_tail.size else None,
+        incut_max_m=float(fin.max()) if fin.size else None,
+    )
+
+
+def _turn_side(kept: list[dict], sel) -> dict:
+    """In-cut over one turn direction. Always reported per direction: a plain left/right
+    bias would otherwise read as in-cut on whichever direction the route favours."""
+    v = np.array([r["incut_mean_m"] for r in kept if sel(r["kappa"])])
+    if not v.size:
+        return dict(n=0)
+    return dict(n=int(v.size), incut_mean_m=float(v.mean()), frac_incut=float((v > 0).mean()))
+
+
+def _mean_or_none(values: list) -> float | None:
+    arr = np.array([v for v in values if v is not None], dtype=float)
+    return float(arr.mean()) if arr.size else None
+
+
+def summarize_model(label: str, rows: list[dict]) -> dict:
+    """Per-model in-cut summary, stratified by turn direction.
+
+    Lost rollouts are excluded from the in-cut and settle statistics -- an off-route pose has
+    no meaningful lateral offset -- and surface instead as ``lost_rate``.
+    """
+    kept = [r for r in rows if not r["lost"] and r["incut_mean_m"] is not None]
+    inc = np.array([r["incut_mean_m"] for r in kept]) if kept else np.array([np.nan])
+    return dict(
+        label=label,
+        n_rollouts=len(rows),
+        lost_rate=_mean_or_none([r["lost"] for r in rows]),
+        recovered_rate=_mean_or_none([r["recovered"] for r in rows]),
+        settle_mean=_mean_or_none([None if r["lost"] else r["usage_settle"] for r in rows]),
+        # + = the model sits toward the inside of bends on average
+        incut_mean_m=float(inc.mean()),
+        incut_p50_m=float(np.percentile(inc, 50)),
+        incut_p95_m=float(np.percentile(inc, 95)),
+        frac_incut=float(np.mean(inc > 0)),
+        left_turns=_turn_side(kept, lambda k: k > 0),
+        right_turns=_turn_side(kept, lambda k: k < 0),
+        n_scored=len(kept),
+    )
+
+
+def score_rollout(
+    model,
+    model_args,
+    tl: RouteTimeline,
+    st: int,
+    kappa: float,
+    off: float,
+    args,
+    draw_pool,
+    out_dir,
+) -> dict | None:
+    """Drive one rollout and turn its per-step records into a result row (None if too short)."""
+    _OFFSET["v"] = off
+    for buf in (_CL_SCORES, _ROUTE_DIST, _SIGNED_LAT):
+        buf.clear()
+    _POSES.clear()
+    drive_rollout(model, model_args, tl, st, args, draw_pool, out_dir)
+    rec = collect_usage(_CL_SCORES, _ROUTE_DIST)
+    if rec is None:
+        return None
+    usage, rd = rec
+    slat = np.array([_SIGNED_LAT[k] for k in sorted(_SIGNED_LAT)])
+    return dict(
+        start=st,
+        offset=off,
+        kappa=round(kappa, 5),
+        **summarize_rollout(usage, rd),
+        **incut_block(slat, rd, kappa),
+        per_step=[round(float(x), 4) for x in usage],
+        per_step_route_dist=[round(float(x), 2) for x in rd],
+        per_step_signed_lat_m=[round(float(x), 4) for x in slat],
+        per_step_pose=[[round(float(v), 3) for v in p] for p in _POSES],
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    add_common_args(ap, start_stride=4, offsets="0")
+    ap.add_argument(
+        "--min_kappa",
+        type=float,
+        default=0.0,
+        help="keep only starts whose window |signed curvature| >= this (1/m). "
+        "0.02 ~ a 50 m radius bend. 0 keeps everything (straights included).",
+    )
+    args = ap.parse_args()
+
+    reproducer_rollout._pre_step = _pre_step_record_pose
+    reproducer_rollout._ego_state_from_frame = _offset_ego_state
+    reproducer_rollout._draw_step = _scoring_draw_step
+
+    offsets = expand_offsets(args.offsets)
+    routes = open_routes(args.npz_root)
+    out_json = Path(args.out_json)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+
+    results: list[dict] = []
+    draw_pool = in_process_draw_pool()
+    for label_path in args.models:
+        label, model_path = label_path.split(":", 1)
+        model, model_args = load_model(model_path, args.device)
+        for key in sorted(routes):
+            tl = RouteTimeline(routes[key], sidecar_dir=Path(args.npz_root))
+            cand = curve_starts(tl, args)
+            print(
+                f"{label} {key}: {len(cand)} starts x {len(offsets)} offsets "
+                f"(min_kappa={args.min_kappa})",
+                flush=True,
+            )
+            for st, kappa in cand:
+                for off in offsets:
+                    row = score_rollout(
+                        model,
+                        model_args,
+                        tl,
+                        st,
+                        kappa,
+                        off,
+                        args,
+                        draw_pool,
+                        out_json.parent / "noop",
+                    )
+                    if row is not None:
+                        results.append(dict(label=label, route=key, **row))
+        print(
+            json.dumps(summarize_model(label, [r for r in results if r["label"] == label])),
+            flush=True,
+        )
+    draw_pool.shutdown(wait=True)
+    out_json.write_text(json.dumps(results))
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/eval_recovery_route.py
+++ b/rlvr/autoresearch/tools/eval_recovery_route.py
@@ -1,0 +1,357 @@
+"""Perturbed-start closed-loop recovery eval on a recorded route.
+
+The question it answers: **put the ego somewhere it should not be, and does the
+model drive back to the lane centre?** Open-loop validation loss cannot answer it
+-- a recipe change has improved val loss monotonically while its closed-loop
+recovery collapsed -- so this is the headline metric for judging a training-recipe
+A/B (augmentation, LR schedule, loss weights, data mix).
+
+Per (model, start frame, lateral offset): rigidly shift the initial ego pose AND
+its world-frame history sideways -- a pure-lateral perturbation with no kinematic
+cue, so nothing in the state hints that a correction is under way -- then roll
+``--steps`` (default 80 = 8 s) closed loop with the perfect tracker, replanning
+every step, and score every REALIZED pose with the canonical
+``compute_centerline_score_batch(usage_mode="baselink")``.
+
+Reported per model: ``recovered_rate``, ``lost_rate``, and the settle
+distribution. **Both rates are needed.** The centerline scorer's coverage-gap
+branch returns exactly 0 for a pose more than 5 m from any valid route-lane
+centre, so a rollout that wanders off the map scores as PERFECTLY centred; this
+tool records each pose's distance to the route alongside the score so "recovered
+to the centreline" and "left the route" cannot be confused. Reading a
+``settle_mean`` without its ``lost_rate`` has produced two wrong conclusions.
+
+Notes on use:
+
+* Evaluate **EMA weights**, not the raw optimizer iterates (extract
+  ``ema_state_dict`` into a ``{"model": ...}`` checkpoint first).
+* Shard by ``--start_begin`` / ``--start_end`` and run several shards in
+  parallel; each uses well under 1 GB of GPU. Aggregate the shard JSONs, and
+  report only complete rows -- shard-level swings of +/-10 points are routine.
+* ``--drop_objects`` gives the empty-world ablation (no other traffic, map
+  intact), which separates "reacts badly to traffic" from "cannot follow the
+  route".
+
+Implementation: the rollout driver is used unmodified; two module-level hooks in
+``scenario_generation.reproducer_rollout`` are swapped for the duration of the
+run -- ``_ego_state_from_frame`` (inject the offset) and ``_draw_step`` (score
+instead of writing a PNG).
+
+Usage:
+    python -m rlvr.autoresearch.tools.eval_recovery_route \\
+        --models base:/path/base.pth treated:/path/treated.pth \\
+        --npz_root <dir with the recorded route NPZ + sidecars> \\
+        --drop_objects --start_stride 4 --offsets 1.0 \\
+        --out_json out/recovery.json
+"""
+
+import argparse
+import json
+import math
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import numpy as np
+import torch
+
+import planner_metrics.subscores as subscores
+from scenario_generation import reproducer_rollout
+from scenario_generation.closed_loop_eval import enumerate_routes
+from scenario_generation.route_timeline import RouteTimeline
+from scenario_generation.simulate import load_model
+
+# Per-step records of the rollout in flight, keyed by step index so the result is
+# independent of the order the render pool happens to run the hook in.
+_CL_SCORES: dict[int, float] = {}
+_ROUTE_DIST: dict[int, float] = {}
+_OFFSET = {"v": 0.0}
+_ORIG_EGO_STATE = reproducer_rollout._ego_state_from_frame
+
+
+def _offset_ego_state(tl, idx):
+    """Shift the start pose and the whole ego history sideways by ``_OFFSET``."""
+    pose, ego_hist, dyn = _ORIG_EGO_STATE(tl, idx)
+    off = _OFFSET["v"]
+    if off != 0.0:
+        nx, ny = -math.sin(pose[2]), math.cos(pose[2])
+        pose[0] += off * nx
+        pose[1] += off * ny
+        ego_hist[:, 0] += off * nx
+        ego_hist[:, 1] += off * ny
+    return pose, ego_hist, dyn
+
+
+# `render_segment` takes every knob explicitly -- commit 6c490ec0c (2026-08-21) removed
+# its defaults on purpose, so a caller cannot inherit a rollout setting it did not choose.
+# These are the values this eval is defined by; the ones that matter for the measurement are
+# the perfect tracker, recorded neighbour history, replanning every step, and no unsticking
+# (a rollout that fails must be recorded as failing, not teleported back onto the route).
+ROLLOUT_SETTINGS = dict(
+    near_miss_thresh=0.5,
+    search_radius=1.5,
+    warmup_steps=0,
+    unstick_after=0,
+    unstick_advance_m=5.0,
+    unstick_radius_mult=3.0,
+    unstick_teleport_after=300,
+    draw_every=1,  # the scoring hook runs per drawn step, so score every step
+    tracker_mode="perfect",
+    neighbor_history_mode="recorded",
+    yaw_gate=True,
+    strong_brake_mps2=-2.5,
+    abort_deviation_m=0.0,  # never abort early: an off-route rollout is a result
+    abort_after=30,
+    abort_max_snaps=0,
+    goal_mode="segment",
+    title_prefix=None,
+    distance_label_offset_m=1.2,
+    view_half_m=50.0,
+    max_stuck_steps=0,
+    goal_reach_m=5.0,
+    interpolate=True,
+    color_by_uuid=True,
+    window=None,
+    timeline_progress_mode="pose",
+)
+
+
+def in_process_draw_pool() -> ThreadPoolExecutor:
+    """The executor the per-step hook MUST run on: one worker, in this process.
+
+    ``render_segment``'s own default (``draw_pool=None``) builds a **spawn
+    ProcessPoolExecutor** -- right for matplotlib, fatal here. The hook would be
+    pickled by module+qualname, re-imported in a child interpreter, and would
+    append its scores to that child's copy of the records, so the parent would
+    collect nothing and report zero rollouts with no error at all. One in-process
+    worker also keeps the hook in step order.
+    """
+    return ThreadPoolExecutor(max_workers=1)
+
+
+def route_distance_m(data: dict) -> float:
+    """Distance from the ego (at the origin of this frame) to the nearest route point."""
+    lanes = data.get("route_lanes", data.get("lanes"))
+    if lanes is None:
+        return float("inf")
+    if lanes.dim() == 4:
+        lanes = lanes[0]
+    centers = lanes[..., :2].reshape(-1, 2)
+    valid = centers.norm(dim=-1) > 1e-3
+    if not bool(valid.any()):
+        return float("inf")
+    return float(centers[valid].norm(dim=-1).min())
+
+
+def centerline_inputs(np_dict: dict) -> tuple[dict, torch.Tensor]:
+    """The scorer's inputs for the realized pose: map tensors + the ego at the origin."""
+    data = {
+        k: torch.as_tensor(np.asarray(v))
+        for k, v in np_dict.items()
+        if k in ("route_lanes", "lanes")
+    }
+    ego_traj = torch.tensor([[[0.0, 0.0, 1.0, 0.0]]], dtype=torch.float32)
+    return data, ego_traj
+
+
+def _scoring_draw_step(np_dict, pred, ego_shape, path, step=0, **kwargs):
+    """Score the realized pose and record its distance to the route (no PNG)."""
+    data, ego_traj = centerline_inputs(np_dict)
+    score = subscores.compute_centerline_score_batch(
+        ego_traj,
+        torch.as_tensor(np.asarray(ego_shape), dtype=torch.float32),
+        data,
+        usage_mode="baselink",
+    )
+    _CL_SCORES[int(step)] = float(score[0])
+    _ROUTE_DIST[int(step)] = route_distance_m(data)
+
+
+def summarize_rollout(usage: np.ndarray, route_dist: np.ndarray) -> dict:
+    """Turn one rollout's per-step records into its verdict.
+
+    ``near`` gates every usage statistic on the pose actually being within the
+    scorer's 5 m coverage radius, so an off-route rollout cannot borrow the
+    coverage-gap zero and read as perfectly centred.
+    """
+    near = route_dist <= 5.0
+    settle_near = usage[-10:][near[-10:]]
+    off_frac = float((~near).mean())
+    lost = bool(off_frac > 0.5 or not near[-10:].any())
+    return dict(
+        n_steps=len(usage),
+        usage_t0=float(usage[0]),
+        usage_mean=float(usage[near].mean()) if near.any() else None,
+        usage_settle=float(settle_near.mean()) if settle_near.size else None,
+        usage_max=float(usage[near].max()) if near.any() else None,
+        frac_off_route=off_frac,
+        lost=lost,
+        # recovered = ended the rollout back on the route and inside half a lane
+        # half-width of its centre
+        recovered=bool((not lost) and settle_near.size and settle_near.mean() <= 0.5),
+    )
+
+
+def expand_offsets(spec: str) -> list[float]:
+    """``"1.0,0.5"`` -> ``[1.0, -1.0, 0.5, -0.5]``; 0 stays a single unperturbed run."""
+    offsets: list[float] = []
+    for tok in spec.split(","):
+        v = float(tok)
+        for cand in (0.0,) if v == 0.0 else (v, -v):
+            if cand not in offsets:
+                offsets.append(cand)
+    return offsets
+
+
+def summarize_model(label: str, rows: list[dict]) -> dict:
+    """Per-model summary. Lost rollouts are excluded from the settle statistics --
+    their score is the coverage-gap zero, not a recovery -- and reported separately
+    as ``lost_rate``, so a model can only look good on settle by staying near the
+    route."""
+    kept = [r for r in rows if not r["lost"] and r["usage_settle"] is not None]
+    settle = np.array([r["usage_settle"] for r in kept]) if kept else np.array([np.nan])
+    return dict(
+        label=label,
+        n_rollouts=len(rows),
+        lost_rate=float(np.mean([r["lost"] for r in rows])) if rows else None,
+        recovered_rate=float(np.mean([r["recovered"] for r in rows])) if rows else None,
+        settle_mean=float(settle.mean()),
+        settle_p50=float(np.percentile(settle, 50)),
+        settle_p95=float(np.percentile(settle, 95)),
+        n_scored=len(kept),
+    )
+
+
+def add_common_args(ap: argparse.ArgumentParser, *, start_stride: int, offsets: str) -> None:
+    """The arguments both route evals share. Only the two defaults differ between them."""
+    ap.add_argument("--models", nargs="+", required=True, help="label:model.pth (args.json beside)")
+    ap.add_argument("--npz_root", required=True, help="recorded route NPZ dir (with sidecars)")
+    ap.add_argument("--start_stride", type=int, default=start_stride, help="a start every N frames")
+    ap.add_argument("--min_speed", type=float, default=4.0, help="skip starts slower than this m/s")
+    ap.add_argument(
+        "--offsets",
+        default=offsets,
+        help="lateral offsets in metres; each non-zero value is expanded to +v and -v",
+    )
+    ap.add_argument("--steps", type=int, default=80, help="rollout length (0.1 s per step)")
+    ap.add_argument("--start_begin", type=int, default=0, help="starts >= this frame (shards work)")
+    ap.add_argument(
+        "--start_end", type=int, default=10**9, help="starts < this frame (shards work)"
+    )
+    ap.add_argument(
+        "--drop_objects",
+        action="store_true",
+        help="empty-world ablation: no other traffic every step, map unchanged",
+    )
+    ap.add_argument("--replan_interval", type=int, default=1)
+    ap.add_argument("--device", default="cuda")
+    ap.add_argument("--out_json", required=True)
+
+
+def open_routes(npz_root: str) -> dict:
+    """Routes under ``npz_root``, or a loud failure -- an empty eval must not look like a pass."""
+    routes = enumerate_routes(Path(npz_root))
+    if not routes:
+        raise SystemExit(f"no routes found under {npz_root}")
+    return routes
+
+
+def candidate_starts(tl: RouteTimeline, args) -> list[int]:
+    """Frames this shard tests: fast enough to be a driving scene, far enough from either end."""
+    lo = max(50, args.start_begin)
+    hi = min(len(tl) - args.steps - 5, args.start_end)
+    return [i for i in range(lo, hi, args.start_stride) if float(tl.speeds[i]) >= args.min_speed]
+
+
+def drive_rollout(
+    model, model_args, tl: RouteTimeline, start: int, args, draw_pool, out_dir
+) -> None:
+    """One closed-loop rollout; the per-step hook fills the module's records."""
+    reproducer_rollout.render_segment(
+        model,
+        model_args,
+        tl,
+        start,
+        start + args.steps,
+        out_dir,
+        device=args.device,
+        replan_interval=args.replan_interval,
+        max_steps=args.steps,
+        drop_objects=args.drop_objects,
+        draw_pool=draw_pool,
+        **ROLLOUT_SETTINGS,
+    )
+
+
+def collect_usage(scores: dict[int, float], dists: dict[int, float]) -> tuple | None:
+    """Per-step records in step order as ``(usage, route_dist)``, or None for a too-short rollout.
+
+    Usage is LINEAR: the raw centerline score is a squared penalty. An empty record means the
+    hook never ran in this process, which is a bug, not a short rollout -- so it raises.
+    """
+    steps = sorted(scores)
+    if not steps:
+        raise RuntimeError(
+            "the scoring hook recorded nothing for a completed rollout -- it did not run in "
+            "this process (see in_process_draw_pool)"
+        )
+    if len(steps) < 10:
+        return None
+    usage = np.sqrt(np.abs(np.array([scores[k] for k in steps])))
+    return usage, np.array([dists[k] for k in steps])
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    add_common_args(ap, start_stride=300, offsets="0.5,0.75,1.0")
+    args = ap.parse_args()
+
+    reproducer_rollout._ego_state_from_frame = _offset_ego_state
+    reproducer_rollout._draw_step = _scoring_draw_step
+
+    offsets = expand_offsets(args.offsets)
+    routes = open_routes(args.npz_root)
+    out_json = Path(args.out_json)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+
+    results: list[dict] = []
+    draw_pool = in_process_draw_pool()
+    for label_path in args.models:
+        label, model_path = label_path.split(":", 1)
+        model, model_args = load_model(model_path, args.device)
+        for key in sorted(routes):
+            tl = RouteTimeline(routes[key], sidecar_dir=Path(args.npz_root))
+            starts = candidate_starts(tl, args)
+            print(f"{label} {key}: {len(starts)} starts x {len(offsets)} offsets", flush=True)
+            for st in starts:
+                for off in offsets:
+                    _OFFSET["v"] = off
+                    _CL_SCORES.clear()
+                    _ROUTE_DIST.clear()
+                    drive_rollout(
+                        model, model_args, tl, st, args, draw_pool, out_json.parent / "noop"
+                    )
+                    rec = collect_usage(_CL_SCORES, _ROUTE_DIST)
+                    if rec is None:
+                        continue
+                    usage, rd = rec
+                    results.append(
+                        dict(
+                            label=label,
+                            route=key,
+                            start=st,
+                            offset=off,
+                            **summarize_rollout(usage, rd),
+                            per_step=[round(float(x), 4) for x in usage],
+                            per_step_route_dist=[round(float(x), 2) for x in rd],
+                        )
+                    )
+        print(
+            json.dumps(summarize_model(label, [r for r in results if r["label"] == label])),
+            flush=True,
+        )
+    draw_pool.shutdown(wait=True)
+    out_json.write_text(json.dumps(results))
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/incut_geometry.py
+++ b/rlvr/autoresearch/tools/incut_geometry.py
@@ -1,0 +1,52 @@
+"""Signed in-cut geometry: is the ego biased toward the INSIDE of a bend?
+
+The recovery harness reports an UNSIGNED lane usage (the scorer computes signed
+``ego_lat`` then returns ``ego_lat.abs() / side_hw``, and the harness then takes
+``sqrt(abs(...))``). An in-cut of 0.4 m and an out-swing of 0.4 m are therefore the
+same number, so a directional question -- does this recipe bias the planner toward
+the inside of a bend -- is invisible to it.
+
+Convention, stated once and unit-tested below:
+
+  signed_lat_m  : + = ego is LEFT of the route direction   (from
+                  ``lat_offset_and_naive_score``, the scorer's own convention)
+  kappa         : + = route turns LEFT (counter-clockwise, yaw increasing)
+  incut_m       = sign(kappa) * signed_lat_m
+                  + = ego is toward the INSIDE of the bend  (cutting the corner)
+                  - = ego is toward the OUTSIDE (swinging wide)
+
+On a left-hand bend the inside of the curve is to the left, so an ego that cuts
+the corner is left of the centreline: same sign as kappa, not opposite.
+"""
+
+import numpy as np
+
+
+def signed_curvature_from_poses(poses: np.ndarray) -> float:
+    """Mean signed curvature (1/m) over a window of (x, y, yaw) poses.
+
+    + = left turn. Uses unwrapped yaw over travelled arc length, which is robust
+    to the pose sampling rate; returns 0.0 for a window with no travel.
+    """
+    poses = np.asarray(poses, dtype=float)
+    if poses.shape[0] < 3:
+        return 0.0
+    seg = np.linalg.norm(np.diff(poses[:, :2], axis=0), axis=1)
+    arc = float(seg.sum())
+    if arc < 1e-3:
+        return 0.0
+    yaw = np.unwrap(poses[:, 2])
+    return float((yaw[-1] - yaw[0]) / arc)
+
+
+def incut_from_signed_lat(signed_lat_m: np.ndarray, kappa: float) -> np.ndarray:
+    """Project signed lateral offset onto the inside of the bend.
+
+    Returns metres, + = toward the inside. A straight window (kappa == 0) has no
+    inside, so it returns all-NaN rather than silently reporting zeros that would
+    dilute a curve-only average.
+    """
+    signed_lat_m = np.asarray(signed_lat_m, dtype=float)
+    if kappa == 0.0:
+        return np.full_like(signed_lat_m, np.nan)
+    return np.sign(kappa) * signed_lat_m

--- a/rlvr/test_incut_geometry.py
+++ b/rlvr/test_incut_geometry.py
@@ -1,0 +1,48 @@
+"""Sign-convention tests for the in-cut geometry helpers."""
+
+import numpy as np
+
+from rlvr.autoresearch.tools.incut_geometry import (
+    incut_from_signed_lat,
+    signed_curvature_from_poses,
+)
+
+R = 20.0
+_TH = np.linspace(0.0, np.pi / 2, 50)
+LEFT_ARC = np.stack([R * np.sin(_TH), R * (1 - np.cos(_TH)), _TH], axis=1)
+RIGHT_ARC = np.stack([R * np.sin(_TH), -R * (1 - np.cos(_TH)), -_TH], axis=1)
+
+
+def test_left_turn_has_positive_curvature_of_one_over_radius():
+    kappa = signed_curvature_from_poses(LEFT_ARC)
+    assert kappa > 0.0
+    assert abs(kappa - 1.0 / R) < 0.02
+
+
+def test_right_turn_has_negative_curvature():
+    assert signed_curvature_from_poses(RIGHT_ARC) < 0.0
+
+
+def test_straight_window_has_zero_curvature():
+    straight = np.stack([np.linspace(0, 50, 50), np.zeros(50), np.zeros(50)], axis=1)
+    assert abs(signed_curvature_from_poses(straight)) < 1e-6
+
+
+def test_degenerate_windows_return_zero_rather_than_raising():
+    assert signed_curvature_from_poses(np.zeros((5, 3))) == 0.0
+    assert signed_curvature_from_poses(np.zeros((1, 3))) == 0.0
+
+
+def test_offset_toward_the_bend_reads_as_incut_on_both_turn_directions():
+    k_left = signed_curvature_from_poses(LEFT_ARC)
+    k_right = signed_curvature_from_poses(RIGHT_ARC)
+    # 0.4 m LEFT of the centreline on a LEFT bend == cutting the corner
+    assert incut_from_signed_lat(np.array([0.4]), k_left)[0] > 0.0
+    # the same offset on a RIGHT bend == swinging wide
+    assert incut_from_signed_lat(np.array([0.4]), k_right)[0] < 0.0
+    # 0.4 m RIGHT on a RIGHT bend == cutting
+    assert incut_from_signed_lat(np.array([-0.4]), k_right)[0] > 0.0
+
+
+def test_straight_window_has_no_inside():
+    assert np.isnan(incut_from_signed_lat(np.array([0.4]), 0.0)[0])


### PR DESCRIPTION
# What

Adds the two closed-loop evals our training-recipe A/Bs are decided by, as repo tools:

| | |
|---|---|
| `rlvr/autoresearch/tools/eval_recovery_route.py` | **perturbed-start recovery** — the headline metric |
| `rlvr/autoresearch/tools/eval_incut_route.py` | **signed in-cut** on curved windows |
| `rlvr/autoresearch/tools/incut_geometry.py` + `rlvr/test_incut_geometry.py` | the sign convention, unit-tested |

Nothing existing changes: four new files, no edits to any current module.

# Why

The last three augmentation rounds were decided by these two scripts, and they lived in campaign scratch directories. A reviewer could not read the code behind a number, and a colleague could not reproduce a verdict from a checkout — the write-ups cite an invocation of a file that is not in the repository.

They also **no longer ran**, for two separate reasons that are worth reading, because both fail quietly:

1. `render_segment`'s parameter defaults were removed in `6c490ec0c` (2026-08-21) — deliberately, so a caller cannot inherit a rollout setting it did not choose. The old call raised `TypeError: missing 22 required positional arguments`.
2. `render_segment`'s default draw pool is a **spawn `ProcessPoolExecutor`** (correct for matplotlib). The per-step scoring hook is a monkeypatched module function, so it was pickled by module+qualname, re-imported in a child interpreter, and filled **that child's** copy of the records. The parent collected nothing and reported **zero rollouts, exit code 0, no error**. A campaign that had not noticed would have concluded "no data" or, worse, quietly compared two empty sets.

Both are now handled explicitly rather than by luck: one `ROLLOUT_SETTINGS` dict passes every knob and documents the values the measurement is defined by, and `in_process_draw_pool()` supplies a one-worker in-process executor. A completed rollout that scored no steps now **raises** instead of being skipped.

# What they measure

**Recovery** — put the ego somewhere it should not be and see whether the model drives back. Per (model, start, offset): rigidly shift the ego pose *and its history* sideways — a pure-lateral perturbation with no kinematic cue, so nothing in the state hints a correction is under way — then 80 steps closed loop, perfect tracker, replanning every step, scoring every realized pose with `compute_centerline_score_batch(usage_mode="baselink")`.

**In-cut** — the recovery score reports `|ego_lat| / side_hw`, which is *the same number* for a 0.4 m in-cut and a 0.4 m out-swing, so it cannot answer "does this recipe cut the inside of bends". This tool records the signed lateral offset and the signed curvature of each start window and projects one onto the other; `incut_m > 0` means toward the inside. It also stores the realized world pose per step, so another metric can be recomputed from the JSON afterwards — an earlier round stored no pose and its results could not be re-analysed when the metric turned out to be the wrong one.

**`lost%` is reported beside `recovered%` in both, and that is not decoration.** The centerline scorer's coverage-gap branch returns exactly 0 for a pose more than 5 m from any valid route lane, so a rollout that leaves the map scores as *perfectly centred*. Both tools record each pose's distance to the route and gate every usage statistic on it. Reading a settle number without its `lost%` has produced two wrong conclusions.

# Verification

Both tools were run against the campaign scripts on identical shards with the same checkpoint, and diffed field by field:

| | rows | worst delta |
|---|---|---|
| recovery (start 224–232, ±1.0 m, `--drop_objects`) | 6 rollouts | **0** |
| in-cut (start 1206–1222, unperturbed, `--min_kappa 0.01`) | 5 curve rollouts | **0** |

Zero across `recovered`/`lost`, every summary statistic, and every per-step array — usage, route distance, signed lateral offset, and the realized poses. Re-checked **after** the complexity refactor, still zero, so the refactor is behaviour-preserving and the published campaign numbers remain quotable against this code.

`rlvr/test_incut_geometry.py`: 6 tests pinning the sign convention on synthetic left/right arcs — that a left bend gives `kappa ≈ +1/R`, that an offset toward the bend reads as in-cut on *both* turn directions, that a straight window has no inside (NaN, not a zero that would dilute a curve-only average), and that degenerate windows return 0 rather than raising. `pre-commit` (ruff + ruff-format) clean.

# Complexity

| | before (scratch) | after |
|---|---|---|
| `eval_incut_route.main` | **D (26)** | B (8) |
| `eval_recovery_route.main` | C (16) | B (10) |
| worst block in the PR | — | **B (10)** |
| file average | B (5.5) | **A (4.5)** |

The two mains were pulled apart into shared helpers the in-cut tool imports rather than copies: `add_common_args`, `open_routes`, `candidate_starts`, `drive_rollout`, `collect_usage`, `summarize_rollout`. In-cut adds only what is specific to it (`curve_starts`, `incut_block`, `score_rollout`).

# Usage

```
python -m rlvr.autoresearch.tools.eval_recovery_route \
    --models incumbent:<a.pth> treated:<b.pth> --npz_root <route NPZ dir> \
    --drop_objects --start_stride 4 --offsets 1.0 --out_json out/recovery.json

python -m rlvr.autoresearch.tools.eval_incut_route \
    --models incumbent:<a.pth> treated:<b.pth> --npz_root <route NPZ dir> \
    --drop_objects --start_stride 4 --offsets 0 --min_kappa 0.01 --out_json out/incut.json
```

Shard with `--start_begin` / `--start_end` and run several in parallel — each uses well under 1 GB of GPU. Evaluate EMA weights, never the raw iterates. Report only complete rows: shard-level swings of ±10 points are routine.
