### PR TITLE
fix(config): call super().__post_init__() in TrainConfig

### DIFF
--- a/diffusion_planner/diffusion_planner/config/train_config.py
+++ b/diffusion_planner/diffusion_planner/config/train_config.py
@@ -182,9 +182,6 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
     deterministic: bool = True
 
     def __post_init__(self) -> None:
-        # ``ClosedLoopConfig.__post_init__`` is what fills in ``pass_conditions``;
-        # without this call it stays None and closed-loop evaluation dies with
-        # ``AttributeError: 'NoneType' object has no attribute 'get_condition'``.
         super().__post_init__()
         if not self.save_dir:
             self.save_dir = self.build_save_dir(self.output_root, self.exp_name)

--- a/diffusion_planner/diffusion_planner/config/train_config.py
+++ b/diffusion_planner/diffusion_planner/config/train_config.py
@@ -182,6 +182,10 @@ class TrainConfig(ClosedLoopConfig, ScenarioOpenLoopConfig, ModelConfig):
     deterministic: bool = True
 
     def __post_init__(self) -> None:
+        # ``ClosedLoopConfig.__post_init__`` is what fills in ``pass_conditions``;
+        # without this call it stays None and closed-loop evaluation dies with
+        # ``AttributeError: 'NoneType' object has no attribute 'get_condition'``.
+        super().__post_init__()
         if not self.save_dir:
             self.save_dir = self.build_save_dir(self.output_root, self.exp_name)
 

--- a/diffusion_planner/tests/test_closed_loop_args.py
+++ b/diffusion_planner/tests/test_closed_loop_args.py
@@ -100,3 +100,38 @@ def test_resolve_closed_loop_duplicate_path_keeps_each_mode(tmp_path):
     assert len(entries) == 2
     assert [e["mode"] for e in entries] == ["objects", "noobj"]
     assert entries[0]["name"] == entries[1]["name"] == "sites"
+
+
+def test_train_config_pass_conditions_is_populated():
+    """``TrainConfig`` must inherit ``ClosedLoopConfig``'s pass-condition loading.
+
+    ``ClosedLoopConfig.__post_init__`` is the only thing that fills in
+    ``_closed_loop_pass_conditions_loaded``, and its docstring promises callers
+    can always do ``cfg.pass_conditions.get_condition(...)`` without a None-check
+    (``run_all_groups_closed_loop.py`` relies on exactly that). A subclass that
+    defines its own ``__post_init__`` without calling ``super()`` silently breaks
+    the promise, and because closed-loop evaluation only runs on the final epoch
+    the crash lands after a full training run.
+    """
+    from diffusion_planner.config import GRPOConfig, TrainConfig
+
+    for cls in (TrainConfig, GRPOConfig):
+        cfg = cls()
+        assert cfg.pass_conditions is not None, (
+            f"{cls.__name__}.pass_conditions is None — "
+            "__post_init__ must call super().__post_init__()"
+        )
+        # The default is strict (all conditions enabled) when no YAML is given.
+        assert cfg.pass_conditions.get_condition("any_group") is not None
+
+
+def test_train_config_post_init_still_sets_save_dir():
+    """The super() call must not displace TrainConfig's own save_dir default."""
+    from diffusion_planner.config import TrainConfig
+
+    cfg = TrainConfig(output_root="/tmp/out", exp_name="my_exp")
+    assert cfg.save_dir.startswith("/tmp/out/")
+    assert cfg.save_dir.endswith("_my_exp")
+
+    explicit = TrainConfig(output_root="/tmp/out", exp_name="my_exp", save_dir="/tmp/explicit")
+    assert explicit.save_dir == "/tmp/explicit"

--- a/diffusion_planner/tests/test_closed_loop_args.py
+++ b/diffusion_planner/tests/test_closed_loop_args.py
@@ -103,15 +103,10 @@ def test_resolve_closed_loop_duplicate_path_keeps_each_mode(tmp_path):
 
 
 def test_train_config_pass_conditions_is_populated():
-    """``TrainConfig`` must inherit ``ClosedLoopConfig``'s pass-condition loading.
+    """``pass_conditions`` must be non-None, as ``run_all_groups_closed_loop.py`` assumes.
 
