### PR TITLE
chore: apply the formatting the pinned hooks expect

### DIFF
--- a/diffusion_planner/diffusion_planner/config/closed_loop_config.py
+++ b/diffusion_planner/diffusion_planner/config/closed_loop_config.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field, asdict
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -20,16 +20,22 @@ class ClosedLoopPassCondition:
     road_border: bool = True  # road_border.collision_count == 0
     red_light_violation: bool = True  # red_light_violation.count == 0
     strong_brake: bool = True  # strong_brake.count == 0
-    goal_reach: bool = True 
-    snap: bool = True 
-
+    goal_reach: bool = True
+    snap: bool = True
 
     def to_dict(self) -> dict[str, bool]:
         return asdict(self)
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "ClosedLoopPassCondition":
-        valid_fields = {"collision", "road_border", "red_light_violation", "strong_brake", "goal_reach", "snap"}
+        valid_fields = {
+            "collision",
+            "road_border",
+            "red_light_violation",
+            "strong_brake",
+            "goal_reach",
+            "snap",
+        }
         filtered = {k: v for k, v in d.items() if k in valid_fields}
         return cls(**filtered)
 
@@ -206,7 +212,9 @@ class ClosedLoopConfig:
         default="",
         path=True,
     )
-    _closed_loop_pass_conditions_loaded: ClosedLoopPassConditionGroups | None = field(default=None, repr=False)
+    _closed_loop_pass_conditions_loaded: ClosedLoopPassConditionGroups | None = field(
+        default=None, repr=False
+    )
 
     def __post_init__(self) -> None:
         """Auto-load ``closed_loop_pass_conditions`` (a YAML path) into the object form.

--- a/diffusion_planner/diffusion_planner/config/config_utils.py
+++ b/diffusion_planner/diffusion_planner/config/config_utils.py
@@ -1,7 +1,7 @@
-from dataclasses import fields
-from typing import Any
 import json
+from dataclasses import fields
 from pathlib import Path
+from typing import Any
 
 
 def save_config(cfg: Any, out_root: str | Path, filename: str) -> None:

--- a/diffusion_planner/run_all_groups_closed_loop.py
+++ b/diffusion_planner/run_all_groups_closed_loop.py
@@ -24,11 +24,11 @@ from diffusion_planner.config.closed_loop_config import (
 from diffusion_planner.config.config_cli import build_config, build_parser, resolve_paths
 from diffusion_planner.config.config_utils import save_config
 from diffusion_planner.utils import ddp
-from tag_toolkit.store import TagStore
 
 from scenario_generation.wandb_closed_loop import (
     log_closed_loop_to_wandb,
 )
+from tag_toolkit.store import TagStore
 
 
 def resolve_closed_loop_inputs(
@@ -91,7 +91,14 @@ def resolve_closed_loop_inputs(
             print(f"Warning: {input_path} has unsupported extension, skipping", file=sys.stderr)
             continue
 
-        entries.append({"name": p.stem if p.suffix else p.name, "groups": groups, "mode": mode, "tag_store": tag_store})
+        entries.append(
+            {
+                "name": p.stem if p.suffix else p.name,
+                "groups": groups,
+                "mode": mode,
+                "tag_store": tag_store,
+            }
+        )
 
     return entries
 

--- a/ros_scripts/parse_rosbag_for_directory.py
+++ b/ros_scripts/parse_rosbag_for_directory.py
@@ -113,9 +113,7 @@ def process_single_bag(args_tuple):
     save_dir = (save_root / proj_id / map_id / mode / date / time).resolve()
 
     has_npz = save_dir.is_dir() and any(save_dir.rglob("*.npz"))
-    has_override_json = mode != "auto" or (
-        save_dir / "control_mode_4_intervals.json"
-    ).is_file()
+    has_override_json = mode != "auto" or (save_dir / "control_mode_4_intervals.json").is_file()
     if has_npz and has_override_json:
         logging.info(f"Already exists: {save_dir}")
         return {

--- a/ros_scripts/parse_rosbag_for_directory_with_map_version.py
+++ b/ros_scripts/parse_rosbag_for_directory_with_map_version.py
@@ -141,9 +141,7 @@ def process_single_bag(args_tuple):
     save_dir = (save_root / project_name / map_name / mode / date / time).resolve()
 
     has_npz = save_dir.is_dir() and any(save_dir.rglob("*.npz"))
-    has_override_json = mode != "auto" or (
-        save_dir / "control_mode_4_intervals.json"
-    ).is_file()
+    has_override_json = mode != "auto" or (save_dir / "control_mode_4_intervals.json").is_file()
     if has_npz and has_override_json:
         logging.info(f"Already exists: {save_dir}")
         return {

--- a/scenario_generation/closed_loop_eval.py
+++ b/scenario_generation/closed_loop_eval.py
@@ -20,8 +20,8 @@ import time
 from pathlib import Path
 
 import numpy as np
-
 from diffusion_planner.config.closed_loop_config import ClosedLoopPassCondition
+
 from scenario_generation.metrics.tdigest import TDIGEST_KEY, is_tdigest_key, merged_percentile
 from scenario_generation.perf_timer import Timers
 from scenario_generation.render_pool import render_pool

--- a/scenario_generation/closed_loop_evaluation.py
+++ b/scenario_generation/closed_loop_evaluation.py
@@ -22,21 +22,21 @@ from typing import Any
 
 from scenario_generation.closed_loop_ddp import shard_items
 from scenario_generation.closed_loop_eval import (
-    evaluate_segment_pass,
     aggregate,
     build_mp4,
     enumerate_multi_root_routes,
+    evaluate_segment_pass,
     format_summary_lines,
     load_segment_rows_with_tdigests,
     segment_row_for_json,
     tdigest_sidecar_row,
 )
-from tag_toolkit import TagStore
 from scenario_generation.inference_compile import compiled_for_inference
 from scenario_generation.perf_timer import Timers
 from scenario_generation.render_pool import render_pool
 from scenario_generation.reproducer_rollout import render_segment
 from scenario_generation.route_timeline import RouteTimeline
+from tag_toolkit import TagStore
 
 
 @dataclass

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -689,7 +689,9 @@ def _wrap_pi(a):
     return (a + np.pi) % (2.0 * np.pi) - np.pi
 
 
-def _gt_deviation_m(tl: RouteTimeline, live_xy: np.ndarray, live_yaw: float, cursor_idx: int) -> float:
+def _gt_deviation_m(
+    tl: RouteTimeline, live_xy: np.ndarray, live_yaw: float, cursor_idx: int
+) -> float:
     """Min yaw-gated point-to-polyline distance from ``live_xy`` to a ±15 s window of
     recorded poses centered on ``cursor_idx``.
 
