### PR TITLE
feat(eval): per-scene clip tooling, plus review fixes for the recovery evals

### DIFF
--- a/rlvr/autoresearch/tools/eval_incut_route.py
+++ b/rlvr/autoresearch/tools/eval_incut_route.py
@@ -1,0 +1,266 @@
+"""Signed in-cut eval: does the model cut the inside of bends?
+
+Same rollout driver and scoring as :mod:`eval_recovery_route` -- closed loop,
+perfect tracker, replan every step -- but it additionally records the **signed**
+lateral offset per step and the **signed curvature** of each start window, so a
+directional bias toward the inside of a bend becomes measurable. The recovery
+harness alone cannot see it: it reports ``|ego_lat| / side_hw``, which is
+identical for an in-cut of 0.4 m and an out-swing of 0.4 m. Measuring the
+absolute offset and calling it in-cut invalidated a whole earlier round.
+
+Sign convention (defined and unit-tested in
+:mod:`rlvr.autoresearch.tools.incut_geometry`): ``incut_m > 0`` means the ego sits
+toward the **inside** of the bend, i.e. cutting the corner.
+
+The default ``--offsets 0`` is unperturbed on purpose: the question is the
+model's natural line through a bend, and a typical in-cut is ~0.25 m, so a 1 m
+injected displacement would swamp it. Pair with ``--min_kappa`` to keep only
+curved windows -- ``0.01`` is a <=100 m radius bend, ``0.02`` a <=50 m one.
+Curve starts are a small minority of a mostly-straight route, so check how many
+survive the filter before trusting a per-turn-direction split, and always report
+left and right turns separately: a plain left/right bias would otherwise read as
+in-cut on whichever direction the route happens to favour.
+
+This tool also records the realized world pose per step, so any other metric can
+be recomputed from the output JSON afterwards. An earlier round stored no pose and
+its results could not be re-analysed once the metric turned out to be the wrong
+one.
+
+Usage:
+    python -m rlvr.autoresearch.tools.eval_incut_route \\
+        --models base:/path/base.pth treated:/path/treated.pth \\
+        --npz_root <dir with the recorded route NPZ + sidecars> \\
+        --drop_objects --start_stride 4 --offsets 0 --min_kappa 0.01 \\
+        --out_json out/incut.json
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+
+import planner_metrics.subscores as subscores
+from rlvr.autoresearch.tools.eval_centerline_metrics import lat_offset_and_naive_score
+from rlvr.autoresearch.tools.eval_recovery_route import (
+    _OFFSET,
+    _offset_ego_state,
+    add_common_args,
+    candidate_starts,
+    centerline_inputs,
+    collect_usage,
+    drive_rollout,
+    expand_offsets,
+    in_process_draw_pool,
+    open_routes,
+    route_distance_m,
+    summarize_rollout,
+)
+from rlvr.autoresearch.tools.incut_geometry import (
+    incut_from_signed_lat,
+    signed_curvature_from_poses,
+)
+from scenario_generation import reproducer_rollout
+from scenario_generation.route_timeline import RouteTimeline
+from scenario_generation.simulate import load_model
+
+_CL_SCORES: dict[int, float] = {}
+_ROUTE_DIST: dict[int, float] = {}
+_SIGNED_LAT: dict[int, float] = {}
+_POSES: list[np.ndarray] = []
+
+_ORIG_PRE_STEP = reproducer_rollout._pre_step
+
+
+def _scoring_draw_step(np_dict, pred, ego_shape, path, step=0, **kwargs):
+    """Record the unsigned score (comparable with the recovery eval) AND the signed offset."""
+    data, ego_traj = centerline_inputs(np_dict)
+    shape_t = torch.as_tensor(np.asarray(ego_shape), dtype=torch.float32)
+    score = subscores.compute_centerline_score_batch(ego_traj, shape_t, data, usage_mode="baselink")
+    k = int(step)
+    _CL_SCORES[k] = float(score[0])
+    _ROUTE_DIST[k] = route_distance_m(data)
+
+    # signed offset, in the scorer's own convention (+ = left of the route direction)
+    ego_half_w = float(np.asarray(ego_shape).reshape(-1)[-1]) / 2.0
+    lat = lat_offset_and_naive_score(ego_traj[0], data, ego_half_w, usage_mode="baselink")
+    _SIGNED_LAT[k] = (
+        float("nan")
+        if lat is None
+        else float(np.asarray(lat["signed_lat_offset_m"]).reshape(-1)[0])
+    )
+
+
+def _pre_step_record_pose(s, gpu_transform: bool = False):
+    """Record the realized world pose each step; otherwise the driver is untouched."""
+    pre = _ORIG_PRE_STEP(s, gpu_transform)
+    if pre is None:
+        return None
+    if getattr(s, "live_pose", None) is not None:
+        _POSES.append(np.asarray(s.live_pose, dtype=float).copy())
+    return pre
+
+
+def curve_starts(tl: RouteTimeline, args) -> list[tuple[int, float]]:
+    """``(start, signed curvature)`` for the starts whose window is curved enough.
+
+    ``--min_kappa 0`` keeps straights too, and a straight window has no inside, so its
+    in-cut is NaN rather than a zero that would dilute a curve-only average.
+    """
+    out = []
+    for i in candidate_starts(tl, args):
+        kappa = signed_curvature_from_poses(tl.poses[i : i + args.steps])
+        if abs(kappa) >= args.min_kappa:
+            out.append((i, float(kappa)))
+    return out
+
+
+def incut_block(signed_lat: np.ndarray, route_dist: np.ndarray, kappa: float) -> dict:
+    """In-cut statistics for one rollout, gated on the pose being near the route."""
+    near = route_dist <= 5.0
+    incut = incut_from_signed_lat(signed_lat, kappa)
+    fin = incut[near][np.isfinite(incut[near])] if near.any() else np.array([])
+    tail = incut[-10:][near[-10:]]
+    fin_tail = tail[np.isfinite(tail)]
+    return dict(
+        # + = toward the inside of the bend (cutting the corner)
+        incut_mean_m=float(fin.mean()) if fin.size else None,
+        incut_settle_m=float(fin_tail.mean()) if fin_tail.size else None,
+        incut_max_m=float(fin.max()) if fin.size else None,
+    )
+
+
+def _turn_side(kept: list[dict], sel) -> dict:
+    """In-cut over one turn direction. Always reported per direction: a plain left/right
+    bias would otherwise read as in-cut on whichever direction the route favours."""
+    v = np.array([r["incut_mean_m"] for r in kept if sel(r["kappa"])])
+    if not v.size:
+        return dict(n=0)
+    return dict(n=int(v.size), incut_mean_m=float(v.mean()), frac_incut=float((v > 0).mean()))
+
+
+def _mean_or_none(values: list) -> float | None:
+    arr = np.array([v for v in values if v is not None], dtype=float)
+    return float(arr.mean()) if arr.size else None
+
+
+def summarize_model(label: str, rows: list[dict]) -> dict:
+    """Per-model in-cut summary, stratified by turn direction.
+
+    Lost rollouts are excluded from the in-cut and settle statistics -- an off-route pose has
+    no meaningful lateral offset -- and surface instead as ``lost_rate``.
+    """
+    kept = [r for r in rows if not r["lost"] and r["incut_mean_m"] is not None]
+    inc = np.array([r["incut_mean_m"] for r in kept]) if kept else np.array([np.nan])
+    return dict(
+        label=label,
+        n_rollouts=len(rows),
+        lost_rate=_mean_or_none([r["lost"] for r in rows]),
+        recovered_rate=_mean_or_none([r["recovered"] for r in rows]),
+        settle_mean=_mean_or_none([None if r["lost"] else r["usage_settle"] for r in rows]),
+        # + = the model sits toward the inside of bends on average
+        incut_mean_m=float(inc.mean()),
+        incut_p50_m=float(np.percentile(inc, 50)),
+        incut_p95_m=float(np.percentile(inc, 95)),
+        frac_incut=float(np.mean(inc > 0)),
+        left_turns=_turn_side(kept, lambda k: k > 0),
+        right_turns=_turn_side(kept, lambda k: k < 0),
+        n_scored=len(kept),
+    )
+
+
+def score_rollout(
+    model,
+    model_args,
+    tl: RouteTimeline,
+    st: int,
+    kappa: float,
+    off: float,
+    args,
+    draw_pool,
+    out_dir,
+) -> dict | None:
+    """Drive one rollout and turn its per-step records into a result row (None if too short)."""
+    _OFFSET["v"] = off
+    for buf in (_CL_SCORES, _ROUTE_DIST, _SIGNED_LAT):
+        buf.clear()
+    _POSES.clear()
+    drive_rollout(model, model_args, tl, st, args, draw_pool, out_dir)
+    rec = collect_usage(_CL_SCORES, _ROUTE_DIST)
+    if rec is None:
+        return None
+    usage, rd = rec
+    slat = np.array([_SIGNED_LAT[k] for k in sorted(_SIGNED_LAT)])
+    return dict(
+        start=st,
+        offset=off,
+        kappa=round(kappa, 5),
+        **summarize_rollout(usage, rd),
+        **incut_block(slat, rd, kappa),
+        per_step=[round(float(x), 4) for x in usage],
+        per_step_route_dist=[round(float(x), 2) for x in rd],
+        per_step_signed_lat_m=[round(float(x), 4) for x in slat],
+        per_step_pose=[[round(float(v), 3) for v in p] for p in _POSES],
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    add_common_args(ap, start_stride=4, offsets="0")
+    ap.add_argument(
+        "--min_kappa",
+        type=float,
+        default=0.0,
+        help="keep only starts whose window |signed curvature| >= this (1/m). "
+        "0.02 ~ a 50 m radius bend. 0 keeps everything (straights included).",
+    )
+    args = ap.parse_args()
+
+    reproducer_rollout._pre_step = _pre_step_record_pose
+    reproducer_rollout._ego_state_from_frame = _offset_ego_state
+    reproducer_rollout._draw_step = _scoring_draw_step
+
+    offsets = expand_offsets(args.offsets)
+    routes = open_routes(args.npz_root)
+    out_json = Path(args.out_json)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+
+    results: list[dict] = []
+    draw_pool = in_process_draw_pool()
+    for label_path in args.models:
+        label, model_path = label_path.split(":", 1)
+        model, model_args = load_model(model_path, args.device)
+        for key in sorted(routes):
+            tl = RouteTimeline(routes[key], sidecar_dir=Path(args.npz_root))
+            cand = curve_starts(tl, args)
+            print(
+                f"{label} {key}: {len(cand)} starts x {len(offsets)} offsets "
+                f"(min_kappa={args.min_kappa})",
+                flush=True,
+            )
+            for st, kappa in cand:
+                for off in offsets:
+                    row = score_rollout(
+                        model,
+                        model_args,
+                        tl,
+                        st,
+                        kappa,
+                        off,
+                        args,
+                        draw_pool,
+                        out_json.parent / "noop",
+                    )
+                    if row is not None:
+                        results.append(dict(label=label, route=key, **row))
+        print(
+            json.dumps(summarize_model(label, [r for r in results if r["label"] == label])),
+            flush=True,
+        )
+    draw_pool.shutdown(wait=True)
+    out_json.write_text(json.dumps(results))
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/eval_incut_route.py
+++ b/rlvr/autoresearch/tools/eval_incut_route.py
@@ -8,6 +8,13 @@ harness alone cannot see it: it reports ``|ego_lat| / side_hw``, which is
 identical for an in-cut of 0.4 m and an out-swing of 0.4 m. Measuring the
 absolute offset and calling it in-cut invalidated a whole earlier round.
 
+One signed curvature is taken per start WINDOW (mean over its 80 frames), so a window that
+changes hand mid-rollout is labelled by whichever bend dominates, and an in-cut on the other
+bend is recorded with the wrong sign. Keep ``--min_kappa`` high enough that the windows it
+admits are single bends, and read a near-zero ``incut_mean_m`` as possibly diluted rather than
+as evidence of neutrality. (The per-step realized pose is stored, so a per-step curvature can
+be recomputed from the output without re-running.)
+
 Sign convention (defined and unit-tested in
 :mod:`rlvr.autoresearch.tools.incut_geometry`): ``incut_m > 0`` means the ego sits
 toward the **inside** of the bend, i.e. cutting the corner.
@@ -45,6 +52,7 @@ import planner_metrics.subscores as subscores
 from rlvr.autoresearch.tools.eval_centerline_metrics import lat_offset_and_naive_score
 from rlvr.autoresearch.tools.eval_recovery_route import (
     _OFFSET,
+    ROUTE_COVERAGE_RADIUS_M,
     _offset_ego_state,
     add_common_args,
     candidate_starts,
@@ -53,9 +61,12 @@ from rlvr.autoresearch.tools.eval_recovery_route import (
     drive_rollout,
     expand_offsets,
     in_process_draw_pool,
+    json_safe,
     open_routes,
+    require_deployable_checkpoint,
     route_distance_m,
     summarize_rollout,
+    write_results,
 )
 from rlvr.autoresearch.tools.incut_geometry import (
     incut_from_signed_lat,
@@ -97,8 +108,9 @@ def _pre_step_record_pose(s, gpu_transform: bool = False):
     pre = _ORIG_PRE_STEP(s, gpu_transform)
     if pre is None:
         return None
-    if getattr(s, "live_pose", None) is not None:
-        _POSES.append(np.asarray(s.live_pose, dtype=float).copy())
+    # `live_pose` is a non-optional field of the rollout state, set at seed and on every
+    # advance, so it is read directly: a `getattr` default here could only hide a real bug.
+    _POSES.append(np.asarray(s.live_pose, dtype=float).copy())
     return pre
 
 
@@ -118,7 +130,7 @@ def curve_starts(tl: RouteTimeline, args) -> list[tuple[int, float]]:
 
 def incut_block(signed_lat: np.ndarray, route_dist: np.ndarray, kappa: float) -> dict:
     """In-cut statistics for one rollout, gated on the pose being near the route."""
-    near = route_dist <= 5.0
+    near = route_dist <= ROUTE_COVERAGE_RADIUS_M
     incut = incut_from_signed_lat(signed_lat, kappa)
     fin = incut[near][np.isfinite(incut[near])] if near.any() else np.array([])
     tail = incut[-10:][near[-10:]]
@@ -136,7 +148,8 @@ def _turn_side(kept: list[dict], sel) -> dict:
     bias would otherwise read as in-cut on whichever direction the route favours."""
     v = np.array([r["incut_mean_m"] for r in kept if sel(r["kappa"])])
     if not v.size:
