### PR TITLE
feat: add mean_centerline_dist_m closed-loop metric

### DIFF
--- a/scenario_generation/closed_loop_eval.py
+++ b/scenario_generation/closed_loop_eval.py
@@ -369,6 +369,8 @@ def format_summary_lines(summary: dict) -> list[str]:
         f"terminated={summary['terminated_counts']}",
         f"turn_indicator transition accuracy: "
         f"{ti['transition_correct']}/{ti['transition_total']} ({ti_acc_str})",
+        f"mean gt_deviation={summary['mean_gt_deviation_m']:.3f} m  "
+        f"mean centerline_deviation={summary['mean_centerline_dist_m']:.3f} m",
     ]
     return lines
 
@@ -403,6 +405,17 @@ def aggregate(
     )
     dev_den = sum(
         r["n_steps_run"] for r in rows if np.isfinite(r.get("mean_gt_deviation_m", float("inf")))
+    )
+    # centerline-deviation pooled the same way as gt-deviation: step-weighted mean.
+    cl_num = sum(
+        r["mean_centerline_dist_m"] * r["n_steps_run"]
+        for r in rows
+        if np.isfinite(r.get("mean_centerline_dist_m", float("inf")))
+    )
+    cl_den = sum(
+        r["n_steps_run"]
+        for r in rows
+        if np.isfinite(r.get("mean_centerline_dist_m", float("inf")))
     )
 
     term_counts: dict[str, int] = {}