@@ -1948,7 +1950,7 @@ def run_segments_batched(
                     replay_mode=timeline_progress_mode,
                     strong_brake_mps2=strong_brake_mps2,
                     yaw_gate=yaw_gate,
-                    goal_mode=goal_mode
+                    goal_mode=goal_mode,
                 )
                 for (tl, start, end) in chunk
             ]

--- a/scenario_generation/scenario_sim_viewer_export.py
+++ b/scenario_generation/scenario_sim_viewer_export.py
@@ -252,17 +252,28 @@ def classify_failure(row: dict[str, Any], verdict: dict[str, Any] | None = None)
     trigger = (verdict.get("trigger") or "") if verdict else ""
     trigger_lower = trigger.lower()
 
-    if (vmax is not None and vmax < 0.5) or "standstill" in trigger_lower or "stand_still" in trigger_lower:
+    if (
+        (vmax is not None and vmax < 0.5)
+        or "standstill" in trigger_lower
+        or "stand_still" in trigger_lower
+    ):
         return "FROZEN_STANDSTILL"
 
-    if any(k in trigger_lower for k in ("lateral_check", "longitudinal_check", "relativedistance", "obstacle_distance")):
+    if any(
+        k in trigger_lower
+        for k in ("lateral_check", "longitudinal_check", "relativedistance", "obstacle_distance")
+    ):
         return "PROXIMITY_DEPARTURE"
 
     unmet = verdict.get("unmet", []) if verdict else []
     if "goal_position" in unmet:
         return "GOAL_STOP_FAILURE"
 
