### PR TITLE
feat: add blinker metrics

### DIFF
--- a/diffusion_planner/run_all_groups_closed_loop.py
+++ b/diffusion_planner/run_all_groups_closed_loop.py
@@ -327,22 +327,18 @@ def _write_groups_manifest(out_dir: Path | str, summaries: dict[str, dict]) -> N
             ),
         }
 
-        _ti_correct = sum(
-            int(s.get("turn_indicator", {}).get("correct", 0) or 0) for s in summaries.values()
-        )
-        _ti_total = sum(
-            int(s.get("turn_indicator", {}).get("total", 0) or 0) for s in summaries.values()
-        )
-        _ti_change_correct = sum(
-            int(s.get("turn_indicator", {}).get("change_correct", 0) or 0)
+        _ti_transition_correct = sum(
+            int(s.get("turn_indicator", {}).get("transition_correct", 0) or 0)
             for s in summaries.values()
         )
-        _ti_change_total = sum(
-            int(s.get("turn_indicator", {}).get("change_total", 0) or 0) for s in summaries.values()
+        _ti_transition_total = sum(
+            int(s.get("turn_indicator", {}).get("transition_total", 0) or 0)
+            for s in summaries.values()
         )
-        agg["turn_indicator_accuracy"] = (_ti_correct / _ti_total) if _ti_total else 0.0
-        agg["turn_indicator_change_accuracy"] = (
-            (_ti_change_correct / _ti_change_total) if _ti_change_total else 0.0
+        # None (not 0.0) when no transition was ever scored across any group -- a silent 0.0
+        # would misread as "always wrong at transitions" rather than "nothing to measure".
+        agg["turn_indicator_transition_accuracy"] = (
+            (_ti_transition_correct / _ti_transition_total) if _ti_transition_total else None
         )
 
         total_pass = sum(int(s.get("pass_count", 0) or 0) for s in summaries.values())

--- a/diffusion_planner/run_all_groups_closed_loop.py
+++ b/diffusion_planner/run_all_groups_closed_loop.py
@@ -327,6 +327,24 @@ def _write_groups_manifest(out_dir: Path | str, summaries: dict[str, dict]) -> N
             ),
         }
 
+        _ti_correct = sum(
+            int(s.get("turn_indicator", {}).get("correct", 0) or 0) for s in summaries.values()
+        )
+        _ti_total = sum(
+            int(s.get("turn_indicator", {}).get("total", 0) or 0) for s in summaries.values()
+        )
+        _ti_change_correct = sum(
+            int(s.get("turn_indicator", {}).get("change_correct", 0) or 0)
+            for s in summaries.values()
+        )
+        _ti_change_total = sum(
+            int(s.get("turn_indicator", {}).get("change_total", 0) or 0) for s in summaries.values()
+        )
+        agg["turn_indicator_accuracy"] = (_ti_correct / _ti_total) if _ti_total else 0.0
+        agg["turn_indicator_change_accuracy"] = (
+            (_ti_change_correct / _ti_change_total) if _ti_change_total else 0.0
+        )
+
         total_pass = sum(int(s.get("pass_count", 0) or 0) for s in summaries.values())
         total_fail = sum(int(s.get("fail_count", 0) or 0) for s in summaries.values())
         agg["n_pass_segments"] = total_pass

--- a/scenario_generation/closed_loop_eval.py
+++ b/scenario_generation/closed_loop_eval.py
@@ -331,6 +331,9 @@ def format_summary_lines(summary: dict) -> list[str]:
     red = summary["red_light_violation"]
     brake = summary["strong_brake"]
     ti = summary["turn_indicator"]
+    ti_acc_str = (
+        f"{ti['transition_accuracy']:.4f}" if ti["transition_accuracy"] is not None else "N/A"
+    )
     repro = summary["reproducer"]
     lines = [
         f"object collision: {obj['collision_segments']}/{n_seg} segments "
@@ -364,9 +367,8 @@ def format_summary_lines(summary: dict) -> list[str]:
         f"reproducer snap_count={repro['snap_count']} expand_count={repro['expand_count']} "
         f"repeat_step_rate={repro['repeat_step_rate']:.4f}  "
         f"terminated={summary['terminated_counts']}",
-        f"turn_indicator accuracy: {ti['correct']}/{ti['total']} ({ti['accuracy']:.4f}), "
-        f"on-change accuracy: {ti['change_correct']}/{ti['change_total']} "
-        f"({ti['change_accuracy']:.4f})",
+        f"turn_indicator transition accuracy: "
+        f"{ti['transition_correct']}/{ti['transition_total']} ({ti_acc_str})",
     ]
     return lines
 
@@ -466,12 +468,12 @@ def aggregate(
     strongest = [float(_require_block(r, "strong_brake")["strongest_mps2"]) for r in rows]
     brake["strongest_mps2"] = min(strongest) if strongest else float("inf")
 
-    turn_correct = sum(int(_require_block(r, "turn_indicator")["correct"]) for r in rows)
-    turn_total = sum(int(_require_block(r, "turn_indicator")["total"]) for r in rows)
-    turn_change_correct = sum(
-        int(_require_block(r, "turn_indicator")["change_correct"]) for r in rows
+    turn_transition_correct = sum(
+        int(_require_block(r, "turn_indicator")["transition_correct"]) for r in rows
     )
-    turn_change_total = sum(int(_require_block(r, "turn_indicator")["change_total"]) for r in rows)
+    turn_transition_total = sum(
+        int(_require_block(r, "turn_indicator")["transition_total"]) for r in rows
+    )
 
     expand = sum(int(_require_block(r, "reproducer")["expand_count"]) for r in rows)
     snap = sum(int(_require_block(r, "reproducer")["snap_count"]) for r in rows)
@@ -493,13 +495,14 @@ def aggregate(
         "red_light_violation": red,
         "strong_brake": brake,
         "turn_indicator": {
-            "correct": turn_correct,
-            "total": turn_total,
-            "accuracy": (turn_correct / turn_total) if turn_total > 0 else 0.0,
-            "change_correct": turn_change_correct,
-            "change_total": turn_change_total,
-            "change_accuracy": (
-                turn_change_correct / turn_change_total if turn_change_total > 0 else 0.0
+            "transition_correct": turn_transition_correct,
+            "transition_total": turn_transition_total,
+            # None (not 0.0) when no transition was ever scored: a silent 0.0 would misread as
+            # "always wrong at transitions" rather than "no transitions to measure".
+            "transition_accuracy": (
+                (turn_transition_correct / turn_transition_total)
+                if turn_transition_total > 0
+                else None
             ),
         },
         "terminated_counts": term_counts,

--- a/scenario_generation/closed_loop_eval.py
+++ b/scenario_generation/closed_loop_eval.py
@@ -330,6 +330,7 @@ def format_summary_lines(summary: dict) -> list[str]:
     rb = summary["road_border"]
     red = summary["red_light_violation"]
     brake = summary["strong_brake"]
+    ti = summary["turn_indicator"]
     repro = summary["reproducer"]
     lines = [
         f"object collision: {obj['collision_segments']}/{n_seg} segments "
@@ -363,6 +364,9 @@ def format_summary_lines(summary: dict) -> list[str]:
         f"reproducer snap_count={repro['snap_count']} expand_count={repro['expand_count']} "
         f"repeat_step_rate={repro['repeat_step_rate']:.4f}  "
         f"terminated={summary['terminated_counts']}",
+        f"turn_indicator accuracy: {ti['correct']}/{ti['total']} ({ti['accuracy']:.4f}), "
+        f"on-change accuracy: {ti['change_correct']}/{ti['change_total']} "
+        f"({ti['change_accuracy']:.4f})",
     ]
     return lines
 
@@ -462,6 +466,13 @@ def aggregate(
     strongest = [float(_require_block(r, "strong_brake")["strongest_mps2"]) for r in rows]
     brake["strongest_mps2"] = min(strongest) if strongest else float("inf")
 
+    turn_correct = sum(int(_require_block(r, "turn_indicator")["correct"]) for r in rows)
+    turn_total = sum(int(_require_block(r, "turn_indicator")["total"]) for r in rows)
+    turn_change_correct = sum(
+        int(_require_block(r, "turn_indicator")["change_correct"]) for r in rows
+    )
+    turn_change_total = sum(int(_require_block(r, "turn_indicator")["change_total"]) for r in rows)
+
     expand = sum(int(_require_block(r, "reproducer")["expand_count"]) for r in rows)
     snap = sum(int(_require_block(r, "reproducer")["snap_count"]) for r in rows)
     normal = sum(int(_require_block(r, "reproducer")["normal_steps"]) for r in rows)
@@ -481,6 +492,16 @@ def aggregate(
         "road_border": rb,
         "red_light_violation": red,
         "strong_brake": brake,
+        "turn_indicator": {
+            "correct": turn_correct,
+            "total": turn_total,
+            "accuracy": (turn_correct / turn_total) if turn_total > 0 else 0.0,
+            "change_correct": turn_change_correct,
+            "change_total": turn_change_total,
+            "change_accuracy": (
+                turn_change_correct / turn_change_total if turn_change_total > 0 else 0.0
+            ),
+        },
         "terminated_counts": term_counts,
         "reproducer": {
             "expand_count": expand,

--- a/scenario_generation/closed_loop_score_keys.py
+++ b/scenario_generation/closed_loop_score_keys.py
@@ -14,6 +14,8 @@ SCORE_EXTRACTORS = {
     "total_snaps": lambda d: d.get("reproducer", {}).get("snap_count"),
     "total_red_light_violations": lambda d: d.get("red_light_violation", {}).get("count"),
     "total_strong_brakes": lambda d: d.get("strong_brake", {}).get("count"),
+    "turn_indicator_accuracy": lambda d: d.get("turn_indicator", {}).get("accuracy"),
+    "turn_indicator_change_accuracy": lambda d: d.get("turn_indicator", {}).get("change_accuracy"),
 }
 
 

--- a/scenario_generation/closed_loop_score_keys.py
+++ b/scenario_generation/closed_loop_score_keys.py
@@ -14,8 +14,9 @@ SCORE_EXTRACTORS = {
     "total_snaps": lambda d: d.get("reproducer", {}).get("snap_count"),
     "total_red_light_violations": lambda d: d.get("red_light_violation", {}).get("count"),
     "total_strong_brakes": lambda d: d.get("strong_brake", {}).get("count"),
-    "turn_indicator_accuracy": lambda d: d.get("turn_indicator", {}).get("accuracy"),
-    "turn_indicator_change_accuracy": lambda d: d.get("turn_indicator", {}).get("change_accuracy"),
+    "turn_indicator_transition_accuracy": lambda d: d.get("turn_indicator", {}).get(
+        "transition_accuracy"
+    ),
 }
 
 

--- a/scenario_generation/replay.py
+++ b/scenario_generation/replay.py
@@ -1185,6 +1185,8 @@ _EGO_COLOR = "#3366cc"
 _ROUTE_COLOR = "#3366cc"
 _GT_PATH_COLOR = "#e69138"
 _GT_DEV_COLOR = "#cc0000"
+_TURN_LAMP_PRED_COLOR = "#e69138"  # amber, like a real turn-signal lamp
+_TURN_LAMP_GT_COLOR = "#ffa726"  # orange -- same family as the pred amber, a shade lighter
 _VIEW_HALF_M = 50.0  # ±50 m window around ego keeps lane detail legible
 _ROAD_BORDER_FLAG_THRESH = 0.5
 _ROAD_BORDER_COORD_EPS_M = 1e-3
@@ -1569,6 +1571,8 @@ def save_step_figure(
     extra_ego_trajectories: list[tuple[np.ndarray, str, str]] | None = None,
     reproducer_ego: tuple[float, float, float] | None = None,
     gt_deviation_viz: tuple[np.ndarray, np.ndarray, float] | None = None,
+    turn_indicator_pred: int | None = None,
+    turn_indicator_gt: int | None = None,
 ) -> None:
     """Render + save the overview PNG for a single replay step.
 
@@ -1583,6 +1587,10 @@ def save_step_figure(
     ``window_xy`` is the recorded-path window the GT-deviation distance was searched over
     (drawn as a thin line); ``nearest_xy`` is the closest point on it, connected to the ego
     with a dashed perpendicular labeled with ``dist_m``.
+
+    ``turn_indicator_pred``/``turn_indicator_gt``: when given, override the HUD's turn-signal
+    reading (``ego.turn_indicators[-1]``, which can lag one step behind a closed-loop
+    caller's freshly-decoded prediction) and add the recorded GT class alongside it.
     """
     from matplotlib.figure import Figure
 
@@ -1748,6 +1756,109 @@ def save_step_figure(
                 wheelbase=agent.wheelbase if is_ego else None,
             )
 
+    def _draw_turn_edge(
+        cx: float,
+        cy: float,
+        heading: float,
+        left_on: bool,
+        right_on: bool,
+        zorder: float,
+        color: str,
+    ) -> None:
+        """Thin colored line along the box's side edge(s) that have an active turn signal,
+        mimicking a real vehicle's blinker more directly than a separate marker would.
+        Left/right are in the box's own frame (heading), not screen left/right. Inactive sides
+        are left untouched -- the plain box outline already reads as "off".
+
+        ``(cx, cy)`` is the REAR-AXLE midpoint (ego convention, same as ``draw_agent_box``'s
+        ``wheelbase`` branch above) -- not the box centroid, so the front/rear extents along
+        the box's own x-axis are asymmetric whenever wheelbase < length.
+
+        Pred (amber) and GT (purple) are drawn with distinct colors, not offset apart, so both
+        stay legible when the live ego and reproducer boxes are close/overlapping without
+        drifting either line off its own box's true edge.
+        """
+        length, width, wheelbase = float(ego.length), float(ego.width), float(ego.wheelbase)
+        half_wid = width / 2.0
+        rear_overhang = (length - wheelbase) / 2.0
+        front_local, rear_local = length - rear_overhang, -rear_overhang
+        fwd = np.array([math.cos(heading), math.sin(heading)])
+        left_dir = np.array([-math.sin(heading), math.cos(heading)])
+        center = np.array([cx, cy])
+        for side_dir, active in ((left_dir, left_on), (-left_dir, right_on)):
+            if not active:
+                continue
+            front_corner = center + fwd * front_local + side_dir * half_wid
+            rear_corner = center + fwd * rear_local + side_dir * half_wid
+            ax.plot(
+                [front_corner[0], rear_corner[0]],
+                [front_corner[1], rear_corner[1]],
+                color=color,
+                lw=2.0,
+                solid_capstyle="round",
+                zorder=zorder,
+            )
+
+    def _draw_turn_fill(
+        cx: float,
+        cy: float,
+        heading: float,
+        left_on: bool,
+        right_on: bool,
+        zorder: float,
+        color: str,
+        alpha: float = 0.5,
+    ) -> None:
+        """Semi-transparent fill over the box's active side HALF (split along its own
+        longitudinal centerline), instead of a hard edge line -- used for the GT box so its
+        outline/label stay untouched and the tint reads as "this half is lit" rather than a
+        line that can visually compete with the amber pred line.
+        """
+        from matplotlib.patches import Polygon
+
+        length, width, wheelbase = float(ego.length), float(ego.width), float(ego.wheelbase)
+        half_wid = width / 2.0
+        rear_overhang = (length - wheelbase) / 2.0
+        front_local, rear_local = length - rear_overhang, -rear_overhang
+        fwd = np.array([math.cos(heading), math.sin(heading)])
+        left_dir = np.array([-math.sin(heading), math.cos(heading)])
+        center = np.array([cx, cy])
+        front_center = center + fwd * front_local
+        rear_center = center + fwd * rear_local
+        for side_dir, active in ((left_dir, left_on), (-left_dir, right_on)):
+            if not active:
+                continue
+            front_side = front_center + side_dir * half_wid
+            rear_side = rear_center + side_dir * half_wid
+            ax.add_patch(
+                Polygon(
+                    np.array([front_center, front_side, rear_side, rear_center]),
+                    closed=True,
+                    facecolor=color,
+                    edgecolor="none",
+                    alpha=alpha,
+                    zorder=zorder,
+                )
+            )
+
+    # 3a-turn) Turn-indicator edge highlight on the LIVE ego box, showing the closed-loop
+    # PREDICTION.
+    pred_cls = (
+        int(turn_indicator_pred)
+        if turn_indicator_pred is not None
+        else (int(ego.turn_indicators[-1]) if ego.turn_indicators is not None else None)
+    )
+    if pred_cls is not None:
+        _draw_turn_edge(
+            ex,
+            ey,
+            float(ego.current_heading),
+            pred_cls == 2,
+            pred_cls == 3,
+            zorder=26,
+            color=_TURN_LAMP_PRED_COLOR,
+        )
+
     # 3a) Hollow reproducer ego (recorded cursor pose in the live-ego frame).
     # Same color as live ego, outline-only, so divergence from the closed-loop ego is visible.
     if reproducer_ego is not None:
@@ -1777,6 +1888,20 @@ def save_step_figure(
             textcoords="offset points",
             zorder=24,
         )
+        # Turn-indicator fill on the reproducer (GT) box, showing the recorded GT class --
+        # kept on the GT box itself rather than overlaid on the live ego, so pred vs GT reads
+        # as two separate boxes each showing their own truth.
+        if turn_indicator_gt is not None:
+            gt_cls = int(turn_indicator_gt)
+            _draw_turn_fill(
+                rx,
+                ry,
+                rh,
+                gt_cls == 2,
+                gt_cls == 3,
+                zorder=25,
+                color=_TURN_LAMP_GT_COLOR,
+            )
 
     # 3a-2) GT-deviation visualization: the recorded-path window this step's deviation was
     # measured against, plus the perpendicular from the live ego to the nearest point on it.
@@ -1857,12 +1982,10 @@ def save_step_figure(
         else float("nan")
     )
 
-    # Ego state readout: speed, steering, current turn-signal class.
+    # Ego state readout: speed, steering. Turn-signal state is shown by the lamp markers
+    # drawn above (section 3a-turn), not as text here.
     ego_speed = float(np.hypot(ego.current_velocity[0], ego.current_velocity[1]))
     ego_speed_kph = ego_speed * 3.6
-    _TI_NAMES = {0: "NONE", 1: "DISABLE", 2: "LEFT", 3: "RIGHT", 4: "KEEP"}
-    ti_cls = int(ego.turn_indicators[-1]) if ego.turn_indicators is not None else 0
-    ti_label = _TI_NAMES.get(ti_cls, f"?{ti_cls}")
     # Display steering in degrees with 1-decimal precision. Under 0.5°
     # the old :+.0f° rounded to "+0°" and was mistakable for radians.
     steer_deg = math.degrees(ego.steering_angle)
@@ -1871,7 +1994,7 @@ def save_step_figure(
         f"Step {step:04d}/{n_steps}  t={step * 0.1:.1f}s  agents={len(scene.agents)}"
         f"\nego  v={ego_speed:.1f} m/s ({ego_speed_kph:.0f} km/h)  "
         f"steer={steer_deg:+.1f}°  yawrate={yaw_rate_deg:+.1f}°/s  "
-        f"turn={ti_label}  goal_d={goal_d:.1f} m"
+        f"goal_d={goal_d:.1f} m"
     )
     if title_prefix:
         title = f"{title_prefix}\n{title}"

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -480,6 +480,13 @@ class _SegState:
     # A collision counts as "deviation collision" when the live ego was more than this far
     # off the recorded GT path at the same step (see ``deviation_collision_block``).
     deviation_collision_thresh_m: float = 2.0
+    # Closed-loop turn-indicator accuracy accumulators (see ``_score_turn_indicator``).
+    # Cumulative over the whole segment (never reset on unstick teleport), like
+    # ``expand_count``/``snap_count``.
+    turn_indicator_correct: int = 0
+    turn_indicator_total: int = 0
+    turn_indicator_change_correct: int = 0
+    turn_indicator_change_total: int = 0
 
 
 def _ego_state_from_frame(tl: RouteTimeline, idx: int) -> tuple[np.ndarray, np.ndarray, "_EgoDyn"]:
@@ -688,6 +695,35 @@ def _hold_turn_indicator(s: _SegState) -> None:
     history scrolling by re-appending the LAST decoded turn indicator, so the next replan
     sees the held signal as if the model had re-confirmed it every step."""
     s.turn_hist = np.append(s.turn_hist[1:], np.int64(s.last_turn_indicator))
+
+
+def _score_turn_indicator(s: _SegState, idx: int) -> None:
+    """Closed-loop turn-indicator accuracy for one REAL inference step.
+
+    Called only right after ``_feed_turn_indicator`` (both in ``render_segment`` and
+    ``run_segments_batched``) -- never after ``_hold_turn_indicator``, since a held/
+    cached-plan step made no fresh prediction and scoring it would conflate "no chance
+    to re-predict" with "was wrong".
+
+    Compares the RESOLVED prediction (``s.last_turn_indicator``, already in {0,1,2,3}
+    via ``resolve_keep_turn_indicator``) against the recorded GT at the same frame
+    ``idx`` the model conditioned on. This is a 4-class comparison, unlike
+    ``validate_model.py``'s training-time metric (raw 5-class argmax vs a KEEP-folded
+    GT) -- intentional, since KEEP never reaches storage/comparison in closed loop.
+
+    "Changed" is read off this frame's OWN GT window (``[-2]`` vs ``[-1]``) rather than
+    tracked across scored steps, so it stays correct even when the cursor skips/repeats
+    frames between scored steps.
+    """
+    gt_window = np.asarray(s.tl.npz(idx)["turn_indicators"]).reshape(-1)
+    gt = int(gt_window[-1])
+    pred = int(s.last_turn_indicator)
+    correct = pred == gt
+    s.turn_indicator_total += 1
+    s.turn_indicator_correct += int(correct)
+    if int(gt_window[-2]) != gt:
+        s.turn_indicator_change_total += 1
+        s.turn_indicator_change_correct += int(correct)
 
 
 # GT-deviation lookup window: ±15 s of recorded trajectory around the cursor. Wide enough to
@@ -1106,6 +1142,20 @@ def deviation_collision_block(collisions: np.ndarray, gt_devs: np.ndarray, thres
     }
 
 
+def turn_indicator_block(correct: int, total: int, change_correct: int, change_total: int) -> dict:
+    """The ``turn_indicator`` segment-row block: closed-loop turn-indicator prediction
+    accuracy, scored only on real inference steps (see ``_score_turn_indicator``). A plain
+    accumulator, like ``reproducer`` -- accuracy ratios are computed at aggregate time, not
+    here, so this stays summable across segments without re-deriving a rate.
+    """
+    return {
+        "correct": int(correct),
+        "total": int(total),
+        "change_correct": int(change_correct),
+        "change_total": int(change_total),
+    }
+
+
 def _finalize(s: _SegState) -> dict:
     cl = s.clearances[: s.k]
     rb = s.rb_dists[: s.k]
@@ -1162,6 +1212,12 @@ def _finalize(s: _SegState) -> dict:
             "count": _event_count(red_mask),
         },
         "strong_brake": strong_brake_block(accels, s.strong_brake_mps2),
+        "turn_indicator": turn_indicator_block(
+            s.turn_indicator_correct,
+            s.turn_indicator_total,
+            s.turn_indicator_change_correct,
+            s.turn_indicator_change_total,
+        ),
         "reproducer": {
             "expand_count": int(s.expand_count),
             "snap_count": int(s.snap_count),
@@ -1914,6 +1970,7 @@ def render_segment(
                 )
                 pred_cur = pred  # fresh plan: drawn + tracked in the current ego frame
                 _feed_turn_indicator(s, outputs)
+                _score_turn_indicator(s, idx)
             else:
                 # Clamp so a `replan_interval` longer than the horizon holds the final plan pose.
                 off = min(offset, len(plan_world[0]) - 1)
@@ -2657,6 +2714,7 @@ def run_segments_batched(
                             int(ti_pred[i]), s.last_turn_indicator
                         )
                         s.turn_hist = np.append(s.turn_hist[1:], np.int64(s.last_turn_indicator))
+                        _score_turn_indicator(s, idx)
                         # Clear the buffer on an unstick teleport: pre-jump frames belong
                         # to a different ego path and must never enter a saved window.
                         if s.save_buf is not None and s.snap_count > prev_snaps:

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -1581,6 +1581,8 @@ def _draw_step(
     extra_ego_trajectories: list[tuple[np.ndarray, str, str]] | None = None,
     reproducer_ego: tuple[float, float, float] | None = None,
     gt_deviation_viz: tuple[np.ndarray, np.ndarray, float] | None = None,
+    turn_indicator_pred: int | None = None,
+    turn_indicator_gt: int | None = None,
 ):
     """Save a PNG of one reproducer step with the EXACT perfect-tracker sim renderer.
 
@@ -1602,6 +1604,12 @@ def _draw_step(
     window and nearest point (both already in the live-ego frame, see ``_gt_deviation_m``)
     this step's GT deviation was measured against, drawn as a thin path line plus the
     perpendicular from the live ego to ``nearest_xy``.
+
+    ``turn_indicator_pred``/``turn_indicator_gt``: this step's resolved closed-loop
+    prediction (``s.last_turn_indicator``) and the recorded GT class, passed explicitly
+    because ``np_dict["turn_indicators"]`` is built at the top of the step (before this
+    step's fresh decode), so reading it back out of ``np_dict`` would show last step's
+    value in the HUD.
     """
     from pathlib import Path
 
@@ -1639,6 +1647,8 @@ def _draw_step(
         extra_ego_trajectories=extra_ego_trajectories,
         reproducer_ego=reproducer_ego,
         gt_deviation_viz=gt_deviation_viz,
+        turn_indicator_pred=turn_indicator_pred,
+        turn_indicator_gt=turn_indicator_gt,
     )
 
 
@@ -2044,6 +2054,10 @@ def render_segment(
                             view_half_m=view_half_m,
                             reproducer_ego=repro_xyh,
                             gt_deviation_viz=gt_dev_viz,
+                            turn_indicator_pred=int(s.last_turn_indicator),
+                            turn_indicator_gt=int(
+                                np.asarray(tl.npz(idx)["turn_indicators"]).reshape(-1)[-1]
+                            ),
                         )
                     )
             snaps_before = s.snap_count

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -480,13 +480,20 @@ class _SegState:
     # A collision counts as "deviation collision" when the live ego was more than this far
     # off the recorded GT path at the same step (see ``deviation_collision_block``).
     deviation_collision_thresh_m: float = 2.0
-    # Closed-loop turn-indicator accuracy accumulators (see ``_score_turn_indicator``).
-    # Cumulative over the whole segment (never reset on unstick teleport), like
-    # ``expand_count``/``snap_count``.
-    turn_indicator_correct: int = 0
-    turn_indicator_total: int = 0
-    turn_indicator_change_correct: int = 0
-    turn_indicator_change_total: int = 0
+    # Closed-loop turn-indicator TRANSITION accuracy accumulators (see
+    # ``_score_turn_indicator``). Only transitions count -- plain per-step accuracy is
+    # dominated by long stable KEEP/NONE periods and doesn't show whether the model switches
+    # indicators correctly, so it isn't tracked at all. Cumulative over the whole segment
+    # (never reset on unstick teleport), like ``expand_count``/``snap_count``.
+    turn_indicator_transition_correct: int = 0
+    turn_indicator_transition_total: int = 0
+    # GT turn-indicator class at the PREVIOUS scored (real-inference) step, so a transition can
+    # be detected across scored steps rather than within one frame's own two-tick window (which
+    # misses a GT transition that happens entirely between two scored steps, e.g. under
+    # ``replan_interval > 1`` or a cursor skip/repeat). Seeded in ``_seed_state`` and re-seeded
+    # on an unstick teleport (see ``_advance_step``), so a teleport's environment jump is never
+    # itself counted as a transition.
+    turn_indicator_prev_scored_gt: int = 0
 
 
 def _ego_state_from_frame(tl: RouteTimeline, idx: int) -> tuple[np.ndarray, np.ndarray, "_EgoDyn"]:
@@ -599,6 +606,7 @@ def _seed_state(
         dyn=dyn,
         turn_hist=turn_hist,
         last_turn_indicator=int(turn_hist[-1]),
+        turn_indicator_prev_scored_gt=int(turn_hist[-1]),
         ego_shape=ego_shape,
         goal_xy=goal_xy,
         clearances=np.full(cap, np.inf, dtype=np.float32),
@@ -698,12 +706,13 @@ def _hold_turn_indicator(s: _SegState) -> None:
 
 
 def _score_turn_indicator(s: _SegState, idx: int) -> None:
-    """Closed-loop turn-indicator accuracy for one REAL inference step.
+    """Closed-loop turn-indicator TRANSITION accuracy for one REAL inference step.
 
-    Called only right after ``_feed_turn_indicator`` (both in ``render_segment`` and
-    ``run_segments_batched``) -- never after ``_hold_turn_indicator``, since a held/
-    cached-plan step made no fresh prediction and scoring it would conflate "no chance
-    to re-predict" with "was wrong".
+    Called only right after resolving/appending the model's prediction (both in
+    ``render_segment`` and ``run_segments_batched``, always BEFORE that step's
+    ``_advance_step`` -- see the call sites) -- never after ``_hold_turn_indicator``,
+    since a held/cached-plan step made no fresh prediction and scoring it would conflate
+    "no chance to re-predict" with "was wrong".
 
     Compares the RESOLVED prediction (``s.last_turn_indicator``, already in {0,1,2,3}
     via ``resolve_keep_turn_indicator``) against the recorded GT at the same frame
@@ -711,19 +720,22 @@ def _score_turn_indicator(s: _SegState, idx: int) -> None:
     ``validate_model.py``'s training-time metric (raw 5-class argmax vs a KEEP-folded
     GT) -- intentional, since KEEP never reaches storage/comparison in closed loop.
 
-    "Changed" is read off this frame's OWN GT window (``[-2]`` vs ``[-1]``) rather than
-    tracked across scored steps, so it stays correct even when the cursor skips/repeats
-    frames between scored steps.
+    Only TRANSITIONS are accumulated: plain per-step accuracy is dominated by long
+    stable KEEP/NONE periods and doesn't demonstrate correct indicator switching, so it
+    isn't tracked at all. "Changed" is read off ``s.turn_indicator_prev_scored_gt`` --
+    the GT at the PREVIOUS SCORED step, not this frame's own ``[-2]``/``[-1]`` window --
+    because scoring only happens on real inference steps; with ``replan_interval > 1``
+    or a cursor skip/repeat, a GT transition can occur entirely BETWEEN two scored
+    steps and never show up in either step's own one-tick-back window. The next scored
+    step is the model's first real chance to react to it, so that's where it's counted.
     """
-    gt_window = np.asarray(s.tl.npz(idx)["turn_indicators"]).reshape(-1)
-    gt = int(gt_window[-1])
+    gt = int(np.asarray(s.tl.npz(idx)["turn_indicators"]).reshape(-1)[-1])
     pred = int(s.last_turn_indicator)
     correct = pred == gt
-    s.turn_indicator_total += 1
-    s.turn_indicator_correct += int(correct)
-    if int(gt_window[-2]) != gt:
-        s.turn_indicator_change_total += 1
-        s.turn_indicator_change_correct += int(correct)
+    if gt != s.turn_indicator_prev_scored_gt:
+        s.turn_indicator_transition_total += 1
+        s.turn_indicator_transition_correct += int(correct)
+    s.turn_indicator_prev_scored_gt = gt
 
 
 # GT-deviation lookup window: ±15 s of recorded trajectory around the cursor. Wide enough to
@@ -958,6 +970,10 @@ def _advance_step(s: _SegState, pred: np.ndarray, idx, device, timers, override=
                     np.asarray(s.tl.npz(tgt)["turn_indicators"]).reshape(-1).astype(np.int64)
                 )
                 s.last_turn_indicator = int(s.turn_hist[-1])
+                # Re-seed the transition-comparison basis too: without this, the next scored
+                # step would compare the pre-teleport GT against the teleport target's GT and
+                # count the environment jump itself as a (spurious) transition.
+                s.turn_indicator_prev_scored_gt = int(s.turn_hist[-1])
                 s.last_collision_uuid = None  # teleported -> next contact is a fresh collision
                 s.in_episode = False
                 s.prev_max_idx = cur.max_idx_reached
@@ -1142,17 +1158,18 @@ def deviation_collision_block(collisions: np.ndarray, gt_devs: np.ndarray, thres
     }
 
 
-def turn_indicator_block(correct: int, total: int, change_correct: int, change_total: int) -> dict:
-    """The ``turn_indicator`` segment-row block: closed-loop turn-indicator prediction
+def turn_indicator_block(transition_correct: int, transition_total: int) -> dict:
+    """The ``turn_indicator`` segment-row block: closed-loop turn-indicator TRANSITION
     accuracy, scored only on real inference steps (see ``_score_turn_indicator``). A plain
-    accumulator, like ``reproducer`` -- accuracy ratios are computed at aggregate time, not
-    here, so this stays summable across segments without re-deriving a rate.
+    accumulator, like ``reproducer`` -- the accuracy ratio is computed at aggregate time, not
+    here, so this stays summable across segments without re-deriving a rate. Only transitions
+    are tracked (no plain per-step accuracy): it's the metric that actually demonstrates
+    correct indicator switching, unlike per-step accuracy which is dominated by long stable
+    KEEP/NONE periods.
     """
     return {
-        "correct": int(correct),
-        "total": int(total),
-        "change_correct": int(change_correct),
-        "change_total": int(change_total),
+        "transition_correct": int(transition_correct),
+        "transition_total": int(transition_total),
     }
 
 
@@ -1213,10 +1230,8 @@ def _finalize(s: _SegState) -> dict:
         },
         "strong_brake": strong_brake_block(accels, s.strong_brake_mps2),
         "turn_indicator": turn_indicator_block(
-            s.turn_indicator_correct,
-            s.turn_indicator_total,
-            s.turn_indicator_change_correct,
-            s.turn_indicator_change_total,
+            s.turn_indicator_transition_correct,
+            s.turn_indicator_transition_total,
         ),
         "reproducer": {
             "expand_count": int(s.expand_count),
@@ -2718,17 +2733,23 @@ def run_segments_batched(
                                 tracked_by_row = dict(zip(rows_b, solved))
                     for i, (s, _np, nb, idx, _suuid, _wbu) in enumerate(built):
                         prev_snaps = s.snap_count
-                        _advance_step(
-                            s, preds[i], idx, device, timers, tracked=tracked_by_row.get(i)
-                        )
                         # Feed the model's predicted turn indicator back into the rolling
                         # history (recorded seed scrolls out within PAST steps) — the saved
                         # context then carries the sim's own signals, never the recorded ones.
+                        # Must run BEFORE ``_advance_step``: an unstick teleport inside it
+                        # re-seeds ``turn_hist``/``last_turn_indicator`` from the teleport
+                        # target's recorded GT (see there), so resolving/scoring afterward would
+                        # use post-teleport state to interpret a prediction that was actually
+                        # made against the pre-teleport frame ``idx`` -- corrupting both the KEEP
+                        # resolution and the score. Mirrors ``render_segment``'s ordering.
                         s.last_turn_indicator = resolve_keep_turn_indicator(
                             int(ti_pred[i]), s.last_turn_indicator
                         )
                         s.turn_hist = np.append(s.turn_hist[1:], np.int64(s.last_turn_indicator))
                         _score_turn_indicator(s, idx)
+                        _advance_step(
+                            s, preds[i], idx, device, timers, tracked=tracked_by_row.get(i)
+                        )
                         # Clear the buffer on an unstick teleport: pre-jump frames belong
                         # to a different ego path and must never enter a saved window.
                         if s.save_buf is not None and s.snap_count > prev_snaps:

--- a/scenario_generation/scenario_sim_metrics.py
+++ b/scenario_generation/scenario_sim_metrics.py
@@ -1,8 +1,9 @@
 """Map scenario_sim rollout series onto the closed-loop segment-row schema.
 
 ``closed_loop_eval.aggregate`` consumes rows made of nested per-category blocks (``object`` /
-``road_border`` / ``red_light_violation`` / ``strong_brake`` / ``reproducer``) and fails fast
-on a missing block, so a missing metric can never read as a zero. The scenario_sim path
+``road_border`` / ``red_light_violation`` / ``strong_brake`` / ``reproducer`` /
+``turn_indicator``) and fails fast on a missing block, so a missing metric can never read as a
+zero. The scenario_sim path
 produces the same raw series as the reproducer path -- per-step clearance, collision,
 road-border distance and speed -- but through a simulator rather than recorded NPZ frames, so
 the mapping onto that schema lives here.
@@ -24,6 +25,7 @@ from scenario_generation.reproducer_rollout import (
     clearance_family_block,
     road_border_collision_mask,
     strong_brake_block,
+    turn_indicator_block,
 )
 
 # scenario_sim has no reproducer cursor: it never expands a window, snaps the ego back or
@@ -90,6 +92,10 @@ def build_segment_row(
         "red_light_violation": _red_light_block(),
         "strong_brake": strong_brake_block(ac, strong_brake_mps2),
         "reproducer": {**_NO_REPRODUCER_CURSOR, "normal_steps": int(n_steps_run)},
+        # No GT turn indicator to score against on this path -- zero counts are the true
+        # measurement (transition_accuracy then aggregates to None/"N/A"), same idea as
+        # ``_NO_REPRODUCER_CURSOR`` above.
+        "turn_indicator": turn_indicator_block(0, 0),
     }
 
 

--- a/scenario_generation/scenario_sim_viewer_export.py
+++ b/scenario_generation/scenario_sim_viewer_export.py
@@ -505,7 +505,7 @@ def write_viewer_tree(
             "n_cases": len(clean_rows),
             "verdicts": _tally_verdicts(case_verdicts),
             "error": scenario_errors.get(scenario),
-            _UNMEASURED_MARKER_KEY: unmeasured + ["reproducer"],
+            _UNMEASURED_MARKER_KEY: unmeasured + ["reproducer", "turn_indicator"],
             "summary": sanitize(summary),
         }
         counts[scenario] = tally

--- a/scenario_generation/tests/test_closed_loop_metrics.py
+++ b/scenario_generation/tests/test_closed_loop_metrics.py
@@ -16,6 +16,7 @@ from scenario_generation.reproducer_rollout import (
     _clearance_stats,
     _event_count,
     deviation_collision_block,
+    turn_indicator_block,
 )
 
 
@@ -332,6 +333,12 @@ def _segment_row(**overrides) -> dict:
             "normal_steps": 3,
             "repeat_steps": 1,
         },
+        "turn_indicator": {
+            "correct": 3,
+            "total": 4,
+            "change_correct": 1,
+            "change_total": 1,
+        },
     }
     row.update(overrides)
     return row
@@ -354,6 +361,10 @@ def test_aggregate_nested_keeps_tdigest_in_json():
     assert summary["reproducer"]["expand_count"] == 1
     assert abs(summary["reproducer"]["repeat_step_rate"] - 0.25) < 1e-9
     assert summary["strong_brake"]["strongest_mps2"] == float("inf")
+    assert summary["turn_indicator"]["correct"] == 3
+    assert summary["turn_indicator"]["total"] == 4
+    assert abs(summary["turn_indicator"]["accuracy"] - 0.75) < 1e-9
+    assert summary["turn_indicator"]["change_accuracy"] == 1.0
     # Human-readable segments.jsonl strips digests; in-memory rows keep them.
     cleaned = metrics_for_json(rows[0])
     assert TDIGEST_KEY not in cleaned["object"]
@@ -395,6 +406,27 @@ def test_aggregate_missing_category_fails():
     bad = _segment_row()
     del bad["object"]
     with pytest.raises(KeyError, match="object"):
+        aggregate([bad], near_miss_thresh=0.5, strong_brake_mps2=-2.5)
+
+
+def test_turn_indicator_block():
+    block = turn_indicator_block(3, 4, 1, 1)
+    assert block == {"correct": 3, "total": 4, "change_correct": 1, "change_total": 1}
+
+
+def test_aggregate_turn_indicator_zero_total_accuracy_is_zero():
+    row = _segment_row(
+        turn_indicator={"correct": 0, "total": 0, "change_correct": 0, "change_total": 0}
+    )
+    summary = aggregate([row], near_miss_thresh=0.5, strong_brake_mps2=-2.5)
+    assert summary["turn_indicator"]["accuracy"] == 0.0
+    assert summary["turn_indicator"]["change_accuracy"] == 0.0
+
+
+def test_aggregate_missing_turn_indicator_category_fails():
+    bad = _segment_row()
+    del bad["turn_indicator"]
+    with pytest.raises(KeyError, match="turn_indicator"):
         aggregate([bad], near_miss_thresh=0.5, strong_brake_mps2=-2.5)
 
 

--- a/scenario_generation/tests/test_closed_loop_metrics.py
+++ b/scenario_generation/tests/test_closed_loop_metrics.py
@@ -334,10 +334,8 @@ def _segment_row(**overrides) -> dict:
             "repeat_steps": 1,
         },
         "turn_indicator": {
-            "correct": 3,
-            "total": 4,
-            "change_correct": 1,
-            "change_total": 1,
+            "transition_correct": 1,
+            "transition_total": 2,
         },
     }
     row.update(overrides)
@@ -361,10 +359,9 @@ def test_aggregate_nested_keeps_tdigest_in_json():
     assert summary["reproducer"]["expand_count"] == 1
     assert abs(summary["reproducer"]["repeat_step_rate"] - 0.25) < 1e-9
     assert summary["strong_brake"]["strongest_mps2"] == float("inf")
-    assert summary["turn_indicator"]["correct"] == 3
-    assert summary["turn_indicator"]["total"] == 4
-    assert abs(summary["turn_indicator"]["accuracy"] - 0.75) < 1e-9
-    assert summary["turn_indicator"]["change_accuracy"] == 1.0
+    assert summary["turn_indicator"]["transition_correct"] == 1
+    assert summary["turn_indicator"]["transition_total"] == 2
+    assert abs(summary["turn_indicator"]["transition_accuracy"] - 0.5) < 1e-9
     # Human-readable segments.jsonl strips digests; in-memory rows keep them.
     cleaned = metrics_for_json(rows[0])
     assert TDIGEST_KEY not in cleaned["object"]
@@ -410,17 +407,14 @@ def test_aggregate_missing_category_fails():
 
 
 def test_turn_indicator_block():
-    block = turn_indicator_block(3, 4, 1, 1)
-    assert block == {"correct": 3, "total": 4, "change_correct": 1, "change_total": 1}
+    block = turn_indicator_block(1, 2)
+    assert block == {"transition_correct": 1, "transition_total": 2}
 
 
-def test_aggregate_turn_indicator_zero_total_accuracy_is_zero():
-    row = _segment_row(
-        turn_indicator={"correct": 0, "total": 0, "change_correct": 0, "change_total": 0}
-    )
+def test_aggregate_turn_indicator_zero_total_accuracy_is_na():
+    row = _segment_row(turn_indicator={"transition_correct": 0, "transition_total": 0})
     summary = aggregate([row], near_miss_thresh=0.5, strong_brake_mps2=-2.5)
-    assert summary["turn_indicator"]["accuracy"] == 0.0
-    assert summary["turn_indicator"]["change_accuracy"] == 0.0
+    assert summary["turn_indicator"]["transition_accuracy"] is None
 
 
 def test_aggregate_missing_turn_indicator_category_fails():

--- a/scenario_generation/tests/test_scenario_sim_viewer_export.py
+++ b/scenario_generation/tests/test_scenario_sim_viewer_export.py
@@ -65,6 +65,7 @@ def _row() -> dict:
             "count": 0,
         },
         "reproducer": {"expand_count": 0, "snap_count": 0, "repeat_steps": 0, "normal_steps": 3},
+        "turn_indicator": {"transition_correct": 0, "transition_total": 0},
         "map_path": _MAP,
     }
 

--- a/scenario_generation/tests/test_turn_indicator_scoring.py
+++ b/scenario_generation/tests/test_turn_indicator_scoring.py
@@ -1,0 +1,264 @@
+"""Tests for closed-loop turn-indicator transition scoring.
+
+Covers the two PR #403 review fixes:
+- the transition condition must compare GT across SCORED steps, not within one frame's own
+  two-tick window (misses a transition that happens entirely between scored steps under
+  ``replan_interval > 1`` or a cursor skip/repeat);
+- ``run_segments_batched`` must resolve/append/score BEFORE ``_advance_step``, so a same-tick
+  unstick teleport (which re-seeds ``turn_hist``/``last_turn_indicator``/
+  ``turn_indicator_prev_scored_gt`` from the teleport target's GT) never corrupts the score for
+  the step that just ran -- matching ``render_segment``'s already-correct ordering.
+
+Route-building helper mirrors ``test_reproducer_unstick.py``'s ``_make_route``, but lets each
+frame's own ``turn_indicators`` window be built from an explicit per-tick GT signal (rather than
+all zeros), so the frame-local ``[-2]``/``[-1]`` window can be distinguished from the
+cross-scored-step comparison in tests.
+"""
+
+import json
+
+import numpy as np
+import pytest
+
+from scenario_generation.perf_timer import Timers
+from scenario_generation.reproducer_rollout import (
+    _advance_step,
+    _hold_turn_indicator,
+    _score_turn_indicator,
+    _seed_state,
+)
+from scenario_generation.route_timeline import RouteTimeline
+from scenario_generation.simulate import resolve_keep_turn_indicator
+
+EGO_SHAPE = np.array([4.76, 7.24, 2.29], dtype=np.float32)
+STEP_M = 0.01  # ~0.1 m/s => below the 0.5 m/s "stuck" threshold, so unstick fires
+
+
+def _ti_window(raw_signal: list[int], i: int) -> np.ndarray:
+    """The (31,) turn_indicators window a real recorded frame ``i`` would carry: a proper
+    sliding history of ``raw_signal`` ending at ``i``, padded with ``raw_signal[0]`` for
+    ticks before the start of the route (mimics how a real bag's early frames are padded).
+    """
+    w = np.empty(31, dtype=np.int64)
+    for k in range(31):
+        j = i - (30 - k)
+        w[k] = raw_signal[j] if j >= 0 else raw_signal[0]
+    return w
+
+
+def _make_route(tmp_path, raw_signal: list[int]) -> RouteTimeline:
+    """A near-stationary straight route along +x, one frame per ``raw_signal`` entry, each
+    frame's ``turn_indicators`` a real sliding window of ``raw_signal`` (see ``_ti_window``).
+    """
+    n = len(raw_signal)
+    past = np.zeros((31, 3), dtype=np.float32)
+    past[:, 0] = (np.arange(31) - 30) * STEP_M
+    paths = []
+    for i in range(n):
+        p = tmp_path / f"route_{i:010d}.npz"
+        np.savez_compressed(
+            p,
+            ego_agent_past=past,
+            ego_shape=EGO_SHAPE,
+            turn_indicators=_ti_window(raw_signal, i),
+        )
+        sidecar = {
+            "timestamp": float(i),
+            "x": float(i * STEP_M),
+            "y": 0.0,
+            "z": 0.0,
+            "qx": 0.0,
+            "qy": 0.0,
+            "qz": 0.0,
+            "qw": 1.0,
+        }
+        (tmp_path / f"route_{i:010d}.json").write_text(json.dumps(sidecar))
+        paths.append(p)
+    return RouteTimeline(paths)
+
+
+def test_resolve_keep_turn_indicator_basic():
+    """KEEP(4) resolves to the previous state; any real class passes through unchanged."""
+    assert resolve_keep_turn_indicator(4, 2) == 2  # KEEP -> prev (LEFT)
+    assert resolve_keep_turn_indicator(4, 0) == 0  # KEEP -> prev (NONE)
+    assert resolve_keep_turn_indicator(3, 2) == 3  # RIGHT passes through regardless of prev
+    assert resolve_keep_turn_indicator(0, 2) == 0  # NONE passes through regardless of prev
+
+
+def test_transition_missed_by_frame_local_window_but_caught_across_scored_steps(tmp_path):
+    """GT flips from NONE to RIGHT between raw ticks 3 and 4. Scoring steps 3 then 6 (as
+    ``replan_interval`` or a cursor skip/repeat would) never visits frame 4 or 5, so neither
+    scored frame's OWN ``[-2]``/``[-1]`` window shows a change (frame 6's own window is
+    RIGHT/RIGHT) -- the old same-frame check would miss this transition entirely. The
+    cross-scored-step comparison (against ``turn_indicator_prev_scored_gt``) catches it.
+    """
+    raw = [0, 0, 0, 0, 3, 3, 3, 3, 3, 3]
+    tl = _make_route(tmp_path, raw)
+    timers = Timers()
+    s = _seed_state(
+        tl,
+        0,
+        len(raw),
+        search_radius=1.5,
+        warmup_steps=1000,
+        near_miss_thresh=0.5,
+        goal_reach_m=0.0,
+        max_stuck_steps=0,
+        timers=timers,
+        max_steps=1000,
+    )
+    assert s.turn_indicator_prev_scored_gt == 0  # seeded from raw[0]
+
+    # Confirm frame 6's OWN window shows no change (the old bug's blind spot).
+    assert int(_ti_window(raw, 6)[-2]) == int(_ti_window(raw, 6)[-1]) == 3
+
+    s.last_turn_indicator = 0  # model correctly predicts NONE at the (unscored) frames before
+    _score_turn_indicator(s, 3)
+    assert s.turn_indicator_transition_total == 0  # no transition yet (0 -> 0)
+
+    s.last_turn_indicator = 3  # model correctly predicts RIGHT by the time it's scored again
+    _score_turn_indicator(s, 6)
+    assert s.turn_indicator_transition_total == 1, "transition between scored steps must be caught"
+    assert s.turn_indicator_transition_correct == 1
+    assert s.turn_indicator_prev_scored_gt == 3
+
+
+def test_hold_turn_indicator_does_not_touch_transition_counters(tmp_path):
+    """A cached-plan step (``replan_interval > 1``, no fresh inference) must never be scored:
+    ``_hold_turn_indicator`` only re-appends the held signal, it must not touch the transition
+    accumulators or the scored-GT tracking field.
+    """
+    raw = [2] * 10
+    tl = _make_route(tmp_path, raw)
+    timers = Timers()
+    s = _seed_state(
+        tl,
+        0,
+        len(raw),
+        search_radius=1.5,
+        warmup_steps=1000,
+        near_miss_thresh=0.5,
+        goal_reach_m=0.0,
+        max_stuck_steps=0,
+        timers=timers,
+        max_steps=1000,
+    )
+    before = (
+        s.turn_indicator_transition_correct,
+        s.turn_indicator_transition_total,
+        s.turn_indicator_prev_scored_gt,
+    )
+    _hold_turn_indicator(s)
+    after = (
+        s.turn_indicator_transition_correct,
+        s.turn_indicator_transition_total,
+        s.turn_indicator_prev_scored_gt,
+    )
+    assert before == after
+
+
+def test_teleport_reseeds_transition_tracking_from_target_gt(tmp_path):
+    """An unstick teleport must re-seed ``turn_indicator_prev_scored_gt`` (like ``turn_hist``/
+    ``last_turn_indicator``) from the teleport target's recorded GT -- otherwise the next
+    scored step would compare the pre-teleport GT against the target's GT and count the
+    environment jump itself as a spurious transition.
+    """
+    n = 20
+    raw = [0] * (n // 2) + [2] * (n - n // 2)  # a real transition partway through the route
+    tl = _make_route(tmp_path, raw)
+    timers = Timers()
+    s = _seed_state(
+        tl,
+        0,
+        n,
+        search_radius=1.5,
+        warmup_steps=1000,  # recorded-pose branch (no tracker needed)
+        near_miss_thresh=0.5,
+        goal_reach_m=0.0,
+        max_stuck_steps=0,
+        timers=timers,
+        max_steps=1000,
+        unstick_after=3,
+        unstick_advance_m=0.05,
+        unstick_radius_mult=1.0,  # disable gentle widen: exercise the teleport path directly
+    )
+    pred = np.zeros((80, 4), dtype=np.float32)
+
+    for i in range(n):
+        s.cursor.last_was_repeat = True  # stuck repeating
+        _advance_step(s, pred, idx=i, device="cpu", timers=timers)
+        if s.snap_count > 0:
+            break
+    else:
+        pytest.fail("unstick never fired on the synthetic stalled route")
+
+    # Find the teleport target the same way test_reproducer_unstick.py does.
+    matches = np.where(np.all(np.isclose(tl.poses, s.live_pose), axis=1))[0]
+    assert len(matches) == 1
+    tgt = int(matches[0])
+    tgt_gt = int(np.asarray(tl.npz(tgt)["turn_indicators"]).reshape(-1)[-1])
+
+    assert s.last_turn_indicator == tgt_gt
+    assert s.turn_indicator_prev_scored_gt == tgt_gt
+
+
+def test_resolve_append_score_before_advance_survives_same_tick_teleport(tmp_path):
+    """Regression for the batched-path ordering bug: resolving a KEEP prediction, appending
+    to ``turn_hist`` and scoring must all use the PRE-teleport state, even when
+    ``_advance_step`` (called right after, matching both ``render_segment`` and the fixed
+    ``run_segments_batched``) teleports on that same tick. A KEEP prediction must resolve
+    against the PRE-teleport ``last_turn_indicator``, not whatever the teleport resets it to.
+
+    The GT deliberately differs between the pre-teleport region (RIGHT) and wherever the
+    teleport lands (LEFT, ``unstick_advance_m`` is large enough to jump well past the split) --
+    if the two states matched, resolving against either one would look identical and the
+    ordering bug would have nothing to expose.
+    """
+    n = 20
+    raw = [3] * 10 + [2] * 10  # RIGHT for the first half, LEFT for the second
+    tl = _make_route(tmp_path, raw)
+    timers = Timers()
+    s = _seed_state(
+        tl,
+        0,
+        n,
+        search_radius=1.5,
+        warmup_steps=1000,
+        near_miss_thresh=0.5,
+        goal_reach_m=0.0,
+        max_stuck_steps=0,
+        timers=timers,
+        max_steps=1000,
+        unstick_after=3,
+        unstick_advance_m=0.15,  # jump well past the raw-signal split (~15 frames at STEP_M=0.01)
+        unstick_radius_mult=1.0,
+    )
+    pred = np.zeros((80, 4), dtype=np.float32)
+    s.last_turn_indicator = 3  # matches raw signal from the start
+
+    teleported = False
+    for i in range(n):
+        s.cursor.last_was_repeat = True
+        pre_teleport_last = s.last_turn_indicator
+        # The fixed ordering, shared by render_segment and run_segments_batched: resolve +
+        # append + score BEFORE _advance_step.
+        s.last_turn_indicator = resolve_keep_turn_indicator(4, s.last_turn_indicator)  # KEEP
+        assert s.last_turn_indicator == pre_teleport_last, (
+            "KEEP must resolve against the PRE-teleport state, not whatever _advance_step "
+            "(called next) might reset it to"
+        )
+        s.turn_hist = np.append(s.turn_hist[1:], np.int64(s.last_turn_indicator))
+        _score_turn_indicator(s, i)
+        _advance_step(s, pred, idx=i, device="cpu", timers=timers)
+        if s.snap_count > 0:
+            teleported = True
+            break
+    if not teleported:
+        pytest.fail("unstick never fired on the synthetic stalled route")
+
+    # Confirm the teleport actually landed somewhere the GT differs from the pre-teleport
+    # region -- otherwise this test couldn't have distinguished the two orderings at all.
+    matches = np.where(np.all(np.isclose(tl.poses, s.live_pose), axis=1))[0]
+    assert len(matches) == 1
+    tgt_gt = int(np.asarray(tl.npz(int(matches[0]))["turn_indicators"]).reshape(-1)[-1])
+    assert tgt_gt == 2, "test setup must land the teleport in the differing-GT region"

--- a/scenario_generation/wandb_closed_loop.py
+++ b/scenario_generation/wandb_closed_loop.py
@@ -51,6 +51,7 @@ _ABS_COLUMNS = [
     ("Segs diverged", "n_segments_diverged"),
     ("Collisions", "total_collision_events"),
     ("Rear collisions", "total_rear_collision_events"),
+    ("Turn indicator accuracy (%)", "turn_indicator_accuracy"),
 ]
 
 _PER_1000STEPS_COLUMNS = [
@@ -67,6 +68,7 @@ _PER_1000STEPS_COLUMNS = [
     ("Segs diverged / 1k steps", "n_segments_diverged"),
     ("Collisions / 1k steps", "total_collision_events"),
     ("Rear collisions / 1k steps", "total_rear_collision_events"),
+    ("Turn indicator accuracy (%)", "turn_indicator_accuracy"),
 ]
 
 
@@ -102,7 +104,12 @@ def _abs_value(source_key: str, summary: dict):
     ``summary.json`` still logs instead of blowing up the upload.
     """
     # Float fields: direct lookup or extract_score fallback.
-    if source_key in ("mean_route_completion", "pass_rate"):
+    if source_key in (
+        "mean_route_completion",
+        "pass_rate",
+        "turn_indicator_accuracy",
+        "turn_indicator_change_accuracy",
+    ):
         if source_key in summary:
             val = summary[source_key]
             return float(val if isinstance(val, (int, float)) else 0.0)
@@ -129,6 +136,8 @@ def _per_1000steps_value(source_key: str, summary: dict) -> float | None:
         "mean_route_completion",
         "pass_rate",
         "mean_gt_deviation_m",  # already a per-step mean
+        "turn_indicator_accuracy",  # already a ratio
+        "turn_indicator_change_accuracy",
     ):
         return _abs_value(source_key, summary)
     denom_key = "n_segments" if source_key == "n_segments_diverged" else "total_steps"
@@ -189,6 +198,21 @@ def _aggregate(group_summaries: dict[str, dict]) -> dict:
     )
     agg["total_rear_collision_events"] = sum(
         int(extract_score(s, "total_rear_collision_events") or 0) for s in objects_only_values
+    )
+
+    # Weighted by scored steps (turn_indicator.total), not by segment count -- segments vary
+    # widely in how many real-inference steps they ran (see reproducer_rollout._score_turn_indicator).
+    ti_correct = sum(int(s.get("turn_indicator", {}).get("correct", 0) or 0) for s in values)
+    ti_total = sum(int(s.get("turn_indicator", {}).get("total", 0) or 0) for s in values)
+    ti_change_correct = sum(
+        int(s.get("turn_indicator", {}).get("change_correct", 0) or 0) for s in values
+    )
+    ti_change_total = sum(
+        int(s.get("turn_indicator", {}).get("change_total", 0) or 0) for s in values
+    )
+    agg["turn_indicator_accuracy"] = (ti_correct / ti_total) if ti_total else 0.0
+    agg["turn_indicator_change_accuracy"] = (
+        (ti_change_correct / ti_change_total) if ti_change_total else 0.0
     )
     return agg
 

--- a/scenario_generation/wandb_closed_loop.py
+++ b/scenario_generation/wandb_closed_loop.py
@@ -51,7 +51,7 @@ _ABS_COLUMNS = [
     ("Segs diverged", "n_segments_diverged"),
     ("Collisions", "total_collision_events"),
     ("Rear collisions", "total_rear_collision_events"),
-    ("Turn indicator accuracy (%)", "turn_indicator_accuracy"),
+    ("Turn indicator transition accuracy (%)", "turn_indicator_transition_accuracy"),
 ]
 
 _PER_1000STEPS_COLUMNS = [
@@ -68,7 +68,7 @@ _PER_1000STEPS_COLUMNS = [
     ("Segs diverged / 1k steps", "n_segments_diverged"),
     ("Collisions / 1k steps", "total_collision_events"),
     ("Rear collisions / 1k steps", "total_rear_collision_events"),
-    ("Turn indicator accuracy (%)", "turn_indicator_accuracy"),
+    ("Turn indicator transition accuracy (%)", "turn_indicator_transition_accuracy"),
 ]
 
 
@@ -104,12 +104,7 @@ def _abs_value(source_key: str, summary: dict):
     ``summary.json`` still logs instead of blowing up the upload.
     """
     # Float fields: direct lookup or extract_score fallback.
-    if source_key in (
-        "mean_route_completion",
-        "pass_rate",
-        "turn_indicator_accuracy",
-        "turn_indicator_change_accuracy",
-    ):
+    if source_key in ("mean_route_completion", "pass_rate"):
         if source_key in summary:
             val = summary[source_key]
             return float(val if isinstance(val, (int, float)) else 0.0)
@@ -118,6 +113,11 @@ def _abs_value(source_key: str, summary: dict):
         # ``inf`` (nothing measured) becomes a blank cell, not a number to be misread.
         dev = summary.get("mean_gt_deviation_m")
         return float(dev) if dev is not None and math.isfinite(float(dev)) else None
+    if source_key == "turn_indicator_transition_accuracy":
+        # None (no transition was ever scored) becomes a blank cell, not a 0.0 to misread as
+        # "always wrong at transitions".
+        val = summary[source_key] if source_key in summary else extract_score(summary, source_key)
+        return float(val) if isinstance(val, (int, float)) else None
 
     # Int fields.
     if source_key in ("n_segments", "total_steps"):
@@ -136,8 +136,7 @@ def _per_1000steps_value(source_key: str, summary: dict) -> float | None:
         "mean_route_completion",
         "pass_rate",
         "mean_gt_deviation_m",  # already a per-step mean
-        "turn_indicator_accuracy",  # already a ratio
-        "turn_indicator_change_accuracy",
+        "turn_indicator_transition_accuracy",  # already a ratio
     ):
         return _abs_value(source_key, summary)
     denom_key = "n_segments" if source_key == "n_segments_diverged" else "total_steps"
@@ -200,19 +199,18 @@ def _aggregate(group_summaries: dict[str, dict]) -> dict:
         int(extract_score(s, "total_rear_collision_events") or 0) for s in objects_only_values
     )
 
-    # Weighted by scored steps (turn_indicator.total), not by segment count -- segments vary
-    # widely in how many real-inference steps they ran (see reproducer_rollout._score_turn_indicator).
-    ti_correct = sum(int(s.get("turn_indicator", {}).get("correct", 0) or 0) for s in values)
-    ti_total = sum(int(s.get("turn_indicator", {}).get("total", 0) or 0) for s in values)
-    ti_change_correct = sum(
-        int(s.get("turn_indicator", {}).get("change_correct", 0) or 0) for s in values
+    # Weighted by scored transitions (turn_indicator.transition_total), not by segment count --
+    # segments vary widely in how many transitions they contained
+    # (see reproducer_rollout._score_turn_indicator).
+    ti_transition_correct = sum(
+        int(s.get("turn_indicator", {}).get("transition_correct", 0) or 0) for s in values
     )
-    ti_change_total = sum(
-        int(s.get("turn_indicator", {}).get("change_total", 0) or 0) for s in values
+    ti_transition_total = sum(
+        int(s.get("turn_indicator", {}).get("transition_total", 0) or 0) for s in values
     )
-    agg["turn_indicator_accuracy"] = (ti_correct / ti_total) if ti_total else 0.0
-    agg["turn_indicator_change_accuracy"] = (
-        (ti_change_correct / ti_change_total) if ti_change_total else 0.0
+    # None (not 0.0) when no transition was ever scored across any group.
+    agg["turn_indicator_transition_accuracy"] = (
+        (ti_transition_correct / ti_transition_total) if ti_transition_total else None
     )
     return agg
 


### PR DESCRIPTION
## Summary

Adds turn-indicator (blinker) evaluation and visualization to the closed-loop pipeline.

- **Metric**: closed-loop turn-indicator g the model's own closed-loop-fed-back prediction against the recorded GT signal at each real inference step. Reported per segment (`segments.jsonl`),  aggregated per group (`summary.json`), ros.json`), and logged to W&B. 
- **Visualization**: the per-step PNGs/vind GT turn-signal state directly as color, replacing the old text-only HUD readout.

## Metric details
- Compares the closed-loop **resolved** prn_indicator`, always in `{NONE, DISABLE, LEFT, RIGHT}` after `resolve_keep_turn_indicator`) against the recorded GT (`turn_indicators[-1]` from the npz). This is intentionally a 4-class comparisovalidate_model.py` metric (raw 5-class argmax vs. a KEEP-folded GT) — KEEP nevern closed loop.
- Scored only on real inference steps (ne when `replan_interval > 1`), so a stale held prediction isn't compared against GT
- "Changed" is read off each frame's own , robust to the cursor skipping/repeating
frames.
- Instrumented in both `render_segment` a a shared `_score_turn_indicator` helper.
- New `turn_indicator` block: `{correct, total, change_correct, change_total}` at the segment level; `{accuracy, change_accuracy}` ratios computed at aggroducer` block's plain-accumulator pattern
— no new `ClosedLoopConfig` threshold needed).                                                                   
- Wired into `closed_loop_score_keys.SCORs_closed_loop._write_groups_manifest` (step-weighted), and `wandb_closed_loop`' 

## Visualization details

In `scenario_generation/replay.py`'s `save_step_figure`:                                                        

- **Predicted signal**: the active side (left/right) of the **live ego box** gets a thin amber edge line along   that side.
- **GT signal**: the active side of the **reproducer (GT) box** — the existing hollow outline box at the recorded cursor pose — gets a semi-transpalf, instead of a second edge line. Using the existing GT box (rather than a markereps pred and GT legible even when the two boxes are far apart or fully coincide. - Both use the box's true wheelbase-based)` is the rear-axle midpoint for ego, same convention as `draw_agent_box`), so the hthe drawn box edge.
- The old text-only `turn=...` HUD line is removed.                                                        

## Test plan                                                                                               

- [x] `pytest scenario_generation/tests/test_closed_loop_metrics.py -v` — 23/23 pass (19 existing + 4 new: builder, zero-total ratio guard, missing-e values).
- [x] `pytest scenario_generation/tests/tscenario_generation/tests/test_stable_pal(render-pool determinism unaffected).
- [x] Manually rendered sample PNGs (via fixture) across pred/GT combinations(correct, false-positive, missed, wrong-s and visually confirmed the highlightposition, color, and alignment with the b

🤖 Generated with [Claude Code](https://claude.com/claude-code)