@@ -486,6 +499,7 @@ def aggregate(
         "total_steps": total_steps,
         "mean_route_completion": float(np.mean(completions)) if completions else 0.0,
         "mean_gt_deviation_m": float(dev_num / dev_den) if dev_den else float("inf"),
+        "mean_centerline_dist_m": float(cl_num / cl_den) if cl_den else float("inf"),
         "n_segments_diverged": n_seg_diverged,
         "diverged_segment_rate": n_seg_diverged / n_seg if n_seg else 0.0,
         "object": obj,

--- a/scenario_generation/metrics/__init__.py
+++ b/scenario_generation/metrics/__init__.py
@@ -1,5 +1,6 @@
 """Closed-loop per-step metric scorers (no aggregation)."""
 
+from scenario_generation.metrics.centerline import score_centerline_step
 from scenario_generation.metrics.ego_traj import ego_traj_ego_frame
 from scenario_generation.metrics.object import score_object_step, score_object_step_batched
 from scenario_generation.metrics.red_light import score_red_light_step
@@ -8,6 +9,7 @@ from scenario_generation.metrics.strong_brake import strong_brake_mask
 
 __all__ = [
     "ego_traj_ego_frame",
+    "score_centerline_step",
     "score_object_step",
     "score_object_step_batched",
     "score_road_border_step",

--- a/scenario_generation/metrics/centerline.py
+++ b/scenario_generation/metrics/centerline.py
@@ -1,0 +1,26 @@
+"""Per-step route-centerline distance for closed-loop eval."""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+from planner_metrics.centerline import compute_centerline_distance_batch
+
+
+def score_centerline_step(np_dict: dict, *, device: str) -> dict:
+    """Ego-to-route-centerline nearest-segment distance at the current step.
+
+    Current pose is the ego-frame origin (``route_lanes``/``lanes`` are already
+    re-centered onto the live ego each step, same as every other per-step scorer
+    here). Falls back to ``lanes`` when ``route_lanes`` is absent, same
+    precedence as the open-loop centerline metric.
+    """
+    centerline_dist_m = float("inf")
+    lanes_key = "route_lanes" if "route_lanes" in np_dict else "lanes"
+    if lanes_key in np_dict:
+        lanes_t = torch.tensor(np.asarray(np_dict[lanes_key]), dtype=torch.float32, device=device)
+        traj = torch.zeros(1, 1, 2, dtype=torch.float32, device=device)
+        dist = compute_centerline_distance_batch(traj, {lanes_key: lanes_t})
+        centerline_dist_m = float(dist[0, 0].item())
+    return {"centerline_dist_m": centerline_dist_m}

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -36,6 +36,7 @@ from planner_metrics.scene_format import future_to_4col
 from scenario_generation.danger_event_selection import OnlineEventSelector
 from scenario_generation.inference_compile import mark_inference_step
 from scenario_generation.metrics import (
+    score_centerline_step,
     score_object_step,
     score_object_step_batched,
     score_red_light_step,
@@ -494,6 +495,13 @@ class _SegState:
     # on an unstick teleport (see ``_advance_step``), so a teleport's environment jump is never
     # itself counted as a transition.
     turn_indicator_prev_scored_gt: int = 0
+    # Running sum/count of per-step route-centerline distance (m), for the
+    # mean_centerline_dist_m metric: mean nearest-segment distance from the live ego to
+    # the route_lanes/lanes centerline polyline (see ``score_centerline_step``). Same
+    # graded-signal treatment as gt_dev_sum/gt_dev_count, just measured against the map
+    # instead of the recorded ego trajectory.
+    centerline_dev_sum: float = 0.0
+    centerline_dev_count: int = 0
 
 
 def _ego_state_from_frame(tl: RouteTimeline, idx: int) -> tuple[np.ndarray, np.ndarray, "_EgoDyn"]:
@@ -821,7 +829,8 @@ def _score_into(
     object_col: bool | None = None,
     object_rear_col: bool | None = None,
 ):
-    """Score this step's object / road-border / red-light metrics into the segment state.
+    """Score this step's object / road-border / centerline / red-light metrics into the
+    segment state.
 
     When ``object_cl`` / ``object_col`` / ``object_rear_col`` are provided (batched path
     already scored neighbors), reuse them instead of calling ``score_object_step`` again.
@@ -839,6 +848,10 @@ def _score_into(
         if np_dict is not None:
             rb = score_road_border_step(np_dict, device=device)
             s.rb_dists[s.k] = float(rb["rb_dist_m"])
+            cl_dev = score_centerline_step(np_dict, device=device)
+            if np.isfinite(cl_dev["centerline_dist_m"]):
+                s.centerline_dev_sum += cl_dev["centerline_dist_m"]
+                s.centerline_dev_count += 1
             red = score_red_light_step(
                 np_dict,
                 device=device,
@@ -1196,6 +1209,9 @@ def _finalize(s: _SegState) -> dict:
         "route_completion": route_completion,
         "mean_gt_deviation_m": float(s.gt_dev_sum / s.gt_dev_count)
         if s.gt_dev_count
+        else float("inf"),
+        "mean_centerline_dist_m": float(s.centerline_dev_sum / s.centerline_dev_count)
+        if s.centerline_dev_count
         else float("inf"),
         "progress_m": progress_m,
         "object": clearance_family_block(cl, s.collisions[: s.k], miss_thresh=s.near_miss_thresh),

--- a/scenario_generation/scenario_sim_viewer_export.py
+++ b/scenario_generation/scenario_sim_viewer_export.py
@@ -28,7 +28,11 @@ from scenario_generation.trajectory_colormap import render_trajectory_colormaps
 
 # ``aggregate`` reduces these from row keys this path never writes, and a mean over no samples
 # is 0.0 -- which reads as a measured total failure. Dropped, and named instead.
-_UNMEASURED_SUMMARY_KEYS = ("mean_route_completion", "mean_gt_deviation_m")
+_UNMEASURED_SUMMARY_KEYS = (
+    "mean_route_completion",
+    "mean_gt_deviation_m",
+    "mean_centerline_dist_m",
+)
 _UNMEASURED_MARKER_KEY = "unmeasured_keys"
 
 # The suite's own names for its scenarios. Copied rather than read, so what a name means stays

--- a/scenario_generation/wandb_closed_loop.py
+++ b/scenario_generation/wandb_closed_loop.py
@@ -43,6 +43,7 @@ _ABS_COLUMNS = [
     ("Route completion (%)", "mean_route_completion"),
     ("Pass rate (%)", "pass_rate"),
     ("GT deviation (m)", "mean_gt_deviation_m"),
+    ("Centerline deviation (m)", "mean_centerline_dist_m"),
     ("Fails", "fail_count"),
     ("Curb hits", "total_curb_hits"),
     ("Snaps", "total_snaps"),
@@ -61,6 +62,7 @@ _PER_1000STEPS_COLUMNS = [
     ("Route completion (%)", "mean_route_completion"),
     ("Pass rate (%)", "pass_rate"),
     ("GT deviation (m)", "mean_gt_deviation_m"),
+    ("Centerline deviation (m)", "mean_centerline_dist_m"),
     ("Curb hits / 1k steps", "total_curb_hits"),
     ("Snaps / 1k steps", "total_snaps"),
     ("Red light / 1k steps", "total_red_light_violations"),
@@ -118,6 +120,9 @@ def _abs_value(source_key: str, summary: dict):
         # "always wrong at transitions".
         val = summary[source_key] if source_key in summary else extract_score(summary, source_key)
         return float(val) if isinstance(val, (int, float)) else None
+    if source_key == "mean_centerline_dist_m":
+        dev = summary.get("mean_centerline_dist_m")
+        return float(dev) if dev is not None and math.isfinite(float(dev)) else None
 
     # Int fields.
     if source_key in ("n_segments", "total_steps"):
@@ -137,6 +142,7 @@ def _per_1000steps_value(source_key: str, summary: dict) -> float | None:
         "pass_rate",
         "mean_gt_deviation_m",  # already a per-step mean
         "turn_indicator_transition_accuracy",  # already a ratio
+        "mean_centerline_dist_m",  # already a per-step mean
     ):
         return _abs_value(source_key, summary)
     denom_key = "n_segments" if source_key == "n_segments_diverged" else "total_steps"
@@ -175,12 +181,23 @@ def _aggregate(group_summaries: dict[str, dict]) -> dict:
             dev_num += float(dev) * steps
             dev_steps += steps
 
+    # Step-weighted mean for mean_centerline_dist_m
+    cl_num = 0.0
+    cl_steps = 0
+    for v in values:
+        cl = v.get("mean_centerline_dist_m", None)
+        steps = int(v.get("total_steps", 0) or 0)
+        if cl is not None and math.isfinite(cl) and steps > 0:
+            cl_num += float(cl) * steps
+            cl_steps += steps
+
     agg: dict = {
         "n_groups": len(values),
         "n_segments": n_segments,
         "total_steps": sum(int(s.get("total_steps", 0) or 0) for s in values),
         "mean_route_completion": _segment_weighted_mean(values, "mean_route_completion"),
         "mean_gt_deviation_m": (dev_num / dev_steps) if dev_steps else float("inf"),
+        "mean_centerline_dist_m": (cl_num / cl_steps) if cl_steps else float("inf"),
         "pass_rate": _segment_weighted_mean(values, "pass_rate"),
         "fail_count": sum(int(s.get("fail_count", 0) or 0) for s in values),
     }


### PR DESCRIPTION
## Summary
- Adds `mean_centerline_dist_m`: mean per-step distance from the live ego to the route centerline (`route_lanes`, falling back to `lanes`), reusing the existing open-loop `compute_centerline_distance_batch` primitive via a new `score_centerline_steon/metrics/centerline.py`).
- Wired through the full closed-loop pipeviation_m` is: `_SegState` accumulation in
`reproducer_rollout.py`, segment `aggregamary line in `closed_loop_eval.py`, the
viewer's unmeasured-key handling in `scennd the wandb tables/aggregation in
`wandb_closed_loop.py`.
- Out of scope for this change (can folloanted): the per-step colormap trace in
`trajectory_colormap.py`, and a lateral/llogous to `mean_gt_deviation_x_m`/`_y_m`.

## Test plan
- [x] `python3 -m py_compile` on all chan
- [x] Ran `run_all_groups_closed_loop.py`osed-loop dataset segment
(worst_model.onnx) — `summary.json` repordist_m` alongside `mean_gt_deviation_m`,no exceptions through scoring, aggregation, or wandb logging.

🤖 Generated with [Claude Code](https://c