### PR TITLE
fix(closed_loop): bind ONNX providers to the rank's CUDA device

### DIFF
--- a/scenario_generation/simulate.py
+++ b/scenario_generation/simulate.py
@@ -120,6 +120,13 @@ class _OnnxModel:
             else {}
             for p in providers
         ]
+        target = torch.device(device)
+        if target.type == "cuda" and any(p in _ACCELERATED for p in providers):
+            # ORT defaults to GPU 0 independently of torch.cuda.set_device() in each rank.
+            device_id = target.index if target.index is not None else torch.cuda.current_device()
+            for provider, option in zip(providers, options):
+                if provider in _ACCELERATED:
+                    option["device_id"] = device_id
         self.session = ort.InferenceSession(
             str(onnx_path), providers=providers, provider_options=options
         )

--- a/scenario_generation/tests/test_onnx_provider.py
+++ b/scenario_generation/tests/test_onnx_provider.py
@@ -9,13 +9,45 @@ import pytest
 
 from scenario_generation.simulate import CPU_EP, CUDA_EP, TENSORRT_EP, _require_accelerator
 
+# Distinct from every index the cases ask for, so a device_id off the wrong source shows up.
+_CURRENT_DEVICE = 2
+_TRT_CACHE = "/engines"
+_TRT_CACHE_OPTIONS = {
+    "trt_engine_cache_enable": True,
+    "trt_engine_cache_path": _TRT_CACHE,
+    "trt_timing_cache_enable": True,
+}
+
 
 class _Session:
-    def __init__(self, active):
-        self._active = active
+    """Stands in for ``ort.InferenceSession``, reporting the providers it was handed as active."""
+
+    def __init__(self, providers, provider_options=None):
+        self.providers = providers
+        self.provider_options = provider_options
 
     def get_providers(self):
-        return self._active
+        return self.providers
+
+    def get_inputs(self):
+        return []
+
+    def get_outputs(self):
+        return []
+
+
+def _open_session(monkeypatch, device, providers=None, **kwargs):
+    """Build an ``_OnnxModel`` against a fake onnxruntime and hand back the session it opened."""
+    import scenario_generation.simulate as simulate
+
+    def _factory(path, providers, provider_options):
+        return _Session(providers, provider_options)
+
+    monkeypatch.setattr(simulate.torch.cuda, "current_device", lambda: _CURRENT_DEVICE)
+    monkeypatch.setitem(
+        sys.modules, "onnxruntime", types.SimpleNamespace(InferenceSession=_factory)
+    )
+    return simulate._OnnxModel("m.onnx", device, providers, **kwargs).session
 
 
 def test_a_gpu_request_that_landed_on_cpu_raises():
@@ -46,52 +78,33 @@ def test_asking_for_cpu_is_not_a_failure():
 def test_the_default_does_not_reach_for_tensorrt(monkeypatch):
     """TensorRT partitions the graph up front and refuses ops it cannot build, so defaulting to
     it turns a model it dislikes into a session that never opens. It has to be asked for."""
-    seen = {}
-
-    class _Session:
-        def __init__(self, path, providers=None, provider_options=None):
-            seen["providers"] = providers
-
-        def get_providers(self):
-            return [CUDA_EP, CPU_EP]
-
-        def get_inputs(self):
-            return []
-
-        def get_outputs(self):
-            return []
-
-    import scenario_generation.simulate as simulate
-
-    monkeypatch.setitem(
-        sys.modules, "onnxruntime", types.SimpleNamespace(InferenceSession=_Session)
-    )
-    simulate._OnnxModel("m.onnx", "cuda")
-
-    assert seen["providers"] == [CUDA_EP, CPU_EP]
+    assert _open_session(monkeypatch, "cuda").providers == [CUDA_EP, CPU_EP]
 
 
 def test_asking_for_cpu_by_device_does_not_request_a_gpu_provider(monkeypatch):
-    seen = {}
+    assert _open_session(monkeypatch, "cpu").providers == [CPU_EP]
 
-    class _Session:
-        def __init__(self, path, providers=None, provider_options=None):
-            seen["providers"] = providers
 
