### PR TITLE
Sync HansRobo->tier4

### DIFF
--- a/diffusion_planner/diffusion_planner/config/closed_loop_config.py
+++ b/diffusion_planner/diffusion_planner/config/closed_loop_config.py
@@ -161,8 +161,8 @@ class ClosedLoopConfig:
     closed_loop_unstick_teleport_after: int = 50
     closed_loop_draw_every: int = 2
     closed_loop_draw_workers: int = cli("render on this many worker processes", default=4)
-    closed_loop_replan_interval: int = 1
-    closed_loop_tracker_mode: str = "mpc"
+    closed_loop_replan_interval: int = 8
+    closed_loop_tracker_mode: str = "perfect"
     closed_loop_neighbor_history_mode: str = "recorded"
     closed_loop_yaw_gate: bool = True
     closed_loop_strong_brake_mps2: float = -2.5

--- a/diffusion_planner/diffusion_planner/config/closed_loop_config.py
+++ b/diffusion_planner/diffusion_planner/config/closed_loop_config.py
@@ -169,6 +169,10 @@ class ClosedLoopConfig:
     closed_loop_abort_deviation_m: float = 50.0
     closed_loop_abort_after: int = 30
     closed_loop_abort_max_snaps: int = 0
+    # Object collisions that happened while the live ego was more than this far off the
+    # recorded GT path at that same step are reported separately as "deviation_collision"
+    # (a breakdown of object.collision_count, not a replacement for it).
+    closed_loop_deviation_collision_thresh_m: float = 2.0
     closed_loop_goal_mode: str = "segment"
     closed_loop_title_prefix: str | None = None
     closed_loop_distance_label_offset_m: float = 1.2

--- a/diffusion_planner/diffusion_planner/config/closed_loop_config.py
+++ b/diffusion_planner/diffusion_planner/config/closed_loop_config.py
@@ -145,6 +145,12 @@ class ClosedLoopConfig:
     closed_loop_seg_len: int = 100000
     # ClosedLoopEvalConfig
     closed_loop_fps: int = 10
+    closed_loop_profile: bool = cli(
+        "print + persist a per-stage timing breakdown (route load, model inference, "
+        "render wait, score/advance, video encode) to <out_dir>/timing_report.txt "
+        "after each group",
+        default=True,
+    )
     # RolloutParams
     closed_loop_near_miss_thresh: float = 0.5
     closed_loop_search_radius: float = 1.5

--- a/diffusion_planner/run_all_groups_closed_loop.py
+++ b/diffusion_planner/run_all_groups_closed_loop.py
@@ -186,6 +186,7 @@ def run_one_group(
                 window=cfg.closed_loop_window,
                 max_steps=cfg.closed_loop_max_steps,
                 timeline_progress_mode=cfg.closed_loop_timeline_progress_mode,  # replay mode
+                deviation_collision_thresh_m=cfg.closed_loop_deviation_collision_thresh_m,
             ),
             fps=float(cfg.closed_loop_fps),
             verbose=False,
@@ -300,6 +301,10 @@ def _write_groups_manifest(out_dir: Path | str, summaries: dict[str, dict]) -> N
             ),
             "total_collision_events": sum(
                 int(s.get("object", {}).get("collision_count", 0) or 0) for s in objects_only_values
+            ),
+            "total_deviation_collision_events": sum(
+                int(s.get("deviation_collision", {}).get("count", 0) or 0)
+                for s in objects_only_values
             ),
         }
 

--- a/diffusion_planner/run_all_groups_closed_loop.py
+++ b/diffusion_planner/run_all_groups_closed_loop.py
@@ -187,6 +187,7 @@ def run_one_group(
                 max_steps=cfg.closed_loop_max_steps,
                 timeline_progress_mode=cfg.closed_loop_timeline_progress_mode,  # replay mode
                 deviation_collision_thresh_m=cfg.closed_loop_deviation_collision_thresh_m,
+                colormap_metrics=tuple(cfg.closed_loop_colormap_metrics) if render_media else (),
             ),
             fps=float(cfg.closed_loop_fps),
             verbose=False,

--- a/diffusion_planner/run_all_groups_closed_loop.py
+++ b/diffusion_planner/run_all_groups_closed_loop.py
@@ -189,7 +189,7 @@ def run_one_group(
             ),
             fps=float(cfg.closed_loop_fps),
             verbose=False,
-            profile=False,
+            profile=cfg.closed_loop_profile,
             max_jobs=None,
             pass_condition=pass_condition,
         ),

--- a/diffusion_planner/valid_predictor.py
+++ b/diffusion_planner/valid_predictor.py
@@ -58,7 +58,13 @@ def get_args(args_list=None):
     parser.add_argument("--batch_size", type=int, default=32)
     parser.add_argument("--device", type=str, default="cuda")
     parser.add_argument("--predicted_neighbor_num", type=int, default=32)
-    parser.add_argument("--resume_model_path", type=str, required=True)
+    parser.add_argument(
+        "--resume_model_path",
+        type=str,
+        required=True,
+        help="checkpoint to load: a .pth (resumed via resume_model, DDP-wrapped) or an "
+        "exported .onnx (loaded as an inference-only session, never DDP-wrapped)",
+    )
     parser.add_argument("--args_json_path", type=str, required=True)
     parser.add_argument("--save_predictions_dir", type=str, default=None)
     parser.add_argument("--scenario_based_open_loop_list", type=str, default=None)
@@ -111,6 +117,10 @@ def run_validation(valid_cfg: ValidConfig):
     if valid_cfg.scenario_based_open_loop_only and not valid_cfg.scenario_based_open_loop_list:
         raise ValueError("--scenario_based_open_loop_only requires Scenario-based Open-loop list")
 
+    # An exported .onnx checkpoint carries its own weights (no state_dict/resume_model, no
+    # DDP-wrappable parameters); everything downstream keys off this instead of valid_cfg.ddp.
+    is_onnx = Path(valid_cfg.resume_model_path).suffix.lower() == ".onnx"
+
     # 1. Restore model configuration from training settings (args.json)
     config_obj = Config(valid_cfg.args_json_path)
 
@@ -138,38 +148,56 @@ def run_validation(valid_cfg: ValidConfig):
     set_seed(valid_cfg.seed + global_rank)
 
     # set up model (restore structure using training config_obj)
-    diffusion_planner = Diffusion_Planner(config_obj)
-    diffusion_planner = diffusion_planner.to(
-        rank if valid_cfg.device == "cuda" else valid_cfg.device
-    )
+    if is_onnx:
+        from scenario_generation.simulate import load_onnx_model
 
