### PR TITLE
feat: add turn-indicator false-positive (spurious-transition) rate metric

### DIFF
--- a/diffusion_planner/run_all_groups_closed_loop.py
+++ b/diffusion_planner/run_all_groups_closed_loop.py
@@ -341,6 +341,18 @@ def _write_groups_manifest(out_dir: Path | str, summaries: dict[str, dict]) -> N
             (_ti_transition_correct / _ti_transition_total) if _ti_transition_total else None
         )
 
+        _ti_fp_count = sum(
+            int(s.get("turn_indicator", {}).get("fp_count", 0) or 0) for s in summaries.values()
+        )
+        _ti_fp_total = sum(
+            int(s.get("turn_indicator", {}).get("fp_total", 0) or 0) for s in summaries.values()
+        )
+        # None (not 0.0) when no GT-steady scored step was ever observed across any group -- a
+        # silent 0.0 would misread as "never flips spuriously" rather than "nothing to measure".
+        agg["turn_indicator_false_positive_rate"] = (
+            (_ti_fp_count / _ti_fp_total) if _ti_fp_total else None
+        )
+
         total_pass = sum(int(s.get("pass_count", 0) or 0) for s in summaries.values())
         total_fail = sum(int(s.get("fail_count", 0) or 0) for s in summaries.values())
         agg["n_pass_segments"] = total_pass

--- a/scenario_generation/closed_loop_eval.py
+++ b/scenario_generation/closed_loop_eval.py
@@ -334,6 +334,9 @@ def format_summary_lines(summary: dict) -> list[str]:
     ti_acc_str = (
         f"{ti['transition_accuracy']:.4f}" if ti["transition_accuracy"] is not None else "N/A"
     )
+    ti_fp_str = (
+        f"{ti['false_positive_rate']:.4f}" if ti["false_positive_rate"] is not None else "N/A"
+    )
     repro = summary["reproducer"]
     lines = [
         f"object collision: {obj['collision_segments']}/{n_seg} segments "
@@ -369,6 +372,8 @@ def format_summary_lines(summary: dict) -> list[str]:
         f"terminated={summary['terminated_counts']}",
         f"turn_indicator transition accuracy: "
         f"{ti['transition_correct']}/{ti['transition_total']} ({ti_acc_str})",
+        f"turn_indicator false positive rate: "
+        f"{ti['fp_count']}/{ti['fp_total']} ({ti_fp_str})",
         f"mean gt_deviation={summary['mean_gt_deviation_m']:.3f} m  "
         f"mean centerline_deviation={summary['mean_centerline_dist_m']:.3f} m",
     ]
@@ -487,6 +492,8 @@ def aggregate(
     turn_transition_total = sum(
         int(_require_block(r, "turn_indicator")["transition_total"]) for r in rows
     )
+    turn_fp_count = sum(int(_require_block(r, "turn_indicator")["fp_count"]) for r in rows)
+    turn_fp_total = sum(int(_require_block(r, "turn_indicator")["fp_total"]) for r in rows)
 
     expand = sum(int(_require_block(r, "reproducer")["expand_count"]) for r in rows)
     snap = sum(int(_require_block(r, "reproducer")["snap_count"]) for r in rows)
@@ -517,6 +524,13 @@ def aggregate(
                 (turn_transition_correct / turn_transition_total)
                 if turn_transition_total > 0
                 else None
+            ),
+            "fp_count": turn_fp_count,
+            "fp_total": turn_fp_total,
+            # None (not 0.0) when no GT-steady scored step ever occurred: a silent 0.0 would
+            # misread as "never flips spuriously" rather than "nothing to measure".
+            "false_positive_rate": (
+                (turn_fp_count / turn_fp_total) if turn_fp_total > 0 else None
             ),
         },
         "terminated_counts": term_counts,

--- a/scenario_generation/closed_loop_score_keys.py
+++ b/scenario_generation/closed_loop_score_keys.py
@@ -17,6 +17,9 @@ SCORE_EXTRACTORS = {
     "turn_indicator_transition_accuracy": lambda d: d.get("turn_indicator", {}).get(
         "transition_accuracy"
     ),
+    "turn_indicator_false_positive_rate": lambda d: d.get("turn_indicator", {}).get(
+        "false_positive_rate"
+    ),
 }
 
 

