### PR TITLE
perf(closed-loop): schedule jobs across groups and barrier once

### DIFF
--- a/diffusion_planner/run_all_groups_closed_loop.py
+++ b/diffusion_planner/run_all_groups_closed_loop.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 import json
 import math
 import sys
+import time
 from datetime import datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import torch
 from diffusion_planner.config.closed_loop_config import (
@@ -25,10 +27,14 @@ from diffusion_planner.config.config_cli import build_config, build_parser, reso
 from diffusion_planner.config.config_utils import save_config
 from diffusion_planner.utils import ddp
 
+from scenario_generation.closed_loop_ddp import shard_items
 from scenario_generation.wandb_closed_loop import (
     log_closed_loop_to_wandb,
 )
 from tag_toolkit.store import TagStore
+
+if TYPE_CHECKING:
+    from scenario_generation.closed_loop_evaluation import FullRouteClosedLoopEvaluation
 
 
 def resolve_closed_loop_inputs(
@@ -103,7 +109,7 @@ def resolve_closed_loop_inputs(
     return entries
 
 
-def run_one_group(
+def build_group_evaluator(
     model,
     model_args,
     npz_root_list: list[str],
@@ -113,9 +119,10 @@ def run_one_group(
     render_media: bool = True,
     pass_condition: ClosedLoopPassCondition | None = None,
     tag_store=None,
-) -> None:
-    """Run closed-loop evaluation for a single group; writes ``summary.json`` + ``segments.jsonl``
-    under ``out_dir``. Wandb logging is left to the caller.
+) -> "FullRouteClosedLoopEvaluation":
+    """Build (but don't run) the evaluator for one group, so a coordinator can schedule
+    every group's jobs together (see ``assign_jobs``). Rank 0 writes the multi-root
+    ``_npz_roots.json`` sidecar here but does *not* barrier; the caller barriers once.
 
     ``mode`` is passed explicitly so it doesn't have to be inferred from ``out_dir``
     (a json_name containing ``__noobj`` would silently misfer).
@@ -144,13 +151,11 @@ def run_one_group(
         npz_root_arg = out_dir / "_npz_roots.json"
         if ddp_rank == 0:
             npz_root_arg.write_text(json.dumps([str(p) for p in npz_root_list]))
-        if ddp_world_size > 1:
-            torch.distributed.barrier()
         npz_root_arg = str(npz_root_arg)
     else:
         npz_root_arg = npz_root_list[0]
 
-    evaluator = FullRouteClosedLoopEvaluation(
+    return FullRouteClosedLoopEvaluation(
         model,
         model_args,
         ClosedLoopEvalConfig(
@@ -192,7 +197,6 @@ def run_one_group(
             fps=float(cfg.closed_loop_fps),
             verbose=False,
             profile=cfg.closed_loop_profile,
-            max_jobs=None,
             pass_condition=pass_condition,
         ),
         npz_root_arg,
@@ -202,7 +206,15 @@ def run_one_group(
         tag_store=tag_store,
     )
 
-    evaluator.run_distributed()
+
+def assign_jobs(evaluators: dict, rank: int, world_size: int) -> dict:
+    """Shard every group's jobs in one pass, avoiding the idle ranks and per-group barriers
+    that sharding each group separately causes. Returns ``{group key: jobs for this rank}``."""
+    jobs = [(key, job) for key, ev in evaluators.items() for job in ev.discover_jobs()]
+    mine: dict[str, list] = {key: [] for key in evaluators}
+    for key, job in shard_items(jobs, rank, world_size):
+        mine[key].append(job)
+    return mine
 
 
 def _make_summary_key(json_name: str, group_name: str) -> str:
@@ -228,7 +240,9 @@ def _load_group_results(
     """
     out_dir = Path(out_dir)
     summaries: dict[str, dict] = {}
-    for summary_file in out_dir.rglob("summary.json"):
+    # Sorted: the aggregates in ``_write_groups_manifest`` sum floats, so filesystem order
+    # would make ``groups.json`` differ in the last bits between identical runs.
+    for summary_file in sorted(out_dir.rglob("summary.json")):
         key = "/".join(summary_file.parent.relative_to(out_dir).parts)
         try:
             summary = json.loads(summary_file.read_text())
@@ -339,10 +353,9 @@ def run_closed_loop_main(
         <out_root>/<json_name>/<group_name>          (objects mode)
         <out_root>/<json_name>__noobj/<group_name>   (noobj mode)
 
-    Multi-GPU: launched via ``torch.distributed.run``. DDP rank is read from ``RANK``.
-    All ranks evaluate all groups; per-group ``run_distributed()`` does its own barrier
-    + rank-0 merge, so by the time we reach aggregation every rank's shards are flushed.
-    Rank 0 then writes the manifest and logs to wandb.
+    Multi-GPU: launched via ``torch.distributed.run``, DDP rank read from ``RANK``. Jobs
+    are packed across ranks in one pass and a single barrier precedes rank-0's merge, so
+    ``elapsed_sec`` is the whole evaluation's wall time (per-group is unmeasurable).
 
     Writes:
         - ``<out_root>/groups.json`` (root aggregate)
@@ -379,6 +392,7 @@ def run_closed_loop_main(
         render_media = cfg.render_media
 
     written_json_labels: set[str] = set()
+    evaluators: dict[str, "FullRouteClosedLoopEvaluation"] = {}
     for entry in entries:
         json_name, mode, groups = entry["name"], entry["mode"], entry["groups"]
         json_label = json_name if mode == "objects" else f"{json_name}__noobj"
@@ -392,7 +406,7 @@ def run_closed_loop_main(
             summary_key = _make_summary_key(json_label, group_name)
             # Per-group condition (falls back to the loaded default if not overridden in YAML).
             group_condition = pass_conditions.get_condition(group_name)
-            run_one_group(
+            evaluators[summary_key] = build_group_evaluator(
                 model,
                 model_args,
                 npz_paths,
@@ -406,7 +420,25 @@ def run_closed_loop_main(
 
         written_json_labels.add(json_label)
 
-    # rank-0 reads the per-group summaries; run_one_group already barriered + merged internally.
+    world_size = ddp.get_world_size()
+    t0 = time.perf_counter()
+    if world_size > 1:
+        torch.distributed.barrier()  # rank 0's ``_npz_roots.json`` sidecars are now visible
+
+    mine = assign_jobs(evaluators, ddp.get_rank(), world_size)
+
+    # An empty list still writes this rank's (empty) shard files, keeping
+    # ``collect_ddp_shards``' all-ranks-present check able to spot a crashed rank.
+    partials = {key: ev.run(mine[key]) for key, ev in evaluators.items()}
+
+    if world_size > 1:
+        torch.distributed.barrier()  # every rank has written its shard
+        if ddp.get_rank() == 0:
+            elapsed_sec = time.perf_counter() - t0  # per-group wall time is not measurable
+            for key, ev in evaluators.items():
+                if partials[key].get("ddp_shard"):
+                    ev.merge_ddp_shards(world_size, elapsed_sec=elapsed_sec)
+
     if ddp.get_rank() == 0:
         all_summaries = _load_group_results(out_root)
         all_group_names = sorted(all_summaries.keys())

--- a/diffusion_planner/tests/test_closed_loop_cli.py
+++ b/diffusion_planner/tests/test_closed_loop_cli.py
@@ -185,15 +185,31 @@ def test_resolve_closed_loop_duplicate_path_keeps_each_mode(tmp_path: Path, monk
 
     captured = []
 
-    def fake_run_one_group(model, model_args, npz_paths, out_dir, cfg, **kwargs):
-        captured.append({"mode": kwargs.get("mode"), "out_dir": str(out_dir)})
+    class FakeEvaluator:
+        ddp_world_size = 1
 
-    monkeypatch.setattr(mod, "run_one_group", fake_run_one_group)
+        def discover_jobs(self):
+            return []
+
+        def run(self, jobs=None):
+            return {}
+
+    def fake_build_group_evaluator(model, model_args, npz_paths, out_dir, cfg, **kwargs):
+        captured.append({"mode": kwargs.get("mode"), "out_dir": str(out_dir)})
+        return FakeEvaluator()
+
+    monkeypatch.setattr(mod, "build_group_evaluator", fake_build_group_evaluator)
+    # The JSON lists placeholder npz paths; this test is about mode propagation, not tagging.
+    monkeypatch.setattr(mod, "TagStore", SimpleNamespace(from_source=lambda _source: None))
+    # ``cfg`` here is a SimpleNamespace, not the real dataclass ``save_config`` expects.
+    monkeypatch.setattr(mod, "save_config", lambda *a, **k: None)
     monkeypatch.setattr(mod, "log_closed_loop_to_wandb", lambda *a, **k: None)
 
     cfg = SimpleNamespace(
         closed_loop_npz_root=[str(json_path), str(json_path)],
         closed_loop_object_modes=["objects", "noobj"],
+        pass_conditions=SimpleNamespace(get_condition=lambda _name: None),
+        closed_loop_max_steps=None,
         closed_loop_near_miss_thresh=0.5,
         closed_loop_search_radius=1.5,
         closed_loop_warmup_steps=0,
@@ -232,3 +248,32 @@ def test_resolve_closed_loop_duplicate_path_keeps_each_mode(tmp_path: Path, monk
         "objects": str(tmp_path / "sites" / "alpha"),
         "noobj": str(tmp_path / "sites__noobj" / "alpha"),
     }
+
+
+def _assign(spec, world_size):
+    """Per-rank assignment for a ``{group: [job_id]}`` spec: [{group: [job ids]}, ...]."""
+    from types import SimpleNamespace
+
+    mod = _load_run_all_groups()
+    evaluators = {
+        group: SimpleNamespace(
+            discover_jobs=lambda ids=ids: [SimpleNamespace(job_id=i) for i in ids]
+        )
+        for group, ids in spec.items()
+    }
+    return [
+        {g: [j.job_id for j in v] for g, v in mod.assign_jobs(evaluators, r, world_size).items()}
+        for r in range(world_size)
+    ]
+
+
+def test_jobs_are_scheduled_across_groups_exactly_once():
+    """Every job runs on exactly one rank, and the 1-route group no longer idles the
+    other three the way per-group sharding did."""
+    spec = {"wide": [f"w{i}" for i in range(9)], "sparse": ["s0"]}
+    shards = _assign(spec, 4)
+
+    for group, ids in spec.items():
+        assert sorted(i for s in shards for i in s[group]) == sorted(ids)
+    per_rank = [sum(len(v) for v in s.values()) for s in shards]
+    assert min(per_rank) >= 2, f"a rank was left nearly idle: {per_rank}"

--- a/scenario_generation/closed_loop_evaluation.py
+++ b/scenario_generation/closed_loop_evaluation.py
@@ -3,9 +3,8 @@
 ``ClosedLoopEvaluation`` defines the shared workflow:
 
   1. ``discover_jobs`` — what to evaluate (routes, bags, classification dates, …)
-  2. ``shard_jobs`` — DDP round-robin assignment (override for custom sharding)
-  3. ``run_job`` — rollout for one job unit (segments via ``render_segment``, etc.)
-  4. ``build_summary`` / ``write_artifacts`` / ``print_summary`` — serialize + terminal output
+  2. ``run_job`` — rollout for one job unit (segments via ``render_segment``, etc.)
+  3. ``build_summary`` / ``write_artifacts`` / ``print_summary`` — serialize + terminal output
 
 ``FullRouteClosedLoopEvaluation`` is the segment-wise evaluator (``segments.jsonl``) over every
 route under an npz_root.
@@ -20,7 +19,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from scenario_generation.closed_loop_ddp import shard_items
 from scenario_generation.closed_loop_eval import (
     aggregate,
     build_mp4,
@@ -140,7 +138,6 @@ class ClosedLoopEvalConfig:
     fps: float
     verbose: bool
     profile: bool
-    max_jobs: int | None
     # Pass-condition for per-segment pass/fail + aggregated pass stats in the summary.
     # ``None`` disables pass evaluation entirely — the segment row never gains a ``passed``
     # field and the summary never carries ``pass_count`` / ``pass_rate`` / ``pass_condition``.
@@ -200,13 +197,11 @@ class ClosedLoopEvaluation(ABC):
             return load_onnx_model(model_path, device)
         return load_model(model_path, device)
 
-    def run(self) -> dict:
-        """Discover jobs, optionally shard for DDP, execute, summarize, and persist."""
+    def run(self, jobs: list[ClosedLoopJob]) -> dict:
+        """Execute ``jobs`` (chosen by the caller), summarize, and persist. An empty list
+        is valid: it still writes this rank's empty shard files, which is what keeps
+        ``collect_ddp_shards``' all-ranks-present check useful."""
         t0 = time.perf_counter()
-        jobs = self.discover_jobs()
-        if self.config.max_jobs is not None:
-            jobs = jobs[: self.config.max_jobs]
-        jobs = self.shard_jobs(jobs)
         if self.config.verbose and jobs and self.ddp_world_size > 1:
             print(
                 f"DDP rank {self.ddp_rank}/{self.ddp_world_size}: "
@@ -228,36 +223,6 @@ class ClosedLoopEvaluation(ABC):
         if self.config.verbose:
             self.print_summary(summary)
         return summary
-
-    def run_distributed(self) -> dict:
-        """Run evaluation; under DDP, barrier then rank-0 ``merge_ddp_shards``.
-
-        Requires an initialized process group whenever ``ddp_world_size > 1``: skipping the
-        barrier (e.g. because torch.distributed was never initialized) would let rank-0 start
-        merging before every other rank has finished writing its ``segments_{rank}.jsonl``
-        shard, silently producing a summary built from a partial/incomplete set of ranks.
-        """
-        t0 = time.perf_counter()
-        partial = self.run()
-        if self.ddp_world_size <= 1:
-            return partial
-        import torch.distributed as dist
-
-        if not (dist.is_available() and dist.is_initialized()):
-            raise RuntimeError(
-                f"closed-loop run_distributed: ddp_world_size={self.ddp_world_size} > 1 but "
-                "torch.distributed is not initialized -- refusing to merge without a barrier "
-                "to guarantee every rank finished writing its shard first."
-            )
-        dist.barrier()
-        if self.ddp_rank != 0:
-            return {}
-        if partial.get("ddp_shard"):
-            return self.merge_ddp_shards(self.ddp_world_size, elapsed_sec=time.perf_counter() - t0)
-        return partial
-
-    def shard_jobs(self, jobs: list[ClosedLoopJob]) -> list[ClosedLoopJob]:
-        return shard_items(jobs, self.ddp_rank, self.ddp_world_size)
 
     def initial_job_extras(self) -> dict[str, Any]:
         return {}


### PR DESCRIPTION
Closed-loop evaluation sharded each group on its own and barriered at every group
boundary, so a group with fewer routes than ranks left ranks idle. This shards all
groups' jobs in one pass and barriers once, at the end. 3 files, +101/-59.

## 1.687x faster on 4xH100

| | `tier4-main` | this PR | |
|---|---:|---:|---|
| wall per evaluation | 3917s | 2314s | **1.687x**, 41% less |

## Output is preserved

| | |
|---|---|
| segment rows | 114 / 114 identical |
| videos | 114 / 114 identical |
| group aggregates | match to float rounding |

Also sorts `_load_group_results`' `rglob`, because `groups.json` sums floats and filesystem
order made it vary between identical runs. This PR's output is bit-identical across
repeated runs; `tier4-main`'s is not.

Depends on #409, which makes `clearance_p5_m` independent of how routes are assigned to
ranks.
