### PR TITLE
feat(frenet-aug): opt-in veto recovery, toward-parked nudge and clearance floor, and one augmenter factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,80 @@ python3 train_run.py \
     --valid_set_list <valid.json>
     # optional: --resume_model_path <.pth> --wandb_run_id <id> --wandb_project_name <name>
 ```
+
+### 3.1. Data augmentation
+
+`--augment_type` selects how the ego start state is perturbed during training. All
+three augmenters keep the recorded future as the target, so the model is trained to
+*recover* toward the drive that was recorded rather than only to copy it.
+
+| value | what it does |
+|---|---|
+| `quintic` | default. Fixed-offset quintic bridge from a perturbed t=0 state. |
+| `bridge` | extended bridge perturbation. |
+| `frenet` | corridor-constrained lateral offset with feasibility filtering, an exact footprint check, and a kinematic rewrite of the ego history. |
+
+Turn augmentation off entirely with `--use_data_augment False`.
+
+#### Ego history perturbation (all augmenters)
+
+```bash
+--ego_past_noise_std 0.1        # default; 0 disables
+```
+
+One factor per augmented scene, drawn from `N(1, std)` and clamped to `±2·std`,
+scaling the ego history about the t=0 sample. The recorded *shape* is preserved and
+the spacing changes, so it perturbs the implied speed history rather than adding
+per-point noise. `quintic` scales the recorded history; `frenet` scales the history
+it rewrote. t=0 itself never moves.
+
+#### Frenet-only options
+
+Every flag below is **off by default**; with all of them at their defaults the
+augmenter reproduces the previous behaviour exactly.
+
+```bash
+--augment_type frenet \
+  --frenet_recovery_rounds 1 \      # retry after a footprint veto
+  --frenet_min_clearance 0.2 \      # metres of clearance to keep from recorded vehicles
+  --frenet_toward_parked_prob 0.3 \ # fraction of eligible scenes nudged toward a parked vehicle
+  --frenet_hist_jitter_lat 0.3 \    # smooth lateral jitter of the history, metres at the oldest sample
+  --frenet_hist_jitter_lon 0.3      # same, along the direction of travel
+```
+
+- **`--frenet_recovery_rounds N`** (default 0). A candidate whose footprint overlaps a
+  recorded vehicle is vetoed, and the scene falls back to plain ground truth. Each
+  round lets such a scene re-select. A retry burns the losing lateral *offset*, not
+  the path shape, because every shape of one offset overlaps the same vehicle.
+  `1` is the operating point; further rounds recover almost nothing, because what
+  survives is blocked geometrically and re-rolling does not move geometry.
+
+- **`--frenet_min_clearance C`** (default 0.0). Metres of exact footprint clearance
+  every accepted candidate must keep from every recorded vehicle, on top of the
+  corridor margin. Applies to the vehicle cut only — the road-edge margin is
+  unaffected. At `0.0` the check is overlap-only, which is the historical behaviour.
+
+- **`--frenet_toward_parked_prob P`** (default 0.0). The corridor is symmetric, so a
+  scene that passes a parked vehicle is as likely to be nudged away from it as toward
+  it. This directs that fraction of eligible scenes toward the vehicle and takes the
+  largest feasible offset, making the t=0 state a harder avoidance than the recorded
+  one, while restricting the merge to horizons that rejoin the recording *before* the
+  vehicle. A scene is eligible only when a parked vehicle bounds the corridor and is
+  still ahead at t=0; if it is already alongside there is no avoidance left to harden.
+
+- **`--frenet_hist_jitter_lat L` / `--frenet_hist_jitter_lon G`** (default 0.0).
+  Smooth per-sample jitter of the ego history, in metres of standard deviation at the
+  oldest sample, perpendicular to and along the direction of travel. The two axes are
+  drawn independently. Unlike `--ego_past_noise_std`, which can only make a
+  correctly-shaped history be traversed at the wrong speed, this makes the history
+  itself imperfect. Applied after the footprint check and with t=0 pinned, so the
+  target and the state the model plans from are unchanged.
+
+Frenet also exposes the sampling grid itself — `--frenet_n_draws`, `--frenet_dy_max`,
+`--frenet_dth_max`, `--frenet_merge_times`, `--frenet_anchors`, `--frenet_acc0_fracs`,
+`--frenet_ranked_temp_s`, `--frenet_seed`. Their defaults are the measured
+configuration; see `diffusion_planner/utils/data_augmentation_frenet.py`.
+
+Use `--seed` to vary model init, data order and augmentation draws. Training is
+otherwise deterministic: two runs at the same seed produce identical weights, so a
+same-seed rerun cannot serve as a control when measuring a recipe change.

--- a/README.md
+++ b/README.md
@@ -147,9 +147,15 @@ augmenter reproduces the previous behaviour exactly.
   survives is blocked geometrically and re-rolling does not move geometry.
 
 - **`--frenet_min_clearance C`** (default 0.0). Metres of exact footprint clearance
-  every accepted candidate must keep from every recorded vehicle, on top of the
-  corridor margin. Applies to the vehicle cut only — the road-edge margin is
-  unaffected. At `0.0` the check is overlap-only, which is the historical behaviour.
+  required from every recorded vehicle, on top of the corridor margin, **at the
+  timesteps the perturbation actually moved the ego**. It is deliberately not a global
+  floor: a candidate coincides with the recorded drive outside its merge window, so a
+  floor applied over the whole horizon would reject scenes for the *recording's* own
+  clearance — which deletes exactly the tight-squeeze scenes the augmentation is most
+  valuable on. True overlap is still rejected everywhere, floor or no floor, so a
+  candidate can be accepted while passing closer than `C` at a timestep where it is
+  bit-identical to ground truth. Applies to the vehicle cut only; the road-edge margin
+  is unaffected. At `0.0` the check is overlap-only, which is the historical behaviour.
 
 - **`--frenet_toward_parked_prob P`** (default 0.0). The corridor is symmetric, so a
   scene that passes a parked vehicle is as likely to be nudged away from it as toward

--- a/README.md
+++ b/README.md
@@ -124,21 +124,25 @@ scaling the ego history about the t=0 sample. The recorded *shape* is preserved 
 the spacing changes, so it perturbs the implied speed history rather than adding
 per-point noise. t=0 itself never moves.
 
-**Left unset, each augmenter keeps the value it has always used** — `quintic` 0.1,
-`frenet` 0.0 — because the two are not perturbing the same thing:
+Left unset it resolves per augmenter, because they do not perturb the same thing:
 
 | augmenter | default | what the factor scales |
 |---|---|---|
 | `quintic` | 0.1 | the RECORDED history, and the current velocity and acceleration with it |
-| `frenet` | 0.0 | the history it rewrote from the perturbed polyline; `ego_current_state` is left bit-identical |
+| `frenet` | 0.1 | the history it rewrote from the perturbed polyline; `ego_current_state` is left bit-identical |
 | `bridge` | n/a | no history perturbation; passing the flag is an error, not a silent no-op |
 
-Passing a number applies it to whichever augmenter is selected, so the flag is still
-sweepable. Two consequences worth knowing before using it as a control variable: a
-`quintic`-vs-`frenet` A/B on this flag is not measuring the same perturbation, and
-turning it on for `frenet` has no measured benefit — on a 2-seed, 8-arm A/B
-(~1,110 perturbed closed-loop rollouts per arm) it moved recovery 28.3% → 30.2%,
-well inside the 17.2-point spread between the control's own two seeds.
+> **⚠ The frenet default is a change.** `tier4-main` hard-passed `0.0` to the frenet
+> augmenter, so a stock `--augment_type frenet` run here trains a different distribution
+> than the same command on main. **Reproducing an existing frenet checkpoint requires
+> `--ego_past_noise_std 0` explicitly.** It is on for flag uniformity, not because it was
+> shown to help: on a 2-seed, 8-arm A/B (~1,113 perturbed closed-loop rollouts per arm,
+> both trackers, replan intervals 1 and 3) it moved recovery 28.3% → 30.2% at replan 1
+> and 52.7% → 52.2% at replan 3, every difference inside the seed spread.
+
+Passing a number applies it to whichever augmenter is selected, so the flag stays
+sweepable. Note that a `quintic`-vs-`frenet` A/B on it is not measuring the same
+perturbation — quintic also rescales the current velocity and acceleration.
 
 #### Frenet-only options
 

--- a/README.md
+++ b/README.md
@@ -159,13 +159,21 @@ Note the std means different things per mode. `0.1` is ±10% of a traversal spee
 jitter, so that is the value to pass; and because the jitter is unclamped, 31.7% of
 draws exceed the std and 4.5% exceed twice it (measured over 200k draws).
 
+**In `jitter` mode the bent history is not re-checked against the footprint
+constraint.** The corridor bounds certify the clean polyline, and the jitter is applied
+afterwards on purpose, so that enabling it cannot change which scenes are accepted. The
+consequence: on a drive that passed a parked vehicle closely, the resulting history can
+place the ego footprint inside that vehicle **in the past**. The future, the training
+target and t=0 are unaffected; what the encoder reads is. Keep the magnitude small
+relative to the clearances in the data.
+
 Passing a number applies it to whichever augmenter is selected, so the flag stays
 sweepable. Note that a `quintic`-vs-`frenet` A/B on it is not measuring the same
 perturbation — quintic also rescales the current velocity and acceleration.
 
 #### Frenet-only options
 
-Every flag below is **off by default**; with all of them at their defaults the
+Every **frenet corridor** flag below is off by default; with those three at their defaults the
 augmenter reproduces the previous behaviour exactly.
 
 ```bash
@@ -185,15 +193,22 @@ augmenter reproduces the previous behaviour exactly.
   survives is blocked geometrically and re-rolling does not move geometry.
 
 - **`--frenet_min_clearance C`** (default 0.0). Metres of exact footprint clearance
-  required from every recorded vehicle, on top of the corridor margin, **at the
-  timesteps the perturbation actually moved the ego**. It is deliberately not a global
-  floor: a candidate coincides with the recorded drive outside its merge window, so a
-  floor applied over the whole horizon would reject scenes for the *recording's* own
-  clearance — which deletes exactly the tight-squeeze scenes the augmentation is most
-  valuable on. True overlap is still rejected everywhere, floor or no floor, so a
-  candidate can be accepted while passing closer than `C` at a timestep where it is
-  bit-identical to ground truth. Applies to the vehicle cut only; the road-edge margin
-  is unaffected. At `0.0` the check is overlap-only, which is the historical behaviour.
+  required from every recorded vehicle. It acts in **two** places, and they are not
+  windowed the same way — worth knowing before choosing a value:
+
+  | where | scope | effect |
+  |---|---|---|
+  | corridor half-width | **whole merge window** | the neighbour cut uses `max(0.10, C)`, so a `C` above the 0.10 corridor margin narrows the band a candidate may occupy at every masked timestep |
+  | exact footprint veto | **only the timesteps the perturbation moved the ego** | a candidate can be accepted while passing closer than `C` at a timestep where it is bit-identical to ground truth |
+
+  The veto's windowing exists because a candidate coincides with the recorded drive
+  outside its merge window, so vetoing there would reject scenes for the *recording's*
+  own clearance. The corridor cut is **not** windowed, so a large `C` can still drop a
+  tight-squeeze scene from augmentation via the corridor rather than the veto. Keep `C`
+  modest for that reason, and note `C ≤ 0.10` leaves the corridor untouched entirely and
+  only tightens the veto. True overlap is rejected everywhere regardless. Applies to the
+  vehicle cut only; the road-edge margin is unaffected. At `0.0` the check is
+  overlap-only, which is the historical behaviour.
 
 - **`--frenet_toward_parked_prob P`** (default 0.0). The corridor is symmetric, so a
   scene that passes a parked vehicle is as likely to be nudged away from it as toward

--- a/README.md
+++ b/README.md
@@ -149,9 +149,7 @@ augmenter reproduces the previous behaviour exactly.
 --augment_type frenet \
   --frenet_recovery_rounds 1 \      # retry after a footprint veto
   --frenet_min_clearance 0.2 \      # metres of clearance to keep from recorded vehicles
-  --frenet_toward_parked_prob 0.3 \ # fraction of eligible scenes nudged toward a parked vehicle
-  --frenet_hist_jitter_lat 0.3 \    # smooth lateral jitter of the history, metres at the oldest sample
-  --frenet_hist_jitter_lon 0.3      # same, along the direction of travel
+  --frenet_toward_parked_prob 0.3   # fraction of eligible scenes nudged toward a parked vehicle
 ```
 
 - **`--frenet_recovery_rounds N`** (default 0). A candidate whose footprint overlaps a
@@ -195,23 +193,6 @@ augmenter reproduces the previous behaviour exactly.
   accepted with the flag off, 8 with it on. The fallback above is what keeps that from
   being 0; it does not recover the rest, and no selection rule can, because a 2.0 m ego
   does not fit a 1.8 m gap. Use `P` as a small fraction, not a global setting.
-
-- **`--frenet_hist_jitter_lat L` / `--frenet_hist_jitter_lon G`** (default 0.0).
-  Smooth per-sample jitter of the ego history, in metres of standard deviation at the
-  oldest sample, perpendicular to and along the direction of travel. The two axes are
-  drawn independently. Unlike `--ego_past_noise_std`, which can only make a
-  correctly-shaped history be traversed at the wrong speed, this makes the history
-  itself imperfect. Applied after the footprint check and with t=0 pinned, so the
-  target and the state the model plans from are unchanged.
-
-  That ordering is deliberate — it keeps acceptance independent of the noise, which is
-  what makes an A/B between the two history perturbations valid — but it has a
-  consequence worth stating: **the jittered history is not re-checked against the
-  footprint constraint.** The corridor bounds certify the clean polyline, so at
-  `L = 0.3` the oldest sample can move ~0.6–0.9 m at 2–3σ, and on a drive that passed a
-  parked vehicle closely the resulting history can put the ego footprint inside that
-  vehicle in the past. The future, the target and t=0 are unaffected; what the encoder
-  reads is. Keep `L` small relative to the clearances in the data.
 
 Frenet also exposes the sampling grid itself — `--frenet_n_draws`, `--frenet_dy_max`,
 `--frenet_dth_max`, `--frenet_merge_times`, `--frenet_anchors`, `--frenet_acc0_fracs`,

--- a/README.md
+++ b/README.md
@@ -113,17 +113,32 @@ three augmenters keep the recorded future as the target, so the model is trained
 
 Turn augmentation off entirely with `--use_data_augment False`.
 
-#### Ego history perturbation (all augmenters)
+#### Ego history perturbation (`quintic` and `frenet`)
 
 ```bash
---ego_past_noise_std 0.1        # default; 0 disables
+--ego_past_noise_std 0.2        # unset = each augmenter's own default; 0 disables
 ```
 
 One factor per augmented scene, drawn from `N(1, std)` and clamped to `±2·std`,
 scaling the ego history about the t=0 sample. The recorded *shape* is preserved and
 the spacing changes, so it perturbs the implied speed history rather than adding
-per-point noise. `quintic` scales the recorded history; `frenet` scales the history
-it rewrote. t=0 itself never moves.
+per-point noise. t=0 itself never moves.
+
+**Left unset, each augmenter keeps the value it has always used** — `quintic` 0.1,
+`frenet` 0.0 — because the two are not perturbing the same thing:
+
+| augmenter | default | what the factor scales |
+|---|---|---|
+| `quintic` | 0.1 | the RECORDED history, and the current velocity and acceleration with it |
+| `frenet` | 0.0 | the history it rewrote from the perturbed polyline; `ego_current_state` is left bit-identical |
+| `bridge` | n/a | no history perturbation; passing the flag is an error, not a silent no-op |
+
+Passing a number applies it to whichever augmenter is selected, so the flag is still
+sweepable. Two consequences worth knowing before using it as a control variable: a
+`quintic`-vs-`frenet` A/B on this flag is not measuring the same perturbation, and
+turning it on for `frenet` has no measured benefit — on a 2-seed, 8-arm A/B
+(~1,110 perturbed closed-loop rollouts per arm) it moved recovery 28.3% → 30.2%,
+well inside the 17.2-point spread between the control's own two seeds.
 
 #### Frenet-only options
 
@@ -188,6 +203,15 @@ augmenter reproduces the previous behaviour exactly.
   correctly-shaped history be traversed at the wrong speed, this makes the history
   itself imperfect. Applied after the footprint check and with t=0 pinned, so the
   target and the state the model plans from are unchanged.
+
+  That ordering is deliberate — it keeps acceptance independent of the noise, which is
+  what makes an A/B between the two history perturbations valid — but it has a
+  consequence worth stating: **the jittered history is not re-checked against the
+  footprint constraint.** The corridor bounds certify the clean polyline, so at
+  `L = 0.3` the oldest sample can move ~0.6–0.9 m at 2–3σ, and on a drive that passed a
+  parked vehicle closely the resulting history can put the ego footprint inside that
+  vehicle in the past. The future, the target and t=0 are unaffected; what the encoder
+  reads is. Keep `L` small relative to the clearances in the data.
 
 Frenet also exposes the sampling grid itself — `--frenet_n_draws`, `--frenet_dy_max`,
 `--frenet_dth_max`, `--frenet_merge_times`, `--frenet_anchors`, `--frenet_acc0_fracs`,

--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ augmenter reproduces the previous behaviour exactly.
 --augment_type frenet \
   --frenet_recovery_rounds 1 \      # retry after a footprint veto
   --frenet_min_clearance 0.2 \      # metres of clearance to keep from recorded vehicles
-  --frenet_toward_parked_prob 0.3   # fraction of eligible scenes nudged toward a parked vehicle
+  --frenet_toward_parked_prob 0.3 \ # fraction of eligible scenes nudged toward a parked vehicle
+  --frenet_hist_jitter_lat 0.3 \    # smooth lateral jitter of the history, metres at the oldest sample
+  --frenet_hist_jitter_lon 0.3      # same, along the direction of travel
 ```
 
 - **`--frenet_recovery_rounds N`** (default 0). A candidate whose footprint overlaps a
@@ -193,6 +195,23 @@ augmenter reproduces the previous behaviour exactly.
   accepted with the flag off, 8 with it on. The fallback above is what keeps that from
   being 0; it does not recover the rest, and no selection rule can, because a 2.0 m ego
   does not fit a 1.8 m gap. Use `P` as a small fraction, not a global setting.
+
+- **`--frenet_hist_jitter_lat L` / `--frenet_hist_jitter_lon G`** (default 0.0).
+  Smooth per-sample jitter of the ego history, in metres of standard deviation at the
+  oldest sample, perpendicular to and along the direction of travel. The two axes are
+  drawn independently. Unlike `--ego_past_noise_std`, which can only make a
+  correctly-shaped history be traversed at the wrong speed, this makes the history
+  itself imperfect. Applied after the footprint check and with t=0 pinned, so the
+  target and the state the model plans from are unchanged.
+
+  That ordering is deliberate — it keeps acceptance independent of the noise, which is
+  what makes an A/B between the two history perturbations valid — but it has a
+  consequence worth stating: **the jittered history is not re-checked against the
+  footprint constraint.** The corridor bounds certify the clean polyline, so at
+  `L = 0.3` the oldest sample can move ~0.6–0.9 m at 2–3σ, and on a drive that passed a
+  parked vehicle closely the resulting history can put the ego footprint inside that
+  vehicle in the past. The future, the target and t=0 are unaffected; what the encoder
+  reads is. Keep `L` small relative to the clearances in the data.
 
 Frenet also exposes the sampling grid itself — `--frenet_n_draws`, `--frenet_dy_max`,
 `--frenet_dth_max`, `--frenet_merge_times`, `--frenet_anchors`, `--frenet_acc0_fracs`,

--- a/README.md
+++ b/README.md
@@ -129,16 +129,22 @@ Left unset it resolves per augmenter, because they do not perturb the same thing
 | augmenter | default | what the factor scales |
 |---|---|---|
 | `quintic` | 0.1 | the RECORDED history, and the current velocity and acceleration with it |
-| `frenet` | 0.1 | the history it rewrote from the perturbed polyline; `ego_current_state` is left bit-identical |
+| `frenet` | **0.0** (off) | the history it rewrote from the perturbed polyline; `ego_current_state` is left bit-identical |
 | `bridge` | n/a | no history perturbation; passing the flag is an error, not a silent no-op |
 
-> **⚠ The frenet default is a change.** `tier4-main` hard-passed `0.0` to the frenet
-> augmenter, so a stock `--augment_type frenet` run here trains a different distribution
-> than the same command on main. **Reproducing an existing frenet checkpoint requires
-> `--ego_past_noise_std 0` explicitly.** It is on for flag uniformity, not because it was
-> shown to help: on a 2-seed, 8-arm A/B (~1,113 perturbed closed-loop rollouts per arm,
-> both trackers, replan intervals 1 and 3) it moved recovery 28.3% → 30.2% at replan 1
-> and 52.7% → 52.2% at replan 3, every difference inside the seed spread.
+**Why frenet defaults to off while quintic does not.** Quintic scales a history the
+recorder actually observed; frenet has already rewritten the past kinematically from the
+perturbed polyline, so the same factor would perturb a history it synthesised. That is
+the reason `tier4-main` hard-passes `0.0` there, and this branch keeps it — a stock
+`--augment_type frenet` run trains exactly what it trains on main.
+
+Measured either way, so the `0.0` is a decision and not an omission: on a 2-seed, 8-arm
+A/B (~1,113 perturbed closed-loop rollouts per arm, both trackers, replan intervals 1
+and 3) enabling it moved recovery 28.3% → 30.2% at replan 1 and 52.7% → 52.2% at replan
+3, with `lost%` 20.3 → 19.8 and 7.7 → 8.0 — every difference inside the seed spread
+(17.2 points on recovered% at replan 1, 1.0 on `lost%` at replan 3). Nothing is given up
+by leaving it off, and `--ego_past_noise_std 0.1` turns it on for anyone revisiting it at
+full dataset scale.
 
 `--ego_past_noise_mode` selects **which** mechanism that std drives, for
 `augment_type=frenet`. Exactly one runs — they are mutually exclusive:
@@ -149,8 +155,8 @@ Left unset it resolves per augmenter, because they do not perturb the same thing
 | `jitter` | a smooth lateral bend of the track, so its *shape* is wrong; three low-frequency modes, exactly zero at t=0 | **metres** at the oldest sample | **no** |
 
 A mode rather than two magnitude flags, because two flags could both be set and the
-combination is reachable by accident — the scale default is non-zero, so asking for
-jitter alone used to silently apply both, and that combination has never been
+combination is reachable by accident — quintic's scale default is non-zero, so asking
+for jitter alone used to silently apply both, and that combination has never been
 evaluated (every jitter arm of the A/B pinned the scale to 0). `jitter` is
 implemented for frenet only; asking for it with another `augment_type` is an error.
 
@@ -173,8 +179,11 @@ perturbation — quintic also rescales the current velocity and acceleration.
 
 #### Frenet-only options
 
-Every **frenet corridor** flag below is off by default; with those three at their defaults the
-augmenter reproduces the previous behaviour exactly.
+Every flag below is off at its default, and so is `--ego_past_noise_std` for frenet, so a
+stock run reproduces the previous behaviour exactly — measured through the path a training
+takes (`build_parser` → `build_config` → `augmenter_from_args`): 432 arrays over
+`ego_agent_past`, `ego_current_state` and `goal_pose`, three `augment_type` values, two
+seeds, worst `|base − head|` of **0.000e+00** for all three.
 
 ```bash
 --augment_type frenet \

--- a/README.md
+++ b/README.md
@@ -177,9 +177,20 @@ augmenter reproduces the previous behaviour exactly.
 
 - **`--frenet_toward_parked_prob P`** (default 0.0). The corridor is symmetric, so a
   scene that passes a parked vehicle is as likely to be nudged away from it as toward
-  it. This directs that fraction of eligible scenes toward the vehicle. A scene is
-  eligible only when a parked vehicle bounds the corridor and is still ahead at t=0; if
-  it is already alongside there is no avoidance left to harden.
+  it. `P` directs a fraction of scenes toward the vehicle instead.
+
+  Precisely, `P` is an independent per-scene coin ANDed with two other conditions —
+  `toward = eligible & (r < P) & do_aug` — so it is the fraction of scenes that are
+  **both** eligible **and** already selected for augmentation by `--augment_prob`. At
+  `P = 1.0` every such scene is nudged, with no further filtering. At the default
+  `augment_prob 0.5` the realised rate is therefore about half of `P × eligible`.
+
+  A scene is eligible only when a *parked* vehicle (not a kerb, not a moving car) bounds
+  the corridor within `--frenet_dy_max` reach **and** is reached at or after the shortest
+  merge horizon; if it is already alongside at t=0 there is no avoidance left to harden.
+  Eligibility is uncommon: **10,958 of 105,093 scenes (10.4%)** on a full-size corpus, and
+  **zero** on the 2,297-scene pipeline-test set, which contains no parked vehicle bounding
+  the corridor ahead — so on that set the flag does nothing at any `P`.
 
   On a row where it can, the augmenter then takes the *largest* feasible offset and
   restricts the merge to horizons that rejoin the recording **before** the vehicle,

--- a/README.md
+++ b/README.md
@@ -170,9 +170,16 @@ augmenter reproduces the previous behaviour exactly.
   horizon, and rather than drop the scene from augmentation the row keeps its ungated
   candidates and takes the ordinary first-feasible offset. Such a row is still nudged
   toward the vehicle but is **not** guaranteed to rejoin in front of it, so the
-  proportion of genuinely hardened scenes is lower than `P` suggests. Enabling the flag
-  also reduces the augmented count somewhat — measured at 10,330 → 9,742 accepted rows
-  on a 105k-scene set at `P = 1.0`.
+  proportion of genuinely hardened scenes is lower than `P` suggests.
+
+  Enabling the flag costs augmented rows, and the aggregate hides how uneven that cost
+  is. On a 105k-scene set at `P = 1.0` the count goes 10,330 → 9,742 (−6%). But on the
+  tight passes the flag exists to serve it is far more expensive: pointing every offset
+  at the vehicle means most candidates are then rejected by the exact footprint check.
+  Measured on one stationary vehicle 25 m ahead at 1.8 m lateral, 128 draws — 91 rows
+  accepted with the flag off, 8 with it on. The fallback above is what keeps that from
+  being 0; it does not recover the rest, and no selection rule can, because a 2.0 m ego
+  does not fit a 1.8 m gap. Use `P` as a small fraction, not a global setting.
 
 - **`--frenet_hist_jitter_lat L` / `--frenet_hist_jitter_lon G`** (default 0.0).
   Smooth per-sample jitter of the ego history, in metres of standard deviation at the

--- a/README.md
+++ b/README.md
@@ -150,8 +150,7 @@ augmenter reproduces the previous behaviour exactly.
   --frenet_recovery_rounds 1 \      # retry after a footprint veto
   --frenet_min_clearance 0.2 \      # metres of clearance to keep from recorded vehicles
   --frenet_toward_parked_prob 0.3 \ # fraction of eligible scenes nudged toward a parked vehicle
-  --frenet_hist_jitter_lat 0.3 \    # smooth lateral jitter of the history, metres at the oldest sample
-  --frenet_hist_jitter_lon 0.3      # same, along the direction of travel
+  --frenet_hist_jitter_lat 0.3      # smooth lateral jitter of the history, metres at the oldest sample
 ```
 
 - **`--frenet_recovery_rounds N`** (default 0). A candidate whose footprint overlaps a
@@ -196,13 +195,19 @@ augmenter reproduces the previous behaviour exactly.
   being 0; it does not recover the rest, and no selection rule can, because a 2.0 m ego
   does not fit a 1.8 m gap. Use `P` as a small fraction, not a global setting.
 
-- **`--frenet_hist_jitter_lat L` / `--frenet_hist_jitter_lon G`** (default 0.0).
-  Smooth per-sample jitter of the ego history, in metres of standard deviation at the
-  oldest sample, perpendicular to and along the direction of travel. The two axes are
-  drawn independently. Unlike `--ego_past_noise_std`, which can only make a
-  correctly-shaped history be traversed at the wrong speed, this makes the history
-  itself imperfect. Applied after the footprint check and with t=0 pinned, so the
-  target and the state the model plans from are unchanged.
+- **`--frenet_hist_jitter_lat L`** (default 0.0). Smooth per-sample jitter of the ego
+  history, in metres of standard deviation at the oldest sample, perpendicular to the
+  direction of travel. Unlike `--ego_past_noise_std`, which can only make a
+  correctly-shaped history be traversed at the wrong speed, this bends the history
+  itself. Applied after the footprint check and with t=0 pinned, so the target and the
+  state the model plans from are unchanged.
+
+  **There is no longitudinal counterpart.** One existed and was removed on measurement:
+  jittering along the path varies the sample spacing, and that arm was the worst of the
+  campaign in all four eval cells on both metrics (8 arms × 2 seeds, ~1,113 perturbed
+  closed-loop rollouts per arm, scored under both trackers at replan intervals 1 and 3).
+  Lateral alone was the best arm on recovery in both cells that had the resolution to
+  tell — and had the smallest seed spread of any arm — which is why it survived.
 
   That ordering is deliberate — it keeps acceptance independent of the noise, which is
   what makes an A/B between the two history perturbations valid — but it has a

--- a/README.md
+++ b/README.md
@@ -140,6 +140,25 @@ Left unset it resolves per augmenter, because they do not perturb the same thing
 > both trackers, replan intervals 1 and 3) it moved recovery 28.3% → 30.2% at replan 1
 > and 52.7% → 52.2% at replan 3, every difference inside the seed spread.
 
+`--ego_past_noise_mode` selects **which** mechanism that std drives, for
+`augment_type=frenet`. Exactly one runs — they are mutually exclusive:
+
+| mode | what it does | units of the std | bounded? |
+|---|---|---|---|
+| `scale` (default) | one factor multiplies the whole rewritten history: the track keeps its shape and is traversed at the wrong speed | dimensionless (`N(1, std)`) | yes, ±2σ |
+| `jitter` | a smooth lateral bend of the track, so its *shape* is wrong; three low-frequency modes, exactly zero at t=0 | **metres** at the oldest sample | **no** |
+
+A mode rather than two magnitude flags, because two flags could both be set and the
+combination is reachable by accident — the scale default is non-zero, so asking for
+jitter alone used to silently apply both, and that combination has never been
+evaluated (every jitter arm of the A/B pinned the scale to 0). `jitter` is
+implemented for frenet only; asking for it with another `augment_type` is an error.
+
+Note the std means different things per mode. `0.1` is ±10% of a traversal speed in
+`scale`, and 0.1 m of lateral displacement in `jitter`. The A/B tested **0.3 m** for
+jitter, so that is the value to pass; and because the jitter is unclamped, 31.7% of
+draws exceed the std and 4.5% exceed twice it (measured over 200k draws).
+
 Passing a number applies it to whichever augmenter is selected, so the flag stays
 sweepable. Note that a `quintic`-vs-`frenet` A/B on it is not measuring the same
 perturbation — quintic also rescales the current velocity and acceleration.
@@ -154,7 +173,8 @@ augmenter reproduces the previous behaviour exactly.
   --frenet_recovery_rounds 1 \      # retry after a footprint veto
   --frenet_min_clearance 0.2 \      # metres of clearance to keep from recorded vehicles
   --frenet_toward_parked_prob 0.3 \ # fraction of eligible scenes nudged toward a parked vehicle
-  --frenet_hist_jitter_lat 0.3      # smooth lateral jitter of the history, metres at the oldest sample
+  --ego_past_noise_mode jitter \   # bend the history instead of stretching it (frenet only)
+  --ego_past_noise_std 0.3          # metres at the oldest sample, in jitter mode
 ```
 
 - **`--frenet_recovery_rounds N`** (default 0). A candidate whose footprint overlaps a
@@ -209,29 +229,6 @@ augmenter reproduces the previous behaviour exactly.
   accepted with the flag off, 8 with it on. The fallback above is what keeps that from
   being 0; it does not recover the rest, and no selection rule can, because a 2.0 m ego
   does not fit a 1.8 m gap. Use `P` as a small fraction, not a global setting.
-
-- **`--frenet_hist_jitter_lat L`** (default 0.0). Smooth per-sample jitter of the ego
-  history, in metres of standard deviation at the oldest sample, perpendicular to the
-  direction of travel. Unlike `--ego_past_noise_std`, which can only make a
-  correctly-shaped history be traversed at the wrong speed, this bends the history
-  itself. Applied after the footprint check and with t=0 pinned, so the target and the
-  state the model plans from are unchanged.
-
-  **There is no longitudinal counterpart.** One existed and was removed on measurement:
-  jittering along the path varies the sample spacing, and that arm was the worst of the
-  campaign in all four eval cells on both metrics (8 arms × 2 seeds, ~1,113 perturbed
-  closed-loop rollouts per arm, scored under both trackers at replan intervals 1 and 3).
-  Lateral alone was the best arm on recovery in both cells that had the resolution to
-  tell — and had the smallest seed spread of any arm — which is why it survived.
-
-  That ordering is deliberate — it keeps acceptance independent of the noise, which is
-  what makes an A/B between the two history perturbations valid — but it has a
-  consequence worth stating: **the jittered history is not re-checked against the
-  footprint constraint.** The corridor bounds certify the clean polyline, so at
-  `L = 0.3` the oldest sample can move ~0.6–0.9 m at 2–3σ, and on a drive that passed a
-  parked vehicle closely the resulting history can put the ego footprint inside that
-  vehicle in the past. The future, the target and t=0 are unaffected; what the encoder
-  reads is. Keep `L` small relative to the clearances in the data.
 
 Frenet also exposes the sampling grid itself — `--frenet_n_draws`, `--frenet_dy_max`,
 `--frenet_dth_max`, `--frenet_merge_times`, `--frenet_anchors`, `--frenet_acc0_fracs`,

--- a/README.md
+++ b/README.md
@@ -159,11 +159,20 @@ augmenter reproduces the previous behaviour exactly.
 
 - **`--frenet_toward_parked_prob P`** (default 0.0). The corridor is symmetric, so a
   scene that passes a parked vehicle is as likely to be nudged away from it as toward
-  it. This directs that fraction of eligible scenes toward the vehicle and takes the
-  largest feasible offset, making the t=0 state a harder avoidance than the recorded
-  one, while restricting the merge to horizons that rejoin the recording *before* the
-  vehicle. A scene is eligible only when a parked vehicle bounds the corridor and is
-  still ahead at t=0; if it is already alongside there is no avoidance left to harden.
+  it. This directs that fraction of eligible scenes toward the vehicle. A scene is
+  eligible only when a parked vehicle bounds the corridor and is still ahead at t=0; if
+  it is already alongside there is no avoidance left to harden.
+
+  On a row where it can, the augmenter then takes the *largest* feasible offset and
+  restricts the merge to horizons that rejoin the recording **before** the vehicle,
+  which is what makes the t=0 state a harder avoidance than the recorded one. Neither
+  is unconditional: on a tight pass that merge restriction can strike out every
+  horizon, and rather than drop the scene from augmentation the row keeps its ungated
+  candidates and takes the ordinary first-feasible offset. Such a row is still nudged
+  toward the vehicle but is **not** guaranteed to rejoin in front of it, so the
+  proportion of genuinely hardened scenes is lower than `P` suggests. Enabling the flag
+  also reduces the augmented count somewhat — measured at 10,330 → 9,742 accepted rows
+  on a 105k-scene set at `P = 1.0`.
 
 - **`--frenet_hist_jitter_lat L` / `--frenet_hist_jitter_lon G`** (default 0.0).
   Smooth per-sample jitter of the ego history, in metres of standard deviation at the

--- a/diffusion_planner/diffusion_planner/config/train_config.py
+++ b/diffusion_planner/diffusion_planner/config/train_config.py
@@ -72,6 +72,20 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
         "naturally takes for the drawn offset and horizon.",
         default_factory=lambda: [0.0, -0.5, 0.5, -1.0, 1.0],
     )
+    frenet_toward_parked_prob: float = cli(
+        "frenet: fraction of scenes where a PARKED vehicle bounds the corridor far enough "
+        "ahead that the avoidance is still in front of the ego, whose nudges are mirrored "
+        "to point AT that vehicle and the largest feasible one is taken. Makes the t=0 "
+        "state a harder avoidance than the recording's. 0 (default) leaves the uniform "
+        "draw untouched.",
+        default=0.0,
+    )
+    frenet_min_clearance: float = cli(
+        "frenet: exact footprint clearance (m) every accepted candidate must keep from "
+        "every recorded neighbour, on top of the corridor margin. Applies to all rows. "
+        "0 (default) keeps the overlap-only veto.",
+        default=0.0,
+    )
     frenet_recovery_rounds: int = cli(
         "frenet: rounds of re-selection allowed after a candidate is vetoed for truly "
         "overlapping a recorded neighbour. Each round burns the losing draw and tries "

--- a/diffusion_planner/diffusion_planner/config/train_config.py
+++ b/diffusion_planner/diffusion_planner/config/train_config.py
@@ -48,7 +48,13 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
         default="quintic",
     )
     num_refine: int = 20
-    ego_past_noise_std: float = 0.1
+    ego_past_noise_std: float = cli(
+        "std of the single per-scene factor that scales an augmented row's ego history "
+        "and its current velocity/acceleration, drawn from N(1, std) and clamped to "
+        "+-2 std. The quintic augmenter scales the RECORDED history; frenet scales the "
+        "history it rewrote from the perturbed polyline. 0 disables it.",
+        default=0.1,
+    )
     use_smoothing_future_trajectory: bool = True
 
     # --- frenet augmentation knobs (ignored unless augment_type=frenet) ---
@@ -102,7 +108,12 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
     # ---------------------------------------------------------
     # Training Parameters
     # ---------------------------------------------------------
-    seed: int = 3407
+    seed: int = cli(
+        "seed for model init, data order and augmentation draws. Vary it to measure the "
+        "run-to-run noise floor: training is otherwise deterministic, so two runs at the "
+        "same seed produce identical weights and cannot serve as a control.",
+        default=3407,
+    )
     train_epochs: int = cli("total training epochs", default=80)
     save_utd: int = cli("checkpoint save cadence in epochs", default=10)
     learning_rate: float = 1e-4

--- a/diffusion_planner/diffusion_planner/config/train_config.py
+++ b/diffusion_planner/diffusion_planner/config/train_config.py
@@ -72,6 +72,12 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
         "naturally takes for the drawn offset and horizon.",
         default_factory=lambda: [0.0, -0.5, 0.5, -1.0, 1.0],
     )
+    frenet_recovery_rounds: int = cli(
+        "frenet: rounds of re-selection allowed after a candidate is vetoed for truly "
+        "overlapping a recorded neighbour. Each round burns the losing draw and tries "
+        "the next one. 0 (default) leaves a vetoed scene on plain ground truth.",
+        default=0,
+    )
     frenet_ranked_temp_s: float = cli(
         "frenet: time constant (s) of the merge-horizon sampling; smaller favours "
         "faster convergence more strongly.",

--- a/diffusion_planner/diffusion_planner/config/train_config.py
+++ b/diffusion_planner/diffusion_planner/config/train_config.py
@@ -49,10 +49,12 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
     )
     num_refine: int = 20
     ego_past_noise_std: float = cli(
-        "std of the single per-scene factor that scales an augmented row's ego history "
-        "and its current velocity/acceleration, drawn from N(1, std) and clamped to "
-        "+-2 std. The quintic augmenter scales the RECORDED history; frenet scales the "
-        "history it rewrote from the perturbed polyline. 0 disables it.",
+        "std of the single per-scene factor scaling an augmented row's ego history, "
+        "drawn from N(1, std) and clamped to +-2 std. WHAT IT SCALES DIFFERS BY "
+        "AUGMENTER: quintic scales the RECORDED history AND the current velocity and "
+        "acceleration; frenet scales the history it rewrote from the perturbed polyline "
+        "and leaves ego_current_state bit-identical. Note the default is non-zero, so "
+        "frenet runs perturb the history unless this is set to 0.",
         default=0.1,
     )
     use_smoothing_future_trajectory: bool = True

--- a/diffusion_planner/diffusion_planner/config/train_config.py
+++ b/diffusion_planner/diffusion_planner/config/train_config.py
@@ -86,6 +86,14 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
         "0 (default) keeps the overlap-only veto.",
         default=0.0,
     )
+    frenet_past_noise_std: float = cli(
+        "frenet: std of the single per-scene factor scaling an AUGMENTED row's rewritten "
+        "history and its current velocity/acceleration, drawn from N(1, std) and clamped "
+        "to +-2 std -- the same history perturbation the quintic augmenter applies via "
+        "--ego_past_noise_std, which frenet otherwise disables because it rewrites the "
+        "past kinematically. 0 (default) leaves the rewritten history alone.",
+        default=0.0,
+    )
     frenet_recovery_rounds: int = cli(
         "frenet: rounds of re-selection allowed after a candidate is vetoed for truly "
         "overlapping a recorded neighbour. Each round burns the losing draw and tries "

--- a/diffusion_planner/diffusion_planner/config/train_config.py
+++ b/diffusion_planner/diffusion_planner/config/train_config.py
@@ -86,20 +86,6 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
         "0 (default) keeps the overlap-only veto.",
         default=0.0,
     )
-    frenet_past_noise_std: float = cli(
-        "frenet: std of the single per-scene factor scaling an AUGMENTED row's rewritten "
-        "history and its current velocity/acceleration, drawn from N(1, std) and clamped "
-        "to +-2 std -- the same history perturbation the quintic augmenter applies via "
-        "--ego_past_noise_std, which frenet otherwise disables because it rewrites the "
-        "past kinematically. 0 (default) leaves the rewritten history alone.",
-        default=0.0,
-    )
-    frenet_recovery_rounds: int = cli(
-        "frenet: rounds of re-selection allowed after a candidate is vetoed for truly "
-        "overlapping a recorded neighbour. Each round burns the losing draw and tries "
-        "the next one. 0 (default) leaves a vetoed scene on plain ground truth.",
-        default=0,
-    )
     frenet_ranked_temp_s: float = cli(
         "frenet: time constant (s) of the merge-horizon sampling; smaller favours "
         "faster convergence more strongly.",

--- a/diffusion_planner/diffusion_planner/config/train_config.py
+++ b/diffusion_planner/diffusion_planner/config/train_config.py
@@ -92,6 +92,13 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
         "0 (default) keeps the overlap-only veto.",
         default=0.0,
     )
+    frenet_hist_jitter_lat: float = cli(
+        "frenet: std (m) of a smooth per-scene LATERAL wobble of the rewritten ego "
+        "history, measured at the oldest history sample and tapering to exactly 0 at "
+        "t=0. Three low-frequency modes, so the track bends rather than looking noisy. "
+        "0 (default) draws nothing.",
+        default=0.0,
+    )
     frenet_ranked_temp_s: float = cli(
         "frenet: time constant (s) of the merge-horizon sampling; smaller favours "
         "faster convergence more strongly.",

--- a/diffusion_planner/diffusion_planner/config/train_config.py
+++ b/diffusion_planner/diffusion_planner/config/train_config.py
@@ -99,6 +99,12 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
         "0 (default) draws nothing.",
         default=0.0,
     )
+    frenet_hist_jitter_lon: float = cli(
+        "frenet: as frenet_hist_jitter_lat, but ALONG the direction of travel. Varies "
+        "the spacing of the history samples, i.e. makes the implied speed history "
+        "wobble rather than be uniformly wrong. 0 (default) draws nothing.",
+        default=0.0,
+    )
     frenet_ranked_temp_s: float = cli(
         "frenet: time constant (s) of the merge-horizon sampling; smaller favours "
         "faster convergence more strongly.",

--- a/diffusion_planner/diffusion_planner/config/train_config.py
+++ b/diffusion_planner/diffusion_planner/config/train_config.py
@@ -105,6 +105,12 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
         "wobble rather than be uniformly wrong. 0 (default) draws nothing.",
         default=0.0,
     )
+    frenet_recovery_rounds: int = cli(
+        "frenet: rounds of re-selection allowed after a candidate is vetoed for truly "
+        "overlapping a recorded neighbour. Each round burns the losing draw and tries "
+        "the next one. 0 (default) leaves a vetoed scene on plain ground truth.",
+        default=0,
+    )
     frenet_ranked_temp_s: float = cli(
         "frenet: time constant (s) of the merge-horizon sampling; smaller favours "
         "faster convergence more strongly.",

--- a/diffusion_planner/diffusion_planner/config/train_config.py
+++ b/diffusion_planner/diffusion_planner/config/train_config.py
@@ -64,6 +64,16 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
         "support it and rejects the flag rather than ignoring it.",
         default=None,
     )
+    ego_past_noise_mode: Literal["scale", "jitter"] = cli(
+        "which history perturbation --ego_past_noise_std drives, for augment_type=frenet. "
+        "scale (default) = one multiplicative factor on the whole rewritten history, so "
+        "the track keeps its shape and is traversed at the wrong speed; the std is "
+        "dimensionless and clamped to +-2 std. jitter = a smooth lateral bend of the "
+        "track, so its SHAPE is wrong; the std is in METRES at the oldest history sample "
+        "and is not clamped. The two are mutually exclusive -- exactly one runs. "
+        "augment_type=quintic supports scale only.",
+        default="scale",
+    )
     use_smoothing_future_trajectory: bool = True
 
     # --- frenet augmentation knobs (ignored unless augment_type=frenet) ---
@@ -102,14 +112,6 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
         "its merge window and a global floor would reject scenes for the recording's own "
         "clearance. True overlap is rejected everywhere regardless. Applies to the "
         "neighbour cut only, never the road edge. 0 (default) keeps the overlap-only veto.",
-        default=0.0,
-    )
-    frenet_hist_jitter_lat: float = cli(
-        "frenet: std (m) of a smooth per-scene LATERAL wobble of the rewritten ego "
-        "history, measured at the oldest history sample and tapering to exactly 0 at "
-        "t=0. Three low-frequency modes, so the track bends rather than looking noisy. "
-        "0 (default) draws nothing. There is no longitudinal counterpart: it was "
-        "measured and removed.",
         default=0.0,
     )
     frenet_recovery_rounds: int = cli(

--- a/diffusion_planner/diffusion_planner/config/train_config.py
+++ b/diffusion_planner/diffusion_planner/config/train_config.py
@@ -55,9 +55,9 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
     ego_past_noise_std: Optional[float] = cli(
         "std of the single per-scene factor scaling an augmented row's ego history, "
         "drawn from N(1, std) and clamped to +-2 std. Unset resolves per augmenter: "
-        "quintic 0.1 and frenet 0.1. The frenet value is a DELIBERATE DEFAULT CHANGE "
-        "-- tier4-main hard-passed 0.0 -- so reproducing a historical frenet run "
-        "requires --ego_past_noise_std 0 explicitly. Passing a number applies it to "
+        "quintic 0.1 and frenet 0.0, matching tier4-main for both. Frenet is off by default because it already rewrites the past kinematically, so this would scale a "
+        "synthesised history rather than a recorded one; pass a number to enable it. "
+        "Passing a number applies it to "
         "whichever augmenter is selected. WHAT IT SCALES DIFFERS BY "
         "AUGMENTER: quintic scales the RECORDED history AND the current velocity and "
         "acceleration; frenet scales the history it rewrote from the perturbed polyline "

--- a/diffusion_planner/diffusion_planner/config/train_config.py
+++ b/diffusion_planner/diffusion_planner/config/train_config.py
@@ -104,19 +104,6 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
         "neighbour cut only, never the road edge. 0 (default) keeps the overlap-only veto.",
         default=0.0,
     )
-    frenet_hist_jitter_lat: float = cli(
-        "frenet: std (m) of a smooth per-scene LATERAL wobble of the rewritten ego "
-        "history, measured at the oldest history sample and tapering to exactly 0 at "
-        "t=0. Three low-frequency modes, so the track bends rather than looking noisy. "
-        "0 (default) draws nothing.",
-        default=0.0,
-    )
-    frenet_hist_jitter_lon: float = cli(
-        "frenet: as frenet_hist_jitter_lat, but ALONG the direction of travel. Varies "
-        "the spacing of the history samples, i.e. makes the implied speed history "
-        "wobble rather than be uniformly wrong. 0 (default) draws nothing.",
-        default=0.0,
-    )
     frenet_recovery_rounds: int = cli(
         "frenet: rounds of re-selection allowed after a candidate is vetoed for truly "
         "overlapping a recorded neighbour. Each round burns the losing draw and tries "

--- a/diffusion_planner/diffusion_planner/config/train_config.py
+++ b/diffusion_planner/diffusion_planner/config/train_config.py
@@ -76,6 +76,10 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
         "augment_type=quintic supports scale only.",
         default="scale",
     )
+    # Written by resolve_history_noise at startup, before args.json is serialized, so
+    # the saved config records the value the run actually applied. NOT a CLI flag --
+    # it is an output. None means no history perturbation was applied at all.
+    ego_past_noise_std_effective: Optional[float] = None
     use_smoothing_future_trajectory: bool = True
 
     # --- frenet augmentation knobs (ignored unless augment_type=frenet) ---

--- a/diffusion_planner/diffusion_planner/config/train_config.py
+++ b/diffusion_planner/diffusion_planner/config/train_config.py
@@ -108,13 +108,8 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
         "frenet: std (m) of a smooth per-scene LATERAL wobble of the rewritten ego "
         "history, measured at the oldest history sample and tapering to exactly 0 at "
         "t=0. Three low-frequency modes, so the track bends rather than looking noisy. "
-        "0 (default) draws nothing.",
-        default=0.0,
-    )
-    frenet_hist_jitter_lon: float = cli(
-        "frenet: as frenet_hist_jitter_lat, but ALONG the direction of travel. Varies "
-        "the spacing of the history samples, i.e. makes the implied speed history "
-        "wobble rather than be uniformly wrong. 0 (default) draws nothing.",
+        "0 (default) draws nothing. There is no longitudinal counterpart: it was "
+        "measured and removed.",
         default=0.0,
     )
     frenet_recovery_rounds: int = cli(

--- a/diffusion_planner/diffusion_planner/config/train_config.py
+++ b/diffusion_planner/diffusion_planner/config/train_config.py
@@ -39,7 +39,11 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
     num_workers: int = 8
     pin_mem: bool = True
 
-    use_data_augment: bool = True
+    use_data_augment: bool = cli(
+        "apply the --augment_type augmenter during training. False trains on the "
+        "recorded states only.",
+        default=True,
+    )
     augment_prob: float = 0.5
     augment_type: Literal["quintic", "bridge", "frenet"] = cli(
         "data augmentation method: quintic (default) = fixed-offset quintic bridge; "
@@ -89,9 +93,12 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
         default=0.0,
     )
     frenet_min_clearance: float = cli(
-        "frenet: exact footprint clearance (m) every accepted candidate must keep from "
-        "every recorded neighbour, on top of the corridor margin. Applies to all rows. "
-        "0 (default) keeps the overlap-only veto.",
+        "frenet: exact footprint clearance (m) required from every recorded neighbour, "
+        "on top of the corridor margin, AT THE TIMESTEPS THE PERTURBATION MOVED THE EGO "
+        "-- not a global floor, since a candidate coincides with the recording outside "
+        "its merge window and a global floor would reject scenes for the recording's own "
+        "clearance. True overlap is rejected everywhere regardless. Applies to the "
+        "neighbour cut only, never the road edge. 0 (default) keeps the overlap-only veto.",
         default=0.0,
     )
     frenet_hist_jitter_lat: float = cli(

--- a/diffusion_planner/diffusion_planner/config/train_config.py
+++ b/diffusion_planner/diffusion_planner/config/train_config.py
@@ -52,14 +52,17 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
         default="quintic",
     )
     num_refine: int = 20
-    ego_past_noise_std: float = cli(
+    ego_past_noise_std: Optional[float] = cli(
         "std of the single per-scene factor scaling an augmented row's ego history, "
-        "drawn from N(1, std) and clamped to +-2 std. WHAT IT SCALES DIFFERS BY "
+        "drawn from N(1, std) and clamped to +-2 std. Unset means each augmenter keeps "
+        "the value it has always used (quintic 0.1, frenet 0.0); passing a number "
+        "applies it to whichever augmenter is selected. WHAT IT SCALES DIFFERS BY "
         "AUGMENTER: quintic scales the RECORDED history AND the current velocity and "
         "acceleration; frenet scales the history it rewrote from the perturbed polyline "
-        "and leaves ego_current_state bit-identical. Note the default is non-zero, so "
-        "frenet runs perturb the history unless this is set to 0.",
-        default=0.1,
+        "and leaves ego_current_state bit-identical -- so a quintic-vs-frenet A/B on "
+        "this flag is not measuring the same perturbation. augment_type=bridge does not "
+        "support it and rejects the flag rather than ignoring it.",
+        default=None,
     )
     use_smoothing_future_trajectory: bool = True
 

--- a/diffusion_planner/diffusion_planner/config/train_config.py
+++ b/diffusion_planner/diffusion_planner/config/train_config.py
@@ -54,9 +54,11 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
     num_refine: int = 20
     ego_past_noise_std: Optional[float] = cli(
         "std of the single per-scene factor scaling an augmented row's ego history, "
-        "drawn from N(1, std) and clamped to +-2 std. Unset means each augmenter keeps "
-        "the value it has always used (quintic 0.1, frenet 0.0); passing a number "
-        "applies it to whichever augmenter is selected. WHAT IT SCALES DIFFERS BY "
+        "drawn from N(1, std) and clamped to +-2 std. Unset resolves per augmenter: "
+        "quintic 0.1 and frenet 0.1. The frenet value is a DELIBERATE DEFAULT CHANGE "
+        "-- tier4-main hard-passed 0.0 -- so reproducing a historical frenet run "
+        "requires --ego_past_noise_std 0 explicitly. Passing a number applies it to "
+        "whichever augmenter is selected. WHAT IT SCALES DIFFERS BY "
         "AUGMENTER: quintic scales the RECORDED history AND the current velocity and "
         "acceleration; frenet scales the history it rewrote from the perturbed polyline "
         "and leaves ego_current_state bit-identical -- so a quintic-vs-frenet A/B on "

--- a/diffusion_planner/diffusion_planner/config/train_config.py
+++ b/diffusion_planner/diffusion_planner/config/train_config.py
@@ -104,6 +104,19 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
         "neighbour cut only, never the road edge. 0 (default) keeps the overlap-only veto.",
         default=0.0,
     )
+    frenet_hist_jitter_lat: float = cli(
+        "frenet: std (m) of a smooth per-scene LATERAL wobble of the rewritten ego "
+        "history, measured at the oldest history sample and tapering to exactly 0 at "
+        "t=0. Three low-frequency modes, so the track bends rather than looking noisy. "
+        "0 (default) draws nothing.",
+        default=0.0,
+    )
+    frenet_hist_jitter_lon: float = cli(
+        "frenet: as frenet_hist_jitter_lat, but ALONG the direction of travel. Varies "
+        "the spacing of the history samples, i.e. makes the implied speed history "
+        "wobble rather than be uniformly wrong. 0 (default) draws nothing.",
+        default=0.0,
+    )
     frenet_recovery_rounds: int = cli(
         "frenet: rounds of re-selection allowed after a candidate is vetoed for truly "
         "overlapping a recorded neighbour. Each round burns the losing draw and tries "

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -19,13 +19,7 @@ from diffusion_planner.model.diffusion_planner import Diffusion_Planner
 from diffusion_planner.scenario_based_open_loop.validate import scenario_based_open_loop_validate
 from diffusion_planner.train_epoch import train_epoch
 from diffusion_planner.utils import ddp
-from diffusion_planner.utils.data_augmentation import StatePerturbation
-from diffusion_planner.utils.data_augmentation_bridge import (
-    StatePerturbation as BridgeStatePerturbation,
-)
-from diffusion_planner.utils.data_augmentation_frenet import (
-    frenet_augmenter_from_args,
-)
+from diffusion_planner.utils.augmenter_factory import augmenter_from_args
 from diffusion_planner.utils.dataset import DiffusionPlannerData, DiffusionPlannerPairData
 from diffusion_planner.utils.lr_schedule import CosineAnnealingWarmUpRestarts, final_phase_lr
 from diffusion_planner.utils.normalizer import ObservationNormalizer, StateNormalizer
@@ -261,21 +255,7 @@ def model_training(args: TrainConfig):
     save_utd = args.save_utd
 
     # set up data loaders
-    if args.use_data_augment:
-        if args.augment_type == "bridge":
-            aug = BridgeStatePerturbation(augment_prob=args.augment_prob, device=args.device)
-        elif args.augment_type == "frenet":
-            aug = frenet_augmenter_from_args(args)
-        else:
-            aug = StatePerturbation(
-                augment_prob=args.augment_prob,
-                num_refine=args.num_refine,
-                device=args.device,
-                ego_past_noise_std=args.ego_past_noise_std,
-                use_smoothing_future_trajectory=args.use_smoothing_future_trajectory,
-            )
-    else:
-        aug = None
+    aug = augmenter_from_args(args)
 
     # prepare dataset
     train_set = DiffusionPlannerData(args.train_set_list)

--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -19,6 +19,7 @@ from diffusion_planner.model.diffusion_planner import Diffusion_Planner
 from diffusion_planner.scenario_based_open_loop.validate import scenario_based_open_loop_validate
 from diffusion_planner.train_epoch import train_epoch
 from diffusion_planner.utils import ddp
+from diffusion_planner.utils.augment_defaults import resolve_history_noise
 from diffusion_planner.utils.augmenter_factory import augmenter_from_args
 from diffusion_planner.utils.dataset import DiffusionPlannerData, DiffusionPlannerPairData
 from diffusion_planner.utils.lr_schedule import CosineAnnealingWarmUpRestarts, final_phase_lr
@@ -218,6 +219,11 @@ def model_training(args: TrainConfig):
     # init ddp
     global_rank, rank, world_size = ddp.ddp_setup_universal(True, args)
     print(f"{global_rank=}, {rank=}")
+
+    # Resolve the per-augmenter history-noise default BEFORE args.json is written, so the
+    # saved configuration is the configuration used. Every rank, because the value feeds
+    # the augmenter each rank builds; rank 0 alone serializes it.
+    resolve_history_noise(args)
 
     if global_rank == 0:
         # Logging

--- a/diffusion_planner/diffusion_planner/utils/augment_defaults.py
+++ b/diffusion_planner/diffusion_planner/utils/augment_defaults.py
@@ -47,41 +47,45 @@ def past_noise_std_for(args) -> float:
 
 
 def resolve_history_noise(args) -> None:
-    """Write the EFFECTIVE history-noise value onto ``args``, in place.
+    """Record the EFFECTIVE history-noise value on ``args``, without destroying the flag.
 
-    Call this once at startup, **before the config is serialized**. Both trainers write
-    ``args.json`` before they build the augmenter, so without this a stock frenet run
-    records ``ego_past_noise_std: null`` while training with 0.1 -- a saved experiment
-    configuration that is not the configuration used, and one whose meaning depends on
-    a future code default rather than on the file. That is the defect the augmenter
-    factory exists to prevent, one level up.
+    Call once at startup, before the config is serialized. Both trainers write
+    ``args.json`` before building the augmenter, so a sentinel that only resolved
+    inside the factory was recorded as null while the run trained with a number.
 
-    Also the only place the bridge rejection can live. The check needs to distinguish
-    "the user passed a value" from "unset", which is exactly the information this
-    function destroys, so it has to run first.
+    The resolved value goes to ``ego_past_noise_std_effective`` and the raw flag is left
+    exactly as the user gave it. Overwriting the flag in place looked simpler but broke
+    round-tripping: ``run_lifelong_r2lpl_rounds`` reads a base run's ``args.json`` and
+    re-feeds the recorded fields as explicit flags, so a frenet run recording 0.1 and a
+    later round overriding ``augment_type`` to bridge died at startup on a flag the user
+    never passed.
 
-    Idempotent: a second call is a no-op, since the value is then already a float.
+    ``None`` in the effective field means "no history perturbation is applied" -- either
+    augmentation is off entirely, or the augmenter does not support the knob.
+
+    Also the only place the mode and bridge rejections can live: both need to tell "the
+    user passed a value" from "unset", which is what resolution would destroy.
+
+    Idempotent.
 
     Raises:
-        ValueError: if ``--ego_past_noise_std`` was passed with an ``augment_type``
-            that cannot honour it.
+        ValueError: on ``jitter`` with a non-frenet augmenter, or on an explicit
+            ``--ego_past_noise_std`` with ``augment_type=bridge``.
     """
     if args.ego_past_noise_mode == "jitter" and args.augment_type != "frenet":
         raise ValueError(
             f"--ego_past_noise_mode jitter is only implemented for augment_type=frenet, "
             f"got {args.augment_type}; drop the flag or pick augment_type=frenet"
         )
-    if args.augment_type == "bridge":
-        if args.ego_past_noise_std is not None:
-            raise ValueError(
-                "--ego_past_noise_std is not supported by augment_type=bridge "
-                "(the bridge augmenter does not perturb the ego history); "
-                "drop the flag or pick another augment_type"
-            )
-        # Left as None deliberately, NOT resolved to a number. Bridge applies no history
-        # perturbation, so None is the honest record: the knob does not apply, rather
-        # than applying at 0. Writing 0.0 here also breaks the second call -- the factory
-        # calls this defensively, and a resolved 0.0 is indistinguishable from a user
-        # passing 0.0, so the rejection above would fire on every ordinary bridge run.
+    if args.augment_type == "bridge" and args.ego_past_noise_std is not None:
+        raise ValueError(
+            "--ego_past_noise_std is not supported by augment_type=bridge "
+            "(the bridge augmenter does not perturb the ego history); "
+            "drop the flag or pick another augment_type"
+        )
+    # Nothing is applied when augmentation is off or the augmenter has no such knob, so
+    # the effective value stays None rather than recording a number no run ever used.
+    if not args.use_data_augment or args.augment_type == "bridge":
+        args.ego_past_noise_std_effective = None
         return
-    args.ego_past_noise_std = past_noise_std_for(args)
+    args.ego_past_noise_std_effective = past_noise_std_for(args)

--- a/diffusion_planner/diffusion_planner/utils/augment_defaults.py
+++ b/diffusion_planner/diffusion_planner/utils/augment_defaults.py
@@ -22,7 +22,10 @@ so a resolver in either of those would be a cycle.
 # replan 1; 1.0 on lost% at replan 3), so the evidence says the perturbation neither
 # helps nor hurts. It is on by default because the flag is uniform across augmenters
 # that support it, NOT because it was shown to improve anything.
-DEFAULT_PAST_NOISE_STD = {"quintic": 0.1, "bridge": 0.0, "frenet": 0.1}
+# No bridge entry on purpose: resolve_history_noise returns before resolving for
+# bridge, so a lookup here can only come from a caller that bypassed it -- and that
+# caller should get the KeyError this dict advertises, not a silent 0.0.
+DEFAULT_PAST_NOISE_STD = {"quintic": 0.1, "frenet": 0.1}
 
 
 def past_noise_std_for(args) -> float:

--- a/diffusion_planner/diffusion_planner/utils/augment_defaults.py
+++ b/diffusion_planner/diffusion_planner/utils/augment_defaults.py
@@ -1,0 +1,33 @@
+"""Per-augmenter defaults for knobs that are shared by name but not by history.
+
+Lives in its own module because both :mod:`augmenter_factory` and
+:mod:`data_augmentation_frenet` need it and the factory imports the frenet builder,
+so a resolver in either of those would be a cycle.
+"""
+
+# `--ego_past_noise_std` unset means "whatever this augmenter has always used", which is
+# NOT the same number for each. Quintic has perturbed the recorded history at 0.1 since
+# it was written. Frenet rewrites the history kinematically from the perturbed polyline
+# and hard-coded 0.0 before the flag was threaded to it, so inheriting quintic's 0.1
+# would silently change every frenet run and leave existing frenet checkpoints
+# unreproducible at their own seed. Bridge has no history perturbation at all.
+#
+# There is no measured reason to change the frenet default either: on a 2-seed, 8-arm
+# A/B (~1,110 perturbed closed-loop rollouts per arm), turning it on moved recovery
+# 28.3% -> 30.2%, well inside the 17.2-point spread between the control's own two seeds.
+DEFAULT_PAST_NOISE_STD = {"quintic": 0.1, "bridge": 0.0, "frenet": 0.0}
+
+
+def past_noise_std_for(args) -> float:
+    """The history-noise std an augmenter should use, honouring an explicit flag.
+
+    ``None`` (the unset default) resolves per augmenter; any number the caller passed
+    wins for every augmenter, so a sweep over the flag still sweeps all of them.
+
+    Raises:
+        KeyError: on an ``augment_type`` with no recorded default, which means a new
+            augmenter was added without deciding what this knob means for it.
+    """
+    if args.ego_past_noise_std is not None:
+        return float(args.ego_past_noise_std)
+    return DEFAULT_PAST_NOISE_STD[args.augment_type]

--- a/diffusion_planner/diffusion_planner/utils/augment_defaults.py
+++ b/diffusion_planner/diffusion_planner/utils/augment_defaults.py
@@ -63,10 +63,17 @@ def resolve_history_noise(args) -> None:
         ValueError: if ``--ego_past_noise_std`` was passed with an ``augment_type``
             that cannot honour it.
     """
-    if args.ego_past_noise_std is not None and args.augment_type == "bridge":
-        raise ValueError(
-            "--ego_past_noise_std is not supported by augment_type=bridge "
-            "(the bridge augmenter does not perturb the ego history); "
-            "drop the flag or pick another augment_type"
-        )
+    if args.augment_type == "bridge":
+        if args.ego_past_noise_std is not None:
+            raise ValueError(
+                "--ego_past_noise_std is not supported by augment_type=bridge "
+                "(the bridge augmenter does not perturb the ego history); "
+                "drop the flag or pick another augment_type"
+            )
+        # Left as None deliberately, NOT resolved to a number. Bridge applies no history
+        # perturbation, so None is the honest record: the knob does not apply, rather
+        # than applying at 0. Writing 0.0 here also breaks the second call -- the factory
+        # calls this defensively, and a resolved 0.0 is indistinguishable from a user
+        # passing 0.0, so the rejection above would fire on every ordinary bridge run.
+        return
     args.ego_past_noise_std = past_noise_std_for(args)

--- a/diffusion_planner/diffusion_planner/utils/augment_defaults.py
+++ b/diffusion_planner/diffusion_planner/utils/augment_defaults.py
@@ -5,27 +5,28 @@ Lives in its own module because both :mod:`augmenter_factory` and
 so a resolver in either of those would be a cycle.
 """
 
-# `--ego_past_noise_std` unset means "the default for this augmenter". Quintic has
-# perturbed the recorded history at 0.1 since it was written. Frenet now matches it.
-# Bridge has no history perturbation at all, so it has no default to speak of and
-# rejects the flag rather than accepting and ignoring it.
+# `--ego_past_noise_std` unset means "the default for this augmenter", and the two
+# supported augmenters disagree on purpose. Quintic has perturbed the RECORDED ego
+# history at 0.1 since it was written. Frenet stays at 0.0, matching `tier4-main`,
+# which hard-passes 0.0 with the reason in-line: frenet already rewrites the past
+# kinematically from the perturbed polyline, so a multiplicative scale on top would
+# perturb a history this augmenter synthesised rather than one it observed.
 #
-# The frenet 0.1 is a DELIBERATE DEFAULT CHANGE, not an inherited value. `tier4-main`
-# hard-passed 0.0 to the frenet augmenter, so a stock `--augment_type frenet` run on
-# this branch trains a different distribution than the same command on main, and
-# reproducing an existing frenet checkpoint needs `--ego_past_noise_std 0` explicitly.
+# The knob is still available to frenet -- `--ego_past_noise_std 0.1`, or the lateral
+# `--ego_past_noise_mode jitter` -- it is simply off unless asked for.
 #
-# Measured before choosing it: on a 2-seed, 8-arm A/B (~1,113 perturbed closed-loop
-# rollouts per arm, both trackers, replan intervals 1 and 3), 0.1 vs 0.0 moved recovery
-# 28.3% -> 30.2% at replan 1 and 52.7% -> 52.2% at replan 3, with lost% 20.3 -> 19.8 and
-# 7.7 -> 8.0. Every one of those is inside the seed spread (17.2 points on recovered% at
-# replan 1; 1.0 on lost% at replan 3), so the evidence says the perturbation neither
-# helps nor hurts. It is on by default because the flag is uniform across augmenters
-# that support it, NOT because it was shown to improve anything.
+# Measured before choosing it, so the 0.0 is a decision rather than an omission: on a
+# 2-seed, 8-arm A/B (~1,113 perturbed closed-loop rollouts per arm, both trackers,
+# replan intervals 1 and 3), 0.1 vs 0.0 moved recovery 28.3% -> 30.2% at replan 1 and
+# 52.7% -> 52.2% at replan 3, with lost% 20.3 -> 19.8 and 7.7 -> 8.0. Every one of
+# those is inside the seed spread (17.2 points on recovered% at replan 1; 1.0 on lost%
+# at replan 3), so the evidence neither justifies nor forbids the perturbation. With
+# nothing measured to gain, the default is the one that leaves a stock
+# `--augment_type frenet` run byte-identical to main.
 # No bridge entry on purpose: resolve_history_noise returns before resolving for
 # bridge, so a lookup here can only come from a caller that bypassed it -- and that
 # caller should get the KeyError this dict advertises, not a silent 0.0.
-DEFAULT_PAST_NOISE_STD = {"quintic": 0.1, "frenet": 0.1}
+DEFAULT_PAST_NOISE_STD = {"quintic": 0.1, "frenet": 0.0}
 
 
 def past_noise_std_for(args) -> float:
@@ -56,7 +57,7 @@ def resolve_history_noise(args) -> None:
     The resolved value goes to ``ego_past_noise_std_effective`` and the raw flag is left
     exactly as the user gave it. Overwriting the flag in place looked simpler but broke
     round-tripping: ``run_lifelong_r2lpl_rounds`` reads a base run's ``args.json`` and
-    re-feeds the recorded fields as explicit flags, so a frenet run recording 0.1 and a
+    re-feeds the recorded fields as explicit flags, so a quintic run recording 0.1 and a
     later round overriding ``augment_type`` to bridge died at startup on a flag the user
     never passed.
 

--- a/diffusion_planner/diffusion_planner/utils/augment_defaults.py
+++ b/diffusion_planner/diffusion_planner/utils/augment_defaults.py
@@ -31,6 +31,9 @@ def past_noise_std_for(args) -> float:
     ``None`` (the unset default) resolves per augmenter; any number the caller passed
     wins for every augmenter, so a sweep over the flag still sweeps all of them.
 
+    Idempotent, so it is safe to call after :func:`resolve_history_noise` has already
+    written the resolved number back onto ``args``.
+
     Raises:
         KeyError: on an ``augment_type`` with no recorded default, which means a new
             augmenter was added without deciding what this knob means for it.
@@ -38,3 +41,32 @@ def past_noise_std_for(args) -> float:
     if args.ego_past_noise_std is not None:
         return float(args.ego_past_noise_std)
     return DEFAULT_PAST_NOISE_STD[args.augment_type]
+
+
+def resolve_history_noise(args) -> None:
+    """Write the EFFECTIVE history-noise value onto ``args``, in place.
+
+    Call this once at startup, **before the config is serialized**. Both trainers write
+    ``args.json`` before they build the augmenter, so without this a stock frenet run
+    records ``ego_past_noise_std: null`` while training with 0.1 -- a saved experiment
+    configuration that is not the configuration used, and one whose meaning depends on
+    a future code default rather than on the file. That is the defect the augmenter
+    factory exists to prevent, one level up.
+
+    Also the only place the bridge rejection can live. The check needs to distinguish
+    "the user passed a value" from "unset", which is exactly the information this
+    function destroys, so it has to run first.
+
+    Idempotent: a second call is a no-op, since the value is then already a float.
+
+    Raises:
+        ValueError: if ``--ego_past_noise_std`` was passed with an ``augment_type``
+            that cannot honour it.
+    """
+    if args.ego_past_noise_std is not None and args.augment_type == "bridge":
+        raise ValueError(
+            "--ego_past_noise_std is not supported by augment_type=bridge "
+            "(the bridge augmenter does not perturb the ego history); "
+            "drop the flag or pick another augment_type"
+        )
+    args.ego_past_noise_std = past_noise_std_for(args)

--- a/diffusion_planner/diffusion_planner/utils/augment_defaults.py
+++ b/diffusion_planner/diffusion_planner/utils/augment_defaults.py
@@ -5,17 +5,24 @@ Lives in its own module because both :mod:`augmenter_factory` and
 so a resolver in either of those would be a cycle.
 """
 
-# `--ego_past_noise_std` unset means "whatever this augmenter has always used", which is
-# NOT the same number for each. Quintic has perturbed the recorded history at 0.1 since
-# it was written. Frenet rewrites the history kinematically from the perturbed polyline
-# and hard-coded 0.0 before the flag was threaded to it, so inheriting quintic's 0.1
-# would silently change every frenet run and leave existing frenet checkpoints
-# unreproducible at their own seed. Bridge has no history perturbation at all.
+# `--ego_past_noise_std` unset means "the default for this augmenter". Quintic has
+# perturbed the recorded history at 0.1 since it was written. Frenet now matches it.
+# Bridge has no history perturbation at all, so it has no default to speak of and
+# rejects the flag rather than accepting and ignoring it.
 #
-# There is no measured reason to change the frenet default either: on a 2-seed, 8-arm
-# A/B (~1,110 perturbed closed-loop rollouts per arm), turning it on moved recovery
-# 28.3% -> 30.2%, well inside the 17.2-point spread between the control's own two seeds.
-DEFAULT_PAST_NOISE_STD = {"quintic": 0.1, "bridge": 0.0, "frenet": 0.0}
+# The frenet 0.1 is a DELIBERATE DEFAULT CHANGE, not an inherited value. `tier4-main`
+# hard-passed 0.0 to the frenet augmenter, so a stock `--augment_type frenet` run on
+# this branch trains a different distribution than the same command on main, and
+# reproducing an existing frenet checkpoint needs `--ego_past_noise_std 0` explicitly.
+#
+# Measured before choosing it: on a 2-seed, 8-arm A/B (~1,113 perturbed closed-loop
+# rollouts per arm, both trackers, replan intervals 1 and 3), 0.1 vs 0.0 moved recovery
+# 28.3% -> 30.2% at replan 1 and 52.7% -> 52.2% at replan 3, with lost% 20.3 -> 19.8 and
+# 7.7 -> 8.0. Every one of those is inside the seed spread (17.2 points on recovered% at
+# replan 1; 1.0 on lost% at replan 3), so the evidence says the perturbation neither
+# helps nor hurts. It is on by default because the flag is uniform across augmenters
+# that support it, NOT because it was shown to improve anything.
+DEFAULT_PAST_NOISE_STD = {"quintic": 0.1, "bridge": 0.0, "frenet": 0.1}
 
 
 def past_noise_std_for(args) -> float:

--- a/diffusion_planner/diffusion_planner/utils/augment_defaults.py
+++ b/diffusion_planner/diffusion_planner/utils/augment_defaults.py
@@ -63,6 +63,11 @@ def resolve_history_noise(args) -> None:
         ValueError: if ``--ego_past_noise_std`` was passed with an ``augment_type``
             that cannot honour it.
     """
+    if args.ego_past_noise_mode == "jitter" and args.augment_type != "frenet":
+        raise ValueError(
+            f"--ego_past_noise_mode jitter is only implemented for augment_type=frenet, "
+            f"got {args.augment_type}; drop the flag or pick augment_type=frenet"
+        )
     if args.augment_type == "bridge":
         if args.ego_past_noise_std is not None:
             raise ValueError(

--- a/diffusion_planner/diffusion_planner/utils/augmentation_checks.py
+++ b/diffusion_planner/diffusion_planner/utils/augmentation_checks.py
@@ -327,8 +327,14 @@ def veto_overlapping(
     valid: torch.Tensor,
     shapes_wl: torch.Tensor,
     near: torch.Tensor,
+    min_clearance: float = 0.0,
 ) -> torch.Tensor:
     """Clear rows whose footprint truly overlaps a recorded neighbor.
+
+    With ``min_clearance > 0`` the row must also keep at least that much exact
+    footprint clearance from every checked neighbour, not merely avoid overlap.
+    The sign-only fast path is used when the floor is 0, so the default is
+    unchanged.
 
     Lateral bounds are a fast approximation — measured to accept ~1.4% of
     winners whose TRUE footprint overlaps a neighbor box — so the accepted
@@ -347,9 +353,10 @@ def veto_overlapping(
         shapes_wl: (B, N, 2) neighbor width, length.
         near: (B, N) neighbors worth checking, from
             :func:`neighbor_lateral_bounds`.
+        min_clearance: metres of exact clearance every checked pair must keep.
 
     Returns:
-        ``rows`` with overlapping scenes set False.
+        ``rows`` with overlapping (or too-close) scenes set False.
     """
     if not bool(rows.any()):
         return rows
@@ -366,7 +373,8 @@ def veto_overlapping(
         shapes_wl[bi, ni],
         valid[bi, ni],
         paired=True,
-        overlap_only=True,  # a veto only asks whether they overlap
+        # sign alone answers "do they overlap"; a positive floor needs the true gap
+        overlap_only=min_clearance <= 0.0,
     )  # (M, T)
-    rows[bi[clr.amin(-1) < 0.0]] = False
+    rows[bi[clr.amin(-1) < min_clearance]] = False
     return rows

--- a/diffusion_planner/diffusion_planner/utils/augmentation_checks.py
+++ b/diffusion_planner/diffusion_planner/utils/augmentation_checks.py
@@ -183,6 +183,7 @@ def neighbor_lateral_bounds(
     wb: torch.Tensor,
     lo: torch.Tensor,
     hi: torch.Tensor,
+    min_clearance: float = 0.0,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Tighten lateral bounds where a recorded neighbor blocks the way.
 
@@ -195,6 +196,11 @@ def neighbor_lateral_bounds(
         xy, tan, nrm: (B, T, 2) ego path, tangent, normal.
         half_l, half_w, wb: (B,) ego half length, half width, wheel base.
         lo, hi: (B, T) bounds to tighten.
+        min_clearance: metres of exact clearance the caller will later demand of
+            every checked pair. It widens ``near`` only: the returned prefilter has
+            to admit every pair that could come within the floor, not merely every
+            pair that could touch, or the floor would go silently unenforced on the
+            pairs it excluded. 0 leaves the prefilter exactly as it was.
 
     Returns:
         tightened (lo, hi) and ``near`` (B, N) — neighbors close enough
@@ -228,9 +234,12 @@ def neighbor_lateral_bounds(
     near = valid_m & (lon.abs() <= half_l_m + ext_lon)
     # Same test, padded, for the exact-OBB veto: the pad covers the ego's
     # longitudinal half-extent growing under a heading change
-    # (half_l*cos + half_w*sin <= half_l + half_w) plus the wb/2 centre shift,
-    # so a pair outside it cannot overlap and skipping it changes no verdict.
-    near_any[vb, vn] = (valid_m & (lon.abs() <= half_l_m + ext_lon + half_w_m + wb_m / 2)).any(-1)
+    # (half_l*cos + half_w*sin <= half_l + half_w) plus the wb/2 centre shift, plus
+    # any clearance floor the caller will demand, so a pair outside it can neither
+    # overlap nor come within the floor and skipping it changes no verdict.
+    near_any[vb, vn] = (
+        valid_m & (lon.abs() <= half_l_m + ext_lon + half_w_m + wb_m / 2 + min_clearance)
+    ).any(-1)
 
     cut_hi = torch.where(
         near & (lat > 0), lat - ext_lat - half_w_m, torch.full_like(lat, torch.inf)

--- a/diffusion_planner/diffusion_planner/utils/augmentation_checks.py
+++ b/diffusion_planner/diffusion_planner/utils/augmentation_checks.py
@@ -337,6 +337,7 @@ def veto_overlapping(
     shapes_wl: torch.Tensor,
     near: torch.Tensor,
     min_clearance: float = 0.0,
+    floor_mask: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Clear rows whose footprint truly overlaps a recorded neighbor.
 
@@ -344,6 +345,13 @@ def veto_overlapping(
     footprint clearance from every checked neighbour, not merely avoid overlap.
     The sign-only fast path is used when the floor is 0, so the default is
     unchanged.
+
+    ``floor_mask`` says WHERE the floor applies. Outside it, only true overlap is
+    vetoed. This matters because a candidate coincides with the recorded drive
+    outside its merge window, so a floor applied over the whole horizon rejects
+    scenes for the RECORDING's clearance rather than for anything the perturbation
+    did -- which silently deletes the tight-squeeze scenes the augmentation is most
+    valuable on. Overlap is still vetoed everywhere, floor or no floor.
 
     Lateral bounds are a fast approximation — measured to accept ~1.4% of
     winners whose TRUE footprint overlaps a neighbor box — so the accepted
@@ -362,7 +370,10 @@ def veto_overlapping(
         shapes_wl: (B, N, 2) neighbor width, length.
         near: (B, N) neighbors worth checking, from
             :func:`neighbor_lateral_bounds`.
-        min_clearance: metres of exact clearance every checked pair must keep.
+        min_clearance: metres of exact clearance every checked pair must keep,
+            at the timesteps ``floor_mask`` selects.
+        floor_mask: (B, T) bool, the timesteps at which ``min_clearance`` applies.
+            ``None`` applies it everywhere (the caller wants the whole horizon).
 
     Returns:
         ``rows`` with overlapping (or too-close) scenes set False.
@@ -385,5 +396,10 @@ def veto_overlapping(
         # sign alone answers "do they overlap"; a positive floor needs the true gap
         overlap_only=min_clearance <= 0.0,
     )  # (M, T)
-    rows[bi[clr.amin(-1) < min_clearance]] = False
+    if min_clearance <= 0.0 or floor_mask is None:
+        rows[bi[clr.amin(-1) < min_clearance]] = False
+        return rows
+    # per-timestep threshold: the floor where the candidate deviates, 0 elsewhere
+    thr = torch.where(floor_mask[bi], min_clearance, 0.0).to(clr.dtype)  # (M, T)
+    rows[bi[(clr < thr).any(-1)]] = False
     return rows

--- a/diffusion_planner/diffusion_planner/utils/augmentation_checks.py
+++ b/diffusion_planner/diffusion_planner/utils/augmentation_checks.py
@@ -336,8 +336,8 @@ def veto_overlapping(
     valid: torch.Tensor,
     shapes_wl: torch.Tensor,
     near: torch.Tensor,
-    min_clearance: float = 0.0,
-    floor_mask: torch.Tensor | None = None,
+    min_clearance: float,
+    floor_mask: torch.Tensor | None,
 ) -> torch.Tensor:
     """Clear rows whose footprint truly overlaps a recorded neighbor.
 
@@ -345,6 +345,12 @@ def veto_overlapping(
     footprint clearance from every checked neighbour, not merely avoid overlap.
     The sign-only fast path is used when the floor is 0, so the default is
     unchanged.
+
+    ``min_clearance`` and ``floor_mask`` are REQUIRED, with no defaults on purpose:
+    omitting the mask once meant "apply the floor over the whole horizon", which
+    silently deleted legitimate tight passes. A caller must now say which it wants.
+    ``floor_mask=None`` still selects the overlap-only fast path, but only when a
+    caller asks for it explicitly.
 
     ``floor_mask`` says WHERE the floor applies. Outside it, only true overlap is
     vetoed. This matters because a candidate coincides with the recorded drive

--- a/diffusion_planner/diffusion_planner/utils/augmenter_factory.py
+++ b/diffusion_planner/diffusion_planner/utils/augmenter_factory.py
@@ -1,0 +1,51 @@
+"""One place where a parsed config becomes an augmenter.
+
+Both training entrypoints used to carry the same ``if augment_type == ...`` ladder,
+and a knob added to one of them was silently dropped by the other: the GRPO path
+accepted every ``--frenet_*`` flag and then trained at the defaults, so a run's
+recorded configuration was not the configuration it used. ``frenet_augmenter_from_args``
+fixed that for one augmenter; this fixes it for all of them, so there is a single
+place a flag has to be threaded through.
+
+Unlike the ladder it replaces, an unrecognised ``augment_type`` raises instead of
+falling through to quintic — the parser's ``Literal`` already constrains the flag,
+and a programmatic caller deserves the error rather than a silent substitution.
+"""
+
+from diffusion_planner.utils.data_augmentation import StatePerturbation
+from diffusion_planner.utils.data_augmentation_bridge import (
+    StatePerturbation as BridgeStatePerturbation,
+)
+from diffusion_planner.utils.data_augmentation_frenet import frenet_augmenter_from_args
+
+AUGMENT_TYPES = ("quintic", "bridge", "frenet")
+
+
+def augmenter_from_args(args):
+    """Build the augmenter a config asks for, or None when augmentation is off.
+
+    Args:
+        args: parsed config carrying ``use_data_augment``, ``augment_type`` and the
+            per-augmenter knobs.
+
+    Returns:
+        The augmenter, or ``None`` if ``use_data_augment`` is false.
+
+    Raises:
+        ValueError: on an ``augment_type`` outside :data:`AUGMENT_TYPES`.
+    """
+    if not args.use_data_augment:
+        return None
+    if args.augment_type == "frenet":
+        return frenet_augmenter_from_args(args)
+    if args.augment_type == "bridge":
+        return BridgeStatePerturbation(augment_prob=args.augment_prob, device=args.device)
+    if args.augment_type == "quintic":
+        return StatePerturbation(
+            augment_prob=args.augment_prob,
+            num_refine=args.num_refine,
+            device=args.device,
+            ego_past_noise_std=args.ego_past_noise_std,
+            use_smoothing_future_trajectory=args.use_smoothing_future_trajectory,
+        )
+    raise ValueError(f"unknown augment_type {args.augment_type!r}; expected one of {AUGMENT_TYPES}")

--- a/diffusion_planner/diffusion_planner/utils/augmenter_factory.py
+++ b/diffusion_planner/diffusion_planner/utils/augmenter_factory.py
@@ -40,16 +40,15 @@ def augmenter_from_args(args):
     """
     if not args.use_data_augment:
         return None
+    # Above the type dispatch, so the mode contract is enforced on EVERY path. It used to
+    # be called only in the bridge branch, which meant a caller that skipped the
+    # trainers' own call got `augment_type=quintic, ego_past_noise_mode=jitter` silently
+    # honoured as scale -- the record-it-and-ignore-it mismatch this module exists to
+    # stop. Idempotent, so the trainers calling it first costs nothing.
+    resolve_history_noise(args)
     if args.augment_type == "frenet":
         return frenet_augmenter_from_args(args)
     if args.augment_type == "bridge":
-        # Bridge takes neither the history noise nor the quintic refinement knobs. The
-        # rejection of an explicitly-passed --ego_past_noise_std lives in
-        # resolve_history_noise, which the trainers call before serializing the config:
-        # it needs to tell "passed" from "unset", and by the time the factory runs the
-        # value has been resolved to a number either way. Called here defensively for
-        # any caller that skipped the resolver.
-        resolve_history_noise(args)
         return BridgeStatePerturbation(augment_prob=args.augment_prob, device=args.device)
     if args.augment_type == "quintic":
         return StatePerturbation(

--- a/diffusion_planner/diffusion_planner/utils/augmenter_factory.py
+++ b/diffusion_planner/diffusion_planner/utils/augmenter_factory.py
@@ -12,6 +12,7 @@ falling through to quintic — the parser's ``Literal`` already constrains the f
 and a programmatic caller deserves the error rather than a silent substitution.
 """
 
+from diffusion_planner.utils.augment_defaults import past_noise_std_for
 from diffusion_planner.utils.data_augmentation import StatePerturbation
 from diffusion_planner.utils.data_augmentation_bridge import (
     StatePerturbation as BridgeStatePerturbation,
@@ -39,13 +40,23 @@ def augmenter_from_args(args):
     if args.augment_type == "frenet":
         return frenet_augmenter_from_args(args)
     if args.augment_type == "bridge":
+        # Bridge takes neither the history noise nor the quintic refinement knobs. Fail
+        # rather than accept a flag, record it in the run's args.json, and ignore it --
+        # that mismatch between recorded and applied config is what this module exists
+        # to stop, and silently dropping the flag here would reproduce it.
+        if args.ego_past_noise_std is not None:
+            raise ValueError(
+                "--ego_past_noise_std is not supported by augment_type=bridge "
+                "(the bridge augmenter does not perturb the ego history); "
+                "drop the flag or pick another augment_type"
+            )
         return BridgeStatePerturbation(augment_prob=args.augment_prob, device=args.device)
     if args.augment_type == "quintic":
         return StatePerturbation(
             augment_prob=args.augment_prob,
             num_refine=args.num_refine,
             device=args.device,
-            ego_past_noise_std=args.ego_past_noise_std,
+            ego_past_noise_std=past_noise_std_for(args),
             use_smoothing_future_trajectory=args.use_smoothing_future_trajectory,
         )
     raise ValueError(f"unknown augment_type {args.augment_type!r}; expected one of {AUGMENT_TYPES}")

--- a/diffusion_planner/diffusion_planner/utils/augmenter_factory.py
+++ b/diffusion_planner/diffusion_planner/utils/augmenter_factory.py
@@ -55,7 +55,7 @@ def augmenter_from_args(args):
             augment_prob=args.augment_prob,
             num_refine=args.num_refine,
             device=args.device,
-            ego_past_noise_std=past_noise_std_for(args),
+            ego_past_noise_std=args.ego_past_noise_std_effective,
             use_smoothing_future_trajectory=args.use_smoothing_future_trajectory,
         )
     raise ValueError(f"unknown augment_type {args.augment_type!r}; expected one of {AUGMENT_TYPES}")

--- a/diffusion_planner/diffusion_planner/utils/augmenter_factory.py
+++ b/diffusion_planner/diffusion_planner/utils/augmenter_factory.py
@@ -12,7 +12,10 @@ falling through to quintic — the parser's ``Literal`` already constrains the f
 and a programmatic caller deserves the error rather than a silent substitution.
 """
 
-from diffusion_planner.utils.augment_defaults import past_noise_std_for
+from diffusion_planner.utils.augment_defaults import (
+    past_noise_std_for,
+    resolve_history_noise,
+)
 from diffusion_planner.utils.data_augmentation import StatePerturbation
 from diffusion_planner.utils.data_augmentation_bridge import (
     StatePerturbation as BridgeStatePerturbation,
@@ -40,16 +43,13 @@ def augmenter_from_args(args):
     if args.augment_type == "frenet":
         return frenet_augmenter_from_args(args)
     if args.augment_type == "bridge":
-        # Bridge takes neither the history noise nor the quintic refinement knobs. Fail
-        # rather than accept a flag, record it in the run's args.json, and ignore it --
-        # that mismatch between recorded and applied config is what this module exists
-        # to stop, and silently dropping the flag here would reproduce it.
-        if args.ego_past_noise_std is not None:
-            raise ValueError(
-                "--ego_past_noise_std is not supported by augment_type=bridge "
-                "(the bridge augmenter does not perturb the ego history); "
-                "drop the flag or pick another augment_type"
-            )
+        # Bridge takes neither the history noise nor the quintic refinement knobs. The
+        # rejection of an explicitly-passed --ego_past_noise_std lives in
+        # resolve_history_noise, which the trainers call before serializing the config:
+        # it needs to tell "passed" from "unset", and by the time the factory runs the
+        # value has been resolved to a number either way. Called here defensively for
+        # any caller that skipped the resolver.
+        resolve_history_noise(args)
         return BridgeStatePerturbation(augment_prob=args.augment_prob, device=args.device)
     if args.augment_type == "quintic":
         return StatePerturbation(

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation.py
@@ -8,6 +8,45 @@ from diffusion_planner.utils.unicycle_accel_curvature import smoothing_future_tr
 TIME_INTERVAL = 0.1
 
 
+def pose_to_cos_sin(x, pad=None):
+    """Widen ``(x, y, heading)`` to the canonical ``(x, y, cos, sin)``, padding kept.
+
+    Thin wrapper over the repo's canonical ``train_epoch.heading_to_cos_sin`` (also
+    idempotent on already-4-col input) that additionally re-zeroes padded rows: a
+    padded slot must not acquire the heading ``cos(0) = 1`` on the way through.
+
+    ``pad`` defaults to the usual all-zero-row test. Pass it explicitly where that
+    test is wrong — an ego history's t=0 sample is legitimately the origin with
+    heading 0 in its own frame, and is not padding.
+    """
+    if x.shape[-1] >= 4:
+        return x
+    # imported inside the function, not at module scope: train_epoch imports this
+    # module, so a top-level import would close the cycle.
+    from diffusion_planner.train_epoch import heading_to_cos_sin
+
+    if pad is None:
+        pad = torch.sum(torch.ne(x, 0), dim=-1) == 0
+    out = heading_to_cos_sin(x)
+    out[pad] = 0.0
+    return out
+
+
+def cos_sin_to_heading(x):
+    """Narrow a trajectory to the canonical 3-col ``(x, y, heading)`` layout.
+
+    The inverse of ``train_epoch.heading_to_cos_sin`` and, like it, idempotent: a
+    ``(..., 3)`` input that already carries a heading is returned unchanged. The
+    augmenters interpolate and transform a HEADING (they normalize angles and take
+    differences), so a 4-col ``(x, y, cos, sin)`` future — what scene-gen and the
+    offline tools emit — is narrowed on the way in rather than silently read as if
+    col 2 were an angle.
+    """
+    if x.shape[-1] < 4:
+        return x
+    return torch.cat([x[..., :2], torch.atan2(x[..., 3], x[..., 2])[..., None]], dim=-1)
+
+
 def vector_transform(vector, transform_mat, bias=None):
     """
     vector: (B, ..., 2)
@@ -187,6 +226,13 @@ class StatePerturbation:
         ).to(device=device)  # shape (B, N+1)
 
     def __call__(self, inputs, ego_future, neighbors_future):
+        # Both fields have two layouts in the wild and this augmenter reads a heading
+        # angle out of the future (quintic BCs) and a heading VECTOR out of the goal
+        # pose (cols 2:4 are rotated). Canonicalize both here; no-op at the canonical
+        # widths, so nothing changes for the training loop that already converts.
+        ego_future = cos_sin_to_heading(ego_future)
+        inputs["goal_pose"] = pose_to_cos_sin(inputs["goal_pose"])
+
         aug_flag, aug_ego_current_state = self.augment(inputs)
 
         # Interpolate future trajectory

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass
 import numpy as np
 import torch
 
+from diffusion_planner.dimensions import EGOSTATE
 from diffusion_planner.utils.augmentation_checks import (
     DT,
     border_lateral_bounds,
@@ -116,7 +117,41 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             cur[rows, 4] = torch.sqrt(vx * vx + vy * vy) * torch.where(vx < 0, -1.0, 1.0)
             cur[rows, 5] = 0.0
             cur[rows, 7] = 0.0  # ay
+        # History noise runs LAST, after the re-centering rather than before it. Only
+        # here is the history expressed about the augmented t=0 pose, so scaling it
+        # about the origin leaves t=0 exactly at the origin and leaves the implied
+        # speed history consistent with the current state it is scaled with. Scaling in
+        # the pre-centering frame would instead drag the t=0 pose away from the current
+        # state the whole batch is then centered on. It also runs after the pad
+        # zeroing, so a padded row is exactly zero and no factor can resurrect it.
+        if self.past_noise_std > 0.0 and rows is not None and bool(rows.any()):
+            self._scale_history(inputs, rows)
         return out
+
+    def _scale_history(self, inputs, rows):
+        """Scale an augmented row's rewritten history by one factor per scene.
+
+        The perturbation the quintic augmenter applies through ``ego_past_noise_std``,
+        which frenet disables at the base class because it rewrites the past
+        kinematically: one N(1, std) scalar per scene clamped to +-2 std, multiplying
+        the history xy and the current velocity and acceleration together, so the
+        implied speed history stays consistent with the state. Non-augmented rows are
+        never touched -- they train on plain ground truth, unscaled.
+
+        The draw comes from the augmenter's own generator, and is taken ONLY when the
+        std is positive, so at the default the generator is left exactly where the
+        unaugmented stream leaves it.
+        """
+        w = self.past_noise_std
+        past, cur = inputs["ego_agent_past"], inputs["ego_current_state"]
+        scale = torch.normal(1.0, w, size=(int(rows.sum()), 1, 1), generator=self.gen).clamp(
+            1.0 - 2 * w, 1.0 + 2 * w
+        )
+        scale = scale.to(device=past.device, dtype=past.dtype)
+        past[rows, :, :2] = past[rows, :, :2] * scale
+        cur[rows, EGOSTATE.VX : EGOSTATE.AY + 1] = (
+            cur[rows, EGOSTATE.VX : EGOSTATE.AY + 1] * scale[:, :, 0]
+        )
 
     def __init__(
         self,
@@ -131,12 +166,16 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         recovery_rounds: int = 0,
         toward_parked_prob: float = 0.0,
         min_clearance: float = 0.0,
+        past_noise_std: float = 0.0,
     ):
         super().__init__(
             augment_prob=augment_prob,
             num_refine=20,
             device=device,
-            ego_past_noise_std=0.0,  # frenet rewrites the past kinematically
+            # frenet rewrites the past kinematically, so the base class must not scale
+            # the RECORDED history; the same perturbation is available on the rewritten
+            # history through past_noise_std below.
+            ego_past_noise_std=0.0,
             use_smoothing_future_trajectory=False,
         )
         # The ego past is rewritten to the perturbed polyline, so it must also be
@@ -182,6 +221,13 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         self.min_clearance = float(min_clearance)
         if self.min_clearance < 0.0:
             raise ValueError(f"min_clearance must be >= 0, got {min_clearance}")
+        # Std of the per-scene history-scale factor. The base class is told 0 above
+        # because frenet rewrites the past kinematically and the quintic scaling would
+        # be applied to the recorded history instead; this knob applies the same
+        # perturbation to the REWRITTEN history. 0 draws nothing and is bit-identical.
+        self.past_noise_std = float(past_noise_std)
+        if self.past_noise_std < 0.0:
+            raise ValueError(f"past_noise_std must be >= 0, got {past_noise_std}")
         self._basis_cache = {}
 
     # ---------- shared basis (depends only on the time grid + knobs) ----------
@@ -809,4 +855,5 @@ def frenet_augmenter_from_args(args) -> "FrenetStatePerturbationTensor":
         recovery_rounds=int(args.frenet_recovery_rounds),
         toward_parked_prob=float(args.frenet_toward_parked_prob),
         min_clearance=float(args.frenet_min_clearance),
+        past_noise_std=float(args.frenet_past_noise_std),
     )

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -540,7 +540,17 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         heading = torch.where(g.norm(dim=-1) > 0.3, torch.atan2(g[..., 1], g[..., 0]), hd_gt)
         return g, heading
 
-    def _veto_true_overlaps(self, inputs, upd, aug_xy, heading):
+    # metres of candidate-vs-recording displacement below which a timestep is
+    # treated as the recorded drive itself. The candidate coincides with GT outside
+    # its merge window, so this is what keeps min_clearance from vetoing a scene for
+    # the recording's own clearance.
+    DEVIATION_EPS = 1e-3
+
+    def _deviates_from_gt(self, aug_xy, xy):
+        """(B, T) bool: timesteps where the candidate is not the recorded drive."""
+        return (aug_xy - xy).norm(dim=-1) > self.DEVIATION_EPS
+
+    def _veto_true_overlaps(self, inputs, upd, aug_xy, heading, xy=None):
         """Drop winners whose footprint truly overlaps a recorded neighbor."""
         if self._nbr_st is None:
             return upd
@@ -554,6 +564,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             inputs["neighbor_agents_past"][:, :, -1][..., [6, 7]],
             self._nbr_near,
             min_clearance=self.min_clearance,
+            floor_mask=None if xy is None else self._deviates_from_gt(aug_xy, xy),
         )
 
     # ---------- toward-parked nudge ----------
@@ -774,7 +785,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         # below, and the feasibility screen above, must judge the clean candidate; the
         # noise is added to the accepted history at the very end, in _perturb_history.
         g, heading = self._headings(aug_xy, tan)
-        upd = self._veto_true_overlaps(inputs, has.clone(), aug_xy, heading)
+        upd = self._veto_true_overlaps(inputs, has.clone(), aug_xy, heading, xy)
         if self.recovery_rounds:
             aug_xy, g, heading, upd = self._recover_vetoed(
                 inputs,
@@ -931,14 +942,14 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             combo_idx, alive = self._sample_merge_then_jerk(feas_k, jerk[rows, cur], merges)
             cand = xy[rows] + L[rows, cur, combo_idx][..., None] * nrm[rows]
             g_r, hd_r = self._headings(cand, tan[rows])
-            keep = self._veto_true_overlaps_rows(inputs, alive.clone(), cand, hd_r, rows)
+            keep = self._veto_true_overlaps_rows(inputs, alive.clone(), cand, hd_r, rows, xy)
             sel = rows[keep]
             aug_xy[sel], g[sel], heading[sel] = cand[keep], g_r[keep], hd_r[keep]
             upd[sel] = True
             adm[rows, cur, :] = False
         return aug_xy, g, heading, upd
 
-    def _veto_true_overlaps_rows(self, inputs, rows_mask, aug_xy, heading, rows):
+    def _veto_true_overlaps_rows(self, inputs, rows_mask, aug_xy, heading, rows, xy=None):
         """:meth:`_veto_true_overlaps` restricted to a subset of scenes."""
         if self._nbr_st is None:
             return rows_mask
@@ -952,6 +963,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             inputs["neighbor_agents_past"][rows][:, :, -1][..., [6, 7]],
             self._nbr_near[rows],
             min_clearance=self.min_clearance,
+            floor_mask=None if xy is None else self._deviates_from_gt(aug_xy, xy[rows]),
         )
 
     def _write_back(self, inputs, ego_future, aug_xy, g, heading, upd, wb, P):

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -114,6 +114,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         knobs: KnobGrid = KnobGrid(),
         seed: int = 0,
         ranked_temp_s: float = 1.0,
+        recovery_rounds: int = 0,
     ):
         super().__init__(
             augment_prob=augment_prob,
@@ -142,6 +143,11 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         )
         self.gen = torch.Generator(device="cpu").manual_seed(seed + rank)
         self.ranked_temp_s = float(ranked_temp_s)
+        # Rounds of draw-level re-selection allowed after an exact-OBB veto. 0 keeps
+        # the original behaviour: a vetoed row falls back to plain GT.
+        self.recovery_rounds = int(recovery_rounds)
+        if self.recovery_rounds < 0:
+            raise ValueError(f"recovery_rounds must be >= 0, got {recovery_rounds}")
         self._basis_cache = {}
 
     # ---------- shared basis (depends only on the time grid + knobs) ----------
@@ -203,6 +209,18 @@ class FrenetStatePerturbationTensor(StatePerturbation):
                 st, valid, shapes_wl, xy, tan, nrm, half_l, half_w, wb, lo, hi
             )
         return lo, hi
+
+    @staticmethod
+    def _headings(aug_xy, tan):
+        """Motion-direction heading of a polyline, falling back to the GT tangent.
+
+        Below 0.3 m/step the finite-difference direction is noise, so the recorded
+        heading is kept rather than derived from a near-zero displacement.
+        """
+        g = ddt(aug_xy, 1)
+        hd_gt = torch.atan2(tan[..., 1], tan[..., 0])
+        heading = torch.where(g.norm(dim=-1) > 0.3, torch.atan2(g[..., 1], g[..., 0]), hd_gt)
+        return g, heading
 
     def _veto_true_overlaps(self, inputs, upd, aug_xy, heading):
         """Drop winners whose footprint truly overlaps a recorded neighbor."""
@@ -304,10 +322,29 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             return self.centric_transform(inputs, ego_future, neighbors_future)
 
         aug_xy = self._select_candidate(
-            admissible, jerk_fut_peak, first, merges, has, L, xy, nrm, B, dev, dtype
+            admissible, jerk_fut_peak, first, merges, L, xy, nrm, B, dev
         )
+        g, heading = self._headings(aug_xy, tan)
+        upd = self._veto_true_overlaps(inputs, has.clone(), aug_xy, heading)
+        if self.recovery_rounds:
+            aug_xy, g, heading, upd = self._recover_vetoed(
+                inputs,
+                admissible,
+                jerk_fut_peak,
+                first,
+                merges,
+                L,
+                xy,
+                nrm,
+                tan,
+                aug_xy,
+                g,
+                heading,
+                upd,
+                has,
+            )
 
-        self._write_back(inputs, ego_future, aug_xy, xy, tan, wb, has, P)
+        self._write_back(inputs, ego_future, aug_xy, g, heading, upd, wb, P)
         return self.centric_transform(inputs, ego_future, neighbors_future)
 
     def _candidate_profiles(self, combos, dy, dth, v0, speed, half_l, lo, hi, dev, dtype):
@@ -357,37 +394,105 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         jerk_fut_peak[b_i, k_i, c_i] = peak
         return feasible, jerk_fut_peak
 
-    def _select_candidate(
-        self, feasible, jerk_fut_peak, first, merges, has, L, xy, nrm, B, dev, dtype
-    ):
+    def _select_candidate(self, feasible, jerk_fut_peak, first, merges, L, xy, nrm, B, dev):
         """Sample a merge horizon per scene, take its lowest-jerk combo, build the polyline."""
         bi = torch.arange(B, device=dev)
-        feas_k = feasible[bi, first]  # (B, C) — valid combos for the chosen draw
-        jerk_k = jerk_fut_peak[bi, first]  # (B, C)
-        BIG = torch.tensor(1e9, device=dev, dtype=dtype)
-        # merge time sampled with per-combo weight exp(-(M-Mmin)/temp), i.e.
         # P(M) ∝ n_feasible_combos(M) * exp(-(M-Mmin)/temp) — biased to fast
         # convergence, slower merges keep a chance; within the sampled M,
-        # lowest peak future jerk wins.
-        m_feas = torch.where(feas_k, merges[None, :], BIG)
-        m_min = m_feas.amin(-1, keepdim=True)
-        w = torch.exp(-(merges[None, :] - m_min) / self.ranked_temp_s) * feas_k
-        w = torch.where(has[:, None], w, torch.ones_like(w))  # avoid all-zero rows
-        pick_m = torch.multinomial(w.cpu().double(), 1, generator=self.gen).to(dev)[:, 0]
-        same_m = feas_k & (merges[None, :] == merges[pick_m][:, None])
-        combo_idx = torch.where(same_m, jerk_k, BIG).argmin(-1)
+        # lowest peak future jerk wins. Shared with the post-veto retry.
+        combo_idx, _ = self._sample_merge_then_jerk(
+            feasible[bi, first], jerk_fut_peak[bi, first], merges
+        )
         Lw = L[bi, first, combo_idx]  # (B, T)
         aug_xy = xy + Lw[..., None] * nrm
         return aug_xy
 
-    def _write_back(self, inputs, ego_future, aug_xy, xy, tan, wb, has, P):
-        """Veto true overlaps, then write history / future / current state in place."""
-        g = ddt(aug_xy, 1)
-        gs = g.norm(dim=-1)
-        hd_gt = torch.atan2(tan[..., 1], tan[..., 0])
-        heading = torch.where(gs > 0.3, torch.atan2(g[..., 1], g[..., 0]), hd_gt)
+    def _sample_merge_then_jerk(self, feas_k, jerk_k, merges):
+        """The merge-then-jerk pick, shared by first selection and recovery.
 
-        upd = self._veto_true_overlaps(inputs, has.clone(), aug_xy, heading)
+        Merge horizon sampled with weight exp(-(M - Mmin) / temp) over the
+        horizons still feasible, then lowest peak future jerk within it.
+        """
+        BIG = torch.tensor(1e9, device=feas_k.device, dtype=jerk_k.dtype)
+        m_feas = torch.where(feas_k, merges[None, :], BIG)
+        w = torch.exp(-(merges[None, :] - m_feas.amin(-1, keepdim=True)) / self.ranked_temp_s)
+        w = w * feas_k
+        alive = w.sum(-1) > 0
+        w = torch.where(alive[:, None], w, torch.ones_like(w))  # avoid all-zero rows
+        pick_m = torch.multinomial(w.cpu().double(), 1, generator=self.gen).to(w.device)[:, 0]
+        same_m = feas_k & (merges[None, :] == merges[pick_m][:, None])
+        return torch.where(same_m, jerk_k, BIG).argmin(-1), alive
+
+    def _recover_vetoed(
+        self,
+        inputs,
+        admissible,
+        jerk,
+        first,
+        merges,
+        L,
+        xy,
+        nrm,
+        tan,
+        aug_xy,
+        g,
+        heading,
+        upd,
+        has,
+    ):
+        """Re-draw for rows whose winner truly overlapped a recorded neighbour.
+
+        The other 39 shapes of the losing draw carry the SAME lateral offset and
+        would overlap the same neighbour, so a retry has to change the draw, not
+        the shape: the losing draw is burned whole and the next surviving one is
+        re-selected and re-checked. Measured on 105k scenes: round 1 recovers
+        ~54% of vetoed rows, round 2 ~7% more, round 3 ~2% — the survivors are
+        blocked geometrically, and re-rolling does not move geometry.
+
+        Rows that never recover keep upd False and train on plain GT, exactly as
+        they do with recovery disabled.
+        """
+        adm = admissible.clone()
+        B = xy.shape[0]
+        adm[torch.arange(B, device=xy.device), first, :] = False
+        for _ in range(self.recovery_rounds):
+            live = has & ~upd
+            if not bool(live.any()):
+                break
+            rows = torch.nonzero(live, as_tuple=True)[0]
+            draw_ok = adm[rows].any(-1)  # (M, K) draws with a shape left to try
+            if not bool(draw_ok.any()):
+                break
+            cur = draw_ok.float().argmax(-1)
+            feas_k = adm[rows, cur]
+            combo_idx, alive = self._sample_merge_then_jerk(feas_k, jerk[rows, cur], merges)
+            cand = xy[rows] + L[rows, cur, combo_idx][..., None] * nrm[rows]
+            g_r, hd_r = self._headings(cand, tan[rows])
+            keep = self._veto_true_overlaps_rows(inputs, alive.clone(), cand, hd_r, rows)
+            sel = rows[keep]
+            aug_xy[sel], g[sel], heading[sel] = cand[keep], g_r[keep], hd_r[keep]
+            upd[sel] = True
+            adm[rows, cur, :] = False
+        return aug_xy, g, heading, upd
+
+    def _veto_true_overlaps_rows(self, inputs, rows_mask, aug_xy, heading, rows):
+        """:meth:`_veto_true_overlaps` restricted to a subset of scenes."""
+        if self._nbr_st is None:
+            return rows_mask
+        hd_cs = torch.stack([heading.cos(), heading.sin()], dim=-1)
+        return veto_overlapping(
+            rows_mask,
+            torch.cat([aug_xy, hd_cs], dim=-1),
+            inputs["ego_shape"][rows],
+            self._nbr_st[rows],
+            self._nbr_valid[rows],
+            inputs["neighbor_agents_past"][rows][:, :, -1][..., [6, 7]],
+            self._nbr_near[rows],
+        )
+
+    def _write_back(self, inputs, ego_future, aug_xy, g, heading, upd, wb, P):
+        """Write history / future / current state in place for the accepted rows."""
+        gs = g.norm(dim=-1)
         # future (x, y, heading) — canonical 3-col layout
         new_fut = torch.cat([aug_xy[:, P:], heading[:, P:, None]], dim=-1)
         ego_future[upd, :, :3] = new_fut[upd]
@@ -450,4 +555,5 @@ def frenet_augmenter_from_args(args) -> "FrenetStatePerturbationTensor":
         ),
         seed=int(args.frenet_seed),
         ranked_temp_s=float(args.frenet_ranked_temp_s),
+        recovery_rounds=int(args.frenet_recovery_rounds),
     )

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -42,13 +42,24 @@ from diffusion_planner.utils.augmentation_checks import (
     unconstrained_bounds,
     veto_overlapping,
 )
-from diffusion_planner.utils.data_augmentation import StatePerturbation
+from diffusion_planner.utils.data_augmentation import (
+    StatePerturbation,
+    cos_sin_to_heading,
+    pose_to_cos_sin,
+)
 
 # extra half-width the corridor keeps from borders and neighbors
 CORRIDOR_MARGIN = 0.10
-# a recorded neighbour slower than this at t=0 counts as parked for the toward-parked
-# nudge; avoiding a MOVING vehicle is a different problem and is deliberately excluded
+# A neighbour counts as parked for the toward-parked nudge when its RECORDED velocity at
+# the last history step is below this. The recorded (vx, vy) is used rather than a
+# finite difference of the centroid: over one 0.1 s step a differenced position amplifies
+# tracker jitter tenfold, so a stationary car wobbling 5 cm would read as 0.5 m/s.
 PARKED_SPEED = 0.5  # m/s
+# ...and it must also STAY put: a car stopped at a light is slow at t=0 and then departs,
+# and the nudge would aim the ego at a lead vehicle that is no longer there. Every
+# recorded future sample must stay within this distance of its t=0 position, which is
+# what makes the "MOVING vehicles are excluded" claim true rather than aspirational.
+PARKED_MAX_DISPLACEMENT = 1.0  # m
 
 
 def quintic_basis(t0: float, t1: float, t: np.ndarray):
@@ -135,7 +146,12 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         # rows augmented in the most recent __call__; centric_transform re-projects
         # velocity/accel to base_link (vy = ay = 0) for exactly these rows
         self._aug_rows = None
+        # corridor by-products, all reset at the top of every _corridor call
         self._nbr_near = None
+        self._nbr_st = None
+        self._nbr_valid = None
+        self._nbr_lo = None
+        self._nbr_hi = None
         self.n_draws = n_draws
         self.dy_max = dy_max
         self.dth_max = dth_max
@@ -206,7 +222,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         return out
 
     # ---------- corridor, fully batched ----------
-    def _corridor(self, inputs, xy, tan, nrm, half_w, half_l, wb):
+    def _corridor(self, inputs, xy, tan, nrm, half_w, half_w_nbr, half_l, wb):
         """Lateral free space per timestep: where can this ego go sideways.
 
         Border and neighbour cuts are computed against separate copies of the
@@ -214,6 +230,13 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         sequence. Both are max/min reductions so the intersection is identical,
         and keeping the neighbour-only pair is what lets the toward-parked nudge ask
         "which side is a VEHICLE on" without mistaking a kerb for a car.
+
+        The two cuts take SEPARATE half-widths: ``min_clearance`` is a floor on the
+        gap to a NEIGHBOUR, and widening the border cut with it as well would drop
+        kerb-hugging scenes out of augmentation entirely (the recorded drives touch
+        the mapped borders, which is exactly why borders are never vetoed either).
+        ``half_w`` cuts against borders, ``half_w_nbr`` against neighbours; they are
+        equal whenever ``min_clearance <= CORRIDOR_MARGIN``.
         """
         # reset per batch so a neighbor-less batch never sees a stale tensor
         self._nbr_st = self._nbr_valid = self._nbr_near = None
@@ -233,15 +256,25 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             shapes_wl = past[:, :, -1][..., [6, 7]]  # width, length
             n_lo, n_hi = unconstrained_bounds(B, T, xy.device, xy.dtype)
             n_lo, n_hi, self._nbr_near = neighbor_lateral_bounds(
-                st, valid, shapes_wl, xy, tan, nrm, half_l, half_w, wb, n_lo, n_hi
+                st,
+                valid,
+                shapes_wl,
+                xy,
+                tan,
+                nrm,
+                half_l,
+                half_w_nbr,
+                wb,
+                n_lo,
+                n_hi,
+                min_clearance=self.min_clearance,
             )
             lo, hi = torch.maximum(lo, n_lo), torch.minimum(hi, n_hi)
             if self.toward_parked_prob > 0.0:
                 # bounds from PARKED neighbours alone: the toward-parked nudge points at
                 # these and nothing else
                 P = inputs["ego_agent_past"].shape[1]
-                step = (st[:, :, P - 1, :2] - st[:, :, P - 2, :2]).norm(dim=-1)
-                parked = valid[:, :, P - 1] & valid[:, :, P - 2] & (step / DT < PARKED_SPEED)
+                parked = self._parked_mask(past, st, valid, P)
                 p_lo, p_hi = unconstrained_bounds(B, T, xy.device, xy.dtype)
                 p_lo, p_hi, _ = neighbor_lateral_bounds(
                     st,
@@ -251,13 +284,39 @@ class FrenetStatePerturbationTensor(StatePerturbation):
                     tan,
                     nrm,
                     half_l,
-                    half_w,
+                    half_w_nbr,
                     wb,
                     p_lo,
                     p_hi,
                 )
                 self._nbr_lo, self._nbr_hi = p_lo, p_hi
         return lo, hi
+
+    @staticmethod
+    def _parked_mask(past, st, valid, P):
+        """Which recorded neighbours are parked for the whole recording.
+
+        Two conditions, both necessary. STOPPED: the dataset's own velocity
+        ``(vx, vy)`` at the last history step is below :data:`PARKED_SPEED` — the
+        recorded velocity, not a one-step position difference, whose 1/DT factor turns
+        centimetres of centroid jitter into half a metre per second. STAYS: no recorded
+        future sample leaves a :data:`PARKED_MAX_DISPLACEMENT` ball around the t=0
+        position, so a vehicle that is merely waiting to move is excluded rather than
+        being treated as parked for the whole horizon.
+
+        Args:
+            past: (B, N, P, >=6) neighbour history; cols 4, 5 are vx, vy.
+            st, valid: from :func:`time_aligned_neighbor_tracks`.
+            P: number of history steps, so index ``P - 1`` is t=0.
+
+        Returns:
+            (B, N) bool.
+        """
+        stopped = valid[:, :, P - 1] & (past[:, :, P - 1, 4:6].norm(dim=-1) < PARKED_SPEED)
+        # invalid future slots contribute 0 displacement: absence of a track is not
+        # evidence of motion, and those slots cut no corridor anyway
+        moved = (st[:, :, P:, :2] - st[:, :, P - 1, None, :2]).norm(dim=-1) * valid[:, :, P:]
+        return stopped & (moved.amax(dim=-1) < PARKED_MAX_DISPLACEMENT)
 
     @staticmethod
     def _headings(aug_xy, tan):
@@ -288,7 +347,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         )
 
     # ---------- toward-parked nudge ----------
-    def _parked_vehicle_ahead(self, P, F, half_w, merge_steps_min):
+    def _parked_vehicle_ahead(self, P, half_w, merge_steps_min):
         """Which scenes can be made into a harder avoidance than the recording?
 
         Eligible when a PARKED vehicle (not a kerb, not a moving car) bounds the
@@ -296,6 +355,15 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         avoidance is still ahead of the ego. An object already beside the ego at t=0 leaves no approach
         to perturb, and no merge horizon could rejoin before it anyway -- so the
         floor is ``min(merge_times)``, derived rather than tuned.
+
+        "Within reach" is a test in OFFSET space: ``neighbor_lateral_bounds`` returns
+        bounds that already have the ego half-width subtracted, so the room it reports
+        is room for the ego's centreline, which is what ``dy_max`` bounds.
+
+        Args:
+            P: number of history steps.
+            half_w: (B,) ego half width; used for its shape/device/dtype only.
+            merge_steps_min: shortest merge horizon in timesteps.
 
         Returns:
             eligible: (B,) bool.
@@ -312,62 +380,146 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         b = torch.arange(slack.shape[0], device=slack.device)
         # the vehicle sits on whichever side left less room at that timestep
         side = torch.where(room_hi[b, t_rel] <= room_lo[b, t_rel], 1.0, -1.0)
-        eligible = (s_min <= self.dy_max + half_w) & (t_rel >= merge_steps_min)
+        eligible = (s_min <= self.dy_max) & (t_rel >= merge_steps_min)
         return eligible, side, t_rel + P
+
+    # ---------- input canonicalisation ----------
+    @staticmethod
+    def _ego_past_4col(past):
+        """Ego history as (x, y, cos, sin), from either recorded layout.
+
+        A 3-col history cannot tell a padded row from the ego's own t=0 sample, which
+        in the ego frame IS the origin with heading 0. Position resolves it: padding is
+        a LEADING prefix, so the last sample is never padding, and the widened array
+        then carries the same padded-rows-are-zero contract the 4-col layout has.
+        """
+        if past.shape[-1] >= 4:
+            return past
+        pad = torch.sum(torch.ne(past, 0), dim=-1) == 0
+        pad[:, -1] = False
+        return pose_to_cos_sin(past, pad=pad)
+
+    def _history_polyline(self, past4):
+        """History positions and tangents, with the zero-padded prefix held.
+
+        Leading history can be zero-padded when a scene starts near the beginning of a
+        recording. Those rows mean "no history", not "the ego was at the origin facing
+        +x", so the pad mask is remembered on the instance and the rows are restored to
+        exact zero after the rewrite and the re-centering (see ``centric_transform``).
+        Same contract as the bridge path.
+
+        Across the padding the first real pose is HELD rather than left at the origin: a
+        (0, 0) position adjacent to a real one is a metres-wide phantom step, which would
+        give the first REAL history sample a heading taken from that jump and a speed
+        spike the feasibility screen would then judge. Replicating makes the differences
+        zero across the padding boundary, so the first real sample keeps its own stored
+        heading.
+        """
+        P = past4.shape[1]
+        self._ego_past_pad = torch.sum(torch.ne(past4[..., :4], 0), dim=-1) == 0  # (B, P)
+        past_xy, past_tan = past4[..., :2], past4[..., 2:4]
+        if not bool(self._ego_past_pad.any()):
+            return past_xy, past_tan
+        first = torch.argmax((~self._ego_past_pad).to(torch.int8), dim=1)  # (B,)
+        idx = torch.arange(P, device=past4.device)[None, :]
+        src = torch.maximum(idx, first[:, None])  # pad -> first real, real -> itself
+        return (
+            torch.gather(past_xy, 1, src[..., None].expand(-1, -1, 2)),
+            torch.gather(past_tan, 1, src[..., None].expand(-1, -1, 2)),
+        )
+
+    # ---------- toward-parked nudge: draws and selection ----------
+    def _toward_parked_draws(self, r, K, P, half_w, do_aug, dy):
+        """Point a fraction of the eligible scenes' drawn offsets AT a parked vehicle.
+
+        On the scenes where a PARKED vehicle bounds the corridor further ahead than the
+        shortest merge, every drawn offset is mirrored to point at that vehicle. Only
+        the SIGN is mirrored, so |dy| keeps the distribution it already had -- the ego's
+        t=0 state becomes a harder avoidance than the recording's, and nothing
+        downstream (dth, merge sampling, shapes, corridor, kinematics, veto) is touched.
+        Candidates too hard to drive are still rejected by the existing feasibility
+        screen, so "harder" cannot become "impossible".
+
+        Returns:
+            toward: (B,) bool or None when the nudge is off.
+            toward_any: ``bool(toward.any())``, computed once and reused.
+            dy: the drawn offsets, mirrored on the toward rows.
+            t_obs: (B,) tightest-corridor timestep, or None when the nudge is off.
+        """
+        if self.toward_parked_prob <= 0.0:
+            return None, False, dy, None
+        merge_steps_min = int(min(self.knobs.merge_times) / DT)
+        eligible, side, t_obs = self._parked_vehicle_ahead(P, half_w, merge_steps_min)
+        toward = eligible & (r[:, 2 * K + 1] < self.toward_parked_prob) & do_aug
+        toward_any = bool(toward.any())
+        if toward_any:
+            dy = torch.where(toward[:, None], side[:, None] * dy.abs(), dy)
+        return toward, toward_any, dy, t_obs
+
+    @staticmethod
+    def _largest_offset_draw(draw_ok, dy):
+        """Index of the still-feasible draw with the biggest |dy|, per scene."""
+        return torch.where(draw_ok, dy.abs(), torch.full_like(dy, -1.0)).argmax(-1)
+
+    def _toward_parked_select(self, admissible, merges, dy, toward, toward_any, t_obs, P):
+        """Merge gate and winner index; a no-op on every row that is not toward-parked.
+
+        Two things happen to a toward row. The recovery has to FINISH while the vehicle
+        still matters, so merge horizons reaching past the tightest-corridor timestep are
+        struck out. And the winner is the LARGEST feasible offset rather than the first
+        feasible draw: mirroring the sign only fixes direction; measured on 105k scenes,
+        first-feasible left the baseline harder in 24.5% of rows, largest-feasible in
+        9.5% -- the remainder being the merge gate refusing a horizon the baseline was
+        allowed. "Harder" has to hold per scene, not on average.
+
+        Returns:
+            admissible (gated), draw_ok (B, K), first (B,) winning draw per scene.
+        """
+        if toward_any:
+            merge_steps = (merges / DT).round().long()  # (C,)
+            in_time = merge_steps[None, :] <= (t_obs - (P - 1))[:, None]  # (B, C)
+            admissible = admissible & torch.where(
+                toward[:, None, None], in_time[:, None, :], torch.ones_like(in_time[:, None, :])
+            )
+        draw_ok = admissible.any(-1)  # (B, K): the drawn perturbation has >=1 valid merge
+        first = draw_ok.float().argmax(-1)  # first feasible PERTURBATION per scene
+        if toward_any:
+            first = torch.where(toward, self._largest_offset_draw(draw_ok, dy), first)
+        return admissible, draw_ok, first
 
     # ---------- the augmentation ----------
     @torch.no_grad()
     def __call__(self, inputs, ego_future, neighbors_future):
-        # ego_future may arrive as (x, y, heading) or (x, y, cos, sin) — same
-        # branch heading_to_cos_sin uses upstream. Canonicalize to 3-col heading
-        # here; centric_transform returns the rebuilt 3-col future either way,
-        # and train_epoch re-converts to cos/sin after augmentation.
-        if ego_future.shape[-1] >= 4:
-            ego_future = torch.cat(
-                [
-                    ego_future[..., :2],
-                    torch.atan2(ego_future[..., 3], ego_future[..., 2])[..., None],
-                ],
-                dim=-1,
-            )
+        # Both fields arrive in either layout depending on the entrypoint. The future is
+        # narrowed to a heading angle (centric_transform returns the rebuilt 3-col future
+        # either way, and train_epoch re-converts afterwards); the history is widened,
+        # because everything below indexes its cols 2:4 as a heading VECTOR. Both are
+        # no-ops at the canonical widths the training loop already supplies.
+        ego_future = cos_sin_to_heading(ego_future)
+        inputs["ego_agent_past"] = self._ego_past_4col(inputs["ego_agent_past"])
         past4 = inputs["ego_agent_past"]  # (B, P, 4) x, y, cos, sin
         B, P, _ = past4.shape
-        # Leading history can be zero-padded when a scene starts near the beginning of a
-        # recording. Those rows mean "no history", not "the ego was at the origin facing
-        # +x", so they are remembered here and restored to exact zero after the rewrite
-        # and the re-centering (see centric_transform). Same contract as the bridge path.
-        self._ego_past_pad = torch.sum(torch.ne(past4[..., :4], 0), dim=-1) == 0  # (B, P)
         F = ego_future.shape[1]
         dev, dtype = past4.device, past4.dtype
         t, combos = self._bases(P, F, dev, dtype)
-        T = P + F
 
         fut_cs = torch.stack([ego_future[..., 2].cos(), ego_future[..., 2].sin()], dim=-1)
-        past_xy, past_tan = past4[..., :2], past4[..., 2:4]
-        if bool(self._ego_past_pad.any()):
-            # Hold the first real pose across the padded prefix instead of leaving it at the
-            # origin. A (0,0) position adjacent to a real one is a metres-wide phantom step:
-            # it would give the first REAL history sample a heading taken from that jump, and
-            # a speed spike the feasibility screen would then judge. Replicating makes the
-            # differences zero across the padding boundary, so the first real sample keeps its
-            # own stored heading. The padded rows themselves are zeroed again at the end.
-            first = torch.argmax((~self._ego_past_pad).to(torch.int8), dim=1)  # (B,)
-            idx = torch.arange(P, device=past4.device)[None, :]
-            src = torch.maximum(idx, first[:, None])  # pad -> first real, real -> itself
-            past_xy = torch.gather(past_xy, 1, src[..., None].expand(-1, -1, 2))
-            past_tan = torch.gather(past_tan, 1, src[..., None].expand(-1, -1, 2))
+        past_xy, past_tan = self._history_polyline(past4)
         xy = torch.cat([past_xy, ego_future[..., :2]], dim=1)  # (B, T, 2)
         tan = torch.cat([past_tan, fut_cs], dim=1)
         nrm = torch.stack([-tan[..., 1], tan[..., 0]], dim=-1)
         speed = ddt(xy, 1).norm(dim=-1).clamp(min=0.5)  # (B, T)
         v0 = speed[:, P - 1]
         wb = inputs["ego_shape"][:, 0]
-        half_w = inputs["ego_shape"][:, 2] / 2 + max(CORRIDOR_MARGIN, self.min_clearance)
+        # min_clearance is a floor on the gap to a NEIGHBOUR only; the border cut keeps
+        # the plain corridor margin (see _corridor).
+        half_w = inputs["ego_shape"][:, 2] / 2 + CORRIDOR_MARGIN
+        half_w_nbr = inputs["ego_shape"][:, 2] / 2 + max(CORRIDOR_MARGIN, self.min_clearance)
         half_l = inputs["ego_shape"][:, 1] / 2
 
-        lo, hi = self._corridor(inputs, xy, tan, nrm, half_w, half_l, wb)
+        lo, hi = self._corridor(inputs, xy, tan, nrm, half_w, half_w_nbr, half_l, wb)
 
-        K, C = self.n_draws, len(combos)
+        K = self.n_draws
         # One extra column ONLY when the toward-parked nudge is on, so at
         # toward_parked_prob = 0 the RNG stream is byte-for-byte what it has always been.
         toward_on = self.toward_parked_prob > 0.0
@@ -382,20 +534,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         dy = (r[:, :K] * 2 - 1) * self.dy_max
         dth = (r[:, K : 2 * K] * 2 - 1) * self.dth_max
 
-        # Toward-parked nudge: on a fraction of the scenes where a PARKED vehicle bounds
-        # the corridor further ahead than the shortest merge, point every drawn offset AT
-        # that vehicle. Only the SIGN is mirrored, so |dy| keeps the distribution it
-        # already had -- the ego's t=0 state becomes a harder avoidance than the
-        # recording's, and nothing downstream (dth, merge sampling, shapes, corridor,
-        # kinematics, veto) is touched. Candidates too hard to drive are still rejected
-        # by the existing feasibility screen, so "harder" cannot become "impossible".
-        toward = None
-        if toward_on:
-            merge_steps_min = int(min(self.knobs.merge_times) / DT)
-            eligible, side, t_obs = self._parked_vehicle_ahead(P, F, half_w, merge_steps_min)
-            toward = eligible & (r[:, 2 * K + 1] < self.toward_parked_prob) & do_aug
-            if bool(toward.any()):
-                dy = torch.where(toward[:, None], side[:, None] * dy.abs(), dy)
+        toward, toward_any, dy, t_obs = self._toward_parked_draws(r, K, P, half_w_nbr, do_aug, dy)
 
         L, in_corr, merges = self._candidate_profiles(
             combos, dy, dth, v0, speed, half_l, lo, hi, dev, dtype
@@ -408,24 +547,10 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         # augment_prob coin, or it is below the low-speed gate -- so the two questions stay
         # separable when reading the selection below.
         admissible = feasible & do_aug[:, None, None]
-        if toward is not None and bool(toward.any()):
-            # the recovery has to finish while the vehicle still matters
-            merge_steps = (merges / DT).round().long()  # (C,)
-            in_time = merge_steps[None, :] <= (t_obs - (P - 1))[:, None]  # (B, C)
-            admissible = admissible & torch.where(
-                toward[:, None, None], in_time[:, None, :], torch.ones_like(in_time[:, None, :])
-            )
-        draw_ok = admissible.any(-1)  # (B, K): the drawn perturbation has >=1 valid merge
+        admissible, draw_ok, first = self._toward_parked_select(
+            admissible, merges, dy, toward, toward_any, t_obs, P
+        )
         has = draw_ok.any(-1)  # (B,)
-        first = draw_ok.float().argmax(-1)  # first feasible PERTURBATION per scene
-        if toward is not None and bool(toward.any()):
-            # Toward-parked rows take the LARGEST feasible offset rather than the first
-            # feasible draw. Mirroring the sign only fixes direction; measured on 105k
-            # scenes, first-feasible left the baseline harder in 24.5% of rows,
-            # largest-feasible in 9.5% -- the remainder being the merge gate refusing a
-            # horizon the baseline was allowed. "Harder" has to hold per scene, not on average.
-            largest = torch.where(draw_ok, dy.abs(), torch.full_like(dy, -1.0)).argmax(-1)
-            first = torch.where(toward, largest, first)
 
         if not bool(has.any()):
             # nothing feasible this batch: every row trains on plain GT
@@ -453,6 +578,9 @@ class FrenetStatePerturbationTensor(StatePerturbation):
                 heading,
                 upd,
                 has,
+                dy,
+                toward,
+                toward_any,
             )
 
         self._write_back(inputs, ego_future, aug_xy, g, heading, upd, wb, P)
@@ -550,6 +678,9 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         heading,
         upd,
         has,
+        dy,
+        toward,
+        toward_any,
     ):
         """Re-draw for rows whose winner truly overlapped a recorded neighbour.
 
@@ -559,6 +690,12 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         re-selected and re-checked. Measured on 105k scenes: round 1 recovers
         ~54% of vetoed rows, round 2 ~7% more, round 3 ~2% — the survivors are
         blocked geometrically, and re-rolling does not move geometry.
+
+        The retry keeps each row's own selection rule: first-feasible everywhere, and
+        LARGEST-feasible on the toward-parked rows. Falling back to first-feasible for a
+        toward row would let it recover on a 3 cm offset and still be counted as a
+        hardened example, which is the whole reason the rule exists (see
+        :meth:`_toward_parked_select`).
 
         Rows that never recover keep upd False and train on plain GT, exactly as
         they do with recovery disabled.
@@ -575,6 +712,8 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             if not bool(draw_ok.any()):
                 break
             cur = draw_ok.float().argmax(-1)
+            if toward_any:
+                cur = torch.where(toward[rows], self._largest_offset_draw(draw_ok, dy[rows]), cur)
             feas_k = adm[rows, cur]
             combo_idx, alive = self._sample_merge_then_jerk(feas_k, jerk[rows, cur], merges)
             cand = xy[rows] + L[rows, cur, combo_idx][..., None] * nrm[rows]

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -46,6 +46,9 @@ from diffusion_planner.utils.data_augmentation import StatePerturbation
 
 # extra half-width the corridor keeps from borders and neighbors
 CORRIDOR_MARGIN = 0.10
+# a recorded neighbour slower than this at t=0 counts as parked for the toward-parked
+# nudge; avoiding a MOVING vehicle is a different problem and is deliberately excluded
+PARKED_SPEED = 0.5  # m/s
 
 
 def quintic_basis(t0: float, t1: float, t: np.ndarray):
@@ -115,6 +118,8 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         seed: int = 0,
         ranked_temp_s: float = 1.0,
         recovery_rounds: int = 0,
+        toward_parked_prob: float = 0.0,
+        min_clearance: float = 0.0,
     ):
         super().__init__(
             augment_prob=augment_prob,
@@ -148,6 +153,19 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         self.recovery_rounds = int(recovery_rounds)
         if self.recovery_rounds < 0:
             raise ValueError(f"recovery_rounds must be >= 0, got {recovery_rounds}")
+        # Fraction of ELIGIBLE scenes (a PARKED vehicle bounding the corridor far enough
+        # ahead that the avoidance is still in front of the ego) whose nudges are mirrored
+        # to point at that vehicle. 0 reproduces the uniform draw exactly.
+        self.toward_parked_prob = float(toward_parked_prob)
+        if not 0.0 <= self.toward_parked_prob <= 1.0:
+            raise ValueError(f"toward_parked_prob must be in [0, 1], got {toward_parked_prob}")
+        # Exact footprint clearance EVERY accepted candidate must keep from every
+        # recorded neighbour, on top of the corridor's own margin. Applies to all rows:
+        # a trajectory that skims a parked car is not a valid target however it was
+        # drawn. 0 keeps today's overlap-only veto and is bit-identical.
+        self.min_clearance = float(min_clearance)
+        if self.min_clearance < 0.0:
+            raise ValueError(f"min_clearance must be >= 0, got {min_clearance}")
         self._basis_cache = {}
 
     # ---------- shared basis (depends only on the time grid + knobs) ----------
@@ -189,9 +207,17 @@ class FrenetStatePerturbationTensor(StatePerturbation):
 
     # ---------- corridor, fully batched ----------
     def _corridor(self, inputs, xy, tan, nrm, half_w, half_l, wb):
-        """Lateral free space per timestep: where can this ego go sideways."""
+        """Lateral free space per timestep: where can this ego go sideways.
+
+        Border and neighbour cuts are computed against separate copies of the
+        unconstrained bounds and then intersected, rather than tightened in
+        sequence. Both are max/min reductions so the intersection is identical,
+        and keeping the neighbour-only pair is what lets the toward-parked nudge ask
+        "which side is a VEHICLE on" without mistaking a kerb for a car.
+        """
         # reset per batch so a neighbor-less batch never sees a stale tensor
         self._nbr_st = self._nbr_valid = self._nbr_near = None
+        self._nbr_lo = self._nbr_hi = None
         B, T, _ = xy.shape
         lo, hi = unconstrained_bounds(B, T, xy.device, xy.dtype)
 
@@ -205,9 +231,32 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             st, valid = time_aligned_neighbor_tracks(past, fut)
             self._nbr_st, self._nbr_valid = st, valid  # reused by the exact-OBB veto
             shapes_wl = past[:, :, -1][..., [6, 7]]  # width, length
-            lo, hi, self._nbr_near = neighbor_lateral_bounds(
-                st, valid, shapes_wl, xy, tan, nrm, half_l, half_w, wb, lo, hi
+            n_lo, n_hi = unconstrained_bounds(B, T, xy.device, xy.dtype)
+            n_lo, n_hi, self._nbr_near = neighbor_lateral_bounds(
+                st, valid, shapes_wl, xy, tan, nrm, half_l, half_w, wb, n_lo, n_hi
             )
+            lo, hi = torch.maximum(lo, n_lo), torch.minimum(hi, n_hi)
+            if self.toward_parked_prob > 0.0:
+                # bounds from PARKED neighbours alone: the toward-parked nudge points at
+                # these and nothing else
+                P = inputs["ego_agent_past"].shape[1]
+                step = (st[:, :, P - 1, :2] - st[:, :, P - 2, :2]).norm(dim=-1)
+                parked = valid[:, :, P - 1] & valid[:, :, P - 2] & (step / DT < PARKED_SPEED)
+                p_lo, p_hi = unconstrained_bounds(B, T, xy.device, xy.dtype)
+                p_lo, p_hi, _ = neighbor_lateral_bounds(
+                    st,
+                    valid & parked[:, :, None],
+                    shapes_wl,
+                    xy,
+                    tan,
+                    nrm,
+                    half_l,
+                    half_w,
+                    wb,
+                    p_lo,
+                    p_hi,
+                )
+                self._nbr_lo, self._nbr_hi = p_lo, p_hi
         return lo, hi
 
     @staticmethod
@@ -235,7 +284,36 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             self._nbr_valid,
             inputs["neighbor_agents_past"][:, :, -1][..., [6, 7]],
             self._nbr_near,
+            min_clearance=self.min_clearance,
         )
+
+    # ---------- toward-parked nudge ----------
+    def _parked_vehicle_ahead(self, P, F, half_w, merge_steps_min):
+        """Which scenes can be made into a harder avoidance than the recording?
+
+        Eligible when a PARKED vehicle (not a kerb, not a moving car) bounds the
+        corridor within a nudge's reach, and it is reached late enough that the
+        avoidance is still ahead of the ego. An object already beside the ego at t=0 leaves no approach
+        to perturb, and no merge horizon could rejoin before it anyway -- so the
+        floor is ``min(merge_times)``, derived rather than tuned.
+
+        Returns:
+            eligible: (B,) bool.
+            side: (B,) +1 / -1, the normal-direction sign the vehicle sits on.
+            t_obs: (B,) index into the full time grid where the corridor is tightest.
+        """
+        if self._nbr_lo is None:
+            z = torch.zeros(half_w.shape[0], dtype=torch.bool, device=half_w.device)
+            return z, torch.ones_like(half_w), torch.zeros_like(z, dtype=torch.long)
+        lo_f, hi_f = self._nbr_lo[:, P:], self._nbr_hi[:, P:]  # future only
+        room_hi, room_lo = hi_f, -lo_f  # room toward +normal / -normal
+        slack = torch.minimum(room_hi, room_lo)  # (B, F)
+        s_min, t_rel = slack.min(dim=1)
+        b = torch.arange(slack.shape[0], device=slack.device)
+        # the vehicle sits on whichever side left less room at that timestep
+        side = torch.where(room_hi[b, t_rel] <= room_lo[b, t_rel], 1.0, -1.0)
+        eligible = (s_min <= self.dy_max + half_w) & (t_rel >= merge_steps_min)
+        return eligible, side, t_rel + P
 
     # ---------- the augmentation ----------
     @torch.no_grad()
@@ -284,14 +362,17 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         speed = ddt(xy, 1).norm(dim=-1).clamp(min=0.5)  # (B, T)
         v0 = speed[:, P - 1]
         wb = inputs["ego_shape"][:, 0]
-        half_w = inputs["ego_shape"][:, 2] / 2 + CORRIDOR_MARGIN
+        half_w = inputs["ego_shape"][:, 2] / 2 + max(CORRIDOR_MARGIN, self.min_clearance)
         half_l = inputs["ego_shape"][:, 1] / 2
 
         lo, hi = self._corridor(inputs, xy, tan, nrm, half_w, half_l, wb)
 
         K, C = self.n_draws, len(combos)
-        r = torch.rand((B, 2 * K + 1), generator=self.gen).to(dev)
-        do_aug = r[:, -1] < self._augment_prob
+        # One extra column ONLY when the toward-parked nudge is on, so at
+        # toward_parked_prob = 0 the RNG stream is byte-for-byte what it has always been.
+        toward_on = self.toward_parked_prob > 0.0
+        r = torch.rand((B, 2 * K + 1 + int(toward_on)), generator=self.gen).to(dev)
+        do_aug = r[:, 2 * K] < self._augment_prob
         # Low-speed / reverse gate (same threshold as the quintic augmenter): a
         # near-stationary ego makes every path-relative feasibility metric
         # degenerate (a pure sideways translation has zero lateral accel/jerk/yaw
@@ -300,6 +381,21 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         do_aug = do_aug & (inputs["ego_current_state"][:, 4] >= 2.0)
         dy = (r[:, :K] * 2 - 1) * self.dy_max
         dth = (r[:, K : 2 * K] * 2 - 1) * self.dth_max
+
+        # Toward-parked nudge: on a fraction of the scenes where a PARKED vehicle bounds
+        # the corridor further ahead than the shortest merge, point every drawn offset AT
+        # that vehicle. Only the SIGN is mirrored, so |dy| keeps the distribution it
+        # already had -- the ego's t=0 state becomes a harder avoidance than the
+        # recording's, and nothing downstream (dth, merge sampling, shapes, corridor,
+        # kinematics, veto) is touched. Candidates too hard to drive are still rejected
+        # by the existing feasibility screen, so "harder" cannot become "impossible".
+        toward = None
+        if toward_on:
+            merge_steps_min = int(min(self.knobs.merge_times) / DT)
+            eligible, side, t_obs = self._parked_vehicle_ahead(P, F, half_w, merge_steps_min)
+            toward = eligible & (r[:, 2 * K + 1] < self.toward_parked_prob) & do_aug
+            if bool(toward.any()):
+                dy = torch.where(toward[:, None], side[:, None] * dy.abs(), dy)
 
         L, in_corr, merges = self._candidate_profiles(
             combos, dy, dth, v0, speed, half_l, lo, hi, dev, dtype
@@ -312,9 +408,24 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         # augment_prob coin, or it is below the low-speed gate -- so the two questions stay
         # separable when reading the selection below.
         admissible = feasible & do_aug[:, None, None]
+        if toward is not None and bool(toward.any()):
+            # the recovery has to finish while the vehicle still matters
+            merge_steps = (merges / DT).round().long()  # (C,)
+            in_time = merge_steps[None, :] <= (t_obs - (P - 1))[:, None]  # (B, C)
+            admissible = admissible & torch.where(
+                toward[:, None, None], in_time[:, None, :], torch.ones_like(in_time[:, None, :])
+            )
         draw_ok = admissible.any(-1)  # (B, K): the drawn perturbation has >=1 valid merge
         has = draw_ok.any(-1)  # (B,)
         first = draw_ok.float().argmax(-1)  # first feasible PERTURBATION per scene
+        if toward is not None and bool(toward.any()):
+            # Toward-parked rows take the LARGEST feasible offset rather than the first
+            # feasible draw. Mirroring the sign only fixes direction; measured on 105k
+            # scenes, first-feasible left the baseline harder in 24.5% of rows,
+            # largest-feasible in 9.5% -- the remainder being the merge gate refusing a
+            # horizon the baseline was allowed. "Harder" has to hold per scene, not on average.
+            largest = torch.where(draw_ok, dy.abs(), torch.full_like(dy, -1.0)).argmax(-1)
+            first = torch.where(toward, largest, first)
 
         if not bool(has.any()):
             # nothing feasible this batch: every row trains on plain GT
@@ -488,6 +599,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             self._nbr_valid[rows],
             inputs["neighbor_agents_past"][rows][:, :, -1][..., [6, 7]],
             self._nbr_near[rows],
+            min_clearance=self.min_clearance,
         )
 
     def _write_back(self, inputs, ego_future, aug_xy, g, heading, upd, wb, P):
@@ -556,4 +668,6 @@ def frenet_augmenter_from_args(args) -> "FrenetStatePerturbationTensor":
         seed=int(args.frenet_seed),
         ranked_temp_s=float(args.frenet_ranked_temp_s),
         recovery_rounds=int(args.frenet_recovery_rounds),
+        toward_parked_prob=float(args.frenet_toward_parked_prob),
+        min_clearance=float(args.frenet_min_clearance),
     )

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -173,6 +173,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         min_clearance: float = 0.0,
         ego_past_noise_std: float = 0.0,
         hist_jitter_lat: float = 0.0,
+        hist_jitter_lon: float = 0.0,
     ):
         super().__init__(
             augment_prob=augment_prob,
@@ -242,6 +243,12 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         self.hist_jitter_lat = float(hist_jitter_lat)
         if self.hist_jitter_lat < 0.0:
             raise ValueError(f"hist_jitter_lat must be >= 0, got {hist_jitter_lat}")
+        # The longitudinal axis varies the SPACING of the history samples, i.e. makes the
+        # implied speed history wobble, rather than being uniformly wrong as it is under
+        # past_noise_std. Same basis, same normalisation, independent coefficients.
+        self.hist_jitter_lon = float(hist_jitter_lon)
+        if self.hist_jitter_lon < 0.0:
+            raise ValueError(f"hist_jitter_lon must be >= 0, got {hist_jitter_lon}")
         # offsets added to the winning polyline's history this call, so the post-veto
         # retry rebuilds its candidates on the same jittered history; None when off
         self._hist_jit = None
@@ -289,11 +296,11 @@ class FrenetStatePerturbationTensor(StatePerturbation):
     # ---------- smooth ego-history jitter (opt-in, depends only on P) ----------
     @property
     def _hist_jitter_on(self) -> bool:
-        return self.hist_jitter_lat > 0.0
+        return self.hist_jitter_lat > 0.0 or self.hist_jitter_lon > 0.0
 
     def _hist_jitter_axes(self, tan, nrm):
         """(std, unit direction) of every axis the jitter is drawn along."""
-        return ((self.hist_jitter_lat, nrm),)
+        return ((self.hist_jitter_lat, nrm), (self.hist_jitter_lon, tan))
 
     def _hist_jitter_basis(self, P, device, dtype):
         """Cached (K, P) low-frequency displacement basis, normalised in amplitude.
@@ -944,4 +951,5 @@ def frenet_augmenter_from_args(args) -> "FrenetStatePerturbationTensor":
         min_clearance=float(args.frenet_min_clearance),
         ego_past_noise_std=float(args.ego_past_noise_std),
         hist_jitter_lat=float(args.frenet_hist_jitter_lat),
+        hist_jitter_lon=float(args.frenet_hist_jitter_lon),
     )

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -62,6 +62,11 @@ PARKED_SPEED = 0.5  # m/s
 # what makes the "MOVING vehicles are excluded" claim true rather than aspirational.
 PARKED_MAX_DISPLACEMENT = 1.0  # m
 
+# Number of low-frequency modes in the ego-history jitter basis. Independent
+# per-sample noise makes a visibly jagged track a model can learn to ignore; three
+# half-sine modes give a smooth, correlated wobble instead.
+HIST_JITTER_MODES = 3
+
 
 def quintic_basis(t0: float, t1: float, t: np.ndarray):
     """Rows: response of l, l', l'', l''' to unit (pos, vel, acc) BCs at t1.
@@ -167,6 +172,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         toward_parked_prob: float = 0.0,
         min_clearance: float = 0.0,
         ego_past_noise_std: float = 0.0,
+        hist_jitter_lat: float = 0.0,
     ):
         super().__init__(
             augment_prob=augment_prob,
@@ -229,7 +235,18 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         self.past_noise_std = float(ego_past_noise_std)
         if self.past_noise_std < 0.0:
             raise ValueError(f"ego_past_noise_std must be >= 0, got {ego_past_noise_std}")
+        # Std (m) of the smooth history jitter AT THE OLDEST history sample, per axis of
+        # the path frame. A different perturbation from past_noise_std above: that one
+        # scales a correctly-shaped track so it is traversed at the wrong speed, this one
+        # bends the track itself. 0 draws nothing and is bit-identical. See _hist_jitter.
+        self.hist_jitter_lat = float(hist_jitter_lat)
+        if self.hist_jitter_lat < 0.0:
+            raise ValueError(f"hist_jitter_lat must be >= 0, got {hist_jitter_lat}")
+        # offsets added to the winning polyline's history this call, so the post-veto
+        # retry rebuilds its candidates on the same jittered history; None when off
+        self._hist_jit = None
         self._basis_cache = {}
+        self._jitter_basis_cache = {}
 
     # ---------- shared basis (depends only on the time grid + knobs) ----------
     def _bases(self, P, F, device, dtype):
@@ -269,6 +286,67 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         return out
 
     # ---------- corridor, fully batched ----------
+    # ---------- smooth ego-history jitter (opt-in, depends only on P) ----------
+    @property
+    def _hist_jitter_on(self) -> bool:
+        return self.hist_jitter_lat > 0.0
+
+    def _hist_jitter_axes(self, tan, nrm):
+        """(std, unit direction) of every axis the jitter is drawn along."""
+        return ((self.hist_jitter_lat, nrm),)
+
+    def _hist_jitter_basis(self, P, device, dtype):
+        """Cached (K, P) low-frequency displacement basis, normalised in amplitude.
+
+        u = 0 at the t=0 sample (column P-1) and u = 1 at the oldest one (column 0),
+        with phi_k(u) = sin(k*pi*u/2) for k = 1..K. Two properties come for free:
+        every mode is smooth, and every mode is EXACTLY zero at u = 0, so the current
+        pose the model plans from cannot be displaced whatever is drawn.
+
+        Amplitude normalisation. The displacement is d(u) = A * sum_k c_k phi_k(u) with
+        c_k iid N(0, 1), so Var[d(u)] = A^2 * sum_k phi_k(u)^2 -- the modes are
+        independent, so their variances (not their amplitudes) add. The flag is defined
+        as the std AT THE OLDEST sample, u = 1, hence
+
+            sigma^2 = A^2 * sum_k phi_k(1)^2   =>   A = sigma / ||phi[:, 0]||_2 ,
+
+        and sum_k sin(k*pi/2)^2 = 1 + 0 + 1 = 2 at K = 3, i.e. A = sigma / sqrt(2). The
+        norm is taken from the basis itself rather than written out, so changing K or
+        the mode family keeps the flag meaning what it says.
+        """
+        key = (P, device, dtype)
+        hit = self._jitter_basis_cache.get(key)
+        if hit is not None:
+            return hit
+        u = np.arange(P - 1, -1, -1, dtype=np.float64) / max(P - 1, 1)
+        k = np.arange(1, HIST_JITTER_MODES + 1, dtype=np.float64)[:, None]
+        phi = np.sin(k * np.pi * u[None, :] / 2.0)  # (K, P), phi[:, P-1] == 0 exactly
+        phi = phi / np.linalg.norm(phi[:, 0])
+        out = torch.tensor(phi, device=device, dtype=dtype)
+        self._jitter_basis_cache[key] = out
+        return out
+
+    def _hist_jitter(self, xy, tan, nrm, P):
+        """Per-scene smooth jitter of the HISTORY, as a (B, T, 2) offset on the polyline.
+
+        Applied to the winning polyline BEFORE the headings are derived from it, so the
+        stored cos/sin describe the jittered track rather than disagreeing with it. Only
+        the history is moved: the future and the merge are left exactly as selected.
+
+        One coefficient draw and one GEMM for the whole batch -- no python loop over
+        scenes or samples; the loop below runs once per AXIS (one or two).
+        """
+        phi = self._hist_jitter_basis(P, xy.device, xy.dtype)  # (K, P)
+        axes = self._hist_jitter_axes(tan, nrm)
+        c = torch.normal(
+            0.0, 1.0, size=(xy.shape[0], len(axes), phi.shape[0]), generator=self.gen
+        ).to(device=xy.device, dtype=xy.dtype)
+        d = c @ phi  # (B, A, P)
+        off = torch.zeros_like(xy)
+        for i, (std, direction) in enumerate(axes):
+            off[:, :P] += (std * d[:, i, :, None]) * direction[:, :P]
+        return off
+
     def _corridor(self, inputs, xy, tan, nrm, half_w, half_w_nbr, half_l, wb):
         """Lateral free space per timestep: where can this ego go sideways.
 
@@ -607,6 +685,12 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         aug_xy = self._select_candidate(
             admissible, jerk_fut_peak, first, merges, L, xy, nrm, B, dev
         )
+        # Jitter the HISTORY before the headings are derived, so the stored cos/sin come
+        # out consistent with the perturbed track for free (and so the veto below judges
+        # the track that will actually be written). Off by default: nothing is drawn.
+        self._hist_jit = self._hist_jitter(xy, tan, nrm, P) if self._hist_jitter_on else None
+        if self._hist_jit is not None:
+            aug_xy = aug_xy + self._hist_jit
         g, heading = self._headings(aug_xy, tan)
         upd = self._veto_true_overlaps(inputs, has.clone(), aug_xy, heading)
         if self.recovery_rounds:
@@ -764,6 +848,8 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             feas_k = adm[rows, cur]
             combo_idx, alive = self._sample_merge_then_jerk(feas_k, jerk[rows, cur], merges)
             cand = xy[rows] + L[rows, cur, combo_idx][..., None] * nrm[rows]
+            if self._hist_jit is not None:
+                cand = cand + self._hist_jit[rows]  # same history jitter as the first pick
             g_r, hd_r = self._headings(cand, tan[rows])
             keep = self._veto_true_overlaps_rows(inputs, alive.clone(), cand, hd_r, rows)
             sel = rows[keep]
@@ -857,4 +943,5 @@ def frenet_augmenter_from_args(args) -> "FrenetStatePerturbationTensor":
         toward_parked_prob=float(args.frenet_toward_parked_prob),
         min_clearance=float(args.frenet_min_clearance),
         ego_past_noise_std=float(args.ego_past_noise_std),
+        hist_jitter_lat=float(args.frenet_hist_jitter_lat),
     )

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -32,7 +32,6 @@ from dataclasses import dataclass
 import numpy as np
 import torch
 
-from diffusion_planner.dimensions import EGOSTATE
 from diffusion_planner.utils.augmentation_checks import (
     DT,
     border_lateral_bounds,
@@ -102,14 +101,6 @@ class FrenetStatePerturbationTensor(StatePerturbation):
 
     def centric_transform(self, inputs, ego_future, neighbors_future):
         out = super().centric_transform(inputs, ego_future, neighbors_future)
-        # Restore "no history" rows to exact zero. Both the rewrite and the parent's
-        # re-centering write real numbers into every history slot, and the encoder reads
-        # ego_agent_past directly -- a transformed pad would be presented to the model as
-        # history that never happened. Applied to the whole batch, not just augmented rows,
-        # so a future non-identity transform on untouched rows cannot reintroduce it.
-        pad = getattr(self, "_ego_past_pad", None)
-        if pad is not None and bool(pad.any()):
-            inputs["ego_agent_past"][pad] = 0.0
         # Dataset convention is base_link: velocity and acceleration are purely
         # longitudinal (raw NPZs carry vy = ay = 0.0 identically). The rebuilt
         # polyline's finite-diff velocity leaves a small tangent/heading residual
@@ -122,41 +113,127 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             cur[rows, 4] = torch.sqrt(vx * vx + vy * vy) * torch.where(vx < 0, -1.0, 1.0)
             cur[rows, 5] = 0.0
             cur[rows, 7] = 0.0  # ay
-        # History noise runs LAST, after the re-centering rather than before it. Only
-        # here is the history expressed about the augmented t=0 pose, so scaling it
-        # about the origin leaves t=0 exactly at the origin and leaves the implied
-        # speed history consistent with the current state it is scaled with. Scaling in
-        # the pre-centering frame would instead drag the t=0 pose away from the current
-        # state the whole batch is then centered on. It also runs after the pad
-        # zeroing, so a padded row is exactly zero and no factor can resurrect it.
-        if self.past_noise_std > 0.0 and rows is not None and bool(rows.any()):
-            self._scale_history(inputs, rows)
+            # ...and only then is the history perturbed. See _perturb_history for why
+            # every history perturbation happens HERE and nowhere earlier.
+            self._perturb_history(inputs, rows)
+        # Restore "no history" rows to exact zero. The rewrite, the parent's re-centering
+        # and the perturbation above all write real numbers into every history slot, and
+        # the encoder reads ego_agent_past directly -- a transformed pad would be
+        # presented to the model as history that never happened. Runs LAST so no
+        # perturbation can resurrect a padded row, and over the whole batch rather than
+        # just the augmented rows, so a future non-identity transform on untouched rows
+        # cannot reintroduce it either.
+        pad = getattr(self, "_ego_past_pad", None)
+        if pad is not None and bool(pad.any()):
+            inputs["ego_agent_past"][pad] = 0.0
         return out
 
-    def _scale_history(self, inputs, rows):
-        """Scale an augmented row's rewritten history by one factor per scene.
+    def _perturb_history(self, inputs, rows):
+        """Both ego-history perturbations, on the ACCEPTED rows, after everything else.
+
+        WHY HERE, i.e. after the veto and after the re-centering. Two reasons, and they
+        are the reason neither perturbation is applied where the candidate is built:
+
+        * The corridor, the kinematic feasibility screen and the exact-OBB veto exist to
+          certify that the candidate is a valid thing to drive. They have to judge CLEAN
+          geometry. A perturbation applied before them bends the HISTORY by motion that
+          never happened, and the plausibility-jerk screen then rejects good candidates
+          for the noise rather than for the candidate -- so which scenes get augmented at
+          all would depend on the noise setting, and an A/B across settings would be
+          comparing different training sets. Applied here, acceptance is identical for
+          every setting of both flags.
+        * The merge is constructed to be jerk-optimal from the CLEAN t=0 state, and the
+          future is the training TARGET. Perturbing the history first and re-deriving the
+          state from it corrupts that target. The point of history noise is that the model
+          should produce the correct trajectory DESPITE an imperfect history, so the noise
+          has to be input-only: the future and the t=0 state stay exactly as validated.
+
+        Ordering within centric_transform. The parent re-centers the history about the
+        augmented t=0 pose, so by the time this runs the history is expressed in the
+        frame the model sees, and the stored cos/sin are that frame's directions -- which
+        is what the jitter's path frame is taken from below. Both perturbations are also
+        frame-agnostic by construction (the scale is about the t=0 SAMPLE, the jitter's
+        basis vanishes there), so re-centering before or after them would give the same
+        answer; doing it before simply means only one frame is ever involved.
+
+        What moves and what does not. NOTHING outside ``ego_agent_past`` columns 0:4 --
+        the positions, and the cos/sin re-derived from them so the stored heading
+        describes the track that is actually written, at every sample except the pinned
+        t = 0 one. The future is untouched and so is ``ego_current_state``, for BOTH
+        perturbations: every arm of an A/B then perturbs exactly what the encoder sees
+        and nothing else. Nor is there any state consistency to maintain, because the
+        history carries no velocity -- ``ego_agent_past`` is (x, y, cos, sin). Of the
+        current state, only ``[:4]`` (pose) and ``[4:5]`` (vx) are read anywhere in the
+        model, loss or eval path: vy, ax, ay, steering and yaw rate are dead inputs, and
+        vx is not an encoder input either -- its only consumer is the longitudinal loss
+        WEIGHT in decoder.py (``position_lon_loss / clamp_min(|vx|, 1)``, and frenet's
+        2 m/s gate means the clamp never binds). Scaling it would re-weight that scene's
+        loss by 1/s rather than perturb its history, which is a second mechanism the
+        jitter does not have and would make the arms incomparable.
+        """
+        if not (self.past_noise_std > 0.0 or self._hist_jitter_on):
+            return  # nothing drawn, nothing written: the default path is bit-identical
+        past = inputs["ego_agent_past"]
+        xy, tan = past[rows, :, :2], past[rows, :, 2:4]
+        if self.past_noise_std > 0.0:
+            xy = self._scale_history(xy)
+        if self._hist_jitter_on:
+            # jitter the SCALED track, so its flagged amplitude is not itself rescaled
+            nrm = torch.stack([-tan[..., 1], tan[..., 0]], dim=-1)
+            xy = xy + self._hist_jitter(xy, tan, nrm, xy.shape[1])
+        # Same heading convention as the polyline rewrite, including its fallback to the
+        # stored tangent below 0.3 m/step: without this the cos/sin would keep describing
+        # the clean track and disagree with the positions next to them.
+        _, heading = self._headings(xy, tan)
+        new = torch.stack([xy[..., 0], xy[..., 1], heading.cos(), heading.sin()], dim=-1).to(
+            past.dtype
+        )
+        # t = 0 is pinned WHOLE. Its position cannot move -- both perturbations vanish
+        # there by construction -- and its heading has to keep agreeing with the
+        # ego_current_state pose, which stays exactly as validated. Without this the
+        # one-sided difference _headings takes at the end of the polyline would rewrite
+        # the t=0 heading from the perturbed sample beside it, and the model would be
+        # handed a current pose and a last history pose that disagree.
+        new[:, -1] = past[rows][:, -1, :4]
+        past[rows, :, :4] = new
+
+    def _scale_history(self, xy):
+        """Scale an accepted row's rewritten history about its t=0 sample.
 
         The perturbation the quintic augmenter applies through ``ego_past_noise_std``.
         Frenet reads the same flag, but applies it to the history it rewrote rather than
-        to the recorded one the base class would have scaled: one N(1, std) scalar per scene clamped to +-2 std, multiplying
-        the history xy and the current velocity and acceleration together, so the
-        implied speed history stays consistent with the state. Non-augmented rows are
-        never touched -- they train on plain ground truth, unscaled.
+        to the recorded one the base class would have scaled: one N(1, std) scalar per
+        scene clamped to +-2 std. Semantically "the ego arrived here faster or slower
+        than recorded", so the scene is the same drive at a different approach speed.
+
+        Scaling is about the t = 0 SAMPLE, ``p_i' = p_0 + s * (p_i - p_0)``, not about
+        the frame origin: t = 0 is then pinned exactly, in any frame, so nothing that was
+        validated moves and the model still plans from the pose it was given.
+
+        POSITIONS ONLY. The current state's velocity and acceleration are deliberately
+        NOT scaled with them -- see :meth:`_perturb_history` for why: there is no history
+        velocity for them to stay consistent with, vy/ax/ay are read by nothing, and vx
+        is only a longitudinal-loss weight, so scaling it would re-weight the loss rather
+        than perturb an input.
 
         The draw comes from the augmenter's own generator, and is taken ONLY when the
         std is positive, so at the default the generator is left exactly where the
         unaugmented stream leaves it.
+
+        Args:
+            xy: (M, P, 2) history positions of the accepted rows.
+
+        Returns:
+            (M, P, 2) scaled history positions.
         """
         w = self.past_noise_std
-        past, cur = inputs["ego_agent_past"], inputs["ego_current_state"]
-        scale = torch.normal(1.0, w, size=(int(rows.sum()), 1, 1), generator=self.gen).clamp(
-            1.0 - 2 * w, 1.0 + 2 * w
+        scale = (
+            torch.normal(1.0, w, size=(xy.shape[0], 1, 1), generator=self.gen)
+            .clamp(1.0 - 2 * w, 1.0 + 2 * w)
+            .to(device=xy.device, dtype=xy.dtype)
         )
-        scale = scale.to(device=past.device, dtype=past.dtype)
-        past[rows, :, :2] = past[rows, :, :2] * scale
-        cur[rows, EGOSTATE.VX : EGOSTATE.AY + 1] = (
-            cur[rows, EGOSTATE.VX : EGOSTATE.AY + 1] * scale[:, :, 0]
-        )
+        p0 = xy[:, -1:, :]  # the t=0 sample, held fixed by construction
+        return p0 + scale * (xy - p0)
 
     def __init__(
         self,
@@ -182,7 +259,8 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             # The base class scales the RECORDED history, which frenet does not keep --
             # it rewrites the past from the perturbed polyline. The same perturbation is
             # applied to that rewrite instead, in _scale_history, so the base class is
-            # disabled here and the caller's value is stored below.
+            # disabled here and the caller's value is stored below. Frenet also applies
+            # it strictly after the veto, which the base class has no equivalent of.
             ego_past_noise_std=0.0,
             use_smoothing_future_trajectory=False,
         )
@@ -232,14 +310,16 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         # Std of the per-scene history-scale factor. The base class is told 0 above
         # because frenet rewrites the past kinematically and the quintic scaling would
         # be applied to the recorded history instead; this knob applies the same
-        # perturbation to the REWRITTEN history. 0 draws nothing and is bit-identical.
+        # perturbation to the REWRITTEN history, after the veto, and to the history
+        # POSITIONS only (see _perturb_history). 0 draws nothing and is bit-identical.
         self.past_noise_std = float(ego_past_noise_std)
         if self.past_noise_std < 0.0:
             raise ValueError(f"ego_past_noise_std must be >= 0, got {ego_past_noise_std}")
         # Std (m) of the smooth history jitter AT THE OLDEST history sample, per axis of
         # the path frame. A different perturbation from past_noise_std above: that one
         # scales a correctly-shaped track so it is traversed at the wrong speed, this one
-        # bends the track itself. 0 draws nothing and is bit-identical. See _hist_jitter.
+        # bends the track itself. Applied after the veto, like the scale, so neither can
+        # move acceptance. 0 draws nothing and is bit-identical. See _hist_jitter.
         self.hist_jitter_lat = float(hist_jitter_lat)
         if self.hist_jitter_lat < 0.0:
             raise ValueError(f"hist_jitter_lat must be >= 0, got {hist_jitter_lat}")
@@ -249,9 +329,6 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         self.hist_jitter_lon = float(hist_jitter_lon)
         if self.hist_jitter_lon < 0.0:
             raise ValueError(f"hist_jitter_lon must be >= 0, got {hist_jitter_lon}")
-        # offsets added to the winning polyline's history this call, so the post-veto
-        # retry rebuilds its candidates on the same jittered history; None when off
-        self._hist_jit = None
         self._basis_cache = {}
         self._jitter_basis_cache = {}
 
@@ -336,9 +413,10 @@ class FrenetStatePerturbationTensor(StatePerturbation):
     def _hist_jitter(self, xy, tan, nrm, P):
         """Per-scene smooth jitter of the HISTORY, as a (B, T, 2) offset on the polyline.
 
-        Applied to the winning polyline BEFORE the headings are derived from it, so the
-        stored cos/sin describe the jittered track rather than disagreeing with it. Only
-        the history is moved: the future and the merge are left exactly as selected.
+        Only the first ``P`` samples are moved; anything past them stays exactly zero, so
+        handing in the whole time grid leaves the future untouched. The caller applies
+        this to the ACCEPTED history only, after the veto, and re-derives the stored
+        cos/sin from the result (see :meth:`_perturb_history`).
 
         One coefficient draw and one GEMM for the whole batch -- no python loop over
         scenes or samples; the loop below runs once per AXIS (one or two).
@@ -692,12 +770,9 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         aug_xy = self._select_candidate(
             admissible, jerk_fut_peak, first, merges, L, xy, nrm, B, dev
         )
-        # Jitter the HISTORY before the headings are derived, so the stored cos/sin come
-        # out consistent with the perturbed track for free (and so the veto below judges
-        # the track that will actually be written). Off by default: nothing is drawn.
-        self._hist_jit = self._hist_jitter(xy, tan, nrm, P) if self._hist_jitter_on else None
-        if self._hist_jit is not None:
-            aug_xy = aug_xy + self._hist_jit
+        # NOTE: the history perturbations are deliberately NOT applied here. The veto
+        # below, and the feasibility screen above, must judge the clean candidate; the
+        # noise is added to the accepted history at the very end, in _perturb_history.
         g, heading = self._headings(aug_xy, tan)
         upd = self._veto_true_overlaps(inputs, has.clone(), aug_xy, heading)
         if self.recovery_rounds:
@@ -855,8 +930,6 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             feas_k = adm[rows, cur]
             combo_idx, alive = self._sample_merge_then_jerk(feas_k, jerk[rows, cur], merges)
             cand = xy[rows] + L[rows, cur, combo_idx][..., None] * nrm[rows]
-            if self._hist_jit is not None:
-                cand = cand + self._hist_jit[rows]  # same history jitter as the first pick
             g_r, hd_r = self._headings(cand, tan[rows])
             keep = self._veto_true_overlaps_rows(inputs, alive.clone(), cand, hd_r, rows)
             sel = rows[keep]

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -131,9 +131,9 @@ class FrenetStatePerturbationTensor(StatePerturbation):
     def _scale_history(self, inputs, rows):
         """Scale an augmented row's rewritten history by one factor per scene.
 
-        The perturbation the quintic augmenter applies through ``ego_past_noise_std``,
-        which frenet disables at the base class because it rewrites the past
-        kinematically: one N(1, std) scalar per scene clamped to +-2 std, multiplying
+        The perturbation the quintic augmenter applies through ``ego_past_noise_std``.
+        Frenet reads the same flag, but applies it to the history it rewrote rather than
+        to the recorded one the base class would have scaled: one N(1, std) scalar per scene clamped to +-2 std, multiplying
         the history xy and the current velocity and acceleration together, so the
         implied speed history stays consistent with the state. Non-augmented rows are
         never touched -- they train on plain ground truth, unscaled.
@@ -166,15 +166,16 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         recovery_rounds: int = 0,
         toward_parked_prob: float = 0.0,
         min_clearance: float = 0.0,
-        past_noise_std: float = 0.0,
+        ego_past_noise_std: float = 0.0,
     ):
         super().__init__(
             augment_prob=augment_prob,
             num_refine=20,
             device=device,
-            # frenet rewrites the past kinematically, so the base class must not scale
-            # the RECORDED history; the same perturbation is available on the rewritten
-            # history through past_noise_std below.
+            # The base class scales the RECORDED history, which frenet does not keep --
+            # it rewrites the past from the perturbed polyline. The same perturbation is
+            # applied to that rewrite instead, in _scale_history, so the base class is
+            # disabled here and the caller's value is stored below.
             ego_past_noise_std=0.0,
             use_smoothing_future_trajectory=False,
         )
@@ -225,9 +226,9 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         # because frenet rewrites the past kinematically and the quintic scaling would
         # be applied to the recorded history instead; this knob applies the same
         # perturbation to the REWRITTEN history. 0 draws nothing and is bit-identical.
-        self.past_noise_std = float(past_noise_std)
+        self.past_noise_std = float(ego_past_noise_std)
         if self.past_noise_std < 0.0:
-            raise ValueError(f"past_noise_std must be >= 0, got {past_noise_std}")
+            raise ValueError(f"ego_past_noise_std must be >= 0, got {ego_past_noise_std}")
         self._basis_cache = {}
 
     # ---------- shared basis (depends only on the time grid + knobs) ----------
@@ -855,5 +856,5 @@ def frenet_augmenter_from_args(args) -> "FrenetStatePerturbationTensor":
         recovery_rounds=int(args.frenet_recovery_rounds),
         toward_parked_prob=float(args.frenet_toward_parked_prob),
         min_clearance=float(args.frenet_min_clearance),
-        past_noise_std=float(args.frenet_past_noise_std),
+        ego_past_noise_std=float(args.ego_past_noise_std),
     )

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass
 import numpy as np
 import torch
 
+from diffusion_planner.utils.augment_defaults import past_noise_std_for
 from diffusion_planner.utils.augmentation_checks import (
     DT,
     border_lateral_bounds,
@@ -182,7 +183,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             nrm = torch.stack([-tan[..., 1], tan[..., 0]], dim=-1)
             xy = xy + self._hist_jitter(xy, tan, nrm, xy.shape[1])
         # Same heading convention as the polyline rewrite, including its fallback to the
-        # stored tangent below 0.3 m/step: without this the cos/sin would keep describing
+        # stored tangent below 0.3 m/s: without this the cos/sin would keep describing
         # the clean track and disagree with the positions next to them.
         _, heading = self._headings(xy, tan)
         new = torch.stack([xy[..., 0], xy[..., 1], heading.cos(), heading.sin()], dim=-1).to(
@@ -532,7 +533,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
     def _headings(aug_xy, tan):
         """Motion-direction heading of a polyline, falling back to the GT tangent.
 
-        Below 0.3 m/step the finite-difference direction is noise, so the recorded
+        Below 0.3 m/s the finite-difference direction is noise, so the recorded
         heading is kept rather than derived from a near-zero displacement.
         """
         g = ddt(aug_xy, 1)
@@ -742,13 +743,18 @@ class FrenetStatePerturbationTensor(StatePerturbation):
     # ---------- the augmentation ----------
     @torch.no_grad()
     def __call__(self, inputs, ego_future, neighbors_future):
-        # Both fields arrive in either layout depending on the entrypoint. The future is
-        # narrowed to a heading angle (centric_transform returns the rebuilt 3-col future
-        # either way, and train_epoch re-converts afterwards); the history is widened,
-        # because everything below indexes its cols 2:4 as a heading VECTOR. Both are
+        # All three fields arrive in either layout depending on the entrypoint. The future
+        # is narrowed to a heading angle (centric_transform returns the rebuilt 3-col
+        # future either way, and train_epoch re-converts afterwards); the history and the
+        # goal pose are widened, because everything below -- and centric_transform, which
+        # rotates goal_pose cols 2:4 -- indexes them as a heading VECTOR. All three are
         # no-ops at the canonical widths the training loop already supplies.
+        # goal_pose is easy to forget here because this __call__ does not read it itself;
+        # it is the inherited centric_transform that does, and a 3-col tensor makes that
+        # rotation raise on a (..., 1) slice.
         ego_future = cos_sin_to_heading(ego_future)
         inputs["ego_agent_past"] = self._ego_past_4col(inputs["ego_agent_past"])
+        inputs["goal_pose"] = pose_to_cos_sin(inputs["goal_pose"])
         past4 = inputs["ego_agent_past"]  # (B, P, 4) x, y, cos, sin
         B, P, _ = past4.shape
         F = ego_future.shape[1]
@@ -1073,7 +1079,7 @@ def frenet_augmenter_from_args(args) -> "FrenetStatePerturbationTensor":
         recovery_rounds=int(args.frenet_recovery_rounds),
         toward_parked_prob=float(args.frenet_toward_parked_prob),
         min_clearance=float(args.frenet_min_clearance),
-        ego_past_noise_std=float(args.ego_past_noise_std),
+        ego_past_noise_std=past_noise_std_for(args),
         hist_jitter_lat=float(args.frenet_hist_jitter_lat),
         hist_jitter_lon=float(args.frenet_hist_jitter_lon),
     )

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -277,8 +277,6 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         self._nbr_valid = None
         self._nbr_lo = None
         self._nbr_hi = None
-        # toward-parked rows that kept ungated candidates: augmented, but NOT hardened
-        self._toward_fellback = None
         self.n_draws = n_draws
         self.dy_max = dy_max
         self.dth_max = dth_max
@@ -555,11 +553,11 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         with the floor off keeps the default path from computing a mask that
         :func:`veto_overlapping` would then ignore.
         """
-        if xy is None or self.min_clearance <= 0.0:
+        if self.min_clearance <= 0.0:
             return None
         return (aug_xy - xy).norm(dim=-1) > self.DEVIATION_EPS
 
-    def _veto_true_overlaps(self, inputs, upd, aug_xy, heading, xy=None):
+    def _veto_true_overlaps(self, inputs, upd, aug_xy, heading, xy):
         """Drop winners whose footprint truly overlaps a recorded neighbor."""
         if self._nbr_st is None:
             return upd
@@ -694,18 +692,25 @@ class FrenetStatePerturbationTensor(StatePerturbation):
     def _toward_parked_select(self, admissible, merges, dy, toward, toward_any, t_obs, P):
         """Merge gate and winner index; a no-op on every row that is not toward-parked.
 
-        Two things happen to a toward row. The recovery has to FINISH while the vehicle
-        still matters, so merge horizons reaching past the tightest-corridor timestep are
-        struck out. And the winner is the LARGEST feasible offset rather than the first
-        feasible draw: mirroring the sign only fixes direction; measured on 105k scenes,
+        Two things happen to a toward row, BOTH conditional on the gate leaving the row
+        something to pick. The recovery has to FINISH while the vehicle still matters,
+        so merge horizons reaching past the tightest-corridor timestep are struck out --
+        unless that would strike out every horizon, in which case the row keeps its
+        ungated candidates and is excluded from ``hardened``. And on a hardened row the
+        winner is the LARGEST feasible offset rather than the first feasible draw:
+        mirroring the sign only fixes direction; measured on 105k scenes,
         first-feasible left the baseline harder in 24.5% of rows, largest-feasible in
         9.5% -- the remainder being the merge gate refusing a horizon the baseline was
         allowed. "Harder" has to hold per scene, not on average.
 
         Returns:
-            admissible (gated), draw_ok (B, K), first (B,) winning draw per scene.
+            admissible (gated where the gate leaves something), draw_ok (B, K),
+            first (B,) winning draw per scene, and hardened (B,) -- the toward rows
+            whose merge really is gated in front of the vehicle. ``hardened`` is None
+            when the nudge is off. It is returned rather than stashed on the instance
+            so the recovery path cannot drift from the first selection.
         """
-        fellback = None  # `toward` is None unless the nudge is on
+        fellback = hardened = None  # `toward` is None unless the nudge is on
         if toward_any:
             merge_steps = (merges / DT).round().long()  # (C,)
             in_time = merge_steps[None, :] <= (t_obs - (P - 1))[:, None]  # (B, C)
@@ -729,8 +734,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             # takes the ordinary first-feasible draw
             hardened = toward & ~fellback
             first = torch.where(hardened, self._largest_offset_draw(draw_ok, dy), first)
-        self._toward_fellback = fellback
-        return admissible, draw_ok, first
+        return admissible, draw_ok, first, hardened
 
     # ---------- the augmentation ----------
     @torch.no_grad()
@@ -792,7 +796,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         # augment_prob coin, or it is below the low-speed gate -- so the two questions stay
         # separable when reading the selection below.
         admissible = feasible & do_aug[:, None, None]
-        admissible, draw_ok, first = self._toward_parked_select(
+        admissible, draw_ok, first, hardened = self._toward_parked_select(
             admissible, merges, dy, toward, toward_any, t_obs, P
         )
         has = draw_ok.any(-1)  # (B,)
@@ -828,6 +832,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
                 has,
                 dy,
                 toward,
+                hardened,
                 toward_any,
             )
 
@@ -928,6 +933,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         has,
         dy,
         toward,
+        hardened,
         toward_any,
     ):
         """Re-draw for rows whose winner truly overlapped a recorded neighbour.
@@ -961,7 +967,14 @@ class FrenetStatePerturbationTensor(StatePerturbation):
                 break
             cur = draw_ok.float().argmax(-1)
             if toward_any:
-                cur = torch.where(toward[rows], self._largest_offset_draw(draw_ok, dy[rows]), cur)
+                # `hardened`, not `toward`: a row that fell back to ungated candidates
+                # takes the ordinary first-feasible draw here too, exactly as it did in
+                # the first selection. Selecting largest-offset for it would reinstate
+                # the rule that only applies when the merge is gated in front of the
+                # vehicle.
+                cur = torch.where(
+                    hardened[rows], self._largest_offset_draw(draw_ok, dy[rows]), cur
+                )
             feas_k = adm[rows, cur]
             combo_idx, alive = self._sample_merge_then_jerk(feas_k, jerk[rows, cur], merges)
             cand = xy[rows] + L[rows, cur, combo_idx][..., None] * nrm[rows]
@@ -973,7 +986,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             adm[rows, cur, :] = False
         return aug_xy, g, heading, upd
 
-    def _veto_true_overlaps_rows(self, inputs, rows_mask, aug_xy, heading, rows, xy=None):
+    def _veto_true_overlaps_rows(self, inputs, rows_mask, aug_xy, heading, rows, xy):
         """:meth:`_veto_true_overlaps` restricted to a subset of scenes."""
         if self._nbr_st is None:
             return rows_mask
@@ -987,7 +1000,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             inputs["neighbor_agents_past"][rows][:, :, -1][..., [6, 7]],
             self._nbr_near[rows],
             min_clearance=self.min_clearance,
-            floor_mask=self._floor_mask(aug_xy, None if xy is None else xy[rows]),
+            floor_mask=self._floor_mask(aug_xy, xy[rows]),
         )
 
     def _write_back(self, inputs, ego_future, aug_xy, g, heading, upd, wb, P):

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -546,8 +546,15 @@ class FrenetStatePerturbationTensor(StatePerturbation):
     # the recording's own clearance.
     DEVIATION_EPS = 1e-3
 
-    def _deviates_from_gt(self, aug_xy, xy):
-        """(B, T) bool: timesteps where the candidate is not the recorded drive."""
+    def _floor_mask(self, aug_xy, xy):
+        """(B, T) bool: timesteps the clearance floor applies at, or None if it is off.
+
+        The mask marks where the candidate is not the recorded drive. Returning None
+        with the floor off keeps the default path from computing a mask that
+        :func:`veto_overlapping` would then ignore.
+        """
+        if xy is None or self.min_clearance <= 0.0:
+            return None
         return (aug_xy - xy).norm(dim=-1) > self.DEVIATION_EPS
 
     def _veto_true_overlaps(self, inputs, upd, aug_xy, heading, xy=None):
@@ -564,7 +571,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             inputs["neighbor_agents_past"][:, :, -1][..., [6, 7]],
             self._nbr_near,
             min_clearance=self.min_clearance,
-            floor_mask=None if xy is None else self._deviates_from_gt(aug_xy, xy),
+            floor_mask=self._floor_mask(aug_xy, xy),
         )
 
     # ---------- toward-parked nudge ----------
@@ -963,7 +970,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             inputs["neighbor_agents_past"][rows][:, :, -1][..., [6, 7]],
             self._nbr_near[rows],
             min_clearance=self.min_clearance,
-            floor_mask=None if xy is None else self._deviates_from_gt(aug_xy, xy[rows]),
+            floor_mask=self._floor_mask(aug_xy, None if xy is None else xy[rows]),
         )
 
     def _write_back(self, inputs, ego_future, aug_xy, g, heading, upd, wb, P):

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -32,7 +32,10 @@ from dataclasses import dataclass
 import numpy as np
 import torch
 
-from diffusion_planner.utils.augment_defaults import past_noise_std_for
+from diffusion_planner.utils.augment_defaults import (
+    past_noise_std_for,
+    resolve_history_noise,
+)
 from diffusion_planner.utils.augmentation_checks import (
     DT,
     border_lateral_bounds,
@@ -1160,6 +1163,13 @@ def frenet_augmenter_from_args(args) -> "FrenetStatePerturbationTensor":
 
     ``argparse`` hands list fields back as strings, so the numeric coercion lives here too.
     """
+    # Resolve here too: this is a public entrypoint, not only reached through
+    # augmenter_from_args, and `ego_past_noise_std_effective` is None on a freshly
+    # parsed config. Reading it unresolved raised TypeError even when the user had
+    # passed an explicit --ego_past_noise_std. Idempotent, so the factory or a trainer
+    # having already called it costs nothing.
+    resolve_history_noise(args)
+
     return FrenetStatePerturbationTensor(
         augment_prob=args.augment_prob,
         device=args.device,

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -63,6 +63,7 @@ from diffusion_planner.utils.data_augmentation import (
 STREAM_STRIDE = 1_000_003
 HIST_STREAM = 1
 TOWARD_STREAM = 2
+RECOVERY_STREAM = 3
 
 CORRIDOR_MARGIN = 0.10
 # A neighbour counts as parked for the toward-parked nudge when its RECORDED velocity at
@@ -318,6 +319,15 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         # Same reasoning as hist_gen, for the toward-parked coin: see __call__.
         self.toward_gen = torch.Generator(device="cpu").manual_seed(
             seed + rank + TOWARD_STREAM * STREAM_STRIDE
+        )
+        # And one for the retry. `_recover_vetoed` draws once per round, a
+        # data-dependent number of times, so off self.gen it shifted every later
+        # corridor draw: measured on 2,297 scenes, recovery_rounds=1 GAINED 340 rows
+        # (the feature working) but also LOST 360 (which pure recovery cannot do,
+        # since it only ever adds), across 46 of 72 batches. An A/B on the flag was
+        # therefore reading a reseed on top of the feature.
+        self.recovery_gen = torch.Generator(device="cpu").manual_seed(
+            seed + rank + RECOVERY_STREAM * STREAM_STRIDE
         )
         self.ranked_temp_s = float(ranked_temp_s)
         # Rounds of draw-level re-selection allowed after an exact-OBB veto. 0 keeps
@@ -980,7 +990,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         aug_xy = xy + Lw[..., None] * nrm
         return aug_xy
 
-    def _sample_merge_then_jerk(self, feas_k, jerk_k, merges):
+    def _sample_merge_then_jerk(self, feas_k, jerk_k, merges, gen=None):
         """The merge-then-jerk pick, shared by first selection and recovery.
 
         Merge horizon sampled with weight exp(-(M - Mmin) / temp) over the
@@ -992,7 +1002,9 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         w = w * feas_k
         alive = w.sum(-1) > 0
         w = torch.where(alive[:, None], w, torch.ones_like(w))  # avoid all-zero rows
-        pick_m = torch.multinomial(w.cpu().double(), 1, generator=self.gen).to(w.device)[:, 0]
+        pick_m = torch.multinomial(
+            w.cpu().double(), 1, generator=self.gen if gen is None else gen
+        ).to(w.device)[:, 0]
         same_m = feas_k & (merges[None, :] == merges[pick_m][:, None])
         return torch.where(same_m, jerk_k, BIG).argmin(-1), alive
 
@@ -1057,7 +1069,9 @@ class FrenetStatePerturbationTensor(StatePerturbation):
                 # vehicle.
                 cur = torch.where(hardened[rows], self._largest_offset_draw(draw_ok, dy[rows]), cur)
             feas_k = adm[rows, cur]
-            combo_idx, alive = self._sample_merge_then_jerk(feas_k, jerk[rows, cur], merges)
+            combo_idx, alive = self._sample_merge_then_jerk(
+                feas_k, jerk[rows, cur], merges, gen=self.recovery_gen
+            )
             cand = xy[rows] + L[rows, cur, combo_idx][..., None] * nrm[rows]
             g_r, hd_r = self._headings(cand, tan[rows])
             keep = self._veto_true_overlaps_rows(inputs, alive.clone(), cand, hd_r, rows, xy)

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -229,7 +229,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         """
         w = self.past_noise_std
         scale = (
-            torch.normal(1.0, w, size=(xy.shape[0], 1, 1), generator=self.gen)
+            torch.normal(1.0, w, size=(xy.shape[0], 1, 1), generator=self.hist_gen)
             .clamp(1.0 - 2 * w, 1.0 + 2 * w)
             .to(device=xy.device, dtype=xy.dtype)
         )
@@ -288,6 +288,17 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             else 0
         )
         self.gen = torch.Generator(device="cpu").manual_seed(seed + rank)
+        # SEPARATE stream for the history perturbations, and not a stylistic choice.
+        # They draw a data-dependent number of values (one factor per ACCEPTED row,
+        # and one coefficient block per axis), so drawing them from self.gen advances
+        # it by an amount that depends on the perturbation being enabled at all. Every
+        # later batch's corridor and merge draws then shift, and the augmenter accepts
+        # a DIFFERENT set of scenes -- measured: turning either perturbation on changed
+        # the accepted set from batch 2 onward, 6 of 16 batches differing, 116 accepted
+        # rows vs 118 (scale) and 110 (jitter). That silently confounds any A/B on these
+        # knobs with a different augmentation realisation, which is the opposite of what
+        # applying them after the veto is for. Off this stream they cannot reach it.
+        self.hist_gen = torch.Generator(device="cpu").manual_seed(seed + rank + 1)
         self.ranked_temp_s = float(ranked_temp_s)
         # Rounds of draw-level re-selection allowed after an exact-OBB veto. 0 keeps
         # the original behaviour: a vetoed row falls back to plain GT.
@@ -431,7 +442,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         phi = self._hist_jitter_basis(P, xy.device, xy.dtype)  # (K, P)
         axes = self._hist_jitter_axes(tan, nrm)
         c = torch.normal(
-            0.0, 1.0, size=(xy.shape[0], len(axes), phi.shape[0]), generator=self.gen
+            0.0, 1.0, size=(xy.shape[0], len(axes), phi.shape[0]), generator=self.hist_gen
         ).to(device=xy.device, dtype=xy.dtype)
         d = c @ phi  # (B, A, P)
         off = torch.zeros_like(xy)

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -50,6 +50,20 @@ from diffusion_planner.utils.data_augmentation import (
 )
 
 # extra half-width the corridor keeps from borders and neighbors
+
+# Stream namespaces for the generators below. The MAIN stream stays exactly
+# ``seed + rank`` -- byte-for-byte what tier4-main uses -- so the default path is
+# unchanged at every rank. The two added streams sit in disjoint blocks a stride
+# apart, because the obvious ``seed + rank + 1`` / ``+ 2`` made the per-rank blocks
+# OVERLAP: at seed 3407, rank 0's history stream is seeded 3408 and so is rank 1's
+# main stream; rank 0's toward stream is 3409, and so are rank 1's history and rank
+# 2's main. The streams were then separated within a rank but correlated ACROSS
+# ranks in a multi-GPU job, which is the opposite of the point. The stride is far
+# above any plausible world size, so ``seed + rank`` cannot reach the next block.
+STREAM_STRIDE = 1_000_003
+HIST_STREAM = 1
+TOWARD_STREAM = 2
+
 CORRIDOR_MARGIN = 0.10
 # A neighbour counts as parked for the toward-parked nudge when its RECORDED velocity at
 # the last history step is below this. The recorded (vx, vy) is used rather than a
@@ -298,9 +312,13 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         # rows vs 118 (scale) and 110 (jitter). That silently confounds any A/B on these
         # knobs with a different augmentation realisation, which is the opposite of what
         # applying them after the veto is for. Off this stream they cannot reach it.
-        self.hist_gen = torch.Generator(device="cpu").manual_seed(seed + rank + 1)
+        self.hist_gen = torch.Generator(device="cpu").manual_seed(
+            seed + rank + HIST_STREAM * STREAM_STRIDE
+        )
         # Same reasoning as hist_gen, for the toward-parked coin: see __call__.
-        self.toward_gen = torch.Generator(device="cpu").manual_seed(seed + rank + 2)
+        self.toward_gen = torch.Generator(device="cpu").manual_seed(
+            seed + rank + TOWARD_STREAM * STREAM_STRIDE
+        )
         self.ranked_temp_s = float(ranked_temp_s)
         # Rounds of draw-level re-selection allowed after an exact-OBB veto. 0 keeps
         # the original behaviour: a vetoed row falls back to plain GT.

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -62,11 +62,6 @@ PARKED_SPEED = 0.5  # m/s
 # what makes the "MOVING vehicles are excluded" claim true rather than aspirational.
 PARKED_MAX_DISPLACEMENT = 1.0  # m
 
-# Number of low-frequency modes in the ego-history jitter basis. Independent
-# per-sample noise makes a visibly jagged track a model can learn to ignore; three
-# half-sine modes give a smooth, correlated wobble instead.
-HIST_JITTER_MODES = 3
-
 
 def quintic_basis(t0: float, t1: float, t: np.ndarray):
     """Rows: response of l, l', l'', l''' to unit (pos, vel, acc) BCs at t1.
@@ -152,36 +147,30 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         Ordering within centric_transform. The parent re-centers the history about the
         augmented t=0 pose, so by the time this runs the history is expressed in the
         frame the model sees, and the stored cos/sin are that frame's directions -- which
-        is what the jitter's path frame is taken from below. Both perturbations are also
-        frame-agnostic by construction (the scale is about the t=0 SAMPLE, the jitter's
-        basis vanishes there), so re-centering before or after them would give the same
-        answer; doing it before simply means only one frame is ever involved.
+        is what the path frame is taken from below. The perturbation is also
+        frame-agnostic by construction (the scale is about the t=0 SAMPLE), so
+        re-centering before or after it would give the same answer; doing it before
+        simply means only one frame is ever involved.
 
         What moves and what does not. NOTHING outside ``ego_agent_past`` columns 0:4 --
         the positions, and the cos/sin re-derived from them so the stored heading
         describes the track that is actually written, at every sample except the pinned
-        t = 0 one. The future is untouched and so is ``ego_current_state``, for BOTH
-        perturbations: every arm of an A/B then perturbs exactly what the encoder sees
-        and nothing else. Nor is there any state consistency to maintain, because the
+        t = 0 one. The future is untouched and so is ``ego_current_state``: every arm of
+        an A/B then perturbs exactly what the encoder sees and nothing else. Nor is there any state consistency to maintain, because the
         history carries no velocity -- ``ego_agent_past`` is (x, y, cos, sin). Of the
         current state, only ``[:4]`` (pose) and ``[4:5]`` (vx) are read anywhere in the
         model, loss or eval path: vy, ax, ay, steering and yaw rate are dead inputs, and
         vx is not an encoder input either -- its only consumer is the longitudinal loss
         WEIGHT in decoder.py (``position_lon_loss / clamp_min(|vx|, 1)``, and frenet's
         2 m/s gate means the clamp never binds). Scaling it would re-weight that scene's
-        loss by 1/s rather than perturb its history, which is a second mechanism the
-        jitter does not have and would make the arms incomparable.
+        loss by 1/s rather than perturb its history -- a second mechanism that would
+        make the arms of an A/B on this flag incomparable.
         """
-        if not (self.past_noise_std > 0.0 or self._hist_jitter_on):
+        if self.past_noise_std <= 0.0:
             return  # nothing drawn, nothing written: the default path is bit-identical
         past = inputs["ego_agent_past"]
         xy, tan = past[rows, :, :2], past[rows, :, 2:4]
-        if self.past_noise_std > 0.0:
-            xy = self._scale_history(xy)
-        if self._hist_jitter_on:
-            # jitter the SCALED track, so its flagged amplitude is not itself rescaled
-            nrm = torch.stack([-tan[..., 1], tan[..., 0]], dim=-1)
-            xy = xy + self._hist_jitter(xy, tan, nrm, xy.shape[1])
+        xy = self._scale_history(xy)
         # Same heading convention as the polyline rewrite, including its fallback to the
         # stored tangent below 0.3 m/s: without this the cos/sin would keep describing
         # the clean track and disagree with the positions next to them.
@@ -250,8 +239,6 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         toward_parked_prob: float = 0.0,
         min_clearance: float = 0.0,
         ego_past_noise_std: float = 0.0,
-        hist_jitter_lat: float = 0.0,
-        hist_jitter_lon: float = 0.0,
     ):
         super().__init__(
             augment_prob=augment_prob,
@@ -316,22 +303,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         self.past_noise_std = float(ego_past_noise_std)
         if self.past_noise_std < 0.0:
             raise ValueError(f"ego_past_noise_std must be >= 0, got {ego_past_noise_std}")
-        # Std (m) of the smooth history jitter AT THE OLDEST history sample, per axis of
-        # the path frame. A different perturbation from past_noise_std above: that one
-        # scales a correctly-shaped track so it is traversed at the wrong speed, this one
-        # bends the track itself. Applied after the veto, like the scale, so neither can
-        # move acceptance. 0 draws nothing and is bit-identical. See _hist_jitter.
-        self.hist_jitter_lat = float(hist_jitter_lat)
-        if self.hist_jitter_lat < 0.0:
-            raise ValueError(f"hist_jitter_lat must be >= 0, got {hist_jitter_lat}")
-        # The longitudinal axis varies the SPACING of the history samples, i.e. makes the
-        # implied speed history wobble, rather than being uniformly wrong as it is under
-        # past_noise_std. Same basis, same normalisation, independent coefficients.
-        self.hist_jitter_lon = float(hist_jitter_lon)
-        if self.hist_jitter_lon < 0.0:
-            raise ValueError(f"hist_jitter_lon must be >= 0, got {hist_jitter_lon}")
         self._basis_cache = {}
-        self._jitter_basis_cache = {}
 
     # ---------- shared basis (depends only on the time grid + knobs) ----------
     def _bases(self, P, F, device, dtype):
@@ -371,68 +343,6 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         return out
 
     # ---------- corridor, fully batched ----------
-    # ---------- smooth ego-history jitter (opt-in, depends only on P) ----------
-    @property
-    def _hist_jitter_on(self) -> bool:
-        return self.hist_jitter_lat > 0.0 or self.hist_jitter_lon > 0.0
-
-    def _hist_jitter_axes(self, tan, nrm):
-        """(std, unit direction) of every axis the jitter is drawn along."""
-        return ((self.hist_jitter_lat, nrm), (self.hist_jitter_lon, tan))
-
-    def _hist_jitter_basis(self, P, device, dtype):
-        """Cached (K, P) low-frequency displacement basis, normalised in amplitude.
-
-        u = 0 at the t=0 sample (column P-1) and u = 1 at the oldest one (column 0),
-        with phi_k(u) = sin(k*pi*u/2) for k = 1..K. Two properties come for free:
-        every mode is smooth, and every mode is EXACTLY zero at u = 0, so the current
-        pose the model plans from cannot be displaced whatever is drawn.
-
-        Amplitude normalisation. The displacement is d(u) = A * sum_k c_k phi_k(u) with
-        c_k iid N(0, 1), so Var[d(u)] = A^2 * sum_k phi_k(u)^2 -- the modes are
-        independent, so their variances (not their amplitudes) add. The flag is defined
-        as the std AT THE OLDEST sample, u = 1, hence
-
-            sigma^2 = A^2 * sum_k phi_k(1)^2   =>   A = sigma / ||phi[:, 0]||_2 ,
-
-        and sum_k sin(k*pi/2)^2 = 1 + 0 + 1 = 2 at K = 3, i.e. A = sigma / sqrt(2). The
-        norm is taken from the basis itself rather than written out, so changing K or
-        the mode family keeps the flag meaning what it says.
-        """
-        key = (P, device, dtype)
-        hit = self._jitter_basis_cache.get(key)
-        if hit is not None:
-            return hit
-        u = np.arange(P - 1, -1, -1, dtype=np.float64) / max(P - 1, 1)
-        k = np.arange(1, HIST_JITTER_MODES + 1, dtype=np.float64)[:, None]
-        phi = np.sin(k * np.pi * u[None, :] / 2.0)  # (K, P), phi[:, P-1] == 0 exactly
-        phi = phi / np.linalg.norm(phi[:, 0])
-        out = torch.tensor(phi, device=device, dtype=dtype)
-        self._jitter_basis_cache[key] = out
-        return out
-
-    def _hist_jitter(self, xy, tan, nrm, P):
-        """Per-scene smooth jitter of the HISTORY, as a (B, T, 2) offset on the polyline.
-
-        Only the first ``P`` samples are moved; anything past them stays exactly zero, so
-        handing in the whole time grid leaves the future untouched. The caller applies
-        this to the ACCEPTED history only, after the veto, and re-derives the stored
-        cos/sin from the result (see :meth:`_perturb_history`).
-
-        One coefficient draw and one GEMM for the whole batch -- no python loop over
-        scenes or samples; the loop below runs once per AXIS (one or two).
-        """
-        phi = self._hist_jitter_basis(P, xy.device, xy.dtype)  # (K, P)
-        axes = self._hist_jitter_axes(tan, nrm)
-        c = torch.normal(
-            0.0, 1.0, size=(xy.shape[0], len(axes), phi.shape[0]), generator=self.gen
-        ).to(device=xy.device, dtype=xy.dtype)
-        d = c @ phi  # (B, A, P)
-        off = torch.zeros_like(xy)
-        for i, (std, direction) in enumerate(axes):
-            off[:, :P] += (std * d[:, i, :, None]) * direction[:, :P]
-        return off
-
     def _corridor(self, inputs, xy, tan, nrm, half_w, half_w_nbr, half_l, wb):
         """Lateral free space per timestep: where can this ego go sideways.
 
@@ -1080,6 +990,4 @@ def frenet_augmenter_from_args(args) -> "FrenetStatePerturbationTensor":
         toward_parked_prob=float(args.frenet_toward_parked_prob),
         min_clearance=float(args.frenet_min_clearance),
         ego_past_noise_std=past_noise_std_for(args),
-        hist_jitter_lat=float(args.frenet_hist_jitter_lat),
-        hist_jitter_lon=float(args.frenet_hist_jitter_lon),
     )

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -62,6 +62,11 @@ PARKED_SPEED = 0.5  # m/s
 # what makes the "MOVING vehicles are excluded" claim true rather than aspirational.
 PARKED_MAX_DISPLACEMENT = 1.0  # m
 
+# Number of low-frequency modes in the ego-history jitter basis. Independent
+# per-sample noise makes a visibly jagged track a model can learn to ignore; three
+# half-sine modes give a smooth, correlated wobble instead.
+HIST_JITTER_MODES = 3
+
 
 def quintic_basis(t0: float, t1: float, t: np.ndarray):
     """Rows: response of l, l', l'', l''' to unit (pos, vel, acc) BCs at t1.
@@ -147,30 +152,36 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         Ordering within centric_transform. The parent re-centers the history about the
         augmented t=0 pose, so by the time this runs the history is expressed in the
         frame the model sees, and the stored cos/sin are that frame's directions -- which
-        is what the path frame is taken from below. The perturbation is also
-        frame-agnostic by construction (the scale is about the t=0 SAMPLE), so
-        re-centering before or after it would give the same answer; doing it before
-        simply means only one frame is ever involved.
+        is what the jitter's path frame is taken from below. Both perturbations are also
+        frame-agnostic by construction (the scale is about the t=0 SAMPLE, the jitter's
+        basis vanishes there), so re-centering before or after them would give the same
+        answer; doing it before simply means only one frame is ever involved.
 
         What moves and what does not. NOTHING outside ``ego_agent_past`` columns 0:4 --
         the positions, and the cos/sin re-derived from them so the stored heading
         describes the track that is actually written, at every sample except the pinned
-        t = 0 one. The future is untouched and so is ``ego_current_state``: every arm of
-        an A/B then perturbs exactly what the encoder sees and nothing else. Nor is there any state consistency to maintain, because the
+        t = 0 one. The future is untouched and so is ``ego_current_state``, for BOTH
+        perturbations: every arm of an A/B then perturbs exactly what the encoder sees
+        and nothing else. Nor is there any state consistency to maintain, because the
         history carries no velocity -- ``ego_agent_past`` is (x, y, cos, sin). Of the
         current state, only ``[:4]`` (pose) and ``[4:5]`` (vx) are read anywhere in the
         model, loss or eval path: vy, ax, ay, steering and yaw rate are dead inputs, and
         vx is not an encoder input either -- its only consumer is the longitudinal loss
         WEIGHT in decoder.py (``position_lon_loss / clamp_min(|vx|, 1)``, and frenet's
         2 m/s gate means the clamp never binds). Scaling it would re-weight that scene's
-        loss by 1/s rather than perturb its history -- a second mechanism that would
-        make the arms of an A/B on this flag incomparable.
+        loss by 1/s rather than perturb its history, which is a second mechanism the
+        jitter does not have and would make the arms incomparable.
         """
-        if self.past_noise_std <= 0.0:
+        if not (self.past_noise_std > 0.0 or self._hist_jitter_on):
             return  # nothing drawn, nothing written: the default path is bit-identical
         past = inputs["ego_agent_past"]
         xy, tan = past[rows, :, :2], past[rows, :, 2:4]
-        xy = self._scale_history(xy)
+        if self.past_noise_std > 0.0:
+            xy = self._scale_history(xy)
+        if self._hist_jitter_on:
+            # jitter the SCALED track, so its flagged amplitude is not itself rescaled
+            nrm = torch.stack([-tan[..., 1], tan[..., 0]], dim=-1)
+            xy = xy + self._hist_jitter(xy, tan, nrm, xy.shape[1])
         # Same heading convention as the polyline rewrite, including its fallback to the
         # stored tangent below 0.3 m/s: without this the cos/sin would keep describing
         # the clean track and disagree with the positions next to them.
@@ -239,6 +250,8 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         toward_parked_prob: float = 0.0,
         min_clearance: float = 0.0,
         ego_past_noise_std: float = 0.0,
+        hist_jitter_lat: float = 0.0,
+        hist_jitter_lon: float = 0.0,
     ):
         super().__init__(
             augment_prob=augment_prob,
@@ -303,7 +316,22 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         self.past_noise_std = float(ego_past_noise_std)
         if self.past_noise_std < 0.0:
             raise ValueError(f"ego_past_noise_std must be >= 0, got {ego_past_noise_std}")
+        # Std (m) of the smooth history jitter AT THE OLDEST history sample, per axis of
+        # the path frame. A different perturbation from past_noise_std above: that one
+        # scales a correctly-shaped track so it is traversed at the wrong speed, this one
+        # bends the track itself. Applied after the veto, like the scale, so neither can
+        # move acceptance. 0 draws nothing and is bit-identical. See _hist_jitter.
+        self.hist_jitter_lat = float(hist_jitter_lat)
+        if self.hist_jitter_lat < 0.0:
+            raise ValueError(f"hist_jitter_lat must be >= 0, got {hist_jitter_lat}")
+        # The longitudinal axis varies the SPACING of the history samples, i.e. makes the
+        # implied speed history wobble, rather than being uniformly wrong as it is under
+        # past_noise_std. Same basis, same normalisation, independent coefficients.
+        self.hist_jitter_lon = float(hist_jitter_lon)
+        if self.hist_jitter_lon < 0.0:
+            raise ValueError(f"hist_jitter_lon must be >= 0, got {hist_jitter_lon}")
         self._basis_cache = {}
+        self._jitter_basis_cache = {}
 
     # ---------- shared basis (depends only on the time grid + knobs) ----------
     def _bases(self, P, F, device, dtype):
@@ -343,6 +371,68 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         return out
 
     # ---------- corridor, fully batched ----------
+    # ---------- smooth ego-history jitter (opt-in, depends only on P) ----------
+    @property
+    def _hist_jitter_on(self) -> bool:
+        return self.hist_jitter_lat > 0.0 or self.hist_jitter_lon > 0.0
+
+    def _hist_jitter_axes(self, tan, nrm):
+        """(std, unit direction) of every axis the jitter is drawn along."""
+        return ((self.hist_jitter_lat, nrm), (self.hist_jitter_lon, tan))
+
+    def _hist_jitter_basis(self, P, device, dtype):
+        """Cached (K, P) low-frequency displacement basis, normalised in amplitude.
+
+        u = 0 at the t=0 sample (column P-1) and u = 1 at the oldest one (column 0),
+        with phi_k(u) = sin(k*pi*u/2) for k = 1..K. Two properties come for free:
+        every mode is smooth, and every mode is EXACTLY zero at u = 0, so the current
+        pose the model plans from cannot be displaced whatever is drawn.
+
+        Amplitude normalisation. The displacement is d(u) = A * sum_k c_k phi_k(u) with
+        c_k iid N(0, 1), so Var[d(u)] = A^2 * sum_k phi_k(u)^2 -- the modes are
+        independent, so their variances (not their amplitudes) add. The flag is defined
+        as the std AT THE OLDEST sample, u = 1, hence
+
+            sigma^2 = A^2 * sum_k phi_k(1)^2   =>   A = sigma / ||phi[:, 0]||_2 ,
+
+        and sum_k sin(k*pi/2)^2 = 1 + 0 + 1 = 2 at K = 3, i.e. A = sigma / sqrt(2). The
+        norm is taken from the basis itself rather than written out, so changing K or
+        the mode family keeps the flag meaning what it says.
+        """
+        key = (P, device, dtype)
+        hit = self._jitter_basis_cache.get(key)
+        if hit is not None:
+            return hit
+        u = np.arange(P - 1, -1, -1, dtype=np.float64) / max(P - 1, 1)
+        k = np.arange(1, HIST_JITTER_MODES + 1, dtype=np.float64)[:, None]
+        phi = np.sin(k * np.pi * u[None, :] / 2.0)  # (K, P), phi[:, P-1] == 0 exactly
+        phi = phi / np.linalg.norm(phi[:, 0])
+        out = torch.tensor(phi, device=device, dtype=dtype)
+        self._jitter_basis_cache[key] = out
+        return out
+
+    def _hist_jitter(self, xy, tan, nrm, P):
+        """Per-scene smooth jitter of the HISTORY, as a (B, T, 2) offset on the polyline.
+
+        Only the first ``P`` samples are moved; anything past them stays exactly zero, so
+        handing in the whole time grid leaves the future untouched. The caller applies
+        this to the ACCEPTED history only, after the veto, and re-derives the stored
+        cos/sin from the result (see :meth:`_perturb_history`).
+
+        One coefficient draw and one GEMM for the whole batch -- no python loop over
+        scenes or samples; the loop below runs once per AXIS (one or two).
+        """
+        phi = self._hist_jitter_basis(P, xy.device, xy.dtype)  # (K, P)
+        axes = self._hist_jitter_axes(tan, nrm)
+        c = torch.normal(
+            0.0, 1.0, size=(xy.shape[0], len(axes), phi.shape[0]), generator=self.gen
+        ).to(device=xy.device, dtype=xy.dtype)
+        d = c @ phi  # (B, A, P)
+        off = torch.zeros_like(xy)
+        for i, (std, direction) in enumerate(axes):
+            off[:, :P] += (std * d[:, i, :, None]) * direction[:, :P]
+        return off
+
     def _corridor(self, inputs, xy, tan, nrm, half_w, half_w_nbr, half_l, wb):
         """Lateral free space per timestep: where can this ego go sideways.
 
@@ -990,4 +1080,6 @@ def frenet_augmenter_from_args(args) -> "FrenetStatePerturbationTensor":
         toward_parked_prob=float(args.frenet_toward_parked_prob),
         min_clearance=float(args.frenet_min_clearance),
         ego_past_noise_std=past_noise_std_for(args),
+        hist_jitter_lat=float(args.frenet_hist_jitter_lat),
+        hist_jitter_lon=float(args.frenet_hist_jitter_lon),
     )

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -972,9 +972,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
                 # the first selection. Selecting largest-offset for it would reinstate
                 # the rule that only applies when the merge is gated in front of the
                 # vehicle.
-                cur = torch.where(
-                    hardened[rows], self._largest_offset_draw(draw_ok, dy[rows]), cur
-                )
+                cur = torch.where(hardened[rows], self._largest_offset_draw(draw_ok, dy[rows]), cur)
             feas_k = adm[rows, cur]
             combo_idx, alive = self._sample_merge_then_jerk(feas_k, jerk[rows, cur], merges)
             cand = xy[rows] + L[rows, cur, combo_idx][..., None] * nrm[rows]

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -299,6 +299,8 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         # knobs with a different augmentation realisation, which is the opposite of what
         # applying them after the veto is for. Off this stream they cannot reach it.
         self.hist_gen = torch.Generator(device="cpu").manual_seed(seed + rank + 1)
+        # Same reasoning as hist_gen, for the toward-parked coin: see __call__.
+        self.toward_gen = torch.Generator(device="cpu").manual_seed(seed + rank + 2)
         self.ranked_temp_s = float(ranked_temp_s)
         # Rounds of draw-level re-selection allowed after an exact-OBB veto. 0 keeps
         # the original behaviour: a vetoed row falls back to plain GT.
@@ -675,7 +677,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         )
 
     # ---------- toward-parked nudge: draws and selection ----------
-    def _toward_parked_draws(self, r, K, P, half_w, do_aug, dy):
+    def _toward_parked_draws(self, r_toward, K, P, half_w, do_aug, dy):
         """Point a fraction of the eligible scenes' drawn offsets AT a parked vehicle.
 
         On the scenes where a PARKED vehicle bounds the corridor further ahead than the
@@ -696,7 +698,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             return None, False, dy, None
         merge_steps_min = int(min(self.knobs.merge_times) / DT)
         eligible, side, t_obs = self._parked_vehicle_ahead(P, half_w, merge_steps_min)
-        toward = eligible & (r[:, 2 * K + 1] < self.toward_parked_prob) & do_aug
+        toward = eligible & (r_toward[:, 0] < self.toward_parked_prob) & do_aug
         toward_any = bool(toward.any())
         if toward_any:
             dy = torch.where(toward[:, None], side[:, None] * dy.abs(), dy)
@@ -795,10 +797,23 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         lo, hi = self._corridor(inputs, xy, tan, nrm, half_w, half_w_nbr, half_l, wb)
 
         K = self.n_draws
-        # One extra column ONLY when the toward-parked nudge is on, so at
-        # toward_parked_prob = 0 the RNG stream is byte-for-byte what it has always been.
+        # The toward-parked coin comes off a SEPARATE stream, and not for tidiness. Drawn
+        # from self.gen it would be one extra column per batch whenever the nudge is on,
+        # which shifts every later corridor and merge draw -- so enabling the flag changed
+        # which scenes were accepted even where no scene was eligible to be nudged.
+        # Measured on the 2,297-scene campaign set, where eligibility is 0 for every row:
+        # 4 of 72 batches accepted a different set, 1824 rows vs 1822, while the
+        # augmentation of any row both arms accepted stayed bit-identical. An A/B on this
+        # flag was therefore comparing a reseed, not the feature. Off this stream the
+        # corridor draws are identical whether the nudge is on or off, and the default
+        # path is unchanged because self.gen is consumed exactly as before.
+        r = torch.rand((B, 2 * K + 1), generator=self.gen).to(dev)
         toward_on = self.toward_parked_prob > 0.0
-        r = torch.rand((B, 2 * K + 1 + int(toward_on)), generator=self.gen).to(dev)
+        r_toward = (
+            torch.rand((B, 1), generator=self.toward_gen).to(dev)
+            if toward_on
+            else torch.zeros((B, 1), device=dev)
+        )
         do_aug = r[:, 2 * K] < self._augment_prob
         # Low-speed / reverse gate (same threshold as the quintic augmenter): a
         # near-stationary ego makes every path-relative feasibility metric
@@ -809,7 +824,9 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         dy = (r[:, :K] * 2 - 1) * self.dy_max
         dth = (r[:, K : 2 * K] * 2 - 1) * self.dth_max
 
-        toward, toward_any, dy, t_obs = self._toward_parked_draws(r, K, P, half_w_nbr, do_aug, dy)
+        toward, toward_any, dy, t_obs = self._toward_parked_draws(
+            r_toward, K, P, half_w_nbr, do_aug, dy
+        )
 
         L, in_corr, merges = self._candidate_profiles(
             combos, dy, dth, v0, speed, half_l, lo, hi, dev, dtype

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -186,14 +186,14 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         loss by 1/s rather than perturb its history, which is a second mechanism the
         jitter does not have and would make the arms incomparable.
         """
-        if not (self.past_noise_std > 0.0 or self._hist_jitter_on):
+        if self.past_noise_std <= 0.0:
             return  # nothing drawn, nothing written: the default path is bit-identical
         past = inputs["ego_agent_past"]
         xy, tan = past[rows, :, :2], past[rows, :, 2:4]
-        if self.past_noise_std > 0.0:
+        # Exactly one mechanism, never both: see past_noise_mode in __init__.
+        if self.past_noise_mode == "scale":
             xy = self._scale_history(xy)
-        if self._hist_jitter_on:
-            # jitter the SCALED track, so its flagged amplitude is not itself rescaled
+        else:
             nrm = torch.stack([-tan[..., 1], tan[..., 0]], dim=-1)
             xy = xy + self._hist_jitter(xy, tan, nrm, xy.shape[1])
         # Same heading convention as the polyline rewrite, including its fallback to the
@@ -264,7 +264,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         toward_parked_prob: float = 0.0,
         min_clearance: float = 0.0,
         ego_past_noise_std: float = 0.0,
-        hist_jitter_lat: float = 0.0,
+        ego_past_noise_mode: str = "scale",
     ):
         super().__init__(
             augment_prob=augment_prob,
@@ -346,14 +346,20 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         self.past_noise_std = float(ego_past_noise_std)
         if self.past_noise_std < 0.0:
             raise ValueError(f"ego_past_noise_std must be >= 0, got {ego_past_noise_std}")
-        # Std (m) of the smooth history jitter AT THE OLDEST history sample, per axis of
-        # the path frame. A different perturbation from past_noise_std above: that one
-        # scales a correctly-shaped track so it is traversed at the wrong speed, this one
-        # bends the track itself. Applied after the veto, like the scale, so neither can
-        # move acceptance. 0 draws nothing and is bit-identical. See _hist_jitter.
-        self.hist_jitter_lat = float(hist_jitter_lat)
-        if self.hist_jitter_lat < 0.0:
-            raise ValueError(f"hist_jitter_lat must be >= 0, got {hist_jitter_lat}")
+        # Which mechanism the std above drives. Exactly one runs: `scale` multiplies the
+        # whole rewritten history by one factor (shape kept, traversal speed wrong, std
+        # dimensionless and clamped to +-2 std); `jitter` bends the track laterally
+        # (shape wrong, std in METRES at the oldest sample, unclamped).
+        #
+        # A mode rather than two magnitudes, because two magnitudes could both be set and
+        # the combination is reachable by accident -- the scale default is non-zero, so
+        # asking for jitter alone used to silently apply both. That combination has never
+        # been evaluated: every jitter arm of the A/B pinned the scale to 0.
+        self.past_noise_mode = str(ego_past_noise_mode)
+        if self.past_noise_mode not in ("scale", "jitter"):
+            raise ValueError(
+                f"ego_past_noise_mode must be 'scale' or 'jitter', got {ego_past_noise_mode!r}"
+            )
         self._basis_cache = {}
         self._jitter_basis_cache = {}
 
@@ -396,10 +402,6 @@ class FrenetStatePerturbationTensor(StatePerturbation):
 
     # ---------- corridor, fully batched ----------
     # ---------- smooth ego-history jitter (opt-in, depends only on P) ----------
-    @property
-    def _hist_jitter_on(self) -> bool:
-        return self.hist_jitter_lat > 0.0
-
     def _hist_jitter_axes(self, tan, nrm):
         """(std, unit direction) of every axis the jitter is drawn along.
 
@@ -415,7 +417,7 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         means the measured lateral configuration reproduces bit-for-bit. ``0.0 * d`` is
         exactly zero, so nothing is added along the path.
         """
-        return ((self.hist_jitter_lat, nrm), (0.0, tan))
+        return ((self.past_noise_std, nrm), (0.0, tan))
 
     def _hist_jitter_basis(self, P, device, dtype):
         """Cached (K, P) low-frequency displacement basis, normalised in amplitude.
@@ -1132,5 +1134,5 @@ def frenet_augmenter_from_args(args) -> "FrenetStatePerturbationTensor":
         toward_parked_prob=float(args.frenet_toward_parked_prob),
         min_clearance=float(args.frenet_min_clearance),
         ego_past_noise_std=past_noise_std_for(args),
-        hist_jitter_lat=float(args.frenet_hist_jitter_lat),
+        ego_past_noise_mode=str(args.ego_past_noise_mode),
     )

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -719,9 +719,12 @@ class FrenetStatePerturbationTensor(StatePerturbation):
             )
             # The gate strikes out horizons reaching past the vehicle. On a tight pass it
             # can strike out ALL of them, and the scene would then train on plain GT --
-            # the option would delete exactly the scenes it exists to harden (measured:
-            # one stationary vehicle 25 m ahead at 1.8 m lateral took acceptance from
-            # 88/128 to 0/128). So the gate is applied only where it leaves something;
+            # the option would delete exactly the scenes it exists to harden (measured on
+            # one stationary vehicle 25 m ahead at 1.8 m lateral, B=128: 91 accepted with
+            # the nudge off, 0 with the gate unconditional). The fallback is a floor, not
+            # a repair: it takes that family to 8/128, because the remaining 120 rows are
+            # genuinely hardened and then lose to the exact OBB veto -- a 2.0 m ego does
+            # not fit a 1.8 m gap. So the gate is applied only where it leaves something;
             # elsewhere the row keeps its ungated candidates and is recorded as NOT
             # hardened, because its merge is no longer guaranteed to finish in front of
             # the vehicle.
@@ -831,7 +834,6 @@ class FrenetStatePerturbationTensor(StatePerturbation):
                 upd,
                 has,
                 dy,
-                toward,
                 hardened,
                 toward_any,
             )
@@ -932,7 +934,6 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         upd,
         has,
         dy,
-        toward,
         hardened,
         toward_any,
     ):
@@ -946,9 +947,12 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         blocked geometrically, and re-rolling does not move geometry.
 
         The retry keeps each row's own selection rule: first-feasible everywhere, and
-        LARGEST-feasible on the toward-parked rows. Falling back to first-feasible for a
-        toward row would let it recover on a 3 cm offset and still be counted as a
-        hardened example, which is the whole reason the rule exists (see
+        LARGEST-feasible on the HARDENED rows -- those whose merge is actually gated in
+        front of the parked vehicle. Falling back to first-feasible for a hardened row
+        would let it recover on a 3 cm offset and still be counted as a hardened example,
+        which is the whole reason the rule exists. A toward-parked row that found no
+        feasible gated draw is NOT hardened (it fell back to the ungated set), so it
+        takes first-feasible here exactly as it did in the first selection (see
         :meth:`_toward_parked_select`).
 
         Rows that never recover keep upd False and train on plain GT, exactly as

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -591,6 +591,16 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         Returns:
             (B, N) bool.
         """
+        # P arrives as the EGO history length. Everything below indexes the NEIGHBOUR
+        # tensors with it, which is only correct while the two time dimensions agree --
+        # previously an implicit assumption. Assert it rather than silently reading the
+        # wrong column if a dataset ever carries a different neighbour history length.
+        if past.shape[2] != P:
+            raise ValueError(
+                f"neighbour history length {past.shape[2]} != ego history length {P}; "
+                "the parked-vehicle test indexes neighbour tensors with the ego length"
+            )
+
         stopped = valid[:, :, P - 1] & (past[:, :, P - 1, 4:6].norm(dim=-1) < PARKED_SPEED)
         # invalid future slots contribute 0 displacement: absence of a track is not
         # evidence of motion, and those slots cut no corridor anyway
@@ -1166,6 +1176,6 @@ def frenet_augmenter_from_args(args) -> "FrenetStatePerturbationTensor":
         recovery_rounds=int(args.frenet_recovery_rounds),
         toward_parked_prob=float(args.frenet_toward_parked_prob),
         min_clearance=float(args.frenet_min_clearance),
-        ego_past_noise_std=past_noise_std_for(args),
+        ego_past_noise_std=args.ego_past_noise_std_effective,
         ego_past_noise_mode=str(args.ego_past_noise_mode),
     )

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -494,20 +494,60 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         B, T, _ = xy.shape
         lo, hi = unconstrained_bounds(B, T, xy.device, xy.dtype)
 
-        ls = inputs.get("line_strings")
-        if ls is not None:
-            lo, hi = border_lateral_bounds(ls, xy, nrm, half_w, lo, hi)
+        # Indexed, not .get(): these are mandatory in the training format, and a missing
+        # key used to degrade SILENTLY to an unconstrained corridor with no neighbours --
+        # which also short-circuits the exact-OBB veto (`_nbr_st is None`) and the
+        # parked-vehicle detector (`_nbr_lo is None`). A caller that dropped a key
+        # therefore got an augmenter that vetoed nothing and reported zero eligible
+        # scenes, with no error. That is not a hypothetical: `neighbor_agents_future` is
+        # also passed as a positional argument, which invites a caller to pop it out of
+        # the dict, and doing so silently disabled every neighbour rule here.
+        missing = [
+            k
+            for k in ("line_strings", "neighbor_agents_past", "neighbor_agents_future")
+            if inputs.get(k) is None
+        ]
+        if missing:
+            raise KeyError(
+                f"frenet augmentation requires {missing} in inputs: without them the "
+                "corridor has no road-border or neighbour cuts, the exact footprint veto "
+                "never runs and no scene is toward-parked eligible. Note that "
+                "neighbor_agents_future must stay IN inputs even though it is also a "
+                "positional argument."
+            )
 
-        past = inputs.get("neighbor_agents_past")
-        fut = inputs.get("neighbor_agents_future")
-        if past is not None and fut is not None:
-            st, valid = time_aligned_neighbor_tracks(past, fut)
-            self._nbr_st, self._nbr_valid = st, valid  # reused by the exact-OBB veto
-            shapes_wl = past[:, :, -1][..., [6, 7]]  # width, length
-            n_lo, n_hi = unconstrained_bounds(B, T, xy.device, xy.dtype)
-            n_lo, n_hi, self._nbr_near = neighbor_lateral_bounds(
+        lo, hi = border_lateral_bounds(inputs["line_strings"], xy, nrm, half_w, lo, hi)
+
+        past = inputs["neighbor_agents_past"]
+        fut = inputs["neighbor_agents_future"]
+        st, valid = time_aligned_neighbor_tracks(past, fut)
+        self._nbr_st, self._nbr_valid = st, valid  # reused by the exact-OBB veto
+        shapes_wl = past[:, :, -1][..., [6, 7]]  # width, length
+        n_lo, n_hi = unconstrained_bounds(B, T, xy.device, xy.dtype)
+        n_lo, n_hi, self._nbr_near = neighbor_lateral_bounds(
+            st,
+            valid,
+            shapes_wl,
+            xy,
+            tan,
+            nrm,
+            half_l,
+            half_w_nbr,
+            wb,
+            n_lo,
+            n_hi,
+            min_clearance=self.min_clearance,
+        )
+        lo, hi = torch.maximum(lo, n_lo), torch.minimum(hi, n_hi)
+        if self.toward_parked_prob > 0.0:
+            # bounds from PARKED neighbours alone: the toward-parked nudge points at
+            # these and nothing else
+            P = inputs["ego_agent_past"].shape[1]
+            parked = self._parked_mask(past, st, valid, P)
+            p_lo, p_hi = unconstrained_bounds(B, T, xy.device, xy.dtype)
+            p_lo, p_hi, _ = neighbor_lateral_bounds(
                 st,
-                valid,
+                valid & parked[:, :, None],
                 shapes_wl,
                 xy,
                 tan,
@@ -515,31 +555,10 @@ class FrenetStatePerturbationTensor(StatePerturbation):
                 half_l,
                 half_w_nbr,
                 wb,
-                n_lo,
-                n_hi,
-                min_clearance=self.min_clearance,
+                p_lo,
+                p_hi,
             )
-            lo, hi = torch.maximum(lo, n_lo), torch.minimum(hi, n_hi)
-            if self.toward_parked_prob > 0.0:
-                # bounds from PARKED neighbours alone: the toward-parked nudge points at
-                # these and nothing else
-                P = inputs["ego_agent_past"].shape[1]
-                parked = self._parked_mask(past, st, valid, P)
-                p_lo, p_hi = unconstrained_bounds(B, T, xy.device, xy.dtype)
-                p_lo, p_hi, _ = neighbor_lateral_bounds(
-                    st,
-                    valid & parked[:, :, None],
-                    shapes_wl,
-                    xy,
-                    tan,
-                    nrm,
-                    half_l,
-                    half_w_nbr,
-                    wb,
-                    p_lo,
-                    p_hi,
-                )
-                self._nbr_lo, self._nbr_hi = p_lo, p_hi
+            self._nbr_lo, self._nbr_hi = p_lo, p_hi
         return lo, hi
 
     @staticmethod

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -277,6 +277,8 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         self._nbr_valid = None
         self._nbr_lo = None
         self._nbr_hi = None
+        # toward-parked rows that kept ungated candidates: augmented, but NOT hardened
+        self._toward_fellback = None
         self.n_draws = n_draws
         self.dy_max = dy_max
         self.dth_max = dth_max
@@ -703,16 +705,31 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         Returns:
             admissible (gated), draw_ok (B, K), first (B,) winning draw per scene.
         """
+        fellback = None  # `toward` is None unless the nudge is on
         if toward_any:
             merge_steps = (merges / DT).round().long()  # (C,)
             in_time = merge_steps[None, :] <= (t_obs - (P - 1))[:, None]  # (B, C)
-            admissible = admissible & torch.where(
+            gated = admissible & torch.where(
                 toward[:, None, None], in_time[:, None, :], torch.ones_like(in_time[:, None, :])
             )
+            # The gate strikes out horizons reaching past the vehicle. On a tight pass it
+            # can strike out ALL of them, and the scene would then train on plain GT --
+            # the option would delete exactly the scenes it exists to harden (measured:
+            # one stationary vehicle 25 m ahead at 1.8 m lateral took acceptance from
+            # 88/128 to 0/128). So the gate is applied only where it leaves something;
+            # elsewhere the row keeps its ungated candidates and is recorded as NOT
+            # hardened, because its merge is no longer guaranteed to finish in front of
+            # the vehicle.
+            fellback = toward & ~gated.any(-1).any(-1) & admissible.any(-1).any(-1)
+            admissible = torch.where(fellback[:, None, None], admissible, gated)
         draw_ok = admissible.any(-1)  # (B, K): the drawn perturbation has >=1 valid merge
         first = draw_ok.float().argmax(-1)  # first feasible PERTURBATION per scene
         if toward_any:
-            first = torch.where(toward, self._largest_offset_draw(draw_ok, dy), first)
+            # largest-offset only where the row is genuinely hardened; a fallback row
+            # takes the ordinary first-feasible draw
+            hardened = toward & ~fellback
+            first = torch.where(hardened, self._largest_offset_draw(draw_ok, dy), first)
+        self._toward_fellback = fellback
         return admissible, draw_ok, first
 
     # ---------- the augmentation ----------

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -251,7 +251,6 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         min_clearance: float = 0.0,
         ego_past_noise_std: float = 0.0,
         hist_jitter_lat: float = 0.0,
-        hist_jitter_lon: float = 0.0,
     ):
         super().__init__(
             augment_prob=augment_prob,
@@ -324,12 +323,6 @@ class FrenetStatePerturbationTensor(StatePerturbation):
         self.hist_jitter_lat = float(hist_jitter_lat)
         if self.hist_jitter_lat < 0.0:
             raise ValueError(f"hist_jitter_lat must be >= 0, got {hist_jitter_lat}")
-        # The longitudinal axis varies the SPACING of the history samples, i.e. makes the
-        # implied speed history wobble, rather than being uniformly wrong as it is under
-        # past_noise_std. Same basis, same normalisation, independent coefficients.
-        self.hist_jitter_lon = float(hist_jitter_lon)
-        if self.hist_jitter_lon < 0.0:
-            raise ValueError(f"hist_jitter_lon must be >= 0, got {hist_jitter_lon}")
         self._basis_cache = {}
         self._jitter_basis_cache = {}
 
@@ -374,11 +367,24 @@ class FrenetStatePerturbationTensor(StatePerturbation):
     # ---------- smooth ego-history jitter (opt-in, depends only on P) ----------
     @property
     def _hist_jitter_on(self) -> bool:
-        return self.hist_jitter_lat > 0.0 or self.hist_jitter_lon > 0.0
+        return self.hist_jitter_lat > 0.0
 
     def _hist_jitter_axes(self, tan, nrm):
-        """(std, unit direction) of every axis the jitter is drawn along."""
-        return ((self.hist_jitter_lat, nrm), (self.hist_jitter_lon, tan))
+        """(std, unit direction) of every axis the jitter is drawn along.
+
+        Only the LATERAL axis has a knob. A longitudinal one existed and was removed on
+        measurement: varying the sample spacing made that arm the worst of the campaign
+        in all four eval cells on both metrics, where lateral alone was the best on
+        recovery.
+
+        The along-path axis is still LISTED, at a hard-zero std. That is deliberate and
+        not dead weight: the coefficient draw below is shaped ``(B, len(axes), K)``, so
+        dropping the entry would shrink the draw and shift the generator stream, and the
+        lateral jitter would produce different numbers for the same seed. Keeping it
+        means the measured lateral configuration reproduces bit-for-bit. ``0.0 * d`` is
+        exactly zero, so nothing is added along the path.
+        """
+        return ((self.hist_jitter_lat, nrm), (0.0, tan))
 
     def _hist_jitter_basis(self, P, device, dtype):
         """Cached (K, P) low-frequency displacement basis, normalised in amplitude.
@@ -1081,5 +1087,4 @@ def frenet_augmenter_from_args(args) -> "FrenetStatePerturbationTensor":
         min_clearance=float(args.frenet_min_clearance),
         ego_past_noise_std=past_noise_std_for(args),
         hist_jitter_lat=float(args.frenet_hist_jitter_lat),
-        hist_jitter_lon=float(args.frenet_hist_jitter_lon),
     )

--- a/diffusion_planner/tests/test_data_augmentation.py
+++ b/diffusion_planner/tests/test_data_augmentation.py
@@ -1195,7 +1195,9 @@ def test_frenet_corridor_unconstrained_without_obstacles():
     )
     nrm = torch.stack([-tan[..., 1], tan[..., 0]], dim=-1)
     wb, ego_l, ego_w = (inputs["ego_shape"][:, i] for i in range(3))
-    lo, hi = aug._corridor(inputs, xy, tan, nrm, ego_w / 2, ego_l / 2, wb)
+    # border and neighbour cuts take separate half-widths (the clearance floor is a
+    # neighbour rule); with min_clearance at its default the two are the same number.
+    lo, hi = aug._corridor(inputs, xy, tan, nrm, ego_w / 2, ego_w / 2, ego_l / 2, wb)
 
     assert float(lo.max()) <= -20.0 + ATOL, f"corridor cut from below with no obstacles: {lo.max()}"
     assert float(hi.min()) >= 20.0 - ATOL, f"corridor cut from above with no obstacles: {hi.min()}"

--- a/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
@@ -36,7 +36,7 @@ EGO_SHAPE = (2.75, 5.0, 2.0)  # wheel base, length, width
 N_SLOTS = 4  # neighbour slots per scene
 
 
-def _scene(batch: int = 1, border_y: float = 6.0, neighbours=()):
+def _scene(batch: int = 1, border_y: float = 6.0, neighbours=(), pad_steps: int = 0):
     """A straight-road batch: ego at EGO_V along +x, kerbs at +-border_y.
 
     ``neighbours`` is a list of dicts, one per occupied slot, applied to EVERY
@@ -63,6 +63,10 @@ def _scene(batch: int = 1, border_y: float = 6.0, neighbours=()):
     cur = torch.zeros(batch, 10)
     cur[:, 2] = 1.0
     cur[:, 4] = EGO_V
+
+    # a scene starting near the beginning of a recording: the leading history is
+    # all-zero, meaning "no history", not "the ego was at the origin"
+    past[:, :pad_steps] = 0.0
 
     xs = torch.linspace(-40.0, 120.0, 20)
     line_strings = torch.zeros(batch, 2, 20, 4)
@@ -347,6 +351,57 @@ def test_min_clearance_does_not_move_the_border_bounds():
         )
     assert torch.equal(bounds[0][0], bounds[1][0])
     assert torch.equal(bounds[0][1], bounds[1][1])
+
+
+# ─────────────────────────── 5. ego-history noise ────────────────────────────
+
+
+def test_past_noise_scales_each_accepted_history_by_one_factor():
+    """One scalar per scene, on the rewritten history and the state it implies."""
+    plain = FrenetStatePerturbationTensor(1.0, "cpu", seed=7)
+    in_ref, _ = _run(plain, batch=8, pad_steps=3)
+    noisy = FrenetStatePerturbationTensor(1.0, "cpu", seed=7, past_noise_std=0.2)
+    in_new, _ = _run(noisy, batch=8, pad_steps=3)
+
+    rows = plain._aug_rows
+    assert torch.equal(rows, noisy._aug_rows), "the scale draw must not shift the decisions"
+    assert bool(rows.any())
+
+    past_ref, past_new = in_ref["ego_agent_past"], in_new["ego_agent_past"]
+    cur_ref, cur_new = in_ref["ego_current_state"], in_new["ego_current_state"]
+
+    # untouched rows train on plain ground truth, unscaled
+    assert torch.equal(past_ref[~rows], past_new[~rows])
+    assert torch.equal(cur_ref[~rows], cur_new[~rows])
+
+    for b in torch.nonzero(rows, as_tuple=True)[0].tolist():
+        real = past_ref[b, :, 0].abs() > 1e-3  # the samples with a length to scale
+        ratio = past_new[b, real, 0] / past_ref[b, real, 0]
+        s = float(ratio[0])
+        assert 1 - 2 * 0.2 <= s <= 1 + 2 * 0.2, s
+        assert torch.allclose(ratio, ratio[0].expand_as(ratio), atol=1e-5), "not one factor"
+        # the state the history implies is scaled with it (vx, vy, ax, ay)
+        assert torch.allclose(cur_new[b, 4:8], cur_ref[b, 4:8] * s, atol=1e-5)
+        # t=0 is the origin of the frame the batch is centred on, before and after
+        assert torch.allclose(past_new[b, -1, :2], torch.zeros(2), atol=1e-5)
+        # "no history" stays no history
+        assert torch.equal(past_new[b, :3], torch.zeros(3, 4))
+
+
+def test_past_noise_at_zero_changes_nothing(monkeypatch):
+    shapes = _rand_spy(monkeypatch)
+    off = FrenetStatePerturbationTensor(1.0, "cpu", seed=7)
+    in_off, fut_off = _run(off, batch=8, pad_steps=3)
+    shapes_off, _ = list(shapes), shapes.clear()
+
+    explicit = FrenetStatePerturbationTensor(1.0, "cpu", seed=7, past_noise_std=0.0)
+    in_on, fut_on = _run(explicit, batch=8, pad_steps=3)
+
+    assert shapes_off == list(shapes)
+    assert torch.equal(off.gen.get_state(), explicit.gen.get_state())
+    assert torch.equal(in_off["ego_agent_past"], in_on["ego_agent_past"])
+    assert torch.equal(in_off["ego_current_state"], in_on["ego_current_state"])
+    assert torch.equal(fut_off, fut_on)
 
 
 # ───────────────────── layout robustness (3-col / 4-col) ─────────────────────

--- a/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
@@ -360,7 +360,7 @@ def test_past_noise_scales_each_accepted_history_by_one_factor():
     """One scalar per scene, on the rewritten history and the state it implies."""
     plain = FrenetStatePerturbationTensor(1.0, "cpu", seed=7)
     in_ref, _ = _run(plain, batch=8, pad_steps=3)
-    noisy = FrenetStatePerturbationTensor(1.0, "cpu", seed=7, past_noise_std=0.2)
+    noisy = FrenetStatePerturbationTensor(1.0, "cpu", seed=7, ego_past_noise_std=0.2)
     in_new, _ = _run(noisy, batch=8, pad_steps=3)
 
     rows = plain._aug_rows
@@ -394,7 +394,7 @@ def test_past_noise_at_zero_changes_nothing(monkeypatch):
     in_off, fut_off = _run(off, batch=8, pad_steps=3)
     shapes_off, _ = list(shapes), shapes.clear()
 
-    explicit = FrenetStatePerturbationTensor(1.0, "cpu", seed=7, past_noise_std=0.0)
+    explicit = FrenetStatePerturbationTensor(1.0, "cpu", seed=7, ego_past_noise_std=0.0)
     in_on, fut_on = _run(explicit, batch=8, pad_steps=3)
 
     assert shapes_off == list(shapes)

--- a/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
@@ -22,6 +22,7 @@ randomness, so a run recorded at the defaults is the run that was trained.
 
 from __future__ import annotations
 
+import pytest
 import torch
 from diffusion_planner.utils.augmentation_checks import DT, time_aligned_neighbor_tracks
 from diffusion_planner.utils.data_augmentation_frenet import (
@@ -402,6 +403,122 @@ def test_past_noise_at_zero_changes_nothing(monkeypatch):
     assert torch.equal(in_off["ego_agent_past"], in_on["ego_agent_past"])
     assert torch.equal(in_off["ego_current_state"], in_on["ego_current_state"])
     assert torch.equal(fut_off, fut_on)
+
+
+# ────────────────────── 6. smooth ego-history jitter ─────────────────────────
+
+
+def _straight_frame(batch: int):
+    """A straight +x polyline with its path frame, as ``__call__`` builds them."""
+    T = P_STEPS + F_STEPS
+    xy = torch.zeros(batch, T, 2)
+    xy[..., 0] = torch.arange(T, dtype=torch.float32) * EGO_V * DT
+    tan = torch.zeros(batch, T, 2)
+    tan[..., 0] = 1.0
+    nrm = torch.stack([-tan[..., 1], tan[..., 0]], dim=-1)
+    return xy, tan, nrm
+
+
+def _jitter_offset(batch: int, seed: int = 5, **kw):
+    aug = FrenetStatePerturbationTensor(1.0, "cpu", seed=seed, **kw)
+    xy, tan, nrm = _straight_frame(batch)
+    return aug._hist_jitter(xy, tan, nrm, P_STEPS), aug
+
+
+def test_hist_jitter_is_exactly_zero_at_t0():
+    """The current pose is what the model plans from; the history must not move it."""
+    off, aug = _jitter_offset(64, hist_jitter_lat=0.4)
+    # the basis itself, before any amplitude: every mode vanishes at u = 0
+    phi = aug._hist_jitter_basis(P_STEPS, torch.device("cpu"), torch.float32)
+    assert torch.equal(phi[:, -1], torch.zeros(phi.shape[0]))
+    # and so does the offset actually applied, exactly -- not "to within a tolerance"
+    assert torch.equal(off[:, P_STEPS - 1], torch.zeros(64, 2))
+    assert torch.equal(off[:, P_STEPS:], torch.zeros(64, F_STEPS, 2)), "the future moved"
+    assert float(off[:, 0].abs().max()) > 0.0, "nothing was jittered; the test proves nothing"
+
+
+def test_hist_jitter_std_at_the_oldest_sample_is_the_requested_one():
+    """The flag is defined as the std at the oldest sample: A = sigma / ||phi[:, 0]||."""
+    sigma = 0.35
+    n = 40000
+    off, _ = _jitter_offset(n, hist_jitter_lat=sigma)
+    emp = float(off[:, 0, 1].std())
+    # Monte-Carlo error on a std from n samples is ~ sigma / sqrt(2n) = 1.2e-3 here;
+    # 5% is many times that and still catches a wrong normalisation constant
+    # (sqrt(2) = 1.41 or K = 3 would both be off by tens of percent).
+    assert abs(emp - sigma) / sigma < 0.05, emp
+    assert abs(float(off[:, 0, 0].mean())) < 1e-2, "lateral jitter moved the path tangent"
+
+
+def test_hist_jitter_is_smooth_not_white():
+    """Independent per-sample noise is a jagged track a model learns to ignore."""
+    sigma = 0.3
+    off, _ = _jitter_offset(4000, hist_jitter_lat=sigma)
+    lat = off[:, :P_STEPS, 1]
+    d2 = lat[:, 2:] - 2 * lat[:, 1:-1] + lat[:, :-2]
+    # white noise of the same per-sample std has second-difference std sigma*sqrt(6)
+    white = float(sigma * (6.0**0.5))
+    assert float(d2.std()) < white / 20.0, (float(d2.std()), white)
+
+
+def test_lateral_jitter_leaves_the_along_path_spacing_alone():
+    """Bending the track sideways must not smuggle in a speed perturbation."""
+    xy, tan, nrm = _straight_frame(4000)
+    off, _ = _jitter_offset(4000, hist_jitter_lat=0.3)
+    step0 = (xy[:, 1:P_STEPS] - xy[:, : P_STEPS - 1]).norm(dim=-1)
+    step1 = ((xy + off)[:, 1:P_STEPS] - (xy + off)[:, : P_STEPS - 1]).norm(dim=-1)
+    # a purely lateral bend only lengthens the step at second order in the bend angle
+    assert abs(float(step1.mean() / step0.mean()) - 1.0) < 0.01
+
+
+def test_hist_jitter_headings_match_the_perturbed_polyline():
+    """The reason the jitter is applied BEFORE _headings rather than after the fact."""
+    aug = FrenetStatePerturbationTensor(1.0, "cpu", seed=13, hist_jitter_lat=0.3)
+    inputs, _ = _run(aug, batch=8)
+    rows = aug._aug_rows
+    assert bool(rows.any()), "nothing was augmented; the test proves nothing"
+    past = inputs["ego_agent_past"][rows]
+    # interior history samples: ddt is a central difference there, and the batch-wide
+    # re-centering is rigid, so the stored heading must be the polyline's own direction
+    g = past[:, 2:, :2] - past[:, :-2, :2]
+    stored = torch.atan2(past[:, 1:-1, 3], past[:, 1:-1, 2])
+    assert torch.allclose(torch.atan2(g[..., 1], g[..., 0]), stored, atol=1e-4)
+    # and the jitter really did bend it away from the straight recording
+    assert float(stored.abs().max()) > 1e-3
+
+
+def _normal_spy(monkeypatch):
+    """Record the shape of every torch.normal drawn from here on."""
+    shapes = []
+    real = torch.normal
+
+    def spy(*args, **kwargs):
+        shapes.append(kwargs.get("size"))
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "normal", spy)
+    return shapes
+
+
+def test_hist_jitter_at_zero_changes_nothing(monkeypatch):
+    shapes = _normal_spy(monkeypatch)
+    off = FrenetStatePerturbationTensor(1.0, "cpu", seed=7)
+    in_off, fut_off = _run(off, batch=8, pad_steps=3)
+    shapes_off, _ = list(shapes), shapes.clear()
+
+    explicit = FrenetStatePerturbationTensor(1.0, "cpu", seed=7, hist_jitter_lat=0.0)
+    in_on, fut_on = _run(explicit, batch=8, pad_steps=3)
+
+    assert shapes_off == list(shapes), "the off value changed how much randomness is drawn"
+    assert torch.equal(off.gen.get_state(), explicit.gen.get_state())
+    assert torch.equal(in_off["ego_agent_past"], in_on["ego_agent_past"])
+    assert torch.equal(in_off["ego_current_state"], in_on["ego_current_state"])
+    assert torch.equal(fut_off, fut_on)
+
+
+def test_hist_jitter_refuses_a_negative_std():
+    with pytest.raises(ValueError, match="hist_jitter_lat"):
+        FrenetStatePerturbationTensor(1.0, "cpu", hist_jitter_lat=-0.1)
 
 
 # ───────────────────── layout robustness (3-col / 4-col) ─────────────────────

--- a/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
@@ -461,14 +461,47 @@ def test_hist_jitter_is_smooth_not_white():
     assert float(d2.std()) < white / 20.0, (float(d2.std()), white)
 
 
+def _spacing_ratio(**kw):
+    """Mean along-path sample spacing of the jittered history, over the unjittered one."""
+    xy, _, _ = _straight_frame(4000)
+    off, _ = _jitter_offset(4000, **kw)
+    step0 = (xy[:, 1:P_STEPS] - xy[:, : P_STEPS - 1]).norm(dim=-1)
+    step1 = ((xy + off)[:, 1:P_STEPS] - (xy + off)[:, : P_STEPS - 1]).norm(dim=-1)
+    return abs(float(step1.std() / step0.mean()))
+
+
 def test_lateral_jitter_leaves_the_along_path_spacing_alone():
     """Bending the track sideways must not smuggle in a speed perturbation."""
-    xy, tan, nrm = _straight_frame(4000)
+    xy, _, _ = _straight_frame(4000)
     off, _ = _jitter_offset(4000, hist_jitter_lat=0.3)
     step0 = (xy[:, 1:P_STEPS] - xy[:, : P_STEPS - 1]).norm(dim=-1)
     step1 = ((xy + off)[:, 1:P_STEPS] - (xy + off)[:, : P_STEPS - 1]).norm(dim=-1)
     # a purely lateral bend only lengthens the step at second order in the bend angle
     assert abs(float(step1.mean() / step0.mean()) - 1.0) < 0.01
+
+
+def test_longitudinal_jitter_is_what_moves_the_spacing():
+    """The point of the second axis: the implied speed history wobbles."""
+    lat_only = _spacing_ratio(hist_jitter_lat=0.3, hist_jitter_lon=0.0)
+    lon_only = _spacing_ratio(hist_jitter_lat=0.0, hist_jitter_lon=0.3)
+    assert lat_only < 0.01, lat_only
+    assert lon_only > 20 * lat_only, (lon_only, lat_only)
+
+
+def test_longitudinal_jitter_std_at_the_oldest_sample_is_the_requested_one():
+    sigma = 0.35
+    off, _ = _jitter_offset(40000, hist_jitter_lon=sigma)
+    assert abs(float(off[:, 0, 0].std()) - sigma) / sigma < 0.05
+    assert float(off[:, 0, 1].abs().max()) == 0.0, "longitudinal jitter moved the path normal"
+    assert torch.equal(off[:, P_STEPS - 1], torch.zeros(40000, 2)), "t=0 moved"
+
+
+def test_the_two_axes_are_drawn_independently():
+    """A lateral-only run must not have its wobble mirrored along the path."""
+    off, _ = _jitter_offset(20000, hist_jitter_lat=0.3, hist_jitter_lon=0.3)
+    lon, lat = off[:, 0, 0], off[:, 0, 1]
+    corr = float((lon * lat).mean() / (lon.std() * lat.std()))
+    assert abs(corr) < 0.05, corr
 
 
 def test_hist_jitter_headings_match_the_perturbed_polyline():
@@ -506,7 +539,9 @@ def test_hist_jitter_at_zero_changes_nothing(monkeypatch):
     in_off, fut_off = _run(off, batch=8, pad_steps=3)
     shapes_off, _ = list(shapes), shapes.clear()
 
-    explicit = FrenetStatePerturbationTensor(1.0, "cpu", seed=7, hist_jitter_lat=0.0)
+    explicit = FrenetStatePerturbationTensor(
+        1.0, "cpu", seed=7, hist_jitter_lat=0.0, hist_jitter_lon=0.0
+    )
     in_on, fut_on = _run(explicit, batch=8, pad_steps=3)
 
     assert shapes_off == list(shapes), "the off value changed how much randomness is drawn"
@@ -519,6 +554,8 @@ def test_hist_jitter_at_zero_changes_nothing(monkeypatch):
 def test_hist_jitter_refuses_a_negative_std():
     with pytest.raises(ValueError, match="hist_jitter_lat"):
         FrenetStatePerturbationTensor(1.0, "cpu", hist_jitter_lat=-0.1)
+    with pytest.raises(ValueError, match="hist_jitter_lon"):
+        FrenetStatePerturbationTensor(1.0, "cpu", hist_jitter_lon=-0.1)
 
 
 # ───────────────────── layout robustness (3-col / 4-col) ─────────────────────

--- a/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
@@ -1,0 +1,374 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""What the frenet augmenter DOES, on synthetic scenes with a known answer.
+
+The factory tests next door pin the plumbing (a flag reaches the object). These
+pin behaviour, and above all the invariant the opt-in flags are worth nothing
+without: at their off values they change no output and consume no extra
+randomness, so a run recorded at the defaults is the run that was trained.
+"""
+
+from __future__ import annotations
+
+import torch
+from diffusion_planner.utils.augmentation_checks import DT, time_aligned_neighbor_tracks
+from diffusion_planner.utils.data_augmentation_frenet import (
+    PARKED_SPEED,
+    FrenetStatePerturbationTensor,
+)
+
+P_STEPS = 21  # history samples, t = -2.0 s .. 0
+F_STEPS = 80  # future samples, t = 0.1 s .. 8.0 s
+EGO_V = 10.0  # m/s, straight and level
+EGO_SHAPE = (2.75, 5.0, 2.0)  # wheel base, length, width
+N_SLOTS = 4  # neighbour slots per scene
+
+
+def _scene(batch: int = 1, border_y: float = 6.0, neighbours=()):
+    """A straight-road batch: ego at EGO_V along +x, kerbs at +-border_y.
+
+    ``neighbours`` is a list of dicts, one per occupied slot, applied to EVERY
+    scene in the batch:
+      ``lon``/``lat``  metres ahead of / left of the ego's t=0 rear axle,
+      ``wl``           (width, length),
+      ``v``            recorded (vx, vy) at t=0,
+      ``steps``        which time-grid indices hold a valid observation
+                       (default: all of them),
+      ``jitter``       amplitude of an alternating centroid wobble, which is what
+                       makes a one-step position difference lie about the speed,
+      ``drift``        metres the box travels over the recorded future.
+    """
+    t_past = torch.arange(-(P_STEPS - 1), 1, dtype=torch.float32) * DT
+    t_fut = torch.arange(1, F_STEPS + 1, dtype=torch.float32) * DT
+    t_all = torch.cat([t_past, t_fut])
+    T = P_STEPS + F_STEPS
+
+    past = torch.zeros(batch, P_STEPS, 4)
+    past[..., 0] = EGO_V * t_past
+    past[..., 2] = 1.0
+    fut = torch.zeros(batch, F_STEPS, 3)
+    fut[..., 0] = EGO_V * t_fut
+    cur = torch.zeros(batch, 10)
+    cur[:, 2] = 1.0
+    cur[:, 4] = EGO_V
+
+    xs = torch.linspace(-40.0, 120.0, 20)
+    line_strings = torch.zeros(batch, 2, 20, 4)
+    for i, sgn in enumerate((1.0, -1.0)):
+        line_strings[:, i, :, 0] = xs
+        line_strings[:, i, :, 1] = sgn * border_y
+        line_strings[:, i, :, 3] = 1.0  # road-border flag
+
+    nb_past = torch.zeros(batch, N_SLOTS, P_STEPS, 11)
+    nb_fut = torch.zeros(batch, N_SLOTS, F_STEPS, 4)
+    for slot, nb in enumerate(neighbours):
+        steps = nb.get("steps", range(T))
+        w, ln = nb.get("wl", (1.8, 4.5))
+        vx, vy = nb.get("v", (0.0, 0.0))
+        jitter = nb.get("jitter", 0.0)
+        drift = nb.get("drift", 0.0)
+        for k in steps:
+            # world x of the neighbour is fixed; the offsets are quoted at t=0
+            x = nb["lon"] + jitter * (1.0 if k % 2 else -1.0)
+            y = nb["lat"]
+            if k >= P_STEPS:
+                x = x + drift * (k - (P_STEPS - 1)) / F_STEPS
+            row = torch.tensor([x, y, 1.0, 0.0, vx, vy, w, ln, 1.0, 0.0, 0.0])
+            if k < P_STEPS:
+                nb_past[:, slot, k] = row
+            else:
+                nb_fut[:, slot, k - P_STEPS] = row[:4]
+    inputs = {
+        "ego_agent_past": past,
+        "ego_current_state": cur,
+        "ego_shape": torch.tensor([EGO_SHAPE]).repeat(batch, 1),
+        "line_strings": line_strings,
+        "neighbor_agents_past": nb_past,
+        "neighbor_agents_future": nb_fut,
+        "goal_pose": torch.zeros(batch, 4),
+        "lanes": torch.zeros(batch, 1, 20, 8),
+        "route_lanes": torch.zeros(batch, 1, 20, 8),
+        "polygons": torch.zeros(batch, 1, 20, 2),
+        "static_objects": torch.zeros(batch, 5, 10),
+    }
+    return inputs, fut, t_all
+
+
+def _run(aug, batch: int = 1, future=None, **scene_kw):
+    """One augmentation pass on a fresh scene.
+
+    Returns what the training loop reads: the augmenter's own return values, not the
+    tensors handed in (a non-canonical future is narrowed to a fresh tensor on the way
+    in, so the caller's copy is not the one that gets rewritten).
+    """
+    inputs, fut, _ = _scene(batch=batch, **scene_kw)
+    inputs, fut, _ = aug(
+        inputs, fut if future is None else future(fut, inputs), inputs["neighbor_agents_future"]
+    )
+    return inputs, fut
+
+
+def _accepted(aug, batch, **scene_kw):
+    _run(aug, batch=batch, **scene_kw)
+    return aug._aug_rows.clone()
+
+
+# ───────────────────────── 1. the defaults invariant ─────────────────────────
+
+
+def _rand_spy(monkeypatch):
+    """Record the shape of every torch.rand drawn from here on."""
+    shapes = []
+    real = torch.rand
+
+    def spy(*args, **kwargs):
+        shapes.append(tuple(args[0]) if args and not isinstance(args[0], int) else args)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "rand", spy)
+    return shapes
+
+
+def test_new_flags_at_their_off_values_change_nothing(monkeypatch):
+    """The whole point of the opt-in flags: OFF must be indistinguishable from absent.
+
+    Same seed, same synthetic batch, plain defaults vs every new kwarg spelled out at
+    its off value. Outputs must match exactly AND the generator must end in the same
+    state, which is what fails the day the extra toward-parked ``torch.rand`` column
+    stops being conditional.
+    """
+    nbr = [{"lon": 30.0, "lat": 1.6, "wl": (1.8, 4.5)}]
+
+    shapes = _rand_spy(monkeypatch)
+    a = FrenetStatePerturbationTensor(1.0, "cpu", seed=11)
+    in_a, fut_a = _run(a, batch=8, neighbours=nbr)
+    state_a = a.gen.get_state()
+
+    shapes_a, _ = list(shapes), shapes.clear()
+    b = FrenetStatePerturbationTensor(
+        1.0, "cpu", seed=11, recovery_rounds=0, toward_parked_prob=0.0, min_clearance=0.0
+    )
+    in_b, fut_b = _run(b, batch=8, neighbours=nbr)
+    shapes_b = list(shapes)
+
+    assert shapes_a == shapes_b, "the off values changed how much randomness is drawn"
+    assert torch.equal(state_a, b.gen.get_state())
+    assert torch.equal(a._aug_rows, b._aug_rows)
+    assert bool(a._aug_rows.any()), "the fixture augments nothing; the test proves nothing"
+    for key in ("ego_agent_past", "ego_current_state"):
+        assert torch.equal(in_a[key], in_b[key]), key
+    assert torch.equal(fut_a, fut_b)
+
+
+def test_toward_parked_off_draws_no_extra_column(monkeypatch):
+    """Pinned separately from the output check: the RNG stream is the fragile part."""
+    shapes = _rand_spy(monkeypatch)
+    off = FrenetStatePerturbationTensor(1.0, "cpu", seed=3)
+    _run(off, batch=2)
+    width_off = [s for s in shapes if s == (2, 2 * off.n_draws + 1)]
+
+    shapes.clear()
+    on = FrenetStatePerturbationTensor(1.0, "cpu", seed=3, toward_parked_prob=0.5)
+    _run(on, batch=2)
+    width_on = [s for s in shapes if s == (2, 2 * on.n_draws + 2)]
+
+    assert width_off and width_on
+
+
+# ───────────────────────── 2. recovery after a veto ──────────────────────────
+
+# A short box, valid for ONE timestep, 3.4 m ahead and 1.0 m left of the t=0 rear
+# axle: outside the corridor's longitudinal window (half_l + ext_lon = 2.9 m) so it
+# imposes no lateral cut, but inside the ego footprint, whose centre sits wb/2
+# further forward. Exactly the ~1% of winners the exact-OBB veto exists to catch.
+_VETO_NBR = [{"lon": 3.4, "lat": 1.0, "wl": (0.8, 0.8), "steps": [P_STEPS - 1]}]
+
+
+def test_recovery_only_ever_adds_rows():
+    """Recovery is a second chance, never a re-decision: accepted rows stay accepted."""
+    flipped = 0
+    for seed in range(6):
+        off = _accepted(
+            FrenetStatePerturbationTensor(1.0, "cpu", seed=seed), 8, neighbours=_VETO_NBR
+        )
+        on = _accepted(
+            FrenetStatePerturbationTensor(1.0, "cpu", seed=seed, recovery_rounds=1),
+            8,
+            neighbours=_VETO_NBR,
+        )
+        assert bool((off & ~on).sum() == 0), f"seed {seed}: recovery dropped an accepted row"
+        flipped += int((on & ~off).sum())
+    assert flipped > 0, "the fixture vetoes nothing; the recovery path is untested"
+
+
+# ───────────────────── 3. parked detection and the nudge ─────────────────────
+
+
+def _parked(neighbours):
+    inputs, _, _ = _scene(neighbours=neighbours)
+    st, valid = time_aligned_neighbor_tracks(
+        inputs["neighbor_agents_past"], inputs["neighbor_agents_future"]
+    )
+    return (
+        FrenetStatePerturbationTensor._parked_mask(
+            inputs["neighbor_agents_past"], st, valid, P_STEPS
+        )[0, 0].item(),
+        st,
+        valid,
+    )
+
+
+def test_a_jittering_parked_box_is_recognised_by_its_recorded_velocity():
+    """A 5 cm centroid wobble is 0.5 m/s to a one-step difference, and 0 to the data."""
+    parked, st, valid = _parked([{"lon": 40.0, "lat": 2.0, "jitter": 0.05, "v": (0.0, 0.0)}])
+    assert parked
+    # the finite difference this replaced would have rejected the very same box
+    step = (st[:, :, P_STEPS - 1, :2] - st[:, :, P_STEPS - 2, :2]).norm(dim=-1)
+    assert float(step[0, 0]) / DT >= PARKED_SPEED
+
+
+def test_a_vehicle_that_departs_is_not_parked():
+    """Stopped at t=0 is not parked: the light turns green and the lead car leaves."""
+    parked, _, _ = _parked([{"lon": 40.0, "lat": 2.0, "v": (0.2, 0.0), "drift": 30.0}])
+    assert not parked
+
+
+def test_a_stationary_vehicle_is_parked():
+    parked, _, _ = _parked([{"lon": 40.0, "lat": 2.0, "v": (0.0, 0.0)}])
+    assert parked
+
+
+def _captured_dy(aug, batch, **scene_kw):
+    """Run the augmenter, returning the drawn offsets it actually built profiles from."""
+    seen = {}
+    real = aug._candidate_profiles
+
+    def spy(combos, dy, *args, **kwargs):
+        seen["dy"] = dy.clone()
+        return real(combos, dy, *args, **kwargs)
+
+    aug._candidate_profiles = spy
+    _run(aug, batch=batch, **scene_kw)
+    return seen["dy"]
+
+
+# a parked car 45 m ahead and 2.0 m left: reached at t ~ 4.5 s, later than the
+# shortest merge, so the scene is eligible for the nudge
+_PARKED_AHEAD = [{"lon": 45.0, "lat": 2.0, "jitter": 0.05, "v": (0.0, 0.0)}]
+
+
+def test_toward_parked_points_every_offset_at_the_parked_car():
+    """The car is on the +normal side, so a nudged scene draws only positive offsets."""
+    on = FrenetStatePerturbationTensor(1.0, "cpu", seed=5, toward_parked_prob=1.0)
+    dy_on = _captured_dy(on, 1, neighbours=_PARKED_AHEAD)
+    assert bool((dy_on > 0).all()), dy_on
+
+    # same augmenter, same RNG width, empty road: nothing to point at, nothing mirrored
+    bare = FrenetStatePerturbationTensor(1.0, "cpu", seed=5, toward_parked_prob=1.0)
+    dy_bare = _captured_dy(bare, 1)
+    assert bool((dy_bare < 0).any()), "the unmirrored draw should straddle zero"
+    assert torch.equal(dy_on, dy_bare.abs())
+
+
+def test_toward_parked_ignores_a_moving_vehicle():
+    """Same geometry, but the car drives off: no mirroring, the draw is untouched."""
+    moving = [dict(_PARKED_AHEAD[0], v=(0.2, 0.0), drift=30.0)]
+    on = FrenetStatePerturbationTensor(1.0, "cpu", seed=5, toward_parked_prob=1.0)
+    bare = FrenetStatePerturbationTensor(1.0, "cpu", seed=5, toward_parked_prob=1.0)
+    assert torch.equal(_captured_dy(on, 1, neighbours=moving), _captured_dy(bare, 1))
+
+
+# ─────────────────────────── 4. the clearance floor ──────────────────────────
+
+# 6.0 m ahead, dead centre: never overlapping, and 1.7 m clear of the ego's front
+# face -- inside a 2.0 m floor but OUTSIDE the un-widened `near` prefilter, so this
+# is also the regression test for the floor being silently unenforced.
+_CLOSE_NBR = [{"lon": 6.0, "lat": 0.0, "wl": (0.8, 0.8), "steps": [P_STEPS - 1]}]
+
+
+def test_min_clearance_rejects_a_candidate_inside_the_floor():
+    loose = _accepted(FrenetStatePerturbationTensor(1.0, "cpu", seed=2), 8, neighbours=_CLOSE_NBR)
+    tight = _accepted(
+        FrenetStatePerturbationTensor(1.0, "cpu", seed=2, min_clearance=2.0),
+        8,
+        neighbours=_CLOSE_NBR,
+    )
+    assert bool(loose.any()), "nothing was accepted without the floor; the test proves nothing"
+    assert not bool(tight.any()), "a candidate 1.7 m from a box passed a 2.0 m floor"
+
+
+def test_min_clearance_leaves_the_border_corridor_alone():
+    """The floor is a NEIGHBOUR rule. Kerbs are 1.6 m away and no car is present, so a
+    scene that augments without the floor must augment identically with it -- widening
+    the border cut instead would drop every kerb-hugging drive out of augmentation."""
+    loose = _accepted(FrenetStatePerturbationTensor(1.0, "cpu", seed=4), 8, border_y=1.6)
+    tight = _accepted(
+        FrenetStatePerturbationTensor(1.0, "cpu", seed=4, min_clearance=2.0), 8, border_y=1.6
+    )
+    assert bool(loose.any()), "the tight corridor accepted nothing; the test proves nothing"
+    assert torch.equal(loose, tight)
+
+
+def test_min_clearance_does_not_move_the_border_bounds():
+    """The same claim one level down, where the two half-widths are actually applied."""
+    bounds = []
+    for mc in (0.0, 2.0):
+        aug = FrenetStatePerturbationTensor(1.0, "cpu", seed=4, min_clearance=mc)
+        inputs, fut, _ = _scene(batch=2, border_y=1.6)
+        xy = torch.cat([inputs["ego_agent_past"][..., :2], fut[..., :2]], dim=1)
+        tan = torch.zeros_like(xy)
+        tan[..., 0] = 1.0
+        nrm = torch.stack([-tan[..., 1], tan[..., 0]], dim=-1)
+        shape = inputs["ego_shape"]
+        half_w = shape[:, 2] / 2 + 0.10
+        bounds.append(
+            aug._corridor(
+                {"line_strings": inputs["line_strings"]},
+                xy,
+                tan,
+                nrm,
+                half_w,
+                shape[:, 2] / 2 + max(0.10, mc),
+                shape[:, 1] / 2,
+                shape[:, 0],
+            )
+        )
+    assert torch.equal(bounds[0][0], bounds[1][0])
+    assert torch.equal(bounds[0][1], bounds[1][1])
+
+
+# ───────────────────── layout robustness (3-col / 4-col) ─────────────────────
+
+
+def test_a_3col_history_and_4col_future_are_accepted():
+    """Scene-gen and the offline tools emit the other layout of each field."""
+    ref = FrenetStatePerturbationTensor(1.0, "cpu", seed=9)
+    in_ref, fut_ref = _run(ref, batch=4, neighbours=_PARKED_AHEAD)
+
+    def to_alt_layout(fut, inputs):
+        past = inputs["ego_agent_past"]
+        inputs["ego_agent_past"] = torch.cat(
+            [past[..., :2], torch.atan2(past[..., 3], past[..., 2])[..., None]], dim=-1
+        )
+        return torch.cat([fut[..., :2], fut[..., 2:3].cos(), fut[..., 2:3].sin()], dim=-1)
+
+    alt = FrenetStatePerturbationTensor(1.0, "cpu", seed=9)
+    in_alt, fut_alt = _run(alt, batch=4, future=to_alt_layout, neighbours=_PARKED_AHEAD)
+
+    assert torch.equal(alt._aug_rows, ref._aug_rows)
+    assert bool(ref._aug_rows.any()), "nothing was augmented; the test proves nothing"
+    assert torch.allclose(in_alt["ego_agent_past"], in_ref["ego_agent_past"], atol=1e-5)
+    assert torch.allclose(in_alt["ego_current_state"], in_ref["ego_current_state"], atol=1e-5)
+    assert torch.allclose(fut_alt, fut_ref, atol=1e-5)

--- a/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
@@ -373,7 +373,7 @@ def test_past_noise_scales_each_accepted_history_by_one_factor():
 
     # untouched rows train on plain ground truth, unscaled
     assert torch.equal(past_ref[~rows], past_new[~rows])
-    assert torch.equal(cur_ref[~rows], cur_new[~rows])
+    assert torch.equal(cur_ref, cur_new), "the scale is history-only"
 
     for b in torch.nonzero(rows, as_tuple=True)[0].tolist():
         real = past_ref[b, :, 0].abs() > 1e-3  # the samples with a length to scale
@@ -381,10 +381,13 @@ def test_past_noise_scales_each_accepted_history_by_one_factor():
         s = float(ratio[0])
         assert 1 - 2 * 0.2 <= s <= 1 + 2 * 0.2, s
         assert torch.allclose(ratio, ratio[0].expand_as(ratio), atol=1e-5), "not one factor"
-        # the state the history implies is scaled with it (vx, vy, ax, ay)
-        assert torch.allclose(cur_new[b, 4:8], cur_ref[b, 4:8] * s, atol=1e-5)
-        # t=0 is the origin of the frame the batch is centred on, before and after
-        assert torch.allclose(past_new[b, -1, :2], torch.zeros(2), atol=1e-5)
+        # ...and NOTHING but the history moves: the current state is an input in its own
+        # right, not a summary of the history, and vx is a loss weight (see
+        # _perturb_history), so scaling it would re-weight the loss rather than perturb
+        assert torch.equal(cur_new[b], cur_ref[b])
+        # t=0 is pinned by construction: the scale is taken about that sample, so it
+        # is the SAMPLE, not the frame origin, that cannot move
+        assert torch.equal(past_new[b, -1], past_ref[b, -1])
         # "no history" stays no history
         assert torch.equal(past_new[b, :3], torch.zeros(3, 4))
 
@@ -505,7 +508,7 @@ def test_the_two_axes_are_drawn_independently():
 
 
 def test_hist_jitter_headings_match_the_perturbed_polyline():
-    """The reason the jitter is applied BEFORE _headings rather than after the fact."""
+    """The jitter runs after the veto, so the stored cos/sin are re-derived from it."""
     aug = FrenetStatePerturbationTensor(1.0, "cpu", seed=13, hist_jitter_lat=0.3)
     inputs, _ = _run(aug, batch=8)
     rows = aug._aug_rows
@@ -581,3 +584,85 @@ def test_a_3col_history_and_4col_future_are_accepted():
     assert torch.allclose(in_alt["ego_agent_past"], in_ref["ego_agent_past"], atol=1e-5)
     assert torch.allclose(in_alt["ego_current_state"], in_ref["ego_current_state"], atol=1e-5)
     assert torch.allclose(fut_alt, fut_ref, atol=1e-5)
+
+
+# ────────────── 7. both perturbations are input-only, post-veto ───────────────
+#
+# The property that makes an A/B between the two history perturbations valid: they are
+# applied to the ACCEPTED history and nothing else, so they cannot move which scenes are
+# augmented, cannot move the training target, and cannot move the pose the model plans
+# from. Everything below is parametrised over both of them for exactly that reason.
+
+_PERTURBATIONS = [
+    pytest.param({"ego_past_noise_std": 0.2}, id="multiplicative"),
+    pytest.param({"hist_jitter_lat": 0.3}, id="jitter_lat"),
+    pytest.param({"hist_jitter_lat": 0.3, "hist_jitter_lon": 0.3}, id="jitter_lat_lon"),
+]
+
+
+def _clean_and_perturbed(seed=11, batch=8, pad_steps=3, **kw):
+    """The same batch augmented twice: once clean, once with a history perturbation."""
+    clean = FrenetStatePerturbationTensor(1.0, "cpu", seed=seed)
+    in_ref, fut_ref = _run(clean, batch=batch, pad_steps=pad_steps)
+    noisy = FrenetStatePerturbationTensor(1.0, "cpu", seed=seed, **kw)
+    in_new, fut_new = _run(noisy, batch=batch, pad_steps=pad_steps)
+    assert bool(clean._aug_rows.any()), "nothing was augmented; the test proves nothing"
+    return (clean, in_ref, fut_ref), (noisy, in_new, fut_new)
+
+
+@pytest.mark.parametrize("kw", _PERTURBATIONS)
+def test_history_noise_cannot_move_which_scenes_are_augmented(kw):
+    """THE point of applying both perturbations after the veto.
+
+    Applied earlier they bend the history the plausibility-jerk screen and the exact-OBB
+    veto judge, so turning the noise on quietly changes the training SET as well as its
+    contents, and the two arms of an A/B are then not comparable.
+    """
+    (clean, _, _), (noisy, _, _) = _clean_and_perturbed(**kw)
+    assert torch.equal(clean._aug_rows, noisy._aug_rows)
+
+
+@pytest.mark.parametrize("kw", _PERTURBATIONS)
+def test_history_noise_leaves_the_training_target_bit_identical(kw):
+    """The future is the target: the model must learn it DESPITE the noisy history."""
+    (_, _, fut_ref), (_, _, fut_new) = _clean_and_perturbed(**kw)
+    assert torch.equal(fut_ref, fut_new)
+
+
+@pytest.mark.parametrize("kw", _PERTURBATIONS)
+def test_history_noise_leaves_the_t0_history_sample_bit_identical(kw):
+    """Pose AND heading: the last history sample is the pose the model plans from."""
+    (_, in_ref, _), (_, in_new, _) = _clean_and_perturbed(**kw)
+    assert torch.equal(in_ref["ego_agent_past"][:, -1], in_new["ego_agent_past"][:, -1])
+    # ...and something upstream of it really did move
+    assert not torch.equal(in_ref["ego_agent_past"], in_new["ego_agent_past"])
+
+
+@pytest.mark.parametrize("kw", _PERTURBATIONS)
+def test_history_noise_leaves_the_current_state_bit_identical(kw):
+    """Every arm perturbs what the encoder sees and NOTHING else.
+
+    The current state is not a summary of the history the model could catch out --
+    ego_agent_past is (x, y, cos, sin) and carries no velocity at all. Of the state,
+    only the pose and vx are read anywhere, and vx is not an encoder input either: it is
+    the divisor of the longitudinal loss weight in decoder.py. Scaling it would make the
+    multiplicative arm a test of history noise AND of loss re-weighting at once, which
+    the jitter arms have no counterpart for.
+    """
+    (_, in_ref, _), (_, in_new, _) = _clean_and_perturbed(**kw)
+    assert torch.equal(in_ref["ego_current_state"], in_new["ego_current_state"])
+
+
+@pytest.mark.parametrize("kw", _PERTURBATIONS)
+def test_stored_history_headings_describe_the_perturbed_track(kw):
+    """The bug the post-veto rewrite fixes: cos/sin used to be left describing the clean
+    positions while the positions beside them had moved."""
+    # no padded prefix here: a "no history" slot is held at exactly zero, so a
+    # difference taken ACROSS it is a phantom step and describes nothing
+    (_, _, _), (noisy, in_new, _) = _clean_and_perturbed(pad_steps=0, **kw)
+    past = in_new["ego_agent_past"][noisy._aug_rows]
+    # interior samples: ddt is a plain central difference there, and _headings keeps the
+    # motion direction wherever the step is longer than 0.3 m (it is, at EGO_V)
+    g = past[:, 2:, :2] - past[:, :-2, :2]
+    stored = torch.atan2(past[:, 1:-1, 3], past[:, 1:-1, 2])
+    assert torch.allclose(torch.atan2(g[..., 1], g[..., 0]), stored, atol=1e-4)

--- a/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
@@ -357,39 +357,68 @@ def test_min_clearance_does_not_move_the_border_bounds():
 # ─────────────────────────── 5. ego-history noise ────────────────────────────
 
 
-def test_past_noise_scales_each_accepted_history_by_one_factor():
-    """One scalar per scene, on the rewritten history and the state it implies."""
-    plain = FrenetStatePerturbationTensor(1.0, "cpu", seed=7)
-    in_ref, _ = _run(plain, batch=8, pad_steps=3)
-    noisy = FrenetStatePerturbationTensor(1.0, "cpu", seed=7, ego_past_noise_std=0.2)
-    in_new, _ = _run(noisy, batch=8, pad_steps=3)
+def _scaled_pair(std=0.2, batch=8, pad_steps=3, seed=7):
+    """The same batch augmented twice, with and without the history scale.
 
+    Returns the shared accepted-row mask plus both (past, current_state) pairs, so each
+    property below can be one short assertion instead of a loop with six of them.
+    """
+    plain = FrenetStatePerturbationTensor(1.0, "cpu", seed=seed)
+    in_ref, _ = _run(plain, batch=batch, pad_steps=pad_steps)
+    noisy = FrenetStatePerturbationTensor(1.0, "cpu", seed=seed, ego_past_noise_std=std)
+    in_new, _ = _run(noisy, batch=batch, pad_steps=pad_steps)
     rows = plain._aug_rows
     assert torch.equal(rows, noisy._aug_rows), "the scale draw must not shift the decisions"
-    assert bool(rows.any())
+    assert bool(rows.any()), "nothing was augmented; the tests prove nothing"
+    return rows, in_ref, in_new
 
+
+def _row_ratios(rows, in_ref, in_new):
+    """Per accepted row, the elementwise new/old ratio over the samples with a length."""
     past_ref, past_new = in_ref["ego_agent_past"], in_new["ego_agent_past"]
-    cur_ref, cur_new = in_ref["ego_current_state"], in_new["ego_current_state"]
-
-    # untouched rows train on plain ground truth, unscaled
-    assert torch.equal(past_ref[~rows], past_new[~rows])
-    assert torch.equal(cur_ref, cur_new), "the scale is history-only"
-
     for b in torch.nonzero(rows, as_tuple=True)[0].tolist():
         real = past_ref[b, :, 0].abs() > 1e-3  # the samples with a length to scale
-        ratio = past_new[b, real, 0] / past_ref[b, real, 0]
+        yield b, past_new[b, real, 0] / past_ref[b, real, 0]
+
+
+def test_past_noise_is_one_factor_per_scene():
+    """One scalar per scene, applied to the whole rewritten history."""
+    rows, in_ref, in_new = _scaled_pair()
+    for b, ratio in _row_ratios(rows, in_ref, in_new):
+        assert torch.allclose(ratio, ratio[0].expand_as(ratio), atol=1e-5), (
+            f"row {b}: not one factor"
+        )
+
+
+def test_past_noise_factor_stays_within_two_sigma():
+    std = 0.2
+    rows, in_ref, in_new = _scaled_pair(std=std)
+    for b, ratio in _row_ratios(rows, in_ref, in_new):
         s = float(ratio[0])
-        assert 1 - 2 * 0.2 <= s <= 1 + 2 * 0.2, s
-        assert torch.allclose(ratio, ratio[0].expand_as(ratio), atol=1e-5), "not one factor"
-        # ...and NOTHING but the history moves: the current state is an input in its own
-        # right, not a summary of the history, and vx is a loss weight (see
-        # _perturb_history), so scaling it would re-weight the loss rather than perturb
-        assert torch.equal(cur_new[b], cur_ref[b])
-        # t=0 is pinned by construction: the scale is taken about that sample, so it
-        # is the SAMPLE, not the frame origin, that cannot move
-        assert torch.equal(past_new[b, -1], past_ref[b, -1])
-        # "no history" stays no history
-        assert torch.equal(past_new[b, :3], torch.zeros(3, 4))
+        assert 1 - 2 * std <= s <= 1 + 2 * std, f"row {b}: {s} outside +-2 sigma"
+
+
+def test_past_noise_leaves_the_current_state_alone():
+    """``ego_current_state`` is an input in its own right, not a summary of the history,
+    and its vx is a LOSS WEIGHT (see _perturb_history) -- scaling it would re-weight the
+    scene's loss rather than perturb what the encoder reads."""
+    rows, in_ref, in_new = _scaled_pair()
+    assert torch.equal(in_ref["ego_current_state"], in_new["ego_current_state"])
+
+
+def test_past_noise_leaves_unaugmented_rows_on_plain_ground_truth():
+    rows, in_ref, in_new = _scaled_pair()
+    assert torch.equal(in_ref["ego_agent_past"][~rows], in_new["ego_agent_past"][~rows])
+
+
+def test_past_noise_pins_t0_and_the_zero_padding():
+    """t=0 is pinned by construction: the scale is about that SAMPLE, not the frame
+    origin. And "no history" has to stay no history."""
+    rows, in_ref, in_new = _scaled_pair()
+    past_ref, past_new = in_ref["ego_agent_past"], in_new["ego_agent_past"]
+    for b in torch.nonzero(rows, as_tuple=True)[0].tolist():
+        assert torch.equal(past_new[b, -1], past_ref[b, -1]), f"row {b}: t=0 moved"
+        assert torch.equal(past_new[b, :3], torch.zeros(3, 4)), f"row {b}: padding written"
 
 
 def test_past_noise_at_zero_changes_nothing(monkeypatch):

--- a/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
@@ -862,3 +862,47 @@ def test_recovery_cannot_see_the_toward_set_at_all():
         "toward and hardened coincide on this scene, so the guard above is vacuous -- "
         "pick a tighter pass or the distinction has stopped being reachable"
     )
+
+
+# ──────────── generator streams must be disjoint across (rank, stream) ────────────
+
+
+def _augmenter_at_rank(monkeypatch, rank, seed=3407):
+    """Build the augmenter as DDP rank ``rank`` sees it, without a real process group."""
+    monkeypatch.setattr(torch.distributed, "is_available", lambda: True)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: rank)
+    return FrenetStatePerturbationTensor(1.0, "cpu", seed=seed)
+
+
+def test_no_generator_state_collides_across_ranks_or_streams(monkeypatch):
+    """Every (rank, stream) pair must start from its own state.
+
+    `seed + rank`, `+ rank + 1`, `+ rank + 2` separated the streams within a rank but
+    made the per-rank blocks overlap, so rank 0's history generator started exactly
+    where rank 1's main generator did (and rank 0's toward matched both rank 1's
+    history and rank 2's main). Ranks in a multi-GPU job then drew correlated
+    perturbations -- the opposite of what splitting the streams is for.
+    """
+    states = {}
+    for rank in range(4):
+        aug = _augmenter_at_rank(monkeypatch, rank)
+        for name in ("gen", "hist_gen", "toward_gen"):
+            key = bytes(getattr(aug, name).get_state().numpy().tobytes())
+            assert key not in states, (
+                f"rank {rank} {name} starts in the same state as {states[key]}"
+            )
+            states[key] = f"rank {rank} {name}"
+    assert len(states) == 12
+
+
+def test_the_main_stream_still_matches_the_unpatched_seeding(monkeypatch):
+    """The main generator must stay `seed + rank`.
+
+    That is what tier4-main uses, so changing it would alter the default path at every
+    rank above 0 even with every new flag off. Only the ADDED streams are namespaced.
+    """
+    for rank in (0, 1, 5):
+        aug = _augmenter_at_rank(monkeypatch, rank, seed=11)
+        expected = torch.Generator(device="cpu").manual_seed(11 + rank)
+        assert torch.equal(aug.gen.get_state(), expected.get_state())

--- a/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
@@ -666,3 +666,88 @@ def test_stored_history_headings_describe_the_perturbed_track(kw):
     g = past[:, 2:, :2] - past[:, :-2, :2]
     stored = torch.atan2(past[:, 1:-1, 3], past[:, 1:-1, 2])
     assert torch.allclose(torch.atan2(g[..., 1], g[..., 0]), stored, atol=1e-4)
+
+
+# ──────────────── 8. the toward-parked fallback and the floor mask ────────────────
+# Regression cover for the three fixes in a00a98588 / a3a77f888 / 74609f900. The
+# defect they answer was silent: the augmenter kept working and simply stopped
+# augmenting the scene family the flag exists for.
+
+_TIGHT_PASS = [{"lon": 25.0, "lat": 1.8, "v": (0.0, 0.0)}]
+
+
+def test_toward_parked_does_not_delete_the_scenes_it_exists_to_harden():
+    """The merge gate can strike out every horizon on a tight pass.
+
+    Applying it unconditionally took this family from 91/128 accepted to 0/128 --
+    the flag deleted its own target. The fallback keeps the row on its ungated
+    candidates instead. It is a floor, not a repair: most rows are still lost to
+    the exact footprint check (a 2.0 m ego does not fit a 1.8 m gap), so this
+    asserts survival, not recovery.
+    """
+    off = _accepted(FrenetStatePerturbationTensor(1.0, "cpu", seed=7), 128, neighbours=_TIGHT_PASS)
+    on = _accepted(
+        FrenetStatePerturbationTensor(1.0, "cpu", seed=7, toward_parked_prob=1.0),
+        128,
+        neighbours=_TIGHT_PASS,
+    )
+    assert int(off.sum()) > 0, "nothing was accepted with the nudge off; the test proves nothing"
+    assert int(on.sum()) > 0, (
+        f"the toward-parked gate deleted the whole tight-pass family: {int(on.sum())}/128 "
+        f"accepted with the nudge on vs {int(off.sum())}/128 without it"
+    )
+
+
+def test_a_row_that_fell_back_is_not_counted_as_hardened():
+    """`hardened` is what the recovery path keys on, so it must exclude fallbacks.
+
+    If a fallback row were reported as hardened, the first selection would take
+    first-feasible while the retry took largest-offset -- an un-hardened row trained
+    as if its merge were gated in front of the vehicle.
+    """
+    aug = FrenetStatePerturbationTensor(1.0, "cpu", seed=7, toward_parked_prob=1.0)
+    seen = {}
+    real = FrenetStatePerturbationTensor._toward_parked_select
+
+    def spy(self, admissible, merges, dy, toward, toward_any, t_obs, P):
+        out = real(self, admissible, merges, dy, toward, toward_any, t_obs, P)
+        if toward_any:
+            seen["toward"], seen["hardened"] = toward.clone(), out[3].clone()
+        return out
+
+    FrenetStatePerturbationTensor._toward_parked_select = spy
+    try:
+        _run(aug, batch=128, neighbours=_TIGHT_PASS)
+    finally:
+        FrenetStatePerturbationTensor._toward_parked_select = real
+
+    assert seen, "the toward-parked branch never ran; the test proves nothing"
+    assert bool((seen["toward"] & ~seen["hardened"]).any()), (
+        "no row fell back on a scene built to empty the gate -- if the geometry changed, "
+        "pick a tighter pass, otherwise the fallback is dead code"
+    )
+    assert bool((seen["hardened"] & ~seen["toward"]).sum() == 0), (
+        "a row is hardened without being toward-parked"
+    )
+
+
+def test_the_clearance_floor_is_off_by_default_and_builds_no_mask():
+    """The default path must not pay for, or be changed by, a feature that is off."""
+    aug = FrenetStatePerturbationTensor(1.0, "cpu", seed=3)
+    xy = torch.zeros(2, 5, 2)
+    assert aug._floor_mask(xy + 1.0, xy) is None, "a mask was built with the floor off"
+
+
+def test_the_floor_applies_only_where_the_candidate_left_the_recording():
+    """A timestep identical to ground truth is judged at threshold 0, not at the floor.
+
+    Without this, a scene is rejected for the clearance of the drive that was actually
+    recorded -- the augmenter vetoing reality.
+    """
+    aug = FrenetStatePerturbationTensor(1.0, "cpu", seed=3, min_clearance=2.0)
+    xy = torch.zeros(1, 4, 2)
+    aug_xy = xy.clone()
+    aug_xy[0, 2:] = 1.0  # departs only at the last two timesteps
+    mask = aug._floor_mask(aug_xy, xy)
+    assert mask is not None
+    assert mask.tolist() == [[False, False, True, True]]

--- a/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
@@ -369,7 +369,11 @@ def test_min_clearance_does_not_move_the_border_bounds():
         half_w = shape[:, 2] / 2 + 0.10
         bounds.append(
             aug._corridor(
-                {"line_strings": inputs["line_strings"]},
+                # the full input dict: _corridor now REQUIRES the neighbour tensors, and
+                # passing a stripped dict is what used to silently give an unvetoed,
+                # neighbour-free corridor. The scene here has no neighbours anyway, so
+                # the border claim is unaffected.
+                inputs,
                 xy,
                 tan,
                 nrm,
@@ -911,3 +915,25 @@ def test_the_main_stream_still_matches_the_unpatched_seeding(monkeypatch):
         aug = _augmenter_at_rank(monkeypatch, rank, seed=11)
         expected = torch.Generator(device="cpu").manual_seed(11 + rank)
         assert torch.equal(aug.gen.get_state(), expected.get_state())
+
+
+def test_a_missing_neighbour_tensor_raises_instead_of_silently_disabling_the_veto():
+    """Dropping a mandatory key used to be a silent no-op with severe consequences.
+
+    Without the neighbour tensors the corridor gets no neighbour cuts, `_nbr_st` stays
+    None so the exact footprint veto returns early, and `_nbr_lo` stays None so no scene
+    is toward-parked eligible. A harness that popped `neighbor_agents_future` out of the
+    dict -- which the positional argument invites -- therefore measured an empty world
+    and reported 0 vetoes and 0 eligible scenes with no error.
+    """
+    aug = FrenetStatePerturbationTensor(1.0, "cpu", seed=3)
+    inputs, fut, nbf = _scene(batch=2)
+    stripped = {k: v for k, v in inputs.items() if k != "neighbor_agents_future"}
+    with pytest.raises(KeyError, match="neighbor_agents_future"):
+        aug(stripped, fut, nbf)
+
+    for key in ("line_strings", "neighbor_agents_past"):
+        aug2 = FrenetStatePerturbationTensor(1.0, "cpu", seed=3)
+        inp, f2, n2 = _scene(batch=2)
+        with pytest.raises(KeyError, match=key):
+            aug2({k: v for k, v in inp.items() if k != key}, f2, n2)

--- a/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
@@ -488,7 +488,7 @@ def _jitter_offset(batch: int, seed: int = 5, **kw):
 
 def test_hist_jitter_is_exactly_zero_at_t0():
     """The current pose is what the model plans from; the history must not move it."""
-    off, aug = _jitter_offset(64, hist_jitter_lat=0.4)
+    off, aug = _jitter_offset(64, ego_past_noise_std=0.4, ego_past_noise_mode="jitter")
     # the basis itself, before any amplitude: every mode vanishes at u = 0
     phi = aug._hist_jitter_basis(P_STEPS, torch.device("cpu"), torch.float32)
     assert torch.equal(phi[:, -1], torch.zeros(phi.shape[0]))
@@ -502,7 +502,7 @@ def test_hist_jitter_std_at_the_oldest_sample_is_the_requested_one():
     """The flag is defined as the std at the oldest sample: A = sigma / ||phi[:, 0]||."""
     sigma = 0.35
     n = 40000
-    off, _ = _jitter_offset(n, hist_jitter_lat=sigma)
+    off, _ = _jitter_offset(n, ego_past_noise_std=sigma, ego_past_noise_mode="jitter")
     emp = float(off[:, 0, 1].std())
     # Monte-Carlo error on a std from n samples is ~ sigma / sqrt(2n) = 1.2e-3 here;
     # 5% is many times that and still catches a wrong normalisation constant
@@ -514,7 +514,7 @@ def test_hist_jitter_std_at_the_oldest_sample_is_the_requested_one():
 def test_hist_jitter_is_smooth_not_white():
     """Independent per-sample noise is a jagged track a model learns to ignore."""
     sigma = 0.3
-    off, _ = _jitter_offset(4000, hist_jitter_lat=sigma)
+    off, _ = _jitter_offset(4000, ego_past_noise_std=sigma, ego_past_noise_mode="jitter")
     lat = off[:, :P_STEPS, 1]
     d2 = lat[:, 2:] - 2 * lat[:, 1:-1] + lat[:, :-2]
     # white noise of the same per-sample std has second-difference std sigma*sqrt(6)
@@ -534,7 +534,7 @@ def _spacing_ratio(**kw):
 def test_lateral_jitter_leaves_the_along_path_spacing_alone():
     """Bending the track sideways must not smuggle in a speed perturbation."""
     xy, _, _ = _straight_frame(4000)
-    off, _ = _jitter_offset(4000, hist_jitter_lat=0.3)
+    off, _ = _jitter_offset(4000, ego_past_noise_std=0.3, ego_past_noise_mode="jitter")
     step0 = (xy[:, 1:P_STEPS] - xy[:, : P_STEPS - 1]).norm(dim=-1)
     step1 = ((xy + off)[:, 1:P_STEPS] - (xy + off)[:, : P_STEPS - 1]).norm(dim=-1)
     # a purely lateral bend only lengthens the step at second order in the bend angle
@@ -547,8 +547,11 @@ def test_there_is_no_longitudinal_axis():
     It made the arm the worst of the campaign in all four eval cells on both metrics,
     where lateral alone was the best on recovery.
     """
-    aug = FrenetStatePerturbationTensor(1.0, "cpu", seed=5, hist_jitter_lat=0.3)
+    aug = FrenetStatePerturbationTensor(
+        1.0, "cpu", seed=5, ego_past_noise_std=0.3, ego_past_noise_mode="jitter"
+    )
     assert not hasattr(aug, "hist_jitter_lon"), "the longitudinal knob came back"
+    assert not hasattr(aug, "hist_jitter_lat"), "the separate jitter magnitude came back"
     with pytest.raises(TypeError):
         FrenetStatePerturbationTensor(1.0, "cpu", hist_jitter_lon=0.3)
 
@@ -561,13 +564,15 @@ def test_there_is_no_longitudinal_axis():
     assert axes[1][0] == 0.0, "the along-path axis has a non-zero std again"
 
     # and it really contributes nothing along the path
-    off, _ = _jitter_offset(4000, hist_jitter_lat=0.3)
+    off, _ = _jitter_offset(4000, ego_past_noise_std=0.3, ego_past_noise_mode="jitter")
     assert float(off[:, 0, 0].abs().max()) == 0.0, "the zero axis moved the path tangent"
 
 
 def test_hist_jitter_headings_match_the_perturbed_polyline():
     """The jitter runs after the veto, so the stored cos/sin are re-derived from it."""
-    aug = FrenetStatePerturbationTensor(1.0, "cpu", seed=13, hist_jitter_lat=0.3)
+    aug = FrenetStatePerturbationTensor(
+        1.0, "cpu", seed=13, ego_past_noise_std=0.3, ego_past_noise_mode="jitter"
+    )
     inputs, _ = _run(aug, batch=8)
     rows = aug._aug_rows
     assert bool(rows.any()), "nothing was augmented; the test proves nothing"
@@ -600,7 +605,7 @@ def test_hist_jitter_at_zero_changes_nothing(monkeypatch):
     in_off, fut_off = _run(off, batch=8, pad_steps=3)
     shapes_off, _ = list(shapes), shapes.clear()
 
-    explicit = FrenetStatePerturbationTensor(1.0, "cpu", seed=7, hist_jitter_lat=0.0)
+    explicit = FrenetStatePerturbationTensor(1.0, "cpu", seed=7, ego_past_noise_std=0.0)
     in_on, fut_on = _run(explicit, batch=8, pad_steps=3)
 
     assert shapes_off == list(shapes), "the off value changed how much randomness is drawn"
@@ -611,8 +616,8 @@ def test_hist_jitter_at_zero_changes_nothing(monkeypatch):
 
 
 def test_hist_jitter_refuses_a_negative_std():
-    with pytest.raises(ValueError, match="hist_jitter_lat"):
-        FrenetStatePerturbationTensor(1.0, "cpu", hist_jitter_lat=-0.1)
+    with pytest.raises(ValueError, match="ego_past_noise_std"):
+        FrenetStatePerturbationTensor(1.0, "cpu", ego_past_noise_std=-0.1)
 
 
 # ───────────────────── layout robustness (3-col / 4-col) ─────────────────────
@@ -659,7 +664,7 @@ def test_a_3col_history_and_4col_future_are_accepted():
 
 _PERTURBATIONS = [
     pytest.param({"ego_past_noise_std": 0.2}, id="multiplicative"),
-    pytest.param({"hist_jitter_lat": 0.3}, id="jitter_lat"),
+    pytest.param({"ego_past_noise_std": 0.3, "ego_past_noise_mode": "jitter"}, id="jitter"),
 ]
 
 

--- a/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
@@ -408,159 +408,6 @@ def test_past_noise_at_zero_changes_nothing(monkeypatch):
     assert torch.equal(fut_off, fut_on)
 
 
-# ────────────────────── 6. smooth ego-history jitter ─────────────────────────
-
-
-def _straight_frame(batch: int):
-    """A straight +x polyline with its path frame, as ``__call__`` builds them."""
-    T = P_STEPS + F_STEPS
-    xy = torch.zeros(batch, T, 2)
-    xy[..., 0] = torch.arange(T, dtype=torch.float32) * EGO_V * DT
-    tan = torch.zeros(batch, T, 2)
-    tan[..., 0] = 1.0
-    nrm = torch.stack([-tan[..., 1], tan[..., 0]], dim=-1)
-    return xy, tan, nrm
-
-
-def _jitter_offset(batch: int, seed: int = 5, **kw):
-    aug = FrenetStatePerturbationTensor(1.0, "cpu", seed=seed, **kw)
-    xy, tan, nrm = _straight_frame(batch)
-    return aug._hist_jitter(xy, tan, nrm, P_STEPS), aug
-
-
-def test_hist_jitter_is_exactly_zero_at_t0():
-    """The current pose is what the model plans from; the history must not move it."""
-    off, aug = _jitter_offset(64, hist_jitter_lat=0.4)
-    # the basis itself, before any amplitude: every mode vanishes at u = 0
-    phi = aug._hist_jitter_basis(P_STEPS, torch.device("cpu"), torch.float32)
-    assert torch.equal(phi[:, -1], torch.zeros(phi.shape[0]))
-    # and so does the offset actually applied, exactly -- not "to within a tolerance"
-    assert torch.equal(off[:, P_STEPS - 1], torch.zeros(64, 2))
-    assert torch.equal(off[:, P_STEPS:], torch.zeros(64, F_STEPS, 2)), "the future moved"
-    assert float(off[:, 0].abs().max()) > 0.0, "nothing was jittered; the test proves nothing"
-
-
-def test_hist_jitter_std_at_the_oldest_sample_is_the_requested_one():
-    """The flag is defined as the std at the oldest sample: A = sigma / ||phi[:, 0]||."""
-    sigma = 0.35
-    n = 40000
-    off, _ = _jitter_offset(n, hist_jitter_lat=sigma)
-    emp = float(off[:, 0, 1].std())
-    # Monte-Carlo error on a std from n samples is ~ sigma / sqrt(2n) = 1.2e-3 here;
-    # 5% is many times that and still catches a wrong normalisation constant
-    # (sqrt(2) = 1.41 or K = 3 would both be off by tens of percent).
-    assert abs(emp - sigma) / sigma < 0.05, emp
-    assert abs(float(off[:, 0, 0].mean())) < 1e-2, "lateral jitter moved the path tangent"
-
-
-def test_hist_jitter_is_smooth_not_white():
-    """Independent per-sample noise is a jagged track a model learns to ignore."""
-    sigma = 0.3
-    off, _ = _jitter_offset(4000, hist_jitter_lat=sigma)
-    lat = off[:, :P_STEPS, 1]
-    d2 = lat[:, 2:] - 2 * lat[:, 1:-1] + lat[:, :-2]
-    # white noise of the same per-sample std has second-difference std sigma*sqrt(6)
-    white = float(sigma * (6.0**0.5))
-    assert float(d2.std()) < white / 20.0, (float(d2.std()), white)
-
-
-def _spacing_ratio(**kw):
-    """Mean along-path sample spacing of the jittered history, over the unjittered one."""
-    xy, _, _ = _straight_frame(4000)
-    off, _ = _jitter_offset(4000, **kw)
-    step0 = (xy[:, 1:P_STEPS] - xy[:, : P_STEPS - 1]).norm(dim=-1)
-    step1 = ((xy + off)[:, 1:P_STEPS] - (xy + off)[:, : P_STEPS - 1]).norm(dim=-1)
-    return abs(float(step1.std() / step0.mean()))
-
-
-def test_lateral_jitter_leaves_the_along_path_spacing_alone():
-    """Bending the track sideways must not smuggle in a speed perturbation."""
-    xy, _, _ = _straight_frame(4000)
-    off, _ = _jitter_offset(4000, hist_jitter_lat=0.3)
-    step0 = (xy[:, 1:P_STEPS] - xy[:, : P_STEPS - 1]).norm(dim=-1)
-    step1 = ((xy + off)[:, 1:P_STEPS] - (xy + off)[:, : P_STEPS - 1]).norm(dim=-1)
-    # a purely lateral bend only lengthens the step at second order in the bend angle
-    assert abs(float(step1.mean() / step0.mean()) - 1.0) < 0.01
-
-
-def test_longitudinal_jitter_is_what_moves_the_spacing():
-    """The point of the second axis: the implied speed history wobbles."""
-    lat_only = _spacing_ratio(hist_jitter_lat=0.3, hist_jitter_lon=0.0)
-    lon_only = _spacing_ratio(hist_jitter_lat=0.0, hist_jitter_lon=0.3)
-    assert lat_only < 0.01, lat_only
-    assert lon_only > 20 * lat_only, (lon_only, lat_only)
-
-
-def test_longitudinal_jitter_std_at_the_oldest_sample_is_the_requested_one():
-    sigma = 0.35
-    off, _ = _jitter_offset(40000, hist_jitter_lon=sigma)
-    assert abs(float(off[:, 0, 0].std()) - sigma) / sigma < 0.05
-    assert float(off[:, 0, 1].abs().max()) == 0.0, "longitudinal jitter moved the path normal"
-    assert torch.equal(off[:, P_STEPS - 1], torch.zeros(40000, 2)), "t=0 moved"
-
-
-def test_the_two_axes_are_drawn_independently():
-    """A lateral-only run must not have its wobble mirrored along the path."""
-    off, _ = _jitter_offset(20000, hist_jitter_lat=0.3, hist_jitter_lon=0.3)
-    lon, lat = off[:, 0, 0], off[:, 0, 1]
-    corr = float((lon * lat).mean() / (lon.std() * lat.std()))
-    assert abs(corr) < 0.05, corr
-
-
-def test_hist_jitter_headings_match_the_perturbed_polyline():
-    """The jitter runs after the veto, so the stored cos/sin are re-derived from it."""
-    aug = FrenetStatePerturbationTensor(1.0, "cpu", seed=13, hist_jitter_lat=0.3)
-    inputs, _ = _run(aug, batch=8)
-    rows = aug._aug_rows
-    assert bool(rows.any()), "nothing was augmented; the test proves nothing"
-    past = inputs["ego_agent_past"][rows]
-    # interior history samples: ddt is a central difference there, and the batch-wide
-    # re-centering is rigid, so the stored heading must be the polyline's own direction
-    g = past[:, 2:, :2] - past[:, :-2, :2]
-    stored = torch.atan2(past[:, 1:-1, 3], past[:, 1:-1, 2])
-    assert torch.allclose(torch.atan2(g[..., 1], g[..., 0]), stored, atol=1e-4)
-    # and the jitter really did bend it away from the straight recording
-    assert float(stored.abs().max()) > 1e-3
-
-
-def _normal_spy(monkeypatch):
-    """Record the shape of every torch.normal drawn from here on."""
-    shapes = []
-    real = torch.normal
-
-    def spy(*args, **kwargs):
-        shapes.append(kwargs.get("size"))
-        return real(*args, **kwargs)
-
-    monkeypatch.setattr(torch, "normal", spy)
-    return shapes
-
-
-def test_hist_jitter_at_zero_changes_nothing(monkeypatch):
-    shapes = _normal_spy(monkeypatch)
-    off = FrenetStatePerturbationTensor(1.0, "cpu", seed=7)
-    in_off, fut_off = _run(off, batch=8, pad_steps=3)
-    shapes_off, _ = list(shapes), shapes.clear()
-
-    explicit = FrenetStatePerturbationTensor(
-        1.0, "cpu", seed=7, hist_jitter_lat=0.0, hist_jitter_lon=0.0
-    )
-    in_on, fut_on = _run(explicit, batch=8, pad_steps=3)
-
-    assert shapes_off == list(shapes), "the off value changed how much randomness is drawn"
-    assert torch.equal(off.gen.get_state(), explicit.gen.get_state())
-    assert torch.equal(in_off["ego_agent_past"], in_on["ego_agent_past"])
-    assert torch.equal(in_off["ego_current_state"], in_on["ego_current_state"])
-    assert torch.equal(fut_off, fut_on)
-
-
-def test_hist_jitter_refuses_a_negative_std():
-    with pytest.raises(ValueError, match="hist_jitter_lat"):
-        FrenetStatePerturbationTensor(1.0, "cpu", hist_jitter_lat=-0.1)
-    with pytest.raises(ValueError, match="hist_jitter_lon"):
-        FrenetStatePerturbationTensor(1.0, "cpu", hist_jitter_lon=-0.1)
-
-
 # ───────────────────── layout robustness (3-col / 4-col) ─────────────────────
 
 
@@ -596,17 +443,14 @@ def test_a_3col_history_and_4col_future_are_accepted():
     assert torch.allclose(in_alt["goal_pose"], in_ref["goal_pose"], atol=1e-5)
 
 
-# ────────────── 7. both perturbations are input-only, post-veto ───────────────
+# ────────────── 6. the history perturbation is input-only, post-veto ──────────
 #
-# The property that makes an A/B between the two history perturbations valid: they are
-# applied to the ACCEPTED history and nothing else, so they cannot move which scenes are
-# augmented, cannot move the training target, and cannot move the pose the model plans
-# from. Everything below is parametrised over both of them for exactly that reason.
+# The property that makes an A/B on the history perturbation valid: it is applied to the
+# ACCEPTED history and nothing else, so it cannot move which scenes are augmented, cannot
+# move the training target, and cannot move the pose the model plans from.
 
 _PERTURBATIONS = [
     pytest.param({"ego_past_noise_std": 0.2}, id="multiplicative"),
-    pytest.param({"hist_jitter_lat": 0.3}, id="jitter_lat"),
-    pytest.param({"hist_jitter_lat": 0.3, "hist_jitter_lon": 0.3}, id="jitter_lat_lon"),
 ]
 
 
@@ -678,7 +522,7 @@ def test_stored_history_headings_describe_the_perturbed_track(kw):
     assert torch.allclose(torch.atan2(g[..., 1], g[..., 0]), stored, atol=1e-4)
 
 
-# ──────────────── 8. the toward-parked fallback and the floor mask ────────────────
+# ──────────────── 7. the toward-parked fallback and the floor mask ────────────────
 # Regression cover for the three fixes in a00a98588 / a3a77f888 / 74609f900. The
 # defect they answer was silent: the augmenter kept working and simply stopped
 # augmenting the scene family the flag exists for.

--- a/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
@@ -483,28 +483,28 @@ def test_lateral_jitter_leaves_the_along_path_spacing_alone():
     assert abs(float(step1.mean() / step0.mean()) - 1.0) < 0.01
 
 
-def test_longitudinal_jitter_is_what_moves_the_spacing():
-    """The point of the second axis: the implied speed history wobbles."""
-    lat_only = _spacing_ratio(hist_jitter_lat=0.3, hist_jitter_lon=0.0)
-    lon_only = _spacing_ratio(hist_jitter_lat=0.0, hist_jitter_lon=0.3)
-    assert lat_only < 0.01, lat_only
-    assert lon_only > 20 * lat_only, (lon_only, lat_only)
+def test_there_is_no_longitudinal_axis():
+    """The lon axis was measured and removed; the flag must not quietly come back.
 
+    It made the arm the worst of the campaign in all four eval cells on both metrics,
+    where lateral alone was the best on recovery.
+    """
+    aug = FrenetStatePerturbationTensor(1.0, "cpu", seed=5, hist_jitter_lat=0.3)
+    assert not hasattr(aug, "hist_jitter_lon"), "the longitudinal knob came back"
+    with pytest.raises(TypeError):
+        FrenetStatePerturbationTensor(1.0, "cpu", hist_jitter_lon=0.3)
 
-def test_longitudinal_jitter_std_at_the_oldest_sample_is_the_requested_one():
-    sigma = 0.35
-    off, _ = _jitter_offset(40000, hist_jitter_lon=sigma)
-    assert abs(float(off[:, 0, 0].std()) - sigma) / sigma < 0.05
-    assert float(off[:, 0, 1].abs().max()) == 0.0, "longitudinal jitter moved the path normal"
-    assert torch.equal(off[:, P_STEPS - 1], torch.zeros(40000, 2)), "t=0 moved"
+    # The axis is still LISTED at a hard-zero std, on purpose: the coefficient draw is
+    # shaped (B, len(axes), K), so dropping it would shift the generator stream and the
+    # lateral jitter would give different numbers for the same seed.
+    _, tan, nrm = _straight_frame(2)
+    axes = aug._hist_jitter_axes(tan, nrm)
+    assert len(axes) == 2, "the draw shape changed; the lateral jitter is no longer reproducible"
+    assert axes[1][0] == 0.0, "the along-path axis has a non-zero std again"
 
-
-def test_the_two_axes_are_drawn_independently():
-    """A lateral-only run must not have its wobble mirrored along the path."""
-    off, _ = _jitter_offset(20000, hist_jitter_lat=0.3, hist_jitter_lon=0.3)
-    lon, lat = off[:, 0, 0], off[:, 0, 1]
-    corr = float((lon * lat).mean() / (lon.std() * lat.std()))
-    assert abs(corr) < 0.05, corr
+    # and it really contributes nothing along the path
+    off, _ = _jitter_offset(4000, hist_jitter_lat=0.3)
+    assert float(off[:, 0, 0].abs().max()) == 0.0, "the zero axis moved the path tangent"
 
 
 def test_hist_jitter_headings_match_the_perturbed_polyline():
@@ -542,9 +542,7 @@ def test_hist_jitter_at_zero_changes_nothing(monkeypatch):
     in_off, fut_off = _run(off, batch=8, pad_steps=3)
     shapes_off, _ = list(shapes), shapes.clear()
 
-    explicit = FrenetStatePerturbationTensor(
-        1.0, "cpu", seed=7, hist_jitter_lat=0.0, hist_jitter_lon=0.0
-    )
+    explicit = FrenetStatePerturbationTensor(1.0, "cpu", seed=7, hist_jitter_lat=0.0)
     in_on, fut_on = _run(explicit, batch=8, pad_steps=3)
 
     assert shapes_off == list(shapes), "the off value changed how much randomness is drawn"
@@ -557,8 +555,6 @@ def test_hist_jitter_at_zero_changes_nothing(monkeypatch):
 def test_hist_jitter_refuses_a_negative_std():
     with pytest.raises(ValueError, match="hist_jitter_lat"):
         FrenetStatePerturbationTensor(1.0, "cpu", hist_jitter_lat=-0.1)
-    with pytest.raises(ValueError, match="hist_jitter_lon"):
-        FrenetStatePerturbationTensor(1.0, "cpu", hist_jitter_lon=-0.1)
 
 
 # ───────────────────── layout robustness (3-col / 4-col) ─────────────────────
@@ -606,7 +602,6 @@ def test_a_3col_history_and_4col_future_are_accepted():
 _PERTURBATIONS = [
     pytest.param({"ego_past_noise_std": 0.2}, id="multiplicative"),
     pytest.param({"hist_jitter_lat": 0.3}, id="jitter_lat"),
-    pytest.param({"hist_jitter_lat": 0.3, "hist_jitter_lon": 0.3}, id="jitter_lat_lon"),
 ]
 
 

--- a/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
@@ -177,19 +177,48 @@ def test_new_flags_at_their_off_values_change_nothing(monkeypatch):
     assert torch.equal(fut_a, fut_b)
 
 
-def test_toward_parked_off_draws_no_extra_column(monkeypatch):
-    """Pinned separately from the output check: the RNG stream is the fragile part."""
+def test_the_toward_parked_flag_does_not_shift_the_corridor_stream(monkeypatch):
+    """The corridor draw must be the same WIDTH whether the nudge is on or off.
+
+    It used to be one column wider when the nudge was on, taken from the same
+    generator, so enabling the flag shifted every later corridor and merge draw and
+    changed which scenes were accepted -- even on a corpus where no scene is eligible
+    to be nudged. An A/B on the flag then compared a reseed, not the feature. The coin
+    now comes off a dedicated generator, so the shared stream is flag-independent.
+    """
     shapes = _rand_spy(monkeypatch)
     off = FrenetStatePerturbationTensor(1.0, "cpu", seed=3)
     _run(off, batch=2)
-    width_off = [s for s in shapes if s == (2, 2 * off.n_draws + 1)]
+    off_widths = {s for s in shapes if len(s) == 2 and s[0] == 2}
 
     shapes.clear()
     on = FrenetStatePerturbationTensor(1.0, "cpu", seed=3, toward_parked_prob=0.5)
     _run(on, batch=2)
-    width_on = [s for s in shapes if s == (2, 2 * on.n_draws + 2)]
+    on_widths = {s for s in shapes if len(s) == 2 and s[0] == 2}
 
-    assert width_off and width_on
+    corridor = (2, 2 * off.n_draws + 1)
+    assert corridor in off_widths, f"corridor draw not seen with the nudge off: {off_widths}"
+    assert corridor in on_widths, f"corridor draw not seen with the nudge on: {on_widths}"
+    assert (2, 2 * off.n_draws + 2) not in on_widths, (
+        "the nudge is back to widening the shared corridor draw"
+    )
+
+
+def test_the_toward_parked_flag_cannot_change_which_scenes_are_augmented():
+    """The consequence of the above, asserted end to end.
+
+    On a scene with no parked vehicle in reach the nudge can never fire, so switching
+    it on must leave the accepted set and the augmented state untouched.
+    """
+    off = FrenetStatePerturbationTensor(1.0, "cpu", seed=3)
+    in_off, fut_off = _run(off, batch=16)
+    on = FrenetStatePerturbationTensor(1.0, "cpu", seed=3, toward_parked_prob=1.0)
+    in_on, fut_on = _run(on, batch=16)
+
+    assert bool(off._aug_rows.any()), "nothing was augmented; the test proves nothing"
+    assert torch.equal(off._aug_rows, on._aug_rows), "the flag moved the accepted set"
+    assert torch.equal(in_off["ego_current_state"], in_on["ego_current_state"])
+    assert torch.equal(fut_off, fut_on)
 
 
 # ───────────────────────── 2. recovery after a veto ──────────────────────────

--- a/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
@@ -574,6 +574,14 @@ def test_a_3col_history_and_4col_future_are_accepted():
         inputs["ego_agent_past"] = torch.cat(
             [past[..., :2], torch.atan2(past[..., 3], past[..., 2])[..., None]], dim=-1
         )
+        # goal_pose has the same two layouts. This augmenter never reads it, but the
+        # inherited centric_transform rotates its cols 2:4, so a 3-col tensor reaching
+        # that far raises -- which is what happened before the canonicalisation was
+        # added to the frenet __call__.
+        goal = inputs["goal_pose"]
+        inputs["goal_pose"] = torch.cat(
+            [goal[..., :2], torch.atan2(goal[..., 3], goal[..., 2])[..., None]], dim=-1
+        )
         return torch.cat([fut[..., :2], fut[..., 2:3].cos(), fut[..., 2:3].sin()], dim=-1)
 
     alt = FrenetStatePerturbationTensor(1.0, "cpu", seed=9)
@@ -584,6 +592,8 @@ def test_a_3col_history_and_4col_future_are_accepted():
     assert torch.allclose(in_alt["ego_agent_past"], in_ref["ego_agent_past"], atol=1e-5)
     assert torch.allclose(in_alt["ego_current_state"], in_ref["ego_current_state"], atol=1e-5)
     assert torch.allclose(fut_alt, fut_ref, atol=1e-5)
+    assert in_alt["goal_pose"].shape[-1] == 4, "a 3-col goal_pose was not widened"
+    assert torch.allclose(in_alt["goal_pose"], in_ref["goal_pose"], atol=1e-5)
 
 
 # ────────────── 7. both perturbations are input-only, post-veto ───────────────
@@ -751,3 +761,51 @@ def test_the_floor_applies_only_where_the_candidate_left_the_recording():
     mask = aug._floor_mask(aug_xy, xy)
     assert mask is not None
     assert mask.tolist() == [[False, False, True, True]]
+
+
+def test_recovery_cannot_see_the_toward_set_at_all():
+    """Guard for the one invariant `_recover_vetoed` exists to hold.
+
+    A fallback row took first-feasible in the first selection, so its retry must too;
+    a genuinely gated row took largest-offset, so its retry must too. Keying the retry
+    on `toward` instead of `hardened` breaks that, and no behavioural test caught it
+    because the two sets differ on only a handful of rows.
+
+    Rather than assert the selection indirectly, this removes the means: the recovery
+    is not given `toward`, so keying on it cannot compile without also re-adding the
+    parameter -- a visible edit rather than a one-word swap. The second assertion keeps
+    the first from going vacuous by checking the two sets really do differ here.
+    """
+    import inspect
+
+    params = list(inspect.signature(FrenetStatePerturbationTensor._recover_vetoed).parameters)
+    assert "hardened" in params, "the recovery no longer takes the hardened set"
+    assert "toward" not in params, (
+        "`toward` is back in _recover_vetoed's signature -- it is the wrong set to key "
+        "the retry on (a fallback row would retry with largest-offset after being "
+        "selected with first-feasible); the recovery must only see `hardened`"
+    )
+
+    seen = {}
+    real_sel = FrenetStatePerturbationTensor._toward_parked_select
+
+    def sel_spy(self, admissible, merges, dy, toward, toward_any, t_obs, P):
+        out = real_sel(self, admissible, merges, dy, toward, toward_any, t_obs, P)
+        if toward_any:
+            seen["toward"], seen["hardened"] = toward.clone(), out[3].clone()
+        return out
+
+    FrenetStatePerturbationTensor._toward_parked_select = sel_spy
+    try:
+        aug = FrenetStatePerturbationTensor(
+            1.0, "cpu", seed=7, toward_parked_prob=1.0, recovery_rounds=2
+        )
+        _run(aug, batch=128, neighbours=_TIGHT_PASS)
+    finally:
+        FrenetStatePerturbationTensor._toward_parked_select = real_sel
+
+    assert seen, "the toward-parked branch never ran; the test proves nothing"
+    assert bool((seen["toward"] != seen["hardened"]).any()), (
+        "toward and hardened coincide on this scene, so the guard above is vacuous -- "
+        "pick a tighter pass or the distinction has stopped being reachable"
+    )

--- a/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_behaviour.py
@@ -408,6 +408,159 @@ def test_past_noise_at_zero_changes_nothing(monkeypatch):
     assert torch.equal(fut_off, fut_on)
 
 
+# ────────────────────── 6. smooth ego-history jitter ─────────────────────────
+
+
+def _straight_frame(batch: int):
+    """A straight +x polyline with its path frame, as ``__call__`` builds them."""
+    T = P_STEPS + F_STEPS
+    xy = torch.zeros(batch, T, 2)
+    xy[..., 0] = torch.arange(T, dtype=torch.float32) * EGO_V * DT
+    tan = torch.zeros(batch, T, 2)
+    tan[..., 0] = 1.0
+    nrm = torch.stack([-tan[..., 1], tan[..., 0]], dim=-1)
+    return xy, tan, nrm
+
+
+def _jitter_offset(batch: int, seed: int = 5, **kw):
+    aug = FrenetStatePerturbationTensor(1.0, "cpu", seed=seed, **kw)
+    xy, tan, nrm = _straight_frame(batch)
+    return aug._hist_jitter(xy, tan, nrm, P_STEPS), aug
+
+
+def test_hist_jitter_is_exactly_zero_at_t0():
+    """The current pose is what the model plans from; the history must not move it."""
+    off, aug = _jitter_offset(64, hist_jitter_lat=0.4)
+    # the basis itself, before any amplitude: every mode vanishes at u = 0
+    phi = aug._hist_jitter_basis(P_STEPS, torch.device("cpu"), torch.float32)
+    assert torch.equal(phi[:, -1], torch.zeros(phi.shape[0]))
+    # and so does the offset actually applied, exactly -- not "to within a tolerance"
+    assert torch.equal(off[:, P_STEPS - 1], torch.zeros(64, 2))
+    assert torch.equal(off[:, P_STEPS:], torch.zeros(64, F_STEPS, 2)), "the future moved"
+    assert float(off[:, 0].abs().max()) > 0.0, "nothing was jittered; the test proves nothing"
+
+
+def test_hist_jitter_std_at_the_oldest_sample_is_the_requested_one():
+    """The flag is defined as the std at the oldest sample: A = sigma / ||phi[:, 0]||."""
+    sigma = 0.35
+    n = 40000
+    off, _ = _jitter_offset(n, hist_jitter_lat=sigma)
+    emp = float(off[:, 0, 1].std())
+    # Monte-Carlo error on a std from n samples is ~ sigma / sqrt(2n) = 1.2e-3 here;
+    # 5% is many times that and still catches a wrong normalisation constant
+    # (sqrt(2) = 1.41 or K = 3 would both be off by tens of percent).
+    assert abs(emp - sigma) / sigma < 0.05, emp
+    assert abs(float(off[:, 0, 0].mean())) < 1e-2, "lateral jitter moved the path tangent"
+
+
+def test_hist_jitter_is_smooth_not_white():
+    """Independent per-sample noise is a jagged track a model learns to ignore."""
+    sigma = 0.3
+    off, _ = _jitter_offset(4000, hist_jitter_lat=sigma)
+    lat = off[:, :P_STEPS, 1]
+    d2 = lat[:, 2:] - 2 * lat[:, 1:-1] + lat[:, :-2]
+    # white noise of the same per-sample std has second-difference std sigma*sqrt(6)
+    white = float(sigma * (6.0**0.5))
+    assert float(d2.std()) < white / 20.0, (float(d2.std()), white)
+
+
+def _spacing_ratio(**kw):
+    """Mean along-path sample spacing of the jittered history, over the unjittered one."""
+    xy, _, _ = _straight_frame(4000)
+    off, _ = _jitter_offset(4000, **kw)
+    step0 = (xy[:, 1:P_STEPS] - xy[:, : P_STEPS - 1]).norm(dim=-1)
+    step1 = ((xy + off)[:, 1:P_STEPS] - (xy + off)[:, : P_STEPS - 1]).norm(dim=-1)
+    return abs(float(step1.std() / step0.mean()))
+
+
+def test_lateral_jitter_leaves_the_along_path_spacing_alone():
+    """Bending the track sideways must not smuggle in a speed perturbation."""
+    xy, _, _ = _straight_frame(4000)
+    off, _ = _jitter_offset(4000, hist_jitter_lat=0.3)
+    step0 = (xy[:, 1:P_STEPS] - xy[:, : P_STEPS - 1]).norm(dim=-1)
+    step1 = ((xy + off)[:, 1:P_STEPS] - (xy + off)[:, : P_STEPS - 1]).norm(dim=-1)
+    # a purely lateral bend only lengthens the step at second order in the bend angle
+    assert abs(float(step1.mean() / step0.mean()) - 1.0) < 0.01
+
+
+def test_longitudinal_jitter_is_what_moves_the_spacing():
+    """The point of the second axis: the implied speed history wobbles."""
+    lat_only = _spacing_ratio(hist_jitter_lat=0.3, hist_jitter_lon=0.0)
+    lon_only = _spacing_ratio(hist_jitter_lat=0.0, hist_jitter_lon=0.3)
+    assert lat_only < 0.01, lat_only
+    assert lon_only > 20 * lat_only, (lon_only, lat_only)
+
+
+def test_longitudinal_jitter_std_at_the_oldest_sample_is_the_requested_one():
+    sigma = 0.35
+    off, _ = _jitter_offset(40000, hist_jitter_lon=sigma)
+    assert abs(float(off[:, 0, 0].std()) - sigma) / sigma < 0.05
+    assert float(off[:, 0, 1].abs().max()) == 0.0, "longitudinal jitter moved the path normal"
+    assert torch.equal(off[:, P_STEPS - 1], torch.zeros(40000, 2)), "t=0 moved"
+
+
+def test_the_two_axes_are_drawn_independently():
+    """A lateral-only run must not have its wobble mirrored along the path."""
+    off, _ = _jitter_offset(20000, hist_jitter_lat=0.3, hist_jitter_lon=0.3)
+    lon, lat = off[:, 0, 0], off[:, 0, 1]
+    corr = float((lon * lat).mean() / (lon.std() * lat.std()))
+    assert abs(corr) < 0.05, corr
+
+
+def test_hist_jitter_headings_match_the_perturbed_polyline():
+    """The jitter runs after the veto, so the stored cos/sin are re-derived from it."""
+    aug = FrenetStatePerturbationTensor(1.0, "cpu", seed=13, hist_jitter_lat=0.3)
+    inputs, _ = _run(aug, batch=8)
+    rows = aug._aug_rows
+    assert bool(rows.any()), "nothing was augmented; the test proves nothing"
+    past = inputs["ego_agent_past"][rows]
+    # interior history samples: ddt is a central difference there, and the batch-wide
+    # re-centering is rigid, so the stored heading must be the polyline's own direction
+    g = past[:, 2:, :2] - past[:, :-2, :2]
+    stored = torch.atan2(past[:, 1:-1, 3], past[:, 1:-1, 2])
+    assert torch.allclose(torch.atan2(g[..., 1], g[..., 0]), stored, atol=1e-4)
+    # and the jitter really did bend it away from the straight recording
+    assert float(stored.abs().max()) > 1e-3
+
+
+def _normal_spy(monkeypatch):
+    """Record the shape of every torch.normal drawn from here on."""
+    shapes = []
+    real = torch.normal
+
+    def spy(*args, **kwargs):
+        shapes.append(kwargs.get("size"))
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "normal", spy)
+    return shapes
+
+
+def test_hist_jitter_at_zero_changes_nothing(monkeypatch):
+    shapes = _normal_spy(monkeypatch)
+    off = FrenetStatePerturbationTensor(1.0, "cpu", seed=7)
+    in_off, fut_off = _run(off, batch=8, pad_steps=3)
+    shapes_off, _ = list(shapes), shapes.clear()
+
+    explicit = FrenetStatePerturbationTensor(
+        1.0, "cpu", seed=7, hist_jitter_lat=0.0, hist_jitter_lon=0.0
+    )
+    in_on, fut_on = _run(explicit, batch=8, pad_steps=3)
+
+    assert shapes_off == list(shapes), "the off value changed how much randomness is drawn"
+    assert torch.equal(off.gen.get_state(), explicit.gen.get_state())
+    assert torch.equal(in_off["ego_agent_past"], in_on["ego_agent_past"])
+    assert torch.equal(in_off["ego_current_state"], in_on["ego_current_state"])
+    assert torch.equal(fut_off, fut_on)
+
+
+def test_hist_jitter_refuses_a_negative_std():
+    with pytest.raises(ValueError, match="hist_jitter_lat"):
+        FrenetStatePerturbationTensor(1.0, "cpu", hist_jitter_lat=-0.1)
+    with pytest.raises(ValueError, match="hist_jitter_lon"):
+        FrenetStatePerturbationTensor(1.0, "cpu", hist_jitter_lon=-0.1)
+
+
 # ───────────────────── layout robustness (3-col / 4-col) ─────────────────────
 
 
@@ -443,14 +596,17 @@ def test_a_3col_history_and_4col_future_are_accepted():
     assert torch.allclose(in_alt["goal_pose"], in_ref["goal_pose"], atol=1e-5)
 
 
-# ────────────── 6. the history perturbation is input-only, post-veto ──────────
+# ────────────── 7. both perturbations are input-only, post-veto ───────────────
 #
-# The property that makes an A/B on the history perturbation valid: it is applied to the
-# ACCEPTED history and nothing else, so it cannot move which scenes are augmented, cannot
-# move the training target, and cannot move the pose the model plans from.
+# The property that makes an A/B between the two history perturbations valid: they are
+# applied to the ACCEPTED history and nothing else, so they cannot move which scenes are
+# augmented, cannot move the training target, and cannot move the pose the model plans
+# from. Everything below is parametrised over both of them for exactly that reason.
 
 _PERTURBATIONS = [
     pytest.param({"ego_past_noise_std": 0.2}, id="multiplicative"),
+    pytest.param({"hist_jitter_lat": 0.3}, id="jitter_lat"),
+    pytest.param({"hist_jitter_lat": 0.3, "hist_jitter_lon": 0.3}, id="jitter_lat_lon"),
 ]
 
 
@@ -522,7 +678,7 @@ def test_stored_history_headings_describe_the_perturbed_track(kw):
     assert torch.allclose(torch.atan2(g[..., 1], g[..., 0]), stored, atol=1e-4)
 
 
-# ──────────────── 7. the toward-parked fallback and the floor mask ────────────────
+# ──────────────── 8. the toward-parked fallback and the floor mask ────────────────
 # Regression cover for the three fixes in a00a98588 / a3a77f888 / 74609f900. The
 # defect they answer was silent: the augmenter kept working and simply stopped
 # augmenting the scene family the flag exists for.

--- a/diffusion_planner/tests/test_frenet_augmenter_factory.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_factory.py
@@ -41,6 +41,8 @@ def _args(**over):
         frenet_seed=0,
         frenet_ranked_temp_s=1.0,
         frenet_recovery_rounds=0,
+        frenet_toward_parked_prob=0.0,
+        frenet_min_clearance=0.0,
     )
     base.update(over)
     return SimpleNamespace(**base)
@@ -141,3 +143,25 @@ def test_factory_refuses_an_unknown_augment_type():
 
     with pytest.raises(ValueError, match="unknown augment_type"):
         augmenter_from_args(_args(use_data_augment=True, augment_type="nope"))
+
+
+def test_toward_parked_and_min_clearance_default_off():
+    aug = frenet_augmenter_from_args(_args())
+    assert aug.toward_parked_prob == 0.0 and aug.min_clearance == 0.0
+
+
+def test_toward_parked_and_min_clearance_reach_the_augmenter():
+    aug = frenet_augmenter_from_args(
+        _args(frenet_toward_parked_prob="0.3", frenet_min_clearance="0.2")
+    )
+    assert aug.toward_parked_prob == 0.3 and aug.min_clearance == 0.2
+
+
+def test_toward_parked_prob_outside_unit_interval_is_refused():
+    with pytest.raises(ValueError, match="toward_parked_prob"):
+        FrenetStatePerturbationTensor(augment_prob=1.0, device="cpu", toward_parked_prob=1.5)
+
+
+def test_negative_min_clearance_is_refused():
+    with pytest.raises(ValueError, match="min_clearance"):
+        FrenetStatePerturbationTensor(augment_prob=1.0, device="cpu", min_clearance=-0.1)

--- a/diffusion_planner/tests/test_frenet_augmenter_factory.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_factory.py
@@ -44,6 +44,7 @@ def _args(**over):
         frenet_toward_parked_prob=0.0,
         frenet_min_clearance=0.0,
         ego_past_noise_std=0.0,
+        frenet_hist_jitter_lat=0.0,
     )
     base.update(over)
     return SimpleNamespace(**base)
@@ -178,6 +179,12 @@ def test_frenet_reads_the_shared_ego_past_noise_std():
     aug = frenet_augmenter_from_args(_args(ego_past_noise_std="0.0"))
     assert aug.past_noise_std == 0.0
     assert aug._ego_past_noise_std == 0.0, "the recorded history must never be scaled"
+
+
+def test_hist_jitter_defaults_off_and_reaches_the_augmenter():
+    assert frenet_augmenter_from_args(_args()).hist_jitter_lat == 0.0
+    aug = frenet_augmenter_from_args(_args(frenet_hist_jitter_lat="0.25"))
+    assert aug.hist_jitter_lat == 0.25
 
 
 def test_negative_past_noise_std_is_refused():

--- a/diffusion_planner/tests/test_frenet_augmenter_factory.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_factory.py
@@ -9,9 +9,19 @@ import ast
 import pathlib
 from types import SimpleNamespace
 
-from diffusion_planner.utils.data_augmentation_frenet import frenet_augmenter_from_args
+import pytest
+from diffusion_planner.utils.data_augmentation_frenet import (
+    FrenetStatePerturbationTensor,
+    frenet_augmenter_from_args,
+)
 
 REPO = pathlib.Path(__file__).resolve().parents[2]
+# constructing any of these in an entrypoint is how a knob gets silently dropped
+DIRECT_CONSTRUCTORS = {
+    "FrenetStatePerturbationTensor",
+    "BridgeStatePerturbation",
+    "StatePerturbation",
+}
 ENTRYPOINTS = (
     REPO / "diffusion_planner" / "diffusion_planner" / "train.py",
     REPO / "diffusion_planner" / "train_grpo_predictor.py",
@@ -30,6 +40,7 @@ def _args(**over):
         frenet_acc0_fracs=[0.0, -0.5, 0.5, -1.0, 1.0],
         frenet_seed=0,
         frenet_ranked_temp_s=1.0,
+        frenet_recovery_rounds=0,
     )
     base.update(over)
     return SimpleNamespace(**base)
@@ -70,6 +81,63 @@ def test_no_entrypoint_constructs_the_augmenter_directly():
             for n in ast.walk(tree)
             if isinstance(n, ast.Call)
             and isinstance(n.func, ast.Name)
-            and n.func.id == "FrenetStatePerturbationTensor"
+            and n.func.id in DIRECT_CONSTRUCTORS
         ]
         assert not direct, f"{path.name} constructs the augmenter directly; use the factory"
+
+
+def test_recovery_rounds_defaults_to_off():
+    """A vetoed scene falls back to plain GT unless recovery is explicitly asked for."""
+    assert frenet_augmenter_from_args(_args()).recovery_rounds == 0
+
+
+def test_recovery_rounds_reaches_the_augmenter():
+    aug = frenet_augmenter_from_args(_args(frenet_recovery_rounds=2))
+    assert aug.recovery_rounds == 2
+
+
+def test_recovery_rounds_from_argparse_string_is_coerced():
+    assert frenet_augmenter_from_args(_args(frenet_recovery_rounds="3")).recovery_rounds == 3
+
+
+def test_negative_recovery_rounds_is_refused():
+    with pytest.raises(ValueError, match="recovery_rounds"):
+        FrenetStatePerturbationTensor(augment_prob=1.0, device="cpu", recovery_rounds=-1)
+
+
+def test_factory_dispatches_every_augment_type():
+    from diffusion_planner.utils.augmenter_factory import AUGMENT_TYPES, augmenter_from_args
+    from diffusion_planner.utils.data_augmentation import StatePerturbation
+    from diffusion_planner.utils.data_augmentation_bridge import (
+        StatePerturbation as BridgeStatePerturbation,
+    )
+
+    def full(**over):
+        return _args(
+            use_data_augment=True,
+            num_refine=20,
+            ego_past_noise_std=0.1,
+            use_smoothing_future_trajectory=False,
+            **over,
+        )
+
+    assert set(AUGMENT_TYPES) == {"quintic", "bridge", "frenet"}
+    got = {t: augmenter_from_args(full(augment_type=t)) for t in AUGMENT_TYPES}
+    assert isinstance(got["frenet"], FrenetStatePerturbationTensor)
+    assert isinstance(got["bridge"], BridgeStatePerturbation)
+    assert type(got["quintic"]) is StatePerturbation
+
+
+def test_factory_returns_none_when_augmentation_is_off():
+    from diffusion_planner.utils.augmenter_factory import augmenter_from_args
+
+    assert augmenter_from_args(_args(use_data_augment=False, augment_type="frenet")) is None
+
+
+def test_factory_refuses_an_unknown_augment_type():
+    """The ladder this replaced fell through to quintic; a silent substitution is worse
+    than an error for a caller that asked for something else."""
+    from diffusion_planner.utils.augmenter_factory import augmenter_from_args
+
+    with pytest.raises(ValueError, match="unknown augment_type"):
+        augmenter_from_args(_args(use_data_augment=True, augment_type="nope"))

--- a/diffusion_planner/tests/test_frenet_augmenter_factory.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_factory.py
@@ -215,3 +215,37 @@ def test_seed_and_past_noise_std_are_real_command_line_flags():
     )
     assert over.seed == 1234
     assert over.ego_past_noise_std == 0.0
+
+
+def test_every_arg_the_factory_reads_exists_on_the_real_config():
+    """Every ``args.<name>`` the augmenter factories read must be a real TrainConfig field.
+
+    The other tests here build a SimpleNamespace and hand-supply the attributes, so a
+    field deleted from TrainConfig still "passes" while every real training crashes at
+    startup with AttributeError. That happened: `frenet_recovery_rounds` was removed by
+    an edit to a neighbouring field and nothing caught it until a training was launched.
+    This reads the attribute names straight out of the source and checks them against
+    the dataclass, so the two cannot drift again.
+    """
+    import ast
+    import re
+    from dataclasses import fields
+    from pathlib import Path
+
+    from diffusion_planner.config.train_config import TrainConfig
+
+    declared = {f.name for f in fields(TrainConfig)}
+    root = Path(__file__).resolve().parents[1] / "diffusion_planner" / "utils"
+    read: set[str] = set()
+    for src in ("data_augmentation_frenet.py", "augmenter_factory.py"):
+        tree = ast.parse((root / src).read_text())
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Attribute)
+                and isinstance(node.value, ast.Name)
+                and node.value.id == "args"
+            ):
+                read.add(node.attr)
+    assert read, "found no args.* reads — the AST walk is broken, not the config"
+    missing = sorted(read - declared)
+    assert not missing, f"read from args but not declared on TrainConfig: {missing}"

--- a/diffusion_planner/tests/test_frenet_augmenter_factory.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_factory.py
@@ -43,6 +43,7 @@ def _args(**over):
         frenet_recovery_rounds=0,
         frenet_toward_parked_prob=0.0,
         frenet_min_clearance=0.0,
+        frenet_past_noise_std=0.0,
     )
     base.update(over)
     return SimpleNamespace(**base)
@@ -165,3 +166,16 @@ def test_toward_parked_prob_outside_unit_interval_is_refused():
 def test_negative_min_clearance_is_refused():
     with pytest.raises(ValueError, match="min_clearance"):
         FrenetStatePerturbationTensor(augment_prob=1.0, device="cpu", min_clearance=-0.1)
+
+
+def test_past_noise_std_defaults_to_off_and_reaches_the_augmenter():
+    """The base class is handed 0.0 unconditionally; this knob is the frenet one."""
+    assert frenet_augmenter_from_args(_args()).past_noise_std == 0.0
+    aug = frenet_augmenter_from_args(_args(frenet_past_noise_std="0.1"))
+    assert aug.past_noise_std == 0.1
+    assert aug._ego_past_noise_std == 0.0, "the recorded history must never be scaled"
+
+
+def test_negative_past_noise_std_is_refused():
+    with pytest.raises(ValueError, match="past_noise_std"):
+        FrenetStatePerturbationTensor(augment_prob=1.0, device="cpu", past_noise_std=-0.1)

--- a/diffusion_planner/tests/test_frenet_augmenter_factory.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_factory.py
@@ -183,3 +183,24 @@ def test_frenet_reads_the_shared_ego_past_noise_std():
 def test_negative_past_noise_std_is_refused():
     with pytest.raises(ValueError, match="past_noise_std"):
         FrenetStatePerturbationTensor(augment_prob=1.0, device="cpu", ego_past_noise_std=-0.1)
+
+
+def test_seed_and_past_noise_std_are_real_command_line_flags():
+    """Both were plain dataclass fields, so the parser rejected them outright.
+
+    The A/B they are needed for cannot run without them: ``--ego_past_noise_std 0`` is
+    the no-history-noise control, and ``--seed`` is the only way to measure the
+    run-to-run noise floor of an otherwise deterministic training.
+    """
+    from diffusion_planner.config import TrainConfig, build_config, build_parser
+
+    parser = build_parser(TrainConfig, description="t")
+    base = build_config(TrainConfig, parser.parse_args([]))
+    assert (base.seed, base.ego_past_noise_std) == (3407, 0.1), "a default moved"
+    assert (base.lr_schedule, base.augment_type) == ("constant", "quintic"), "a default moved"
+
+    over = build_config(
+        TrainConfig, parser.parse_args(["--seed", "1234", "--ego_past_noise_std", "0.0"])
+    )
+    assert over.seed == 1234
+    assert over.ego_past_noise_std == 0.0

--- a/diffusion_planner/tests/test_frenet_augmenter_factory.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_factory.py
@@ -43,7 +43,7 @@ def _args(**over):
         frenet_recovery_rounds=0,
         frenet_toward_parked_prob=0.0,
         frenet_min_clearance=0.0,
-        frenet_past_noise_std=0.0,
+        ego_past_noise_std=0.0,
     )
     base.update(over)
     return SimpleNamespace(**base)
@@ -168,14 +168,18 @@ def test_negative_min_clearance_is_refused():
         FrenetStatePerturbationTensor(augment_prob=1.0, device="cpu", min_clearance=-0.1)
 
 
-def test_past_noise_std_defaults_to_off_and_reaches_the_augmenter():
-    """The base class is handed 0.0 unconditionally; this knob is the frenet one."""
-    assert frenet_augmenter_from_args(_args()).past_noise_std == 0.0
-    aug = frenet_augmenter_from_args(_args(frenet_past_noise_std="0.1"))
-    assert aug.past_noise_std == 0.1
+def test_frenet_reads_the_shared_ego_past_noise_std():
+    """Frenet honours the same flag as quintic -- there is no separate frenet knob.
+
+    The base class is still handed 0.0: it would scale the RECORDED history, which
+    frenet discards. The value reaches frenet's own scaling of the rewritten history.
+    """
+    assert frenet_augmenter_from_args(_args(ego_past_noise_std="0.1")).past_noise_std == 0.1
+    aug = frenet_augmenter_from_args(_args(ego_past_noise_std="0.0"))
+    assert aug.past_noise_std == 0.0
     assert aug._ego_past_noise_std == 0.0, "the recorded history must never be scaled"
 
 
 def test_negative_past_noise_std_is_refused():
     with pytest.raises(ValueError, match="past_noise_std"):
-        FrenetStatePerturbationTensor(augment_prob=1.0, device="cpu", past_noise_std=-0.1)
+        FrenetStatePerturbationTensor(augment_prob=1.0, device="cpu", ego_past_noise_std=-0.1)

--- a/diffusion_planner/tests/test_frenet_augmenter_factory.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_factory.py
@@ -45,6 +45,7 @@ def _args(**over):
         frenet_min_clearance=0.0,
         ego_past_noise_std=0.0,
         frenet_hist_jitter_lat=0.0,
+        frenet_hist_jitter_lon=0.0,
     )
     base.update(over)
     return SimpleNamespace(**base)
@@ -182,9 +183,12 @@ def test_frenet_reads_the_shared_ego_past_noise_std():
 
 
 def test_hist_jitter_defaults_off_and_reaches_the_augmenter():
-    assert frenet_augmenter_from_args(_args()).hist_jitter_lat == 0.0
-    aug = frenet_augmenter_from_args(_args(frenet_hist_jitter_lat="0.25"))
-    assert aug.hist_jitter_lat == 0.25
+    plain = frenet_augmenter_from_args(_args())
+    assert plain.hist_jitter_lat == 0.0 and plain.hist_jitter_lon == 0.0
+    aug = frenet_augmenter_from_args(
+        _args(frenet_hist_jitter_lat="0.25", frenet_hist_jitter_lon="0.1")
+    )
+    assert aug.hist_jitter_lat == 0.25 and aug.hist_jitter_lon == 0.1
 
 
 def test_negative_past_noise_std_is_refused():

--- a/diffusion_planner/tests/test_frenet_augmenter_factory.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_factory.py
@@ -380,18 +380,41 @@ def test_an_explicit_zero_is_recorded_as_zero_not_as_unset():
     assert args.ego_past_noise_std == 0.0
 
 
-def test_resolving_twice_changes_nothing():
-    """The factory calls the resolver defensively, so it runs twice in a real run."""
+@pytest.mark.parametrize(
+    "augment_type,expected", [("quintic", 0.1), ("frenet", 0.1), ("bridge", None)]
+)
+def test_resolving_twice_changes_nothing(augment_type, expected):
+    """The factory calls the resolver defensively, so it runs twice in a real run.
+
+    Covers BRIDGE, which is the case that broke: resolving an omitted bridge value to
+    0.0 made the second call mistake it for an explicitly supplied unsupported flag and
+    raise, so every ordinary bridge run failed. An unset bridge value stays None.
+    """
     from diffusion_planner.utils.augment_defaults import resolve_history_noise
 
-    args = _resolved_config("--augment_type", "quintic")
+    args = _resolved_config("--augment_type", augment_type)
     resolve_history_noise(args)
     resolve_history_noise(args)
-    assert args.ego_past_noise_std == 0.1
+    assert args.ego_past_noise_std == expected
+
+
+@pytest.mark.parametrize("augment_type", ["quintic", "frenet", "bridge"])
+def test_the_exact_production_ordering_builds_an_augmenter(augment_type):
+    """resolve -> serialize -> factory (which resolves again) -> build, for all three.
+
+    The ordering a real trainer uses. Asserting only "it builds" is the point: this is
+    the path that raised for bridge.
+    """
+    from diffusion_planner.utils.augmenter_factory import augmenter_from_args
+
+    args = _resolved_config("--augment_type", augment_type)
+    assert augmenter_from_args(args) is not None
 
 
 def test_bridge_still_rejects_the_flag_at_resolve_time():
     """The rejection moved to the resolver; it must not have been lost in the move."""
     with pytest.raises(ValueError, match="not supported by augment_type=bridge"):
         _resolved_config("--augment_type", "bridge", "--ego_past_noise_std", "0.4")
-    assert _resolved_config("--augment_type", "bridge").ego_past_noise_std == 0.0
+    # an unset bridge value stays None: the knob does not apply to bridge, and writing a
+    # number here is what made the resolver's second call reject every bridge run
+    assert _resolved_config("--augment_type", "bridge").ego_past_noise_std is None

--- a/diffusion_planner/tests/test_frenet_augmenter_factory.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_factory.py
@@ -219,11 +219,19 @@ def test_seed_and_past_noise_std_are_real_command_line_flags():
     # reaches a training, and that is what silently moved once already.
     from diffusion_planner.utils.augment_defaults import past_noise_std_for
 
-    for augment_type, expected in (("quintic", 0.1), ("frenet", 0.1), ("bridge", 0.0)):
+    for augment_type, expected in (("quintic", 0.1), ("frenet", 0.1)):
         resolved = past_noise_std_for(
             build_config(TrainConfig, parser.parse_args(["--augment_type", augment_type]))
         )
         assert resolved == expected, f"{augment_type} history noise moved to {resolved}"
+
+    # bridge has no entry on purpose: resolve_history_noise returns before resolving for
+    # it, so reaching this lookup means a caller bypassed the resolver, and that caller
+    # should get a KeyError rather than a silent 0.0 for a knob bridge cannot honour.
+    with pytest.raises(KeyError):
+        past_noise_std_for(
+            build_config(TrainConfig, parser.parse_args(["--augment_type", "bridge"]))
+        )
 
     over = build_config(
         TrainConfig, parser.parse_args(["--seed", "1234", "--ego_past_noise_std", "0.0"])

--- a/diffusion_planner/tests/test_frenet_augmenter_factory.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_factory.py
@@ -46,11 +46,15 @@ def _args(**over):
         ego_past_noise_std=0.0,
         ego_past_noise_mode="scale",
         use_data_augment=True,
+        # the builder resolves the effective value itself, which needs these two
+        augment_type="frenet",
     )
     base.update(over)
-    # resolve_history_noise normally writes this before anything reads it; these
-    # namespace stand-ins bypass the trainers, so mirror the flag unless overridden.
-    base.setdefault("ego_past_noise_std_effective", base["ego_past_noise_std"])
+    # Deliberately NOT pre-populating ego_past_noise_std_effective. Doing so hid a
+    # regression where the builder read that field unresolved and raised TypeError on
+    # any freshly parsed config; the builder resolves for itself, so the stand-in must
+    # arrive unresolved exactly as a real parsed config does.
+    base.setdefault("use_data_augment", True)
     return SimpleNamespace(**base)
 
 
@@ -438,3 +442,38 @@ def test_bridge_still_rejects_the_flag_at_resolve_time():
     # an unset bridge value stays None: the knob does not apply to bridge, and writing a
     # number here is what made the resolver's second call reject every bridge run
     assert _resolved_config("--augment_type", "bridge").ego_past_noise_std_effective is None
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--augment_type", "frenet"],
+        ["--augment_type", "frenet", "--ego_past_noise_std", "0.3"],
+        [
+            "--augment_type",
+            "frenet",
+            "--ego_past_noise_std",
+            "0.3",
+            "--ego_past_noise_mode",
+            "jitter",
+        ],
+    ],
+)
+def test_the_direct_builder_works_on_a_freshly_parsed_config(argv):
+    """frenet_augmenter_from_args is a public entrypoint, not only reached via the factory.
+
+    It briefly read `ego_past_noise_std_effective` -- which is None until something
+    resolves it -- and so raised TypeError on any parsed config, even one carrying an
+    explicit --ego_past_noise_std. Nothing caught it because the namespace fixture in
+    this file pre-populated that field; it no longer does.
+    """
+    from diffusion_planner.config.config_cli import build_config, build_parser
+    from diffusion_planner.config.train_config import TrainConfig
+    from diffusion_planner.utils.data_augmentation_frenet import frenet_augmenter_from_args
+
+    args = build_config(TrainConfig, build_parser(TrainConfig).parse_args(argv))
+    args.device = "cpu"
+    aug = frenet_augmenter_from_args(args)  # no separate resolve step
+    assert aug.past_noise_std is not None
+    if "--ego_past_noise_std" in argv:
+        assert aug.past_noise_std == float(argv[argv.index("--ego_past_noise_std") + 1])

--- a/diffusion_planner/tests/test_frenet_augmenter_factory.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_factory.py
@@ -44,7 +44,7 @@ def _args(**over):
         frenet_toward_parked_prob=0.0,
         frenet_min_clearance=0.0,
         ego_past_noise_std=0.0,
-        frenet_hist_jitter_lat=0.0,
+        ego_past_noise_mode="scale",
     )
     base.update(over)
     return SimpleNamespace(**base)
@@ -183,11 +183,17 @@ def test_frenet_reads_the_shared_ego_past_noise_std():
     assert aug._ego_past_noise_std == 0.0, "the recorded history must never be scaled"
 
 
-def test_hist_jitter_defaults_off_and_reaches_the_augmenter():
+def test_the_noise_mode_defaults_to_scale_and_reaches_the_augmenter():
+    """One magnitude, one mode. The two mechanisms are mutually exclusive."""
     plain = frenet_augmenter_from_args(_args())
-    assert plain.hist_jitter_lat == 0.0
-    aug = frenet_augmenter_from_args(_args(frenet_hist_jitter_lat="0.25"))
-    assert aug.hist_jitter_lat == 0.25
+    assert plain.past_noise_mode == "scale"
+    jit = frenet_augmenter_from_args(_args(ego_past_noise_mode="jitter", ego_past_noise_std="0.3"))
+    assert jit.past_noise_mode == "jitter" and jit.past_noise_std == 0.3
+
+
+def test_an_unknown_noise_mode_is_refused():
+    with pytest.raises(ValueError, match="ego_past_noise_mode"):
+        frenet_augmenter_from_args(_args(ego_past_noise_mode="wobble"))
 
 
 def test_negative_past_noise_std_is_refused():

--- a/diffusion_planner/tests/test_frenet_augmenter_factory.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_factory.py
@@ -45,8 +45,12 @@ def _args(**over):
         frenet_min_clearance=0.0,
         ego_past_noise_std=0.0,
         ego_past_noise_mode="scale",
+        use_data_augment=True,
     )
     base.update(over)
+    # resolve_history_noise normally writes this before anything reads it; these
+    # namespace stand-ins bypass the trainers, so mirror the flag unless overridden.
+    base.setdefault("ego_past_noise_std_effective", base["ego_past_noise_std"])
     return SimpleNamespace(**base)
 
 
@@ -370,12 +374,14 @@ def test_saved_config_equals_applied_config(augment_type):
     from diffusion_planner.utils.augmenter_factory import augmenter_from_args
 
     args = _resolved_config("--augment_type", augment_type)
-    saved = json.loads(json.dumps({"ego_past_noise_std": args.ego_past_noise_std}))
+    saved = json.loads(
+        json.dumps({"ego_past_noise_std_effective": args.ego_past_noise_std_effective})
+    )
     applied = _past_noise(augmenter_from_args(args))
 
-    assert saved["ego_past_noise_std"] is not None, "args.json would record null"
-    assert saved["ego_past_noise_std"] == applied, (
-        f"{augment_type}: args.json records {saved['ego_past_noise_std']} "
+    assert saved["ego_past_noise_std_effective"] is not None, "args.json would record null"
+    assert saved["ego_past_noise_std_effective"] == applied, (
+        f"{augment_type}: args.json records {saved['ego_past_noise_std_effective']} "
         f"but the augmenter trains with {applied}"
     )
 
@@ -385,13 +391,13 @@ def test_the_resolved_value_survives_a_json_round_trip():
     import json
 
     args = _resolved_config("--augment_type", "frenet")
-    assert json.loads(json.dumps(args.ego_past_noise_std)) == 0.1
+    assert json.loads(json.dumps(args.ego_past_noise_std_effective)) == 0.1
 
 
 def test_an_explicit_zero_is_recorded_as_zero_not_as_unset():
     """The reproducibility escape hatch has to be visible in the saved config."""
     args = _resolved_config("--augment_type", "frenet", "--ego_past_noise_std", "0")
-    assert args.ego_past_noise_std == 0.0
+    assert args.ego_past_noise_std_effective == 0.0
 
 
 @pytest.mark.parametrize(
@@ -409,7 +415,7 @@ def test_resolving_twice_changes_nothing(augment_type, expected):
     args = _resolved_config("--augment_type", augment_type)
     resolve_history_noise(args)
     resolve_history_noise(args)
-    assert args.ego_past_noise_std == expected
+    assert args.ego_past_noise_std_effective == expected
 
 
 @pytest.mark.parametrize("augment_type", ["quintic", "frenet", "bridge"])
@@ -431,4 +437,4 @@ def test_bridge_still_rejects_the_flag_at_resolve_time():
         _resolved_config("--augment_type", "bridge", "--ego_past_noise_std", "0.4")
     # an unset bridge value stays None: the knob does not apply to bridge, and writing a
     # number here is what made the resolver's second call reject every bridge run
-    assert _resolved_config("--augment_type", "bridge").ego_past_noise_std is None
+    assert _resolved_config("--augment_type", "bridge").ego_past_noise_std_effective is None

--- a/diffusion_planner/tests/test_frenet_augmenter_factory.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_factory.py
@@ -270,11 +270,20 @@ def test_every_arg_the_factory_reads_exists_on_the_real_config():
 
 
 def _from_cli(*argv):
+    """Build an augmenter the way a training does: real parser, real config, real factory.
+
+    ``device`` is forced to CPU afterwards. ``TrainConfig.device`` defaults to "cuda", so
+    without this the augmenter's constructor raises ``RuntimeError: No CUDA GPUs are
+    available`` on a CPU-only host and these tests never reach their assertions. The
+    device is not what is under test here -- the flag resolution is -- and every other
+    test in this file constructs on CPU for the same reason.
+    """
     from diffusion_planner.config.config_cli import build_config, build_parser
     from diffusion_planner.config.train_config import TrainConfig
     from diffusion_planner.utils.augmenter_factory import augmenter_from_args
 
     args = build_config(TrainConfig, build_parser(TrainConfig).parse_args(list(argv)))
+    args.device = "cpu"
     return augmenter_from_args(args)
 
 

--- a/diffusion_planner/tests/test_frenet_augmenter_factory.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_factory.py
@@ -44,6 +44,8 @@ def _args(**over):
         frenet_toward_parked_prob=0.0,
         frenet_min_clearance=0.0,
         ego_past_noise_std=0.0,
+        frenet_hist_jitter_lat=0.0,
+        frenet_hist_jitter_lon=0.0,
     )
     base.update(over)
     return SimpleNamespace(**base)
@@ -180,6 +182,15 @@ def test_frenet_reads_the_shared_ego_past_noise_std():
     aug = frenet_augmenter_from_args(_args(ego_past_noise_std="0.0"))
     assert aug.past_noise_std == 0.0
     assert aug._ego_past_noise_std == 0.0, "the recorded history must never be scaled"
+
+
+def test_hist_jitter_defaults_off_and_reaches_the_augmenter():
+    plain = frenet_augmenter_from_args(_args())
+    assert plain.hist_jitter_lat == 0.0 and plain.hist_jitter_lon == 0.0
+    aug = frenet_augmenter_from_args(
+        _args(frenet_hist_jitter_lat="0.25", frenet_hist_jitter_lon="0.1")
+    )
+    assert aug.hist_jitter_lat == 0.25 and aug.hist_jitter_lon == 0.1
 
 
 def test_negative_past_noise_std_is_refused():

--- a/diffusion_planner/tests/test_frenet_augmenter_factory.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_factory.py
@@ -44,8 +44,6 @@ def _args(**over):
         frenet_toward_parked_prob=0.0,
         frenet_min_clearance=0.0,
         ego_past_noise_std=0.0,
-        frenet_hist_jitter_lat=0.0,
-        frenet_hist_jitter_lon=0.0,
     )
     base.update(over)
     return SimpleNamespace(**base)
@@ -182,15 +180,6 @@ def test_frenet_reads_the_shared_ego_past_noise_std():
     aug = frenet_augmenter_from_args(_args(ego_past_noise_std="0.0"))
     assert aug.past_noise_std == 0.0
     assert aug._ego_past_noise_std == 0.0, "the recorded history must never be scaled"
-
-
-def test_hist_jitter_defaults_off_and_reaches_the_augmenter():
-    plain = frenet_augmenter_from_args(_args())
-    assert plain.hist_jitter_lat == 0.0 and plain.hist_jitter_lon == 0.0
-    aug = frenet_augmenter_from_args(
-        _args(frenet_hist_jitter_lat="0.25", frenet_hist_jitter_lon="0.1")
-    )
-    assert aug.hist_jitter_lat == 0.25 and aug.hist_jitter_lon == 0.1
 
 
 def test_negative_past_noise_std_is_refused():

--- a/diffusion_planner/tests/test_frenet_augmenter_factory.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_factory.py
@@ -227,7 +227,7 @@ def test_seed_and_past_noise_std_are_real_command_line_flags():
     # reaches a training, and that is what silently moved once already.
     from diffusion_planner.utils.augment_defaults import past_noise_std_for
 
-    for augment_type, expected in (("quintic", 0.1), ("frenet", 0.1)):
+    for augment_type, expected in (("quintic", 0.1), ("frenet", 0.0)):
         resolved = past_noise_std_for(
             build_config(TrainConfig, parser.parse_args(["--augment_type", augment_type]))
         )
@@ -313,20 +313,22 @@ def _past_noise(aug):
     return getattr(aug, "past_noise_std", getattr(aug, "_ego_past_noise_std", None))
 
 
-def test_frenet_defaults_to_the_same_history_noise_as_quintic():
-    """A DELIBERATE default change: tier4-main hard-passed 0.0 to the frenet augmenter.
+def test_frenet_does_not_inherit_quintics_history_noise():
+    """Frenet is 0.0, as on tier4-main, so a stock frenet run is unchanged by this branch.
 
-    Pinned here because it is the one thing on this branch that alters a stock run --
-    reproducing a pre-branch frenet checkpoint needs `--ego_past_noise_std 0`. Measured
-    as neither helping nor hurting (inside the seed spread on an 8-arm A/B); it is on
-    for flag uniformity, not for a measured gain.
+    The two defaults diverge deliberately: quintic scales a RECORDED history, frenet one
+    it rewrote kinematically from the perturbed polyline. This is the assertion that
+    keeps a shared flag name from quietly merging the two recipes -- it did exactly that
+    once, which left existing frenet checkpoints unreproducible at their own seed.
+    Measured either way: 0.1 sat inside the seed spread on an 8-arm A/B, so nothing is
+    given up by defaulting it off.
     """
-    assert _past_noise(_from_cli("--augment_type", "frenet")) == 0.1
+    assert _past_noise(_from_cli("--augment_type", "frenet")) == 0.0
 
 
-def test_frenet_history_noise_can_still_be_turned_off():
-    """The escape hatch the reproducibility note points at."""
-    assert _past_noise(_from_cli("--augment_type", "frenet", "--ego_past_noise_std", "0")) == 0.0
+def test_frenet_history_noise_is_still_reachable():
+    """Off by default is not gone: the knob still applies to frenet when asked for."""
+    assert _past_noise(_from_cli("--augment_type", "frenet", "--ego_past_noise_std", "0.1")) == 0.1
 
 
 def test_quintic_keeps_the_history_noise_it_has_always_had():
@@ -394,18 +396,18 @@ def test_the_resolved_value_survives_a_json_round_trip():
     """A reader of args.json must get the effective number, not a sentinel."""
     import json
 
-    args = _resolved_config("--augment_type", "frenet")
+    args = _resolved_config("--augment_type", "quintic")
     assert json.loads(json.dumps(args.ego_past_noise_std_effective)) == 0.1
 
 
 def test_an_explicit_zero_is_recorded_as_zero_not_as_unset():
-    """The reproducibility escape hatch has to be visible in the saved config."""
-    args = _resolved_config("--augment_type", "frenet", "--ego_past_noise_std", "0")
+    """A deliberate 0 must be distinguishable in the saved config from an unset flag."""
+    args = _resolved_config("--augment_type", "quintic", "--ego_past_noise_std", "0")
     assert args.ego_past_noise_std_effective == 0.0
 
 
 @pytest.mark.parametrize(
-    "augment_type,expected", [("quintic", 0.1), ("frenet", 0.1), ("bridge", None)]
+    "augment_type,expected", [("quintic", 0.1), ("frenet", 0.0), ("bridge", None)]
 )
 def test_resolving_twice_changes_nothing(augment_type, expected):
     """The factory calls the resolver defensively, so it runs twice in a real run.

--- a/diffusion_planner/tests/test_frenet_augmenter_factory.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_factory.py
@@ -327,3 +327,71 @@ def test_bridge_refuses_a_flag_it_cannot_honour():
 
 def test_bridge_is_fine_without_the_flag():
     assert _from_cli("--augment_type", "bridge") is not None
+
+
+# ───────── the SAVED configuration must be the configuration APPLIED ─────────
+#
+# Both trainers write args.json before they build the augmenter, so a sentinel default
+# that only resolves inside the factory is recorded as null while the run trains with a
+# number. That makes the saved experiment configuration inaccurate and its meaning
+# dependent on a future code default rather than on the file.
+
+
+def _resolved_config(*argv):
+    from diffusion_planner.config.config_cli import build_config, build_parser
+    from diffusion_planner.config.train_config import TrainConfig
+    from diffusion_planner.utils.augment_defaults import resolve_history_noise
+
+    args = build_config(TrainConfig, build_parser(TrainConfig).parse_args(list(argv)))
+    args.device = "cpu"
+    resolve_history_noise(args)  # what the trainers call before serializing
+    return args
+
+
+@pytest.mark.parametrize("augment_type", ["frenet", "quintic"])
+def test_saved_config_equals_applied_config(augment_type):
+    """Serialize the way the trainers do, then build the augmenter, and compare."""
+    import json
+
+    from diffusion_planner.utils.augmenter_factory import augmenter_from_args
+
+    args = _resolved_config("--augment_type", augment_type)
+    saved = json.loads(json.dumps({"ego_past_noise_std": args.ego_past_noise_std}))
+    applied = _past_noise(augmenter_from_args(args))
+
+    assert saved["ego_past_noise_std"] is not None, "args.json would record null"
+    assert saved["ego_past_noise_std"] == applied, (
+        f"{augment_type}: args.json records {saved['ego_past_noise_std']} "
+        f"but the augmenter trains with {applied}"
+    )
+
+
+def test_the_resolved_value_survives_a_json_round_trip():
+    """A reader of args.json must get the effective number, not a sentinel."""
+    import json
+
+    args = _resolved_config("--augment_type", "frenet")
+    assert json.loads(json.dumps(args.ego_past_noise_std)) == 0.1
+
+
+def test_an_explicit_zero_is_recorded_as_zero_not_as_unset():
+    """The reproducibility escape hatch has to be visible in the saved config."""
+    args = _resolved_config("--augment_type", "frenet", "--ego_past_noise_std", "0")
+    assert args.ego_past_noise_std == 0.0
+
+
+def test_resolving_twice_changes_nothing():
+    """The factory calls the resolver defensively, so it runs twice in a real run."""
+    from diffusion_planner.utils.augment_defaults import resolve_history_noise
+
+    args = _resolved_config("--augment_type", "quintic")
+    resolve_history_noise(args)
+    resolve_history_noise(args)
+    assert args.ego_past_noise_std == 0.1
+
+
+def test_bridge_still_rejects_the_flag_at_resolve_time():
+    """The rejection moved to the resolver; it must not have been lost in the move."""
+    with pytest.raises(ValueError, match="not supported by augment_type=bridge"):
+        _resolved_config("--augment_type", "bridge", "--ego_past_noise_std", "0.4")
+    assert _resolved_config("--augment_type", "bridge").ego_past_noise_std == 0.0

--- a/diffusion_planner/tests/test_frenet_augmenter_factory.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_factory.py
@@ -45,7 +45,6 @@ def _args(**over):
         frenet_min_clearance=0.0,
         ego_past_noise_std=0.0,
         frenet_hist_jitter_lat=0.0,
-        frenet_hist_jitter_lon=0.0,
     )
     base.update(over)
     return SimpleNamespace(**base)
@@ -186,11 +185,9 @@ def test_frenet_reads_the_shared_ego_past_noise_std():
 
 def test_hist_jitter_defaults_off_and_reaches_the_augmenter():
     plain = frenet_augmenter_from_args(_args())
-    assert plain.hist_jitter_lat == 0.0 and plain.hist_jitter_lon == 0.0
-    aug = frenet_augmenter_from_args(
-        _args(frenet_hist_jitter_lat="0.25", frenet_hist_jitter_lon="0.1")
-    )
-    assert aug.hist_jitter_lat == 0.25 and aug.hist_jitter_lon == 0.1
+    assert plain.hist_jitter_lat == 0.0
+    aug = frenet_augmenter_from_args(_args(frenet_hist_jitter_lat="0.25"))
+    assert aug.hist_jitter_lat == 0.25
 
 
 def test_negative_past_noise_std_is_refused():

--- a/diffusion_planner/tests/test_frenet_augmenter_factory.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_factory.py
@@ -118,10 +118,12 @@ def test_factory_dispatches_every_augment_type():
     )
 
     def full(**over):
+        # ego_past_noise_std unset: bridge rejects it outright and the other two resolve
+        # it per augmenter, so None is the only value valid for all three.
         return _args(
             use_data_augment=True,
             num_refine=20,
-            ego_past_noise_std=0.1,
+            ego_past_noise_std=None,
             use_smoothing_future_trajectory=False,
             **over,
         )
@@ -207,8 +209,18 @@ def test_seed_and_past_noise_std_are_real_command_line_flags():
 
     parser = build_parser(TrainConfig, description="t")
     base = build_config(TrainConfig, parser.parse_args([]))
-    assert (base.seed, base.ego_past_noise_std) == (3407, 0.1), "a default moved"
+    assert (base.seed, base.ego_past_noise_std) == (3407, None), "a default moved"
     assert (base.lr_schedule, base.augment_type) == ("constant", "quintic"), "a default moved"
+
+    # The sentinel is only half the contract; what it RESOLVES to is the thing that
+    # reaches a training, and that is what silently moved once already.
+    from diffusion_planner.utils.augment_defaults import past_noise_std_for
+
+    for augment_type, expected in (("quintic", 0.1), ("frenet", 0.0), ("bridge", 0.0)):
+        resolved = past_noise_std_for(
+            build_config(TrainConfig, parser.parse_args(["--augment_type", augment_type]))
+        )
+        assert resolved == expected, f"{augment_type} history noise moved to {resolved}"
 
     over = build_config(
         TrainConfig, parser.parse_args(["--seed", "1234", "--ego_past_noise_std", "0.0"])
@@ -249,3 +261,53 @@ def test_every_arg_the_factory_reads_exists_on_the_real_config():
     assert read, "found no args.* reads — the AST walk is broken, not the config"
     missing = sorted(read - declared)
     assert not missing, f"read from args but not declared on TrainConfig: {missing}"
+
+
+# ─────────── the CLI default is the one that ships; test THAT, not the class ───────────
+#
+# Every behavioural test builds the augmenter directly, where the class default for the
+# history noise is 0.0. The value a training actually gets comes from the parser, and the
+# two diverged once already: the flag was threaded to frenet and picked up quintic's 0.1,
+# silently changing the frenet recipe and leaving existing frenet checkpoints
+# unreproducible at their own seed. These go through the real parser for that reason.
+
+
+def _from_cli(*argv):
+    from diffusion_planner.config.config_cli import build_config, build_parser
+    from diffusion_planner.config.train_config import TrainConfig
+    from diffusion_planner.utils.augmenter_factory import augmenter_from_args
+
+    args = build_config(TrainConfig, build_parser(TrainConfig).parse_args(list(argv)))
+    return augmenter_from_args(args)
+
+
+def _past_noise(aug):
+    return getattr(aug, "past_noise_std", getattr(aug, "_ego_past_noise_std", None))
+
+
+def test_frenet_perturbs_no_history_unless_asked():
+    """Frenet rewrites the history kinematically; it hard-coded 0.0 before the flag
+    existed, and inheriting quintic's 0.1 would change every frenet run."""
+    assert _past_noise(_from_cli("--augment_type", "frenet")) == 0.0
+
+
+def test_quintic_keeps_the_history_noise_it_has_always_had():
+    assert _past_noise(_from_cli("--augment_type", "quintic")) == 0.1
+
+
+@pytest.mark.parametrize("augment_type,value", [("frenet", 0.1), ("quintic", 0.0)])
+def test_an_explicit_flag_wins_for_either_augmenter(augment_type, value):
+    """The per-augmenter default must not make the flag un-sweepable."""
+    aug = _from_cli("--augment_type", augment_type, "--ego_past_noise_std", str(value))
+    assert _past_noise(aug) == value
+
+
+def test_bridge_refuses_a_flag_it_cannot_honour():
+    """Accepting it would record a value in args.json that the run never applied --
+    the exact recorded-config-is-not-used-config defect the factory exists to stop."""
+    with pytest.raises(ValueError, match="not supported by augment_type=bridge"):
+        _from_cli("--augment_type", "bridge", "--ego_past_noise_std", "0.4")
+
+
+def test_bridge_is_fine_without_the_flag():
+    assert _from_cli("--augment_type", "bridge") is not None

--- a/diffusion_planner/tests/test_frenet_augmenter_factory.py
+++ b/diffusion_planner/tests/test_frenet_augmenter_factory.py
@@ -213,7 +213,7 @@ def test_seed_and_past_noise_std_are_real_command_line_flags():
     # reaches a training, and that is what silently moved once already.
     from diffusion_planner.utils.augment_defaults import past_noise_std_for
 
-    for augment_type, expected in (("quintic", 0.1), ("frenet", 0.0), ("bridge", 0.0)):
+    for augment_type, expected in (("quintic", 0.1), ("frenet", 0.1), ("bridge", 0.0)):
         resolved = past_noise_std_for(
             build_config(TrainConfig, parser.parse_args(["--augment_type", augment_type]))
         )
@@ -291,17 +291,27 @@ def _past_noise(aug):
     return getattr(aug, "past_noise_std", getattr(aug, "_ego_past_noise_std", None))
 
 
-def test_frenet_perturbs_no_history_unless_asked():
-    """Frenet rewrites the history kinematically; it hard-coded 0.0 before the flag
-    existed, and inheriting quintic's 0.1 would change every frenet run."""
-    assert _past_noise(_from_cli("--augment_type", "frenet")) == 0.0
+def test_frenet_defaults_to_the_same_history_noise_as_quintic():
+    """A DELIBERATE default change: tier4-main hard-passed 0.0 to the frenet augmenter.
+
+    Pinned here because it is the one thing on this branch that alters a stock run --
+    reproducing a pre-branch frenet checkpoint needs `--ego_past_noise_std 0`. Measured
+    as neither helping nor hurting (inside the seed spread on an 8-arm A/B); it is on
+    for flag uniformity, not for a measured gain.
+    """
+    assert _past_noise(_from_cli("--augment_type", "frenet")) == 0.1
+
+
+def test_frenet_history_noise_can_still_be_turned_off():
+    """The escape hatch the reproducibility note points at."""
+    assert _past_noise(_from_cli("--augment_type", "frenet", "--ego_past_noise_std", "0")) == 0.0
 
 
 def test_quintic_keeps_the_history_noise_it_has_always_had():
     assert _past_noise(_from_cli("--augment_type", "quintic")) == 0.1
 
 
-@pytest.mark.parametrize("augment_type,value", [("frenet", 0.1), ("quintic", 0.0)])
+@pytest.mark.parametrize("augment_type,value", [("frenet", 0.3), ("quintic", 0.0)])
 def test_an_explicit_flag_wins_for_either_augmenter(augment_type, value):
     """The per-augmenter default must not make the flag un-sweepable."""
     aug = _from_cli("--augment_type", augment_type, "--ego_past_noise_std", str(value))

--- a/diffusion_planner/train_grpo_predictor.py
+++ b/diffusion_planner/train_grpo_predictor.py
@@ -18,11 +18,7 @@ from diffusion_planner.grpo_epoch import train_grpo_epoch
 from diffusion_planner.model.diffusion_planner import Diffusion_Planner
 from diffusion_planner.train import closed_loop_validate
 from diffusion_planner.utils import ddp
-from diffusion_planner.utils.data_augmentation import StatePerturbation
-from diffusion_planner.utils.data_augmentation_bridge import (
-    StatePerturbation as BridgeStatePerturbation,
-)
-from diffusion_planner.utils.data_augmentation_frenet import frenet_augmenter_from_args
+from diffusion_planner.utils.augmenter_factory import augmenter_from_args
 from diffusion_planner.utils.dataset import DiffusionPlannerData
 from diffusion_planner.utils.lr_schedule import CosineAnnealingWarmUpRestarts
 from diffusion_planner.utils.neighbor_db import NeighborPatternDB
@@ -116,23 +112,9 @@ def model_training(args):
     if global_rank == 0 and args.w_kinematic > 0.0:
         print(f"Kinematic-feasibility reward enabled: w_kinematic={args.w_kinematic}")
 
-    if args.use_data_augment:
-        if args.augment_type == "bridge":
-            aug = BridgeStatePerturbation(augment_prob=args.augment_prob, device=args.device)
-        elif args.augment_type == "frenet":
-            aug = frenet_augmenter_from_args(args)
-        else:
-            aug = StatePerturbation(
-                augment_prob=args.augment_prob,
-                num_refine=args.num_refine,
-                device=args.device,
-                ego_past_noise_std=args.ego_past_noise_std,
-                use_smoothing_future_trajectory=args.use_smoothing_future_trajectory,
-            )
-        if global_rank == 0:
-            print(f"Data augmentation enabled: type={args.augment_type} prob={args.augment_prob}")
-    else:
-        aug = None
+    aug = augmenter_from_args(args)
+    if aug is not None and global_rank == 0:
+        print(f"Data augmentation enabled: type={args.augment_type} prob={args.augment_prob}")
 
     train_set = DiffusionPlannerData(args.train_set_list)
     valid_set = DiffusionPlannerData(args.valid_set_list)

--- a/diffusion_planner/train_grpo_predictor.py
+++ b/diffusion_planner/train_grpo_predictor.py
@@ -18,6 +18,7 @@ from diffusion_planner.grpo_epoch import train_grpo_epoch
 from diffusion_planner.model.diffusion_planner import Diffusion_Planner
 from diffusion_planner.train import closed_loop_validate
 from diffusion_planner.utils import ddp
+from diffusion_planner.utils.augment_defaults import resolve_history_noise
 from diffusion_planner.utils.augmenter_factory import augmenter_from_args
 from diffusion_planner.utils.dataset import DiffusionPlannerData
 from diffusion_planner.utils.lr_schedule import CosineAnnealingWarmUpRestarts
@@ -54,6 +55,11 @@ def model_training(args):
     print(f"{global_rank=}, {rank=}")
 
     save_path = args.save_dir
+    # Resolve the per-augmenter history-noise default BEFORE args.json is written, so
+    # the saved configuration is the configuration used. Every rank, because the value
+    # feeds the augmenter each rank builds; rank 0 alone serializes it.
+    resolve_history_noise(args)
+
     if global_rank == 0:
         print("------------- {} -------------".format(args.exp_name))
         print("Scenes per step (batch_size): {}".format(args.batch_size))

--- a/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
+++ b/rlvr/autoresearch/tools/run_lifelong_r2lpl_rounds.py
@@ -2405,6 +2405,7 @@ def _base_train_invocation(
         "augment_type",
         "num_refine",
         "ego_past_noise_std",
+        "ego_past_noise_mode",
         "use_smoothing_future_trajectory",
         "use_data_augment",
         "seed",

--- a/rlvr/autoresearch/tools/viz_det_compare.py
+++ b/rlvr/autoresearch/tools/viz_det_compare.py
@@ -267,7 +267,8 @@ def main():
 
             gt_np = None
             if args.show_gt:
-                _gt = np.load(sp, allow_pickle=True)["ego_agent_future"]
+                with np.load(sp, allow_pickle=True) as _npz:
+                    _gt = _npz["ego_agent_future"]
                 # Legacy 3-col [x, y, heading] futures must be widened to the
                 # canonical [x, y, cos, sin] that draw_traj indexes.
                 gt_np = future_to_4col(

--- a/rlvr/autoresearch/tools/viz_det_compare.py
+++ b/rlvr/autoresearch/tools/viz_det_compare.py
@@ -30,6 +30,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import torch
 
+from planner_metrics.scene_format import future_to_4col
 from preference_optimization.utils import load_npz_data
 from rlvr.autoresearch.tools.eval_det_avoidance import (
     aggregate_stats,
@@ -267,7 +268,11 @@ def main():
             gt_np = None
             if args.show_gt:
                 _gt = np.load(sp, allow_pickle=True)["ego_agent_future"]
-                gt_np = _gt[:, :4] if _gt.shape[-1] >= 4 else _gt
+                # Legacy 3-col [x, y, heading] futures must be widened to the
+                # canonical [x, y, cos, sin] that draw_traj indexes.
+                gt_np = future_to_4col(
+                    _gt[:, :4] if _gt.shape[-1] > 4 else _gt, zero_rows_are_padding=False
+                )
             cached_gt.append(gt_np)
 
             if args.no_viz:


### PR DESCRIPTION
Opt-in options for the frenet corridor augmentation, plus the general-factory follow-up agreed in #373's review.

## No default changes

With every flag at its default the augmenter is byte-identical to `tier4-main` for **all three** `augment_type` values, through the path a training actually takes (`build_parser` → `build_config` → `augmenter_from_args`):

| augment_type | arrays differing | worst \|base − head\| |
|---|---|---|
| `quintic` | 0 / 144 | 0.000e+00 |
| `bridge` | 0 / 144 | 0.000e+00 |
| `frenet` | 0 / 144 | 0.000e+00 |

432 arrays over `ego_agent_past`, `ego_current_state` and `goal_pose`, three types × two seeds × 24 batches, base tree archived from `origin/tier4-main` and run in a separate process.

`--ego_past_noise_std` resolves per augmenter — 0.1 for quintic, **0.0 for frenet**, both matching main. They differ deliberately: quintic scales a history the recorder observed, while frenet has already rewritten the past kinematically from the perturbed polyline, so the same factor would perturb a history frenet synthesised rather than one it saw. That is the reason main hard-passes 0.0 there (`data_augmentation_frenet.py:122`), and this branch keeps it.

An earlier revision of this branch defaulted frenet to 0.1 for flag uniformity. That was measured as harmless (§7) but bought nothing, so it is reverted — uniformity across a shared flag *name* is the weaker argument when the two augmenters are not doing the same thing to the same data. `--ego_past_noise_std 0.1` still enables it.

<details>
<summary><b>What changed since the review rounds</b> (this body previously carried claims that were wrong)</summary>

Corrected here, all verified:

- **The frenet history-noise default is back to main's `0.0`,** so the branch now changes no default at all. It briefly inherited quintic's `0.1` silently, then deliberately with a warning; it is now off, because the A/B in §7 showed nothing to gain and main's asymmetry is well-founded.
- **The "0 of 2,297 eligible" toward-parked figures were an artifact of a broken probe** and are withdrawn. The probe popped `neighbor_agents_future` out of the batch, but `_corridor` reads neighbours from `inputs`, so every neighbour rule — the veto and the parked detector alike — was silently disabled and reported inert. Re-measured with the tensor left in place: **242 eligible rows** on this dataset (~10.5%, consistent with the 10.4% on the large corpus), 6 rows vetoed at defaults and 11 with the floor at 0.2.
- **`--frenet_min_clearance` is not a global floor.** It applies only at the timesteps the perturbation moved the ego. The previously quoted "realised global minimum clearance" figures are withdrawn: they described behaviour the code no longer has, and a global floor rejected scenes for the *recording's* own clearance.
- **The byte-identity proof was invalid and is now valid.** It used to construct `FrenetStatePerturbationTensor` directly, whose constructor default differs from the CLI default — so it measured a path no training takes. It now goes through the parser and factory, and a regression test pins the resolved value per augmenter.
- **The longitudinal history jitter was measured and deleted**, and the surviving lateral one is now a *mode* of `--ego_past_noise_std` rather than its own magnitude flag (§5), so the untested scale+jitter combination is unreachable.
- **The history perturbation no longer perturbs the augmentation itself** (see §6).
</details>

---

## 1. `--frenet_recovery_rounds N` — retry after an exact-OBB veto

Default `0` (today's behaviour). A candidate vetoed for truly overlapping a recorded neighbour drops its scene to plain ground truth. That is a lost row, but more importantly a **selection bias**: the overlap check runs after selection, so scenes whose first feasible draw happens to overlap are silently excluded.

Each round burns the losing **draw**, not its shape — the other 39 shapes of a draw carry the same lateral offset and overlap the same neighbour. On 105k scenes, retrying the shape recovers 1 of 13 vetoed rows; retrying the draw recovers 11 of 14.

105,093 scenes, 3 seeds, denominator the 69,006 above the 2 m/s gate:

| rounds | accepted | delta |
|---|---|---|
| 0 | 97.11% | — |
| **1** | **97.46%** | **+0.35** |
| 2 | 97.51% | +0.05 |
| 3 | 97.52% | +0.01 |

Round 1 recovers ~54% of vetoed rows; survivors are blocked geometrically and re-rolling does not move geometry, so **1 is the operating point**. Cost 0.95 ms/batch amortised against a 9.9 ms augmenter, with ~0.6% of rows entering the loop.

## 2. `--frenet_min_clearance C` — a floor only where the perturbation moved the ego

Default `0.0` (overlap-only, today's behaviour). Requires `C` metres of exact signed-OBB clearance from every recorded neighbour, on top of the corridor margin, **at the timesteps the candidate actually left the recording**.

It is deliberately **not** global. A candidate coincides with the recorded drive outside its merge window, so a floor over the whole horizon rejects scenes for the recording's own clearance — measured: 8/8 zero-displacement candidates rejected at `min_clearance=2.0` with 1.7 m of real clearance. That deletes exactly the tight-squeeze scenes the augmentation is most valuable on. True overlap is rejected everywhere regardless, so a candidate can be accepted while passing closer than `C` at a timestep where it is bit-identical to ground truth. Applies to the vehicle cut only, never the road edge.

Clearance comes from `planner_metrics.subscores.compute_ego_neighbor_signed_clearance` (exact signed OBB↔OBB, ego rear-axle, neighbours centroid) — the floor is a margin *on top of* an exact check, not a substitute for one.

## 3. `--frenet_toward_parked_prob P` — aim the nudge at a parked vehicle

Default `0.0`. The corridor is symmetric, so a scene threading past a parked vehicle is as likely to be nudged away from it as toward it. `P` directs that fraction of eligible rows at the vehicle, making the t=0 state a harder avoidance than the recording while the merge still rejoins in time to clear it.

On 105k scenes: 10,958 rows eligible (10.4%). Largest-feasible offset makes t=0 harder than the recording in 90.0% of them vs 73.6% for first-feasible; rows whose merge lands after the vehicle go 2,402 → 0; accepted rows 10,330 → 9,742.

**Two things to know before enabling it.**

The aggregate −6% hides a very uneven cost. On the tight passes the flag exists to serve, pointing every offset at the vehicle means most candidates are then rejected by the exact footprint check. Measured on one stationary vehicle 25 m ahead at 1.8 m lateral, 128 draws: **91 rows accepted with the flag off, 8 with it on.** A fallback (below) is what keeps that from being 0; nothing recovers the rest, because a 2.0 m ego does not fit a 1.8 m gap. Use `P` as a small fraction, not a global setting.

The merge gate can strike out every horizon on such a pass, which would drop the scene from augmentation entirely — the option deleting its own target. So the gate is applied only where it leaves something; elsewhere the row keeps its ungated candidates and is recorded as **not hardened**, and the recovery path in §1 keys on that same hardened set so a fallback row cannot be retried under a rule it was not selected under.

Also: only 19.3% of eligible rows show a real ground-truth avoidance (ego ≥ 0.5 m off the vehicle's side). The rest are ordinary passes the nudge converts *into* an avoidance.

## 4. `--ego_past_noise_std` — now resolved per augmenter

One flag, three behaviours, because the augmenters do not perturb the same thing:

| augmenter | default | what the factor scales |
|---|---|---|
| `quintic` | 0.1 (unchanged) | the RECORDED history, and current velocity/acceleration with it |
| `frenet` | **0.0**, as on main — it already rewrites the past kinematically | the history it rewrote from the perturbed polyline; `ego_current_state` left bit-identical |
| `bridge` | n/a | no history perturbation; passing the flag **raises** rather than being ignored |

Passing a number applies it to whichever augmenter is selected, so the flag stays sweepable. A `quintic`-vs-`frenet` A/B on it is not measuring the same perturbation, since quintic also rescales the current velocity and acceleration.

Bridge raising rather than ignoring is deliberate: accepting a flag, recording it in the run's `args.json` and applying nothing is the recorded-config-is-not-used-config defect this factory exists to prevent.

**Measured, and it did not earn a non-zero default.** See §7.

## 5. `--ego_past_noise_mode` — which mechanism the magnitude drives

One magnitude (`--ego_past_noise_std`), one selector, **mutually exclusive** — exactly one runs:

| mode | what it does | units of the std | bounded? |
|---|---|---|---|
| `scale` (default) | one factor multiplies the whole rewritten history: the track keeps its shape and is traversed at the wrong speed | dimensionless, `N(1, std)` | yes, ±2σ |
| `jitter` | a smooth lateral bend, so the track's *shape* is wrong; three low-frequency modes, exactly zero at t=0 | **metres** at the oldest sample | **no** |

**Why a mode and not a second magnitude flag.** There used to be `--frenet_hist_jitter_lat`, independent of `--ego_past_noise_std`. Both could be set, and because quintic's scale default is non-zero, **asking for jitter alone could silently apply both** — a combination that has never been evaluated, since every jitter arm of the A/B pinned the scale to 0 (§7). The mode makes that unreachable. Verified exclusive: at std 0.3, `scale` gives a 6.96 m max history deviation and `jitter` 0.55 m, and the two outputs are not equal.

`jitter` is implemented for **frenet only**; quintic and bridge raise rather than accept and ignore it.

**The std means different things per mode.** `0.1` is ±10% of a traversal speed under `scale` and 0.1 m of displacement under `jitter`. The A/B tested **0.3 m** for jitter, so that is the value to pass.

**The jitter is unclamped**, unlike the scale. Measured over 200k draws at std 0.3: 31.7% of draws exceed the std, 4.5% exceed twice it, maximum seen 1.379 m. And it is applied after the footprint check with t=0 pinned, so the target and planning pose are unchanged — but **the bent history is not re-checked against the footprint constraint**, so on a drive that passed a parked vehicle closely the resulting history can place the ego footprint inside that vehicle in the past. Keep the magnitude small relative to the clearances in the data.

**There is no longitudinal counterpart.** One existed and was deleted on measurement (§7).

## 6. The history perturbation no longer disturbs the augmentation

Found while removing the longitudinal axis, and the more important half of that change.

Both history perturbations drew from `self.gen`, the same generator as the corridor offset and merge draws, and both consume a **data-dependent** number of values (one factor per accepted row for the scale, one coefficient block per axis for the jitter). So enabling either advanced the generator by an amount that depended on it being enabled, every later batch's corridor draws shifted, and the augmenter **accepted a different set of scenes**.

16 batches of 32, seed 0, against the same run with the perturbation off:

| arm | batches with a different accepted set | accepted rows |
|---|---|---|
| control (off) | — | 116 |
| `ego_past_noise_std=0.1` | 6/16 | 118 |
| jitter mode, std 0.3 | 6/16 | 110 |

Divergence began at batch 2 and reached 6.3 m of ego-history displacement — not perturbation amplitude, which is sub-metre, but different scenes augmented at different offsets (`dy_max` is 2.0 m, compounded through the history rewrite).

The perturbations now draw from a separate `hist_gen`. After: **0/16 batches differ, 116 accepted rows in every arm**, training target bit-identical to the unperturbed run.

The existing test asserted this property and passed, because it compares a single batch — and within one batch the ordering does hold, since the perturbation runs after the veto. The leak was across batches, through the shared stream.

## 7. Closed-loop A/B of the history perturbations

8 arms (4 recipes × 2 seeds), 200 epochs, cosine-annealed, on the pipeline-test set. Scored on perturbed recovery, ~1,113 rollouts per arm per cell, complete rows only, EMA weights, under both trackers at replan intervals 1 and 3.

Arm means over the two seeds, `recovered% / lost%`:

| arm | perfect/r1 | mpc/r1 | perfect/r3 | mpc/r3 |
|---|---|---|---|---|
| control (no perturbation) | 28.3 / 20.3 | 31.3 / 18.3 | 52.7 / **7.7** | 53.0 / **7.4** |
| `ego_past_noise_std 0.1` | 30.2 / 19.8 | 34.8 / 18.1 | 52.2 / 8.0 | 52.8 / 8.0 |
| jitter mode, std 0.3 | 25.5 / 17.3 | 33.1 / 23.0 | **53.5** / 8.4 | **54.5** / 8.1 |
| + longitudinal jitter 0.3 *(deleted)* | 21.0 / 27.4 | 30.5 / 24.1 | 47.2 / 10.6 | 48.4 / 10.0 |

Read the replan-3 cells: the seed spread on `lost%` there is 0.5–3.5 points, against 6–16 at replan 1, so those are the only cells with the resolution to separate arms. (At replan 1 the control's own two seeds differ by **17.2 points** on `recovered%` — larger than every arm-to-arm difference in the campaign.) The two trackers agree to within 1.2 points on every arm, so the tracker is not a lever here.

**Outcomes:**

- **Longitudinal jitter deleted.** Worst arm in all four cells on both metrics.
- **Lateral jitter kept, reachable only via `--ego_past_noise_mode jitter`.** Best arm on recovery in both resolved cells, and the smallest seed spread of any arm (7.2/7.1 on recovered%, 0.5/0.5 on lost%). Its `lost%` is 0.7 higher, inside the control's own spread.
- **Multiplicative noise stays off for frenet (0.0, as on main).** 28.3 → 30.2 on recovered% at replan 1 and 52.7 → 52.2 at replan 3 are both well inside the seed spread, so the A/B neither justifies nor forbids it — and with nothing measured to gain, the default that leaves a stock run byte-identical to main is the better one.

**Caveat that applies to all of it:** these arms were trained before §6, so each differed from the control by a different augmentation realisation as well as by its history perturbation. The verdict is unaffected — every arm sat inside the seed noise — but the runs are not bit-reproducible on this head, and the campaign measured "perturbation plus a different realisation".

### Re-run: landed, and it is a null result

An 11-arm re-run on this head: `INC`, `REC`, `FL` reproducing the original cumulative ladder for continuity, plus three **single-factor** arms so the flags can be attributed, and `TP`. 200 epochs, annealed (`--lr_schedule cosine`), same data and recipe throughout.

The original ladder cannot attribute anything, because `REC` changed three things at once against `INC`:

| | INC (default) | REC |
|---|---|---|
| `frenet_n_draws` | 16 | **40** |
| `frenet_acc0_fracs` | `[0.0, -0.5, 0.5, -1.0, 1.0]` | **`-0.5 0.5`** |
| `frenet_recovery_rounds` | 0 | **1** |

so `REC − INC` conflates the recovery retry with a redistributed sampling grid (16×5 = 80 shapes → 40×2 = 80, more offsets and fewer curvature shapes). Only `FL − REC` was ever clean. The added arms each change exactly one thing from `INC`:

| arm | flags | isolates |
|---|---|---|
| `GRID` | `--frenet_n_draws 40 --frenet_acc0_fracs -0.5 0.5` | the sampling grid alone |
| `RCV` | `--frenet_recovery_rounds 1` | §1 alone |
| `FLR` | `--frenet_min_clearance 0.2` | §2 alone |

All arms pin `--ego_past_noise_std 0`, which is also the shipped frenet default, so the ablation and a stock run perturb the history identically.

**Result — perturbed recovery at ep200 (EMA weights), `--replan_interval 3`, ~1,114 rollouts per arm across both routes:**

| arm | adds | lost% | recovered% |
|---|---|---|---|
| **INC** s3407 | incumbent | **8.3** | 60.6 |
| **INC** s1234 | incumbent | **9.6** | 57.9 |
| `GRID` s3407 | 40 draws, ±0.5 acc0 | 7.8 | 50.4 |
| `GRID` s1234 | " | 9.1 | 39.3 |
| `RCV` s3407 | `recovery_rounds 1` | 9.0 | 54.5 |
| `RCV` s1234 | " | 8.4 | 46.8 |
| `FLR` s3407 | `min_clearance 0.2` | 8.5 | 45.2 |
| `FLR` s1234 | " | 7.9 | 58.3 |
| `TP` s3407 ⚠ | `toward_parked_prob 1.0` | 8.1 | 50.2 |
| `REC` s3407 ⚠ | GRID+RCV | 9.8 | 58.0 |
| `FL` s3407 ⚠ | GRID+RCV+FLR | 9.6 | 44.5 |

**The noise floor on `lost%` is 0.6–1.3 points**, from four same-config seed pairs. Every arm lands in 7.8–9.8, and the incumbent's own two seeds (8.3 / 9.6) cover nearly the whole spread. **No flag moves recovery on this dataset**, which is why none of them changes a default.

Two limits on reading that table:

- **`recovered%` is not usable at this scale.** `GRID`'s two seeds differ by **19.3 points** on it while differing by 1.3 on `lost%`. The recovered/unsettled split is dominated by training luck even under the annealed schedule; only `lost%` has the resolution to separate arms.
- ⚠ **`TP`, `REC` and `FL` trained in a separate batch on a different node**, single seed. Cross-batch comparison is what carries a shared offset, so those three are *consistent with* the incumbent rather than measured against it.

`toward_parked_prob` **is** exercised here, contrary to an earlier claim in this body: eligibility on this dataset is **242 rows**, not zero (see the withdrawn figures above).

### Why the earlier A/B is not evidence

An earlier 9-arm A/B of `recovery_rounds` / `min_clearance` / `toward_parked_prob` found no arm beating the incumbent. **None of it is evidence about the current code**, for two independent reasons:

- Its floor arms ran before §2 made the floor per-timestep, so they measured the global-floor behaviour that no longer exists.
- Its toward-parked arm (arm D = arm C plus `toward_parked_prob 1.0`) was contaminated by **an RNG reseed on top of the nudge.** Enabling the flag used to take one extra column off the shared corridor draw, shifting every later draw: 4 of 72 batches accepted a different set, 1,824 rows against 1,822, while any row both arms accepted was augmented bit-identically. Arm D's 18.9 / 20.2 against arm C's 17.5 / 20.9 is therefore not attributable to the nudge. Fixed in `39214607b` (0 of 72 batches, 1,824 against 1,824), and the flag is re-measured as the `TP` arm above.

## 8. One augmenter factory

`frenet_augmenter_from_args` fixed the dropped-flag bug for one augmenter, but both entrypoints still carried the same `augment_type` ladder — the bug that made the GRPO path accept every `--frenet_*` flag and then train at the defaults. `augmenter_from_args(args)` is now the single place a config becomes an augmenter and owns the `use_data_augment` check, so each entrypoint is one line. An AST guard in the tests covers all three constructors, so a future direct construction in an entrypoint fails the suite.

**One deliberate behaviour change:** the ladder's `else` meant an unrecognised `augment_type` silently became quintic. The factory raises. The parser's `Literal` already constrains the flag, so this is only reachable programmatically, where a silent substitution is worse than an error.

## 9. A 3-col GT future crashed `viz_det_compare --show_gt`

Unrelated and small enough to ride along. `--show_gt` handed `ego_agent_future` to `draw_traj` unchanged below four columns, but `draw_traj` reads the heading as `traj[ts, 2:4]`, so a canonical 3-col `[x, y, heading]` future raised `IndexError`. Widened through `planner_metrics.scene_format.future_to_4col` rather than by hand; `zero_rows_are_padding=False` is deliberate, since this is a single-agent trajectory where `(0, 0)` is real data rather than an empty slot. 4-col output is bit-identical with dtype preserved.

## Evidence

**Default-path byte identity**, through `build_parser` → `build_config` → `augmenter_from_args`, 432 arrays, two seeds — see the table at the top of this body. All three augment types at `0.000e+00`.

**Positive control on the same harness**, so the identity result is not vacuous. Every flag is live on this dataset (2,297 scenes, 900 rows augmented at defaults):

| arm | rows augmented | vetoed by the exact OBB check | toward-parked eligible |
|---|---|---|---|
| defaults | 900 | 6 | — |
| `recovery_rounds 1` | 905 | 6 | — |
| `min_clearance 0.2` | 889 | 11 | — |
| `min_clearance 0.5` | 875 | 5 | — |
| `toward_parked_prob 1.0` | 900 | 6 | **242** |

Each moves the output in its expected direction: the retry recovers rows, the floor rejects them, and the nudge re-selects within the same count.

**Tests.** 87 pass in the two frenet suites, on CPU-only hosts as well as with a GPU. The 36 remaining failures in the wider suite are pre-existing `StatePerturbation.__init__` signature drifts, identical on the pristine `tier4-main` tree (32 in `test_data_augmentation.py`, 2 in `test_closed_loop_cli.py`, 2 in `test_closed_loop_args.py`); `test_cluster.py` cannot collect for want of `sklearn`. `ruff check` and `ruff format` clean.

**Cyclomatic complexity.** No PR-owned function above **B**. The three above B are pre-existing, and this PR *reduces* two of them:

| function | base | head |
|---|---|---|
| `train.py:model_training` | F (54) | F (51) |
| `train_grpo_predictor:model_training` | E (33) | E (31) |
| `viz_det_compare:main` | F (67) | F (67), untouched |

## What is not validated

Stated plainly, because "off by default" is not the same as "known good":

- **All three corridor flags are now measured on this dataset, and none of them helps** (the re-run above). That is why every one of them stays off by default. It is a null result at this scale, not a demonstration that the corridor does nothing — read it as "these do not earn a default change".
- **`--frenet_toward_parked_prob` has the weakest evidence of the three.** Its arm is single-seed and trained in a separate batch from the incumbent it would be compared against, so it is consistent with `INC` rather than measured against it.
- Both history-noise modes were A/B'd (§7) and neither beat the control, which is why `scale` now resolves to 0.0 for frenet. `jitter` is kept because it held its own — best arm on recovery in both resolved cells, smallest seed spread of any arm — and reaching it needs an explicit mode.
- Every closed-loop number in this body comes from a 2,297-scene pipeline-test set. The full dataset is ~5.4M scenes; acceptance rates and corridor behaviour differ at that scale, so none of these nulls should be read as settled for a full-size training.

## Not included

**Nested frenet config** (the remaining #373 follow-up). It needs nesting support in `config_cli`, which every trainer's config derives from, and wants a bit-identity proof of its own that bundling with a behavioural change would muddy. It should migrate the `frenet_*` fields and the bridge knobs together, in its own PR.






