### PR TITLE
perf(closed-loop): write per-step frames to scratch, not into the results

### DIFF
--- a/scenario_generation/closed_loop_evaluation.py
+++ b/scenario_generation/closed_loop_evaluation.py
@@ -13,6 +13,7 @@ route under an npz_root.
 from __future__ import annotations
 
 import json
+import tempfile
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -430,11 +431,17 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
             digests_path.open("w", encoding="utf-8") as fdigest,
             # One pool for every segment: a spawned worker re-imports torch and matplotlib.
             render_pool(self.config.params.draw_workers) as draw_pool,
+            # ffmpeg consumes and deletes these, so they must not land in the output tree.
+            tempfile.TemporaryDirectory(prefix="closed_loop_frames_") as frames_root,
         ):
             for ri, job in enumerate(jobs):
                 assert isinstance(job, FullRouteRouteJob)
                 partial = self.run_job(
-                    job, segments_file=fout, digest_file=fdigest, draw_pool=draw_pool
+                    job,
+                    segments_file=fout,
+                    digest_file=fdigest,
+                    draw_pool=draw_pool,
+                    frames_root=Path(frames_root),
                 )
                 merged.rows.extend(partial.rows)
                 merged.video_mp4s.extend(partial.video_mp4s)
@@ -452,16 +459,18 @@ class FullRouteClosedLoopEvaluation(ClosedLoopEvaluation):
         segments_file=None,
         digest_file=None,
         draw_pool=None,
+        frames_root: Path | None = None,
     ) -> JobRunResult:
         assert isinstance(job, FullRouteRouteJob)
         params = self.config.params
+        frames_root = frames_root if frames_root is not None else self.out_dir
         timers = Timers()
         tl = RouteTimeline(job.route_paths, sidecar_dir=job.npz_root, timers=timers)
         rows: list[dict] = []
         video_mp4s: list[Path] = []
 
         for start, end in tl.iter_segments(job.seg_len):
-            png_dir = self.out_dir / f"{job.route_key}_{start}_{end}"
+            png_dir = frames_root / f"{job.route_key}_{start}_{end}"
             metrics = render_segment(
                 self.model,
                 self.model_args,


### PR DESCRIPTION
Shortens a 4-in-1 model evaluation by **4.4 min (−4.0%)**, from 110.8 min.

## Problem

Per-step PNGs are transient: ffmpeg encodes them into the segment MP4 and deletes them, and
none survive the run. They were written into the output directory, which on a cluster is
shared storage, so one closed-loop lap pushed 86,829 create/read/unlink cycles through NFS
for files thrown away seconds later.

One file's create + read-back + unlink costs **16.8 ms on NFS** against 0.19 ms on tmpfs and
0.15 ms on local disk.

## Change

The frames go to a `TemporaryDirectory`. Only the frames move.

## Result

4 GPUs, current defaults, each pair launched at the same minute on separate nodes:

| evaluation | before | after | |
|---|---:|---:|---:|
| closed-loop lap (by-site, objects + noobj) | 38.53 min | 36.58 min | **−1.95** |
| closed-loop override | 28.15 min | 25.67 min | **−2.48** |

The two stages that touch the PNGs are the two that moved; everything else is run-to-run
noise.

| stage | lap | override |
|---|---:|---:|
| `render_drain` | 606.6 → 438.8 s | 423.7 → 317.3 s |
| `build_mp4` | 226.7 → 186.7 s | 158.3 → 123.6 s |

## For review

- **The location follows `TMPDIR` rather than being hardcoded.** There is no size-independent
  winner between tmpfs and local disk, the spread between them is at most 0.19 ms per frame
  against the 16.6 ms that leaving NFS saves, and `/dev/shm` is sized differently per machine.
- **`closed_loop_eval.run_closed_loop_eval` has the same pattern and is deliberately
  untouched.** It is a separate entry point and not on the path measured here.
