### PR TITLE
fix(viewer_export): keep accepting the flag its callers still pass

### DIFF
--- a/scenario_generation/scenario_sim_viewer_export.py
+++ b/scenario_generation/scenario_sim_viewer_export.py
@@ -600,6 +600,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     p.add_argument("--run_dir", required=True, type=Path, help="a finished suite run directory")
     p.add_argument("--out_root", required=True, type=Path, help="viewer tree to write")
+    # A case's video is published whenever the run left one, and the colormaps are drawn for
+    # every case, so there is nothing here for a flag to turn on. The drivers that deliver a run
+    # pass it because a revision where it did gate that is still in circulation; refusing it
+    # would cost them the export rather than the media.
+    p.add_argument(
+        "--include_legacy_media",
+        action="store_true",
+        help="accepted and ignored: a case's video and colormaps are published unconditionally",
+    )
     return p.parse_args(argv)
 
 

--- a/scenario_generation/tests/test_scenario_sim_viewer_export.py
+++ b/scenario_generation/tests/test_scenario_sim_viewer_export.py
@@ -17,6 +17,7 @@ from scenario_generation.scenario_sim_viewer_export import (
     export,
     key_aliases,
     load_submitted,
+    main,
 )
 
 # Shaped like a suite's map path, because the map id is read out of it. Nothing on disk.
@@ -236,3 +237,27 @@ def test_a_case_carries_what_its_expansion_set(tmp_path):
     assert cases[0]["parameters"] == {"speed": "8.3"}
     entry = json.loads((out / "scenarios.json").read_text())[_SC1]
     assert entry["description"] == _DESCRIPTION
+
+
+def test_the_flag_a_delivering_driver_passes_costs_nothing(tmp_path):
+    """A run must not be lost at argument parsing.
+
+    The drivers that deliver a run pass ``--include_legacy_media``, from a revision where it
+    gated whether a case's video was published. It no longer gates anything -- so it has to be
+    accepted, and accepting it has to leave the same tree behind.
+    """
+    run = _make_run(tmp_path / "run", [_rel(_SC1), _rel(_SC2)])
+    plain, with_flag = tmp_path / "plain", tmp_path / "with_flag"
+
+    assert main(["--run_dir", str(run), "--out_root", str(plain)]) == 0
+    assert (
+        main(["--run_dir", str(run), "--out_root", str(with_flag), "--include_legacy_media"]) == 0
+    )
+
+    assert sorted(p.relative_to(with_flag) for p in with_flag.rglob("*")) == sorted(
+        p.relative_to(plain) for p in plain.rglob("*")
+    )
+    for name in ("run.json", "scenarios.json", "cases.jsonl"):
+        assert (with_flag / name).read_text() == (plain / name).read_text().replace(
+            str(plain), str(with_flag)
+        )


### PR DESCRIPTION
## What

`scenario_sim_viewer_export` accepts `--include_legacy_media` again, and ignores it.

## Why

Every driver that delivers a finished suite run passes `--include_legacy_media` — the suite
driver's own delivery step and the two export jobs. This entry point takes `--run_dir` and
`--out_root` only, so argparse rejects the call and the delivery step exits non-zero instead of
exporting:

```
scenario_sim_viewer_export.py: error: unrecognized arguments: --include_legacy_media
```

The flag comes from a revision where it gated whether a case's existing mp4 was published and
whether the legacy PNG colormaps were drawn. Neither is gated here: `write_viewer_tree`
publishes a case's video whenever the run left one, and draws a colormap per metric for every
case. So there is nothing left for the flag to turn on, and refusing it costs the export rather
than the media.

## Impact this fixes

The failure lands on the last step of a run that has already finished. The simulation itself
completes (`rows=464/464 failed=0 rejected=0`) and writes `segments.jsonl` / `summary.json`, but
the viewer dataset is never published — so the run does not appear in the shared delivery tree
and `train.py`'s `scenario_sim_validate` returns on the driver's non-zero rc before it logs
`scenario_sim/pass_rate` to W&B. Every training-loop `scenario_sim` evaluation on the shared
cluster has been losing its delivery and its W&B metrics this way; the runs affected so far are
being re-exported by hand from their run directories.

## Test

`test_the_flag_a_delivering_driver_passes_costs_nothing` drives `main()` twice over one run —
with the flag and without — and asserts the two viewer trees are identical, file for file and
byte for byte. The contract is that passing it costs nothing, not merely that the parser
tolerates it. It reproduces the exact `unrecognized arguments` error when the fix is reverted.