--- a/scenario_generation/reproducer_rollout.py
+++ b/scenario_generation/reproducer_rollout.py
@@ -495,6 +495,22 @@ class _SegState:
     # on an unstick teleport (see ``_advance_step``), so a teleport's environment jump is never
     # itself counted as a transition.
     turn_indicator_prev_scored_gt: int = 0
+    # Closed-loop turn-indicator SPURIOUS-TRANSITION ("false positive") counters: how often the
+    # model's own resolved prediction changes from ITS OWN previous scored prediction while GT
+    # held steady since the previous scored step. Mirrors turn_indicator_transition_*, but is
+    # keyed off the model's own prior prediction (turn_indicator_prev_scored_pred), not GT --
+    # comparing against GT's previous value would just remeasure transition_accuracy's
+    # complement. Gated on the SAME "GT unchanged since previous scored step" condition
+    # ``_score_turn_indicator`` already computes for the transition counters, so every scored
+    # step falls into exactly one of {gt changed -> transition_total} or
+    # {gt unchanged -> fp_total}, never both.
+    turn_indicator_fp_count: int = 0
+    turn_indicator_fp_total: int = 0
+    # Model's own RESOLVED prediction at the PREVIOUS scored (real-inference) step -- the
+    # baseline turn_indicator_fp_count/total is measured against. Seeded in ``_seed_state`` and
+    # re-seeded on an unstick teleport, exactly like ``turn_indicator_prev_scored_gt``, so a
+    # teleport's environment jump is never itself counted as a spurious flip.
+    turn_indicator_prev_scored_pred: int = 0
     # Running sum/count of per-step route-centerline distance (m), for the
     # mean_centerline_dist_m metric: mean nearest-segment distance from the live ego to
     # the route_lanes/lanes centerline polyline (see ``score_centerline_step``). Same
