### PR TITLE
fix(config): prevent runtime-only fields from breaking training config serialization

### DIFF
--- a/diffusion_planner/diffusion_planner/train.py
+++ b/diffusion_planner/diffusion_planner/train.py
@@ -237,7 +237,11 @@ def model_training(args: TrainConfig):
         args_dict = vars(args)
         args_dict = {
             k: v if not isinstance(v, (StateNormalizer, ObservationNormalizer)) else v.to_dict()
+            # Config objects may contain private runtime caches.  In particular,
+            # ClosedLoopConfig stores the parsed pass-condition YAML here; it is
+            # not part of the JSON config and is not JSON serializable.
             for k, v in args_dict.items()
+            if not k.startswith("_")
         }
         args_dict["major_version"] = 5
 

--- a/diffusion_planner/tests/test_train_config_serialization.py
+++ b/diffusion_planner/tests/test_train_config_serialization.py
@@ -1,0 +1,27 @@
+"""Tests for the training configuration JSON contract."""
+
+import json
+
+from diffusion_planner.config import TrainConfig
+
+
+def test_train_config_runtime_fields_are_not_saved_as_json(tmp_path):
+    """The closed-loop pass-condition cache must not break args.json writing."""
+    cfg = TrainConfig(
+        exp_name="serialization_test",
+        save_dir=str(tmp_path),
+    )
+
+    args_dict = {
+        key: value
+        for key, value in vars(cfg).items()
+        if not key.startswith("_")
+    }
+    args_dict["major_version"] = 5
+
+    output = tmp_path / "args.json"
+    output.write_text(json.dumps(args_dict, indent=4), encoding="utf-8")
+
+    saved = json.loads(output.read_text(encoding="utf-8"))
+    assert "_closed_loop_pass_conditions_loaded" not in saved
+    assert saved["major_version"] == 5

--- a/diffusion_planner/train_grpo_predictor.py
+++ b/diffusion_planner/train_grpo_predictor.py
@@ -70,6 +70,7 @@ def model_training(args):
         args_dict = {
             k: v if not isinstance(v, (StateNormalizer, ObservationNormalizer)) else v.to_dict()
             for k, v in args_dict.items()
+            if not k.startswith("_")
         }
         args_dict["major_version"] = 4
 


### PR DESCRIPTION
## Summary

  Fix training startup failure when saving `args.json`.

  `ClosedLoopConfig` always initializes the internal
  `_closed_loop_pass_conditions_loaded` field, even when closed-loop evaluation
  is not enabled. This field contains a `ClosedLoopPassConditionGroups` object,
  which is not JSON serializable.

  As a result, every training run fails during `args.json` generation.

  ## Fix
  Exclude private runtime-only fields from the serialized training configuration.

  ## Testing

  - Python compile check passed