-    if valid_cfg.ddp:
-        diffusion_planner = DDP(diffusion_planner, device_ids=[rank], find_unused_parameters=True)
-
-    if global_rank == 0:
-        print(
-            "Model Params: {}".format(
-                sum(p.numel() for p in ddp.get_model(diffusion_planner, valid_cfg.ddp).parameters())
-            )
+        onnx_device = f"cuda:{rank}" if valid_cfg.device == "cuda" else valid_cfg.device
+        # args.json is read again here (from next to the .onnx) but discarded: config_obj
+        # above (from --args_json_path) is the one actually used downstream.
+        diffusion_planner, _ = load_onnx_model(valid_cfg.resume_model_path, onnx_device)
+        model_is_ddp = False
+        print(f"ONNX model loaded from {valid_cfg.resume_model_path}")
+    else:
+        diffusion_planner = Diffusion_Planner(config_obj)
+        diffusion_planner = diffusion_planner.to(
+            rank if valid_cfg.device == "cuda" else valid_cfg.device
         )
 
-    # optimizer (dummy)
-    params = [{"params": ddp.get_model(diffusion_planner, valid_cfg.ddp).parameters(), "lr": 0.0}]
-    optimizer = optim.AdamW(params)
+        if valid_cfg.ddp:
+            diffusion_planner = DDP(
+                diffusion_planner, device_ids=[rank], find_unused_parameters=True
+            )
+        model_is_ddp = valid_cfg.ddp
 
-    # load weights
-    print(f"Model loaded from {valid_cfg.resume_model_path}")
-    model_ema = ModelEma(diffusion_planner, decay=0.999, device=valid_cfg.device)
+        if global_rank == 0:
+            print(
+                "Model Params: {}".format(
+                    sum(
+                        p.numel()
+                        for p in ddp.get_model(diffusion_planner, model_is_ddp).parameters()
+                    )
+                )
+            )
 
-    diffusion_planner, _, _, _, _, _ = resume_model(
-        valid_cfg.resume_model_path,
-        diffusion_planner,
-        optimizer,
-        None,  # scheduler is not needed
-        model_ema,
-        valid_cfg.device,
-        use_ddp=valid_cfg.ddp,
-    )
+        # optimizer (dummy)
+        params = [
+            {"params": ddp.get_model(diffusion_planner, model_is_ddp).parameters(), "lr": 0.0}
+        ]
+        optimizer = optim.AdamW(params)
+
+        # load weights
+        print(f"Model loaded from {valid_cfg.resume_model_path}")
+        model_ema = ModelEma(diffusion_planner, decay=0.999, device=valid_cfg.device)
+
+        diffusion_planner, _, _, _, _, _ = resume_model(
+            valid_cfg.resume_model_path,
+            diffusion_planner,
+            optimizer,
+            None,  # scheduler is not needed
+            model_ema,
+            valid_cfg.device,
+            use_ddp=valid_cfg.ddp,
+        )
 
     if valid_cfg.ddp:
         torch.distributed.barrier()
@@ -234,7 +262,7 @@ def run_validation(valid_cfg: ValidConfig):
                 ddp=False,
             )
             summary = run_scenario_based_open_loop_validation(
-                ddp.get_model(diffusion_planner, valid_cfg.ddp),
+                ddp.get_model(diffusion_planner, model_is_ddp),
                 scenario_open_loop_args,
                 visualization_dir=output_root / "scenario_based_open_loop" / "visualization",
                 details_dir=output_root / "scenario_based_open_loop" / "details",

--- a/diffusion_planner/valid_run.py
+++ b/diffusion_planner/valid_run.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Run closed/open-loop L2 validation across all visible GPUs (Python replacement for valid_run.sh).
 
-Thin launcher only: derives the checkpoint/config/output paths from --model_dir and runs
-valid_predictor.py under torch.distributed.run. Standard validation renders the prediction PNGs
-per-clip MP4s on rank 0 when --save_predictions_dir is set.
+Thin launcher only: derives the checkpoint/config/output paths from --model_dir and/or
+--model_path and runs valid_predictor.py under torch.distributed.run. Standard validation
+renders the prediction PNGs per-clip MP4s on rank 0 when --save_predictions_dir is set.
 """
 
 import argparse
@@ -17,11 +17,19 @@ from run_utils import gpu_count, tee_run
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--model_dir", required=True, help="dir holding best_model.pth + args.json")
     p.add_argument(
-        "--checkpoint",
+        "--model_dir",
         default="",
-        help="checkpoint .pth to validate; defaults to <model_dir>/best_model.pth",
+        help="dir holding best_model.pth + args.json; defaults to --model_path's parent dir. "
+        "One of --model_dir / --model_path is required",
+    )
+    p.add_argument(
+        "--model_path",
+        default="",
+        help="checkpoint to validate: a .pth, or an exported .onnx (args.json is still read "
+        "from --model_dir, not from next to the .onnx); defaults to <model_dir>/best_model.pth "
+        "(named to match --model_path on the closed-loop side). One of --model_dir / "
+        "--model_path is required",
     )
     p.add_argument(
         "--output_dir",
@@ -45,8 +53,10 @@ def main() -> None:
         raise ValueError("--scenario_based_open_loop_only requires Scenario-based Open-loop list")
     if args.batch_size < 1:
         raise ValueError("--batch_size must be at least 1")
-    model_dir = Path(args.model_dir)
-    model_path = Path(args.checkpoint) if args.checkpoint else model_dir / "best_model.pth"
+    if not args.model_dir and not args.model_path:
+        raise ValueError("one of --model_dir or --model_path is required")
+    model_dir = Path(args.model_dir) if args.model_dir else Path(args.model_path).parent
+    model_path = Path(args.model_path) if args.model_path else model_dir / "best_model.pth"
     args_json_path = model_dir / "args.json"
     if not model_path.is_file():
         raise FileNotFoundError(f"Validation checkpoint not found: {model_path}")

--- a/planner_metrics/geometry.py
+++ b/planner_metrics/geometry.py
@@ -1028,6 +1028,20 @@ def build_road_border_segments(
     return seg_a.gather(1, idx), seg_b.gather(1, idx), keep.gather(1, order)
 
 
+def point_inside_any_lane_polygon(point: torch.Tensor, lanes: torch.Tensor) -> bool:
+    """Is ``point`` (2,) inside any lane polygon built from ``lanes`` (S, P, D>=8)?
+
+    Shared by every "is the ego inside a lanelet" check -- the closed-loop metric
+    (:func:`scenario_generation.metrics.road_border.score_road_border_step`) and the
+    per-step render label (:func:`scenario_generation.replay._ego_border_distance`) -- so
+    the sign convention used to draw the road-border distance matches the one logged to
+    ``rollout.jsonl``.
+    """
+    edge_v1, edge_v2, edge_poly_id, n_polys = _build_lane_polygons(lanes)
+    inside = _point_in_polygons(point.reshape(1, 2), edge_v1, edge_v2, edge_poly_id, n_polys)
+    return bool(inside[0].item())
+
+
 __all__ = [
     "_build_ego_bbox_corners",
     "_LN_X",
@@ -1053,4 +1067,5 @@ __all__ = [
     "_point_to_segments_signed_min_dist",
     "_classify_outer_boundaries",
     "build_road_border_segments",
+    "point_inside_any_lane_polygon",
 ]

--- a/scenario_generation/closed_loop_eval.py
+++ b/scenario_generation/closed_loop_eval.py
@@ -342,6 +342,7 @@ def aggregate(
     near_miss_thresh: float,
     *,
     strong_brake_mps2: float = -2.5,
+    deviation_collision_thresh_m: float = 2.0,
     pass_condition: "ClosedLoopPassCondition | None" = None,
 ) -> dict:
     """Aggregate per-segment nested metric rows into a closed-loop summary.
@@ -398,6 +399,15 @@ def aggregate(
     red = _event_family_block(
         rows, "red_light_violation", dual=False, total_steps=total_steps, n_seg=n_seg
     )
+    dev_col = _event_family_block(
+        rows,
+        "deviation_collision",
+        dual=False,
+        total_steps=total_steps,
+        n_seg=n_seg,
+        thresh_key="thresh_m",
+        thresh_value=float(deviation_collision_thresh_m),
+    )
     brake = _event_family_block(
         rows,
         "strong_brake",
@@ -425,6 +435,7 @@ def aggregate(
         "n_segments_diverged": n_seg_diverged,
         "diverged_segment_rate": n_seg_diverged / n_seg if n_seg else 0.0,
         "object": obj,
+        "deviation_collision": dev_col,
         "road_border": rb,
         "red_light_violation": red,
         "strong_brake": brake,

--- a/scenario_generation/closed_loop_evaluation.py
+++ b/scenario_generation/closed_loop_evaluation.py
@@ -466,6 +466,9 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
                 merged.rows.extend(partial.rows)
                 merged.video_mp4s.extend(partial.video_mp4s)
                 merged.extras["route_keys"].append(job.route_key)
+                partial_timers = partial.extras.get("timers")
+                if partial_timers is not None:
+                    merged.extras.setdefault("timers", Timers()).merge(partial_timers)
                 self.on_job_complete(job, partial, ri, len(jobs))
         return merged
 
@@ -479,7 +482,7 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
     ) -> JobRunResult:
         assert isinstance(job, FullRouteRouteJob)
         params = self.config.params
-        timers = Timers() if self.config.profile else None
+        timers = Timers()
         tl = RouteTimeline(job.route_paths, sidecar_dir=job.npz_root, timers=timers)
         rows: list[dict] = []
         video_mp4s: list[Path] = []
@@ -495,6 +498,7 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
                 png_dir,
                 **params.render_kwargs(),
                 draw_pool=draw_pool,
+                timers=timers,
             )
             row = {"route": job.route_key, **metrics}
             if self.config.pass_condition is not None:
@@ -519,7 +523,8 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
                     print(f"  [{job.route_key}] segment [{start},{end}] -> 0 frames, no video")
                 continue
             seg_mp4 = self.out_dir / f"{job.route_key}_{start}_{end}.mp4"
-            build_mp4(png_dir, seg_mp4, self.config.fps)
+            with timers("build_mp4"):
+                build_mp4(png_dir, seg_mp4, self.config.fps)
             video_mp4s.append(seg_mp4)
             if self.config.verbose:
                 obj = metrics["object"]
@@ -529,9 +534,7 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
                     f"min_clr={obj['clearance_min_m']:.3f}"
                 )
 
-        extras: dict[str, Any] = {}
-        if timers is not None:
-            extras["timers"] = timers
+        extras: dict[str, Any] = {"timers": timers}
         return JobRunResult(rows=rows, video_mp4s=video_mp4s, extras=extras)
 
     def on_job_complete(
@@ -562,6 +565,9 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
         summary["elapsed_sec"] = elapsed_sec
         summary["video_mp4s"] = result.video_mp4s
         summary["segments"] = result.rows
+        timers = result.extras.get("timers")
+        if timers is not None:
+            summary["timers_detail"] = timers.as_dict()
         return summary
 
     def write_artifacts(self, summary: dict, result: JobRunResult) -> None:
@@ -571,6 +577,11 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
                 f,
                 indent=4,
             )
+        timers = result.extras.get("timers")
+        if self.config.profile and timers is not None:
+            report = timers.report(summary.get("total_steps"))
+            (self.out_dir / "timing_report.txt").write_text(report + "\n")
+            print(f"\n=== timing breakdown: {self.out_dir} ===\n{report}")
 
     def print_summary(self, summary: dict) -> None:
         n_seg = summary["n_segments"]

--- a/scenario_generation/closed_loop_evaluation.py
+++ b/scenario_generation/closed_loop_evaluation.py
@@ -87,6 +87,10 @@ class RolloutParams:
     window: tuple[int, int] | None
     max_steps: int | None
     timeline_progress_mode: str
+    # A collision counts as "deviation collision" (reported alongside, not instead of,
+    # object.collision_count) when the live ego was more than this far off the recorded
+    # GT path at that same step. See ``reproducer_rollout.deviation_collision_block``.
+    deviation_collision_thresh_m: float = 2.0
 
     def render_kwargs(self) -> dict[str, Any]:
         return {
@@ -120,6 +124,7 @@ class RolloutParams:
             "window": self.window,
             "max_steps": self.max_steps,
             "timeline_progress_mode": self.timeline_progress_mode,
+            "deviation_collision_thresh_m": self.deviation_collision_thresh_m,
         }
 
 
@@ -555,6 +560,7 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
             result.rows,
             self.config.params.near_miss_thresh,
             strong_brake_mps2=self.config.params.strong_brake_mps2,
+            deviation_collision_thresh_m=self.config.params.deviation_collision_thresh_m,
             pass_condition=self.config.pass_condition,
         )
         summary["npz_root"] = str(self.npz_root)