-        return dict(n=0)
+        # Same keys either way: an aggregator indexing incut_mean_m must see None, not KeyError.
+        return dict(n=0, incut_mean_m=None, frac_incut=None)
     return dict(n=int(v.size), incut_mean_m=float(v.mean()), frac_incut=float((v > 0).mean()))
 
 
@@ -152,7 +165,24 @@ def summarize_model(label: str, rows: list[dict]) -> dict:
     no meaningful lateral offset -- and surface instead as ``lost_rate``.
     """
     kept = [r for r in rows if not r["lost"] and r["incut_mean_m"] is not None]
-    inc = np.array([r["incut_mean_m"] for r in kept]) if kept else np.array([np.nan])
+    if not kept:
+        # No scored curve rollout. `frac_incut` over an all-NaN array would evaluate to 0.0 and
+        # read as "this model never cuts corners", which is a fabricated result, not a no-op.
+        return dict(
+            label=label,
+            n_rollouts=len(rows),
+            lost_rate=_mean_or_none([r["lost"] for r in rows]),
+            recovered_rate=_mean_or_none([r["recovered"] for r in rows]),
+            settle_mean=None,
+            incut_mean_m=None,
+            incut_p50_m=None,
+            incut_p95_m=None,
+            frac_incut=None,
+            left_turns=dict(n=0, incut_mean_m=None, frac_incut=None),
+            right_turns=dict(n=0, incut_mean_m=None, frac_incut=None),
+            n_scored=0,
+        )
+    inc = np.array([r["incut_mean_m"] for r in kept])
     return dict(
         label=label,
         n_rollouts=len(rows),
@@ -186,7 +216,7 @@ def score_rollout(
     for buf in (_CL_SCORES, _ROUTE_DIST, _SIGNED_LAT):
         buf.clear()
     _POSES.clear()
-    drive_rollout(model, model_args, tl, st, args, draw_pool, out_dir)
+    terminated = drive_rollout(model, model_args, tl, st, args, draw_pool, out_dir)
     rec = collect_usage(_CL_SCORES, _ROUTE_DIST)
     if rec is None:
         return None
@@ -196,6 +226,7 @@ def score_rollout(
         start=st,
         offset=off,
         kappa=round(kappa, 5),
+        terminated=terminated,
         **summarize_rollout(usage, rd),
         **incut_block(slat, rd, kappa),
         per_step=[round(float(x), 4) for x in usage],
@@ -230,6 +261,7 @@ def main():
     draw_pool = in_process_draw_pool()
     for label_path in args.models:
         label, model_path = label_path.split(":", 1)
+        require_deployable_checkpoint(model_path)
         model, model_args = load_model(model_path, args.device)
         for key in sorted(routes):
             tl = RouteTimeline(routes[key], sidecar_dir=Path(args.npz_root))
@@ -255,11 +287,13 @@ def main():
                     if row is not None:
                         results.append(dict(label=label, route=key, **row))
         print(
-            json.dumps(summarize_model(label, [r for r in results if r["label"] == label])),
+            json.dumps(
+                json_safe(summarize_model(label, [r for r in results if r["label"] == label]))
+            ),
             flush=True,
         )
     draw_pool.shutdown(wait=True)
-    out_json.write_text(json.dumps(results))
+    write_results(out_json, results, args)
 
 
 if __name__ == "__main__":

--- a/rlvr/autoresearch/tools/eval_incut_route.py
+++ b/rlvr/autoresearch/tools/eval_incut_route.py
@@ -165,30 +165,36 @@ def summarize_model(label: str, rows: list[dict]) -> dict:
     no meaningful lateral offset -- and surface instead as ``lost_rate``.
     """
     kept = [r for r in rows if not r["lost"] and r["incut_mean_m"] is not None]
-    if not kept:
-        # No scored curve rollout. `frac_incut` over an all-NaN array would evaluate to 0.0 and
-        # read as "this model never cuts corners", which is a fabricated result, not a no-op.
-        return dict(
-            label=label,
-            n_rollouts=len(rows),
-            lost_rate=_mean_or_none([r["lost"] for r in rows]),
-            recovered_rate=_mean_or_none([r["recovered"] for r in rows]),
-            settle_mean=None,
-            incut_mean_m=None,
-            incut_p50_m=None,
-            incut_p95_m=None,
-            frac_incut=None,
-            left_turns=dict(n=0, incut_mean_m=None, frac_incut=None),
-            right_turns=dict(n=0, incut_mean_m=None, frac_incut=None),
-            n_scored=0,
-        )
-    inc = np.array([r["incut_mean_m"] for r in kept])
     return dict(
         label=label,
         n_rollouts=len(rows),
         lost_rate=_mean_or_none([r["lost"] for r in rows]),
         recovered_rate=_mean_or_none([r["recovered"] for r in rows]),
         settle_mean=_mean_or_none([None if r["lost"] else r["usage_settle"] for r in rows]),
+        n_scored=len(kept),
+        **_incut_summary(kept),
+    )
+
+
+def _incut_summary(kept: list[dict]) -> dict:
+    """The in-cut half of the summary, or all-None when nothing was scored.
+
+    With no scored curve rollout there is no in-cut to report. Computing it anyway over an
+    all-NaN array makes ``frac_incut`` evaluate to 0.0, which reads as "this model never cuts
+    corners" — a fabricated result rather than a missing one.
+    """
+    if not kept:
+        empty = dict(n=0, incut_mean_m=None, frac_incut=None)
+        return dict(
+            incut_mean_m=None,
+            incut_p50_m=None,
+            incut_p95_m=None,
+            frac_incut=None,
+            left_turns=empty,
+            right_turns=dict(empty),
+        )
+    inc = np.array([r["incut_mean_m"] for r in kept])
+    return dict(
         # + = the model sits toward the inside of bends on average
         incut_mean_m=float(inc.mean()),
         incut_p50_m=float(np.percentile(inc, 50)),
@@ -196,7 +202,6 @@ def summarize_model(label: str, rows: list[dict]) -> dict:
         frac_incut=float(np.mean(inc > 0)),
         left_turns=_turn_side(kept, lambda k: k > 0),
         right_turns=_turn_side(kept, lambda k: k < 0),
-        n_scored=len(kept),
     )
 
 