@@ -587,6 +603,8 @@ def _seed_state(
     # Closed-loop turn indicators: seed from the recorded frame, then feed the model's own
     # prediction back each step (phasing the seed out) — the model context never carries the
     # recorded driver's signals beyond the seed, only its own predictions.
+    # ``turn_indicator_prev_scored_pred`` is seeded the same way since nothing has been
+    # predicted yet.
     turn_hist = np.asarray(tl.npz(start)["turn_indicators"]).reshape(-1).astype(np.int64)
     if tracker_mode == "perfect":
         tracker = PerfectTracker(dt=DT)
@@ -615,6 +633,7 @@ def _seed_state(
         turn_hist=turn_hist,
         last_turn_indicator=int(turn_hist[-1]),
         turn_indicator_prev_scored_gt=int(turn_hist[-1]),
+        turn_indicator_prev_scored_pred=int(turn_hist[-1]),
         ego_shape=ego_shape,
         goal_xy=goal_xy,
         clearances=np.full(cap, np.inf, dtype=np.float32),
@@ -709,7 +728,9 @@ def _feed_turn_indicator(s: _SegState, outputs) -> None:
 def _hold_turn_indicator(s: _SegState) -> None:
     """Cached-plan step (``replan_interval`` > 1, no fresh inference): keep the 10 Hz turn
     history scrolling by re-appending the LAST decoded turn indicator, so the next replan
-    sees the held signal as if the model had re-confirmed it every step."""
+    sees the held signal as if the model had re-confirmed it every step. Touches only
+    ``turn_hist`` -- never the scoring accumulators or either ``prev_scored_*`` field
+    (including the spurious-transition FP counters), since no fresh prediction was made."""
     s.turn_hist = np.append(s.turn_hist[1:], np.int64(s.last_turn_indicator))
 
 
@@ -736,6 +757,17 @@ def _score_turn_indicator(s: _SegState, idx: int) -> None:
     or a cursor skip/repeat, a GT transition can occur entirely BETWEEN two scored
     steps and never show up in either step's own one-tick-back window. The next scored
     step is the model's first real chance to react to it, so that's where it's counted.
+
+    Also accumulates the SPURIOUS-TRANSITION ("false positive") counters
+    ``turn_indicator_fp_count``/``turn_indicator_fp_total``: on a scored step where GT did
+    NOT change since the previous scored step (the complement of the transition-accuracy
+    gate above), a "false positive" is a resolved prediction that changed from the model's
+    OWN previous scored prediction (``turn_indicator_prev_scored_pred``), not from GT -- GT
+    is steady by construction in this branch, so comparing against GT would just remeasure
+    the same population as an inverted transition metric. The two counter pairs are
+    mutually exclusive per scored step (one increments the transition pair, the other
+    increments the fp pair, never both), so ``transition_total + fp_total`` across a run
+    always equals the total number of scored steps.
     """
     gt = int(np.asarray(s.tl.npz(idx)["turn_indicators"]).reshape(-1)[-1])
     pred = int(s.last_turn_indicator)
@@ -743,7 +775,11 @@ def _score_turn_indicator(s: _SegState, idx: int) -> None:
     if gt != s.turn_indicator_prev_scored_gt:
         s.turn_indicator_transition_total += 1
         s.turn_indicator_transition_correct += int(correct)
+    else:
+        s.turn_indicator_fp_total += 1
+        s.turn_indicator_fp_count += int(pred != s.turn_indicator_prev_scored_pred)
     s.turn_indicator_prev_scored_gt = gt
+    s.turn_indicator_prev_scored_pred = pred
 
 
 # GT-deviation lookup window: ±15 s of recorded trajectory around the cursor. Wide enough to
@@ -983,10 +1019,12 @@ def _advance_step(s: _SegState, pred: np.ndarray, idx, device, timers, override=
                     np.asarray(s.tl.npz(tgt)["turn_indicators"]).reshape(-1).astype(np.int64)
                 )
                 s.last_turn_indicator = int(s.turn_hist[-1])
-                # Re-seed the transition-comparison basis too: without this, the next scored
-                # step would compare the pre-teleport GT against the teleport target's GT and
-                # count the environment jump itself as a (spurious) transition.
+                # Re-seed the transition-comparison basis too (both the GT baseline and the
+                # model's own prediction baseline): without this, the next scored step would
+                # compare pre-teleport state against the teleport target's GT/context and count
+                # the environment jump itself as a (spurious) transition or false positive.
                 s.turn_indicator_prev_scored_gt = int(s.turn_hist[-1])
+                s.turn_indicator_prev_scored_pred = int(s.turn_hist[-1])
                 s.last_collision_uuid = None  # teleported -> next contact is a fresh collision
                 s.in_episode = False
                 s.prev_max_idx = cur.max_idx_reached
@@ -1171,18 +1209,28 @@ def deviation_collision_block(collisions: np.ndarray, gt_devs: np.ndarray, thres
     }
 
 
-def turn_indicator_block(transition_correct: int, transition_total: int) -> dict:
+def turn_indicator_block(
+    transition_correct: int, transition_total: int, fp_count: int, fp_total: int
+) -> dict:
     """The ``turn_indicator`` segment-row block: closed-loop turn-indicator TRANSITION
-    accuracy, scored only on real inference steps (see ``_score_turn_indicator``). A plain
-    accumulator, like ``reproducer`` -- the accuracy ratio is computed at aggregate time, not
-    here, so this stays summable across segments without re-deriving a rate. Only transitions
-    are tracked (no plain per-step accuracy): it's the metric that actually demonstrates
-    correct indicator switching, unlike per-step accuracy which is dominated by long stable
-    KEEP/NONE periods.
+    accuracy AND spurious-transition ("false positive") rate, both scored only on real
+    inference steps (see ``_score_turn_indicator``). Plain accumulators, like ``reproducer``
+    -- both ratios are computed at aggregate time, not here, so this stays summable across
+    segments without re-deriving a rate.
+
+    ``transition_*`` and ``fp_*`` partition the same population of scored steps (GT-changed
+    vs GT-unchanged since the previous scored step) into two disjoint, complementary
+    metrics: transition accuracy asks "did the model follow a real GT change correctly?";
+    the false-positive rate asks "did the model flip when GT gave it no reason to?" Only
+    transitions/flips are tracked (no plain per-step accuracy): it's what actually
+    demonstrates correct indicator switching vs. spurious switching, unlike per-step
+    accuracy which is dominated by long stable KEEP/NONE periods.
     """
     return {
         "transition_correct": int(transition_correct),
         "transition_total": int(transition_total),
+        "fp_count": int(fp_count),
+        "fp_total": int(fp_total),
     }
 
 
@@ -1248,6 +1296,8 @@ def _finalize(s: _SegState) -> dict:
         "turn_indicator": turn_indicator_block(
             s.turn_indicator_transition_correct,
             s.turn_indicator_transition_total,
+            s.turn_indicator_fp_count,
+            s.turn_indicator_fp_total,
         ),
         "reproducer": {
             "expand_count": int(s.expand_count),

--- a/scenario_generation/scenario_sim_metrics.py
+++ b/scenario_generation/scenario_sim_metrics.py
@@ -93,9 +93,9 @@ def build_segment_row(
         "strong_brake": strong_brake_block(ac, strong_brake_mps2),
         "reproducer": {**_NO_REPRODUCER_CURSOR, "normal_steps": int(n_steps_run)},
         # No GT turn indicator to score against on this path -- zero counts are the true
-        # measurement (transition_accuracy then aggregates to None/"N/A"), same idea as
-        # ``_NO_REPRODUCER_CURSOR`` above.
-        "turn_indicator": turn_indicator_block(0, 0),
+        # measurement (transition_accuracy/false_positive_rate then aggregate to None/"N/A"),
+        # same idea as ``_NO_REPRODUCER_CURSOR`` above.
+        "turn_indicator": turn_indicator_block(0, 0, 0, 0),
     }
 
 

--- a/scenario_generation/tests/test_closed_loop_metrics.py
+++ b/scenario_generation/tests/test_closed_loop_metrics.py
@@ -336,6 +336,8 @@ def _segment_row(**overrides) -> dict:
         "turn_indicator": {
             "transition_correct": 1,
             "transition_total": 2,
+            "fp_count": 1,
+            "fp_total": 3,
         },
     }
     row.update(overrides)
@@ -362,6 +364,9 @@ def test_aggregate_nested_keeps_tdigest_in_json():
     assert summary["turn_indicator"]["transition_correct"] == 1
     assert summary["turn_indicator"]["transition_total"] == 2
     assert abs(summary["turn_indicator"]["transition_accuracy"] - 0.5) < 1e-9
+    assert summary["turn_indicator"]["fp_count"] == 1
+    assert summary["turn_indicator"]["fp_total"] == 3
+    assert abs(summary["turn_indicator"]["false_positive_rate"] - 1 / 3) < 1e-9
     # Human-readable segments.jsonl strips digests; in-memory rows keep them.
     cleaned = metrics_for_json(rows[0])
     assert TDIGEST_KEY not in cleaned["object"]
@@ -407,14 +412,39 @@ def test_aggregate_missing_category_fails():
 
 
 def test_turn_indicator_block():
-    block = turn_indicator_block(1, 2)
-    assert block == {"transition_correct": 1, "transition_total": 2}
+    block = turn_indicator_block(1, 2, 0, 3)
+    assert block == {
+        "transition_correct": 1,
+        "transition_total": 2,
+        "fp_count": 0,
+        "fp_total": 3,
+    }
 
 
 def test_aggregate_turn_indicator_zero_total_accuracy_is_na():
-    row = _segment_row(turn_indicator={"transition_correct": 0, "transition_total": 0})
+    row = _segment_row(
+        turn_indicator={
+            "transition_correct": 0,
+            "transition_total": 0,
+            "fp_count": 0,
+            "fp_total": 3,
+        }
+    )
     summary = aggregate([row], near_miss_thresh=0.5, strong_brake_mps2=-2.5)
     assert summary["turn_indicator"]["transition_accuracy"] is None
+
+
+def test_aggregate_turn_indicator_fp_zero_total_rate_is_na():
+    row = _segment_row(
+        turn_indicator={
+            "transition_correct": 0,
+            "transition_total": 2,
+            "fp_count": 0,
+            "fp_total": 0,
+        }
+    )
+    summary = aggregate([row], near_miss_thresh=0.5, strong_brake_mps2=-2.5)
+    assert summary["turn_indicator"]["false_positive_rate"] is None
 
 
 def test_aggregate_missing_turn_indicator_category_fails():

--- a/scenario_generation/tests/test_scenario_sim_viewer_export.py
+++ b/scenario_generation/tests/test_scenario_sim_viewer_export.py
@@ -65,7 +65,12 @@ def _row() -> dict:
             "count": 0,
         },
         "reproducer": {"expand_count": 0, "snap_count": 0, "repeat_steps": 0, "normal_steps": 3},
-        "turn_indicator": {"transition_correct": 0, "transition_total": 0},
+        "turn_indicator": {
+            "transition_correct": 0,
+            "transition_total": 0,
+            "fp_count": 0,
+            "fp_total": 0,
+        },
         "map_path": _MAP,
     }
 

