### PR TITLE
fix(tag_toolkit): refresh the route-tag index instead of leaving a stale one

### DIFF
--- a/tag_toolkit/scripts/tag_management/write_route_tags_from_csv.py
+++ b/tag_toolkit/scripts/tag_management/write_route_tags_from_csv.py
@@ -13,8 +13,11 @@ Usage::
         /path/to/dataset \\
         /path/to/mapping.csv \\
         --match-col t4_dataset_id \\
-        --tag-dimensions devops_site devops_override_label \\
-        [--output-index /path/to/output.tags.db]
+        --tag-dimensions devops_site devops_override_label
+
+The TagStore index is rewritten afterwards, to ``<source stem>.tags.db`` beside the
+source unless ``--output-index`` says otherwise, because readers open that file on
+sight: leaving the old one in place would serve the tags as they were before this run.
 
 All file writes are batched (per-file fsync deferred) and synced once at
 the end for maximum performance.
@@ -370,9 +373,27 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         default=None,
         dest="output_index",
-        help="Output path for the .tags.db index file (optional)",
+        help="Where to write the .tags.db index. Defaults to <source stem>.tags.db next "
+        "to the source, which is where readers look for it. Pass --no-index to write none.",
+    )
+    parser.add_argument(
+        "--no-index",
+        action="store_true",
+        dest="no_index",
+        help="Write no index. The sidecars are still tagged, so any index beside the "
+        "source is left describing the tags as they were before this run.",
     )
     return parser.parse_args()
+
+
+def default_index_output(source: Path) -> Path | None:
+    """``<source stem>.tags.db`` beside ``source`` -- the path ``from_source`` reads.
+
+    A source that is already a database indexes itself; a directory has no stem to key on.
+    """
+    if source.name.endswith(".tags.db") or source.is_dir():
+        return None
+    return source.parent / f"{source.stem}.tags.db"
 
 
 def main() -> int:
@@ -413,13 +434,19 @@ def main() -> int:
         dry_run=args.dry_run,
     )
 
-    # Save index if requested
-    if args.output_index and not args.dry_run:
-        print(f"[3/3] Saving index to {args.output_index}...")
-        store.export_index(args.output_index)
-        print(f"  Index saved to {args.output_index}")
+    index_output = args.output_index or default_index_output(args.source)
+    if args.dry_run:
+        print("[3/3] Skipping index save (dry run)")
+    elif args.no_index:
+        print("[3/3] Skipping index save (--no-index)")
+        if index_output and index_output.exists():
+            print(f"  WARNING: {index_output} now predates these tags", file=sys.stderr)
+    elif index_output is None:
+        print("[3/3] Skipping index save (the source is not a path list)")
     else:
-        print("[3/3] Skipping index save (use --output-index to save)")
+        print(f"[3/3] Saving index to {index_output}...")
+        store.export_index(index_output)
+        print(f"  Index saved to {index_output}")
 
     # Summary
     print()

--- a/tag_toolkit/store/_index.py
+++ b/tag_toolkit/store/_index.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from collections import Counter
 from pathlib import Path
 from typing import TYPE_CHECKING, Sequence
@@ -48,6 +49,13 @@ class _IndexMixin:
         if db_path.exists() and not force_rebuild:
             return TagStore(db_path)
 
+        # The fallback shares its call with the fast path, so without this a rebuild --
+        # which reads every sidecar under the source -- is indistinguishable from a load.
+        print(
+            f"[TagStore] no index at {db_path}; scanning sidecars instead "
+            "(build it once to skip this)",
+            file=sys.stderr,
+        )
         store = TagStore()
         store.rebuild_index(source)
 