--- a/rlvr/autoresearch/tools/eval_recovery_route.py
+++ b/rlvr/autoresearch/tools/eval_recovery_route.py
@@ -1,0 +1,357 @@
+"""Perturbed-start closed-loop recovery eval on a recorded route.
+
+The question it answers: **put the ego somewhere it should not be, and does the
+model drive back to the lane centre?** Open-loop validation loss cannot answer it
+-- a recipe change has improved val loss monotonically while its closed-loop
+recovery collapsed -- so this is the headline metric for judging a training-recipe
+A/B (augmentation, LR schedule, loss weights, data mix).
+
+Per (model, start frame, lateral offset): rigidly shift the initial ego pose AND
+its world-frame history sideways -- a pure-lateral perturbation with no kinematic
+cue, so nothing in the state hints that a correction is under way -- then roll
+``--steps`` (default 80 = 8 s) closed loop with the perfect tracker, replanning
+every step, and score every REALIZED pose with the canonical
+``compute_centerline_score_batch(usage_mode="baselink")``.
+
+Reported per model: ``recovered_rate``, ``lost_rate``, and the settle
+distribution. **Both rates are needed.** The centerline scorer's coverage-gap
+branch returns exactly 0 for a pose more than 5 m from any valid route-lane
+centre, so a rollout that wanders off the map scores as PERFECTLY centred; this
+tool records each pose's distance to the route alongside the score so "recovered
+to the centreline" and "left the route" cannot be confused. Reading a
+``settle_mean`` without its ``lost_rate`` has produced two wrong conclusions.
+
+Notes on use:
+
+* Evaluate **EMA weights**, not the raw optimizer iterates (extract
+  ``ema_state_dict`` into a ``{"model": ...}`` checkpoint first).
+* Shard by ``--start_begin`` / ``--start_end`` and run several shards in
+  parallel; each uses well under 1 GB of GPU. Aggregate the shard JSONs, and
+  report only complete rows -- shard-level swings of +/-10 points are routine.
+* ``--drop_objects`` gives the empty-world ablation (no other traffic, map
+  intact), which separates "reacts badly to traffic" from "cannot follow the
+  route".
+
+Implementation: the rollout driver is used unmodified; two module-level hooks in
+``scenario_generation.reproducer_rollout`` are swapped for the duration of the
+run -- ``_ego_state_from_frame`` (inject the offset) and ``_draw_step`` (score
+instead of writing a PNG).
+
+Usage:
+    python -m rlvr.autoresearch.tools.eval_recovery_route \\
+        --models base:/path/base.pth treated:/path/treated.pth \\
+        --npz_root <dir with the recorded route NPZ + sidecars> \\
+        --drop_objects --start_stride 4 --offsets 1.0 \\
+        --out_json out/recovery.json
+"""
+
+import argparse
+import json
+import math
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import numpy as np
+import torch
+
+import planner_metrics.subscores as subscores
+from scenario_generation import reproducer_rollout
+from scenario_generation.closed_loop_eval import enumerate_routes
+from scenario_generation.route_timeline import RouteTimeline
+from scenario_generation.simulate import load_model
+
+# Per-step records of the rollout in flight, keyed by step index so the result is
+# independent of the order the render pool happens to run the hook in.
+_CL_SCORES: dict[int, float] = {}
+_ROUTE_DIST: dict[int, float] = {}
+_OFFSET = {"v": 0.0}
+_ORIG_EGO_STATE = reproducer_rollout._ego_state_from_frame
+
+
+def _offset_ego_state(tl, idx):
+    """Shift the start pose and the whole ego history sideways by ``_OFFSET``."""
+    pose, ego_hist, dyn = _ORIG_EGO_STATE(tl, idx)
+    off = _OFFSET["v"]
+    if off != 0.0:
+        nx, ny = -math.sin(pose[2]), math.cos(pose[2])
+        pose[0] += off * nx
+        pose[1] += off * ny
+        ego_hist[:, 0] += off * nx
+        ego_hist[:, 1] += off * ny
+    return pose, ego_hist, dyn
+
+
+# `render_segment` takes every knob explicitly -- commit 6c490ec0c (2026-08-21) removed
+# its defaults on purpose, so a caller cannot inherit a rollout setting it did not choose.
+# These are the values this eval is defined by; the ones that matter for the measurement are
+# the perfect tracker, recorded neighbour history, replanning every step, and no unsticking
+# (a rollout that fails must be recorded as failing, not teleported back onto the route).
+ROLLOUT_SETTINGS = dict(
+    near_miss_thresh=0.5,
+    search_radius=1.5,
+    warmup_steps=0,
+    unstick_after=0,
+    unstick_advance_m=5.0,
+    unstick_radius_mult=3.0,
+    unstick_teleport_after=300,
+    draw_every=1,  # the scoring hook runs per drawn step, so score every step
+    tracker_mode="perfect",
+    neighbor_history_mode="recorded",
+    yaw_gate=True,
+    strong_brake_mps2=-2.5,
+    abort_deviation_m=0.0,  # never abort early: an off-route rollout is a result
+    abort_after=30,
+    abort_max_snaps=0,
+    goal_mode="segment",
+    title_prefix=None,
+    distance_label_offset_m=1.2,
+    view_half_m=50.0,
+    max_stuck_steps=0,
+    goal_reach_m=5.0,
+    interpolate=True,
+    color_by_uuid=True,
+    window=None,
+    timeline_progress_mode="pose",
+)
+
+
+def in_process_draw_pool() -> ThreadPoolExecutor:
+    """The executor the per-step hook MUST run on: one worker, in this process.
+
+    ``render_segment``'s own default (``draw_pool=None``) builds a **spawn
+    ProcessPoolExecutor** -- right for matplotlib, fatal here. The hook would be
+    pickled by module+qualname, re-imported in a child interpreter, and would
+    append its scores to that child's copy of the records, so the parent would
+    collect nothing and report zero rollouts with no error at all. One in-process
+    worker also keeps the hook in step order.
+    """
+    return ThreadPoolExecutor(max_workers=1)
+
+
+def route_distance_m(data: dict) -> float:
+    """Distance from the ego (at the origin of this frame) to the nearest route point."""
+    lanes = data.get("route_lanes", data.get("lanes"))
+    if lanes is None:
+        return float("inf")
+    if lanes.dim() == 4:
+        lanes = lanes[0]
+    centers = lanes[..., :2].reshape(-1, 2)
+    valid = centers.norm(dim=-1) > 1e-3
+    if not bool(valid.any()):
+        return float("inf")
+    return float(centers[valid].norm(dim=-1).min())
+
+
+def centerline_inputs(np_dict: dict) -> tuple[dict, torch.Tensor]:
+    """The scorer's inputs for the realized pose: map tensors + the ego at the origin."""
+    data = {
+        k: torch.as_tensor(np.asarray(v))
+        for k, v in np_dict.items()
+        if k in ("route_lanes", "lanes")
+    }
+    ego_traj = torch.tensor([[[0.0, 0.0, 1.0, 0.0]]], dtype=torch.float32)
+    return data, ego_traj
+
+
+def _scoring_draw_step(np_dict, pred, ego_shape, path, step=0, **kwargs):
+    """Score the realized pose and record its distance to the route (no PNG)."""
+    data, ego_traj = centerline_inputs(np_dict)
+    score = subscores.compute_centerline_score_batch(
+        ego_traj,
+        torch.as_tensor(np.asarray(ego_shape), dtype=torch.float32),
+        data,
+        usage_mode="baselink",
+    )
+    _CL_SCORES[int(step)] = float(score[0])
+    _ROUTE_DIST[int(step)] = route_distance_m(data)
+
+
+def summarize_rollout(usage: np.ndarray, route_dist: np.ndarray) -> dict:
+    """Turn one rollout's per-step records into its verdict.
+
+    ``near`` gates every usage statistic on the pose actually being within the
+    scorer's 5 m coverage radius, so an off-route rollout cannot borrow the
+    coverage-gap zero and read as perfectly centred.
+    """
+    near = route_dist <= 5.0
+    settle_near = usage[-10:][near[-10:]]
+    off_frac = float((~near).mean())
+    lost = bool(off_frac > 0.5 or not near[-10:].any())
+    return dict(
+        n_steps=len(usage),
+        usage_t0=float(usage[0]),
+        usage_mean=float(usage[near].mean()) if near.any() else None,
+        usage_settle=float(settle_near.mean()) if settle_near.size else None,
+        usage_max=float(usage[near].max()) if near.any() else None,
+        frac_off_route=off_frac,
+        lost=lost,
+        # recovered = ended the rollout back on the route and inside half a lane
+        # half-width of its centre
+        recovered=bool((not lost) and settle_near.size and settle_near.mean() <= 0.5),
+    )
+
+
+def expand_offsets(spec: str) -> list[float]:
+    """``"1.0,0.5"`` -> ``[1.0, -1.0, 0.5, -0.5]``; 0 stays a single unperturbed run."""
+    offsets: list[float] = []
+    for tok in spec.split(","):
+        v = float(tok)
+        for cand in (0.0,) if v == 0.0 else (v, -v):
+            if cand not in offsets:
+                offsets.append(cand)
+    return offsets
+
+
+def summarize_model(label: str, rows: list[dict]) -> dict:
+    """Per-model summary. Lost rollouts are excluded from the settle statistics --
+    their score is the coverage-gap zero, not a recovery -- and reported separately
+    as ``lost_rate``, so a model can only look good on settle by staying near the
+    route."""
+    kept = [r for r in rows if not r["lost"] and r["usage_settle"] is not None]
+    settle = np.array([r["usage_settle"] for r in kept]) if kept else np.array([np.nan])
+    return dict(
+        label=label,
+        n_rollouts=len(rows),
+        lost_rate=float(np.mean([r["lost"] for r in rows])) if rows else None,
+        recovered_rate=float(np.mean([r["recovered"] for r in rows])) if rows else None,
+        settle_mean=float(settle.mean()),
+        settle_p50=float(np.percentile(settle, 50)),
+        settle_p95=float(np.percentile(settle, 95)),
+        n_scored=len(kept),
+    )
+
+
+def add_common_args(ap: argparse.ArgumentParser, *, start_stride: int, offsets: str) -> None:
+    """The arguments both route evals share. Only the two defaults differ between them."""
+    ap.add_argument("--models", nargs="+", required=True, help="label:model.pth (args.json beside)")
+    ap.add_argument("--npz_root", required=True, help="recorded route NPZ dir (with sidecars)")
+    ap.add_argument("--start_stride", type=int, default=start_stride, help="a start every N frames")
+    ap.add_argument("--min_speed", type=float, default=4.0, help="skip starts slower than this m/s")
+    ap.add_argument(
+        "--offsets",
+        default=offsets,
+        help="lateral offsets in metres; each non-zero value is expanded to +v and -v",
+    )
+    ap.add_argument("--steps", type=int, default=80, help="rollout length (0.1 s per step)")
+    ap.add_argument("--start_begin", type=int, default=0, help="starts >= this frame (shards work)")
+    ap.add_argument(
+        "--start_end", type=int, default=10**9, help="starts < this frame (shards work)"
+    )
+    ap.add_argument(
+        "--drop_objects",
+        action="store_true",
+        help="empty-world ablation: no other traffic every step, map unchanged",
+    )
+    ap.add_argument("--replan_interval", type=int, default=1)
+    ap.add_argument("--device", default="cuda")
+    ap.add_argument("--out_json", required=True)
+
+
+def open_routes(npz_root: str) -> dict:
+    """Routes under ``npz_root``, or a loud failure -- an empty eval must not look like a pass."""
+    routes = enumerate_routes(Path(npz_root))
+    if not routes:
+        raise SystemExit(f"no routes found under {npz_root}")
+    return routes
+
+
+def candidate_starts(tl: RouteTimeline, args) -> list[int]:
+    """Frames this shard tests: fast enough to be a driving scene, far enough from either end."""
+    lo = max(50, args.start_begin)
+    hi = min(len(tl) - args.steps - 5, args.start_end)
+    return [i for i in range(lo, hi, args.start_stride) if float(tl.speeds[i]) >= args.min_speed]
+
+
+def drive_rollout(
+    model, model_args, tl: RouteTimeline, start: int, args, draw_pool, out_dir
+) -> None:
+    """One closed-loop rollout; the per-step hook fills the module's records."""
+    reproducer_rollout.render_segment(
+        model,
+        model_args,
+        tl,
+        start,
+        start + args.steps,
+        out_dir,
+        device=args.device,
+        replan_interval=args.replan_interval,
+        max_steps=args.steps,
+        drop_objects=args.drop_objects,
+        draw_pool=draw_pool,
+        **ROLLOUT_SETTINGS,
+    )
+
+
+def collect_usage(scores: dict[int, float], dists: dict[int, float]) -> tuple | None:
+    """Per-step records in step order as ``(usage, route_dist)``, or None for a too-short rollout.
+
+    Usage is LINEAR: the raw centerline score is a squared penalty. An empty record means the
+    hook never ran in this process, which is a bug, not a short rollout -- so it raises.
+    """
+    steps = sorted(scores)
+    if not steps:
+        raise RuntimeError(
+            "the scoring hook recorded nothing for a completed rollout -- it did not run in "
+            "this process (see in_process_draw_pool)"
+        )
+    if len(steps) < 10:
+        return None
+    usage = np.sqrt(np.abs(np.array([scores[k] for k in steps])))
+    return usage, np.array([dists[k] for k in steps])
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    add_common_args(ap, start_stride=300, offsets="0.5,0.75,1.0")
+    args = ap.parse_args()
+
+    reproducer_rollout._ego_state_from_frame = _offset_ego_state
+    reproducer_rollout._draw_step = _scoring_draw_step
+
+    offsets = expand_offsets(args.offsets)
+    routes = open_routes(args.npz_root)
+    out_json = Path(args.out_json)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+
+    results: list[dict] = []
+    draw_pool = in_process_draw_pool()
+    for label_path in args.models:
+        label, model_path = label_path.split(":", 1)
+        model, model_args = load_model(model_path, args.device)
+        for key in sorted(routes):
+            tl = RouteTimeline(routes[key], sidecar_dir=Path(args.npz_root))
+            starts = candidate_starts(tl, args)
+            print(f"{label} {key}: {len(starts)} starts x {len(offsets)} offsets", flush=True)
+            for st in starts:
+                for off in offsets:
+                    _OFFSET["v"] = off
+                    _CL_SCORES.clear()
+                    _ROUTE_DIST.clear()
+                    drive_rollout(
+                        model, model_args, tl, st, args, draw_pool, out_json.parent / "noop"
+                    )
+                    rec = collect_usage(_CL_SCORES, _ROUTE_DIST)
+                    if rec is None:
+                        continue
+                    usage, rd = rec
+                    results.append(
+                        dict(
+                            label=label,
+                            route=key,
+                            start=st,
+                            offset=off,
+                            **summarize_rollout(usage, rd),
+                            per_step=[round(float(x), 4) for x in usage],
+                            per_step_route_dist=[round(float(x), 2) for x in rd],
+                        )
+                    )
+        print(
+            json.dumps(summarize_model(label, [r for r in results if r["label"] == label])),
+            flush=True,
+        )
+    draw_pool.shutdown(wait=True)
+    out_json.write_text(json.dumps(results))
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/eval_recovery_route.py
+++ b/rlvr/autoresearch/tools/eval_recovery_route.py
@@ -13,7 +13,7 @@ cue, so nothing in the state hints that a correction is under way -- then roll
 every step, and score every REALIZED pose with the canonical
 ``compute_centerline_score_batch(usage_mode="baselink")``.
 