--- a/scenario_generation/closed_loop_evaluation.py
+++ b/scenario_generation/closed_loop_evaluation.py
@@ -90,7 +90,10 @@ class RolloutParams:
     # A collision counts as "deviation collision" (reported alongside, not instead of,
     # object.collision_count) when the live ego was more than this far off the recorded
     # GT path at that same step. See ``reproducer_rollout.deviation_collision_block``.
-    deviation_collision_thresh_m: float = 2.0
+    deviation_collision_thresh_m: float
+    # Metrics for the optional post-rollout trajectory-colormap PNGs.  An empty tuple keeps
+    # the generic evaluator's historical behavior (the CLI caller opts in explicitly).
+    colormap_metrics: tuple[str, ...]
 
     def render_kwargs(self) -> dict[str, Any]:
         return {
@@ -505,6 +508,19 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
                 draw_pool=draw_pool,
                 timers=timers,
             )
+
+            if params.colormap_metrics:
+                from scenario_generation.trajectory_colormap import render_trajectory_colormaps
+
+                render_trajectory_colormaps(
+                    png_dir,
+                    self.out_dir,
+                    f"{job.route_key}_{start}_{end}",
+                    metrics=params.colormap_metrics,
+                    near_miss_thresh=params.near_miss_thresh,
+                    strong_brake_mps2=params.strong_brake_mps2,
+                    title=f"{job.route_key} [{start},{end}]",
+                )
             row = {"route": job.route_key, **metrics}
             if self.config.pass_condition is not None:
                 row["passed"] = evaluate_segment_pass(row, self.config.pass_condition)

--- a/scenario_generation/metrics/road_border.py
+++ b/scenario_generation/metrics/road_border.py
@@ -6,6 +6,9 @@ import numpy as np
 import torch
 
 from planner_metrics.config import RewardConfig
+from planner_metrics.geometry import (
+    point_inside_any_lane_polygon,
+)
 from planner_metrics.subscores import compute_road_border_penalty
 
 
@@ -18,12 +21,183 @@ def _as_float_tensor(value, device: str) -> torch.Tensor:
     return torch.tensor(np.asarray(value), dtype=torch.float32, device=device)
 
 