-    if term in ("max_steps", "sim_terminated") or "simulationtime" in trigger_lower or "timeout" in trigger_lower:
+    if (
+        term in ("max_steps", "sim_terminated")
+        or "simulationtime" in trigger_lower
+        or "timeout" in trigger_lower
+    ):
         return "SPEED_TIMEOUT"
 
     if unmet or trigger:
@@ -514,8 +525,7 @@ def write_viewer_tree(
         }
 
     meta["verdicts"] = {
-        key: sum(e["verdicts"][key] for e in scenarios.values())
-        for key in _TALLY_KEYS
+        key: sum(e["verdicts"][key] for e in scenarios.values()) for key in _TALLY_KEYS
     }
 
     tree.cases.write_text("\n".join(case_lines) + "\n", encoding="utf-8")

--- a/scenario_generation/tests/test_wandb_scenario_sim.py
+++ b/scenario_generation/tests/test_wandb_scenario_sim.py
@@ -46,8 +46,8 @@ def test_bucket_selection():
     """Distinct failure modes get their own bucket; a count-defined bucket ranks by that count;
     an unmeasured clearance is not evidence of danger; braking hard is not a failure."""
     rows = [
-        _case("err", terminated="worker_failed"),                    # never ran
-        _case("frozen", max_speed_mps=0.1, progress=3.0),            # ran and stopped dead
+        _case("err", terminated="worker_failed"),  # never ran
+        _case("frozen", max_speed_mps=0.1, progress=3.0),  # ran and stopped dead
         _case("collision", collisions=1, clearance=0.0, progress=20.0),
         _case("unmeasured", collisions=1, clearance=None, progress=1.0),
         _case("rb_few", borders=1, clearance=0.5),
@@ -98,8 +98,12 @@ def test_build_scenario_sim_wandb_payload(tmp_path):
 
     rows = [
         _case(
-            "ego_speed2p7778", collisions=1, clearance=0.0, progress=10.0,
-            case_key="uuid123_route0", scenario="uuid123",
+            "ego_speed2p7778",
+            collisions=1,
+            clearance=0.0,
+            progress=10.0,
+            case_key="uuid123_route0",
+            scenario="uuid123",
         )
     ]
 

--- a/scenario_generation/wandb_scenario_sim.py
+++ b/scenario_generation/wandb_scenario_sim.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, NamedTuple
 
 import wandb
+
 from scenario_generation.scenario_sim_viewer_export import (
     FAILURE_CATEGORIES,
     ViewerTree,
@@ -136,18 +137,42 @@ def _mean(values: list[float]) -> float:
 _METRICS: tuple[tuple[str, str, str | None, Any], ...] = (
     ("total_cases", "Cases", None, len),
     ("passed_cases", "Passed", None, lambda vs: sum(1 for v in vs if v.is_pass)),
-    ("pass_rate", "Pass rate", "{:.2f}%",
-     lambda vs: _ratio(sum(1 for v in vs if v.is_pass), len(vs))),
-    ("collision_cases", "Cases with an object collision", None,
-     lambda vs: sum(1 for v in vs if v.obj_cols > 0)),
-    ("road_border_cases", "Cases touching a road border", None,
-     lambda vs: sum(1 for v in vs if v.rb_cols > 0)),
-    ("strong_brake_cases", "Cases braking hard", None,
-     lambda vs: sum(1 for v in vs if v.sb_count > 0)),
-    ("mean_case_min_clearance_m", "Mean of per-case min clearance (m)", "{:.2f}",
-     lambda vs: _mean([v.clearance for v in vs if v.clearance is not None and v.clearance >= 0])),
-    ("mean_progress_m", "Mean progress (m)", None,
-     lambda vs: _mean([v.progress for v in vs if v.progress is not None])),
+    (
+        "pass_rate",
+        "Pass rate",
+        "{:.2f}%",
+        lambda vs: _ratio(sum(1 for v in vs if v.is_pass), len(vs)),
+    ),
+    (
+        "collision_cases",
+        "Cases with an object collision",
+        None,
+        lambda vs: sum(1 for v in vs if v.obj_cols > 0),
+    ),
+    (
+        "road_border_cases",
+        "Cases touching a road border",
+        None,
+        lambda vs: sum(1 for v in vs if v.rb_cols > 0),
+    ),
+    (
+        "strong_brake_cases",
+        "Cases braking hard",
+        None,
+        lambda vs: sum(1 for v in vs if v.sb_count > 0),
+    ),
+    (
+        "mean_case_min_clearance_m",
+        "Mean of per-case min clearance (m)",
+        "{:.2f}",
+        lambda vs: _mean([v.clearance for v in vs if v.clearance is not None and v.clearance >= 0]),
+    ),
+    (
+        "mean_progress_m",
+        "Mean progress (m)",
+        None,
+        lambda vs: _mean([v.progress for v in vs if v.progress is not None]),
+    ),
 )
 
 
@@ -220,16 +245,18 @@ def build_scenario_sim_wandb_payload(
 
     table_rows = []
     for v in map(_view, rows):
-        table_rows.append([
-            _case_name(v.row),
-            v.row["result_kind"],
-            v.category,
-            v.obj_cols > 0,
-            v.rb_cols > 0,
-            v.sb_count > 0,
-            f"{v.clearance:.2f}" if v.clearance is not None else "-",
-            f"{v.progress:.1f}" if v.progress is not None else "-",
-        ])
+        table_rows.append(
+            [
+                _case_name(v.row),
+                v.row["result_kind"],
+                v.category,
+                v.obj_cols > 0,
+                v.rb_cols > 0,
+                v.sb_count > 0,
+                f"{v.clearance:.2f}" if v.clearance is not None else "-",
+                f"{v.progress:.1f}" if v.progress is not None else "-",
+            ]
+        )
 
     payload[f"{prefix}/cases_table"] = wandb.Table(columns=_TABLE_COLUMNS, data=table_rows)
     return payload

--- a/tag_toolkit/store/_index.py
+++ b/tag_toolkit/store/_index.py
@@ -23,7 +23,9 @@ class _IndexMixin:
     """Mixin providing index management methods for TagStore."""
 
     @staticmethod
-    def from_source(source: str | Path, *, save: bool = False, force_rebuild: bool = False) -> "TagStore":
+    def from_source(
+        source: str | Path, *, save: bool = False, force_rebuild: bool = False
+    ) -> "TagStore":
         """Load a TagStore for *source*, auto-building the index from sidecars.
 
         By default this is read-only and in-memory: it tries to open a same-named


### PR DESCRIPTION
## Problem

`pre-commit run --all-files` fails on `tier4-main`. `ruff` and `ruff format` rewrite ten files:

```
ruff (legacy alias)......................................................Failed
ruff format..............................................................Failed
```

The `pre-commit` workflow runs exactly that command on every pull request, so any PR opened
against this branch is red before its own changes are considered. That makes the signal useless:
a real formatting problem in a new change is indistinguishable from the existing failure.

## Change

The diff is the hooks' own output and nothing else — import ordering, trailing whitespace, and
line wrapping — across:

- `diffusion_planner/diffusion_planner/config/{closed_loop_config,config_utils}.py`
- `ros_scripts/parse_rosbag_for_directory{,_with_map_version}.py`
- `scenario_generation/{closed_loop_eval,closed_loop_evaluation,reproducer_rollout}.py`
- `scenario_generation/{scenario_sim_viewer_export,wandb_scenario_sim}.py`
- `scenario_generation/tests/test_wandb_scenario_sim.py`

After it, every hook passes:

```
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
uv-lock..................................................................Passed
...
```

## Verification

No behaviour change: the set of failing tests under `scenario_generation/tests/` and
`diffusion_planner/tests/` is identical before and after.