-        def get_providers(self):
-            return [CPU_EP]
+@pytest.mark.parametrize(
+    "device,providers,expected",
+    [
+        # 0 is a real GPU, not "unset": it must not read as absent and fall back to the default.
+        ("cuda:0", [CUDA_EP, CPU_EP], {CUDA_EP: {"device_id": 0}, CPU_EP: {}}),
+        ("cuda", [CUDA_EP, CPU_EP], {CUDA_EP: {"device_id": _CURRENT_DEVICE}, CPU_EP: {}}),
+        (
+            "cuda:1",
+            [TENSORRT_EP, CUDA_EP, CPU_EP],
+            {
+                TENSORRT_EP: {"device_id": 1, **_TRT_CACHE_OPTIONS},
+                CUDA_EP: {"device_id": 1},
+                CPU_EP: {},
+            },
+        ),
+    ],
+)
+def test_gpu_providers_follow_requested_device(monkeypatch, device, providers, expected):
+    """ORT ignores torch.cuda.set_device() and defaults to GPU 0, so every rank of a distributed
+    run piles onto the first visible GPU unless the provider itself carries the index."""
+    session = _open_session(monkeypatch, device, providers, engine_cache_dir=_TRT_CACHE)
 
-        def get_inputs(self):
-            return []
-
-        def get_outputs(self):
-            return []
-
-    import scenario_generation.simulate as simulate
-
-    monkeypatch.setitem(
-        sys.modules, "onnxruntime", types.SimpleNamespace(InferenceSession=_Session)
-    )
-    simulate._OnnxModel("m.onnx", "cpu")
-
-    assert seen["providers"] == [CPU_EP]
+    assert dict(zip(session.providers, session.provider_options)) == expected


### PR DESCRIPTION
## Problem

ONNX Runtime takes no device from torch. The CLI selects `cuda:{local_rank}`, but every rank's ORT session opens on GPU 0.

Live CUDA contexts per pid, 4 ranks on 4 H100s, same node and same onnx, two arms differing only by the 7 lines below:

**Without the fix**

```
GPU  pid      mem
0    ...510   754 MiB   rank 0: torch + its own ORT session
0    ...511   658 MiB   rank 1's ORT session
0    ...512   658 MiB   rank 2's ORT session
0    ...513   658 MiB   rank 3's ORT session
1    ...511   618 MiB   rank 1: torch only
2    ...512   618 MiB   rank 2: torch only
3    ...513   618 MiB   rank 3: torch only
```

**With the fix**

```
GPU  pid      mem
0    ...324   754 MiB   rank 0
1    ...325   754 MiB   rank 1
2    ...326   754 MiB   rank 2
3    ...327   754 MiB   rank 3
```

Every non-zero rank held a second context on GPU 0 — its ORT session — while its own GPU carried only the torch context. GPU 0 served all four ranks while GPUs 1-3 sat in a collective-wait kernel: 0% memory bandwidth, ~120 W against a 700 W TDP.

## Effect on closed-loop lap

`run_all_groups_closed_loop.py` over 11 routes x 2 object modes, 4 ranks on one node, ONNX planner. Both arms ran back to back in one allocation on the same tree; only `scenario_generation/simulate.py` differed.

```
                          baseline    with fix    ratio
wall                        8902 s      5263 s     1.69x
  startup                   1120 s       629 s     (page cache, not the change)
  route 1 -> route 22       7779 s      4631 s     1.68x
```

Per-route speedup tracks route length, from 0.92x on a 20-second route to 2.84x on the longest (6604 steps). Short routes are dominated by setup and I/O; long ones by inference, which is what serialised onto GPU 0. It is 1.7x rather than 4x because GPU 0 was not saturated — inference is roughly half the critical path, the rest is CPU-side simulation.

Results are unchanged: the per-mode `groups.json` of both arms are byte-identical. The cross-mode aggregate differs in the last 1-2 ULP (`mean_route_completion` ...171 vs ...173), which is summation order, not behaviour.

## Fix

Pass the requested index to the CUDA and TensorRT provider options; an unindexed `cuda` follows `torch.cuda.current_device()`. Seven lines. CPU-only sessions and the TensorRT cache options are unchanged.

## Notes

- Tests add three cases: `cuda:0` (index 0 is a real GPU, not "unset"), unindexed `cuda`, and `cuda:1` with TensorRT (nonzero index, cache options preserved). The deletions are the three fake ORT sessions already in `test_onnx_provider.py` folded onto one helper.
- With `device="cuda"` (no index) on a host without CUDA, `torch.cuda.current_device()` now raises before the session opens, replacing `_require_accelerator`'s actionable message with a raw torch error. Left as-is: the eval CLI always passes `cuda:{local_rank}`, which never reaches that path.

Reference: https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#device_id