+def _ego_inside_lane(np_dict: dict, device: str) -> bool | None:
+    """Is the ego origin inside any lane polygon? ``None`` when ``lanes`` is absent
+    (sign cannot be determined, e.g. older callers/tests that only pass line_strings)."""
+    if "lanes" not in np_dict:
+        return None
+    lanes_t = _as_float_tensor(np_dict["lanes"], device)
+    if lanes_t.dim() == 4:
+        lanes_t = lanes_t[0]
+    origin = torch.zeros(2, dtype=torch.float32, device=device)
+    return point_inside_any_lane_polygon(origin, lanes_t)
+
+
+def _ego_intersects_border_segments(
+    seg_p1: torch.Tensor,
+    seg_p2: torch.Tensor,
+    ego_shape: torch.Tensor,
+    ego_pose: torch.Tensor | None = None,
+) -> bool:
+    """Whether any border segment intersects the current ego OBB.
+
+    In the ego frame the OBB is an axis-aligned rectangle.  ``ego_pose`` is
+    ``[x, y, cos_yaw, sin_yaw]`` in the segment frame; it is omitted when the
+    segments are already in the current ego frame.  This exact test avoids
+    missing an intersection between the 80 sampled perimeter points.
+    """
+    if seg_p1.shape[0] == 0:
+        return False
+
+    if ego_pose is not None:
+        offset = torch.stack([ego_pose[0], ego_pose[1]])
+        cos_yaw, sin_yaw = ego_pose[2], ego_pose[3]
+        rot_inv = torch.stack([torch.stack([cos_yaw, sin_yaw]), torch.stack([-sin_yaw, cos_yaw])])
+        seg_p1 = (seg_p1 - offset) @ rot_inv.T
+        seg_p2 = (seg_p2 - offset) @ rot_inv.T
+
+    length = ego_shape[1]
+    width = ego_shape[2]
+    wheelbase = ego_shape[0]
+    rear_overhang = (length - wheelbase) / 2.0
+    xmin = -rear_overhang
+    xmax = length - rear_overhang
+    ymin = -width / 2.0
+    ymax = width / 2.0
+
+    def cross(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        return a[..., 0] * b[..., 1] - a[..., 1] * b[..., 0]
+
+    def point_in_rect(p: torch.Tensor) -> torch.Tensor:
+        eps = 1e-6
+        return (
+            (p[:, 0] >= xmin - eps)
+            & (p[:, 0] <= xmax + eps)
+            & (p[:, 1] >= ymin - eps)
+            & (p[:, 1] <= ymax + eps)
+        )
+
+    # An endpoint inside is an intersection.
+    if point_in_rect(seg_p1).any() or point_in_rect(seg_p2).any():
+        return True
+
+    rect = torch.stack(
+        [
+            torch.stack([xmin, ymin]),
+            torch.stack([xmax, ymin]),
+            torch.stack([xmax, ymax]),
+            torch.stack([xmin, ymax]),
+        ]
+    )
+    rect_next = torch.roll(rect, shifts=-1, dims=0)
+
+    # Inclusive segment intersection, vectorized over border segments and
+    # rectangle edges.  The epsilon also treats touching as intersection.
+    a = seg_p1[:, None, :]
+    b = seg_p2[:, None, :]
+    c = rect[None, :, :]
+    d = rect_next[None, :, :]
+    ab = b - a
+    cd = d - c
+    ac = c - a
+    ad = d - a
+    ca = a - c
+    cb = b - c
+    o1 = cross(ab, ac)
+    o2 = cross(ab, ad)
+    o3 = cross(cd, ca)
+    o4 = cross(cd, cb)
+    eps = 1e-6
+    bbox_overlap = (
+        (torch.minimum(a[..., 0], b[..., 0]) <= torch.maximum(c[..., 0], d[..., 0]) + eps)
+        & (torch.maximum(a[..., 0], b[..., 0]) + eps >= torch.minimum(c[..., 0], d[..., 0]))
+        & (torch.minimum(a[..., 1], b[..., 1]) <= torch.maximum(c[..., 1], d[..., 1]) + eps)
+        & (torch.maximum(a[..., 1], b[..., 1]) + eps >= torch.minimum(c[..., 1], d[..., 1]))
+    )
+    proper = (o1 * o2 <= eps) & (o3 * o4 <= eps) & bbox_overlap
+    return bool(proper.any().item())
+
+
+@torch.no_grad()
+def _ego_inside_road_border_corridor(
+    line_strings: torch.Tensor,
+    *,
+    max_longitudinal_m: float = 50.0,
+    max_side_pair_gap_m: float = 10.0,
+) -> bool:
+    """Return whether ego is inside a polygon formed by two border segments."""
+    if line_strings.dim() == 4:
+        line_strings = line_strings[0]
+    xy = line_strings[..., :2]
+    valid = (line_strings[..., 3] > 0.5) & (xy.norm(dim=-1) > 1e-3)
+    pair_valid = valid[:, :-1] & valid[:, 1:]
+    if not bool(pair_valid.any().item()):
+        return False
+    p1, p2 = xy[:, :-1][pair_valid], xy[:, 1:][pair_valid]
+    seg = p2 - p1
+    length2 = (seg * seg).sum(dim=-1).clamp_min(1e-10)
+    t = ((-p1 * seg).sum(dim=-1) / length2).clamp(0.0, 1.0)
+    closest = p1 + t[:, None] * seg
+    usable = closest[:, 0].abs() <= max_longitudinal_m
+    upper_mask = usable & (closest[:, 1] > 1e-4)
+    lower_mask = usable & (closest[:, 1] < -1e-4)
+    upper_points = closest[upper_mask]
+    lower_points = closest[lower_mask]
+    if not upper_points.numel() or not lower_points.numel():
+        return False
+
+    # Build every plausible upper/lower quadrilateral at once.  The previous
+    # implementation called point-in-polygon from a Python double loop, which
+    # was expensive because this function runs once per simulation step.
+    upper_indices = torch.where(upper_mask)[0]
+    lower_indices = torch.where(lower_mask)[0]
+    upper = torch.stack((p1[upper_indices], p2[upper_indices]), dim=1)
+    lower = torch.stack((p1[lower_indices], p2[lower_indices]), dim=1)
+    upper_order = torch.argsort(upper[..., 0], dim=1)
+    lower_order = torch.argsort(lower[..., 0], dim=1)
+    upper = upper.gather(1, upper_order[..., None].expand(-1, -1, 2))
+    lower = lower.gather(1, lower_order[..., None].expand(-1, -1, 2))
+
+    pair_valid = (
+        closest[upper_indices, 0][:, None] - closest[lower_indices, 0][None, :]
+    ).abs() <= max_side_pair_gap_m
+    polygons = torch.stack(
+        (
+            upper[:, None, 0, :].expand(-1, lower.shape[0], -1),
+            upper[:, None, 1, :].expand(-1, lower.shape[0], -1),
+            lower[None, :, 1, :].expand(upper.shape[0], -1, -1),
+            lower[None, :, 0, :].expand(upper.shape[0], -1, -1),
+        ),
+        dim=2,
+    )
+
+    # Vectorized ray casting for the origin against all quadrilaterals.
+    v1 = polygons
+    v2 = torch.roll(polygons, shifts=-1, dims=2)
+    y1, y2 = v1[..., 1], v2[..., 1]
+    x1, x2 = v1[..., 0], v2[..., 0]
+    cond_y = (y1 > 0) != (y2 > 0)
+    dy = y2 - y1
+    safe_dy = torch.where(dy.abs() < 1e-10, torch.ones_like(dy), dy)
+    crossing_x = x1 - y1 * (x2 - x1) / safe_dy
+    inside = (cond_y & (0 < crossing_x)).sum(dim=2) % 2 == 1
+    return bool((inside & pair_valid).any().item())
+
+
 def score_road_border_step(np_dict: dict, *, device: str) -> dict:
     """Ego-to-road-border distance at the current step.
 
     Uses ``line_strings`` channel 3 as road border. Collision / miss masks are
     derived later in ``_finalize`` from the distance series. Current pose is the
     ego-frame origin; history is not needed.
+
+    Signed by lane containment when ``lanes`` is available: positive while the ego
+    origin is inside a lane polygon (normal clearance), negative once it has crossed
+    outside (magnitude = how far past the border) -- this is the opposite convention
+    from ``_point_to_segments_signed_min_dist`` (lane departure: +outside/-inside),
+    chosen to match how ``rb_dist_m`` is consumed downstream: smaller/more negative
+    already reads as "worse" (collision thresholds, ``clearance_min_m``/``p5``), so
+    inside=positive keeps that ordering intact once crossings go negative.
     """
     rb_dist_m = float("inf")
     if "line_strings" in np_dict and "ego_shape" in np_dict:
@@ -38,5 +212,27 @@ def score_road_border_step(np_dict: dict, *, device: str) -> dict:
             traj, ego_shape_t, data, config=RewardConfig()
         )
         rb_dist_m = float(per_ts_min[0, 0].item())
-
+        if np.isfinite(rb_dist_m):
+            inside = _ego_inside_lane(np_dict, device)
+            # A border crossing/contact takes precedence over the signed
+            # clearance: the requested value at intersection is exactly 0.
+            if "line_strings" in np_dict:
+                ls_for_intersection = ls
+                border_xy = ls_for_intersection[..., :2]
+                valid = (ls_for_intersection[..., 3] > 0.5) & (border_xy.norm(dim=-1) > 1e-3)
+                valid_pair = valid[:, :-1] & valid[:, 1:]
+                idx = torch.where(valid_pair.reshape(-1))[0]
+                seg_p1 = border_xy[:, :-1].reshape(-1, 2)[idx]
+                seg_p2 = border_xy[:, 1:].reshape(-1, 2)[idx]
+                if _ego_intersects_border_segments(seg_p1, seg_p2, ego_shape_t):
+                    rb_dist_m = 0.0
+            border_inside = False
+            if rb_dist_m != 0.0 and inside is False:
+                # Lane polygons are the primary containment test.  At turns
+                # the lane representation can be incomplete, so only use the
+                # road-border corridor as a fallback when no lane contains
+                # the ego origin.
+                border_inside = _ego_inside_road_border_corridor(ls_for_intersection)
+                if not border_inside:
+                    rb_dist_m = -rb_dist_m
     return {"rb_dist_m": rb_dist_m}

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -65,6 +65,9 @@ matplotlib.use("Agg")
 import numpy as np
 import torch
 
+from planner_metrics.geometry import (
+    point_inside_any_lane_polygon,
+)
 from planner_metrics.vehicle_collision import obb_corners
 
 # Live per-step lane / border / centerline scoring. Imports are module-
@@ -91,6 +94,10 @@ from scenario_generation.gui.lanelet_scene_builder import (
     LaneletSceneBuilder,
     _obb_collides,
     _obb_corners,
+)
+from scenario_generation.metrics.road_border import (
+    _ego_inside_road_border_corridor,
+    _ego_intersects_border_segments,
 )
 from scenario_generation.render_pool import render_pool
 from scenario_generation.route import Route