--- a/tag_toolkit/tests/test_write_route_tags_index.py
+++ b/tag_toolkit/tests/test_write_route_tags_index.py
@@ -1,0 +1,73 @@
+"""``TagStore.from_source`` opens ``<source stem>.tags.db`` without checking whether the
+sidecars moved on since it was built, so a tag writer that skips the index hands every
+later reader the previous run's answers.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "tag_toolkit" / "scripts" / "tag_management" / "write_route_tags_from_csv.py"
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tag_toolkit import TagStore  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location("write_route_tags_from_csv", SCRIPT)
+script = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(script)
+
+
+@pytest.fixture
+def dataset(tmp_path: Path):
+    """One route whose sidecars carry a t4_dataset_id, plus a path list naming it."""
+    route = tmp_path / "proj" / "1234_site" / "auto" / "2026-01-01" / "00-00-00"
+    route.mkdir(parents=True)
+    for i in (1, 2):
+        npz = route / f"00-00-00_00000000_0000000{i}.npz"
+        npz.write_bytes(b"")
+        npz.with_suffix(".json").write_text(json.dumps({"t4_dataset_id": "abc", "tags": []}))
+    source = tmp_path / "path_list.json"
+    source.write_text(json.dumps([str(route)]))
+    csv_path = tmp_path / "map.csv"
+    csv_path.write_text("t4_dataset_id,devops_site\nabc,odaiba\n")
+    return source, csv_path
+
+
+def _run(source: Path, csv_path: Path, *extra: str) -> int:
+    argv = [
+        "write_route_tags_from_csv.py",
+        str(source),
+        str(csv_path),
+        "--match-col",
+        "t4_dataset_id",
+        "--tag-dimensions",
+        "devops_site",
+        *extra,
+    ]
+    old, sys.argv = sys.argv, argv
+    try:
+        return script.main()
+    finally:
+        sys.argv = old
+
+
+def test_a_second_run_leaves_the_index_agreeing_with_the_sidecars(dataset):
+    """The failure this guards: tags change, the index does not, readers see the old ones."""
+    source, csv_path = dataset
+    _run(source, csv_path)
+
+    csv_path.write_text("t4_dataset_id,devops_site\nabc,shiojiri\n")
+    _run(source, csv_path)
+
+    indexed = TagStore(source.parent / "path_list.tags.db").tags_of(
+        scope=source, granularity="route"
+    )
+    assert "devops_site:shiojiri" in indexed


### PR DESCRIPTION
Tagging routes without `--output-index` left every later reader answering from the previous
run's tags, with nothing in the output to say so.

## Problem

Everything that reads route tags goes through `TagStore.from_source`. It opens
`<source stem>.tags.db` beside the source if that file exists, and otherwise rebuilds the
index by reading every sidecar. It never checks whether the sidecars changed after the index
was built.

`write_route_tags_from_csv.py` wrote the index only when `--output-index` was passed, so a run
that tagged sidecars and skipped the flag left the old `.tags.db` in place — and readers trust
it on sight. Nothing in either run's output says the two disagree. We are about to ship a
`.tags.db` alongside the dataset, which turns this from a latent hazard into the normal case.

The rebuild is the other half of the same silence: it happens inside the same call as the fast
path, so a caller cannot tell one from the other. On the by-site closed-loop set (103,160
frames) it costs 184–353 s per rank depending on NFS load, and the closed-loop lap pays it once
per rank per object mode.

## Change

- The index defaults to `<source stem>.tags.db` next to the source — the path readers look at.
  `--output-index` still overrides it. `--no-index` skips it and names the file it just left
  describing the tags as they were. A directory source and a `.tags.db` source get no default:
  the first has no stem to key the index on, the second already is one.
- `TagStore.from_source` names the missing index on stderr before it rescans.

## For review

- **The default flipped.** An invocation that passed no index flag wrote nothing before and
  writes `<source stem>.tags.db` now. That is the change — opt-in is what made staleness
  possible — but it does mean existing scripts start producing a file. `--no-index` is the
  opt-out.
- **`from_source` still does not detect a stale index.** It cannot without stat'ing every
  sidecar, which is the scan it exists to avoid. This closes the writer that was producing
  stale indexes; it does not make an arbitrary `.tags.db` trustworthy.