-    ``ClosedLoopConfig.__post_init__`` is the only thing that fills in
-    ``_closed_loop_pass_conditions_loaded``, and its docstring promises callers
-    can always do ``cfg.pass_conditions.get_condition(...)`` without a None-check
-    (``run_all_groups_closed_loop.py`` relies on exactly that). A subclass that
-    defines its own ``__post_init__`` without calling ``super()`` silently breaks
-    the promise, and because closed-loop evaluation only runs on the final epoch
-    the crash lands after a full training run.
+    A subclass whose ``__post_init__`` skips ``super()`` leaves it None, and the
+    crash only surfaces on the final epoch of a full training run.
     """
     from diffusion_planner.config import GRPOConfig, TrainConfig
 
@@ -121,7 +116,6 @@ def test_train_config_pass_conditions_is_populated():
             f"{cls.__name__}.pass_conditions is None — "
             "__post_init__ must call super().__post_init__()"
         )
-        # The default is strict (all conditions enabled) when no YAML is given.
         assert cfg.pass_conditions.get_condition("any_group") is not None
 
 


### PR DESCRIPTION
## What

`TrainConfig.__post_init__` now calls `super().__post_init__()`.

## Why

`TrainConfig` defines its own `__post_init__` to default `save_dir`, which shadows `ClosedLoopConfig.__post_init__` — the only place that populates `_closed_loop_pass_conditions_loaded`. So `cfg.pass_conditions` is `None` on every `TrainConfig` (and `GRPOConfig`), and closed-loop evaluation dies at `run_all_groups_closed_loop.py:388`:

```
group_condition = pass_conditions.get_condition(group_name)
AttributeError: 'NoneType' object has no attribute 'get_condition'
```

`ClosedLoopConfig.__post_init__` documents the opposite contract — *"Callers can therefore always do `cfg.pass_conditions.get_condition(...)` without a None-check"* — and `run_all_groups_closed_loop.py` relies on exactly that.

Instantiating each config class shows the split:

```
ClosedLoopConfig   post_init=ClosedLoopConfig.__post_init__   pass_conditions=OK
BaseConfig         post_init=ClosedLoopConfig.__post_init__   pass_conditions=OK
ValidConfig        post_init=ClosedLoopConfig.__post_init__   pass_conditions=OK
TrainConfig        post_init=TrainConfig.__post_init__        pass_conditions=None  <- broken
GRPOConfig         post_init=TrainConfig.__post_init__        pass_conditions=None  <- broken
```

Introduced in #80.

## Impact

Only the training entry points are affected (`train_run.py` → `train_predictor.py`, and GRPO). The standalone CLI builds a `ClosedLoopConfig` directly, so scripted evaluation runs are unaffected — which is why this went unnoticed.

The nasty part is the timing: `train.py` only reaches closed-loop evaluation when `epoch + 1 == train_epochs`, so the crash lands *after* a full training run completes. An 80-epoch job burned five days of 8×H100 before failing, with no earlier symptom. Passing `--closed_loop_pass_conditions` does not work around it, since it is `__post_init__` itself that never runs; the only workaround today is to disable closed-loop evaluation entirely.

Checkpoints survive — only the closed-loop results are lost.

## Tests

Two regression tests added to `diffusion_planner/tests/test_closed_loop_args.py`:

- `test_train_config_pass_conditions_is_populated` — `pass_conditions` is non-None and usable on both `TrainConfig` and `GRPOConfig`. Fails on `tier4-main`, passes here.
- `test_train_config_post_init_still_sets_save_dir` — the `super()` call does not displace `TrainConfig`'s own `save_dir` defaulting (both the generated and the explicitly-passed case).

So a future subclass that forgets the `super()` call fails fast in CI rather than at the end of a multi-day run.

`pytest diffusion_planner/tests/test_closed_loop_args.py` → 5 passed. The 2 failures in that file (`test_resolve_closed_loop_defaults_modes_to_objects`, `test_resolve_closed_loop_duplicate_path_keeps_each_mode`) are pre-existing on `tier4-main` — they need `/data/s` to exist — and are untouched by this change.
