### PR TITLE
chore(frenet-aug): drop two dead imports, and say why the bridge lookup raises

### DIFF
--- a/diffusion_planner/diffusion_planner/utils/augment_defaults.py
+++ b/diffusion_planner/diffusion_planner/utils/augment_defaults.py
@@ -44,7 +44,16 @@ def past_noise_std_for(args) -> float:
     """
     if args.ego_past_noise_std is not None:
         return float(args.ego_past_noise_std)
-    return DEFAULT_PAST_NOISE_STD[args.augment_type]
+    try:
+        return DEFAULT_PAST_NOISE_STD[args.augment_type]
+    except KeyError:
+        raise KeyError(
+            f"no history-noise default recorded for augment_type={args.augment_type!r}. "
+            f"Known: {sorted(DEFAULT_PAST_NOISE_STD)}. bridge is absent on purpose -- it "
+            "does not perturb the ego history, and resolve_history_noise returns before "
+            "reaching here, so this means the resolver was bypassed. A new augmenter "
+            "needs an entry (or an early return) rather than a default it never chose."
+        ) from None
 
 
 def resolve_history_noise(args) -> None:

--- a/diffusion_planner/diffusion_planner/utils/augmenter_factory.py
+++ b/diffusion_planner/diffusion_planner/utils/augmenter_factory.py
@@ -12,10 +12,7 @@ falling through to quintic — the parser's ``Literal`` already constrains the f
 and a programmatic caller deserves the error rather than a silent substitution.
 """
 
-from diffusion_planner.utils.augment_defaults import (
-    past_noise_std_for,
-    resolve_history_noise,
-)
+from diffusion_planner.utils.augment_defaults import resolve_history_noise
 from diffusion_planner.utils.data_augmentation import StatePerturbation
 from diffusion_planner.utils.data_augmentation_bridge import (
     StatePerturbation as BridgeStatePerturbation,

--- a/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
+++ b/diffusion_planner/diffusion_planner/utils/data_augmentation_frenet.py
@@ -32,10 +32,7 @@ from dataclasses import dataclass
 import numpy as np
 import torch
 
-from diffusion_planner.utils.augment_defaults import (
-    past_noise_std_for,
-    resolve_history_noise,
-)
+from diffusion_planner.utils.augment_defaults import resolve_history_noise
 from diffusion_planner.utils.augmentation_checks import (
     DT,
     border_lateral_bounds,


### PR DESCRIPTION
Re-targets #406 at `tier4-main`. #406 was merged into `feat/frenet-veto-recovery` 12 minutes *after* #389 had already been squash-merged to `tier4-main`, so its content never reached main. Same commit, cherry-picked onto `tier4-main`.

## 1. Two dead imports

`past_noise_std_for` was imported by `augmenter_factory.py` and `data_augmentation_frenet.py` and called by neither — both go through `resolve_history_noise`, which wraps it. Misleading about where the history-noise default is resolved. `ruff check` is configured for import sorting here, so F401 only shows under an explicit `--select`.

## 2. A KeyError that explains itself

`DEFAULT_PAST_NOISE_STD` deliberately has no `bridge` entry, so a caller bypassing `resolve_history_noise` fails loudly instead of getting a plausible `0.0` for a knob bridge cannot honour. Design unchanged — but a bare `KeyError: 'bridge'` says none of that. The message now names the known types, states the omission is deliberate, and points at the two ways to reach it. **Exception type deliberately unchanged**; the guard and its test both depend on `KeyError`.

## Verification

- 87 tests pass in the two frenet suites; `ruff check`/`format` clean; `radon cc` unchanged (`past_noise_std_for` A(2), `resolve_history_noise` B(7)).
- No behaviour change: neither import was called; the raise site's condition and exception type are identical.
- No re-export chain broken — the only consumer outside the module is the test, which imports from `augment_defaults` directly.