-Reported per model: ``recovered_rate``, ``lost_rate``, and the settle
+Reported per model: ``recovered_rate``, ``lost_rate``, ``unsettled_rate``, and the settle
 distribution. **Both rates are needed, and that is not decoration.** Because
 these tools score ONE pose per call, ``compute_centerline_score_batch`` takes its
 coverage-gap branch and returns exactly 0 for a pose further than
@@ -81,6 +81,7 @@ _OFFSET = {"v": 0.0}
 # `_PROXIMITY` in subscores.compute_centerline_score_batch, which is not importable;
 # if that value ever changes, this must change with it or the gate and the score
 # will disagree about which poses count.
+SETTLE_WINDOW = 10  # final steps (1 s) that decide lost / recovered
 ROUTE_COVERAGE_RADIUS_M = 5.0
 _ORIG_EGO_STATE = reproducer_rollout._ego_state_from_frame
 
@@ -215,25 +216,40 @@ def _scoring_draw_step(np_dict, pred, ego_shape, path, step=0, **kwargs):
 def summarize_rollout(usage: np.ndarray, route_dist: np.ndarray) -> dict:
     """Turn one rollout's per-step records into its verdict.
 
-    ``near`` gates every usage statistic on the pose actually being within the
-    scorer's 5 m coverage radius, so an off-route rollout cannot borrow the
-    coverage-gap zero and read as perfectly centred.
+    Three outcomes: ``lost`` (ended off the route), ``recovered`` (whole settle
+    window on the route and centred), or neither (``unsettled``). ``near`` gates
+    every usage statistic on the pose actually being within the scorer's 5 m
+    coverage radius, so an off-route rollout cannot borrow the coverage-gap zero
+    and read as perfectly centred.
     """
     near = route_dist <= ROUTE_COVERAGE_RADIUS_M
-    settle_near = usage[-10:][near[-10:]]
+    window = near[-SETTLE_WINDOW:]
     off_frac = float((~near).mean())
-    lost = bool(off_frac > 0.5 or not near[-10:].any())
+    # lost = ENDED off the route (or spent most of the rollout off it). This is the
+    # literal reading; a rollout that swerved out during the last second but was
+    # back inside at the final step is not lost.
+    lost = bool(off_frac > 0.5 or not near[-1])
+    # recovered = the ENTIRE settle window is on the route and the ego sits inside
+    # half a lane half-width of its centre across it. Off-route steps are never
+    # filtered out of the window: with the old ``usage[-10:][near[-10:]]`` a single
+    # near step could carry the mean while the other nine sat off-route, which is
+    # how an off-route ending used to certify as recovered.
+    settled = bool(window.all())
+    settle_usage = usage[-SETTLE_WINDOW:]
+    recovered = bool((not lost) and settled and settle_usage.mean() <= 0.5)
+    # Rollouts that are neither -- ended on-route but were still swerving through
+    # the coverage radius a second earlier -- are reported as such rather than
+    # being forced onto one side.
     return dict(
         n_steps=len(usage),
         usage_t0=float(usage[0]),
         usage_mean=float(usage[near].mean()) if near.any() else None,
-        usage_settle=float(settle_near.mean()) if settle_near.size else None,
+        usage_settle=float(settle_usage.mean()) if settled else None,
         usage_max=float(usage[near].max()) if near.any() else None,
         frac_off_route=off_frac,
         lost=lost,
-        # recovered = ended the rollout back on the route and inside half a lane
-        # half-width of its centre
-        recovered=bool((not lost) and settle_near.size and settle_near.mean() <= 0.5),
+        recovered=recovered,
+        unsettled=bool((not lost) and not recovered),
     )
 
 
@@ -260,6 +276,7 @@ def summarize_model(label: str, rows: list[dict]) -> dict:
         n_rollouts=len(rows),
         lost_rate=float(np.mean([r["lost"] for r in rows])) if rows else None,
         recovered_rate=float(np.mean([r["recovered"] for r in rows])) if rows else None,
+        unsettled_rate=float(np.mean([r["unsettled"] for r in rows])) if rows else None,
         settle_mean=float(settle.mean()),
         settle_p50=float(np.percentile(settle, 50)),
         settle_p95=float(np.percentile(settle, 95)),

