### PR TITLE
chore(frenet-aug): drop two dead imports, and say why the bridge lookup raises

### DIFF
--- a/diffusion_planner/diffusion_planner/utils/augment_defaults.py
+++ b/diffusion_planner/diffusion_planner/utils/augment_defaults.py
@@ -44,7 +44,16 @@ def past_noise_std_for(args) -> float:
     """
     if args.ego_past_noise_std is not None:
         return float(args.ego_past_noise_std)
-    return DEFAULT_PAST_NOISE_STD[args.augment_type]
+    try:
+        return DEFAULT_PAST_NOISE_STD[args.augment_type]
+    except KeyError:
+        raise KeyError(
+            f"no history-noise default recorded for augment_type={args.augment_type!r}. "
+            f"Known: {sorted(DEFAULT_PAST_NOISE_STD)}. bridge is absent on purpose -- it "
+            "does not perturb the ego history, and resolve_history_noise returns before "
+            "reaching here, so this means the resolver was bypassed. A new augmenter "
+            "needs an entry (or an early return) rather than a default it never chose."
+        ) from None
 
 
 def resolve_history_noise(args) -> None:

--- a/diffusion_planner/diffusion_planner/utils/augmenter_factory.py
+++ b/diffusion_planner/diffusion_planner/utils/augmenter_factory.py
@@ -12,10 +12,7 @@ falling through to quintic — the parser's ``Literal`` already constrains the f
 and a programmatic caller deserves the error rather than a silent substitution.
 """
 
-from diffusion_planner.utils.augment_defaults import (
-    past_noise_std_for,
-    resolve_history_noise,
-)
+from diffusion_planner.utils.augment_defaults import resolve_history_noise
 from diffusion_planner.utils.data_augmentation import StatePerturbation
 from diffusion_planner.utils.data_augmentation_bridge import (
     StatePerturbation as BridgeStatePerturbation,

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -32,10 +32,7 @@ from dataclasses import dataclass
 import numpy as np
 import torch
 
-from diffusion_planner.utils.augment_defaults import (
-    past_noise_std_for,
-    resolve_history_noise,
-)
+from diffusion_planner.utils.augment_defaults import resolve_history_noise
 from diffusion_planner.utils.augmentation_checks import (
     DT,
     border_lateral_bounds,


### PR DESCRIPTION
Two small cleanups on top of #389. No behaviour change.

## 1. Two dead imports

`past_noise_std_for` was imported by `augmenter_factory.py` and by `data_augmentation_frenet.py` and called by neither — both go through `resolve_history_noise`, which wraps it.

Harmless at runtime, but misleading about where the history-noise default is resolved: it made the function look reachable from two modules that never touch it. `ruff check` is configured for import sorting in this repo, so F401 only appears under an explicit `--select F401`.

The third unused import in that directory (`data_augmentation.py:5`) is pre-existing on `tier4-main` and is left alone.

## 2. A `KeyError` that explains itself

`DEFAULT_PAST_NOISE_STD` deliberately has no `bridge` entry, so a caller that bypasses `resolve_history_noise` fails loudly instead of receiving a plausible `0.0` for a knob bridge cannot honour. That is the intended design and is unchanged here — but a bare `KeyError: 'bridge'` tells the reader nothing about it.

Now:

```
no history-noise default recorded for augment_type='bridge'. Known: ['frenet', 'quintic'].
bridge is absent on purpose -- it does not perturb the ego history, and
resolve_history_noise returns before reaching here, so this means the resolver was
bypassed. A new augmenter needs an entry (or an early return) rather than a default it
never chose.
```

It names the known types, says the omission is deliberate, and points at the two ways to reach it: a bypassed resolver, or a new `augment_type` added without deciding what this knob means for it. **The exception type is deliberately unchanged** — both the guard and its test depend on `KeyError`.

## Verification

- 87 tests pass in the two frenet suites, on a CPU-only host and with a GPU.
- `ruff check` and `ruff format` clean; `--select F401` now clean for both touched files.
- No behaviour change: neither import was called, and the raise site's condition and exception type are the same.

## Base branch

Stacked on `feat/frenet-veto-recovery` (#389), which is where both symbols were introduced. If #389 merges first this can be retargeted at `tier4-main` and will still apply.