--- a/scenario_generation/tests/test_turn_indicator_scoring.py
+++ b/scenario_generation/tests/test_turn_indicator_scoring.py
@@ -9,6 +9,13 @@ Covers the two PR #403 review fixes:
   ``turn_indicator_prev_scored_gt`` from the teleport target's GT) never corrupts the score for
   the step that just ran -- matching ``render_segment``'s already-correct ordering.
 
+Also covers the spurious-transition ("false positive") counters added alongside the transition
+counters: they must fire only when GT holds steady across scored steps AND the model's own
+resolved prediction flips from its own previous scored prediction, must stay untouched by
+GT-transition steps and by held/cached-plan steps, and must reseed correctly on an unstick
+teleport -- exactly the same set of edge cases as the transition counters, since both live in
+the same scoring function and partition the same population of scored steps.
+
 Route-building helper mirrors ``test_reproducer_unstick.py``'s ``_make_route``, but lets each
 frame's own ``turn_indicators`` window be built from an explicit per-tick GT signal (rather than
 all zeros), so the frame-local ``[-2]``/``[-1]`` window can be distinguished from the
@@ -123,6 +130,93 @@ def test_transition_missed_by_frame_local_window_but_caught_across_scored_steps(
     assert s.turn_indicator_prev_scored_gt == 3
 
 
+def test_score_turn_indicator_counts_fp_on_gt_steady_pred_flip(tmp_path):
+    """When GT holds steady across scored steps, a resolved prediction that changes from the
+    model's OWN previous scored prediction is a spurious transition -- counted as a false
+    positive, independent of whether it happens to match GT.
+    """
+    raw = [0] * 10
+    tl = _make_route(tmp_path, raw)
+    timers = Timers()
+    s = _seed_state(
+        tl,
+        0,
+        len(raw),
+        search_radius=1.5,
+        warmup_steps=1000,
+        near_miss_thresh=0.5,
+        goal_reach_m=0.0,
+        max_stuck_steps=0,
+        timers=timers,
+        max_steps=1000,
+    )
+    s.last_turn_indicator = 0  # matches the seeded baseline: no flip
+    _score_turn_indicator(s, 3)
+    assert (s.turn_indicator_fp_total, s.turn_indicator_fp_count) == (1, 0)
+
+    s.last_turn_indicator = 1  # spurious flip: GT is still 0 at idx 6
+    _score_turn_indicator(s, 6)
+    assert (s.turn_indicator_fp_total, s.turn_indicator_fp_count) == (2, 1)
+    assert s.turn_indicator_transition_total == 0, "GT never changed, so no transition either"
+
+
+def test_score_turn_indicator_no_fp_when_pred_stable(tmp_path):
+    """When GT holds steady AND the model's own prediction also stays put, no false positive
+    is counted -- only the opportunity (``fp_total``) accumulates.
+    """
+    raw = [0] * 10
+    tl = _make_route(tmp_path, raw)
+    timers = Timers()
+    s = _seed_state(
+        tl,
+        0,
+        len(raw),
+        search_radius=1.5,
+        warmup_steps=1000,
+        near_miss_thresh=0.5,
+        goal_reach_m=0.0,
+        max_stuck_steps=0,
+        timers=timers,
+        max_steps=1000,
+    )
+    s.last_turn_indicator = 0
+    _score_turn_indicator(s, 3)
+    _score_turn_indicator(s, 6)
+    assert (s.turn_indicator_fp_total, s.turn_indicator_fp_count) == (2, 0)
+
+
+def test_score_turn_indicator_gt_change_steps_do_not_touch_fp_counters(tmp_path):
+    """A scored step where GT changes must accumulate only the transition counters, never the
+    spurious-transition FP counters -- the two counter pairs partition the same population of
+    scored steps and must stay disjoint (``transition_total + fp_total`` == scored-step count).
+    """
+    raw = [0, 0, 0, 0, 3, 3, 3, 3, 3, 3]
+    tl = _make_route(tmp_path, raw)
+    timers = Timers()
+    s = _seed_state(
+        tl,
+        0,
+        len(raw),
+        search_radius=1.5,
+        warmup_steps=1000,
+        near_miss_thresh=0.5,
+        goal_reach_m=0.0,
+        max_stuck_steps=0,
+        timers=timers,
+        max_steps=1000,
+    )
+    s.last_turn_indicator = 0
+    _score_turn_indicator(s, 3)  # GT unchanged (0 -> 0): a genuine FP opportunity
+    assert s.turn_indicator_fp_total == 1
+    fp_before = (s.turn_indicator_fp_count, s.turn_indicator_fp_total)
+
+    s.last_turn_indicator = 3  # a real GT transition (0 -> 3)
+    _score_turn_indicator(s, 6)
+    assert s.turn_indicator_transition_total == 1
+    assert (s.turn_indicator_fp_count, s.turn_indicator_fp_total) == fp_before
+    assert s.turn_indicator_transition_total + s.turn_indicator_fp_total == 2  # disjoint partition
+
+
 def test_hold_turn_indicator_does_not_touch_transition_counters(tmp_path):
     """A cached-plan step (``replan_interval > 1``, no fresh inference) must never be scored:
     ``_hold_turn_indicator`` only re-appends the held signal, it must not touch the transition
@@ -153,6 +247,40 @@ def test_hold_turn_indicator_does_not_touch_transition_counters(tmp_path):
         s.turn_indicator_transition_correct,
         s.turn_indicator_transition_total,
         s.turn_indicator_prev_scored_gt,
+    )
+    assert before == after
+
+
+def test_hold_turn_indicator_does_not_touch_fp_counters(tmp_path):
+    """A cached-plan step must never touch the spurious-transition FP counters or the model's
+    own-prediction baseline (``turn_indicator_prev_scored_pred``) either -- only ``turn_hist``
+    changes.
+    """
+    raw = [2] * 10
+    tl = _make_route(tmp_path, raw)
+    timers = Timers()
+    s = _seed_state(
+        tl,
+        0,
+        len(raw),
+        search_radius=1.5,
+        warmup_steps=1000,
+        near_miss_thresh=0.5,
+        goal_reach_m=0.0,
+        max_stuck_steps=0,
+        timers=timers,
+        max_steps=1000,
+    )
+    before = (
+        s.turn_indicator_fp_count,
+        s.turn_indicator_fp_total,
+        s.turn_indicator_prev_scored_pred,
+    )
+    _hold_turn_indicator(s)
+    after = (
+        s.turn_indicator_fp_count,
+        s.turn_indicator_fp_total,
+        s.turn_indicator_prev_scored_pred,
     )
     assert before == after
 
@@ -200,6 +328,49 @@ def test_teleport_reseeds_transition_tracking_from_target_gt(tmp_path):
 
     assert s.last_turn_indicator == tgt_gt
     assert s.turn_indicator_prev_scored_gt == tgt_gt
+
+
+def test_teleport_reseeds_fp_tracking_from_target_pred(tmp_path):
+    """An unstick teleport must re-seed ``turn_indicator_prev_scored_pred`` (like
+    ``turn_indicator_prev_scored_gt``) from the teleport target's recorded GT -- otherwise the
+    next scored step would compare the model's pre-teleport prediction baseline against the
+    target's context and count the environment jump itself as a spurious flip.
+    """
+    n = 20
+    raw = [0] * (n // 2) + [2] * (n - n // 2)  # a real transition partway through the route
+    tl = _make_route(tmp_path, raw)
+    timers = Timers()
+    s = _seed_state(
+        tl,
+        0,
+        n,
+        search_radius=1.5,
+        warmup_steps=1000,  # recorded-pose branch (no tracker needed)
+        near_miss_thresh=0.5,
+        goal_reach_m=0.0,
+        max_stuck_steps=0,
+        timers=timers,
+        max_steps=1000,
+        unstick_after=3,
+        unstick_advance_m=0.05,
+        unstick_radius_mult=1.0,  # disable gentle widen: exercise the teleport path directly
+    )
+    pred = np.zeros((80, 4), dtype=np.float32)
+
+    for i in range(n):
+        s.cursor.last_was_repeat = True  # stuck repeating
+        _advance_step(s, pred, idx=i, device="cpu", timers=timers)
+        if s.snap_count > 0:
+            break
+    else:
+        pytest.fail("unstick never fired on the synthetic stalled route")
+
+    matches = np.where(np.all(np.isclose(tl.poses, s.live_pose), axis=1))[0]
+    assert len(matches) == 1
+    tgt = int(matches[0])
+    tgt_gt = int(np.asarray(tl.npz(tgt)["turn_indicators"]).reshape(-1)[-1])
+
+    assert s.turn_indicator_prev_scored_pred == tgt_gt
 
 
 def test_resolve_append_score_before_advance_survives_same_tick_teleport(tmp_path):

--- a/scenario_generation/wandb_closed_loop.py
+++ b/scenario_generation/wandb_closed_loop.py
@@ -53,6 +53,7 @@ _ABS_COLUMNS = [
     ("Collisions", "total_collision_events"),
     ("Rear collisions", "total_rear_collision_events"),
     ("Turn indicator transition accuracy (%)", "turn_indicator_transition_accuracy"),
+    ("Turn indicator false positive rate (%)", "turn_indicator_false_positive_rate"),
 ]
 
 _PER_1000STEPS_COLUMNS = [
@@ -71,6 +72,7 @@ _PER_1000STEPS_COLUMNS = [
     ("Collisions / 1k steps", "total_collision_events"),
     ("Rear collisions / 1k steps", "total_rear_collision_events"),
     ("Turn indicator transition accuracy (%)", "turn_indicator_transition_accuracy"),
+    ("Turn indicator false positive rate (%)", "turn_indicator_false_positive_rate"),
 ]
 
 
@@ -120,6 +122,11 @@ def _abs_value(source_key: str, summary: dict):
         # "always wrong at transitions".
         val = summary[source_key] if source_key in summary else extract_score(summary, source_key)
         return float(val) if isinstance(val, (int, float)) else None
+    if source_key == "turn_indicator_false_positive_rate":
+        # None (no GT-steady scored step was ever observed) becomes a blank cell, not a 0.0 to
+        # misread as "never flips spuriously".
+        val = summary[source_key] if source_key in summary else extract_score(summary, source_key)
+        return float(val) if isinstance(val, (int, float)) else None
     if source_key == "mean_centerline_dist_m":
         dev = summary.get("mean_centerline_dist_m")
         return float(dev) if dev is not None and math.isfinite(float(dev)) else None
@@ -142,6 +149,7 @@ def _per_1000steps_value(source_key: str, summary: dict) -> float | None:
         "pass_rate",
         "mean_gt_deviation_m",  # already a per-step mean
         "turn_indicator_transition_accuracy",  # already a ratio
+        "turn_indicator_false_positive_rate",  # already a ratio
         "mean_centerline_dist_m",  # already a per-step mean
     ):
         return _abs_value(source_key, summary)
@@ -228,6 +236,16 @@ def _aggregate(group_summaries: dict[str, dict]) -> dict:
     # None (not 0.0) when no transition was ever scored across any group.
     agg["turn_indicator_transition_accuracy"] = (
         (ti_transition_correct / ti_transition_total) if ti_transition_total else None
+    )
+
+    # Weighted by scored GT-steady steps (turn_indicator.fp_total), not by segment count --
+    # segments vary widely in how many GT-steady scored steps they contained
+    # (see reproducer_rollout._score_turn_indicator).
+    ti_fp_count = sum(int(s.get("turn_indicator", {}).get("fp_count", 0) or 0) for s in values)
+    ti_fp_total = sum(int(s.get("turn_indicator", {}).get("fp_total", 0) or 0) for s in values)
+    # None (not 0.0) when no GT-steady scored step was ever observed across any group.
+    agg["turn_indicator_false_positive_rate"] = (
+        (ti_fp_count / ti_fp_total) if ti_fp_total else None
     )
     return agg
 


### PR DESCRIPTION
## Summary

Adds a closed-loop turn-indicator false-positive (spurious-transition) rate metric, the complement of the existing turn_indicator_transition_accuracy (#403).

- The existing metric answers: "when GT c?" (gated on a real GT transition,transition-based, not per-step).
- This metric answers the mirror question: "when GT holds steady, does the model flip anyway?"                  

Both are computed in the same _score_turnpopulation of real-inference (scored) steps, and are mutually exclusive per step: transition_total + fp_total always equals the number of scored steps a segment.

## Metric details

- Scope: every scored step where GT did nscored step — regardless of which class(NONE/DISABLE/LEFT/RIGHT) it's holding, not restricted to None.
- Event: a "false positive" is the model'g from its own previous scored prediction(turn_indicator_prev_scored_pred), not onstruction in this branch, so comparingagainst GT would just remeasure transittead of measuring spurious model behavior.
- New _SegState fields: turn_indicator_fpl (accumulators) and turn_indicator_prev_scored_pred (baseline, lifecycle mirrors turn_indicator_prev_scored_gt: seeded in         _seed_state, updated every scored step,port so the environment jump itself isnever counted as a spurious flip).
- turn_indicator segment-row block extendtransition_total} to also carry {fp_count,fp_total}; the false_positive_rate ratien fp_total == 0) is derived at aggregatetime, same convention as transition_acc
- Held/cached-plan steps (_hold_turn_indicator, no fresh inference) never touch the new counters, same as the   existing ones.
- Wired through closed_loop_eval.aggregate/format_summary_lines, closed_loop_score_keys.SCORE_EXTRACTORS,       scenario_sim_metrics (zero-count block,at path), wandb_closed_loop (new tablecolumn + weighted-by-fp_total aggregatid_loop._write_groups_manifest.

## Test plan

- [x] pytest scenario_generation/tests/test_turn_indicator_scoring.py -v  — new tests cover: FP counted only whenGT is steady and the model's own predicsteady and prediction is stable;GT-transition steps never touch the FP  pairs partition the scored steps,verified via transition_total + fp_totas don't touch the FP counters; unstickteleport re-seeds turn_indicator_prev_scored_pred.
- [x] pytest scenario_generation/tests/te— turn_indicator_block (4-arg), aggregatepooling of fp_count/fp_total/false_posi → None guard.
- [x] pytest scenario_generation/tests/te.py -v — fixture updated to the new blockshape.
- [x] pytest scenario_generation/tests/ - pre-existing failure(test_wandb_scenario_sim.py::test_serieonfirmed unrelated to this change(reproduces identically on the unmodifing order-dependent mock-state issue).

🤖 Generated with Claude Code