--- a/rlvr/autoresearch/tools/eval_recovery_route.py
+++ b/rlvr/autoresearch/tools/eval_recovery_route.py
@@ -314,9 +314,14 @@ def candidate_starts(tl: RouteTimeline, args) -> list[int]:
 
 def drive_rollout(
     model, model_args, tl: RouteTimeline, start: int, args, draw_pool, out_dir
-) -> None:
-    """One closed-loop rollout; the per-step hook fills the module's records."""
-    reproducer_rollout.render_segment(
+) -> str:
+    """One closed-loop rollout; the per-step hook fills the module's records.
+
+    Returns how it ended (``goal`` / ``stuck`` / ``diverged`` / ``max_steps``): a rollout
+    cut short for a reason is not the same result as one that ran its full budget, so the
+    row records it.
+    """
+    outcome = reproducer_rollout.render_segment(
         model,
         model_args,
         tl,
@@ -330,6 +335,7 @@ def drive_rollout(
         draw_pool=draw_pool,
         **ROLLOUT_SETTINGS,
     )
+    return str(outcome["terminated"])
 
 
 MIN_SCORED_STEPS = 10

--- a/rlvr/autoresearch/tools/eval_recovery_route.py
+++ b/rlvr/autoresearch/tools/eval_recovery_route.py
@@ -2,9 +2,9 @@
 
 The question it answers: **put the ego somewhere it should not be, and does the
 model drive back to the lane centre?** Open-loop validation loss cannot answer it
--- a recipe change has improved val loss monotonically while its closed-loop
-recovery collapsed -- so this is the headline metric for judging a training-recipe
-A/B (augmentation, LR schedule, loss weights, data mix).
+-- it measures agreement with a recorded future from an on-distribution state,
+which is a different question -- so this is the headline metric for judging a
+training-recipe A/B (augmentation, LR schedule, loss weights, data mix).
 
 Per (model, start frame, lateral offset): rigidly shift the initial ego pose AND
 its world-frame history sideways -- a pure-lateral perturbation with no kinematic
@@ -14,28 +14,38 @@ every step, and score every REALIZED pose with the canonical
 ``compute_centerline_score_batch(usage_mode="baselink")``.
 
 Reported per model: ``recovered_rate``, ``lost_rate``, and the settle
-distribution. **Both rates are needed.** The centerline scorer's coverage-gap
-branch returns exactly 0 for a pose more than 5 m from any valid route-lane
-centre, so a rollout that wanders off the map scores as PERFECTLY centred; this
-tool records each pose's distance to the route alongside the score so "recovered
-to the centreline" and "left the route" cannot be confused. Reading a
-``settle_mean`` without its ``lost_rate`` has produced two wrong conclusions.
+distribution. **Both rates are needed, and that is not decoration.** Because
+these tools score ONE pose per call, ``compute_centerline_score_batch`` takes its
+coverage-gap branch and returns exactly 0 for a pose further than
+``subscores._PROXIMITY`` from any valid route-lane centre -- so a rollout that
+wanders off the map scores as PERFECTLY centred. This tool therefore records each
+pose's distance to the route alongside the score and gates every usage statistic
+on it, so "recovered to the centreline" and "left the route" cannot be confused.
+Never read a settle number without its ``lost_rate`` beside it.
 
 Notes on use:
 
-* Evaluate **EMA weights**, not the raw optimizer iterates (extract
-  ``ema_state_dict`` into a ``{"model": ...}`` checkpoint first).
+* Point ``--models`` at a **deployable checkpoint**: one whose weights are the
+  EMA copy, not the raw optimizer iterates. A training milestone holds both, and
+  ``simulate.load_model`` would silently take the raw ones, so this tool refuses
+  a checkpoint that still carries ``ema_state_dict`` and tells you how to
+  convert it.
 * Shard by ``--start_begin`` / ``--start_end`` and run several shards in
-  parallel; each uses well under 1 GB of GPU. Aggregate the shard JSONs, and
-  report only complete rows -- shard-level swings of +/-10 points are routine.
+  parallel; a rollout needs little GPU memory. Aggregate the shard JSONs and
+  report only complete rows: a single shard is not a result.
 * ``--drop_objects`` gives the empty-world ablation (no other traffic, map
   intact), which separates "reacts badly to traffic" from "cannot follow the
   route".
 
 Implementation: the rollout driver is used unmodified; two module-level hooks in
-``scenario_generation.reproducer_rollout`` are swapped for the duration of the
-run -- ``_ego_state_from_frame`` (inject the offset) and ``_draw_step`` (score
-instead of writing a PNG).
+``scenario_generation.reproducer_rollout`` are replaced for the process --
+``_ego_state_from_frame`` (inject the offset) and ``_draw_step`` (score instead
+of writing a PNG). They are not restored, so import this module for its helpers,
+never for a side-effect-free call.
+
+Alongside ``--out_json`` the tool writes ``<out_json>.meta.json`` recording the
+argv, the resolved checkpoints, the rollout settings and how many rollouts were
+skipped -- so a number in a write-up can always be traced back to its run.
 
 Usage:
     python -m rlvr.autoresearch.tools.eval_recovery_route \\
@@ -48,6 +58,7 @@ Usage:
 import argparse
 import json
 import math
+import sys
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -65,6 +76,12 @@ from scenario_generation.simulate import load_model
 _CL_SCORES: dict[int, float] = {}
 _ROUTE_DIST: dict[int, float] = {}
 _OFFSET = {"v": 0.0}
+
+# The radius inside which the centerline scorer actually scores. Mirrors the local
+# `_PROXIMITY` in subscores.compute_centerline_score_batch, which is not importable;
+# if that value ever changes, this must change with it or the gate and the score
+# will disagree about which poses count.
+ROUTE_COVERAGE_RADIUS_M = 5.0
 _ORIG_EGO_STATE = reproducer_rollout._ego_state_from_frame
 
 
@@ -118,21 +135,50 @@ ROLLOUT_SETTINGS = dict(
 def in_process_draw_pool() -> ThreadPoolExecutor:
     """The executor the per-step hook MUST run on: one worker, in this process.
 
-    ``render_segment``'s own default (``draw_pool=None``) builds a **spawn
+    Passing ``draw_pool=None`` makes ``render_segment`` build a **spawn
     ProcessPoolExecutor** -- right for matplotlib, fatal here. The hook would be
     pickled by module+qualname, re-imported in a child interpreter, and would
-    append its scores to that child's copy of the records, so the parent would
-    collect nothing and report zero rollouts with no error at all. One in-process
-    worker also keeps the hook in step order.
+    record its scores in that child's copy of the records, so the parent would
+    collect nothing at all (``collect_usage`` raises on exactly that). One
+    in-process worker also keeps the hook in step order.
     """
     return ThreadPoolExecutor(max_workers=1)
 
 
+def require_deployable_checkpoint(model_path: str) -> None:
+    """Refuse a training milestone that still carries raw optimizer iterates.
+
+    ``simulate.load_model`` does ``ckpt.get("model", ckpt)``, and a milestone saved
+    by the trainer holds BOTH ``model`` (the raw iterates, which at a live learning
+    rate are one arbitrary sample of a random walk) and ``ema_state_dict`` (the
+    deployable copy). Loading the raw ones produces a plausible-looking but wrong
+    verdict with no warning at all, so this fails loudly instead.
+    """
+    ckpt = torch.load(model_path, map_location="cpu", weights_only=False)
+    if isinstance(ckpt, dict) and "ema_state_dict" in ckpt:
+        raise SystemExit(
+            f"{model_path} is a training milestone carrying both raw and EMA weights; "
+            "load_model would silently use the RAW iterates. Convert it first:\n"
+            '  ck = torch.load(src, map_location="cpu", weights_only=False)\n'
+            '  ema = {k.removeprefix("module."): v for k, v in ck["ema_state_dict"].items()}\n'
+            '  torch.save({"model": ema}, dst)   # and copy args.json next to dst'
+        )
+
+
 def route_distance_m(data: dict) -> float:
-    """Distance from the ego (at the origin of this frame) to the nearest route point."""
+    """Distance from the ego (at the origin of this frame) to the nearest route point.
+
+    ``route_lanes`` with a ``lanes`` fallback mirrors what the scorer itself does
+    (``subscores.compute_centerline_score_batch``); the gate has to be computed off
+    the same geometry the score was, or the two halves of the metric disagree. A
+    frame carrying neither is not a route frame, and raises.
+    """
     lanes = data.get("route_lanes", data.get("lanes"))
     if lanes is None:
-        return float("inf")
+        raise KeyError(
+            "frame carries neither 'route_lanes' nor 'lanes'; the route-distance gate "
+            "cannot be computed, and without it every rollout would score as lost"
+        )
     if lanes.dim() == 4:
         lanes = lanes[0]
     centers = lanes[..., :2].reshape(-1, 2)
@@ -173,7 +219,7 @@ def summarize_rollout(usage: np.ndarray, route_dist: np.ndarray) -> dict:
     scorer's 5 m coverage radius, so an off-route rollout cannot borrow the
     coverage-gap zero and read as perfectly centred.
     """
-    near = route_dist <= 5.0
+    near = route_dist <= ROUTE_COVERAGE_RADIUS_M
     settle_near = usage[-10:][near[-10:]]
     off_frac = float((~near).mean())
     lost = bool(off_frac > 0.5 or not near[-10:].any())
@@ -225,7 +271,13 @@ def add_common_args(ap: argparse.ArgumentParser, *, start_stride: int, offsets: 
     """The arguments both route evals share. Only the two defaults differ between them."""
     ap.add_argument("--models", nargs="+", required=True, help="label:model.pth (args.json beside)")
     ap.add_argument("--npz_root", required=True, help="recorded route NPZ dir (with sidecars)")
-    ap.add_argument("--start_stride", type=int, default=start_stride, help="a start every N frames")
+    ap.add_argument(
+        "--start_stride",
+        type=int,
+        default=start_stride,
+        help="test a start every N frames; the defaults are the protocol these tools were "
+        "calibrated on, so changing one changes the sample size and the noise floor with it",
+    )
     ap.add_argument("--min_speed", type=float, default=4.0, help="skip starts slower than this m/s")
     ap.add_argument(
         "--offsets",
@@ -248,11 +300,9 @@ def add_common_args(ap: argparse.ArgumentParser, *, start_stride: int, offsets: 
 
 
 def open_routes(npz_root: str) -> dict:
-    """Routes under ``npz_root``, or a loud failure -- an empty eval must not look like a pass."""
-    routes = enumerate_routes(Path(npz_root))
-    if not routes:
-        raise SystemExit(f"no routes found under {npz_root}")
-    return routes
+    """Routes under ``npz_root``. ``enumerate_routes`` itself raises on an empty tree, so an
+    eval can never quietly score zero scenes and look like a pass."""
+    return enumerate_routes(Path(npz_root))
 
 
 def candidate_starts(tl: RouteTimeline, args) -> list[int]:
@@ -282,11 +332,20 @@ def drive_rollout(
     )
 
 
+MIN_SCORED_STEPS = 10
+
+# Rollouts dropped for being shorter than MIN_SCORED_STEPS, so the count can be reported
+# rather than quietly shrinking the denominator.
+SKIPPED: dict[str, int] = {"short_rollouts": 0}
+
+
 def collect_usage(scores: dict[int, float], dists: dict[int, float]) -> tuple | None:
     """Per-step records in step order as ``(usage, route_dist)``, or None for a too-short rollout.
 
     Usage is LINEAR: the raw centerline score is a squared penalty. An empty record means the
-    hook never ran in this process, which is a bug, not a short rollout -- so it raises.
+    hook never ran in this process, which is a bug, not a short rollout -- so it raises. A
+    rollout with 1..MIN_SCORED_STEPS-1 steps IS dropped (its settle window would be the
+    perturbation itself) but counted in ``SKIPPED`` and reported, never silently.
     """
     steps = sorted(scores)
     if not steps:
@@ -294,15 +353,53 @@ def collect_usage(scores: dict[int, float], dists: dict[int, float]) -> tuple | 
             "the scoring hook recorded nothing for a completed rollout -- it did not run in "
             "this process (see in_process_draw_pool)"
         )
-    if len(steps) < 10:
+    if len(steps) < MIN_SCORED_STEPS:
+        SKIPPED["short_rollouts"] += 1
         return None
     usage = np.sqrt(np.abs(np.array([scores[k] for k in steps])))
     return usage, np.array([dists[k] for k in steps])
 
 
+def json_safe(obj):
+    """Replace every non-finite float with None.
+
+    ``json.dumps`` emits the bare literal ``NaN``, which no strict JSON reader accepts --
+    and these files exist to be aggregated across shards.
+    """
+    if isinstance(obj, float):
+        return obj if math.isfinite(obj) else None
+    if isinstance(obj, dict):
+        return {k: json_safe(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [json_safe(v) for v in obj]
+    return obj
+
+
+def write_results(out_json: Path, results: list[dict], args) -> None:
+    """Write the rows, plus a sidecar recording what produced them.
+
+    The rows stay a bare list so existing aggregators keep working; the provenance goes
+    beside them, because a results file nobody can trace back to a checkpoint and a shard
+    range is the problem this tool exists to fix.
+    """
+    out_json.write_text(json.dumps(json_safe(results)))
+    meta = dict(
+        argv=sys.argv,
+        models=args.models,
+        npz_root=args.npz_root,
+        n_rows=len(results),
+        skipped=dict(SKIPPED),
+        rollout_settings=ROLLOUT_SETTINGS,
+        args={k: v for k, v in vars(args).items() if k != "models"},
+    )
+    out_json.with_suffix(out_json.suffix + ".meta.json").write_text(
+        json.dumps(json_safe(meta), indent=1, default=str)
+    )
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
-    add_common_args(ap, start_stride=300, offsets="0.5,0.75,1.0")
+    add_common_args(ap, start_stride=4, offsets="1.0")
     args = ap.parse_args()
 
     reproducer_rollout._ego_state_from_frame = _offset_ego_state
@@ -317,6 +414,7 @@ def main():
     draw_pool = in_process_draw_pool()
     for label_path in args.models:
         label, model_path = label_path.split(":", 1)
+        require_deployable_checkpoint(model_path)
         model, model_args = load_model(model_path, args.device)
         for key in sorted(routes):
             tl = RouteTimeline(routes[key], sidecar_dir=Path(args.npz_root))
@@ -327,7 +425,7 @@ def main():
                     _OFFSET["v"] = off
                     _CL_SCORES.clear()
                     _ROUTE_DIST.clear()
-                    drive_rollout(
+                    terminated = drive_rollout(
                         model, model_args, tl, st, args, draw_pool, out_json.parent / "noop"
                     )
                     rec = collect_usage(_CL_SCORES, _ROUTE_DIST)
@@ -340,17 +438,17 @@ def main():
                             route=key,
                             start=st,
                             offset=off,
+                            terminated=terminated,
                             **summarize_rollout(usage, rd),
                             per_step=[round(float(x), 4) for x in usage],
                             per_step_route_dist=[round(float(x), 2) for x in rd],
                         )
                     )
-        print(
-            json.dumps(summarize_model(label, [r for r in results if r["label"] == label])),
-            flush=True,
-        )
+        summary = summarize_model(label, [r for r in results if r["label"] == label])
+        summary["skipped_short_rollouts"] = SKIPPED["short_rollouts"]
+        print(json.dumps(json_safe(summary)), flush=True)
     draw_pool.shutdown(wait=True)
-    out_json.write_text(json.dumps(results))
+    write_results(out_json, results, args)
 
 
 if __name__ == "__main__":

--- a/rlvr/autoresearch/tools/find_disagreeing_starts.py
+++ b/rlvr/autoresearch/tools/find_disagreeing_starts.py
@@ -91,10 +91,12 @@ def main():
         f"and {args.lose} {'lost' if not args.any_non_recovery else 'not recovering'}"
     )
     for route, start, offset in keys[: args.limit]:
+        # printed in the renderer's own flag form, --route first: start indices collide
+        # between routes, so a pick is only meaningful together with its route
         print(
-            f"  --start {start:<5} --offset {offset:+.1f}   "
-            f"{args.win} {describe(win_rows[(route, start, offset)]):>5} | "
-            f"{args.lose} {describe(lose_rows[(route, start, offset)]):>5}   route={route}"
+            f"  --route {route} --start {start} --offset {offset:+.1f}"
+            f"   # {args.win} {describe(win_rows[(route, start, offset)])}"
+            f" | {args.lose} {describe(lose_rows[(route, start, offset)])}"
         )
 
     if args.out_json:

--- a/rlvr/autoresearch/tools/find_disagreeing_starts.py
+++ b/rlvr/autoresearch/tools/find_disagreeing_starts.py
@@ -1,0 +1,116 @@
+"""Find the rollouts where two arms disagree, so a clip is worth rendering.
+
+A clip is only evidence when the two arms did something different from the SAME
+start. This reads the per-rollout rows written by
+:mod:`rlvr.autoresearch.tools.eval_recovery_route` for two or more labels and lists
+the starts where one arm recovered and another was lost — the cases where a
+side-by-side clip shows the difference the table reports.
+
+Rows are keyed by ``(route, start, offset)``. The route matters: an eval spans more
+than one recorded drive and start indices collide between them, so a
+``(start, offset)`` key alone silently mixes two different places.
+
+Usage:
+    # every shard JSON of both arms, in any order
+    python -m rlvr.autoresearch.tools.find_disagreeing_starts \\
+        --rows $CAMP/recovery/*.json \\
+        --win treatedEP200 --lose incumbentEP200 --limit 10
+
+    # machine-readable, to drive the clip renderer
+    python -m rlvr.autoresearch.tools.find_disagreeing_starts \\
+        --rows $CAMP/recovery/*.json --win A --lose B --out_json picks.json
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+
+def load_rows(paths: list[str]) -> dict[str, dict]:
+    """``{label: {(route, start, offset): row}}`` from any number of shard JSONs."""
+    per_label: dict[str, dict] = {}
+    for p in paths:
+        for row in json.loads(Path(p).read_text()):
+            key = (row.get("route", ""), row["start"], round(row["offset"], 2))
+            per_label.setdefault(row["label"], {})[key] = row
+    return per_label
+
+
+def describe(row: dict) -> str:
+    """``LOST`` or the settle value — the same verdict the tables report."""
+    if row["lost"]:
+        return "LOST"
+    settle = row.get("usage_settle")
+    return f"{settle:.3f}" if settle is not None else "n/a"
+
+
+def disagreements(win_rows: dict, lose_rows: dict, *, require_lost: bool) -> list[tuple]:
+    """Keys where ``win`` recovered and ``lose`` did not, over their common starts.
+
+    ``require_lost`` demands the losing arm actually left the route, which makes the
+    clearest clips; without it, "did not recover" also includes rollouts that stayed
+    near the route but never settled.
+    """
+    common = sorted(set(win_rows) & set(lose_rows))
+    out = []
+    for key in common:
+        w, lose = win_rows[key], lose_rows[key]
+        if not w["recovered"]:
+            continue
+        if lose["lost"] if require_lost else not lose["recovered"]:
+            out.append(key)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--rows", nargs="+", required=True, help="recovery row JSONs (shards ok)")
+    ap.add_argument("--win", required=True, help="label expected to recover")
+    ap.add_argument("--lose", required=True, help="label expected to fail")
+    ap.add_argument(
+        "--any_non_recovery",
+        action="store_true",
+        help="count 'did not recover' rather than only 'left the route' for --lose",
+    )
+    ap.add_argument("--limit", type=int, default=10, help="how many to print")
+    ap.add_argument("--out_json", default=None, help="also write the picks here")
+    args = ap.parse_args()
+
+    per_label = load_rows(args.rows)
+    for label in (args.win, args.lose):
+        if label not in per_label:
+            raise SystemExit(
+                f"no rows for label {label!r}; found {sorted(per_label)} in the given files"
+            )
+
+    win_rows, lose_rows = per_label[args.win], per_label[args.lose]
+    keys = disagreements(win_rows, lose_rows, require_lost=not args.any_non_recovery)
+    common = len(set(win_rows) & set(lose_rows))
+    print(
+        f"{len(keys)} of {common} shared rollouts have {args.win} recovering "
+        f"and {args.lose} {'lost' if not args.any_non_recovery else 'not recovering'}"
+    )
+    for route, start, offset in keys[: args.limit]:
+        print(
+            f"  --start {start:<5} --offset {offset:+.1f}   "
+            f"{args.win} {describe(win_rows[(route, start, offset)]):>5} | "
+            f"{args.lose} {describe(lose_rows[(route, start, offset)]):>5}   route={route}"
+        )
+
+    if args.out_json:
+        picks = [
+            dict(
+                route=route,
+                start=start,
+                offset=offset,
+                win=describe(win_rows[(route, start, offset)]),
+                lose=describe(lose_rows[(route, start, offset)]),
+            )
+            for route, start, offset in keys
+        ]
+        Path(args.out_json).write_text(json.dumps(picks, indent=1))
+        print(f"wrote {len(picks)} picks to {args.out_json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/incut_geometry.py
+++ b/rlvr/autoresearch/tools/incut_geometry.py
@@ -1,0 +1,52 @@
+"""Signed in-cut geometry: is the ego biased toward the INSIDE of a bend?
+
+The recovery harness reports an UNSIGNED lane usage (the scorer computes signed
+``ego_lat`` then returns ``ego_lat.abs() / side_hw``, and the harness then takes
+``sqrt(abs(...))``). An in-cut of 0.4 m and an out-swing of 0.4 m are therefore the
+same number, so a directional question -- does this recipe bias the planner toward
+the inside of a bend -- is invisible to it.
+
+Convention, stated once and unit-tested below:
+
+  signed_lat_m  : + = ego is LEFT of the route direction   (from
+                  ``lat_offset_and_naive_score``, the scorer's own convention)
+  kappa         : + = route turns LEFT (counter-clockwise, yaw increasing)
+  incut_m       = sign(kappa) * signed_lat_m
+                  + = ego is toward the INSIDE of the bend  (cutting the corner)
+                  - = ego is toward the OUTSIDE (swinging wide)
+
+On a left-hand bend the inside of the curve is to the left, so an ego that cuts
+the corner is left of the centreline: same sign as kappa, not opposite.
+"""
+
+import numpy as np
+
+
+def signed_curvature_from_poses(poses: np.ndarray) -> float:
+    """Mean signed curvature (1/m) over a window of (x, y, yaw) poses.
+
+    + = left turn. Uses unwrapped yaw over travelled arc length, which is robust
+    to the pose sampling rate; returns 0.0 for a window with no travel.
+    """
+    poses = np.asarray(poses, dtype=float)
+    if poses.shape[0] < 3:
+        return 0.0
+    seg = np.linalg.norm(np.diff(poses[:, :2], axis=0), axis=1)
+    arc = float(seg.sum())
+    if arc < 1e-3:
+        return 0.0
+    yaw = np.unwrap(poses[:, 2])
+    return float((yaw[-1] - yaw[0]) / arc)
+
+
+def incut_from_signed_lat(signed_lat_m: np.ndarray, kappa: float) -> np.ndarray:
+    """Project signed lateral offset onto the inside of the bend.
+
+    Returns metres, + = toward the inside. A straight window (kappa == 0) has no
+    inside, so it returns all-NaN rather than silently reporting zeros that would
+    dilute a curve-only average.
+    """
+    signed_lat_m = np.asarray(signed_lat_m, dtype=float)
+    if kappa == 0.0:
+        return np.full_like(signed_lat_m, np.nan)
+    return np.sign(kappa) * signed_lat_m

--- a/rlvr/autoresearch/tools/render_recovery_clip.py
+++ b/rlvr/autoresearch/tools/render_recovery_clip.py
@@ -1,0 +1,224 @@
+"""Render one perturbed-start rollout as a video, so a table row can be watched.
+
+Same protocol as :mod:`rlvr.autoresearch.tools.eval_recovery_route` — the ego pose AND
+its world-frame history are rigidly shifted sideways at t=0, then the model drives
+closed loop with the perfect tracker — but the harness's real per-step renderer runs
+instead of the silent scorer, so the rollout becomes PNGs and a WebM.
+
+The per-step lane usage is recorded on the way through **with the same scorer the
+tables use**, so the caption numbers cannot drift from the numbers they illustrate.
+Pass two ``--models`` and ``--hstack`` to get the side-by-side clip: one start, one
+perturbation, two arms, which is the only form in which a clip is evidence.
+
+Pick the start with :mod:`rlvr.autoresearch.tools.find_disagreeing_starts` rather than
+by eye — a clip of a start where both arms behave the same shows nothing.
+
+Usage:
+    python -m rlvr.autoresearch.tools.render_recovery_clip \\
+        --models incumbent:$OUT_A/epoch0200_ema/best_model.pth \\
+                 treated:$OUT_B/epoch0200_ema/best_model.pth \\
+        --npz_root <route NPZ dir> --start 1206 --offset 1.0 \\
+        --drop_objects --hstack --out_dir clips/
+"""
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+import numpy as np
+
+import planner_metrics.subscores as subscores  # noqa: I001  (kept last: heavy import)
+from rlvr.autoresearch.tools.eval_recovery_route import (
+    _OFFSET,
+    ROLLOUT_SETTINGS,
+    _offset_ego_state,
+    centerline_inputs,
+    collect_usage,
+    in_process_draw_pool,
+    require_deployable_checkpoint,
+    route_distance_m,
+    summarize_rollout,
+)
+from scenario_generation import reproducer_rollout
+from scenario_generation.closed_loop_eval import enumerate_routes
+from scenario_generation.route_timeline import RouteTimeline
+from scenario_generation.simulate import load_model
+
+_CL_SCORES: dict[int, float] = {}
+_ROUTE_DIST: dict[int, float] = {}
+_ORIG_DRAW = reproducer_rollout._draw_step
+
+
+def _scoring_draw_step(np_dict, pred, ego_shape, path, step=0, **kwargs):
+    """Score the realized pose, then hand off to the harness's real renderer."""
+    import torch
+
+    data, ego_traj = centerline_inputs(np_dict)
+    score = subscores.compute_centerline_score_batch(
+        ego_traj,
+        torch.as_tensor(np.asarray(ego_shape), dtype=torch.float32),
+        data,
+        usage_mode="baselink",
+    )
+    _CL_SCORES[int(step)] = float(score[0])
+    _ROUTE_DIST[int(step)] = route_distance_m(data)
+    return _ORIG_DRAW(np_dict, pred, ego_shape, path, step=step, **kwargs)
+
+
+def encode_webm(png_dir: Path, out_webm: Path, fps: int) -> None:
+    """PNG sequence -> VP9 WebM, the format these write-ups use."""
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-loglevel",
+            "error",
+            "-framerate",
+            str(fps),
+            "-pattern_type",
+            "glob",
+            "-i",
+            str(png_dir / "*.png"),
+            "-c:v",
+            "libvpx-vp9",
+            "-b:v",
+            "0",
+            "-crf",
+            "32",
+            "-row-mt",
+            "1",
+            "-pix_fmt",
+            "yuv420p",
+            str(out_webm),
+        ],
+        check=True,
+    )
+
+
+def hstack_webm(left: Path, right: Path, out_webm: Path) -> None:
+    """Two clips side by side. Each pane's camera follows its own vehicle, so the
+    thing to compare is the vehicles' motion, not the backgrounds."""
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-loglevel",
+            "error",
+            "-i",
+            str(left),
+            "-i",
+            str(right),
+            "-filter_complex",
+            "hstack=inputs=2",
+            "-c:v",
+            "libvpx-vp9",
+            "-b:v",
+            "0",
+            "-crf",
+            "32",
+            "-row-mt",
+            "1",
+            str(out_webm),
+        ],
+        check=True,
+    )
+
+
+def render_one(label, model_path, tl, args, out_root, stem, draw_pool) -> tuple[Path, dict]:
+    """One arm's clip plus the verdict for its caption."""
+    model, model_args = load_model(model_path, args.device)
+    png_dir = out_root / f"{stem}_{label}"
+    png_dir.mkdir(parents=True, exist_ok=True)
+    _OFFSET["v"] = args.offset
+    _CL_SCORES.clear()
+    _ROUTE_DIST.clear()
+
+    settings = dict(ROLLOUT_SETTINGS)
+    sign = "L" if args.offset > 0 else "R"
+    settings["title_prefix"] = (
+        f"{label}  |  start {args.start}  {sign}{abs(args.offset):g}m"
+        f"  |  {'no traffic' if args.drop_objects else 'with traffic'}"
+    )
+    reproducer_rollout.render_segment(
+        model,
+        model_args,
+        tl,
+        args.start,
+        args.start + args.steps,
+        png_dir,
+        device=args.device,
+        replan_interval=args.replan_interval,
+        max_steps=args.steps,
+        drop_objects=args.drop_objects,
+        draw_pool=draw_pool,
+        **settings,
+    )
+    rec = collect_usage(_CL_SCORES, _ROUTE_DIST)
+    if rec is None:
+        raise SystemExit(
+            f"{label}: rollout was too short to score ({len(_CL_SCORES)} steps); "
+            "pick a start further from the end of the route"
+        )
+    usage, route_dist = rec
+    webm = out_root / f"{stem}_{label}.webm"
+    encode_webm(png_dir, webm, args.fps)
+    verdict = summarize_rollout(usage, route_dist)
+    verdict["per_step"] = [round(float(x), 4) for x in usage]
+    return webm, verdict
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--models", nargs="+", required=True, help="label:model.pth (1 or 2)")
+    ap.add_argument("--npz_root", required=True, help="recorded route NPZ dir (with sidecars)")
+    ap.add_argument("--start", type=int, required=True, help="start frame")
+    ap.add_argument("--offset", type=float, required=True, help="lateral shift, m (sign matters)")
+    ap.add_argument("--steps", type=int, default=80)
+    ap.add_argument("--replan_interval", type=int, default=1)
+    ap.add_argument("--drop_objects", action="store_true")
+    ap.add_argument("--fps", type=int, default=10, help="10 = real time at draw_every 1")
+    ap.add_argument("--device", default="cuda")
+    ap.add_argument("--hstack", action="store_true", help="also emit the side-by-side clip")
+    ap.add_argument("--out_dir", required=True)
+    args = ap.parse_args()
+
+    reproducer_rollout._ego_state_from_frame = _offset_ego_state
+    reproducer_rollout._draw_step = _scoring_draw_step
+
+    routes = enumerate_routes(Path(args.npz_root))
+    key = sorted(routes)[0]
+    tl = RouteTimeline(routes[key], sidecar_dir=Path(args.npz_root))
+    out_root = Path(args.out_dir)
+    out_root.mkdir(parents=True, exist_ok=True)
+    sign = "L" if args.offset > 0 else "R"
+    world = "notraffic" if args.drop_objects else "traffic"
+    stem = f"start{args.start}_{sign}{abs(args.offset):g}m_{world}"
+
+    draw_pool = in_process_draw_pool()
+    clips, report = [], {}
+    for spec in args.models:
+        label, model_path = spec.split(":", 1)
+        require_deployable_checkpoint(model_path)
+        webm, verdict = render_one(label, model_path, tl, args, out_root, stem, draw_pool)
+        clips.append(webm)
+        report[label] = verdict
+        print(
+            f"{label}: {'LOST' if verdict['lost'] else 'recovered' if verdict['recovered'] else 'settled short'}"
+            f"  settle={verdict['usage_settle']}  -> {webm.name}",
+            flush=True,
+        )
+    draw_pool.shutdown(wait=True)
+
+    if args.hstack:
+        if len(clips) != 2:
+            raise SystemExit("--hstack needs exactly two --models")
+        pair = out_root / f"COMPARE_{stem}.webm"
+        hstack_webm(clips[0], clips[1], pair)
+        print("pair:", pair)
+
+    (out_root / f"{stem}_report.json").write_text(json.dumps(report, indent=1))
+
+
+if __name__ == "__main__":
+    main()

--- a/rlvr/autoresearch/tools/render_recovery_clip.py
+++ b/rlvr/autoresearch/tools/render_recovery_clip.py
@@ -149,13 +149,27 @@ def select_route(routes: dict, requested: str | None) -> str:
     )
 
 
+def fresh_frame_dir(png_dir: Path) -> Path:
+    """Start every render from an empty frame directory.
+
+    ``encode_webm`` hands ffmpeg the glob ``*.png``, so any frame left over from
+    an earlier run of the same clip identity would be encoded into the new video.
+    A shorter rerender overwrites ``00000..00049`` and leaves ``00050..00079`` in
+    place; the clip then shows 80 frames while its verdict was scored on 50. Only
+    this run's frames may reach the encoder, so stale ones are removed first.
+    """
+    png_dir.mkdir(parents=True, exist_ok=True)
+    for stale in png_dir.glob("*.png"):
+        stale.unlink()
+    return png_dir
+
+
 def render_one(
     label, model_path, tl, args, out_root, stem, draw_pool, stem_route
 ) -> tuple[Path, dict]:
     """One arm's clip plus the verdict for its caption."""
     model, model_args = load_model(model_path, args.device)
-    png_dir = out_root / f"{stem}_{label}"
-    png_dir.mkdir(parents=True, exist_ok=True)
+    png_dir = fresh_frame_dir(out_root / f"{stem}_{label}")
     _OFFSET["v"] = args.offset
     _CL_SCORES.clear()
     _ROUTE_DIST.clear()

--- a/rlvr/autoresearch/tools/render_recovery_clip.py
+++ b/rlvr/autoresearch/tools/render_recovery_clip.py
@@ -17,7 +17,7 @@ Usage:
     python -m rlvr.autoresearch.tools.render_recovery_clip \\
         --models incumbent:$OUT_A/epoch0200_ema/best_model.pth \\
                  treated:$OUT_B/epoch0200_ema/best_model.pth \\
-        --npz_root <route NPZ dir> --start 1206 --offset 1.0 \\
+        --npz_root <route NPZ dir> --route <key> --start 1206 --offset 1.0 \\
         --drop_objects --hstack --out_dir clips/
 """
 
@@ -125,7 +125,33 @@ def hstack_webm(left: Path, right: Path, out_webm: Path) -> None:
     )
 
 
-def render_one(label, model_path, tl, args, out_root, stem, draw_pool) -> tuple[Path, dict]:
+def select_route(routes: dict, requested: str | None) -> str:
+    """The route key to render, or a loud failure.
+
+    ``find_disagreeing_starts`` keys every pick by ``(route, start, offset)`` because start
+    indices collide between the recorded drives an eval spans. Picking a route here on the
+    tool's own initiative would therefore render a *different place* at the same start index
+    and caption it with the other drive's numbers, so a multi-route root demands ``--route``
+    rather than defaulting to one.
+    """
+    if requested is not None:
+        if requested not in routes:
+            raise SystemExit(
+                f"route {requested!r} not found under --npz_root; available: {sorted(routes)}"
+            )
+        return requested
+    if len(routes) == 1:
+        return next(iter(routes))
+    raise SystemExit(
+        "--npz_root holds more than one route "
+        f"({sorted(routes)}); pass --route with the key find_disagreeing_starts printed, "
+        "because start indices collide between routes"
+    )
+
+
+def render_one(
+    label, model_path, tl, args, out_root, stem, draw_pool, stem_route
+) -> tuple[Path, dict]:
     """One arm's clip plus the verdict for its caption."""
     model, model_args = load_model(model_path, args.device)
     png_dir = out_root / f"{stem}_{label}"
@@ -137,7 +163,7 @@ def render_one(label, model_path, tl, args, out_root, stem, draw_pool) -> tuple[
     settings = dict(ROLLOUT_SETTINGS)
     sign = "L" if args.offset > 0 else "R"
     settings["title_prefix"] = (
-        f"{label}  |  start {args.start}  {sign}{abs(args.offset):g}m"
+        f"{label}  |  {stem_route}  start {args.start}  {sign}{abs(args.offset):g}m"
         f"  |  {'no traffic' if args.drop_objects else 'with traffic'}"
     )
     reproducer_rollout.render_segment(
@@ -172,6 +198,12 @@ def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--models", nargs="+", required=True, help="label:model.pth (1 or 2)")
     ap.add_argument("--npz_root", required=True, help="recorded route NPZ dir (with sidecars)")
+    ap.add_argument(
+        "--route",
+        default=None,
+        help="route key from find_disagreeing_starts; required when --npz_root holds more "
+        "than one recorded drive, since start indices collide between them",
+    )
     ap.add_argument("--start", type=int, required=True, help="start frame")
     ap.add_argument("--offset", type=float, required=True, help="lateral shift, m (sign matters)")
     ap.add_argument("--steps", type=int, default=80)
@@ -187,20 +219,21 @@ def main():
     reproducer_rollout._draw_step = _scoring_draw_step
 
     routes = enumerate_routes(Path(args.npz_root))
-    key = sorted(routes)[0]
+    key = select_route(routes, args.route)
     tl = RouteTimeline(routes[key], sidecar_dir=Path(args.npz_root))
     out_root = Path(args.out_dir)
     out_root.mkdir(parents=True, exist_ok=True)
     sign = "L" if args.offset > 0 else "R"
     world = "notraffic" if args.drop_objects else "traffic"
-    stem = f"start{args.start}_{sign}{abs(args.offset):g}m_{world}"
+    # the route is in the filename so two drives' clips can never be confused
+    stem = f"{key}_start{args.start}_{sign}{abs(args.offset):g}m_{world}"
 
     draw_pool = in_process_draw_pool()
     clips, report = [], {}
     for spec in args.models:
         label, model_path = spec.split(":", 1)
         require_deployable_checkpoint(model_path)
-        webm, verdict = render_one(label, model_path, tl, args, out_root, stem, draw_pool)
+        webm, verdict = render_one(label, model_path, tl, args, out_root, stem, draw_pool, key)
         clips.append(webm)
         report[label] = verdict
         print(
@@ -217,7 +250,11 @@ def main():
         hstack_webm(clips[0], clips[1], pair)
         print("pair:", pair)
 
-    (out_root / f"{stem}_report.json").write_text(json.dumps(report, indent=1))
+    (out_root / f"{stem}_report.json").write_text(
+        json.dumps(
+            {"route": key, "start": args.start, "offset": args.offset, "arms": report}, indent=1
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/rlvr/test_clip_route_selection.py
+++ b/rlvr/test_clip_route_selection.py
@@ -1,0 +1,38 @@
+"""Route selection for the clip renderer.
+
+Start indices collide between the recorded drives an eval spans, so a pick from
+``find_disagreeing_starts`` is only meaningful together with its route. These tests pin the
+behaviour that a multi-route root must be disambiguated explicitly rather than silently
+rendering whichever route sorts first.
+"""
+
+import pytest
+
+from rlvr.autoresearch.tools.render_recovery_clip import select_route
+
+TWO = {"drive-B_00000000": ["b.npz"], "drive-A_00000000": ["a.npz"]}
+ONE = {"drive-A_00000000": ["a.npz"]}
+
+
+def test_single_route_needs_no_flag():
+    assert select_route(ONE, None) == "drive-A_00000000"
+
+
+def test_two_routes_without_route_flag_is_refused():
+    """The regression: this used to return the lexicographically first route, so a pick
+    belonging to drive B rendered drive A at the same start index."""
+    with pytest.raises(SystemExit) as e:
+        select_route(TWO, None)
+    assert "--route" in str(e.value)
+
+
+def test_two_routes_honour_the_requested_route():
+    assert select_route(TWO, "drive-B_00000000") == "drive-B_00000000"
+    assert select_route(TWO, "drive-A_00000000") == "drive-A_00000000"
+
+
+def test_unknown_route_is_refused_and_lists_what_exists():
+    with pytest.raises(SystemExit) as e:
+        select_route(TWO, "drive-C_00000000")
+    msg = str(e.value)
+    assert "drive-C_00000000" in msg and "drive-A_00000000" in msg

--- a/rlvr/test_incut_geometry.py
+++ b/rlvr/test_incut_geometry.py
@@ -1,0 +1,48 @@
+"""Sign-convention tests for the in-cut geometry helpers."""
+
+import numpy as np
+
+from rlvr.autoresearch.tools.incut_geometry import (
+    incut_from_signed_lat,
+    signed_curvature_from_poses,
+)
+
+R = 20.0
+_TH = np.linspace(0.0, np.pi / 2, 50)
+LEFT_ARC = np.stack([R * np.sin(_TH), R * (1 - np.cos(_TH)), _TH], axis=1)
+RIGHT_ARC = np.stack([R * np.sin(_TH), -R * (1 - np.cos(_TH)), -_TH], axis=1)
+
+
+def test_left_turn_has_positive_curvature_of_one_over_radius():
+    kappa = signed_curvature_from_poses(LEFT_ARC)
+    assert kappa > 0.0
+    assert abs(kappa - 1.0 / R) < 0.02
+
+
+def test_right_turn_has_negative_curvature():
+    assert signed_curvature_from_poses(RIGHT_ARC) < 0.0
+
+
+def test_straight_window_has_zero_curvature():
+    straight = np.stack([np.linspace(0, 50, 50), np.zeros(50), np.zeros(50)], axis=1)
+    assert abs(signed_curvature_from_poses(straight)) < 1e-6
+
+
+def test_degenerate_windows_return_zero_rather_than_raising():
+    assert signed_curvature_from_poses(np.zeros((5, 3))) == 0.0
+    assert signed_curvature_from_poses(np.zeros((1, 3))) == 0.0
+
+
+def test_offset_toward_the_bend_reads_as_incut_on_both_turn_directions():
+    k_left = signed_curvature_from_poses(LEFT_ARC)
+    k_right = signed_curvature_from_poses(RIGHT_ARC)
+    # 0.4 m LEFT of the centreline on a LEFT bend == cutting the corner
+    assert incut_from_signed_lat(np.array([0.4]), k_left)[0] > 0.0
+    # the same offset on a RIGHT bend == swinging wide
+    assert incut_from_signed_lat(np.array([0.4]), k_right)[0] < 0.0
+    # 0.4 m RIGHT on a RIGHT bend == cutting
+    assert incut_from_signed_lat(np.array([-0.4]), k_right)[0] > 0.0
+
+
+def test_straight_window_has_no_inside():
+    assert np.isnan(incut_from_signed_lat(np.array([0.4]), 0.0)[0])

--- a/rlvr/test_recovery_verdict.py
+++ b/rlvr/test_recovery_verdict.py
@@ -1,0 +1,79 @@
+"""The recovery verdict and the clip frame directory, pinned against two review findings.
+
+1. A rollout that ends OFF the route must not be classified as recovered. The old
+   ``lost`` test used ``near[-10:].any()``: one near-route sample in the final
+   window was enough to escape it, and the settle mean -- taken over that single
+   sample -- could then read as recovered.
+2. Re-rendering the same clip identity must not encode frames left over from an
+   earlier, longer run: ffmpeg is given ``*.png``.
+"""
+
+import numpy as np
+
+from rlvr.autoresearch.tools.eval_recovery_route import summarize_rollout
+from rlvr.autoresearch.tools.render_recovery_clip import fresh_frame_dir
+
+
+def test_off_route_ending_is_lost_not_recovered():
+    # 71 near-route steps, then 9 off-route; the one near sample in the final
+    # window sits perfectly on the centreline. This is the exact trace from the
+    # review: it used to return lost=False, recovered=True.
+    route_dist = np.concatenate([np.zeros(71), np.full(9, 20.0)])
+    usage = np.zeros(80)
+    v = summarize_rollout(usage, route_dist)
+    assert v["lost"] is True
+    assert v["recovered"] is False
+
+
+def test_near_final_window_with_low_usage_is_recovered():
+    route_dist = np.zeros(80)
+    usage = np.concatenate([np.linspace(1.0, 0.0, 70), np.full(10, 0.1)])
+    v = summarize_rollout(usage, route_dist)
+    assert v["lost"] is False
+    assert v["recovered"] is True
+    assert v["unsettled"] is False
+    assert abs(v["usage_settle"] - 0.1) < 1e-9
+
+
+def test_swerve_in_final_window_but_on_route_at_end_is_unsettled():
+    # off-route three steps from the end, back inside at the final step: it did
+    # not END off the route, so it is not lost -- but it did not settle either
+    route_dist = np.zeros(80)
+    route_dist[-3] = 20.0
+    v = summarize_rollout(np.zeros(80), route_dist)
+    assert v["lost"] is False
+    assert v["recovered"] is False
+    assert v["unsettled"] is True
+    assert v["usage_settle"] is None
+
+
+def test_off_route_steps_cannot_be_filtered_out_of_the_settle_mean():
+    # nine near steps at usage 0.9 and one off-route step: the old code dropped
+    # the off step and averaged the rest; now the window is not settled at all
+    route_dist = np.zeros(80)
+    route_dist[-5] = 20.0
+    usage = np.full(80, 0.9)
+    v = summarize_rollout(usage, route_dist)
+    assert v["recovered"] is False and v["lost"] is False
+
+
+def test_fresh_frame_dir_removes_stale_frames(tmp_path):
+    png_dir = tmp_path / "clip_A"
+    png_dir.mkdir()
+    # a previous 80-frame run
+    for i in range(80):
+        (png_dir / f"{i:05d}.png").write_bytes(b"old")
+    out = fresh_frame_dir(png_dir)
+    assert out == png_dir
+    assert list(png_dir.glob("*.png")) == []
+    # a shorter rerender now writes only its own frames, and only those reach *.png
+    for i in range(50):
+        (png_dir / f"{i:05d}.png").write_bytes(b"new")
+    frames = sorted(png_dir.glob("*.png"))
+    assert len(frames) == 50
+    assert all(f.read_bytes() == b"new" for f in frames)
+
+
+def test_fresh_frame_dir_creates_missing_dir(tmp_path):
+    png_dir = tmp_path / "nested" / "clip_B"
+    assert fresh_frame_dir(png_dir).is_dir()


### PR DESCRIPTION
# What

Follow-up to [#384](https://github.com/tier4/Diffusion-Planner/pull/384). Two new tools that turn a row of the recovery table back into something you can watch, plus the fixes from #384's review round.

| | |
|---|---|
| `rlvr/autoresearch/tools/find_disagreeing_starts.py` | **new** — which starts one arm recovers and another loses |
| `rlvr/autoresearch/tools/render_recovery_clip.py` | **new** — render one of those starts as a side-by-side clip |
| `rlvr/autoresearch/tools/eval_recovery_route.py`, `eval_incut_route.py` | review fixes (see below) |

**This PR contains #384's commit as well** — its branch could not be updated (`GH013 … Cannot update this protected ref` on both force-push and fast-forward), so the follow-up work is delivered here on a fresh branch. Reviewing this one supersedes #384.

# Why the clip tooling belongs in the repo

The evals produce rates. The evidence a reader actually looks at is a clip of one start where two arms did different things — and that step was still being done by scratch scripts. Two consequences, both of which have already happened:

- a write-up could show a clip nobody could regenerate;
- the caption numbers came from a different code path than the tables, so they could disagree with the row they illustrate and nobody would know.

Both tools import their rollout settings, perturbation hook and scoring path from `eval_recovery_route` rather than reimplementing them, so a clip is generated under the same settings as the measurement **by construction**. Verified end to end: for start 1258 the clip reports `settle=0.1667` / `LOST`, which is exactly what the eval rows say for that start.

`find_disagreeing_starts` keys rows by `(route, start, offset)`. An eval spans more than one recorded drive and start indices collide between them, so a `(start, offset)` key silently mixes two different places on the map; the scratch version worked around this by globbing one route's shards only.

# Review fixes from #384

- **[BLOCKER] Raw weights were scored silently.** A training milestone carries both `model` (raw optimizer iterates) and `ema_state_dict`, and `simulate.load_model` takes `model`. Pointing either tool at `epochNNNN/best_model.pth` therefore scored the raw iterates with no warning — a plausible but wrong verdict. `require_deployable_checkpoint` now refuses such a checkpoint and prints the conversion snippet.
- **Rollouts vanished from the denominator.** 1–9-step rollouts were dropped by a bare `continue`. Still excluded (their settle window would be the perturbation itself), now counted and reported as `skipped_short_rollouts`.
- **`route_distance_m` returned `inf`** when a frame had neither `route_lanes` nor `lanes`, marking every rollout lost — "drove off the map" rather than "the input has no map". Raises now.
- **`json.dumps` emitted bare `NaN`**, which no strict JSON reader accepts, in files whose purpose is to be aggregated across shards. Non-finite floats are written as `null`.
- **In-cut `frac_incut` was 0.0 when nothing was scored**, reading as "never cuts corners" off an all-NaN array. It and its siblings return `None`; `_turn_side` keeps its keys so an aggregator sees `None`, not `KeyError`.
- Rows now record `terminated`; each run writes `<out_json>.meta.json` with argv, checkpoints and rollout settings; the 5 m coverage radius is one named constant shared by both tools; recovery's argparse defaults are the protocol the published numbers were produced with.

Docstring corrections: the draw-pool note no longer claims the failure is silent (`collect_usage` raises on it), and `speed` is documented as unable to show reversing — the tracker reports a non-negative magnitude, so measure it from consecutive `ego` positions in `rollout.jsonl`.

Not taken: per-step signed curvature for the in-cut window. It would change what the metric measures, and the job here is to land the measurement as it was made; the limitation is in the module docstring instead.

# A bug the end-to-end test caught

`drive_rollout` never returned `render_segment`'s outcome, so `terminated` — the field added in response to review, the one that says whether a rollout reached the goal or merely ran out of budget — was **`null` on every row**. Lint, complexity and unit tests all passed; only running the eval and reading the output found it. Fixed, re-run, now `terminated='max_steps'`.

# Verification

- Both evals reproduce the campaign scripts they replace with **worst delta exactly 0** across `recovered`/`lost`, every summary statistic, and every per-step array including realized poses (recovery: 6 rollouts; in-cut: 5 curve rollouts).
- Clip tooling exercised end to end on real checkpoints: the picker found 5 of 42 shared rollouts where one arm recovers and the other is lost; the renderer produced both panes plus the `hstack` pair, with a report matching the eval rows.
- `rlvr/test_incut_geometry.py`: 6 tests pinning the sign convention on synthetic arcs — pass.
- `ruff check` + `ruff format --check` clean on all six files.
- Complexity: every block A or B (worst B(10)); average **A (4.05)**.

# Usage

```
python -m rlvr.autoresearch.tools.find_disagreeing_starts \
    --rows $CAMP/recovery/*.json --win TREATED --lose INCUMBENT --limit 6

python -m rlvr.autoresearch.tools.render_recovery_clip \
    --models incumbent:<a.pth> treated:<b.pth> --npz_root <route dir> \
    --start <n> --offset 1.0 --drop_objects --hstack --out_dir $CAMP/clips
```

Written up, with the measured output of both commands, in [How to A/B a training-recipe change](https://tier4.atlassian.net/wiki/spaces/ATT/pages/5531206307) §5c.