@@ -1461,7 +1468,13 @@ def _ego_nearest_moving_npc(
 
 
 def _ego_border_distance(ego, map_data) -> tuple[np.ndarray, np.ndarray, float] | None:
-    """Road-border distance from the shared reward metric."""
+    """Road-border distance from the shared reward metric.
+
+    Signed by lane containment when ``map_data.lanes`` is non-empty: positive while
+    ``ego`` is inside some lane polygon, negative once it has crossed outside --
+    matches ``scenario_generation.metrics.road_border.score_road_border_step``'s
+    convention, so this render label agrees with the value logged to rollout.jsonl.
+    """
     if ego is None:
         return None
     if map_data is None or map_data.line_strings is None:
@@ -1508,6 +1521,32 @@ def _ego_border_distance(ego, map_data) -> tuple[np.ndarray, np.ndarray, float] 
     rb_dist = float(per_ts_min[0, 0].item())
     if not math.isfinite(rb_dist):
         return None
+    border_p1 = torch.from_numpy(border_xy[:, :-1].reshape(-1, 2)[valid_pair.reshape(-1)])
+    border_p2 = torch.from_numpy(border_xy[:, 1:].reshape(-1, 2)[valid_pair.reshape(-1)])
+    if _ego_intersects_border_segments(
+        border_p1,
+        border_p2,
+        ego_shape,
+        ego_pose=ego_traj[0, 0],
+    ):
+        rb_dist = 0.0
+    lanes = np.asarray(map_data.lanes, dtype=np.float32) if map_data.lanes is not None else None
+    if lanes is not None and lanes.size > 0:
+        pt = torch.tensor(
+            [float(ego.current_position[0]), float(ego.current_position[1])], dtype=torch.float32
+        )
+        lane_inside = point_inside_any_lane_polygon(pt, torch.from_numpy(lanes))
+        if rb_dist != 0.0 and not lane_inside:
+            # ``line_strings`` are in world coordinates here, while the
+            # corridor helper intentionally works in the ego-local frame.
+            dx = border_xy - np.asarray(ego.current_position, dtype=np.float32)
+            c, s = math.cos(h), math.sin(h)
+            local_border = line_strings.copy()
+            local_border[..., 0] = dx[..., 0] * c + dx[..., 1] * s
+            local_border[..., 1] = -dx[..., 0] * s + dx[..., 1] * c
+            border_inside = _ego_inside_road_border_corridor(torch.from_numpy(local_border))
+            if not border_inside:
+                rb_dist = -rb_dist
     return ego_pts[0, 0].numpy(), border_pts[0, 0].numpy(), rb_dist
 
 

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -1183,6 +1183,8 @@ _LANE_BORDER_COLOR = "#888888"
 _ROAD_BORDER_COLOR = "#dd2222"
 _EGO_COLOR = "#3366cc"
 _ROUTE_COLOR = "#3366cc"
+_GT_PATH_COLOR = "#e69138"
+_GT_DEV_COLOR = "#cc0000"
 _VIEW_HALF_M = 50.0  # ±50 m window around ego keeps lane detail legible
 _ROAD_BORDER_FLAG_THRESH = 0.5
 _ROAD_BORDER_COORD_EPS_M = 1e-3
@@ -1566,6 +1568,7 @@ def save_step_figure(
     metrics: dict | None = None,
     extra_ego_trajectories: list[tuple[np.ndarray, str, str]] | None = None,
     reproducer_ego: tuple[float, float, float] | None = None,
+    gt_deviation_viz: tuple[np.ndarray, np.ndarray, float] | None = None,
 ) -> None:
     """Render + save the overview PNG for a single replay step.
 
@@ -1574,6 +1577,12 @@ def save_step_figure(
 
     ``reproducer_ego``: optional ``(x, y, heading)`` in the live-ego frame for the
     recorded cursor ego, drawn as a hollow outline in ``_EGO_COLOR``.
+
+    ``gt_deviation_viz``: optional ``(window_xy, nearest_xy, dist_m)``, all already in the
+    live-ego frame (same convention as ``reproducer_ego`` -- no further transform here).
+    ``window_xy`` is the recorded-path window the GT-deviation distance was searched over
+    (drawn as a thin line); ``nearest_xy`` is the closest point on it, connected to the ego
+    with a dashed perpendicular labeled with ``dist_m``.
     """
     from matplotlib.figure import Figure
 
@@ -1768,6 +1777,31 @@ def save_step_figure(
             textcoords="offset points",
             zorder=24,
         )
+
+    # 3a-2) GT-deviation visualization: the recorded-path window this step's deviation was
+    # measured against, plus the perpendicular from the live ego to the nearest point on it.
+    if gt_deviation_viz is not None:
+        window_xy, nearest_xy, dist_m = gt_deviation_viz
+        if window_xy is not None and len(window_xy) >= 2:
+            ax.plot(
+                window_xy[:, 0],
+                window_xy[:, 1],
+                "-",
+                color=_GT_PATH_COLOR,
+                lw=1.3,
+                alpha=0.55,
+                zorder=6,
+            )
+        if nearest_xy is not None:
+            nx, ny = float(nearest_xy[0]), float(nearest_xy[1])
+            ax.plot([ex, nx], [ey, ny], "--", color=_GT_DEV_COLOR, lw=1.5, zorder=22)
+            ax.annotate(
+                f"{float(dist_m):.2f} m",
+                ((ex + nx) / 2, (ey + ny) / 2),
+                fontsize=7,
+                color=_GT_DEV_COLOR,
+                zorder=24,
+            )
 
     # 3b) Extra ego-frame trajectories (e.g. GT vs model output side by side).
     # Each entry: (traj[T, >=4] with x, y, cos, sin in the CURRENT ego frame,

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -1555,8 +1555,10 @@ def render_segment(
     fired this many times in one segment — repeated snapping is itself a sign of a bad rollout.
 
     Per-step ``rollout.jsonl`` lines (next to the PNGs) always include ``clearance_m``,
-    ``collision``, ``rb_dist_m`` (ego-to-road-border distance; ``None`` when the frame
-    carries no lane geometry), and ``red_light_violation`` alongside the ego pose — see
+    ``collision``, ``rb_dist_m`` (ego-to-road-border distance, signed by lane
+    containment when ``lanes`` is available: positive while inside a lane polygon,
+    negative once the ego has crossed outside; ``None`` when the frame carries no
+    lane geometry), and ``red_light_violation`` alongside the ego pose — see
     :mod:`scenario_generation.trajectory_colormap` for the trajectory-colormap consumer
     (which also derives a "strong_brake" colormap from consecutive ``speed`` samples).
 

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -26,6 +26,7 @@ from concurrent.futures import Executor
 from contextlib import nullcontext
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import NamedTuple
 
 import numpy as np
 import torch
@@ -471,6 +472,13 @@ class _SegState:
     # the model trains. Accumulated only in render_segment's loop; 0 count -> reported inf.
     gt_dev_sum: float = 0.0
     gt_dev_count: int = 0
+    # Per-step GT deviation (m), parallel to ``clearances``/``collisions`` -- lets
+    # ``deviation_collision_block`` AND it against ``collisions`` positionally.
+    # None for manually-built states that never step (like ``accels``/``clearances``).
+    gt_devs: np.ndarray | None = None
+    # A collision counts as "deviation collision" when the live ego was more than this far
+    # off the recorded GT path at the same step (see ``deviation_collision_block``).
+    deviation_collision_thresh_m: float = 2.0
 
 
 def _ego_state_from_frame(tl: RouteTimeline, idx: int) -> tuple[np.ndarray, np.ndarray, "_EgoDyn"]:
@@ -527,6 +535,7 @@ def _seed_state(
     tracker_mode="mpc_batched",
     strong_brake_mps2=-2.5,
     yaw_gate: bool = True,
+    deviation_collision_thresh_m: float = 2.0,
 ) -> _SegState:
     from scenario_generation.mpc_tracker import MPCTracker, PerfectTracker
 
@@ -589,6 +598,8 @@ def _seed_state(
         rb_dists=np.full(cap, np.inf, dtype=np.float32),
         red_light=np.zeros(cap, dtype=bool),
         accels=np.zeros(cap, dtype=np.float32),
+        gt_devs=np.full(cap, np.inf, dtype=np.float32),
+        deviation_collision_thresh_m=float(deviation_collision_thresh_m),
         strong_brake_mps2=float(strong_brake_mps2),
         prev_max_idx=cursor.max_idx_reached,
         max_steps=cap,
@@ -689,9 +700,18 @@ def _wrap_pi(a):
     return (a + np.pi) % (2.0 * np.pi) - np.pi
 
 
+class GTDeviation(NamedTuple):
+    """Result of ``_gt_deviation_m``: the min distance plus enough to visualize it."""
+
+    dist_m: float
+    nearest_xy: np.ndarray | None  # world (2,); None when no valid/yaw-gated window point
+    lo: int  # recorded-pose window bounds ([lo, hi)) the distance was searched over
+    hi: int
+
+
 def _gt_deviation_m(
     tl: RouteTimeline, live_xy: np.ndarray, live_yaw: float, cursor_idx: int
-) -> float:
+) -> GTDeviation:
     """Min yaw-gated point-to-polyline distance from ``live_xy`` to a ±15 s window of
     recorded poses centered on ``cursor_idx``.
 
@@ -713,12 +733,12 @@ def _gt_deviation_m(
     hi = min(n, int(cursor_idx) + _GT_DEV_WINDOW_FRAMES + 1)
     window = tl.poses[lo:hi]  # (M, 3) -- xy + yaw
     if len(window) == 0:
-        return _GT_DEV_INF
+        return GTDeviation(_GT_DEV_INF, None, lo, hi)
     if len(window) == 1:
         pose = window[0]
         if abs(_wrap_pi(float(pose[2]) - float(live_yaw))) > (np.pi / 2.0):
-            return _GT_DEV_INF
-        return float(np.linalg.norm(live_xy - pose[:2]))
+            return GTDeviation(_GT_DEV_INF, None, lo, hi)
+        return GTDeviation(float(np.linalg.norm(live_xy - pose[:2])), pose[:2].copy(), lo, hi)
     a = window[:-1, :2]
     b = window[1:, :2]
     ab = b - a  # (M-1, 2)
@@ -734,7 +754,10 @@ def _gt_deviation_m(
     seg_yaw = np.arctan2(ab[:, 1], ab[:, 0])
     wrong_heading = np.abs(_wrap_pi(seg_yaw - float(live_yaw))) > (np.pi / 2.0)
     d = np.where(wrong_heading, _GT_DEV_INF, d)
-    return float(d.min())
+    i = int(np.argmin(d))
+    if not np.isfinite(d[i]):
+        return GTDeviation(_GT_DEV_INF, None, lo, hi)
+    return GTDeviation(float(d[i]), proj[i].copy(), lo, hi)
 
 
 def _score_into(
@@ -908,6 +931,33 @@ def _post_step(s: _SegState, pred: np.ndarray, neighbors_live, idx, device, time
     _advance_step(s, pred, idx, device, timers)
 
 
+def _event_onsets(mask: np.ndarray, clear_frames: int = EVENT_COUNT_CLEAR_FRAMES) -> list:
+    """Onset step index of each rising-edge event in ``mask``, with falling-edge debounce.
+
+    Entering True from outside an event starts a new event (its onset is recorded). While
+    in an event, a False gap shorter than ``clear_frames`` keeps the latch (no new onset on
+    the next True); only ``clear_frames`` consecutive Falses release it so a later True is a
+    new event. ``len(_event_onsets(mask)) == _event_count(mask)`` always.
+    """
+    onsets = []
+    if mask.size == 0:
+        return onsets
+    in_event = False
+    false_run = 0
+    for i, v in enumerate(mask.astype(bool)):
+        if v:
+            if not in_event:
+                onsets.append(i)
+                in_event = True
+            false_run = 0
+        elif in_event:
+            false_run += 1
+            if false_run >= clear_frames:
+                in_event = False
+                false_run = 0
+    return onsets
+
+
 def _event_count(mask: np.ndarray, clear_frames: int = EVENT_COUNT_CLEAR_FRAMES) -> int:
     """Rising-edge event count with falling-edge debounce.
 
@@ -916,23 +966,7 @@ def _event_count(mask: np.ndarray, clear_frames: int = EVENT_COUNT_CLEAR_FRAMES)
     ``clear_frames`` consecutive Falses release it so a later True is a new event. Used for
     collision / near-miss / strong-brake ``*_count`` (``*_steps`` stay raw).
     """
-    if mask.size == 0:
-        return 0
-    count = 0
-    in_event = False
-    false_run = 0
-    for v in mask.astype(bool):
-        if v:
-            if not in_event:
-                count += 1
-                in_event = True
-            false_run = 0
-        elif in_event:
-            false_run += 1
-            if false_run >= clear_frames:
-                in_event = False
-                false_run = 0
-    return count
+    return len(_event_onsets(mask, clear_frames))
 
 
 def _clearance_stats(values: np.ndarray) -> dict:
@@ -1006,6 +1040,33 @@ def strong_brake_block(accels: np.ndarray, thresh_mps2: float) -> dict:
     }
 
 
+def deviation_collision_block(collisions: np.ndarray, gt_devs: np.ndarray, thresh_m: float) -> dict:
+    """The ``deviation_collision`` segment-row block: object collisions that happened while
+    the live ego was more than ``thresh_m`` off the recorded GT path at that same step.
+
+    A breakdown of ``object.collision_count``, not a replacement -- every deviation
+    collision is also counted there. ``gt_devs`` steps with no valid GT window (``inf``,
+    see ``_gt_deviation_m``) are treated as deviated (conservative: can't confirm the ego
+    was on-path).
+
+    ``count`` classifies each raw collision event (as delimited by ``_event_onsets`` on
+    ``collisions``, same debounce as ``object.collision_count``) exactly once, at its onset
+    step -- not by re-running the debounced event counter over the AND-filtered per-step
+    mask. A single uninterrupted collision that dips in and out of deviation mid-event would
+    otherwise be double-counted here while staying one event in ``object.collision_count``,
+    breaking the breakdown invariant. ``steps`` stays a raw per-step tally.
+    """
+    thresh_m = float(thresh_m)
+    mask = collisions & (gt_devs > thresh_m)
+    onsets = _event_onsets(collisions)
+    count = sum(1 for i in onsets if gt_devs[i] > thresh_m)
+    return {
+        "thresh_m": thresh_m,
+        "steps": int(mask.sum()),
+        "count": count,
+    }
+
+
 def _finalize(s: _SegState) -> dict:
     cl = s.clearances[: s.k]
     rb = s.rb_dists[: s.k]
@@ -1032,6 +1093,13 @@ def _finalize(s: _SegState) -> dict:
         else float("inf"),
         "progress_m": progress_m,
         "object": clearance_family_block(cl, s.collisions[: s.k], miss_thresh=s.near_miss_thresh),
+        "deviation_collision": (
+            deviation_collision_block(
+                s.collisions[: s.k], s.gt_devs[: s.k], s.deviation_collision_thresh_m
+            )
+            if s.gt_devs is not None
+            else {"thresh_m": float(s.deviation_collision_thresh_m), "steps": 0, "count": 0}
+        ),
         "road_border": clearance_family_block(
             rb, road_border_collision_mask(rb), miss_thresh=s.near_miss_thresh
         ),
@@ -1402,6 +1470,7 @@ def _draw_step(
     view_half_m: float = 50.0,
     extra_ego_trajectories: list[tuple[np.ndarray, str, str]] | None = None,
     reproducer_ego: tuple[float, float, float] | None = None,
+    gt_deviation_viz: tuple[np.ndarray, np.ndarray, float] | None = None,
 ):
     """Save a PNG of one reproducer step with the EXACT perfect-tracker sim renderer.
 
@@ -1418,6 +1487,11 @@ def _draw_step(
 
     ``reproducer_ego``: optional ``(x, y, heading)`` of the recorded cursor ego in
     the live-ego frame, drawn as a hollow outline matching the live ego color.
+
+    ``gt_deviation_viz``: optional ``(window_xy, nearest_xy, dist_m)`` -- the recorded-path
+    window and nearest point (both already in the live-ego frame, see ``_gt_deviation_m``)
+    this step's GT deviation was measured against, drawn as a thin path line plus the
+    perpendicular from the live ego to ``nearest_xy``.
     """
     from pathlib import Path
 
@@ -1454,6 +1528,7 @@ def _draw_step(
         road_border_polylines=_polylines_from_tensor(data["line_strings"], border_only=True),
         extra_ego_trajectories=extra_ego_trajectories,
         reproducer_ego=reproducer_ego,
+        gt_deviation_viz=gt_deviation_viz,
     )
 
 
@@ -1482,6 +1557,7 @@ def render_segment(
     abort_deviation_m: float,
     abort_after: int,
     abort_max_snaps: int,
+    deviation_collision_thresh_m: float,
     drop_objects: bool,
     goal_mode: str,
     title_prefix: str | None,
@@ -1598,6 +1674,7 @@ def render_segment(
         goal_mode=goal_mode,
         strong_brake_mps2=strong_brake_mps2,
         yaw_gate=yaw_gate,
+        deviation_collision_thresh_m=deviation_collision_thresh_m,
     )
     # Build per-track interpolation anchors over the frames this render visits.
     # The cursor maps sim steps to recorded frames in ~[start, end]; a small
@@ -1678,9 +1755,12 @@ def render_segment(
             # from the live ego to a ±15 s window of recorded poses around the cursor's current frame
             # (see ``_gt_deviation_m``). Pure xy distance to the cursor frame would over-report drift
             # whenever the cursor is mid-repeat / mid-cooldown.
-            gt_deviation_m = _gt_deviation_m(tl, s.live_pose[:2], s.live_pose[2], idx)
+            gt_dev = _gt_deviation_m(tl, s.live_pose[:2], s.live_pose[2], idx)
+            gt_deviation_m = gt_dev.dist_m
             s.gt_dev_sum += gt_deviation_m
             s.gt_dev_count += 1
+            if s.gt_devs is not None:
+                s.gt_devs[k] = gt_deviation_m
             if abort_deviation_m > 0 and gt_deviation_m > abort_deviation_m:
                 deviation_streak += 1
             else:
@@ -1745,6 +1825,12 @@ def render_segment(
                         else None,
                         "red_light_violation": bool(s.red_light[k]),
                         "gt_deviation_m": round(gt_deviation_m, 3),
+                        # collision AND off the recorded GT path by > deviation_collision_thresh_m
+                        # (see ``deviation_collision_block``); same per-step definition the
+                        # segment-level "deviation_collision" metric rolls up from.
+                        "deviation_collision": bool(
+                            s.collisions[k] and gt_deviation_m > s.deviation_collision_thresh_m
+                        ),
                     }
                 )
                 + "\n"
@@ -1810,6 +1896,23 @@ def render_segment(
                 and k % draw_every == 0
             ):
                 repro_xyh = _world_pose_to_ego(tl.poses[idx], s.live_pose)
+                gt_dev_viz = None
+                if gt_dev.nearest_xy is not None:
+                    window_xy = _world_plan_to_ego(
+                        tl.poses[gt_dev.lo : gt_dev.hi, :2],
+                        tl.poses[gt_dev.lo : gt_dev.hi, 2],
+                        s.live_pose[0],
+                        s.live_pose[1],
+                        s.live_pose[2],
+                    )[:, :2]
+                    nearest_xy = _world_plan_to_ego(
+                        gt_dev.nearest_xy[None, :],
+                        np.zeros(1),
+                        s.live_pose[0],
+                        s.live_pose[1],
+                        s.live_pose[2],
+                    )[0, :2]
+                    gt_dev_viz = (window_xy, nearest_xy, gt_deviation_m)
                 with timers("render_submit"):
                     pending.append(
                         draw.submit(
@@ -1825,6 +1928,7 @@ def render_segment(
                             distance_label_offset_m=distance_label_offset_m,
                             view_half_m=view_half_m,
                             reproducer_ego=repro_xyh,
+                            gt_deviation_viz=gt_dev_viz,
                         )
                     )
             snaps_before = s.snap_count

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -1495,6 +1495,7 @@ def render_segment(
     max_steps: int | None,
     timeline_progress_mode: str,
     draw_pool: Executor | None,
+    timers: Timers | None = None,
 ) -> dict:
     """Re-run one segment with per-step PNG rendering (live-ego frame).
 
@@ -1573,7 +1574,7 @@ def render_segment(
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     cap = max_steps if max_steps is not None else 3 * (end - start)
-    timers = Timers()
+    timers = timers or Timers()
     s = _seed_state(
         tl=tl,
         start=start,
@@ -1639,7 +1640,8 @@ def render_segment(
         )
         while not s.done:
             k = s.k
-            pre = _pre_step(s)
+            with timers("input_build"):
+                pre = _pre_step(s)
             if pre is None:
                 dbg.write(
                     json.dumps(
@@ -1754,10 +1756,12 @@ def render_segment(
             offset = k % replan_interval
             override = None
             if plan_world is None or offset == 0:
-                data = _to_torch_batch([np_dict], model_args, device)
+                with timers("to_torch"):
+                    data = _to_torch_batch([np_dict], model_args, device)
                 # No-op unless the model was compiled with cudagraphs; one inference is one step.
                 mark_inference_step()
-                _, outputs = model(data)
+                with timers("model_forward"):
+                    _, outputs = model(data)
                 pred = outputs["prediction"][0, 0].cpu().numpy()
                 plan_world = _ego_pred_to_world(
                     pred[:, :2], pred[:, 2:4], s.live_pose[0], s.live_pose[1], s.live_pose[2]
@@ -1804,22 +1808,23 @@ def render_segment(
                 and k % draw_every == 0
             ):
                 repro_xyh = _world_pose_to_ego(tl.poses[idx], s.live_pose)
-                pending.append(
-                    draw.submit(
-                        _draw_step,
-                        np_dict,
-                        pred_cur,
-                        s.ego_shape,
-                        out_dir / f"{k:05d}.png",
-                        neighbor_ids=nids if color_by_uuid else None,
-                        step=k,
-                        total=cap,
-                        title_prefix=title_prefix,
-                        distance_label_offset_m=distance_label_offset_m,
-                        view_half_m=view_half_m,
-                        reproducer_ego=repro_xyh,
+                with timers("render_submit"):
+                    pending.append(
+                        draw.submit(
+                            _draw_step,
+                            np_dict,
+                            pred_cur,
+                            s.ego_shape,
+                            out_dir / f"{k:05d}.png",
+                            neighbor_ids=nids if color_by_uuid else None,
+                            step=k,
+                            total=cap,
+                            title_prefix=title_prefix,
+                            distance_label_offset_m=distance_label_offset_m,
+                            view_half_m=view_half_m,
+                            reproducer_ego=repro_xyh,
+                        )
                     )
-                )
             snaps_before = s.snap_count
             _advance_step(s, pred_cur, idx, device, timers, override=override)
             if s.snap_count > snaps_before:
@@ -1829,8 +1834,9 @@ def render_segment(
                 plan_world = None
     # Every PNG must be on disk before the caller globs the directory for ffmpeg, and a worker
     # exception only surfaces here.
-    for f in pending:
-        f.result()
+    with timers("render_drain"):
+        for f in pending:
+            f.result()
     return _finalize(s)
 
 

--- a/scenario_generation/simulate.py
+++ b/scenario_generation/simulate.py
@@ -93,6 +93,11 @@ class _OnnxModel:
     everything else float32; ``delay`` is reshaped to the graph's ``[1, 1]``), run the session, and
     wrap the two outputs back into torch tensors on ``device``."""
 
+    # nn.Module parity: the open-loop validator toggles train/eval mode around inference
+    # (``was_training = model.training`` / ``model.train(was_training)``); the graph is
+    # inference-only, so this is always False and train() is a no-op.
+    training = False
+
     def __init__(
         self,
         onnx_path: str | Path,
@@ -153,6 +158,9 @@ class _OnnxModel:
         return None, outputs
 
     def eval(self):  # parity with nn.Module (no-op)
+        return self
+
+    def train(self, mode: bool = True):  # parity with nn.Module (no-op)
         return self
 
 

--- a/scenario_generation/tests/test_closed_loop_metrics.py
+++ b/scenario_generation/tests/test_closed_loop_metrics.py
@@ -155,6 +155,118 @@ def test_road_border_step_near_border_counts_miss():
     assert out["rb_dist_m"] < 0.3
 
 
+def _border_ls() -> np.ndarray:
+    ls = np.zeros((1, 4, 4), dtype=np.float32)
+    ls[0, 0, :2] = (-2.0, 0.05)
+    ls[0, 1, :2] = (2.0, 0.05)
+    ls[0, 0, 3] = 1.0
+    ls[0, 1, 3] = 1.0
+    return ls
+
+
+def _nonintersecting_border_ls() -> np.ndarray:
+    ls = _border_ls()
+    ls[0, :2, 1] = 2.0
+    return ls
+
+
+def _two_sided_border_ls() -> np.ndarray:
+    ls = np.zeros((2, 2, 4), dtype=np.float32)
+    ls[:, 0, :2] = (-2.0, 2.0)
+    ls[:, 1, :2] = (2.0, 2.0)
+    ls[0, :, 1] = 2.0
+    ls[1, :, 1] = -2.0
+    ls[..., 3] = 1.0
+    return ls
+
+
+def test_road_border_step_signed_positive_when_inside_lane():
+    lanes = np.zeros((1, 2, 33), dtype=np.float32)
+    lanes[0, :, :2] = [(-5.0, 0.0), (5.0, 0.0)]  # centerline through the ego
+    lanes[0, :, 4:6] = (0.0, 1.0)  # left boundary 1m to the left
+    lanes[0, :, 6:8] = (0.0, -1.0)  # right boundary 1m to the right -> ego origin inside
+    out = score_road_border_step(
+        {
+            "line_strings": _nonintersecting_border_ls(),
+            "ego_shape": np.array([2.7, 4.0, 2.0], dtype=np.float32),
+            "lanes": lanes,
+        },
+        device="cpu",
+    )
+    assert np.isfinite(out["rb_dist_m"])
+    assert out["rb_dist_m"] > 0
+
+
+def test_road_border_step_signed_negative_when_outside_lane():
+    lanes = np.zeros((1, 2, 33), dtype=np.float32)
+    lanes[0, :, :2] = [(-5.0, 5.0), (5.0, 5.0)]  # lane shifted away from the ego origin
+    lanes[0, :, 4:6] = (0.0, 1.0)
+    lanes[0, :, 6:8] = (0.0, -1.0)
+    out = score_road_border_step(
+        {
+            "line_strings": _nonintersecting_border_ls(),
+            "ego_shape": np.array([2.7, 4.0, 2.0], dtype=np.float32),
+            "lanes": lanes,
+        },
+        device="cpu",
+    )
+    assert np.isfinite(out["rb_dist_m"])
+    assert out["rb_dist_m"] < 0
+
+
+def test_road_border_step_uses_border_corridor_when_lane_is_missing():
+    lanes = np.zeros((1, 2, 33), dtype=np.float32)
+    lanes[0, :, :2] = [(-5.0, 5.0), (5.0, 5.0)]
+    lanes[0, :, 4:6] = (0.0, 1.0)
+    lanes[0, :, 6:8] = (0.0, -1.0)
+    out = score_road_border_step(
+        {
+            "line_strings": _two_sided_border_ls(),
+            "ego_shape": np.array([2.7, 4.0, 2.0], dtype=np.float32),
+            "lanes": lanes,
+        },
+        device="cpu",
+    )
+    assert np.isfinite(out["rb_dist_m"])
+    assert out["rb_dist_m"] > 0
+
+
+def test_road_border_step_does_not_pair_unrelated_border_branches():
+    ls = np.zeros((2, 2, 4), dtype=np.float32)
+    ls[0, :, :2] = [(30.0, 2.0), (40.0, 2.0)]
+    ls[1, :, :2] = [(-30.0, -2.0), (-40.0, -2.0)]
+    ls[..., 3] = 1.0
+    lanes = np.zeros((1, 2, 33), dtype=np.float32)
+    lanes[0, :, :2] = [(-5.0, 5.0), (5.0, 5.0)]
+    lanes[0, :, 4:6] = (0.0, 1.0)
+    lanes[0, :, 6:8] = (0.0, -1.0)
+    out = score_road_border_step(
+        {
+            "line_strings": ls,
+            "ego_shape": np.array([2.7, 4.0, 2.0], dtype=np.float32),
+            "lanes": lanes,
+        },
+        device="cpu",
+    )
+    assert out["rb_dist_m"] < 0
+
+
+def test_road_border_step_is_zero_when_border_intersects_ego():
+    lanes = np.zeros((1, 3, 33), dtype=np.float32)
+    lanes[0, :, :2] = [(-5.0, 0.0), (0.0, 0.0), (5.0, 0.0)]
+    lanes[0, :, 4:6] = (0.0, 2.0)
+    lanes[0, :, 6:8] = (0.0, -2.0)
+    out = score_road_border_step(
+        {
+            "line_strings": _border_ls(),
+            "ego_shape": np.array([2.7, 4.0, 2.0], dtype=np.float32),
+            "lanes": lanes,
+        },
+        device="cpu",
+    )
+    assert out["rb_dist_m"] == 0.0
+
+
 def test_strong_brake_mask():
     # Isolated spike (-5) does not count; only the 2nd frame of a consecutive pair does.
     # Uses an explicit thresh (not the default) so the fixture values stay readable.

--- a/scenario_generation/tests/test_closed_loop_metrics.py
+++ b/scenario_generation/tests/test_closed_loop_metrics.py
@@ -12,7 +12,11 @@ from scenario_generation.metrics.ego_traj import ego_traj_ego_frame
 from scenario_generation.metrics.red_light import score_red_light_step
 from scenario_generation.metrics.road_border import score_road_border_step
 from scenario_generation.metrics.strong_brake import strong_brake_mask
-from scenario_generation.reproducer_rollout import _clearance_stats, _event_count
+from scenario_generation.reproducer_rollout import (
+    _clearance_stats,
+    _event_count,
+    deviation_collision_block,
+)
 
 
 def _default_hist(live: np.ndarray) -> np.ndarray:
@@ -311,6 +315,11 @@ def _segment_row(**overrides) -> dict:
             TDIGEST_KEY: tdigest_dict_from_values(rb_vals),
         },
         "red_light_violation": {"steps": 1, "count": 1},
+        "deviation_collision": {
+            "thresh_m": 2.0,
+            "steps": 0,
+            "count": 0,
+        },
         "strong_brake": {
             "thresh_mps2": -2.5,
             "strongest_mps2": float("inf"),
@@ -435,3 +444,22 @@ def test_segment_row_for_json_strips_tdigest():
 
 def test_event_count_debounce_unchanged():
     assert _event_count(np.array([1, 0, 0, 0, 1], dtype=bool)) == 2
+
+
+def test_deviation_collision_block_classifies_one_collision_event_once():
+    # A single uninterrupted collision event (never drops out, so
+    # object.collision_count == _event_count(collisions) == 1) whose GT deviation dips
+    # below threshold for >= EVENT_COUNT_CLEAR_FRAMES steps mid-event and then rises again.
+    # Filtering-then-event-counting the AND mask would (wrongly) see this as two
+    # deviation-collision events; classifying the one collision event at its onset must not.
+    collisions = np.ones(12, dtype=bool)
+    gt_devs = np.array([3.0, 3.0, 3.0, 1.0, 1.0, 1.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0])
+    thresh_m = 2.0
+
+    assert _event_count(collisions) == 1
+
+    block = deviation_collision_block(collisions, gt_devs, thresh_m)
+
+    assert block["count"] == 1
+    assert block["count"] <= _event_count(collisions)
+    assert block["steps"] == int((collisions & (gt_devs > thresh_m)).sum())

--- a/scenario_generation/tests/test_reproducer_recenter.py
+++ b/scenario_generation/tests/test_reproducer_recenter.py
@@ -96,7 +96,8 @@ def test_ego_border_distance_keeps_large_real_clearance():
     line_strings[0, 0, :2] = [-10.0, far_border_y_m]
     line_strings[0, 1, :2] = [10.0, far_border_y_m]
     line_strings[0, :2, 3] = 1.0
-    map_data = SimpleNamespace(line_strings=line_strings)
+    lanes = None
+    map_data = SimpleNamespace(line_strings=line_strings, lanes=lanes)
 
     rb_info = _ego_border_distance(ego, map_data)
 

--- a/scenario_generation/tests/test_scenario_sim_viewer_export.py
+++ b/scenario_generation/tests/test_scenario_sim_viewer_export.py
@@ -56,6 +56,7 @@ def _row() -> dict:
         "object": dict(clearance),
         "road_border": dict(clearance),
         "red_light_violation": {"steps": 0, "count": 0, "measured": False},
+        "deviation_collision": {"thresh_m": 2.0, "steps": 0, "count": 0},
         # inf is the in-band "no braking event" value the rollout writes.
         "strong_brake": {
             "thresh_mps2": -2.5,


### PR DESCRIPTION
Brings the six `HansRobo/Diffusion-Planner` PRs that landed after #367/#382 into `tier4-main`.

Cherry-picked onto `tier4/tier4-main` as a topic branch, so the PR carries exactly six commits and the pure content delta — no phantom commits from the fork's already-merged history.

| # | Upstream PR | Change |
|---|---|---|
| 1 | [HansRobo#87](https://github.com/HansRobo/Diffusion-Planner/pull/87) | support onnx model in open loop |
| 2 | [HansRobo#90](https://github.com/HansRobo/Diffusion-Planner/pull/90) | show timing breakdown |
| 3 | [HansRobo#79](https://github.com/HansRobo/Diffusion-Planner/pull/79) | sign `rb_dist_m` by lane containment (inside +, outside −) |
| 4 | [HansRobo#91](https://github.com/HansRobo/Diffusion-Planner/pull/91) | use perfect tracker and replan interval 8 |
| 5 | [HansRobo#89](https://github.com/HansRobo/Diffusion-Planner/pull/89) | add collision metrics with gt deviation |
| 6 | [HansRobo#92](https://github.com/HansRobo/Diffusion-Planner/pull/92) | add trajectry color map |

Everything else on `HansRobo:tier4-main` is already here — the pre-#367 commits survive as rebased twins, and HansRobo#83 landed as #382.

Please merge with **rebase and merge** to keep the six commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
